### PR TITLE
[CPU] Conditionally allocate memory using the shapes upper bound

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -108,6 +108,7 @@ void regmodule_properties(py::module m) {
     wrap_property_RW(m_intel_cpu,
                      ov::intel_cpu::sparse_weights_decompression_rate,
                      "sparse_weights_decompression_rate");
+    wrap_property_RW(m_intel_cpu, ov::intel_cpu::alloc_max_size, "alloc_max_size");
 
     // Submodule intel_gpu
     py::module m_intel_gpu =

--- a/src/inference/include/openvino/runtime/intel_cpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_cpu/properties.hpp
@@ -63,5 +63,27 @@ static constexpr Property<bool> denormals_optimization{"CPU_DENORMALS_OPTIMIZATI
  */
 static constexpr Property<float> sparse_weights_decompression_rate{"CPU_SPARSE_WEIGHTS_DECOMPRESSION_RATE"};
 
+/**
+ * @brief This property controls whether the plugin uses tensor partial shapes to pre-allocate memory using
+ * the upper bound
+ * @ingroup ov_runtime_cpu_prop_cpp_api
+ *
+ * Using the information about the shape ranges may be beneficial for more optimal memory allocation as the whole memory
+ * reuse plan may be calculated at the compilation stage. The major disadvantage of this approach is the fact that
+ * the upper bound may be too large and exceed the avalable memory, even though it is never reached. Thus, it does make
+ * sense to controll the strategy depending on the specific application scenario.
+ *
+ * @code
+ * ie.set_property(ov::intel_cpu::alloc_max_size(true)); // enable upper bound memory allocation
+ * @endcode
+ *
+ * The following code disables upper bound memory allocation
+ *
+ * @code
+ * ie.set_property(ov::intel_cpu::alloc_max_size(false)); // disable upper bound memory allocation
+ * @endcode
+ */
+static constexpr Property<bool> alloc_max_size{"CPU_ALLOCATE_MAX_SIZE"};
+
 }  // namespace intel_cpu
 }  // namespace ov

--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -222,6 +222,7 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
             RO_property(ov::intel_cpu::sparse_weights_decompression_rate.name()),
             RO_property(ov::hint::dynamic_quantization_group_size.name()),
             RO_property(ov::hint::kv_cache_precision.name()),
+            RO_property(ov::intel_cpu::alloc_max_size.name()),
         };
 
         OPENVINO_SUPPRESS_DEPRECATED_START
@@ -291,6 +292,8 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
     } else if (name == ov::intel_cpu::denormals_optimization) {
         return decltype(ov::intel_cpu::denormals_optimization)::value_type(config.denormalsOptMode ==
                                                                            Config::DenormalsOptMode::DO_On);
+    } else if (name == ov::intel_cpu::alloc_max_size) {
+        return decltype(ov::intel_cpu::alloc_max_size)::value_type(config.allocateMaxSize);
     } else if (name == ov::intel_cpu::sparse_weights_decompression_rate) {
         return decltype(ov::intel_cpu::sparse_weights_decompression_rate)::value_type(
             config.fcSparseWeiDecompressionRate);

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -328,6 +328,17 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
                                ov::intel_cpu::denormals_optimization.name(),
                                ". Expected only true/false");
             }
+        } else if (key == ov::intel_cpu::alloc_max_size.name()) {
+            try {
+                allocateMaxSize = val.as<bool>();
+            } catch (ov::Exception&) {
+                allocateMaxSize = false;
+                OPENVINO_THROW("Wrong valuse ",
+                               val.as<std::string>(),
+                               " for property key ",
+                               ov::intel_cpu::alloc_max_size.name(),
+                               ". Expected only true/false");
+            }
         } else if (key == ov::intel_cpu::snippets_mode.name()) {
             try {
                 auto const mode = val.as<ov::intel_cpu::SnippetsMode>();

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -93,6 +93,9 @@ struct Config {
     // is reserved.
     bool DAZOn = false;
 
+    // Don't use partial shape upper bound memory allocation by default.
+    bool allocateMaxSize = false;
+
     void readProperties(const ov::AnyMap& config, const ModelType modelType = ModelType::Unknown);
 
     void updateProperties();

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -115,7 +115,7 @@ void Memory::create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
 
     if (nullptr != data) {
         m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
-    } else {
+    } else if (m_pMemDesc->isDefined()) {
         m_mgrHandle->resize(memSize);
     }
 }

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -107,10 +107,12 @@ void Memory::create(MemoryDescPtr desc, const void* data, bool pads_zeroing) {
     m_padsZeroing = pads_zeroing;
     dnnlMemHandle.resetDnnlPrim();
 
-    if (!m_pMemDesc->isDefined()) {
+    const size_t memSize = m_pMemDesc->getMaxMemSize();
+
+    if (MemoryDesc::UNDEFINED_SIZE == memSize) {
         return;
     }
-    auto memSize = m_pMemDesc->getCurrentMemSize();
+
     if (nullptr != data) {
         m_mgrHandle->setExtBuff(const_cast<void*>(data), memSize);
     } else {

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -130,7 +130,7 @@ void Memory::load(const IMemory& src, bool ftz) const {
 void Memory::nullify() {
     void* dataPtr = getData();
     if (dataPtr != nullptr)
-        memset(dataPtr, 0, getDesc().getCurrentMemSize());
+        memset(dataPtr, 0, getDesc().getMaxMemSize());
 }
 
 void Memory::redefineDesc(MemoryDescPtr desc) {

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -775,8 +775,8 @@ void Graph::AllocateWithReuse(const std::vector<size_t>& syncNodesInds) {
             int e_start = edge->getParent()->execIndex;
             int e_finish = edge->getChild()->execIndex;
 
-            if (boxSize != -1 && edge->getDesc().isDefined()) {
-                int64_t e_size = edge->getDesc().getCurrentMemSize();  // size in bytes (from the beginning of data to the last element)
+            if (boxSize != -1 && edge->getDesc().hasDefinedMaxSize()) {
+                int64_t e_size = edge->getDesc().getMaxMemSize();  // size in bytes (from the beginning of data to the last element)
                 boxSize = std::max(e_size, boxSize);
             } else {
                 boxSize = -1;

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -465,6 +465,7 @@ ov::Any Plugin::get_ro_property(const std::string& name, const ov::AnyMap& optio
             RW_property(ov::intel_cpu::sparse_weights_decompression_rate.name()),
             RW_property(ov::hint::dynamic_quantization_group_size.name()),
             RW_property(ov::hint::kv_cache_precision.name()),
+            RW_property(ov::intel_cpu::alloc_max_size.name()),
         };
 
         OPENVINO_SUPPRESS_DEPRECATED_START
@@ -515,6 +516,8 @@ ov::Any Plugin::get_ro_property(const std::string& name, const ov::AnyMap& optio
     } else if (name == ov::intel_cpu::denormals_optimization) {
         return decltype(ov::intel_cpu::denormals_optimization)::value_type(engConfig.denormalsOptMode ==
                                                                            Config::DenormalsOptMode::DO_On);
+    } else if (name == ov::intel_cpu::alloc_max_size) {
+        return decltype(ov::intel_cpu::alloc_max_size)::value_type(engConfig.allocateMaxSize);
     } else if (name == ov::intel_cpu::sparse_weights_decompression_rate) {
         return decltype(ov::intel_cpu::sparse_weights_decompression_rate)::value_type(
             engConfig.fcSparseWeiDecompressionRate);


### PR DESCRIPTION
### Details:
If the specific property is set, the plugin tries to preallocate memory at the compilation stage using the information about the upper bound of the partially defined tensor shapes.

### Tickets:
 - CVS-146701
