### PR TITLE
[TF FE] Stabilize Bitwise layer tests on all platforms and fix u16 bug

### DIFF
--- a/src/frontends/tensorflow/src/tf_utils.cpp
+++ b/src/frontends/tensorflow/src/tf_utils.cpp
@@ -297,7 +297,7 @@ Any unpack_tensor_proto(const ::tensorflow::TensorProto& tensor_proto,
             break;
         case u16:
             val_size = tensor_proto.int_val_size();
-            extract_compressed_tensor_content<uint16_t, int32_t>(tensor_proto, val_size, &res);
+            extract_compressed_tensor_content<uint16_t, uint16_t>(tensor_proto, val_size, &res);
             break;
         case u64:
             val_size = tensor_proto.uint64_val_size();

--- a/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BinaryOps.py
@@ -1,9 +1,8 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import platform
-
 import numpy as np
+import platform
 import pytest
 from common.tf_layer_test_class import CommonTFLayerTest
 
@@ -66,15 +65,12 @@ class TestBinaryOps(CommonTFLayerTest):
             'FloorMod': tf.raw_ops.FloorMod,
             'FloorDiv': tf.raw_ops.FloorDiv,
             'Xdivy': tf.raw_ops.Xdivy,
-            'BitwiseAnd': tf.raw_ops.BitwiseAnd,
-            'BitwiseOr': tf.raw_ops.BitwiseOr,
-            'BitwiseXor': tf.raw_ops.BitwiseXor,
         }
 
         input_type = np.float32
         if op_type in ["LogicalAnd", "LogicalOr", "LogicalXor"]:
             input_type = bool
-        elif op_type in ["BitwiseAnd", "BitwiseOr", "BitwiseXor", 'Pow']:
+        elif op_type in ['Pow']:
             input_type = np.int32
         self.input_type = input_type
 
@@ -100,21 +96,21 @@ class TestBinaryOps(CommonTFLayerTest):
     @pytest.mark.parametrize("op_type",
                              ['Add', 'AddV2', 'Sub', 'Mul', 'Div', 'RealDiv', 'SquaredDifference', 'Pow',
                               'Maximum', 'Minimum', 'Equal', 'NotEqual', 'Mod', 'Greater', 'GreaterEqual', 'Less',
-                              'LessEqual', 'LogicalAnd', 'LogicalOr', 'FloorMod', 'FloorDiv',
-                              'Xdivy', 'BitwiseAnd', 'BitwiseOr', 'BitwiseXor', ])
+                              'LessEqual', 'LogicalAnd', 'LogicalOr', 'FloorMod', 'FloorDiv', 'Xdivy'])
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.xfail(condition=platform.system() == 'Darwin' and platform.machine() == 'arm64',
                        reason='Ticket - 122716')
     def test_binary_op(self, x_shape, y_shape, ie_device, precision, ir_version, temp_dir, op_type,
                        use_legacy_frontend):
-        if use_legacy_frontend and op_type in ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor', 'Xdivy']:
-            pytest.skip("Bitwise and Xdivy ops are supported only by new TF FE.")
-        if op_type in ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor', 'Pow', 'Mod'] and ie_device == 'GPU':
-            pytest.skip("GPU does not support Bitwise ops. For Mod and Pow it has inference mismatch")
+        if use_legacy_frontend and op_type in ['Xdivy']:
+            pytest.skip("Xdivy op is supported only by new TF FE.")
+        if op_type in ['Pow', 'Mod'] and ie_device == 'GPU':
+            pytest.skip("For Mod and Pow GPU has inference mismatch")
         if op_type in ['Mod', 'FloorDiv', 'FloorMod']:
             pytest.skip("Inference mismatch for Mod and FloorDiv")
-        if ie_device == 'GPU' and precision == 'FP16' and op_type in ['Equal', 'NotEqual', 'Greater', 'GreaterEqual', 'Less', 'LessEqual']:
-            pytest.skip("Accuracy mismatch on GPU")            
+        if ie_device == 'GPU' and precision == 'FP16' and op_type in ['Equal', 'NotEqual', 'Greater', 'GreaterEqual',
+                                                                      'Less', 'LessEqual']:
+            pytest.skip("Accuracy mismatch on GPU")
         self._test(*self.create_add_placeholder_const_net(x_shape=x_shape, y_shape=y_shape, op_type=op_type), ie_device,
                    precision, ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Bitwise.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Bitwise.py
@@ -60,7 +60,7 @@ class TestBitwise(CommonTFLayerTest):
     @pytest.mark.parametrize('y_shape', [[4], [2, 3, 4]])
     @pytest.mark.parametrize('is_y_const', [True, False])
     @pytest.mark.parametrize('input_type', [np.int8, np.int16, np.int32, np.int64,
-                                            np.uint8, np.uint32, np.uint64])
+                                            np.uint8, np.uint16, np.uint32, np.uint64])
     @pytest.mark.parametrize("op_type", ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor'])
     @pytest.mark.precommit
     @pytest.mark.nightly

--- a/tests/layer_tests/tensorflow_tests/test_tf_Bitwise.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Bitwise.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import platform
+import pytest
+import tensorflow as tf
+from common.tf_layer_test_class import CommonTFLayerTest
+
+rng = np.random.default_rng(21097)
+
+op_type_to_tf = {
+    'BitwiseAnd': tf.raw_ops.BitwiseAnd,
+    'BitwiseOr': tf.raw_ops.BitwiseOr,
+    'BitwiseXor': tf.raw_ops.BitwiseXor,
+}
+
+
+def generate_input(x_shape, x_type):
+    if np.issubdtype(x_type, np.signedinteger):
+        return rng.integers(-100, 100, x_shape).astype(x_type)
+    return rng.integers(0, 200, x_shape).astype(x_type)
+
+
+class TestBitwise(CommonTFLayerTest):
+    def _prepare_input(self, inputs_info):
+        inputs_data = {}
+
+        assert 'x:0' in inputs_info, "Test error: inputs_info must contain `x`"
+        x_shape = inputs_info['x:0']
+        inputs_data['x:0'] = generate_input(x_shape, self.input_type)
+        if not self.is_y_const:
+            assert 'y:0' in inputs_info, "Test error: inputs_info must contain `y`"
+            y_shape = inputs_info['y:0']
+            inputs_data['y:0'] = generate_input(y_shape, self.input_type)
+        return inputs_data
+
+    def create_bitwise_net(self, x_shape, y_shape, is_y_const, input_type, op_type):
+        self.is_y_const = is_y_const
+        self.input_type = input_type
+        tf.compat.v1.reset_default_graph()
+        # Create the graph and model
+        with tf.compat.v1.Session() as sess:
+            x = tf.compat.v1.placeholder(input_type, x_shape, 'x')
+            if is_y_const:
+                constant_value = generate_input(y_shape, input_type)
+                y = tf.constant(constant_value, dtype=input_type)
+            else:
+                y = tf.compat.v1.placeholder(input_type, y_shape, 'y')
+            op_type_to_tf[op_type](x=x, y=y, name=op_type)
+
+            tf.compat.v1.global_variables_initializer()
+            tf_net = sess.graph_def
+
+        ref_net = None
+
+        return tf_net, ref_net
+
+    @pytest.mark.parametrize('x_shape', [[4], [3, 4], [1, 2, 3, 4]])
+    @pytest.mark.parametrize('y_shape', [[4], [2, 3, 4]])
+    @pytest.mark.parametrize('is_y_const', [True, False])
+    @pytest.mark.parametrize('input_type', [np.int8, np.int16, np.int32, np.int64,
+                                            np.uint8, np.uint32, np.uint64])
+    @pytest.mark.parametrize("op_type", ['BitwiseAnd', 'BitwiseOr', 'BitwiseXor'])
+    @pytest.mark.precommit
+    @pytest.mark.nightly
+    def test_bitwise(self, x_shape, y_shape, is_y_const, input_type, op_type, ie_device, precision, ir_version,
+                     temp_dir, use_legacy_frontend):
+        self._test(*self.create_bitwise_net(x_shape=x_shape, y_shape=y_shape, is_y_const=is_y_const,
+                                            input_type=input_type, op_type=op_type),
+                   ie_device, precision, ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)

--- a/tests/layer_tests/tensorflow_tests/test_tf_Bitwise.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Bitwise.py
@@ -66,6 +66,8 @@ class TestBitwise(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_bitwise(self, x_shape, y_shape, is_y_const, input_type, op_type, ie_device, precision, ir_version,
                      temp_dir, use_legacy_frontend):
+        if ie_device == 'GPU':
+            pytest.skip("148540: Bitwise ops are not supported on GPU")
         self._test(*self.create_bitwise_net(x_shape=x_shape, y_shape=y_shape, is_y_const=is_y_const,
                                             input_type=input_type, op_type=op_type),
                    ie_device, precision, ir_version, temp_dir=temp_dir, use_legacy_frontend=use_legacy_frontend)


### PR DESCRIPTION
**Details:** Fix u16 bug "Tensor data with element type u16, is not representable as pointer to i32"

**Ticket:** 122716
