### PR TITLE
[GPU] Relaxed condition to select strided_slice impl with gpu

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
@@ -82,7 +82,7 @@ bool mark_shape_of_subgraphs::can_mark_node(const program_node& node) {
     // Exclude stride_slice primitive if it's input is big const ternsor, else CPU reference implementation
     // will lead to huge performance drop.
     if (node.is_type<strided_slice>() && node.get_dependency(0).is_constant() &&
-        node.get_dependency(0).get_output_layout().count() > 1024 * 1024) {
+        node.get_dependency(0).get_output_layout().count() > 128 * 1024) {
         return false;
     }
 


### PR DESCRIPTION
### Details:
 - Relaxed condition set in https://github.com/openvinotoolkit/openvino/pull/25601
 - Checked with actual model which contains 128x1024 size strided_slice (baichuan 7b) 
 - For both platform with small EU count and many EU count, using gpu impl was better
![image](https://github.com/user-attachments/assets/259e3843-f722-40e3-b001-9786e6bb7906)


### Tickets:
 - *ticket-id*
