### PR TITLE
fix inplace conflict after MergeReorderAndTranspose

### DIFF
--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -221,7 +221,7 @@ protected:
     void ResolveInplaceDirections();
     void InitOptimalPrimitiveDescriptors();
     void ResolveEdgeConflicts();
-    void ResolveComplexInplaceConflicts();
+    bool ResolveComplexInplaceConflicts();
     bool ProcessDynNodes();
     void GroupParallelNodes();
     void Allocate(const std::vector<size_t>& syncNodesInds);

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -2217,6 +2217,14 @@ void GraphOptimizer::DropDoubleReorders(Graph &graph) {
             Reorder* nn = dynamic_cast<Reorder*>(nextNode.get());
             if (nn == nullptr)
                 OPENVINO_THROW("Cannot get reorder layer ", nextNode->getName());
+            bool nnIsOptimized = nn->getOptimized();
+            if (n->getOptimized() || nnIsOptimized) {
+                if (nnIsOptimized) {
+                    processed.insert(nextNode);
+                }
+                processed.insert(node);
+                continue;
+            }
 
             NodePtr p = n->getParentEdgeAt(0)->getParent();
             NodePtr c = nn->getChildEdgeAt(0)->getChild();


### PR DESCRIPTION
### Details:
 - *MergeReorderAndTranspose in ApplyImplSpecificGraphOptimizations() modify the graph structure,  it is possible to import inplace conflict*
 

### Tickets:
 - *[25744](https://github.com/openvinotoolkit/openvino/issues/25744)*
 - *[CVS-148691](https://jira.devtools.intel.com/browse/CVS-148691)*
