### PR TITLE
[CPU][ARM] Enable ACL MVN executor for `initAcrossChannels` option in NHWC layout

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.hpp
@@ -68,11 +68,6 @@ public:
             DEBUG_LOG("NEMeanStdDevNormalizationLayer supports normalize_variance=true only");
             return false;
         }
-        if (!mvnAttrs.initAcrossChannels_ &&
-            getAclDataLayoutByMemoryDesc(srcDescs[0]) == arm_compute::DataLayout::NHWC) {
-            DEBUG_LOG("initAcrossChannels = false is not supported by ACL for NHWC layout");
-            return false;
-        }
 
         return true;
     }


### PR DESCRIPTION
### Details:
 - This configuration (initAcrossChannels is true and NHWC is used) was disabled for ACL executor to enable `yolo_v3_tiny`. The last check shows this restriction is not required anymore. 

### Tickets:
 - *ticket-id*
