### PR TITLE
[GPU] Revert changes for fake alignment

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -210,7 +210,7 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
     }
 
     if (orig_input_layout.format == format::bfyx && orig_output_layout.format == format::bfyx && can_apply_fake_alignment) {
-         auto batch_size = std::accumulate(input_shape.begin(),
+        auto batch_size = std::accumulate(input_shape.begin(),
                                           input_shape.end() - 1,
                                           size_t{1},
                                           std::multiplies<size_t>());
@@ -234,16 +234,6 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         input_shape[0] = align_to(batch_size, fake_align_base);
         output_shape[0] = align_to(batch_size, fake_align_base);
 
-        const auto &dev_info = orig_impl_param.get_program().get_engine().get_device_info();
-
-        // The target HW of this patch is limited because of performance concern
-        if (dev_info.supports_immad && dev_info.dev_type == device_type::integrated_gpu) {
-            // Check whether the input node has enough space for output data. Otherwise, fake alignment is not possible due to page fault
-            // i.e. predecessor node was supposed be increased already
-            if (orig_input_layout.is_static() && dep_memory(0).count() < ov::shape_size(input_shape)) {
-               return std::move(orig_impl_param);
-            }
-        }
         auto updated_param = orig_impl_param;
         updated_param.input_layouts[0] = orig_input_layout.clone_with_other_shape(input_shape);
         updated_param.output_layouts[0] = orig_output_layout.clone_with_other_shape(output_shape);

--- a/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
@@ -47,7 +47,7 @@ public:
     template<typename ShapeType>
     static std::vector<layout> calc_output_layouts(fully_connected_node const& /*node*/, const kernel_impl_params& impl_param);
     static layout calc_output_layout(fully_connected_node const& node, kernel_impl_params const& impl_param);
-    kernel_impl_params get_fake_aligned_params(kernel_impl_params const& orig_impl_param) override;
+    static kernel_impl_params get_fake_aligned_params(kernel_impl_params const& orig_impl_param);
     static std::string to_string(fully_connected_node const& node);
 
     typed_primitive_inst(network& network, fully_connected_node const& node);

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -305,10 +305,6 @@ public:
     virtual int32_t get_prealloc_iter_num() { return -1; }
     virtual void update_shape_info_tensor(const kernel_impl_params& params);
 
-    virtual kernel_impl_params get_fake_aligned_params(kernel_impl_params const& orig_impl_param) {
-        return std::move(orig_impl_param);
-    }
-
 protected:
     primitive_inst(network& network, program_node const& node, bool allocate_memory);
 
@@ -456,6 +452,7 @@ protected:
         }
         return false;
     }
+    kernel_impl_params get_fake_aligned_params_if_possible(kernel_impl_params const& orig_impl_param);
 
     // This could be implemented via single map std::unordered_map<instrumentation::perf_counter_key, std::tuple<int64_t, size_t>>
     // but the overhead on using perf_counter_key as map key is too big, thus we use hash as map key
@@ -531,6 +528,10 @@ public:
 
     template<typename T>
     static std::vector<layout> calc_output_layouts(const typed_node& node, const kernel_impl_params& impl_param) { return {}; }
+
+    static kernel_impl_params get_fake_aligned_params(kernel_impl_params const& orig_impl_param) {
+        return std::move(orig_impl_param);
+    }
 
     typed_primitive_inst_base(network& network, typed_node const& node)
         : typed_primitive_inst_base(network, node, do_allocate_memory(node)) {}

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type.h
@@ -45,6 +45,7 @@ struct primitive_type {
 
     virtual layout calc_output_layout(const program_node& node, const kernel_impl_params& params) const = 0;
     virtual std::vector<layout> calc_output_layouts(const program_node& node, const kernel_impl_params& impl_param) const = 0;
+    virtual kernel_impl_params get_fake_aligned_params(kernel_impl_params const& orig_impl_param) const = 0;
     virtual std::string to_string(const program_node& node) const = 0;
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_type_base.h
@@ -125,6 +125,10 @@ struct primitive_type_base : primitive_type {
         return res;
     }
 
+    kernel_impl_params get_fake_aligned_params(kernel_impl_params const& orig_impl_param) const override {
+        return typed_primitive_inst<PType>::get_fake_aligned_params(orig_impl_param);
+    }
+
     std::string to_string(const cldnn::program_node& node) const override {
         OPENVINO_ASSERT(node.type() == this, "[GPU] primitive_type_base::to_string: primitive type mismatch");
         return typed_primitive_inst<PType>::to_string(node);

--- a/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "intel_gpu/runtime/execution_config.hpp"
-#include "intel_gpu/runtime/internal_properties.hpp"
 #include "test_utils.h"
 
 #include <intel_gpu/primitives/input_layout.hpp>
@@ -48,28 +46,21 @@ TEST_P(fully_connected_fake_align_test, fake_alignment) {
     auto weight_layout_prim = std::make_shared<input_layout>("weight", p.weight_layout);
     auto fully_connected_prim = std::make_shared<fully_connected>("output", input_info("input"), "weight", "", p.data_type, input_size);
 
-    ov::intel_gpu::ExecutionConfig config;
-    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    cldnn::program prog(engine);
 
-    auto prog = std::make_shared<cldnn::program>(engine, config);
-
-    auto& input_node = prog->get_or_create(input_layout_prim);
-    auto& weight_node = prog->get_or_create(weight_layout_prim);
-    auto& fully_connected_node = prog->get_or_create(fully_connected_prim);
-    program_wrapper::add_connection(*prog, input_node, fully_connected_node);
-    program_wrapper::add_connection(*prog, weight_node, fully_connected_node);
-
-
-    fully_connected_node.recalc_output_layout();
-    network net(prog);
-    auto fc = net.get_primitive("output");
+    auto& input_node = prog.get_or_create(input_layout_prim);
+    auto& weight_node = prog.get_or_create(weight_layout_prim);
+    auto& fully_connected_node = prog.get_or_create(fully_connected_prim);
+    program_wrapper::add_connection(prog, input_node, fully_connected_node);
+    program_wrapper::add_connection(prog, weight_node, fully_connected_node);
 
     auto impl_param = fully_connected_node.get_kernel_impl_params();
+    impl_param->output_layouts[0] = fully_connected_inst::calc_output_layouts<ov::PartialShape>(fully_connected_node, *fully_connected_node.get_kernel_impl_params())[0];
 
     if (impl_param->get_input_layout().is_dynamic() || impl_param->get_output_layout().is_dynamic()) {
-        EXPECT_THROW(fc->get_fake_aligned_params(*impl_param), std::exception);
+        EXPECT_THROW(fully_connected_inst::get_fake_aligned_params(*impl_param), std::exception);
     } else {
-        auto updated_param = fc->get_fake_aligned_params(*impl_param);
+        auto updated_param = fully_connected_inst::get_fake_aligned_params(*impl_param);
         if (!engine.get_device_info().supports_immad) {
             ASSERT_EQ(updated_param.get_input_layout(), p.expected_input_layout_igpu);
             ASSERT_EQ(updated_param.get_output_layout(), p.expected_output_layout_igpu);
@@ -82,6 +73,15 @@ TEST_P(fully_connected_fake_align_test, fake_alignment) {
 
 INSTANTIATE_TEST_SUITE_P(smoke, fully_connected_fake_align_test,
     testing::ValuesIn(std::vector<fc_fake_align_params>{
+        {
+            layout{ov::PartialShape{0, 1024}, data_types::i8, format::bfyx, padding{{1,1,1,1}, 0}},    // input_layout
+            layout{ov::PartialShape{1000, 1024}, data_types::i8, format::bfyx},                        // weight layout
+            data_types::f16,
+            layout{ov::PartialShape{0, 1024}, data_types::i8, format::bfyx, padding{{1,1,1,1}, 0}},    // fake_aligned input layout_igpu
+            layout{ov::PartialShape{0, 1000}, data_types::f16, format::bfyx},                          // fake_aligned output layout_igpu
+            layout{ov::PartialShape{0, 1024}, data_types::i8, format::bfyx, padding{{1,1,1,1}, 0}},    // fake_aligned input layout_dgpu
+            layout{ov::PartialShape{0, 1000}, data_types::f16, format::bfyx}                           // fake_aligned output layout_dgpu
+        },
         {
             layout{ov::PartialShape{11, 1024}, data_types::i8, format::bfyx, padding{{1,1,1,1}, 0}},   // input_layout
             layout{ov::PartialShape{1000, 1024}, data_types::i8, format::bfyx},                        // weight layout
@@ -247,14 +247,13 @@ TEST_P(fully_connected_skip_fake_align_test, skip_fake_alignment_case) {
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     network network(engine, topology, config);
-    auto fc = network.get_primitive("fc_prim1");
 
     auto impl_param = network.get_primitive("fc_prim1")->get_impl_params();
 
     if (impl_param->get_input_layout().is_dynamic() || impl_param->get_output_layout().is_dynamic()) {
-        EXPECT_THROW(fc->get_fake_aligned_params(*impl_param), std::exception);
+        EXPECT_THROW(fully_connected_inst::get_fake_aligned_params(*impl_param), std::exception);
     } else {
-        auto updated_param = fc->get_fake_aligned_params(*impl_param);
+        auto updated_param = fully_connected_inst::get_fake_aligned_params(*impl_param);
         if (!engine.get_device_info().supports_immad) {
             ASSERT_EQ(updated_param.get_input_layout(), p.expected_input_layout_igpu);
             ASSERT_EQ(updated_param.get_output_layout(), p.expected_output_layout_igpu);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -69,7 +69,7 @@ public:
         const auto  primitve  = prim_inst->desc();
 
         const auto primitive_hash = primitve->hash();
-        const auto params_hash = prim_inst->get_fake_aligned_params(*prim_inst->get_impl_params()).hash();
+        const auto params_hash = primitve->type->get_fake_aligned_params(*prim_inst->get_impl_params()).hash();
         if (!engine.get_device_info().supports_immad) {
             ASSERT_EQ(primitive_hash, 8017451717095756666UL);
             ASSERT_EQ(params_hash, 4374037685392472517UL);


### PR DESCRIPTION
### Details:
 - Revert a part of https://github.com/openvinotoolkit/openvino/pull/25886 related to fake alignment changes to avoid OOR exception
