### PR TITLE
[GPU] Fix Crop->Reshape (Squeeze/Unsqueeze modes) buffer optimization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -512,6 +512,12 @@ bool crop_in_place_optimization::match(const program_node& node,
         if (node.get_program().is_body_program() && node.get_dependency(0).is_type<lstm_elt>()) {
             return false;
         }
+
+        GPU_DEBUG_GET_INSTANCE(debug_config);
+        GPU_DEBUG_IF(debug_config->disable_runtime_buffer_fusing && node.is_dynamic()) {
+            return false;
+        }
+
         // optimization is available for cropping across depth(features) or batch
         // if output padding has defined padding across features already it wouldn't
         // work because it expect to have zeros in the padded area.
@@ -553,18 +559,22 @@ bool crop_in_place_optimization::optimize(crop_node& node) {
                                                    node.get_primitive()->axis,
                                                    false);
     } else if (can_crop_be_optimized_simple_data_format(crop_layout, input_layout)) {
-        std::vector<layout> reshape_layouts;
-        if (node.get_users().front()->is_type<reshape>() && node.get_users().front()->as<reshape>().is_runtime_propagatable_padding()) {
-            reshape_layouts.push_back(node.get_users().front()->get_output_layout());
+        std::pair<const program_node*, layout> user_info;
+        if (node.get_users().front()->is_type<reshape>()) {
+            auto& reshape_node = node.get_users().front()->as<reshape>();
+            if (reshape_node.is_runtime_propagatable_padding()) {
+                user_info.first = &reshape_node;
+                user_info.second = reshape_node.get_output_layout();
+            }
         }
         update_in_place_crop_padding_simple_data_format(crop_layout,
                                                         input_layout,
-                                                        reshape_layouts,
+                                                        user_info,
                                                         crop_params->input_offsets[0],
                                                         node.get_primitive()->axis,
                                                         false);
-        if (reshape_layouts.size() > 0) {
-            node.get_users().front()->set_output_layout(reshape_layouts[0]);
+        if (user_info.first) {
+            node.get_users().front()->set_output_layout(user_info.second);
         }
     }
     node.set_output_layout(crop_layout);
@@ -632,24 +642,51 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
 
 void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format(layout& crop_layout,
                                                                                  layout& input_layout,
-                                                                                 std::vector<layout>& user_layouts,
+                                                                                 std::pair<const program_node*, layout>& user_info,
                                                                                  const tensor offsets,
                                                                                  size_t crop_axis,
                                                                                  bool is_runtime) {
-    auto crop_axis_legacy = crop_axis;
-    if (crop_axis_legacy >= 2) {
-        auto spatial_axis = crop_axis_legacy - 2;
-        // Default and minimum number of dimensions is 4
-        auto spatial_size = std::max<size_t>(crop_layout.get_partial_shape().size(), 4) - 2;
-        crop_axis_legacy = spatial_size - spatial_axis - 1 + 2;
-    }
+    auto convert_axis_to_legacy = [](size_t axis, size_t rank) {
+        auto axis_legacy = axis;
+        if (axis_legacy >= 2) {
+            auto spatial_axis = axis_legacy - 2;
+            // Default and minimum number of dimensions is 4
+            auto spatial_size = std::max<size_t>(rank, 4) - 2;
+            axis_legacy = spatial_size - spatial_axis - 1 + 2;
+        }
+
+        return axis_legacy;
+    };
+
+    auto crop_axis_legacy = convert_axis_to_legacy(crop_axis, crop_layout.get_partial_shape().size());
+
     // If it's build-time and node is dynamic, only dynamic padding is set first
     if ((crop_layout.is_dynamic() || input_layout.is_dynamic()) && !is_runtime) {
         auto dyn_pad_sizes = tensor(0).sizes();
         dyn_pad_sizes[crop_axis_legacy] = 1;
         crop_layout.data_padding.set_dynamic_pad(tensor(dyn_pad_sizes));
-        for (auto& user_layout : user_layouts) {
-            user_layout.data_padding.set_dynamic_pad(tensor(dyn_pad_sizes));
+
+        if (user_info.first && user_info.first->is_type<reshape>()) {
+            auto reshape_desc = user_info.first->as<reshape>().get_primitive();
+            auto reshape_mode = reshape_desc->mode;
+            if (reshape_mode == reshape::reshape_mode::base) {
+                user_info.second.data_padding.set_dynamic_pad(tensor(dyn_pad_sizes));
+            } else if (reshape_mode == reshape::reshape_mode::unsqueeze || reshape_mode == reshape::reshape_mode::squeeze) {
+                auto reshape_ps = user_info.second.get_partial_shape();
+                auto output_pattern = reshape_desc->output_pattern;
+
+                auto reshape_axis = crop_axis;
+                for (size_t i = 0; i < output_pattern.size(); i++) {
+                    if (output_pattern[i] <= static_cast<int64_t>(reshape_axis)) {
+                        reshape_axis += reshape_mode == reshape::reshape_mode::unsqueeze ? 1 : -1;
+                    }
+                }
+
+                auto dyn_pad_mask = tensor(0).sizes();
+                auto reshape_axis_legacy = convert_axis_to_legacy(reshape_axis, reshape_ps.size());
+                dyn_pad_mask[reshape_axis_legacy] = 1;
+                user_info.second.data_padding.set_dynamic_pad(tensor(dyn_pad_mask));
+            }
         }
         return;
     }
@@ -673,14 +710,40 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
         auto dyn_pad_sizes = lower_sizes;
         dyn_pad_sizes[crop_axis_legacy] = 1;
         crop_layout.data_padding = padding(lower_sizes, upper_sizes, 0.f, tensor(dyn_pad_sizes));
-        for (auto& user_layout : user_layouts) {
-            auto reshape_rank = user_layout.get_partial_shape().size();
-            auto reshape_last_dim = user_layout.get_partial_shape().to_shape()[reshape_rank - 1];
-            if (lower_sizes[crop_axis_legacy])
-                lower_sizes[crop_axis_legacy] /= reshape_last_dim;
-            if (upper_sizes[crop_axis_legacy])
-                upper_sizes[crop_axis_legacy] /= reshape_last_dim;
-            user_layout.data_padding = padding(lower_sizes, upper_sizes, 0.f, tensor(dyn_pad_sizes));
+        if (user_info.first) {
+            auto reshape_desc = user_info.first->as<reshape>().get_primitive();
+            auto reshape_mode = reshape_desc->mode;
+            if (reshape_mode == reshape::reshape_mode::base) {
+                auto reshape_rank = user_info.second.get_partial_shape().size();
+                auto reshape_last_dim = user_info.second.get_partial_shape().to_shape()[reshape_rank - 1];
+                if (lower_sizes[crop_axis_legacy])
+                    lower_sizes[crop_axis_legacy] /= reshape_last_dim;
+                if (upper_sizes[crop_axis_legacy])
+                    upper_sizes[crop_axis_legacy] /= reshape_last_dim;
+                user_info.second.data_padding = padding(lower_sizes, upper_sizes, 0.f, tensor(dyn_pad_sizes));
+            } else {
+                auto reshape_ps = user_info.second.get_partial_shape();
+                auto output_pattern = reshape_desc->output_pattern;
+
+                auto reshape_axis = crop_axis;
+                for (size_t i = 0; i < output_pattern.size(); i++) {
+                    if (output_pattern[i] <= static_cast<int64_t>(reshape_axis)) {
+                        reshape_axis += reshape_mode == reshape::reshape_mode::unsqueeze ? 1 : -1;
+                    }
+                }
+
+                const auto output_rank = std::max(reshape_ps.size(), static_cast<size_t>(4));
+                std::vector<int32_t> reshape_lower_sizes(output_rank, 0);
+                std::vector<int32_t> reshape_upper_sizes(output_rank, 0);
+                std::vector<int32_t> reshape_dyn_pad_mask(output_rank, 0);
+
+                const auto reshape_axis_legacy = convert_axis_to_legacy(reshape_axis, reshape_ps.size());
+                reshape_lower_sizes[reshape_axis_legacy] = lower_sizes[crop_axis_legacy];
+                reshape_upper_sizes[reshape_axis_legacy] = upper_sizes[crop_axis_legacy];
+                reshape_dyn_pad_mask[reshape_axis_legacy] = 1;
+
+                user_info.second.data_padding = padding(reshape_lower_sizes, reshape_upper_sizes, 0.f, tensor(reshape_dyn_pad_mask));
+            }
         }
     } else {
         crop_layout.data_padding = padding(lower_sizes, upper_sizes);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.h
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.h
@@ -82,7 +82,7 @@ struct crop_in_place_optimization : pattern_match_optimization_typed<crop_in_pla
                                                            bool is_runtime);
     static void update_in_place_crop_padding_simple_data_format(layout& crop_layout,
                                                                 layout& pred_layout,
-                                                                std::vector<layout>& user_layouts,
+                                                                std::pair<const program_node*, layout>& user_info,
                                                                 const tensor offsets,
                                                                 size_t crop_axis,
                                                                 bool is_runtime);

--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -32,8 +32,11 @@ public:
 
     bool is_runtime_propagatable_padding() const {
         auto prim = typed_desc();
-        if (prim->mode == reshape::reshape_mode::squeeze || prim->mode == reshape::reshape_mode::unsqueeze)
-            return true;
+        if (prim->mode == reshape::reshape_mode::squeeze || prim->mode == reshape::reshape_mode::unsqueeze) {
+            // For proper padding propagation we need to know output pattern at model loading stage
+            // in case of squeeze/unsqueeze mode
+            return prim->output_pattern.size() > 0;
+        }
 
         // TODO: This function is to limit condition to a specific case (crop + reshape) among cases for the base mode
         if (!input().is_type<crop>())

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rope_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rope_ref.cl
@@ -73,13 +73,13 @@ KERNEL(rope_ref)(
     uint cos_sin_h = h < INPUT1_SIZE_Y ? h : 0;
 
 #ifndef SIN_COS_HAVE_DYNAMIC_PADDINGS
-    uint cos_sin_idx = INPUT1_GET_INDEX(cos_sin_b, cos_sin_h, cos_sin_p, 0);
+    uint cos_sin_idx = INPUT1_GET_INDEX(cos_sin_b, cos_sin_p, cos_sin_h, 0);
 
     uint cos_idx = cos_sin_idx;
     uint sin_idx = cos_sin_idx;
 #else
-    uint cos_idx = INPUT1_GET_INDEX(cos_sin_b, cos_sin_h, cos_sin_p, 0);
-    uint sin_idx = INPUT2_GET_INDEX(cos_sin_b, cos_sin_h, cos_sin_p, 0);
+    uint cos_idx = INPUT1_GET_INDEX(cos_sin_b, cos_sin_p, cos_sin_h, 0);
+    uint sin_idx = INPUT2_GET_INDEX(cos_sin_b, cos_sin_p, cos_sin_h, 0);
 #endif
 
     uint output_idx = OUTPUT_GET_INDEX(b, p, h, 0);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
@@ -63,6 +63,10 @@ JitConstants RoPEKernelBase::GetJitConstants(const rope_params& params, RoPEKern
         jit.AddConstant(MakeJitConstant("TRANSPOSED_INPUT0_BATCH_PITCH", "INPUT0_BATCH_PITCH"));
     }
 
+    if (params.inputs[0].has_dynamic_pad() || params.inputs[1].has_dynamic_pad()) {
+        jit.AddConstant(MakeJitConstant("SIN_COS_HAVE_DYNAMIC_PADDINGS", true));
+    }
+
     if (params.is_qwen) {
         jit.AddConstant(MakeJitConstant("QWEN", true));
     } else if (params.is_chatglm) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
@@ -63,7 +63,7 @@ JitConstants RoPEKernelBase::GetJitConstants(const rope_params& params, RoPEKern
         jit.AddConstant(MakeJitConstant("TRANSPOSED_INPUT0_BATCH_PITCH", "INPUT0_BATCH_PITCH"));
     }
 
-    if (params.inputs[0].has_dynamic_pad() || params.inputs[1].has_dynamic_pad()) {
+    if (!params.is_chatglm && (params.inputs[1].has_dynamic_pad() || params.inputs[2].has_dynamic_pad())) {
         jit.AddConstant(MakeJitConstant("SIN_COS_HAVE_DYNAMIC_PADDINGS", true));
     }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
@@ -9,6 +9,7 @@
 #include "openvino/op/squeeze.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/core/validation_util.hpp"
 
 #include "intel_gpu/primitives/reshape.hpp"
 #include "intel_gpu/primitives/reorder.hpp"
@@ -30,6 +31,8 @@ static void CreateCommonReshapeOp(ProgramBuilder& p, const std::shared_ptr<ov::N
         std::vector<int64_t> output_pattern = {};
         if (second_const_input != nullptr) {
             output_pattern = second_const_input->cast_vector<int64_t>();
+            if (mode == cldnn::reshape::reshape_mode::unsqueeze || mode == cldnn::reshape::reshape_mode::squeeze)
+                ov::util::normalize_axes(op.get(), op->get_output_partial_shape(0).size(), output_pattern);
         }
 
         // If second input is absent (it's optional in Squeeze op) or it's constant, create reshape with single input and compile time out pattern

--- a/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
@@ -31,8 +31,9 @@ static void CreateCommonReshapeOp(ProgramBuilder& p, const std::shared_ptr<ov::N
         std::vector<int64_t> output_pattern = {};
         if (second_const_input != nullptr) {
             output_pattern = second_const_input->cast_vector<int64_t>();
-            if (mode == cldnn::reshape::reshape_mode::unsqueeze || mode == cldnn::reshape::reshape_mode::squeeze)
-                ov::util::normalize_axes(op.get(), op->get_output_partial_shape(0).size(), output_pattern);
+            if (mode == cldnn::reshape::reshape_mode::unsqueeze || mode == cldnn::reshape::reshape_mode::squeeze) {
+                ov::util::try_normalize_axes(output_pattern, op->get_output_partial_shape(0).rank(), *op);
+            }
         }
 
         // If second input is absent (it's optional in Squeeze op) or it's constant, create reshape with single input and compile time out pattern

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -777,6 +777,85 @@ TEST(prepare_buffer_fusing, in_place_crop_dynamic) {
         ASSERT_EQ(output_ptr_3[i], out3[i]);
 }
 
+TEST(prepare_buffer_fusing, in_place_crop_dynamic_reshape_unsqueeze) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ ov::PartialShape{-1, -1, 4}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory({ {1, 2, 4}, data_types::f32, format::bfyx });
+    auto weights_mem = engine.allocate_memory({ {8, 4}, data_types::u8, format::bfyx });
+    auto bias_mem = engine.allocate_memory({ {1, 1, 8}, data_types::f32, format::bfyx });
+    auto scale_mem = engine.allocate_memory({ {8, 1}, data_types::f32, format::bfyx });
+    auto zp_mem = engine.allocate_memory({ {8, 1}, data_types::f32, format::bfyx });
+    auto axis_mem = engine.allocate_memory({ {}, data_types::i64, format::bfyx });
+    auto splits_length_mem = engine.allocate_memory({ {2}, data_types::i64, format::bfyx });
+
+    int64_t axis = 2;
+    set_values(input_mem, { -0.5f,  2.0f,  0.5f,  1.0f,
+                             0.5f, -2.0f, -0.5f, -1.0f });
+    set_values<int64_t>(axis_mem, {axis});
+    set_values<int64_t>(splits_length_mem, { 2, 6 });
+    set_values<uint8_t>(weights_mem, { 1,  2,  3,  4,
+                                       5,  6,  7,  8,
+                                       9, 10, 11, 12,
+                                      13, 14, 15,  0,
+                                      15, 14, 13, 12,
+                                      11, 10,  9,  8,
+                                       7,  6,  5,  4,
+                                       3,  2,  1,  0});
+    set_values(bias_mem, { 1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.0f, 7.0f, 2.0f });
+    set_values(scale_mem, { 2.0f, 4.0f, -2.0f, -4.0f, 0.5f, -0.5f, 2.0f, 2.0f });
+    set_values(zp_mem, { 1.0f, 2.0f, 2.0f, 1.0f, 4.0f, 1.0f, 6.0f, 2.0f });
+
+    std::vector<float> out1 = { 13.f, 58.f, -11.f, -62.f };
+    std::vector<float> out2 = { -51.f, -108.f, 18.5f, -18.f, 1.f, -4.f, 57.f, 100.f, -8.5f, 6.f, 13.f, 8.f };
+    std::vector<float> out3 = { 13.f, 58.f, -51.f, -108.f, 18.5f, -18.f, 1.f, -4.f, -11.f, -62.f, 57.f, 100.f, -8.5f, 6.f, 13.f, 8.f };
+
+    cldnn::crop_ngraph_op_mode op_mode = cldnn::crop_ngraph_op_mode::variadic_split;
+    topology topology(
+        input_layout("input", in_layout),
+        data("axis", axis_mem),
+        data("splits_length", splits_length_mem),
+        data("weights", weights_mem),
+        data("bias", bias_mem),
+        data("scale", scale_mem),
+        data("zp", zp_mem),
+        fully_connected("fc", input_info("input"), "weights", "bias", "scale", "zp", data_types::f32, 3, 2),
+        crop("crop1", { input_info("fc"), input_info("axis"), input_info("splits_length") }, cldnn::tensor(1), cldnn::tensor(0), op_mode, 0, axis),
+        reorder("output1", input_info("crop1"), format::bfyx, data_types::f32),
+        crop("crop2", { input_info("fc"), input_info("axis"), input_info("splits_length") }, cldnn::tensor(1), cldnn::tensor(0), op_mode, 1, axis),
+        reshape("reshape", input_info("crop2"), false, std::vector<int64_t>{1}, ov::PartialShape{-1, 1, -1, 6}, cldnn::reshape::reshape_mode::unsqueeze),
+        reorder("output2", input_info("reshape"), format::bfyx, data_types::f32, std::vector<float>(), reorder_mean_mode::subtract, padding(), true),
+        reorder("output3", input_info("fc"), format::bfyx, data_types::f32)
+    );
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("output1").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    for (size_t i = 0; i < out1.size(); i++)
+        ASSERT_EQ(output_ptr[i], out1[i]);
+
+    auto output_2 = outputs.at("output2").get_memory();
+    cldnn::mem_lock<float> output_ptr_2(output_2, get_test_stream());
+
+    for (size_t i = 0; i < out2.size(); i++)
+        ASSERT_EQ(output_ptr_2[i], out2[i]);
+
+    auto output_3 = outputs.at("output3").get_memory();
+    cldnn::mem_lock<float> output_ptr_3(output_3, get_test_stream());
+
+    for (size_t i = 0; i < out3.size(); i++)
+        ASSERT_EQ(output_ptr_3[i], out3[i]);
+}
+
 TEST(prepare_buffer_fusing, in_place_crop_dynamic_split_lengths) {
     auto& engine = get_test_engine();
 

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
@@ -35,12 +35,14 @@ inline padding get_pad(format fmt, std::vector<int64_t> axes, bool is_dynamic) {
     std::vector<int32_t> upper(fmt.dimension(), 0);
     std::vector<int32_t> mask(fmt.dimension(), 0);
 
+    auto start_pad_val = 13;
     for (auto& axis : axes) {
-        lower[axis] = 13 + axis;
-        upper[axis] = 25 + axis;
+        lower[axis] = start_pad_val;
+        upper[axis] = start_pad_val / 2;
         if (is_dynamic) {
             mask[axis] = 1;
         }
+        start_pad_val += 5;
     }
 
     return padding(tensor(fmt, lower, 0).sizes(), tensor(fmt, upper, 0).sizes(), 0.0f, tensor(fmt, mask, 0));
@@ -281,19 +283,29 @@ INSTANTIATE_TEST_SUITE_P(smoke, unsqueeze_test,
             layout{ov::PartialShape{1}, data_types::f32, format::bfyx}
         },
         {
+            layout{ov::PartialShape{1, 128}, data_types::f32, format::bfyx, get_pad(format::bfyx, {0, 1}, true)},
+            layout{ov::PartialShape{2}, data_types::i64, format::bfyx}, {1, 3}, ov::PartialShape::dynamic(4),
+            layout{ov::PartialShape{1, 1, 128, 1}, data_types::f32, format::bfyx, get_pad(format::bfyx, {0, 2}, true)}
+        },
+        {
+            layout{ov::PartialShape{1, 1, 128}, data_types::f32, format::bfyx, get_pad(format::bfyx, {2}, true)},
+            layout{ov::PartialShape{1}, data_types::i64, format::bfyx}, {1}, ov::PartialShape::dynamic(4),
+            layout{ov::PartialShape{1, 1, 1, 128}, data_types::f32, format::bfyx, get_pad(format::bfyx, {3}, true)}
+        },
+        {
             layout{ov::PartialShape{1, 10, 20, 30}, data_types::f32, format::bfyx, get_pad(format::bfyx, {2}, true)},
             layout{ov::PartialShape{1}, data_types::i64, format::bfyx}, {1}, ov::PartialShape::dynamic(5),
-            layout{ov::PartialShape{1, 1, 10, 20, 30}, data_types::f32, format::bfzyx, get_pad(format::bfyx, {2}, true)}
+            layout{ov::PartialShape{1, 1, 10, 20, 30}, data_types::f32, format::bfzyx, get_pad(format::bfzyx, {3}, true)}
         },
         {
             layout{ov::PartialShape{1, 10, 20, 30}, data_types::f32, format::bfyx, get_pad(format::bfyx, {2, 3}, true)},
             layout{ov::PartialShape{1}, data_types::i64, format::bfyx}, {1}, ov::PartialShape::dynamic(5),
-            layout{ov::PartialShape{1, 1, 10, 20, 30}, data_types::f32, format::bfzyx, get_pad(format::bfyx, {2, 3}, true)}
+            layout{ov::PartialShape{1, 1, 10, 20, 30}, data_types::f32, format::bfzyx, get_pad(format::bfzyx, {3, 4}, true)}
         },
         {
             layout{ov::PartialShape{1, 10, 20, 30}, data_types::f32, format::bfyx, get_pad(format::bfyx, {2, 3}, true)},
             layout{ov::PartialShape{2}, data_types::i64, format::bfyx}, {1, 4}, ov::PartialShape::dynamic(6),
-            layout{ov::PartialShape{1, 1, 10, 20, 1, 30}, data_types::f32, format::bfwzyx, get_pad(format::bfyx, {2, 3}, true)}
+            layout{ov::PartialShape{1, 1, 10, 20, 1, 30}, data_types::f32, format::bfwzyx, get_pad(format::bfwzyx, {3, 5}, true)}
         }
     }));
 }  // shape_infer_tests


### PR DESCRIPTION
These changes fix a significant accuracy issue (reducing perplexity from 120 000 to 17) for Llama models with precalculated constant sin/cos values. However, there is still a problem with sin/cos representation in FP16 precision, which will be addressed in a separate PR.

### Details:
 - Fixed Crop->Reshape (Squeeze/Unsqueeze modes) buffer optimization
 - Update rope_ref kernel to support dynamic paddings for cos/sin inputs
 - Fix propagate_padding() function and update shape infer tests

### Tickets:
 - [CVS-148220](https://jira.devtools.intel.com/browse/CVS-148220), [CVS-146283](https://jira.devtools.intel.com/browse/CVS-146283)
