### PR TITLE
[NPU] Disable MCL in case of UD28

### DIFF
--- a/src/inference/include/openvino/runtime/intel_npu/level_zero/level_zero.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/level_zero/level_zero.hpp
@@ -100,7 +100,7 @@ public:
     }
 
     /**
-     * @brief This function is used to obtain remote tensor object from user-supplied Direct3D 12 Core object
+     * @brief This function is used to obtain remote tensor object from user-supplied NT handle object
      * @param type Tensor element type
      * @param shape Tensor shape
      * @param buffer A void* object that should be wrapped by a remote tensor

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -10,11 +10,11 @@
 #include "ze_command_queue_npu_ext.h"
 #include "zero_utils.hpp"
 
-namespace {
 #ifdef _WIN32
+namespace {
 constexpr uint32_t WIN_DRIVER_NO_MCL_SUPPORT = 2688;
-#endif
 }  // namespace
+#endif
 
 namespace intel_npu {
 

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -10,6 +10,12 @@
 #include "ze_command_queue_npu_ext.h"
 #include "zero_utils.hpp"
 
+namespace {
+#ifdef _WIN32
+constexpr uint32_t WIN_DRIVER_NO_MCL_SUPPORT = 2688;
+#endif
+}  // namespace
+
 namespace intel_npu {
 
 const ze_driver_uuid_t ZeroInitStructsHolder::uuid = ze_intel_npu_driver_uuid;
@@ -169,9 +175,15 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
         std::make_unique<ze_graph_dditable_ext_decorator>(graph_ddi_table_ext, driver_ext_version);
 
     // Query the mutable command list version
-    std::string mutable_comamnd_list_name;
-    log.debug("ZeroInitStructsHolder - tie output of queryMutableCommandListVersion");
-    mutable_command_list_version = queryMutableCommandListVersion(extProps, count);
+#ifdef _WIN32
+    // The 2688 Windows driver version doesn't support as expected the MutableCommandList feature
+    if (driver_properties.driverVersion != WIN_DRIVER_NO_MCL_SUPPORT) {
+#endif
+        log.debug("ZeroInitStructsHolder - tie output of queryMutableCommandListVersion");
+        mutable_command_list_version = queryMutableCommandListVersion(extProps, count);
+#ifdef _WIN32
+    }
+#endif
 
     log.debug("Mutable command list version %d.%d",
               ZE_MAJOR_VERSION(mutable_command_list_version),

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -275,7 +275,7 @@ public:
     };
 
     void updateCommandList(const TensorData& tensors_data, uint32_t index, size_t batch_size) override {
-        OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_IP_PULL,
+        OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_IP_UMCL,
                           itt::domains::LevelZeroBackend,
                           "IntegratedPipeline",
                           "updateCommandList");


### PR DESCRIPTION
### Details:
 - *The UD28 Windows driver version doesn't support as expected the MutableCommandList feature - just disable this feature from the plugin in case this driver is used*

### Tickets:
 - *EISW-133845*
