### PR TITLE
[GPU] updated not to set OneDNN related variables for cldnn layers

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -142,10 +142,8 @@ public:
             }
         }
 #ifdef ENABLE_ONEDNN_FOR_GPU
-        if (get_preferred_impl_type() == impl_types::onednn) {
-            params->fused_desc_onednn = get_fused_primitives_onednn();
-            params->attrs_onednn = get_onednn_primitive_attributes();
-        }
+        params->fused_desc_onednn   = get_fused_primitives_onednn();
+        params->attrs_onednn        = get_onednn_primitive_attributes();
 #endif // ENABLE_ONEDNN_FOR_GPU
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -142,8 +142,10 @@ public:
             }
         }
 #ifdef ENABLE_ONEDNN_FOR_GPU
-        params->fused_desc_onednn   = get_fused_primitives_onednn();
-        params->attrs_onednn        = get_onednn_primitive_attributes();
+        if (get_preferred_impl_type() == impl_types::onednn) {
+            params->fused_desc_onednn = get_fused_primitives_onednn();
+            params->attrs_onednn = get_onednn_primitive_attributes();
+        }
 #endif // ENABLE_ONEDNN_FOR_GPU
         return params;
     }

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -988,6 +988,11 @@ void program_node::load(cldnn::BinaryInputBuffer& ib) {
         ib >> fused_prims_onednn[idx].dims;
         ib >> make_data(&fused_prims_onednn[idx].dt, sizeof(dnnl::memory::data_type));
     }
+
+    // added a dummpy onednn_attrs to prevent initializing it for non-onednn impls
+    if (impl_type != impl_types::onednn) {
+        onednn_attrs = std::make_shared<dnnl::primitive_attr>();
+    }
 #endif // ENABLE_ONEDNN_FOR_GPU
 }
 


### PR DESCRIPTION
### Details:
 - This PR updates non-onednn layers not to initialize `onednn_attrs`.

### Tickets:
 - 149028