### PR TITLE
[intel-npu] Update `core_threading` tests

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
@@ -17,16 +17,6 @@ const Params params[] = {
                 {{ov::device::priorities(ov::test::utils::DEVICE_NPU, ov::test::utils::DEVICE_CPU)}}},
 };
 
-const Params paramsStreams[] = {
-        std::tuple<Device, Config>{ov::test::utils::DEVICE_NPU, {{ov::num_streams(ov::streams::AUTO)}}},
-};
-
-const Params paramsStreamsDRIVER[] = {
-        std::tuple<Device, Config>{ov::test::utils::DEVICE_NPU,
-                                   {{ov::num_streams(ov::streams::AUTO),
-                                     ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::DRIVER)}}},
-};
-
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTest, testing::ValuesIn(params),
@@ -36,11 +26,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadin
                          testing::Combine(testing::ValuesIn(params), testing::Values(4), testing::Values(50)),
                          (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>));
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_Streams_NPU, CoreThreadingTestsWithCacheEnabled,
-                         testing::Combine(testing::ValuesIn(paramsStreamsDRIVER), testing::Values(20),
-                                          testing::Values(10)),
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU, CoreThreadingTestsWithCacheEnabled,
+                         testing::Combine(testing::ValuesIn(params), testing::Values(20), testing::Values(10)),
                          (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithCacheEnabled>));
-
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_Streams_NPU, CoreThreadingTestsWithIter,
-                         testing::Combine(testing::ValuesIn(paramsStreams), testing::Values(4), testing::Values(50)),
-                         (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>));


### PR DESCRIPTION
### Details:
 - *Remove instantiated tests with `NUM_STREAMS` property*
 - *Activate `CoreThreadingTestsWithCacheEnabled` tests*

### Tickets:
 - *E112064*
