### PR TITLE
[RISCV64] Disabled FuseFCAndConvertOnWeights in SHL case

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -919,6 +919,10 @@ void GraphOptimizer::MergeConvertAndScaleShift(Graph& graph) {
 }
 
 void GraphOptimizer::FuseFCAndConvertOnWeights(Graph& graph) {
+#if defined(OV_CPU_WITH_SHL)
+    return;
+#endif
+
     // This optimization fuses Convert (fp16 -> bf16/fp32) on weights directly to FC input to allow precision conversion handling based on internal logic
     // (e.g. fuse conversion with weights reordering)
     auto& graphNodes = graph.GetNodes();


### PR DESCRIPTION
### Details:
 - *ShlFCExecutor supports only f32 weights for now. If there is Convert to FP32 between FP16 Weights and FC, these Convert+Weights should be constant-folded on CPU Plugin side. Otherwise, ShlFCExecutor won't be choosen. This PR disables the optimization `FuseFCAndConvertOnWeights` in SHL case*
![image](https://github.com/user-attachments/assets/63b49581-e877-4214-b96c-8ab7a3a6fe77)


### Tickets:
 - *N/A*
