### PR TITLE
[CPU][ARM] MLAS transpose executor deprioritised

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -51,11 +51,6 @@ public:
             DEBUG_LOG("NEPermute requires the same input and output precisions");
             return false;
         }
-        if (srcDescs[0]->getPrecision() != ov::element::f32 &&
-            srcDescs[0]->getPrecision() != ov::element::i8) {
-            DEBUG_LOG("NEPermute supports 1, 2, 4 bytes data types. FP16 implementation is disabled due to performance issues");
-            return false;
-        }
         return true;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/transpose_list.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/transpose_list.cpp
@@ -9,9 +9,9 @@ namespace intel_cpu {
 
 const std::vector<TransposeExecutorDesc>& getTransposeExecutorsList() {
     static const std::vector<TransposeExecutorDesc> descs = {
-            OV_CPU_INSTANCE_MLAS_ARM64(ExecutorType::Mlas, std::make_shared<MlasTransposeExecutorBuilder>())
             OV_CPU_INSTANCE_COMMON(ExecutorType::Common, std::make_shared<RefOptimizedTransposeExecutorBuilder>())
             OV_CPU_INSTANCE_ACL(ExecutorType::Acl, std::make_shared<ACLTransposeExecutorBuilder>())
+            OV_CPU_INSTANCE_MLAS_ARM64(ExecutorType::Mlas, std::make_shared<MlasTransposeExecutorBuilder>())
             OV_CPU_INSTANCE_X64(ExecutorType::jit_x64, std::make_shared<JitTransposeExecutorBuilder>())
             OV_CPU_INSTANCE_COMMON(ExecutorType::Common, std::make_shared<RefTransposeExecutorBuilder>())
     };


### PR DESCRIPTION
### Details:
 - The latest performance reports on Ampere show ACL transpose executor provides better performance rather than MLAS Transpose executor (details are in the ticket). Therefore,  MLAS Transpose executor priority has been decreased.
 - Redundant check has been deleted in ACL Transpose executor.

### Tickets:
 - CVS-148625
