### PR TITLE
Revert "[GPU] Avoid crop buffer fusing when dynamic shape and squeeze/unsqueeze reshape mode"

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -484,10 +484,10 @@ bool crop_in_place_optimization::match(const program_node& node,
         if (node.is_dynamic() && (user->is_type<convolution>() || user->is_type<gemm>()))
             return false;
         if (user->is_type<reshape>()) {
-            auto& reshape_node = user->as<reshape>();
-            // runtime buffer fusing is only handled when there is only one reshape user and reshape mode is base
-            if (node.is_dynamic() && (node.get_users().size() != 1 || reshape_node.get_primitive()->mode != reshape::reshape_mode::base))
+            // runtime buffer fusing is only handled when there is only one reshape user
+            if (node.is_dynamic() && node.get_users().size() != 1)
                 return false;
+            auto& reshape_node = user->as<reshape>();
             if (can_reshape_be_optimized(reshape_node) &&
                 (!node.is_dynamic() || !reshape_node.is_runtime_propagatable_padding()))
                 return false;


### PR DESCRIPTION
### Details:
 - This revert https://github.com/openvinotoolkit/openvino/pull/25700
 - As support for Crop->Reshape(Squeeze/Unsqueeze modes) buffer optimization was added by https://github.com/openvinotoolkit/openvino/pull/25836

### Tickets:
 - 146626
