### PR TITLE
single-image-test: set DYNAMIC_QUANTIZATION_GROUP_SIZE to 0 for CPU

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -1267,6 +1267,7 @@ void setupOVCore(ov::Core& core) {
 
     if (FLAGS_device == "CPU") {
         core.set_property(flagDevice, {{"LP_TRANSFORMS_MODE", "NO"}});
+        core.set_property(flagDevice, {{"DYNAMIC_QUANTIZATION_GROUP_SIZE", "0"}});
     }
 
     if (FLAGS_pc) {


### PR DESCRIPTION
### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
