### PR TITLE
[GPU] Runtime weights fix and reorder_kernel_bfyx_to_blocked_format kernel fix

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_bfyx_to_blocked_format.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel_bfyx_to_blocked_format.cpp
@@ -143,7 +143,7 @@ static std::vector<size_t> GetBestLwsFromGws(const reorder_params& params, const
     std::vector<size_t> dims{ 0, 1, 2 };
 
     // SLM size: elemsize * tile_width * tile_width * work_items <= 64K
-    const size_t elem_size = params.inputs[0].ElementSize();
+    const size_t elem_size = params.outputs[0].ElementSize();
     const size_t max_local_mem_size = params.engineInfo.maxLocalMemSize;
     const size_t max_work_group_size = params.engineInfo.maxWorkGroupSize;
     size_t max_num_work_items = std::min(max_work_group_size, max_local_mem_size / (elem_size * tile_width * tile_size));


### PR DESCRIPTION
### Details:
 - *Useless reorders lead to incorrect propagation of weights formats -> disabled adding reorders for runtime weights in reorder_inputs pass*
 - *Fix lws calculation for reorder_kernel_bfyx_to_blocked_format kernel*

### Tickets:
 - *[146165](https://jira.devtools.intel.com/browse/CVS-146165)*
