### PR TITLE
[RISCV64] Moved FC weights repacking to model compilation stage

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
@@ -5,12 +5,44 @@
 #include "shl_fullyconnected.hpp"
 
 #include "csinn/csi_nn.h"
+#include "rvv/rvv.h"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/memory_arguments.hpp"
+#include "nodes/common/cpu_memcpy.h"
 #include "utils/debug_capabilities.h"
 
 namespace ov {
 namespace intel_cpu {
+namespace {
+static MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory, const ExecutorContext::CPtr context) {
+    DEBUG_LOG("ShlFCExecutor: prepack weights");
+
+    auto create = [&]() {
+        const auto& weiDesc = weightsMemory->getDescPtr();
+        MemoryPtr _ptr = std::make_shared<Memory>(context->getEngine(),
+                                                  intel_cpu::CpuBlockedMemoryDesc(ov::element::f32, weightsMemory->getShape()));
+        cpu_parallel_memcpy(_ptr->getData(), weightsMemory->getData(), weightsMemory->getSize());
+        DEBUG_LOG("ShlFCExecutor: cache miss, perform packing");
+        const auto repack_wei = ShlTensor(ShlSession(), precisionToShlDataType(weiDesc->getPrecision()), getShlDataLayoutByMemoryDesc(weiDesc, true),
+                                          weiDesc->getShape().getStaticDims(), _ptr->getData());
+        shl_rvv_fc_gemm_reorder_weight_fp32(repack_wei.get());
+        return _ptr;
+    };
+
+    auto weightCache = context->getWeightsCache();
+    if (weightCache != nullptr) {
+        const auto& wgtDims = weightsMemory->getStaticDims();
+        std::string format = "gemm_shl_" + std::to_string(wgtDims[0]) + "_" + std::to_string(wgtDims[1]);
+        const std::string string_hash = format + "_" + std::to_string(weightsMemory->getSize()) + "_" +
+                                        std::to_string(reinterpret_cast<uint64_t>(weightsMemory->getData()));
+        DEBUG_LOG("ShlFCExecutor: findOrCreate, string_hash: ", string_hash);
+        return *weightCache->findOrCreate(string_hash, create);
+    }
+
+    DEBUG_LOG("ShlFCExecutor: Weights cache is not available");
+    return create();
+}
+} // namespace
 
 bool ShlFCExecutor::supports(const FCConfig& config) {
     if (config.attrs.weightsNonTransposed) {
@@ -53,7 +85,8 @@ bool ShlFCExecutor::supports(const FCConfig& config) {
 ShlFCExecutor::ShlFCExecutor(const FCAttrs& attrs,
                              const PostOps& postOps,
                              const MemoryArgs& memory,
-                             const ExecutorContext::CPtr context) {
+                             const ExecutorContext::CPtr context)
+    : packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context)) {
     const auto& srcDesc = memory.at(ARG_SRC)->getDescPtr();
     const auto& weiDesc = memory.at(ARG_WEI)->getDescPtr();
     const auto& dstDesc = memory.at(ARG_DST)->getDescPtr();
@@ -93,7 +126,7 @@ bool ShlFCExecutor::update(const MemoryArgs& memory) {
 
 void ShlFCExecutor::execute(const MemoryArgs& memory) {
     src.setData(memory.at(ARG_SRC)->getData());
-    wei.setData(memory.at(ARG_WEI)->getData());
+    wei.setData(packedWeights->getData());
     dst.setData(memory.at(ARG_DST)->getData());
     if (with_bias) {
         bias.setData(memory.at(ARG_BIAS)->getData());

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
@@ -36,6 +36,8 @@ private:
     ShlSession sess = {};
     ShlFCParams params = {};
 
+    const MemoryCPtr packedWeights;
+
     bool with_bias = false;
 };
 using ShlFCExecutorPtr = std::shared_ptr<ShlFCExecutor>;


### PR DESCRIPTION
### Details:
 - *Moved FullyConnected RVV weights repacking from execution stage to compilation model stage*
 - *PR to the SHL repository: https://github.com/openvinotoolkit/shl/pull/6*

### Tickets:
 - *N/A*
