### PR TITLE
Fix `output_size` dynamic dimensions support for `Col2Im-15` for CPU `StaticShape`

### DIFF
--- a/src/core/shape_inference/include/col2im_shape_inference.hpp
+++ b/src/core/shape_inference/include/col2im_shape_inference.hpp
@@ -87,7 +87,7 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
             idx++;
             output_shape[idx] = (*output_size_val)[1];
             const size_t L_idx = is_batched ? 2 : 1;
-            if (data_shape.rank().is_static() && data_shape[L_idx].is_static()) {
+            if (data_shape.rank().is_static() && data_shape[L_idx].is_static() && (*output_size_val).is_static()) {
                 constexpr size_t spatial_dims = 2;
 
                 const auto& pads_begin = op->get_pads_begin();

--- a/src/core/shape_inference/include/col2im_shape_inference.hpp
+++ b/src/core/shape_inference/include/col2im_shape_inference.hpp
@@ -17,7 +17,7 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
                                  const std::vector<TShape>& input_shapes,
                                  const ITensorAccessor& tensor_accessor = make_tensor_accessor()) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 3);
-
+    std::cout << "\n\nCOL2IM SHAPE INFER;\n\n";
     const auto& data_shape = input_shapes[0];
     const auto& output_size_shape = input_shapes[1];
     const auto& kernel_shape = input_shapes[2];
@@ -67,6 +67,7 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
         const size_t C_idx = is_batched ? 1 : 0;
         const auto kernel_val = ov::op::get_input_const_data_as<TRShape, int64_t>(op, 2, tensor_accessor);
         if (kernel_val && data_shape.rank().is_static() && data_shape[C_idx].is_static()) {
+            std::cout << "\n\nconst auto& dividend = data_shape[C_idx].get_length();\n\n";
             const auto& dividend = data_shape[C_idx].get_length();
             const auto divisor = ((*kernel_val)[0] * (*kernel_val)[1]);
             output_shape[idx] = dividend / divisor;
@@ -99,11 +100,13 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
                     using TVal = typename TShape::value_type::value_type;
                     TVal L_calculated = 1;
                     for (size_t d = 0; d < spatial_dims; ++d) {
+                        std::cout << "\n\n(*output_size_val)[d].get_length()\n\n";
                         L_calculated *= (((*output_size_val)[d].get_length() + pads_begin[d] + pads_end[d] -
                                           dilations[d] * ((*kernel_val)[d] - 1) - 1) /
                                          strides[d]) +
                                         1;
                     }
+                    std::cout << "\n\nconst auto L = data_shape[L_idx].get_length()\n\n";
                     const auto L = data_shape[L_idx].get_length();
                     NODE_SHAPE_INFER_CHECK(
                         op,

--- a/src/core/shape_inference/include/col2im_shape_inference.hpp
+++ b/src/core/shape_inference/include/col2im_shape_inference.hpp
@@ -17,7 +17,6 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
                                  const std::vector<TShape>& input_shapes,
                                  const ITensorAccessor& tensor_accessor = make_tensor_accessor()) {
     NODE_VALIDATION_CHECK(op, input_shapes.size() == 3);
-    std::cout << "\n\nCOL2IM SHAPE INFER;\n\n";
     const auto& data_shape = input_shapes[0];
     const auto& output_size_shape = input_shapes[1];
     const auto& kernel_shape = input_shapes[2];
@@ -67,7 +66,6 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
         const size_t C_idx = is_batched ? 1 : 0;
         const auto kernel_val = ov::op::get_input_const_data_as<TRShape, int64_t>(op, 2, tensor_accessor);
         if (kernel_val && data_shape.rank().is_static() && data_shape[C_idx].is_static()) {
-            std::cout << "\n\nconst auto& dividend = data_shape[C_idx].get_length();\n\n";
             const auto& dividend = data_shape[C_idx].get_length();
             const auto divisor = ((*kernel_val)[0] * (*kernel_val)[1]);
             output_shape[idx] = dividend / divisor;
@@ -100,13 +98,11 @@ std::vector<TRShape> shape_infer(const Col2Im* op,
                     using TVal = typename TShape::value_type::value_type;
                     TVal L_calculated = 1;
                     for (size_t d = 0; d < spatial_dims; ++d) {
-                        std::cout << "\n\n(*output_size_val)[d].get_length()\n\n";
                         L_calculated *= (((*output_size_val)[d].get_length() + pads_begin[d] + pads_end[d] -
                                           dilations[d] * ((*kernel_val)[d] - 1) - 1) /
                                          strides[d]) +
                                         1;
                     }
-                    std::cout << "\n\nconst auto L = data_shape[L_idx].get_length()\n\n";
                     const auto L = data_shape[L_idx].get_length();
                     NODE_SHAPE_INFER_CHECK(
                         op,

--- a/src/core/tests/type_prop/col2im.cpp
+++ b/src/core/tests/type_prop/col2im.cpp
@@ -247,6 +247,46 @@ TEST_F(TypePropCol2ImTest, dynamic_batch_size) {
     EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{Dimension::dynamic(), 3, 32, 32}));
 }
 
+TEST_F(TypePropCol2ImTest, dynamic_output_size_from_shape_of) {
+    const auto data = std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), 12, 324});
+    const auto output_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), Dimension::dynamic()}));
+    const auto kernel_size = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{2}, std::vector<int32_t>{2, 2});
+    const auto strides = Strides{2, 2};
+    const auto dilations = Strides{2, 2};
+    const auto pads_begin = Shape{3, 3};
+    const auto pads_end = Shape{3, 3};
+
+    const auto op = make_op(data, output_size, kernel_size, strides, dilations, pads_begin, pads_end);
+    op->validate_and_infer_types();
+
+    EXPECT_EQ(op->get_strides(), (Strides{2, 2}));
+    EXPECT_EQ(op->get_dilations(), (Strides{2, 2}));
+    EXPECT_EQ(op->get_pads_begin(), (Shape{3, 3}));
+    EXPECT_EQ(op->get_pads_end(), (Shape{3, 3}));
+    EXPECT_EQ(op->get_output_element_type(0), element::i64);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{Dimension::dynamic(), 3, Dimension::dynamic(), Dimension::dynamic()}));
+}
+
+TEST_F(TypePropCol2ImTest, dynamic_kernel_size_from_shape_of) {
+    const auto data = std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), 12, 324});
+    const auto output_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, Shape{32, 32}));
+    const auto kernel_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), Dimension::dynamic()}));
+    const auto strides = Strides{2, 2};
+    const auto dilations = Strides{2, 2};
+    const auto pads_begin = Shape{3, 3};
+    const auto pads_end = Shape{3, 3};
+
+    const auto op = make_op(data, output_size, kernel_size, strides, dilations, pads_begin, pads_end);
+    op->validate_and_infer_types();
+
+    EXPECT_EQ(op->get_strides(), (Strides{2, 2}));
+    EXPECT_EQ(op->get_dilations(), (Strides{2, 2}));
+    EXPECT_EQ(op->get_pads_begin(), (Shape{3, 3}));
+    EXPECT_EQ(op->get_pads_end(), (Shape{3, 3}));
+    EXPECT_EQ(op->get_output_element_type(0), element::i64);
+    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{Dimension::dynamic(), Dimension::dynamic(), 32, 32}));
+}
+
 TEST_F(TypePropCol2ImTest, interval_data_shape) {
     const auto data = std::make_shared<Parameter>(element::i64, PartialShape{{4, 5}, {12, 16}, {324, 623}});
     const auto output_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, Shape{32, 32}));

--- a/src/core/tests/type_prop/col2im.cpp
+++ b/src/core/tests/type_prop/col2im.cpp
@@ -249,7 +249,8 @@ TEST_F(TypePropCol2ImTest, dynamic_batch_size) {
 
 TEST_F(TypePropCol2ImTest, dynamic_output_size_from_shape_of) {
     const auto data = std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), 12, 324});
-    const auto output_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), Dimension::dynamic()}));
+    const auto output_size = std::make_shared<ShapeOf>(
+        std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), Dimension::dynamic()}));
     const auto kernel_size = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{2}, std::vector<int32_t>{2, 2});
     const auto strides = Strides{2, 2};
     const auto dilations = Strides{2, 2};
@@ -264,13 +265,15 @@ TEST_F(TypePropCol2ImTest, dynamic_output_size_from_shape_of) {
     EXPECT_EQ(op->get_pads_begin(), (Shape{3, 3}));
     EXPECT_EQ(op->get_pads_end(), (Shape{3, 3}));
     EXPECT_EQ(op->get_output_element_type(0), element::i64);
-    EXPECT_EQ(op->get_output_partial_shape(0), (PartialShape{Dimension::dynamic(), 3, Dimension::dynamic(), Dimension::dynamic()}));
+    EXPECT_EQ(op->get_output_partial_shape(0),
+              (PartialShape{Dimension::dynamic(), 3, Dimension::dynamic(), Dimension::dynamic()}));
 }
 
 TEST_F(TypePropCol2ImTest, dynamic_kernel_size_from_shape_of) {
     const auto data = std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), 12, 324});
     const auto output_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, Shape{32, 32}));
-    const auto kernel_size = std::make_shared<ShapeOf>(std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), Dimension::dynamic()}));
+    const auto kernel_size = std::make_shared<ShapeOf>(
+        std::make_shared<Parameter>(element::i64, PartialShape{Dimension::dynamic(), Dimension::dynamic()}));
     const auto strides = Strides{2, 2};
     const auto dilations = Strides{2, 2};
     const auto pads_begin = Shape{3, 3};

--- a/src/core/tests/type_prop/col2im.cpp
+++ b/src/core/tests/type_prop/col2im.cpp
@@ -258,7 +258,6 @@ TEST_F(TypePropCol2ImTest, dynamic_output_size_from_shape_of) {
     const auto pads_end = Shape{3, 3};
 
     const auto op = make_op(data, output_size, kernel_size, strides, dilations, pads_begin, pads_end);
-    op->validate_and_infer_types();
 
     EXPECT_EQ(op->get_strides(), (Strides{2, 2}));
     EXPECT_EQ(op->get_dilations(), (Strides{2, 2}));
@@ -280,7 +279,6 @@ TEST_F(TypePropCol2ImTest, dynamic_kernel_size_from_shape_of) {
     const auto pads_end = Shape{3, 3};
 
     const auto op = make_op(data, output_size, kernel_size, strides, dilations, pads_begin, pads_end);
-    op->validate_and_infer_types();
 
     EXPECT_EQ(op->get_strides(), (Strides{2, 2}));
     EXPECT_EQ(op->get_dilations(), (Strides{2, 2}));

--- a/src/plugins/intel_cpu/src/nodes/col2im.cpp
+++ b/src/plugins/intel_cpu/src/nodes/col2im.cpp
@@ -10,7 +10,7 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 Col2Im::Col2Im(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
-    : Node(op, context, NgraphShapeInferFactory(op, EMPTY_PORT_MASK)) {
+    : Node(op, context, NgraphShapeInferFactory(op, PortMask(1, 2))) {
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);

--- a/tests/model_hub_tests/pytorch/hf_transformers_models
+++ b/tests/model_hub_tests/pytorch/hf_transformers_models
@@ -127,7 +127,7 @@ mobilebert,google/mobilebert-uncased
 mobilenet_v1,google/mobilenet_v1_0.75_192
 mobilenet_v2,google/mobilenet_v2_1.0_224
 mobilevit,apple/mobilevit-small
-mobilevitv2,apple/mobilevitv2-1.0-imagenet1k-256,xfail,(CVS-148673) Col2Im: Static shape inference lacks constant data on port 1
+mobilevitv2,apple/mobilevitv2-1.0-imagenet1k-256
 mpnet,sentence-transformers/all-mpnet-base-v2
 mpt,team-lucid/mptk-1b
 mra,uw-madison/mra-base-512-4

--- a/tests/model_hub_tests/pytorch/test_timm.py
+++ b/tests/model_hub_tests/pytorch/test_timm.py
@@ -73,7 +73,8 @@ class TestTimmConvertModel(TestTorchConvertModel):
                                       "vit_base_patch8_224.augreg_in21k",
                                       "beit_base_patch16_224.in22k_ft_in22k",
                                       "sequencer2d_l.in1k",
-                                      "gcresnext26ts.ch_in1k"])
+                                      "gcresnext26ts.ch_in1k",
+                                      "volo_d2_224.sail_in1k"])
     @pytest.mark.precommit
     def test_convert_model_precommit(self, name, ie_device):
         self.mode = "trace"

--- a/tests/model_hub_tests/pytorch/timm_models
+++ b/tests/model_hub_tests/pytorch/timm_models
@@ -532,11 +532,11 @@ vit_wee_patch16_reg1_gap_256.sbb_in1k,None
 vit_xsmall_patch16_clip_224.tinyclip_yfcc15m,None
 vitamin_base_224.datacomp1b_clip,None,xfail,RuntimeError Error in loading state_dict for VisionTransformer
 vitamin_large2_224.datacomp1b_clip,None
-volo_d1_224.sail_in1k,None
-volo_d2_224.sail_in1k,None
-volo_d3_224.sail_in1k,None
-volo_d4_224.sail_in1k,None
-volo_d5_224.sail_in1k,None
+volo_d1_224.sail_in1k,None,xfail_export,Requested None inlined input for op aten.index.Tensor
+volo_d2_224.sail_in1k,None,xfail_export,Requested None inlined input for op aten.index.Tensor
+volo_d3_224.sail_in1k,None,xfail_export,Requested None inlined input for op aten.index.Tensor
+volo_d4_224.sail_in1k,None,xfail_export,Requested None inlined input for op aten.index.Tensor
+volo_d5_224.sail_in1k,None,xfail_export,Requested None inlined input for op aten.index.Tensor
 wide_resnet101_2.tv2_in1k,None
 wide_resnet50_2.racm_in1k,None
 xception41.tf_in1k,None

--- a/tests/model_hub_tests/pytorch/timm_models
+++ b/tests/model_hub_tests/pytorch/timm_models
@@ -532,11 +532,11 @@ vit_wee_patch16_reg1_gap_256.sbb_in1k,None
 vit_xsmall_patch16_clip_224.tinyclip_yfcc15m,None
 vitamin_base_224.datacomp1b_clip,None,xfail,RuntimeError Error in loading state_dict for VisionTransformer
 vitamin_large2_224.datacomp1b_clip,None
-volo_d1_224.sail_in1k,None,xfail,Cannot get length of dynamic dimension
-volo_d2_224.sail_in1k,None,xfail,Cannot get length of dynamic dimension
-volo_d3_224.sail_in1k,None,xfail,Cannot get length of dynamic dimension
-volo_d4_224.sail_in1k,None,xfail,Cannot get length of dynamic dimension
-volo_d5_224.sail_in1k,None,xfail,Cannot get length of dynamic dimension
+volo_d1_224.sail_in1k,None
+volo_d2_224.sail_in1k,None
+volo_d3_224.sail_in1k,None
+volo_d4_224.sail_in1k,None
+volo_d5_224.sail_in1k,None
 wide_resnet101_2.tv2_in1k,None
 wide_resnet50_2.racm_in1k,None
 xception41.tf_in1k,None


### PR DESCRIPTION
### Details
   - `trace` case has been fixed, `export` case is still failing for PT FE affected models, but now with an error unrelated to `Col2Im`

### Tickets:
 - CVS-148673
