### PR TITLE
Zero backend and compiler adapter to share single L0 context

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -148,6 +148,9 @@ struct NetworkDescription final {
 
     // use to pass graphHandle from compiler to backend executor
     void* graphHandleVoidPtr = nullptr;
+    void* propsVoidPtr = nullptr;
+    void* inputDescriptors = nullptr;
+    void* outputDescriptors = nullptr;
 };
 
 /**

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -204,7 +204,10 @@ public:
     virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
     // Needed only by the driver compiler, to populate the actual blob content inside the NetworkDescription
-    virtual void fillCompiledNetwork([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
+    virtual std::vector<uint8_t> getCompiledNetwork(
+        [[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription) {
+        return std::vector<uint8_t>();
+    }
 
 protected:
     virtual ~ICompiler() = default;

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -145,6 +145,9 @@ struct NetworkDescription final {
     std::vector<uint8_t> compiledNetwork;
 
     NetworkMetadata metadata;
+
+    // to test if passing graphHandle from compiler to backend executor 
+    void* graphHandleVoidPtr;
 };
 
 /**

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -147,7 +147,7 @@ struct NetworkDescription final {
     NetworkMetadata metadata;
 
     // use to pass graphHandle from compiler to backend executor 
-    void* graphHandleVoidPtr;
+    void* graphHandleVoidPtr = nullptr;
 };
 
 /**

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -112,7 +112,7 @@ struct NetworkMetadata final {
 
     size_t numStreams = 1;
 
-    // use to pass graphHandle from compiler to backend executor
+    // Used primarily in the CID path to pass the level zero graph handle from compiler to the backend executor
     void* graphHandle = nullptr;
 
     /**
@@ -138,6 +138,7 @@ struct NetworkDescription final {
     NetworkDescription(std::vector<uint8_t>&& compiledNetwork, NetworkMetadata&& metadata)
         : compiledNetwork(std::move(compiledNetwork)),
           metadata(std::move(metadata)) {}
+    NetworkDescription(NetworkMetadata&& metadata) : metadata(std::move(metadata)) {}
     // Force move semantics to prevent blob copies
     NetworkDescription(const NetworkDescription&) = delete;
     NetworkDescription(NetworkDescription&&) = default;
@@ -199,10 +200,10 @@ public:
                                                                     const std::vector<uint8_t>& network,
                                                                     const Config& config) const = 0;
 
-    // Only need for driver compiler to release graph handle now
+    // Needed only by the driver compiler, to release the graph handle
     virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
-    // Only need for driver compiler to fill blob now
+    // Needed only by the driver compiler, to populate the actual blob content inside the NetworkDescription
     virtual void fillCompiledNetwork([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
 protected:

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -206,7 +206,7 @@ public:
     // Needed only by the driver compiler, to populate the actual blob content inside the NetworkDescription
     virtual std::vector<uint8_t> getCompiledNetwork(
         [[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription) {
-        return std::vector<uint8_t>();
+        return networkDescription->compiledNetwork;
     }
 
 protected:

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -201,11 +201,10 @@ public:
                                                                     const Config& config) const = 0;
 
     // Needed only by the driver compiler, to release the graph handle
-    virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
+    virtual void release(std::shared_ptr<const NetworkDescription> networkDescription){};
 
     // Needed only by the driver compiler, to populate the actual blob content inside the NetworkDescription
-    virtual std::vector<uint8_t> getCompiledNetwork(
-        [[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription) {
+    virtual std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
         return networkDescription->compiledNetwork;
     }
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -112,6 +112,9 @@ struct NetworkMetadata final {
 
     size_t numStreams = 1;
 
+    // use to pass graphHandle from compiler to backend executor
+    void* graphHandle = nullptr;
+
     /**
      * @brief Binds the (state input, state output) and (dynamic tensor, shape tensor) pairs using the
      * "relatedDescriptorIndex" attribute.
@@ -146,8 +149,6 @@ struct NetworkDescription final {
 
     NetworkMetadata metadata;
 
-    // use to pass graphHandle from compiler to backend executor
-    void* graphHandle = nullptr;
     void* propsVoidPtr = nullptr;
     void* inputDescriptors = nullptr;
     void* outputDescriptors = nullptr;

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -148,10 +148,6 @@ struct NetworkDescription final {
     std::vector<uint8_t> compiledNetwork;
 
     NetworkMetadata metadata;
-
-    void* propsVoidPtr = nullptr;
-    void* inputDescriptors = nullptr;
-    void* outputDescriptors = nullptr;
 };
 
 /**
@@ -204,10 +200,10 @@ public:
                                                                     const Config& config) const = 0;
 
     // Only need for driver compiler to release graph handle now
-    virtual void release(std::shared_ptr<const NetworkDescription> networkDescription){};
+    virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
     // Only need for driver compiler to fill blob now
-    virtual void fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription){};
+    virtual void fillCompiledNetwork([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
 protected:
     virtual ~ICompiler() = default;

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -146,7 +146,7 @@ struct NetworkDescription final {
 
     NetworkMetadata metadata;
 
-    // to test if passing graphHandle from compiler to backend executor 
+    // use to pass graphHandle from compiler to backend executor 
     void* graphHandleVoidPtr;
 };
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -200,10 +200,9 @@ public:
                                                                     const std::vector<uint8_t>& network,
                                                                     const Config& config) const = 0;
 
-    // Needed only by the driver compiler, to release the graph handle
-    virtual void release(std::shared_ptr<const NetworkDescription> networkDescription){};
+    // Driver compiler can use this to release graphHandle, if we do not have executor
+    virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
-    // Needed only by the driver compiler, to populate the actual blob content inside the NetworkDescription
     virtual std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
         return networkDescription->compiledNetwork;
     }

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -146,7 +146,7 @@ struct NetworkDescription final {
 
     NetworkMetadata metadata;
 
-    // use to pass graphHandle from compiler to backend executor 
+    // use to pass graphHandle from compiler to backend executor
     void* graphHandleVoidPtr = nullptr;
 };
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -147,7 +147,7 @@ struct NetworkDescription final {
     NetworkMetadata metadata;
 
     // use to pass graphHandle from compiler to backend executor
-    void* graphHandleVoidPtr = nullptr;
+    void* graphHandle = nullptr;
     void* propsVoidPtr = nullptr;
     void* inputDescriptors = nullptr;
     void* outputDescriptors = nullptr;
@@ -201,6 +201,12 @@ public:
     virtual std::vector<ov::ProfilingInfo> process_profiling_output(const std::vector<uint8_t>& profData,
                                                                     const std::vector<uint8_t>& network,
                                                                     const Config& config) const = 0;
+
+    // Only need for driver compiler to release graph handle now
+    virtual void release(std::shared_ptr<const NetworkDescription> networkDescription){};
+
+    // Only need for driver compiler to fill blob now
+    virtual void fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription){};
 
 protected:
     virtual ~ICompiler() = default;

--- a/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
@@ -31,6 +31,8 @@ public:
     void* getContext() const override;
     void* getDriverHandle() const;
     void* getDeviceHandle() const;
+    char* getGraphExtName();
+    uint32_t getTargetVersion();
 
     void updateInfo(const Config& config) override;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
@@ -29,6 +29,9 @@ public:
     bool isCommandQueueExtSupported() const override;
 
     void* getContext() const override;
+    void* getDriverHandle() const;
+    void* getDeviceHandle() const;
+
     void updateInfo(const Config& config) override;
 
 private:

--- a/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
@@ -32,7 +32,7 @@ public:
     void* getDriverHandle() const;
     void* getDeviceHandle() const;
     char* getGraphExtName();
-    uint32_t getTargetVersion();
+    ze_graph_dditable_ext_last_t* getGraphDDITableExt();
 
     void updateInfo(const Config& config) override;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -28,12 +28,6 @@ public:
 
     ~ZeroInitStructsHolder();
 
-    inline ze_driver_handle_t getDriver() const {
-        return driver_handle;
-    }
-    inline ze_device_handle_t getDevice() const {
-        return device_handle;
-    }
     inline ze_graph_dditable_ext_curr_t* getGraphDdiTable() const {
         return graph_dditable_ext_decorator.get();
     }
@@ -63,31 +57,35 @@ public:
     }
 
     static ze_driver_handle_t& getDriverHandle() {
-        return shared_driver_handle;
+        return driver_handle;
     }
 
     static void setDriverHandle(ze_driver_handle_t &newDriverHandle)  {
-        shared_driver_handle=newDriverHandle;
+        driver_handle=newDriverHandle;
     }
 
     static ze_device_handle_t& getDeviceHandle() {
-        return shared_device_handle;
+        return device_handle;
     }
 
     static void setDeviceHandle(ze_device_handle_t &newDeviceHandle)  {
-        shared_device_handle=newDeviceHandle;
+        device_handle=newDeviceHandle;
+    }
+
+    inline ze_driver_handle_t getDriver() const {
+        return driver_handle;
+    }
+    inline ze_device_handle_t getDevice() const {
+        return device_handle;
     }
 
 private:
     static const ze_driver_uuid_t uuid;
     Logger log;
 
-    ze_driver_handle_t driver_handle = nullptr;
-    ze_device_handle_t device_handle = nullptr;
-
     static ze_context_handle_t context;
-    static ze_driver_handle_t shared_driver_handle;
-    static ze_device_handle_t shared_device_handle;
+    static ze_driver_handle_t driver_handle;
+    static ze_device_handle_t device_handle;
 
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_command_queue_npu_dditable_ext_curr_t* _command_queue_npu_dditable_ext = nullptr;

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -28,6 +28,15 @@ public:
 
     ~ZeroInitStructsHolder();
 
+    inline ze_driver_handle_t getDriver() const {
+        return driver_handle;
+    }
+    inline ze_device_handle_t getDevice() const {
+        return device_handle;
+    }
+    inline ze_context_handle_t getContext() const {
+        return context;
+    }
     inline ze_graph_dditable_ext_curr_t* getGraphDdiTable() const {
         return graph_dditable_ext_decorator.get();
     }
@@ -48,44 +57,13 @@ public:
     }
 
 
-    static ze_context_handle_t& getContext() {
-        return context;
-    }
-
-    static void setContext(ze_context_handle_t &newContext)  {
-        context=newContext;
-    }
-
-    static ze_driver_handle_t& getDriverHandle() {
-        return driver_handle;
-    }
-
-    static void setDriverHandle(ze_driver_handle_t &newDriverHandle)  {
-        driver_handle=newDriverHandle;
-    }
-
-    static ze_device_handle_t& getDeviceHandle() {
-        return device_handle;
-    }
-
-    static void setDeviceHandle(ze_device_handle_t &newDeviceHandle)  {
-        device_handle=newDeviceHandle;
-    }
-
-    inline ze_driver_handle_t getDriver() const {
-        return driver_handle;
-    }
-    inline ze_device_handle_t getDevice() const {
-        return device_handle;
-    }
-
 private:
     static const ze_driver_uuid_t uuid;
     Logger log;
 
-    static ze_context_handle_t context;
-    static ze_driver_handle_t driver_handle;
-    static ze_device_handle_t device_handle;
+    ze_context_handle_t context = nullptr;
+    ze_driver_handle_t driver_handle = nullptr;
+    ze_device_handle_t device_handle = nullptr;
 
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_command_queue_npu_dditable_ext_curr_t* _command_queue_npu_dditable_ext = nullptr;

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -34,9 +34,6 @@ public:
     inline ze_device_handle_t getDevice() const {
         return device_handle;
     }
-    inline ze_context_handle_t getContext() const {
-        return context;
-    }
     inline ze_graph_dditable_ext_curr_t* getGraphDdiTable() const {
         return graph_dditable_ext_decorator.get();
     }
@@ -56,13 +53,44 @@ public:
         return mutable_command_list_version;
     }
 
+
+    static ze_context_handle_t& getContext() {
+        return context;
+    }
+
+    static void setContext(ze_context_handle_t &newContext)  {
+        context=newContext;
+    }
+
+    // // -------
+    // static ze_driver_handle_t& getDriverHandle() {
+    //     return shared_driver_handle;
+    // }
+
+    // static void setDriverHandle(ze_driver_handle_t &newDriverHandle)  {
+    //     shared_driver_handle=newDriverHandle;
+    // }
+
+    // static ze_device_handle_t& getDeviceHandle() {
+    //     return shared_device_handle;
+    // }
+
+    // static void setDeviceHandle(ze_device_handle_t &newDeviceHandle)  {
+    //     shared_device_handle=newDeviceHandle;
+    // }
+    // //------------
+
 private:
     static const ze_driver_uuid_t uuid;
     Logger log;
 
     ze_driver_handle_t driver_handle = nullptr;
     ze_device_handle_t device_handle = nullptr;
-    ze_context_handle_t context = nullptr;
+
+    static ze_context_handle_t context;
+    // static ze_driver_handle_t shared_driver_handle;
+    // static ze_device_handle_t shared_device_handle;
+
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_command_queue_npu_dditable_ext_curr_t* _command_queue_npu_dditable_ext = nullptr;
     ze_graph_profiling_dditable_ext_t* _graph_profiling_ddi_table_ext = nullptr;

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -62,23 +62,21 @@ public:
         context=newContext;
     }
 
-    // // -------
-    // static ze_driver_handle_t& getDriverHandle() {
-    //     return shared_driver_handle;
-    // }
+    static ze_driver_handle_t& getDriverHandle() {
+        return shared_driver_handle;
+    }
 
-    // static void setDriverHandle(ze_driver_handle_t &newDriverHandle)  {
-    //     shared_driver_handle=newDriverHandle;
-    // }
+    static void setDriverHandle(ze_driver_handle_t &newDriverHandle)  {
+        shared_driver_handle=newDriverHandle;
+    }
 
-    // static ze_device_handle_t& getDeviceHandle() {
-    //     return shared_device_handle;
-    // }
+    static ze_device_handle_t& getDeviceHandle() {
+        return shared_device_handle;
+    }
 
-    // static void setDeviceHandle(ze_device_handle_t &newDeviceHandle)  {
-    //     shared_device_handle=newDeviceHandle;
-    // }
-    // //------------
+    static void setDeviceHandle(ze_device_handle_t &newDeviceHandle)  {
+        shared_device_handle=newDeviceHandle;
+    }
 
 private:
     static const ze_driver_uuid_t uuid;
@@ -88,8 +86,8 @@ private:
     ze_device_handle_t device_handle = nullptr;
 
     static ze_context_handle_t context;
-    // static ze_driver_handle_t shared_driver_handle;
-    // static ze_device_handle_t shared_device_handle;
+    static ze_driver_handle_t shared_driver_handle;
+    static ze_device_handle_t shared_device_handle;
 
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_command_queue_npu_dditable_ext_curr_t* _command_queue_npu_dditable_ext = nullptr;

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -39,7 +39,7 @@ public:
     }
     inline char* getGraphExtName() const {
         return graphExtName;
-    } 
+    }
     inline uint32_t getTargetVersion() const {
         return targetVersion;
     }

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -37,6 +37,12 @@ public:
     inline ze_context_handle_t getContext() const {
         return context;
     }
+    inline char* getGraphExtName() const {
+        return graphExtName;
+    } 
+    inline uint32_t getTargetVersion() const {
+        return targetVersion;
+    }
     inline ze_graph_dditable_ext_curr_t* getGraphDdiTable() const {
         return graph_dditable_ext_decorator.get();
     }
@@ -64,6 +70,8 @@ private:
     ze_context_handle_t context = nullptr;
     ze_driver_handle_t driver_handle = nullptr;
     ze_device_handle_t device_handle = nullptr;
+    char* graphExtName;
+    uint32_t targetVersion = 0;
 
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_command_queue_npu_dditable_ext_curr_t* _command_queue_npu_dditable_ext = nullptr;

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -62,7 +62,6 @@ public:
         return mutable_command_list_version;
     }
 
-
 private:
     static const ze_driver_uuid_t uuid;
     Logger log;

--- a/src/plugins/intel_npu/src/backend/include/zero_init.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_init.hpp
@@ -40,8 +40,8 @@ public:
     inline char* getGraphExtName() const {
         return graphExtName;
     }
-    inline uint32_t getTargetVersion() const {
-        return targetVersion;
+    inline ze_graph_dditable_ext_last_t* getGraphDDITableExt() {
+        return graph_ddi_table_ext;
     }
     inline ze_graph_dditable_ext_curr_t* getGraphDdiTable() const {
         return graph_dditable_ext_decorator.get();
@@ -70,7 +70,7 @@ private:
     ze_driver_handle_t driver_handle = nullptr;
     ze_device_handle_t device_handle = nullptr;
     char* graphExtName;
-    uint32_t targetVersion = 0;
+    ze_graph_dditable_ext_last_t* graph_ddi_table_ext = nullptr;
 
     std::unique_ptr<ze_graph_dditable_ext_decorator> graph_dditable_ext_decorator;
     ze_command_queue_npu_dditable_ext_curr_t* _command_queue_npu_dditable_ext = nullptr;

--- a/src/plugins/intel_npu/src/backend/include/zero_types.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_types.hpp
@@ -13,7 +13,7 @@
 /**
  * @brief Last version of Table of Graph Extension functions used within plugin
  */
-using ze_graph_dditable_ext_last_t = ze_graph_dditable_ext_1_5_t;
+using ze_graph_dditable_ext_last_t = ze_graph_dditable_ext_1_6_t;
 
 /**
  * @brief Table of Graph Extension functions pointers and function wrappers
@@ -124,6 +124,13 @@ public:
                                                  ze_graph_memory_query_t* query) {
         throwWhenUnsupported("pfnQueryContextMemory", ZE_GRAPH_EXT_VERSION_1_5);
         return _impl->pfnQueryContextMemory(hContext, type, query);
+    }
+
+    // version 1.6
+    ze_result_t ZE_APICALL pfnDeviceGetGraphProperties2(ze_device_handle_t hDevice,
+                                                        ze_device_graph_properties_2_t* pDeviceGraphProperties) {
+        throwWhenUnsupported("pfnDeviceGetGraphProperties2", ZE_GRAPH_EXT_VERSION_1_6);
+        return _impl->pfnDeviceGetGraphProperties2(hDevice, pDeviceGraphProperties);
     }
 };
 

--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -76,6 +76,14 @@ void* ZeroEngineBackend::getDeviceHandle() const {
     return _instance->getDevice();
 }
 
+char* ZeroEngineBackend::getGraphExtName() {
+    return _instance->getGraphExtName();
+}
+
+uint32_t ZeroEngineBackend::getTargetVersion() {
+    return _instance->getTargetVersion();
+}
+
 void ZeroEngineBackend::updateInfo(const Config& config) {
     _logger.setLevel(config.get<LOG_LEVEL>());
     if (_devices.size() > 0) {

--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -68,6 +68,14 @@ void* ZeroEngineBackend::getContext() const {
     return _instance->getContext();
 }
 
+void* ZeroEngineBackend::getDriverHandle() const {
+    return _instance->getDriver();
+}
+
+void* ZeroEngineBackend::getDeviceHandle() const {
+    return _instance->getDevice();
+}
+
 void ZeroEngineBackend::updateInfo(const Config& config) {
     _logger.setLevel(config.get<LOG_LEVEL>());
     if (_devices.size() > 0) {

--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -80,8 +80,8 @@ char* ZeroEngineBackend::getGraphExtName() {
     return _instance->getGraphExtName();
 }
 
-uint32_t ZeroEngineBackend::getTargetVersion() {
-    return _instance->getTargetVersion();
+ze_graph_dditable_ext_last_t* ZeroEngineBackend::getGraphDDITableExt() {
+    return _instance->getGraphDDITableExt();
 }
 
 void ZeroEngineBackend::updateInfo(const Config& config) {

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -66,7 +66,7 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
 
     // _graph is a nullptr for CIP path
     // _graph will get graphHandle from compiler for CiD path
-    if (_networkDesc->graphHandle == nullptr) {
+    if (_networkDesc->metadata.graphHandle == nullptr) {
         _logger.info("Create graph handle on executor");
         _logger.debug("ZeroExecutor::ZeroExecutor - create graph");
         OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_GRAPH, itt::domains::LevelZeroBackend, "Executor::ZeroExecutor", "graphCreate");
@@ -107,7 +107,7 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
     } else {
         _logger.info("Reuse graphhandle created from compiler");
         try {
-            _graph = static_cast<ze_graph_handle_t>(_networkDesc->graphHandle);
+            _graph = static_cast<ze_graph_handle_t>(_networkDesc->metadata.graphHandle);
             // from compiler
             _props = *static_cast<ze_graph_properties_t*>(_networkDesc->propsVoidPtr);
             _input_descriptors =

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -49,21 +49,21 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
                                                       _initStructs->getCommandQueueDdiTable(),
                                                       _config,
                                                       group_ordinal)}} {
-    _logger.debug("ZeroExecutor::ZeroExecutor init start - create graph_command_list");
+    _logger.debug("create graph_command_list");
     OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "Executor::ZeroExecutor");
     CommandList graph_command_list(_initStructs->getDevice(),
                                    _initStructs->getContext(),
                                    _initStructs->getGraphDdiTable(),
                                    _config,
                                    _group_ordinal);
-    _logger.debug("ZeroExecutor::ZeroExecutor - create graph_command_queue");
+    _logger.debug("create graph_command_queue");
     CommandQueue graph_command_queue(_initStructs->getDevice(),
                                      _initStructs->getContext(),
                                      ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
                                      _initStructs->getCommandQueueDdiTable(),
                                      _config,
                                      _group_ordinal);
-    _logger.debug("ZeroExecutor::ZeroExecutor - create fence");
+    _logger.debug("create fence");
     Fence fence(graph_command_queue, _config);
 
     OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_GRAPH, itt::domains::LevelZeroBackend, "Executor::ZeroExecutor", "graphCreate");
@@ -71,7 +71,7 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
     // _graph is a nullptr for CIP path, a new handle will be obtained from the driver based on the given
     // compiledNetwork _graph gets (reuses) graphHandle from the compiler for CID path
     if (_networkDesc->metadata.graphHandle == nullptr) {
-        _logger.info("ZeroExecutor::ZeroExecutor - Create graph handle on executor");
+        _logger.info("create graph handle on executor");
         ze_graph_desc_t desc{ZE_STRUCTURE_TYPE_GRAPH_DESC_PROPERTIES,
                              nullptr,
                              ZE_GRAPH_FORMAT_NATIVE,
@@ -84,12 +84,12 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
             _graph_ddi_table_ext->pfnCreate(_initStructs->getContext(), _initStructs->getDevice(), &desc, &_graph));
 
     } else {
-        _logger.info("ZeroExecutor::ZeroExecutor - Reuse graph handle created from compiler");
+        _logger.info("reuse graph handle created from compiler");
         _graph = static_cast<ze_graph_handle_t>(_networkDesc->metadata.graphHandle);
     }
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "pfnGetProperties");
-    _logger.debug("ZeroExecutor::ZeroExecutor - performing pfnGetProperties");
+    _logger.debug("performing pfnGetProperties");
     zeroUtils::throwOnFail("pfnGetProperties", _graph_ddi_table_ext->pfnGetProperties(_graph, &_props));
     auto targetDriverExtVersion = _initStructs->getDriverExtVersion();
     if (targetDriverExtVersion <= ZE_GRAPH_EXT_VERSION_1_1) {
@@ -98,7 +98,7 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
     }
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "pfnGetArgumentProperties3");
-    _logger.debug("ZeroExecutor::ZeroExecutor - performing pfnGetArgumentProperties3");
+    _logger.debug("performing pfnGetArgumentProperties3");
     for (uint32_t index = 0; index < _props.numGraphArgs; ++index) {
         ze_graph_argument_properties_3_t arg3;
         zeroUtils::throwOnFail("pfnGetArgumentProperties3",
@@ -112,17 +112,17 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
     }
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "appendGraphInitialize");
-    _logger.debug("ZeroExecutor::ZeroExecutor - performing appendGraphInitialize");
+    _logger.debug("performing appendGraphInitialize");
     graph_command_list.appendGraphInitialize(_graph);
-    _logger.debug("ZeroExecutor::ZeroExecutor - closing graph command list");
+    _logger.debug("closing graph command list");
     graph_command_list.close();
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "queue_execute");
-    _logger.debug("ZeroExecutor::ZeroExecutor - performing executeCommandList");
+    _logger.debug("performing executeCommandList");
     graph_command_queue.executeCommandList(graph_command_list, fence);
-    _logger.debug("ZeroExecutor::ZeroExecutor - performing hostSynchronize");
+    _logger.debug("performing hostSynchronize");
     fence.hostSynchronize();
-    _logger.debug("ZeroExecutor::ZeroExecutor - hostSynchronize completed");
+    _logger.debug("hostSynchronize completed");
 
     if (config.has<WORKLOAD_TYPE>()) {
         setWorkloadType(config.get<WORKLOAD_TYPE>());
@@ -160,7 +160,7 @@ void ZeroExecutor::mutexUnlock() const {
 }
 
 ZeroExecutor::~ZeroExecutor() {
-    _logger.debug("ZeroExecutor::~ZeroExecutor - pfnDestroy _graph ");
+    _logger.debug("~ZeroExecutor() - pfnDestroy _graph ");
     auto result = _graph_ddi_table_ext->pfnDestroy(_graph);
     if (ZE_RESULT_SUCCESS != result) {
         _logger.error("_graph_ddi_table_ext->pfnDestroy failed %#X", uint64_t(result));

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -63,15 +63,11 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
                                      _initStructs->getCommandQueueDdiTable(),
                                      _config,
                                      _group_ordinal);
-    try {
-        _graph = *static_cast<ze_graph_handle_t*>(_networkDesc->graphHandleVoidPtr);
-    } catch (const std::exception& e) {
-        _logger.error("Failed to get graph handle from network description, ", e.what());
-    }
 
     // _graph is a nullptr for CIP path
     // _graph will get graphHandle from compiler for CiD path
-    if (_graph == nullptr) {
+    if (_networkDesc->graphHandleVoidPtr == nullptr) {
+        _logger.debug("_networkDesc->graphHandleVoidPtr is nulltpr");
         _logger.debug("ZeroExecutor::ZeroExecutor - create graph");
         OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_GRAPH, itt::domains::LevelZeroBackend, "Executor::ZeroExecutor", "graphCreate");
 
@@ -85,6 +81,13 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
         zeroUtils::throwOnFail(
             "pfnCreate",
             _graph_ddi_table_ext->pfnCreate(_initStructs->getContext(), _initStructs->getDevice(), &desc, &_graph));
+    } else {
+        _logger.debug("_networkDesc->graphHandleVoidPtr is not nulltpr");
+        try {
+            _graph = *static_cast<ze_graph_handle_t*>(_networkDesc->graphHandleVoidPtr);
+        } catch (const std::exception& e) {
+            _logger.error("Failed to get graph handle from network description, ", e.what());
+        }
     }
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "pfnGetProperties");

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -66,8 +66,8 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
 
     // _graph is a nullptr for CIP path
     // _graph will get graphHandle from compiler for CiD path
-    if (_networkDesc->graphHandleVoidPtr == nullptr) {
-        _logger.debug("_networkDesc->graphHandleVoidPtr is nulltpr");
+    if (_networkDesc->graphHandle == nullptr) {
+        _logger.info("Create graph handle on executor");
         _logger.debug("ZeroExecutor::ZeroExecutor - create graph");
         OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_GRAPH, itt::domains::LevelZeroBackend, "Executor::ZeroExecutor", "graphCreate");
 
@@ -105,9 +105,9 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
         }
 
     } else {
-        _logger.debug("_networkDesc->graphHandleVoidPtr is not nulltpr");
+        _logger.info("Reuse graphhandle created from compiler");
         try {
-            _graph = *static_cast<ze_graph_handle_t*>(_networkDesc->graphHandleVoidPtr);
+            _graph = static_cast<ze_graph_handle_t>(_networkDesc->graphHandle);
             // from compiler
             _props = *static_cast<ze_graph_properties_t*>(_networkDesc->propsVoidPtr);
             _input_descriptors =

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -63,14 +63,15 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
                                      _initStructs->getCommandQueueDdiTable(),
                                      _config,
                                      _group_ordinal);
+    _logger.debug("ZeroExecutor::ZeroExecutor - create fence");
+    Fence fence(graph_command_queue, _config);
 
     OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_GRAPH, itt::domains::LevelZeroBackend, "Executor::ZeroExecutor", "graphCreate");
 
     // _graph is a nullptr for CIP path, a new handle will be obtained from the driver based on the given
     // compiledNetwork _graph gets (reuses) graphHandle from the compiler for CID path
     if (_networkDesc->metadata.graphHandle == nullptr) {
-        _logger.info("Create graph handle on executor");
-        _logger.debug("ZeroExecutor::ZeroExecutor - create graph");
+        _logger.info("ZeroExecutor::ZeroExecutor - Create graph handle on executor");
         ze_graph_desc_t desc{ZE_STRUCTURE_TYPE_GRAPH_DESC_PROPERTIES,
                              nullptr,
                              ZE_GRAPH_FORMAT_NATIVE,
@@ -83,11 +84,12 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
             _graph_ddi_table_ext->pfnCreate(_initStructs->getContext(), _initStructs->getDevice(), &desc, &_graph));
 
     } else {
-        _logger.info("Reuse graphhandle created from compiler");
+        _logger.info("ZeroExecutor::ZeroExecutor - Reuse graph handle created from compiler");
         _graph = static_cast<ze_graph_handle_t>(_networkDesc->metadata.graphHandle);
     }
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "pfnGetProperties");
+    _logger.debug("ZeroExecutor::ZeroExecutor - performing pfnGetProperties");
     zeroUtils::throwOnFail("pfnGetProperties", _graph_ddi_table_ext->pfnGetProperties(_graph, &_props));
     auto targetDriverExtVersion = _initStructs->getDriverExtVersion();
     if (targetDriverExtVersion <= ZE_GRAPH_EXT_VERSION_1_1) {
@@ -114,9 +116,6 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
     graph_command_list.appendGraphInitialize(_graph);
     _logger.debug("ZeroExecutor::ZeroExecutor - closing graph command list");
     graph_command_list.close();
-
-    _logger.debug("ZeroExecutor::ZeroExecutor - create fence");
-    Fence fence(graph_command_queue, _config);
 
     OV_ITT_TASK_NEXT(ZERO_EXECUTOR_GRAPH, "queue_execute");
     _logger.debug("ZeroExecutor::ZeroExecutor - performing executeCommandList");
@@ -161,6 +160,7 @@ void ZeroExecutor::mutexUnlock() const {
 }
 
 ZeroExecutor::~ZeroExecutor() {
+    _logger.debug("ZeroExecutor::~ZeroExecutor - pfnDestroy _graph ");
     auto result = _graph_ddi_table_ext->pfnDestroy(_graph);
     if (ZE_RESULT_SUCCESS != result) {
         _logger.error("_graph_ddi_table_ext->pfnDestroy failed %#X", uint64_t(result));

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -66,8 +66,8 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
 
     OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_GRAPH, itt::domains::LevelZeroBackend, "Executor::ZeroExecutor", "graphCreate");
 
-    // _graph is a nullptr for CIP path
-    // _graph will get graphHandle from compiler for CiD path
+    // _graph is a nullptr for CIP path, a new handle will be obtained from the driver based on the given
+    // compiledNetwork _graph gets (reuses) graphHandle from the compiler for CID path
     if (_networkDesc->metadata.graphHandle == nullptr) {
         _logger.info("Create graph handle on executor");
         _logger.debug("ZeroExecutor::ZeroExecutor - create graph");

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -75,6 +75,11 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
                          _networkDesc->compiledNetwork.size(),
                          _networkDesc->compiledNetwork.data(),
                          nullptr};
+
+    // GET THE graph handle from the compiler
+    ze_graph_handle_t* originalPtr = static_cast<ze_graph_handle_t*>(networkDescription->graphHandleVoidPtr);
+    _graph = *originalPtr;
+
     zeroUtils::throwOnFail(
         "pfnCreate",
         _graph_ddi_table_ext->pfnCreate(_initStructs->getContext(), _initStructs->getDevice(), &desc, &_graph));

--- a/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_executor.cpp
@@ -71,7 +71,7 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
     // _graph is a nullptr for CIP path, a new handle will be obtained from the driver based on the given
     // compiledNetwork _graph gets (reuses) graphHandle from the compiler for CID path
     if (_networkDesc->metadata.graphHandle == nullptr) {
-        _logger.info("create graph handle on executor");
+        _logger.debug("create graph handle on executor");
         ze_graph_desc_t desc{ZE_STRUCTURE_TYPE_GRAPH_DESC_PROPERTIES,
                              nullptr,
                              ZE_GRAPH_FORMAT_NATIVE,
@@ -84,7 +84,7 @@ ZeroExecutor::ZeroExecutor(const std::shared_ptr<const ZeroInitStructsHolder>& i
             _graph_ddi_table_ext->pfnCreate(_initStructs->getContext(), _initStructs->getDevice(), &desc, &_graph));
 
     } else {
-        _logger.info("reuse graph handle created from compiler");
+        _logger.debug("reuse graph handle created from compiler");
         _graph = static_cast<ze_graph_handle_t>(_networkDesc->metadata.graphHandle);
     }
 

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -204,22 +204,6 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
 
-    // Allocate memory for the char array
-    graphExtName = new char[graph_ext_name.size() + 1];
-    // Copy the contents of the string to the char array
-    std::strcpy(graphExtName, graph_ext_name.c_str());
-    graph_ext_name.clear();
-
-    const uint16_t adapterMajorVersion = 1;
-    uint16_t driverMajorVersion = ZE_MAJOR_VERSION(driver_ext_version);
-    if (adapterMajorVersion != driverMajorVersion) {
-        OPENVINO_THROW("ze_init.cpp: adapterMajorVersion: ",
-                       adapterMajorVersion,
-                       " and driverMajorVersion: ",
-                       driverMajorVersion,
-                       " mismatch!");
-    }
-
 #if defined(NPU_PLUGIN_DEVELOPER_BUILD)
     auto adapterManualConfig = std::getenv("ADAPTER_MANUAL_CONFIG");
     if (adapterManualConfig != nullptr) {

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -167,7 +167,6 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     }
 
     // Load our graph extension
-    ze_graph_dditable_ext_last_t* graph_ddi_table_ext = nullptr;
     zeroUtils::throwOnFail("zeDriverGetExtensionFunctionAddress",
                            zeDriverGetExtensionFunctionAddress(driver_handle,
                                                                graph_ext_name.c_str(),
@@ -210,27 +209,8 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     // Copy the contents of the string to the char array
     std::strcpy(graphExtName, graph_ext_name.c_str());
 
-    for (uint32_t i = 0; i < count; ++i) {
-        auto& property = extProps[i];
-
-        if (strncmp(property.name, ZE_GRAPH_EXT_NAME, strlen(ZE_GRAPH_EXT_NAME)) != 0) {
-            continue;
-        }
-
-        // If the driver version is latest, will just use its name.
-        if (property.version == ZE_GRAPH_EXT_VERSION_CURRENT) {
-            targetVersion = property.version;
-            break;
-        }
-
-        // Use the latest version supported by the driver.
-        if (property.version > targetVersion) {
-            targetVersion = property.version;
-        }
-    }
-
     const uint16_t adapterMajorVersion = 1;
-    uint16_t driverMajorVersion = ZE_MAJOR_VERSION(targetVersion);
+    uint16_t driverMajorVersion = ZE_MAJOR_VERSION(driver_ext_version);
     if (adapterMajorVersion != driverMajorVersion) {
         OPENVINO_THROW("ze_init.cpp: adapterMajorVersion: ",
                        adapterMajorVersion,
@@ -243,15 +223,15 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     auto adapterManualConfig = std::getenv("ADAPTER_MANUAL_CONFIG");
     if (adapterManualConfig != nullptr) {
         if (strcmp(adapterManualConfig, "ZE_extension_graph_1_6") == 0) {
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_6;
+            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_6;
         } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_5") == 0) {
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_5;
+            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_5;
         } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_4") == 0) {
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_4;
+            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_4;
         } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_3") == 0) {
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_3;
+            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_3;
         } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_2") == 0) {
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_2;
+            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_2;
         } else {
             OPENVINO_THROW("Using unsupported ADAPTER_MANUAL_CONFIG!");
         }

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -208,6 +208,7 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     graphExtName = new char[graph_ext_name.size() + 1];
     // Copy the contents of the string to the char array
     std::strcpy(graphExtName, graph_ext_name.c_str());
+    graph_ext_name.clear();
 
     const uint16_t adapterMajorVersion = 1;
     uint16_t driverMajorVersion = ZE_MAJOR_VERSION(driver_ext_version);

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -206,16 +206,12 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     // Get our target device
     zeroUtils::throwOnFail("zeDeviceGet", zeDeviceGet(driver_handle, &device_count, &device_handle));
 
-    printf(" Debug - ZeroInitStructsHolder zeContextCreate  Start ! \n");
-    
-    // Create context from backend
+    // Create context from backend to be shared with compiler
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     
     setDriverHandle(driver_handle);
     setDeviceHandle(device_handle);
-
-    printf(" Debug - ZeroInitStructsHolder zeContextCreate Done ! \n");
 
     log.debug("ZeroInitStructsHolder initialize complete");
 }

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -239,6 +239,25 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
                        " mismatch!");
     }
 
+#if defined(NPU_PLUGIN_DEVELOPER_BUILD)
+    auto adapterManualConfig = std::getenv("ADAPTER_MANUAL_CONFIG");
+    if (adapterManualConfig != nullptr) {
+        if (strcmp(adapterManualConfig, "ZE_extension_graph_1_6") == 0) {
+            targetVersion = ZE_GRAPH_EXT_VERSION_1_6;
+        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_5") == 0) {
+            targetVersion = ZE_GRAPH_EXT_VERSION_1_5;
+        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_4") == 0) {
+            targetVersion = ZE_GRAPH_EXT_VERSION_1_4;
+        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_3") == 0) {
+            targetVersion = ZE_GRAPH_EXT_VERSION_1_3;
+        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_2") == 0) {
+            targetVersion = ZE_GRAPH_EXT_VERSION_1_2;
+        } else {
+            OPENVINO_THROW("Using unsupported ADAPTER_MANUAL_CONFIG!");
+        }
+    }
+#endif
+
     log.debug("ZeroInitStructsHolder initialize complete");
 }
 

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -20,6 +20,11 @@ namespace intel_npu {
 
 const ze_driver_uuid_t ZeroInitStructsHolder::uuid = ze_intel_npu_driver_uuid;
 
+// // Define the static member
+ze_context_handle_t ZeroInitStructsHolder::context = nullptr;
+// ze_driver_handle_t ZeroInitStructsHolder::shared_driver_handle = nullptr;
+// ze_device_handle_t ZeroInitStructsHolder::shared_device_handle = nullptr;
+
 static std::tuple<uint32_t, std::string> queryDriverExtensionVersion(
     std::vector<ze_driver_extension_properties_t>& extProps,
     uint32_t count) {
@@ -201,12 +206,22 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     // Get our target device
     zeroUtils::throwOnFail("zeDeviceGet", zeDeviceGet(driver_handle, &device_count, &device_handle));
 
+    printf(" Debug - ZeroInitStructsHolder zeContextCreate  Start ! \n");
+    
+    // Create context from backend
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
+    
+    // setDriverHandle(driver_handle);
+    // setDeviceHandle(device_handle);
+
+    printf(" Debug - ZeroInitStructsHolder zeContextCreate Done ! \n");
+
     log.debug("ZeroInitStructsHolder initialize complete");
 }
 
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {
+    printf(" Debug - ZeroInitStructsHolder Destructor !  \n");
     if (context) {
         log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
         auto result = zeContextDestroy(context);

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -200,7 +200,7 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     // Get our target device
     zeroUtils::throwOnFail("zeDeviceGet", zeDeviceGet(driver_handle, &device_count, &device_handle));
 
-    // Create context from backend to be shared with compiler
+    // Create context - share between the compiler and the backend
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     log.debug("ZeroInitStructsHolder initialize complete");

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -20,11 +20,6 @@ namespace intel_npu {
 
 const ze_driver_uuid_t ZeroInitStructsHolder::uuid = ze_intel_npu_driver_uuid;
 
-// // Define the static member
-ze_context_handle_t ZeroInitStructsHolder::context = nullptr;
-ze_driver_handle_t ZeroInitStructsHolder::driver_handle = nullptr;
-ze_device_handle_t ZeroInitStructsHolder::device_handle = nullptr;
-
 static std::tuple<uint32_t, std::string> queryDriverExtensionVersion(
     std::vector<ze_driver_extension_properties_t>& extProps,
     uint32_t count) {

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -22,8 +22,8 @@ const ze_driver_uuid_t ZeroInitStructsHolder::uuid = ze_intel_npu_driver_uuid;
 
 // // Define the static member
 ze_context_handle_t ZeroInitStructsHolder::context = nullptr;
-ze_driver_handle_t ZeroInitStructsHolder::shared_driver_handle = nullptr;
-ze_device_handle_t ZeroInitStructsHolder::shared_device_handle = nullptr;
+ze_driver_handle_t ZeroInitStructsHolder::driver_handle = nullptr;
+ze_device_handle_t ZeroInitStructsHolder::device_handle = nullptr;
 
 static std::tuple<uint32_t, std::string> queryDriverExtensionVersion(
     std::vector<ze_driver_extension_properties_t>& extProps,
@@ -209,9 +209,6 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     // Create context from backend to be shared with compiler
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
-    
-    setDriverHandle(driver_handle);
-    setDeviceHandle(device_handle);
 
     log.debug("ZeroInitStructsHolder initialize complete");
 }

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -203,26 +203,6 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     // Create context from backend to be shared with compiler
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
-
-#if defined(NPU_PLUGIN_DEVELOPER_BUILD)
-    auto adapterManualConfig = std::getenv("ADAPTER_MANUAL_CONFIG");
-    if (adapterManualConfig != nullptr) {
-        if (strcmp(adapterManualConfig, "ZE_extension_graph_1_6") == 0) {
-            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_6;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_5") == 0) {
-            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_5;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_4") == 0) {
-            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_4;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_3") == 0) {
-            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_3;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_2") == 0) {
-            driver_ext_version = ZE_GRAPH_EXT_VERSION_1_2;
-        } else {
-            OPENVINO_THROW("Using unsupported ADAPTER_MANUAL_CONFIG!");
-        }
-    }
-#endif
-
     log.debug("ZeroInitStructsHolder initialize complete");
 }
 

--- a/src/plugins/intel_npu/src/backend/src/zero_init.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_init.cpp
@@ -22,8 +22,8 @@ const ze_driver_uuid_t ZeroInitStructsHolder::uuid = ze_intel_npu_driver_uuid;
 
 // // Define the static member
 ze_context_handle_t ZeroInitStructsHolder::context = nullptr;
-// ze_driver_handle_t ZeroInitStructsHolder::shared_driver_handle = nullptr;
-// ze_device_handle_t ZeroInitStructsHolder::shared_device_handle = nullptr;
+ze_driver_handle_t ZeroInitStructsHolder::shared_driver_handle = nullptr;
+ze_device_handle_t ZeroInitStructsHolder::shared_device_handle = nullptr;
 
 static std::tuple<uint32_t, std::string> queryDriverExtensionVersion(
     std::vector<ze_driver_extension_properties_t>& extProps,
@@ -212,8 +212,8 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     zeroUtils::throwOnFail("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     
-    // setDriverHandle(driver_handle);
-    // setDeviceHandle(device_handle);
+    setDriverHandle(driver_handle);
+    setDeviceHandle(device_handle);
 
     printf(" Debug - ZeroInitStructsHolder zeContextCreate Done ! \n");
 

--- a/src/plugins/intel_npu/src/compiler/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/compiler/CMakeLists.txt
@@ -21,9 +21,7 @@ target_include_directories(${TARGET_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-# for testing L0 context share
 include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/backend/include)
-# for plugin's NPUbackend share
 include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/include)
 
 target_link_libraries(${TARGET_NAME}

--- a/src/plugins/intel_npu/src/compiler/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/compiler/CMakeLists.txt
@@ -23,6 +23,8 @@ target_include_directories(${TARGET_NAME}
 
 # for testing L0 context share
 include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/backend/include)
+# for plugin's NPUbackend share
+include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/include)
 
 target_link_libraries(${TARGET_NAME}
     PUBLIC

--- a/src/plugins/intel_npu/src/compiler/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/compiler/CMakeLists.txt
@@ -21,6 +21,9 @@ target_include_directories(${TARGET_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
+# for testing L0 context share
+include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/backend/include)
+
 target_link_libraries(${TARGET_NAME}
     PUBLIC
         openvino::npu_al

--- a/src/plugins/intel_npu/src/compiler/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/compiler/CMakeLists.txt
@@ -21,14 +21,12 @@ target_include_directories(${TARGET_NAME}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
-include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/backend/include)
-include_directories(${CMAKE_SOURCE_DIR}/src/plugins/intel_npu/src/plugin/include)
-
 target_link_libraries(${TARGET_NAME}
     PUBLIC
         openvino::npu_al
     PRIVATE
         openvino_npu_zero_result_parser
+        openvino_npu_level_zero_backend
         openvino::runtime
         openvino::runtime::dev
         ze_loader

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -8,6 +8,7 @@
 
 #include "intel_npu/al/icompiler.hpp"
 #include "intel_npu/utils/logger/logger.hpp"
+#include "backends.hpp" 
 
 namespace intel_npu {
 namespace driverCompilerAdapter {
@@ -18,7 +19,7 @@ namespace driverCompilerAdapter {
  */
 class LevelZeroCompilerAdapter final : public ICompiler {
 public:
-    LevelZeroCompilerAdapter();
+    LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> npuBackends);
 
     uint32_t getSupportedOpsetVersion() const override final;
 

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -6,9 +6,9 @@
 
 #include <ze_graph_ext.h>
 
+#include "backends.hpp"
 #include "intel_npu/al/icompiler.hpp"
 #include "intel_npu/utils/logger/logger.hpp"
-#include "backends.hpp" 
 
 namespace intel_npu {
 namespace driverCompilerAdapter {

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -39,7 +39,6 @@ private:
      * @brief Separate externals calls to separate class
      */
     std::shared_ptr<ICompiler> apiAdapter;
-    ze_driver_handle_t _driverHandle = nullptr;
     Logger _logger;
 };
 

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -34,6 +34,10 @@ public:
                                                             const std::vector<uint8_t>& network,
                                                             const Config& config) const override final;
 
+    void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
+
+    void fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+
 private:
     /**
      * @brief Separate externals calls to separate class

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -36,7 +36,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    void fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
 private:
     /**

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -6,9 +6,9 @@
 
 #include <ze_graph_ext.h>
 
-#include "backends.hpp"
 #include "intel_npu/al/icompiler.hpp"
 #include "intel_npu/utils/logger/logger.hpp"
+#include "npu.hpp"
 
 namespace intel_npu {
 namespace driverCompilerAdapter {
@@ -19,7 +19,7 @@ namespace driverCompilerAdapter {
  */
 class LevelZeroCompilerAdapter final : public ICompiler {
 public:
-    LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> npuBackends);
+    LevelZeroCompilerAdapter(std::shared_ptr<IEngineBackend> iEngineBackend);
 
     uint32_t getSupportedOpsetVersion() const override final;
 

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -109,8 +109,6 @@ private:
                              ze_graph_compiler_version_info_t compilerVersion) const;
     std::string serializeConfig(const Config& config, ze_graph_compiler_version_info_t& compilerVersion) const;
 
-    void processInputOutputDescriptors(ze_graph_argument_properties_3_t arg, uint32_t index);
-
     template <typename T = TableExtension, typename std::enable_if_t<NotSupportArgumentMetadata(T), bool> = true>
     void getMetadata(TableExtension* graphDdiTableExt,
                      ze_graph_handle_t graphHandle,
@@ -181,10 +179,6 @@ private:
     ze_driver_handle_t _driverHandle = nullptr;
     ze_device_handle_t _deviceHandle = nullptr;
     ze_context_handle_t _context = nullptr;
-
-    mutable ze_graph_properties_t _props{};
-    std::vector<intel_npu::ZeroExecutor::ArgumentDescriptor> inputDescriptors;
-    std::vector<intel_npu::ZeroExecutor::ArgumentDescriptor> outputDescriptors;
 
     TableExtension* _graphDdiTableExt = nullptr;
     Logger _logger;

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -48,7 +48,7 @@ using SerializedIR = std::pair<size_t, std::shared_ptr<uint8_t>>;
 template <typename TableExtension>
 class LevelZeroCompilerInDriver final : public ICompiler {
 public:
-    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t driverHandle, ze_context_handle_t &_context);
+    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t& driverHandle, ze_device_handle_t& deviceHandle, ze_context_handle_t& _context);
     LevelZeroCompilerInDriver(const LevelZeroCompilerInDriver&) = delete;
     LevelZeroCompilerInDriver& operator=(const LevelZeroCompilerInDriver&) = delete;
     ~LevelZeroCompilerInDriver() override;
@@ -178,12 +178,13 @@ private:
 
 template <typename TableExtension>
 LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char* extName,
-                                                                     ze_driver_handle_t driverHandle, ze_context_handle_t& context)
+                                                                     ze_driver_handle_t& driverHandle, ze_device_handle_t& deviceHandle, ze_context_handle_t& context)
     : _driverHandle(driverHandle),
       _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
     
     // Aceept context from adapter
     _context = context;
+    _deviceHandle=deviceHandle;
 
     // Load our graph extension
     auto result =
@@ -200,7 +201,7 @@ LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char*
         OPENVINO_THROW("Failed to get device. Error code: ", std::hex, result);
     }
 
-    printf(" Debug - zero_cid.hpp accept contextHandle from backend/adapater \n");
+    // printf(" Debug - zero_cid.hpp accept contextHandle from backend/adapater \n");
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -201,7 +201,6 @@ LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char*
         OPENVINO_THROW("Failed to get device. Error code: ", std::hex, result);
     }
 
-    // printf(" Debug - zero_cid.hpp accept contextHandle from backend/adapater \n");
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -184,18 +184,5 @@ private:
     Logger _logger;
 };
 
-template <typename TableExtension>
-LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(ze_driver_handle_t driverHandle,
-                                                                     ze_device_handle_t deviceHandle,
-                                                                     ze_context_handle_t zeContext,
-                                                                     ze_graph_dditable_ext_last_t* graph_ddi_table_ext)
-    : _driverHandle(driverHandle),
-      _deviceHandle(deviceHandle),
-      _context(zeContext),
-      _graphDdiTableExt(reinterpret_cast<TableExtension*>(graph_ddi_table_ext)),
-      _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
-    _logger.info("LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver - initialization");
-}
-
 }  // namespace driverCompilerAdapter
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -11,6 +11,7 @@
 #include "intel_npu/al/icompiler.hpp"
 #include "intel_npu/utils/logger/logger.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
+#include "zero_executor.hpp"
 
 namespace intel_npu {
 namespace driverCompilerAdapter {
@@ -104,6 +105,8 @@ private:
                              ze_graph_compiler_version_info_t compilerVersion) const;
     std::string serializeConfig(const Config& config, ze_graph_compiler_version_info_t& compilerVersion) const;
 
+    void processInputOutputDescriptors(ze_graph_argument_properties_3_t arg, uint32_t index);
+
     template <typename T = TableExtension, typename std::enable_if_t<NotSupportArgumentMetadata(T), bool> = true>
     void getMetadata(TableExtension* graphDdiTableExt,
                      ze_graph_handle_t graphHandle,
@@ -174,6 +177,10 @@ private:
     ze_driver_handle_t _driverHandle = nullptr;
     ze_device_handle_t _deviceHandle = nullptr;
     ze_context_handle_t _context = nullptr;
+
+    mutable ze_graph_properties_t _props{};
+    std::vector<intel_npu::ZeroExecutor::ArgumentDescriptor> inputDescriptors;
+    std::vector<intel_npu::ZeroExecutor::ArgumentDescriptor> outputDescriptors;
 
     TableExtension* _graphDdiTableExt = nullptr;
     Logger _logger;

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -100,7 +100,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    void fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
 private:
     NetworkMetadata getNetworkMeta(ze_graph_handle_t graphHandle) const;

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -48,7 +48,10 @@ using SerializedIR = std::pair<size_t, std::shared_ptr<uint8_t>>;
 template <typename TableExtension>
 class LevelZeroCompilerInDriver final : public ICompiler {
 public:
-    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t driverHandle, ze_device_handle_t deviceHandle, ze_context_handle_t zeContext);
+    LevelZeroCompilerInDriver(const char* extName,
+                              ze_driver_handle_t driverHandle,
+                              ze_device_handle_t deviceHandle,
+                              ze_context_handle_t zeContext);
     LevelZeroCompilerInDriver(const LevelZeroCompilerInDriver&) = delete;
     LevelZeroCompilerInDriver& operator=(const LevelZeroCompilerInDriver&) = delete;
     ~LevelZeroCompilerInDriver() override;
@@ -178,13 +181,14 @@ private:
 
 template <typename TableExtension>
 LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char* extName,
-                                                                     ze_driver_handle_t driverHandle, ze_device_handle_t deviceHandle, ze_context_handle_t zeContext)
+                                                                     ze_driver_handle_t driverHandle,
+                                                                     ze_device_handle_t deviceHandle,
+                                                                     ze_context_handle_t zeContext)
     : _driverHandle(driverHandle),
       _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
-    
     // Aceept context from adapter
     _context = zeContext;
-    _deviceHandle=deviceHandle;
+    _deviceHandle = deviceHandle;
 
     // Load our graph extension
     auto result =
@@ -200,7 +204,6 @@ LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char*
     if (ZE_RESULT_SUCCESS != result) {
         OPENVINO_THROW("Failed to get device. Error code: ", std::hex, result);
     }
-
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -192,7 +192,6 @@ LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(ze_driver_h
     : _driverHandle(driverHandle),
       _graphDdiTableExt(reinterpret_cast<TableExtension*>(graph_ddi_table_ext)),
       _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
-    // Aceept context from adapter
     _context = zeContext;
     _deviceHandle = deviceHandle;
 }

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -190,10 +190,11 @@ LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(ze_driver_h
                                                                      ze_context_handle_t zeContext,
                                                                      ze_graph_dditable_ext_last_t* graph_ddi_table_ext)
     : _driverHandle(driverHandle),
+      _deviceHandle(deviceHandle),
+      _context(zeContext),
       _graphDdiTableExt(reinterpret_cast<TableExtension*>(graph_ddi_table_ext)),
       _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
-    _context = zeContext;
-    _deviceHandle = deviceHandle;
+    _logger.info("LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver - initialization");
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -98,6 +98,10 @@ public:
      */
     static std::string serializeIOInfo(const std::shared_ptr<const ov::Model>& model, const bool useIndices);
 
+    void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
+
+    void fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+
 private:
     NetworkMetadata getNetworkMeta(ze_graph_handle_t graphHandle) const;
 

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -48,7 +48,7 @@ using SerializedIR = std::pair<size_t, std::shared_ptr<uint8_t>>;
 template <typename TableExtension>
 class LevelZeroCompilerInDriver final : public ICompiler {
 public:
-    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t& driverHandle, ze_device_handle_t& deviceHandle, ze_context_handle_t& _context);
+    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t driverHandle, ze_device_handle_t deviceHandle, ze_context_handle_t zeContext);
     LevelZeroCompilerInDriver(const LevelZeroCompilerInDriver&) = delete;
     LevelZeroCompilerInDriver& operator=(const LevelZeroCompilerInDriver&) = delete;
     ~LevelZeroCompilerInDriver() override;
@@ -178,12 +178,12 @@ private:
 
 template <typename TableExtension>
 LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char* extName,
-                                                                     ze_driver_handle_t& driverHandle, ze_device_handle_t& deviceHandle, ze_context_handle_t& context)
+                                                                     ze_driver_handle_t driverHandle, ze_device_handle_t deviceHandle, ze_context_handle_t zeContext)
     : _driverHandle(driverHandle),
       _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
     
     // Aceept context from adapter
-    _context = context;
+    _context = zeContext;
     _deviceHandle=deviceHandle;
 
     // Load our graph extension

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -48,7 +48,7 @@ using SerializedIR = std::pair<size_t, std::shared_ptr<uint8_t>>;
 template <typename TableExtension>
 class LevelZeroCompilerInDriver final : public ICompiler {
 public:
-    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t driverHandle);
+    LevelZeroCompilerInDriver(const char* extName, ze_driver_handle_t driverHandle, ze_context_handle_t &_context);
     LevelZeroCompilerInDriver(const LevelZeroCompilerInDriver&) = delete;
     LevelZeroCompilerInDriver& operator=(const LevelZeroCompilerInDriver&) = delete;
     ~LevelZeroCompilerInDriver() override;
@@ -178,9 +178,13 @@ private:
 
 template <typename TableExtension>
 LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char* extName,
-                                                                     ze_driver_handle_t driverHandle)
+                                                                     ze_driver_handle_t driverHandle, ze_context_handle_t& context)
     : _driverHandle(driverHandle),
       _logger("LevelZeroCompilerInDriver", Logger::global().level()) {
+    
+    // Aceept context from adapter
+    _context = context;
+
     // Load our graph extension
     auto result =
         zeDriverGetExtensionFunctionAddress(_driverHandle, extName, reinterpret_cast<void**>(&_graphDdiTableExt));
@@ -196,11 +200,7 @@ LevelZeroCompilerInDriver<TableExtension>::LevelZeroCompilerInDriver(const char*
         OPENVINO_THROW("Failed to get device. Error code: ", std::hex, result);
     }
 
-    ze_context_desc_t contextDesc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
-    result = zeContextCreate(_driverHandle, &contextDesc, &_context);
-    if (ZE_RESULT_SUCCESS != result) {
-        OPENVINO_THROW("Failed to initialize context for device. Error code: ", std::hex, result);
-    }
+    printf(" Debug - zero_cid.hpp accept contextHandle from backend/adapater \n");
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -22,7 +22,7 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
     _logger.debug("initialize LevelZeroCompilerAdapter start");
 
     ov::SoPtr<intel_npu::IEngineBackend> soPtrBackend = npuBackends->getIEngineBackend();
-    std::shared_ptr<intel_npu::IEngineBackend> iEngineBackend = soPtrBackend._ptr;  // Extract the raw pointer
+    std::shared_ptr<intel_npu::IEngineBackend> iEngineBackend = soPtrBackend._ptr;
     std::shared_ptr<ZeroEngineBackend> zeroBackend = nullptr;
     zeroBackend = std::dynamic_pointer_cast<ZeroEngineBackend>(iEngineBackend);
     if (!zeroBackend) {
@@ -30,7 +30,7 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
     }
 
     uint32_t driverExtVersion = zeroBackend->getDriverExtVersion();
-
+    char* graph_ext_name = zeroBackend->getGraphExtName();
     ze_context_handle_t zeContext = (ze_context_handle_t)zeroBackend->getContext();
     ze_driver_handle_t driverHandle = (ze_driver_handle_t)zeroBackend->getDriverHandle();
     ze_device_handle_t deviceHandle = (ze_device_handle_t)zeroBackend->getDeviceHandle();
@@ -73,7 +73,11 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
                                                                                               graph_ddi_table_ext);
         break;
     }
-    _logger.info("initialize LevelZeroCompilerAdapter complete, using ext_version :  %u", driverExtVersion);
+
+    _logger.info("initialize LevelZeroCompilerAdapter complete, using driverExtVersion: %d.%d (%s)",
+                 ZE_MAJOR_VERSION(driverExtVersion),
+                 ZE_MINOR_VERSION(driverExtVersion),
+                 graph_ext_name);
 }
 
 uint32_t LevelZeroCompilerAdapter::getSupportedOpsetVersion() const {

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -110,8 +110,9 @@ void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription>
     apiAdapter->release(networkDescription);
 }
 
-void LevelZeroCompilerAdapter::fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
-    apiAdapter->fillCompiledNetwork(networkDescription);
+std::vector<uint8_t> LevelZeroCompilerAdapter::getCompiledNetwork(
+    std::shared_ptr<const NetworkDescription> networkDescription) {
+    return apiAdapter->getCompiledNetwork(networkDescription);
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -54,62 +54,39 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
         return;
     }
 
-#if defined(NPU_PLUGIN_DEVELOPER_BUILD)
-    auto adapterManualConfig = std::getenv("ADAPTER_MANUAL_CONFIG");
-    if (adapterManualConfig != nullptr) {
-        if (strcmp(adapterManualConfig, "ZE_extension_graph_1_6") == 0) {
-            _logger.info("With ADAPTER_MANUAL_CONFIG. Using ZE_GRAPH_EXT_VERSION_1_6");
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_6;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_5") == 0) {
-            _logger.info("With ADAPTER_MANUAL_CONFIG. Using ZE_GRAPH_EXT_VERSION_1_5");
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_5;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_4") == 0) {
-            _logger.info("With ADAPTER_MANUAL_CONFIG. Using ZE_GRAPH_EXT_VERSION_1_4");
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_4;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_3") == 0) {
-            _logger.info("With ADAPTER_MANUAL_CONFIG. Using ZE_GRAPH_EXT_VERSION_1_3");
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_3;
-        } else if (strcmp(adapterManualConfig, "ZE_extension_graph_1_2") == 0) {
-            _logger.info("With ADAPTER_MANUAL_CONFIG. Using ZE_GRAPH_EXT_VERSION_1_2");
-            targetVersion = ZE_GRAPH_EXT_VERSION_1_2;
-        } else {
-            OPENVINO_THROW("Using unsupported ADAPTER_MANUAL_CONFIG!");
-        }
-    }
-#endif
-
-    if (ZE_GRAPH_EXT_VERSION_1_3 == targetVersion) {
-        _logger.info("Using ZE_GRAPH_EXT_VERSION_1_3");
+    switch (targetVersion) {
+    case ZE_GRAPH_EXT_VERSION_1_3:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_3_t>>(graphExtName,
                                                                                               driverHandle,
                                                                                               deviceHandle,
                                                                                               zeContext);
-    } else if (ZE_GRAPH_EXT_VERSION_1_4 == targetVersion) {
-        _logger.info("Using ZE_GRAPH_EXT_VERSION_1_4");
+        break;
+    case ZE_GRAPH_EXT_VERSION_1_4:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_4_t>>(graphExtName,
                                                                                               driverHandle,
                                                                                               deviceHandle,
                                                                                               zeContext);
-    } else if (ZE_GRAPH_EXT_VERSION_1_5 == targetVersion) {
-        _logger.info("Using ZE_GRAPH_EXT_VERSION_1_5");
+        break;
+    case ZE_GRAPH_EXT_VERSION_1_5:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_5_t>>(graphExtName,
                                                                                               driverHandle,
                                                                                               deviceHandle,
                                                                                               zeContext);
-    } else if (ZE_GRAPH_EXT_VERSION_1_6 == targetVersion) {
-        _logger.info("Using ZE_GRAPH_EXT_VERSION_1_6");
+        break;
+    case ZE_GRAPH_EXT_VERSION_1_6:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_6_t>>(graphExtName,
                                                                                               driverHandle,
                                                                                               deviceHandle,
                                                                                               zeContext);
-    } else {
-        _logger.info("Using ZE_GRAPH_EXT_VERSION_1_2");
+        break;
+    default:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_2_t>>(graphExtName,
                                                                                               driverHandle,
                                                                                               deviceHandle,
                                                                                               zeContext);
+        break;
     }
-    _logger.debug("initialize zeAPI end");
+    _logger.info("initialize LevelZeroCompilerAdapter complete, using ext_version :  %s", targetVersion);
 }
 
 uint32_t LevelZeroCompilerAdapter::getSupportedOpsetVersion() const {

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -41,6 +41,8 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
         return;
     }
 
+    _logger.info("LevelZeroCompilerAdapter::LevelZeroCompilerAdapter - creating adapter using driverExtVersion");
+
     switch (driverExtVersion) {
     case ZE_GRAPH_EXT_VERSION_1_3:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_3_t>>(driverHandle,
@@ -107,11 +109,14 @@ std::vector<ov::ProfilingInfo> LevelZeroCompilerAdapter::process_profiling_outpu
 }
 
 void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription> networkDescription) {
+    _logger.debug("LevelZeroCompilerAdapter::release - using adapter to release networkDescription");
     apiAdapter->release(networkDescription);
 }
 
 std::vector<uint8_t> LevelZeroCompilerAdapter::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
+    _logger.debug("LevelZeroCompilerAdapter::getCompiledNetwork - using adapter to perform "
+                  "getCompiledNetwork(networkDescription)");
     return apiAdapter->getCompiledNetwork(networkDescription);
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -38,7 +38,6 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
     ze_context_handle_t zeContext = (ze_context_handle_t)zeroBackend->getContext();
     ze_driver_handle_t driverHandle = (ze_driver_handle_t)zeroBackend->getDriverHandle();
     ze_device_handle_t deviceHandle = (ze_device_handle_t)zeroBackend->getDeviceHandle();
-    char* graphExtName = zeroBackend->getGraphExtName();
     ze_graph_dditable_ext_last_t* graph_ddi_table_ext = zeroBackend->getGraphDDITableExt();
 
     if (driverHandle == nullptr) {
@@ -78,7 +77,7 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
                                                                                               graph_ddi_table_ext);
         break;
     }
-    _logger.info("initialize LevelZeroCompilerAdapter complete, using ext_version :  %s", driverExtVersion);
+    _logger.info("initialize LevelZeroCompilerAdapter complete, using ext_version :  %u", driverExtVersion);
 }
 
 uint32_t LevelZeroCompilerAdapter::getSupportedOpsetVersion() const {

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -37,11 +37,11 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
     ze_graph_dditable_ext_last_t* graph_ddi_table_ext = zeroBackend->getGraphDDITableExt();
 
     if (driverHandle == nullptr) {
-        OPENVINO_THROW("LevelZeroCompilerAdapter: Failed to get properties about zeDriver");
+        OPENVINO_THROW("LevelZeroCompilerAdapter failed to get properties about zeDriver");
         return;
     }
 
-    _logger.info("LevelZeroCompilerAdapter::LevelZeroCompilerAdapter - creating adapter using driverExtVersion");
+    _logger.info("LevelZeroCompilerAdapter creating adapter using driverExtVersion");
 
     switch (driverExtVersion) {
     case ZE_GRAPH_EXT_VERSION_1_3:
@@ -109,14 +109,13 @@ std::vector<ov::ProfilingInfo> LevelZeroCompilerAdapter::process_profiling_outpu
 }
 
 void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription> networkDescription) {
-    _logger.debug("LevelZeroCompilerAdapter::release - using adapter to release networkDescription");
+    _logger.info("release - using adapter to release networkDescription");
     apiAdapter->release(networkDescription);
 }
 
 std::vector<uint8_t> LevelZeroCompilerAdapter::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
-    _logger.debug("LevelZeroCompilerAdapter::getCompiledNetwork - using adapter to perform "
-                  "getCompiledNetwork(networkDescription)");
+    _logger.info("getCompiledNetwork - using adapter to perform getCompiledNetwork(networkDescription)");
     return apiAdapter->getCompiledNetwork(networkDescription);
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -30,7 +30,7 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
     }
 
     uint32_t driverExtVersion = zeroBackend->getDriverExtVersion();
-    char* graph_ext_name = zeroBackend->getGraphExtName();
+
     ze_context_handle_t zeContext = (ze_context_handle_t)zeroBackend->getContext();
     ze_driver_handle_t driverHandle = (ze_driver_handle_t)zeroBackend->getDriverHandle();
     ze_device_handle_t deviceHandle = (ze_device_handle_t)zeroBackend->getDeviceHandle();
@@ -74,10 +74,9 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
         break;
     }
 
-    _logger.info("initialize LevelZeroCompilerAdapter complete, using driverExtVersion: %d.%d (%s)",
+    _logger.info("initialize LevelZeroCompilerAdapter complete, using driverExtVersion: %d.%d",
                  ZE_MAJOR_VERSION(driverExtVersion),
-                 ZE_MINOR_VERSION(driverExtVersion),
-                 graph_ext_name);
+                 ZE_MINOR_VERSION(driverExtVersion));
 }
 
 uint32_t LevelZeroCompilerAdapter::getSupportedOpsetVersion() const {

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -24,13 +24,9 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
     ov::SoPtr<intel_npu::IEngineBackend> soPtrBackend = npuBackends->getIEngineBackend();
     std::shared_ptr<intel_npu::IEngineBackend> iEngineBackend = soPtrBackend._ptr;  // Extract the raw pointer
     std::shared_ptr<ZeroEngineBackend> zeroBackend = nullptr;
-    try {
-        zeroBackend = std::dynamic_pointer_cast<ZeroEngineBackend>(iEngineBackend);
-        if (!zeroBackend) {
-            OPENVINO_THROW("LevelZeroCompilerAdapter init failed to cast zeroBackend, zeroBackend is a nullptr");
-        }
-    } catch (const std::exception& e) {
-        OPENVINO_THROW("LevelZeroCompilerAdapter init failed to cast zeroBackend");
+    zeroBackend = std::dynamic_pointer_cast<ZeroEngineBackend>(iEngineBackend);
+    if (!zeroBackend) {
+        OPENVINO_THROW("LevelZeroCompilerAdapter init failed to cast zeroBackend, zeroBackend is a nullptr");
     }
 
     uint32_t driverExtVersion = zeroBackend->getDriverExtVersion();

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -107,5 +107,13 @@ std::vector<ov::ProfilingInfo> LevelZeroCompilerAdapter::process_profiling_outpu
     OPENVINO_THROW("Profiling post-processing is not implemented.");
 }
 
+void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription> networkDescription) {
+    apiAdapter->release(networkDescription);
+}
+
+void LevelZeroCompilerAdapter::fillCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
+    apiAdapter->fillCompiledNetwork(networkDescription);
+}
+
 }  // namespace driverCompilerAdapter
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -10,6 +10,7 @@
 #include "intel_npu/utils/zero/zero_result.hpp"
 #include "ze_intel_npu_uuid.h"
 #include "zero_compiler_in_driver.hpp"
+#include "zero_init.hpp"
 
 namespace intel_npu {
 namespace driverCompilerAdapter {
@@ -155,26 +156,30 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter() : _logger("LevelZeroCompile
         }
     }
 #endif
+
+    ze_context_handle_t _context;
+    _context = ZeroInitStructsHolder::getContext();
+
     if (ZE_GRAPH_EXT_VERSION_1_3 == targetVersion) {
         _logger.info("Using ZE_GRAPH_EXT_VERSION_1_3");
         apiAdapter =
-            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_3_t>>(graphExtName, _driverHandle);
+            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_3_t>>(graphExtName, _driverHandle, _context);
     } else if (ZE_GRAPH_EXT_VERSION_1_4 == targetVersion) {
         _logger.info("Using ZE_GRAPH_EXT_VERSION_1_4");
         apiAdapter =
-            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_4_t>>(graphExtName, _driverHandle);
+            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_4_t>>(graphExtName, _driverHandle, _context);
     } else if (ZE_GRAPH_EXT_VERSION_1_5 == targetVersion) {
         _logger.info("Using ZE_GRAPH_EXT_VERSION_1_5");
         apiAdapter =
-            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_5_t>>(graphExtName, _driverHandle);
+            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_5_t>>(graphExtName, _driverHandle, _context);
     } else if (ZE_GRAPH_EXT_VERSION_1_6 == targetVersion) {
         _logger.info("Using ZE_GRAPH_EXT_VERSION_1_6");
         apiAdapter =
-            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_6_t>>(graphExtName, _driverHandle);
+            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_6_t>>(graphExtName, _driverHandle, _context);
     } else {
         _logger.info("Using ZE_GRAPH_EXT_VERSION_1_2");
         apiAdapter =
-            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_2_t>>(graphExtName, _driverHandle);
+            std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_2_t>>(graphExtName, _driverHandle, _context);
     }
     _logger.debug("initialize zeAPI end");
 }

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -4,7 +4,6 @@
 
 #include "driver_compiler_adapter.hpp"
 
-#include "backends.hpp"
 #include "graph_transformations.hpp"
 #include "intel_npu/al/config/common.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
@@ -17,12 +16,10 @@
 namespace intel_npu {
 namespace driverCompilerAdapter {
 
-LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> npuBackends)
+LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<IEngineBackend> iEngineBackend)
     : _logger("LevelZeroCompilerAdapter", Logger::global().level()) {
     _logger.debug("initialize LevelZeroCompilerAdapter start");
 
-    ov::SoPtr<intel_npu::IEngineBackend> soPtrBackend = npuBackends->getIEngineBackend();
-    std::shared_ptr<intel_npu::IEngineBackend> iEngineBackend = soPtrBackend._ptr;
     std::shared_ptr<ZeroEngineBackend> zeroBackend = nullptr;
     zeroBackend = std::dynamic_pointer_cast<ZeroEngineBackend>(iEngineBackend);
     if (!zeroBackend) {
@@ -31,14 +28,13 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<NPUBackends> 
 
     uint32_t driverExtVersion = zeroBackend->getDriverExtVersion();
 
-    ze_context_handle_t zeContext = (ze_context_handle_t)zeroBackend->getContext();
-    ze_driver_handle_t driverHandle = (ze_driver_handle_t)zeroBackend->getDriverHandle();
-    ze_device_handle_t deviceHandle = (ze_device_handle_t)zeroBackend->getDeviceHandle();
+    ze_context_handle_t zeContext = static_cast<ze_context_handle_t>(zeroBackend->getContext());
+    ze_driver_handle_t driverHandle = static_cast<ze_driver_handle_t>(zeroBackend->getDriverHandle());
+    ze_device_handle_t deviceHandle = static_cast<ze_device_handle_t>(zeroBackend->getDeviceHandle());
     ze_graph_dditable_ext_last_t* graph_ddi_table_ext = zeroBackend->getGraphDDITableExt();
 
     if (driverHandle == nullptr) {
         OPENVINO_THROW("LevelZeroCompilerAdapter failed to get properties about zeDriver");
-        return;
     }
 
     _logger.info("LevelZeroCompilerAdapter creating adapter using driverExtVersion");

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -389,8 +389,8 @@ std::vector<uint8_t> LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwo
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork returning blob");
         return blob;
     } else {
-        OPENVINO_THROW("LevelZeroCompilerInDriver getCompiledNetwork : failed to get blob from nulltpr graphHandle");
-        return std::vector<uint8_t>();
+        _logger.info("return the blob from network description");
+        return networkDescription->compiledNetwork;
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -888,10 +888,13 @@ NetworkDescription LevelZeroCompilerInDriver<TableExtension>::compile(const std:
     try {
         networkDescription.graphHandleVoidPtr = static_cast<void*>(new ze_graph_handle_t(graphHandle));
         if (networkDescription.graphHandleVoidPtr == nullptr) {
-            OPENVINO_THROW("LevelZeroCompilerInDriver<TableExtension>::compile Failed to cast and allocate memory for graphHandleVoidPtr.");
+            OPENVINO_THROW("LevelZeroCompilerInDriver<TableExtension>::compile Failed to cast and allocate memory for "
+                           "graphHandleVoidPtr.");
         }
     } catch (const std::exception& e) {
-        OPENVINO_THROW("LevelZeroCompilerInDriver<TableExtension>::compile Failed to cast and allocate memory for graphHandleVoidPtr. ", e.what());
+        OPENVINO_THROW("LevelZeroCompilerInDriver<TableExtension>::compile Failed to cast and allocate memory for "
+                       "graphHandleVoidPtr. ",
+                       e.what());
     }
 
     return networkDescription;

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -890,19 +890,30 @@ NetworkDescription LevelZeroCompilerInDriver<TableExtension>::compile(const std:
     auto networkMeta = getNetworkMeta(graphHandle);
     networkMeta.name = model->get_friendly_name();
 
-    result = _graphDdiTableExt->pfnDestroy(graphHandle);
 
-    if (ZE_RESULT_SUCCESS != result) {
-        OPENVINO_THROW("Failed to compile network. L0 pfnDestroy",
-                       " result: ",
-                       ze_result_to_string(result),
-                       ", code 0x",
-                       std::hex,
-                       uint64_t(result));
-    }
+    // We dont destroy the graphHandle here, as it can be share for ZeroExecutor
+    //-------------------------
+    // result = _graphDdiTableExt->pfnDestroy(graphHandle);
+
+    // if (ZE_RESULT_SUCCESS != result) {
+    //     OPENVINO_THROW("Failed to compile network. L0 pfnDestroy",
+    //                    " result: ",
+    //                    ze_result_to_string(result),
+    //                    ", code 0x",
+    //                    std::hex,
+    //                    uint64_t(result));
+    // }
+    //-------------------------
 
     _logger.debug("compile end");
-    return NetworkDescription(std::move(blob), std::move(networkMeta));
+
+    auto networkDescription = NetworkDescription(std::move(blob), std::move(networkMeta));
+
+    // to test if return the same graphHandle to backend for ZeroExecutor, still able to work
+    void* graphHandleVoidPtr = static_cast<void*>(&graphHandle);
+    networkDescription.graphHandleVoidPtr = graphHandleVoidPtr;
+
+    return networkDescription;
 }
 
 template <typename TableExtension>

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -181,7 +181,7 @@ namespace driverCompilerAdapter {
 
 template <typename TableExtension>
 LevelZeroCompilerInDriver<TableExtension>::~LevelZeroCompilerInDriver() {
-    printf("\n Debug - skip zero_cid destructor - zeContextDestroy(_context) ! \n");
+    // printf("\n Debug - skip zero_cid destructor - zeContextDestroy(_context) ! \n");
     // zeContextDestroy(_context) remove the shard _context from backend instead of here 
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -907,7 +907,7 @@ NetworkDescription LevelZeroCompilerInDriver<TableExtension>::compile(const std:
 
     _logger.debug("compile end");
 
-    auto networkDescription = NetworkDescription(std::vector<uint8_t>(), std::move(networkMeta));
+    auto networkDescription = NetworkDescription(std::move(networkMeta));
     return networkDescription;
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -340,11 +340,8 @@ void LevelZeroCompilerInDriver<TableExtension>::release(std::shared_ptr<const Ne
         auto result = _graphDdiTableExt->pfnDestroy(graphHandle);
 
         if (ZE_RESULT_SUCCESS != result) {
-            _logger.error("Failed to release graph handle. L0 pfnDestroy",
-                          " result: ",
-                          ze_result_to_string(result),
-                          ", code 0x",
-                          std::hex,
+            _logger.error("Failed to release graph handle. L0 pfnDestroy result: %s, code %#X",
+                          ze_result_to_string(result).c_str(),
                           uint64_t(result));
         }
     }

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -16,6 +16,7 @@
 #include "intel_npu/al/prefix.hpp"
 #include "intel_npu/utils/zero/zero_result.hpp"
 #include "openvino/core/model.hpp"
+#include "zero_executor.hpp"
 
 namespace {
 
@@ -897,6 +898,11 @@ NetworkDescription LevelZeroCompilerInDriver<TableExtension>::compile(const std:
                        e.what());
     }
 
+    // Use const_cast to remove const qualifier
+    networkDescription.propsVoidPtr = const_cast<void*>(static_cast<const void*>(&_props));
+    networkDescription.inputDescriptors = const_cast<void*>(static_cast<const void*>(&inputDescriptors));
+    networkDescription.outputDescriptors = const_cast<void*>(static_cast<const void*>(&outputDescriptors));
+
     return networkDescription;
 }
 
@@ -1027,6 +1033,17 @@ static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
             metadata.has_value() ? std::optional(shapeFromIRModel) : std::nullopt};
 }
 
+// process _input_descriptors & _output_descriptors for zero_executor
+template <typename TableExtension>
+void LevelZeroCompilerInDriver<TableExtension>::processInputOutputDescriptors(ze_graph_argument_properties_3_t arg,
+                                                                              uint32_t index) {
+    if (arg.type == ZE_GRAPH_ARGUMENT_TYPE_INPUT) {
+        inputDescriptors.push_back(intel_npu::ZeroExecutor::ArgumentDescriptor{arg, index});
+    } else {
+        outputDescriptors.push_back(intel_npu::ZeroExecutor::ArgumentDescriptor{arg, index});
+    }
+}
+
 template <typename TableExtension>
 template <typename T, std::enable_if_t<NotSupportArgumentMetadata(T), bool>>
 void LevelZeroCompilerInDriver<TableExtension>::getMetadata(TableExtension* graphDdiTableExt,
@@ -1044,6 +1061,8 @@ void LevelZeroCompilerInDriver<TableExtension>::getMetadata(TableExtension* grap
                        std::hex,
                        uint64_t(result));
     }
+
+    const_cast<LevelZeroCompilerInDriver*>(this)->processInputOutputDescriptors(arg, index);
 
     switch (arg.type) {
     case ZE_GRAPH_ARGUMENT_TYPE_INPUT: {
@@ -1075,6 +1094,8 @@ void LevelZeroCompilerInDriver<TableExtension>::getMetadata(TableExtension* grap
                        std::hex,
                        uint64_t(result));
     }
+
+    const_cast<LevelZeroCompilerInDriver*>(this)->processInputOutputDescriptors(arg, index);
 
     std::optional<ze_graph_argument_metadata_t> optionalMetadata = std::nullopt;
 
@@ -1108,9 +1129,7 @@ void LevelZeroCompilerInDriver<TableExtension>::getMetadata(TableExtension* grap
 
 template <typename TableExtension>
 NetworkMetadata LevelZeroCompilerInDriver<TableExtension>::getNetworkMeta(ze_graph_handle_t graphHandle) const {
-    ze_graph_properties_t graphProperties{};
-
-    auto result = _graphDdiTableExt->pfnGetProperties(graphHandle, &graphProperties);
+    auto result = _graphDdiTableExt->pfnGetProperties(graphHandle, &_props);
 
     if (ZE_RESULT_SUCCESS != result) {
         OPENVINO_THROW("L0 pfnGetProperties",
@@ -1123,7 +1142,7 @@ NetworkMetadata LevelZeroCompilerInDriver<TableExtension>::getNetworkMeta(ze_gra
 
     NetworkMetadata meta;
 
-    for (uint32_t index = 0; index < graphProperties.numGraphArgs; ++index) {
+    for (uint32_t index = 0; index < _props.numGraphArgs; ++index) {
         getMetadata(_graphDdiTableExt, graphHandle, index, meta.inputs, meta.outputs);
     }
     // TODO: support this information in CiD [track: E#33479]

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -337,7 +337,8 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeIOInfo(const std
 template <typename TableExtension>
 void LevelZeroCompilerInDriver<TableExtension>::release(std::shared_ptr<const NetworkDescription> networkDescription) {
     if (networkDescription->metadata.graphHandle != nullptr) {
-        result = _graphDdiTableExt->pfnDestroy(networkDescription->metadata.graphHandle);
+        ze_graph_handle_t graphHandle = static_cast<ze_graph_handle_t>(networkDescription->metadata.graphHandle);
+        auto result = _graphDdiTableExt->pfnDestroy(graphHandle);
 
         if (ZE_RESULT_SUCCESS != result) {
             _logger.error("Failed to release graph handle. L0 pfnDestroy",
@@ -359,7 +360,7 @@ void LevelZeroCompilerInDriver<TableExtension>::fillCompiledNetwork(
         // Get blob size first
         size_t blobSize = -1;
 
-        result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, &blobSize, nullptr);
+        auto result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, &blobSize, nullptr);
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
                         "Failed to compile network. L0 pfnGetNativeBinary get blob size",
@@ -385,7 +386,8 @@ void LevelZeroCompilerInDriver<TableExtension>::fillCompiledNetwork(
                         ". ",
                         getLatestBuildError());
 
-        networkDescription->compiledNetwork = std::move(blob);
+        auto networkDesp = const_cast<NetworkDescription*>(networkDescription.get());
+        networkDesp->compiledNetwork = std::move(blob);
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -348,7 +348,7 @@ void LevelZeroCompilerInDriver<TableExtension>::release(std::shared_ptr<const Ne
 }
 
 template <typename TableExtension>
-void LevelZeroCompilerInDriver<TableExtension>::fillCompiledNetwork(
+std::vector<uint8_t> LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
     if (networkDescription->metadata.graphHandle != nullptr) {
         ze_graph_handle_t graphHandle = static_cast<ze_graph_handle_t>(networkDescription->metadata.graphHandle);
@@ -382,8 +382,7 @@ void LevelZeroCompilerInDriver<TableExtension>::fillCompiledNetwork(
                         ". ",
                         getLatestBuildError());
 
-        auto networkDesp = const_cast<NetworkDescription*>(networkDescription.get());
-        networkDesp->compiledNetwork = std::move(blob);
+        return std::move(blob);
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -181,7 +181,7 @@ namespace driverCompilerAdapter {
 
 template <typename TableExtension>
 LevelZeroCompilerInDriver<TableExtension>::~LevelZeroCompilerInDriver() {
-    // zeContextDestroy(_context) remove the shared _context from backend instead of here
+    _logger.debug("LevelZeroCompilerInDriver obj destroyed");
 }
 
 /**

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -878,7 +878,6 @@ ze_result_t LevelZeroCompilerInDriver<TableExtension>::seriazlideIRModelAndCreat
     }
 
     _logger.info("compileIR Using extension version: %s", typeid(TableExtension).name());
-    _logger.debug("seriazlideIRModelAndCreateGraph - performing createGraph");
     ze_result_t result = createGraph(format, serializedIR, buildFlags, flags, &graphHandle);
 
     if (ZE_RESULT_SUCCESS != result) {

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -365,7 +365,7 @@ void LevelZeroCompilerInDriver<TableExtension>::release(std::shared_ptr<const Ne
 template <typename TableExtension>
 std::vector<uint8_t> LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
-    if (networkDescription->metadata.graphHandle != nullptr) {
+    if (networkDescription->metadata.graphHandle != nullptr && networkDescription->compiledNetwork.size() == 0) {
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork get blob from graphHandle");
         ze_graph_handle_t graphHandle = static_cast<ze_graph_handle_t>(networkDescription->metadata.graphHandle);
 

--- a/src/plugins/intel_npu/src/plugin/include/backends.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/backends.hpp
@@ -28,6 +28,7 @@ public:
     std::shared_ptr<IDevice> getDevice(const std::string& specificName = "") const;
     std::shared_ptr<IDevice> getDevice(const ov::AnyMap& paramMap) const;
     std::vector<std::string> getAvailableDevicesNames() const;
+    ov::SoPtr<IEngineBackend> getIEngineBackend();
     std::string getBackendName() const;
     uint32_t getDriverVersion() const;
     uint32_t getDriverExtVersion() const;

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -62,6 +62,11 @@ public:
 
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
 
+    // For CID path mean it get the blob from compiler through pfnGetNativeBinary using
+    // networkDescription->metadata.graphHandle.
+
+    // For CIP path mean it get the blob from
+    // networkDescription->compiledNetwork.
     void export_model(std::ostream& stream) const override;
 
     std::shared_ptr<const ov::Model> get_runtime_model() const override;

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -56,6 +56,8 @@ public:
 
     CompiledModel& operator=(const CompiledModel&) = delete;
 
+    ~CompiledModel() override;
+
     std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override;
 
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -49,7 +49,7 @@ public:
                   const std::shared_ptr<const ov::IPlugin>& plugin,
                   const std::shared_ptr<const NetworkDescription>& networkDescription,
                   const std::shared_ptr<IDevice>& device,
-                  const std::optional<ov::SoPtr<ICompiler>>& compiler,
+                  const ov::SoPtr<ICompiler>& compiler,
                   const Config& config);
 
     CompiledModel(const CompiledModel&) = delete;
@@ -95,7 +95,7 @@ private:
     std::map<std::string, std::tuple<bool, ov::PropertyMutability, std::function<ov::Any(const Config&)>>> _properties;
     std::vector<ov::PropertyName> _supportedProperties;
 
-    ov::SoPtr<ICompiler> _compiler;
+    const ov::SoPtr<ICompiler> _compiler;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -95,7 +95,7 @@ private:
     std::map<std::string, std::tuple<bool, ov::PropertyMutability, std::function<ov::Any(const Config&)>>> _properties;
     std::vector<ov::PropertyName> _supportedProperties;
 
-    std::optional<ov::SoPtr<ICompiler>> _compiler;
+    ov::SoPtr<ICompiler> _compiler;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -101,6 +101,9 @@ private:
     std::vector<ov::PropertyName> _supportedProperties;
 
     const ov::SoPtr<ICompiler> _compiler;
+
+    // If we are on import_model path instead of compile_model path
+    bool _imported = false;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiled_model.hpp
@@ -101,9 +101,6 @@ private:
     std::vector<ov::PropertyName> _supportedProperties;
 
     const ov::SoPtr<ICompiler> _compiler;
-
-    // If we are on import_model path instead of compile_model path
-    bool _imported = false;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/include/compiler.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiler.hpp
@@ -6,14 +6,15 @@
 
 #pragma once
 
+#include "backends.hpp"
 #include "intel_npu/al/icompiler.hpp"
 #include "intel_npu/utils/logger/logger.hpp"
 #include "npu_private_properties.hpp"  // AL
 #include "openvino/runtime/so_ptr.hpp"
-#include "backends.hpp"
 
 namespace intel_npu {
 
-ov::SoPtr<ICompiler> createCompiler(std::shared_ptr<intel_npu::NPUBackends> npuBackends, ov::intel_npu::CompilerType compilerType);
+ov::SoPtr<ICompiler> createCompiler(std::shared_ptr<intel_npu::NPUBackends> npuBackends,
+                                    ov::intel_npu::CompilerType compilerType);
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/include/compiler.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/compiler.hpp
@@ -10,9 +10,10 @@
 #include "intel_npu/utils/logger/logger.hpp"
 #include "npu_private_properties.hpp"  // AL
 #include "openvino/runtime/so_ptr.hpp"
+#include "backends.hpp"
 
 namespace intel_npu {
 
-ov::SoPtr<ICompiler> createCompiler(ov::intel_npu::CompilerType compilerType);
+ov::SoPtr<ICompiler> createCompiler(std::shared_ptr<intel_npu::NPUBackends> npuBackends, ov::intel_npu::CompilerType compilerType);
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -131,6 +131,10 @@ NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, 
     }
 }
 
+ov::SoPtr<IEngineBackend> NPUBackends::getIEngineBackend() {
+    return _backend;
+}
+
 std::string NPUBackends::getBackendName() const {
     if (_backend != nullptr) {
         return _backend->getName();

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -140,11 +140,6 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
 void CompiledModel::export_model(std::ostream& stream) const {
     _logger.debug("CompiledModel::export_model");
 
-    // For CID path mean it get the blob from compiler through pfnGetNativeBinary using
-    // networkDescription->metadata.graphHandle
-
-    // For CIP path mean it get the blob from
-    // networkDescription->compiledNetwork
     const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
 
     stream.write(reinterpret_cast<const char*>(blob.data()), blob.size());

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -150,7 +150,8 @@ void CompiledModel::export_model(std::ostream& stream) const {
     std::stringstream str;
     str << "Blob size: " << blob.size() << ", hash: " << std::hex << hash(blob);
     _logger.info(str.str().c_str());
-    // if graphHandle is not null, release blob here to reduce peak mem
+    // If graphHandle is not a nullptr it means there is still an instance of the blob maintained inside the driver and
+    // we can release the copy of the blob here to reduce memory consumption.
     if (_networkPtr->metadata.graphHandle != nullptr) {
         auto& blobFilled = const_cast<NetworkDescription*>(_networkPtr.get())->compiledNetwork;
         blobFilled.clear();

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -143,9 +143,9 @@ void CompiledModel::export_model(std::ostream& stream) const {
     // For CID path mean it get the blob from compiler through pfnGetNativeBinary using
     // networkDescription->metadata.graphHandle
 
-    // For CIP path mean it get the blob form
+    // For CIP path mean it get the blob from
     // networkDescription->compiledNetwork
-    const auto& blob = _compiler->getCompiledNetwork(_networkPtr);
+    const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
 
     stream.write(reinterpret_cast<const char*>(blob.data()), blob.size());
     std::stringstream str;

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -56,7 +56,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
     OPENVINO_ASSERT(compiler != nullptr, "NPU CompiledModel: the pointer towards the compiler object is null");
 
     try {
-        _logger.debug("CompiledModel::CompiledModel - performing compile and expecting a network description");
+        _logger.debug("performing compile and expecting a network description");
         _networkPtr = std::make_shared<const NetworkDescription>(_compiler->compile(model, config));
     } catch (const std::exception& ex) {
         OPENVINO_THROW(ex.what());
@@ -103,10 +103,10 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
 }
 
 CompiledModel::~CompiledModel() {
-    _logger.debug("CompiledModel::~CompiledModel()");
+    _logger.debug("~CompiledModel()");
     // Call compiler to destroy graphHandle only if no executor created
     if (_executorPtr == nullptr) {
-        _logger.debug("CompiledModel::~CompiledModel() - _executorPtr is a nullptr, compiler release _executorPtr");
+        _logger.debug("~CompiledModel() - _executorPtr is a nullptr, compiler release _executorPtr");
         _compiler->release(_networkPtr);
     }
 }
@@ -138,14 +138,14 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
 }
 
 void CompiledModel::export_model(std::ostream& stream) const {
-    _logger.info("CompiledModel::export_model");
+    _logger.debug("CompiledModel::export_model");
 
-    // FOr CID path mean it get the blob from compiler through pfnGetNativeBinary using
+    // For CID path mean it get the blob from compiler through pfnGetNativeBinary using
     // networkDescription->metadata.graphHandle
 
     // For CIP path mean it get the blob form
     // networkDescription->compiledNetwork
-    std::vector<uint8_t> blob = _compiler->getCompiledNetwork(_networkPtr);
+    const auto& blob = _compiler->getCompiledNetwork(_networkPtr);
 
     stream.write(reinterpret_cast<const char*>(blob.data()), blob.size());
     std::stringstream str;

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -87,8 +87,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
       _config(config),
       _logger("CompiledModel", config.get<LOG_LEVEL>()),
       _device(device),
-      _compiler(compiler),
-      _imported(true) {
+      _compiler(compiler) {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::CompiledModel");
     OPENVINO_ASSERT(_networkPtr != nullptr,
                     "NPU CompiledModel: the pointer towards the NetworkDescription object is null");
@@ -140,14 +139,7 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
 
 void CompiledModel::export_model(std::ostream& stream) const {
     _logger.debug("CompiledModel::export_model");
-
-    if (_imported) {
-        OPENVINO_THROW("The CompiledModel is created from import_model path."
-                       "Application shall already hold a compiled model in memory!");
-    }
-
     const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
-
     stream.write(reinterpret_cast<const char*>(blob.data()), blob.size());
     std::stringstream str;
     str << "Blob size: " << blob.size() << ", hash: " << std::hex << hash(blob);

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -87,7 +87,8 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
       _config(config),
       _logger("CompiledModel", config.get<LOG_LEVEL>()),
       _device(device),
-      _compiler(compiler) {
+      _compiler(compiler),
+      _imported(true) {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "CompiledModel::CompiledModel");
     OPENVINO_ASSERT(_networkPtr != nullptr,
                     "NPU CompiledModel: the pointer towards the NetworkDescription object is null");
@@ -139,6 +140,11 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
 
 void CompiledModel::export_model(std::ostream& stream) const {
     _logger.debug("CompiledModel::export_model");
+
+    if (_imported) {
+        OPENVINO_THROW("The CompiledModel is created from import_model path."
+                       "Application shall already hold a compiled model in memory!");
+    }
 
     const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
 

--- a/src/plugins/intel_npu/src/plugin/src/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiler.cpp
@@ -53,6 +53,7 @@ ov::SoPtr<ICompiler> loadCompiler(const std::string& libpath) {
 ov::SoPtr<ICompiler> createCompilerAdapter(std::shared_ptr<NPUBackends> npuBackends, const Logger& log) {
     log.info("Driver compiler will be used.");
 #ifdef ENABLE_DRIVER_COMPILER_ADAPTER
+    log.info("ENABLE_DRIVER_COMPILER_ADAPTER");
     const auto compilerInterface = std::make_shared<driverCompilerAdapter::LevelZeroCompilerAdapter>(npuBackends);
     return ov::SoPtr<ICompiler>(compilerInterface);
 #else
@@ -87,6 +88,7 @@ ov::SoPtr<ICompiler> intel_npu::createCompiler(std::shared_ptr<intel_npu::NPUBac
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "intel_npu::createCompiler");
     auto logger = Logger::global().clone("createCompiler");
     try {
+        logger.info("intel_npu::createCompiler - performing createCompilerImpl");
         return createCompilerImpl(npuBackends, compilerType, logger);
     } catch (const std::exception& ex) {
         OPENVINO_THROW("Got an error during compiler creation: ", ex.what());

--- a/src/plugins/intel_npu/src/plugin/src/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiler.cpp
@@ -50,10 +50,10 @@ ov::SoPtr<ICompiler> loadCompiler(const std::string& libpath) {
     return ov::SoPtr<ICompiler>(compiler, compilerSO);
 }
 
-ov::SoPtr<ICompiler> createCompilerAdapter(const Logger& log) {
+ov::SoPtr<ICompiler> createCompilerAdapter(std::shared_ptr<NPUBackends> npuBackends, const Logger& log) {
     log.info("Driver compiler will be used.");
 #ifdef ENABLE_DRIVER_COMPILER_ADAPTER
-    const auto compilerInterface = std::make_shared<driverCompilerAdapter::LevelZeroCompilerAdapter>();
+    const auto compilerInterface = std::make_shared<driverCompilerAdapter::LevelZeroCompilerAdapter>(npuBackends);
     return ov::SoPtr<ICompiler>(compilerInterface);
 #else
     OPENVINO_THROW("NPU Compiler Adapter is not enabled");
@@ -67,12 +67,12 @@ ov::SoPtr<ICompiler> createNPUCompiler(const Logger& log) {
     return loadCompiler(libPath);
 }
 
-ov::SoPtr<ICompiler> createCompilerImpl(ov::intel_npu::CompilerType compilerType, const Logger& log) {
+ov::SoPtr<ICompiler> createCompilerImpl(std::shared_ptr<NPUBackends> npuBackends, ov::intel_npu::CompilerType compilerType, const Logger& log) {
     switch (compilerType) {
     case ov::intel_npu::CompilerType::MLIR:
         return createNPUCompiler(log);
     case ov::intel_npu::CompilerType::DRIVER:
-        return createCompilerAdapter(log);
+        return createCompilerAdapter(npuBackends, log);
     default:
         OPENVINO_THROW("Invalid NPU_COMPILER_TYPE");
     }
@@ -80,11 +80,11 @@ ov::SoPtr<ICompiler> createCompilerImpl(ov::intel_npu::CompilerType compilerType
 
 }  // namespace
 
-ov::SoPtr<ICompiler> intel_npu::createCompiler(ov::intel_npu::CompilerType compilerType) {
+ov::SoPtr<ICompiler> intel_npu::createCompiler(std::shared_ptr<intel_npu::NPUBackends> npuBackends, ov::intel_npu::CompilerType compilerType) {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "intel_npu::createCompiler");
     auto logger = Logger::global().clone("createCompiler");
     try {
-        return createCompilerImpl(compilerType, logger);
+        return createCompilerImpl(npuBackends, compilerType, logger);
     } catch (const std::exception& ex) {
         OPENVINO_THROW("Got an error during compiler creation: ", ex.what());
     } catch (...) {

--- a/src/plugins/intel_npu/src/plugin/src/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiler.cpp
@@ -88,7 +88,7 @@ ov::SoPtr<ICompiler> intel_npu::createCompiler(std::shared_ptr<intel_npu::NPUBac
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "intel_npu::createCompiler");
     auto logger = Logger::global().clone("createCompiler");
     try {
-        logger.info("intel_npu::createCompiler - performing createCompilerImpl");
+        logger.debug("performing createCompilerImpl");
         return createCompilerImpl(npuBackends, compilerType, logger);
     } catch (const std::exception& ex) {
         OPENVINO_THROW("Got an error during compiler creation: ", ex.what());

--- a/src/plugins/intel_npu/src/plugin/src/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiler.cpp
@@ -67,7 +67,9 @@ ov::SoPtr<ICompiler> createNPUCompiler(const Logger& log) {
     return loadCompiler(libPath);
 }
 
-ov::SoPtr<ICompiler> createCompilerImpl(std::shared_ptr<NPUBackends> npuBackends, ov::intel_npu::CompilerType compilerType, const Logger& log) {
+ov::SoPtr<ICompiler> createCompilerImpl(std::shared_ptr<NPUBackends> npuBackends,
+                                        ov::intel_npu::CompilerType compilerType,
+                                        const Logger& log) {
     switch (compilerType) {
     case ov::intel_npu::CompilerType::MLIR:
         return createNPUCompiler(log);
@@ -80,7 +82,8 @@ ov::SoPtr<ICompiler> createCompilerImpl(std::shared_ptr<NPUBackends> npuBackends
 
 }  // namespace
 
-ov::SoPtr<ICompiler> intel_npu::createCompiler(std::shared_ptr<intel_npu::NPUBackends> npuBackends, ov::intel_npu::CompilerType compilerType) {
+ov::SoPtr<ICompiler> intel_npu::createCompiler(std::shared_ptr<intel_npu::NPUBackends> npuBackends,
+                                               ov::intel_npu::CompilerType compilerType) {
     OV_ITT_SCOPED_TASK(itt::domains::NPUPlugin, "intel_npu::createCompiler");
     auto logger = Logger::global().clone("createCompiler");
     try {

--- a/src/plugins/intel_npu/src/plugin/src/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiler.cpp
@@ -53,8 +53,11 @@ ov::SoPtr<ICompiler> loadCompiler(const std::string& libpath) {
 ov::SoPtr<ICompiler> createCompilerAdapter(std::shared_ptr<NPUBackends> npuBackends, const Logger& log) {
     log.info("Driver compiler will be used.");
 #ifdef ENABLE_DRIVER_COMPILER_ADAPTER
-    log.info("ENABLE_DRIVER_COMPILER_ADAPTER");
-    const auto compilerInterface = std::make_shared<driverCompilerAdapter::LevelZeroCompilerAdapter>(npuBackends);
+    if (npuBackends->getBackendName() != "LEVEL0") {
+        OPENVINO_THROW("NPU Compiler Adapter must be used with LEVEL0 backend");
+    }
+    const auto compilerInterface =
+        std::make_shared<driverCompilerAdapter::LevelZeroCompilerAdapter>(npuBackends->getIEngineBackend()._ptr);
     return ov::SoPtr<ICompiler>(compilerInterface);
 #else
     OPENVINO_THROW("NPU Compiler Adapter is not enabled");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -750,6 +750,12 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
         _logger.debug("Successfully read %zu bytes into blob.", graphSize);
 
         auto meta = compiler->parse(blob, localConfig);
+        // graphHandle is reused by backend if we use driver compiler
+        // Can release blob memory
+        if (meta.graphHandle != nullptr) {
+            blob.clear();
+            blob.shrink_to_fit();
+        }
         meta.name = "net" + std::to_string(_compiledModelLoadCounter++);
 
         const std::shared_ptr<ov::Model> modelDummy = create_dummy_model(meta.inputs, meta.outputs);

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -768,7 +768,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
                                                         shared_from_this(),
                                                         networkDescription,
                                                         device,
-                                                        profiling ? std::optional(compiler) : std::nullopt,
+                                                        compiler,
                                                         localConfig);
     } catch (const std::exception& ex) {
         OPENVINO_THROW("Can't import network: ", ex.what());

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -752,17 +752,10 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
         auto meta = compiler->parse(blob, localConfig);
         // If graphHandle is not a nullptr it means there is still an instance of the blob maintained inside the driver
         // and we can release the copy of the blob here to reduce memory consumption.
-        if (meta.graphHandle != nullptr) {
-            // TODO: Not share handle and keep blob in profiling case now
-            if (localConfig.get<PERF_COUNT>()) {
-                auto tempMeta = meta;
-                compiler->release(
-                    std::make_shared<const NetworkDescription>(std::vector<uint8_t>(), std::move(tempMeta)));
-                meta.graphHandle = nullptr;
-            } else {
-                blob.clear();
-                blob.shrink_to_fit();
-            }
+        // Profiling mode is an exception.
+        if (meta.graphHandle != nullptr && !localConfig.get<PERF_COUNT>()) {
+            blob.clear();
+            blob.shrink_to_fit();
         }
         meta.name = "net" + std::to_string(_compiledModelLoadCounter++);
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -753,8 +753,16 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
         // If graphHandle is not a nullptr it means there is still an instance of the blob maintained inside the driver
         // and we can release the copy of the blob here to reduce memory consumption.
         if (meta.graphHandle != nullptr) {
-            blob.clear();
-            blob.shrink_to_fit();
+            // TODO: Not share handle and keep blob in profiling case now
+            if (localConfig.get<PERF_COUNT>()) {
+                auto tempMeta = meta;
+                compiler->release(
+                    std::make_shared<const NetworkDescription>(std::vector<uint8_t>(), std::move(tempMeta)));
+                meta.graphHandle = nullptr;
+            } else {
+                blob.clear();
+                blob.shrink_to_fit();
+            }
         }
         meta.name = "net" + std::to_string(_compiledModelLoadCounter++);
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -675,10 +675,9 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
     OV_ITT_TASK_NEXT(PLUGIN_COMPILE_MODEL, "compile");
 
     std::shared_ptr<ov::ICompiledModel> compiledModel;
-
     try {
         bool profiling = localConfig.get<PERF_COUNT>();
-
+        printf (" Debug - KY compile_model from plugin call getCompiler\n");
         compiledModel = std::make_shared<CompiledModel>(model,
                                                         shared_from_this(),
                                                         device,
@@ -812,7 +811,7 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
 
 ov::SoPtr<ICompiler> Plugin::getCompiler(const Config& config) const {
     auto compilerType = config.get<COMPILER_TYPE>();
-    return createCompiler(compilerType);
+    return createCompiler(_backends, compilerType);
 }
 
 std::atomic<int> Plugin::_compiledModelLoadCounter{1};

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -677,7 +677,6 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
     std::shared_ptr<ov::ICompiledModel> compiledModel;
     try {
         bool profiling = localConfig.get<PERF_COUNT>();
-        printf (" Debug - KY compile_model from plugin call getCompiler\n");
         compiledModel = std::make_shared<CompiledModel>(model,
                                                         shared_from_this(),
                                                         device,

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -750,13 +750,6 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
         _logger.debug("Successfully read %zu bytes into blob.", graphSize);
 
         auto meta = compiler->parse(blob, localConfig);
-        // If graphHandle is not a nullptr it means there is still an instance of the blob maintained inside the driver
-        // and we can release the copy of the blob here to reduce memory consumption.
-        // Profiling mode is an exception.
-        if (meta.graphHandle != nullptr && !localConfig.get<PERF_COUNT>()) {
-            blob.clear();
-            blob.shrink_to_fit();
-        }
         meta.name = "net" + std::to_string(_compiledModelLoadCounter++);
 
         const std::shared_ptr<ov::Model> modelDummy = create_dummy_model(meta.inputs, meta.outputs);

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -821,9 +821,8 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
 }
 
 ov::SoPtr<ICompiler> Plugin::getCompiler(const Config& config) const {
-    _logger.debug("Plugin::getCompiler - get compiler type");
     auto compilerType = config.get<COMPILER_TYPE>();
-    _logger.debug("Plugin::getCompiler - performing createCompiler");
+    _logger.debug("performing createCompiler");
     return createCompiler(_backends, compilerType);
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -760,8 +760,6 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
 
         const std::shared_ptr<ov::Model> modelDummy = create_dummy_model(meta.inputs, meta.outputs);
 
-        bool profiling = localConfig.get<PERF_COUNT>();
-
         auto networkDescription = std::make_shared<const NetworkDescription>(std::move(blob), std::move(meta));
 
         compiledModel = std::make_shared<CompiledModel>(modelDummy,

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -813,7 +813,9 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
 }
 
 ov::SoPtr<ICompiler> Plugin::getCompiler(const Config& config) const {
+    _logger.debug("Plugin::getCompiler - get compiler type");
     auto compilerType = config.get<COMPILER_TYPE>();
+    _logger.debug("Plugin::getCompiler - performing createCompiler");
     return createCompiler(_backends, compilerType);
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -750,8 +750,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
         _logger.debug("Successfully read %zu bytes into blob.", graphSize);
 
         auto meta = compiler->parse(blob, localConfig);
-        // graphHandle is reused by backend if we use driver compiler
-        // Can release blob memory
+        // If graphHandle is not a nullptr it means there is still an instance of the blob maintained inside the driver
+        // and we can release the copy of the blob here to reduce memory consumption.
         if (meta.graphHandle != nullptr) {
             blob.clear();
             blob.shrink_to_fit();


### PR DESCRIPTION
### Details:
 - share the same L0 context from backend to compiler
 - and perform zeDestroy(context) in backend only 

### Tickets:
 - *ticket-id*
