### PR TITLE
Fix ONNX frontend code generation

### DIFF
--- a/src/frontends/onnx/frontend/CMakeLists.txt
+++ b/src/frontends/onnx/frontend/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 if(NOT BUILD_SHARED_LIBS)
     file(GLOB_RECURSE op_list "src/op/*.cpp")
-    set(static_reg_file "src/static_reg.hpp")
+    set(static_reg_file ${CMAKE_CURRENT_BINARY_DIR}/static_reg.hpp)
     file(WRITE ${static_reg_file} "// Copyright (C) 2018-2024 Intel Corporation\n// SPDX-License-Identifier: Apache-2.0\n// Auto generated file, DO NOT EDIT INLINE\n\n")
     file(APPEND ${static_reg_file} "#include \"core/operator_set.hpp\"\n\n")
     file(APPEND ${static_reg_file} "#define ONNX_DECL_OP(op) extern ov::OutputVector op(const Node&)\n\n")


### PR DESCRIPTION
### Details

ONNX frontend has code generation when `BUILD_SHARED_LIBS=OFF` which targets a file inside source directory.
When configuring the project, the generated file is written to the sources directory.
If two configurations are running at the same time (i.e. when trying to build the package with `vcpkg` it configures debug and release builds concurrently), both `cmake` instances append lines to the same file inside source directory which leads to corrupted file content and cryptic build errors.

This change makes the script write generated header file to a directory inside build directory, so that two different configuration processes don't interfere with each other.