### PR TITLE
[GPU] Fixed moving a temporary object

### DIFF
--- a/src/plugins/intel_gpu/src/graph/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/kv_cache.cpp
@@ -38,7 +38,7 @@ std::vector<layout> kv_cache_inst::calc_output_layouts(kv_cache_node const& /*no
     if (desc->num_outputs > 1)
         input_shapes.push_back(impl_param.get_input_layout(2).get<ShapeType>());
 
-    std::vector<ShapeType> output_shapes = std::move(shape_infer(&op, input_shapes));
+    std::vector<ShapeType> output_shapes = shape_infer(&op, input_shapes);
 
     static const std::map<size_t, size_t> ports_map = {{0, 0}, {1, 2}};
 


### PR DESCRIPTION
### Details:
 - *Fixed extra `std::move()` warning-error from https://github.com/openvinotoolkit/openvino/pull/25886*

### Tickets:
 - *N/A*
