### PR TITLE
[GPU][TRANSFORMATIONS] Disable per pass validation in some cases

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -424,6 +424,7 @@ bool MarkSugraphsToKeepInMixedPrecision::run_on_model(const shared_ptr<ov::Model
     RUN_ON_MODEL_SCOPE(MarkSugraphsToKeepInMixedPrecision);
 
     Manager manager(get_pass_config(), "MarkSugraphsToKeepInMixedPrecision");
+    manager.set_per_pass_validation(false);
     // Mark root of Division with eps pattern to keep in FP32
     REGISTER_PASS(manager, MarkDivWithEps)
     REGISTER_PASS(manager, MarkExpInReduceOpPath)

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -777,6 +777,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
     {
         ov::pass::Manager manager("GPU:PostLPT");
+        manager.set_per_pass_validation(false);
 
         // Other ops support eltwise fusions
         const std::vector<DiscreteTypeInfo> allowed_data_movement_ops = {


### PR DESCRIPTION
### Details:
 - Disable per pass validation for GPU specific passes and mixed precision markup to improve model loading time
