### PR TITLE
[GPU] Enable b_fs_yx_fsv16 format for shape-agnostic quantize and reorder kernels

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/compile_graph.cpp
@@ -114,7 +114,9 @@ void compile_graph::run(program& p) {
 
         if (node->is_dynamic() && !is_planar) {
             if (!(node->is_type<convolution>() && node->get_output_layout().format == cldnn::format::b_fs_yx_fsv16) &&
-                !(node->is_type<group_normalization>() && node->get_output_layout().format == cldnn::format::b_fs_yx_fsv16)) {
+                !(node->is_type<group_normalization>() && node->get_output_layout().format == cldnn::format::b_fs_yx_fsv16) &&
+                !(node->is_type<reorder>() && node->get_output_layout().format == cldnn::format::b_fs_yx_fsv16) &&
+                !(node->is_type<quantize>() && node->get_output_layout().format == cldnn::format::b_fs_yx_fsv16)) {
                 can_select_impl = false;
             }
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -142,6 +142,7 @@ attach_quantize_impl::attach_quantize_impl() {
         format::bfwzyx,
         format::bfuwzyx,
         format::bfvuwzyx,
+        format::b_fs_yx_fsv16,
     };
 
     auto keys = implementation_map<quantize>::combine(types, formats);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -181,6 +181,7 @@ attach_reorder_impl::attach_reorder_impl() {
         format::bfyx,
         format::bfzyx,
         format::bfwzyx,
+        format::b_fs_yx_fsv16
     };
     implementation_map<reorder>::add(impl_types::ocl, shape_types::dynamic_shape, reorder_impl::create, types, formats);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/quantize_gpu_test.cpp
@@ -749,6 +749,109 @@ TEST(quantize_gpu, dynamic) {
     }
 }
 
+TEST(quantize_gpu, dynamic_fsv16) {
+    auto& engine = get_test_engine();
+
+    auto input       = engine.allocate_memory({ { 1, 16, 2, 2 }, data_types::f32, format::bfyx });
+    auto input_low   = engine.allocate_memory({ { 1, 16, 1, 1 }, data_types::f32, format::bfyx });
+    auto input_high  = engine.allocate_memory({ { 1, 16, 1, 1 }, data_types::f32, format::bfyx });
+    auto output_low  = engine.allocate_memory({ { 1, 1,  1, 1 }, data_types::f32, format::bfyx });
+    auto output_high = engine.allocate_memory({ { 1, 1,  1, 1 }, data_types::f32, format::bfyx });
+
+    layout in_dyn_layout { ov::PartialShape::dynamic(4), data_types::f32, format::bfyx };
+
+    set_values(input, { -1.0f, 2.1f, 3.0f, 4.0f,
+                         5.0f, 2.0f, 2.0f, 3.0f,
+                         4.0f, 6.0f, 3.0f, 3.0f,
+                         3.0f, 5.0f, 1.0f, 1.0f,
+
+                         1.0f, 1.0f, 1.0f, 1.0f,
+                         4.0f, 6.0f, 3.0f, 3.0f,
+                         3.0f, 5.0f, 1.0f, 1.0f,
+                         1.0f, 1.0f, 1.0f, 1.0f,
+
+                         1.0f, 2.0f, 3.0f, 4.0f,
+                         5.0f, 2.0f, 2.0f, 3.0f,
+                         4.0f, 6.0f, 3.0f, 3.0f,
+                         3.0f, 5.0f, 1.0f, 1.0f,
+
+                         1.0f, 1.0f, 1.0f, 1.0f,
+                         4.0f, 6.0f, 3.0f, 3.0f,
+                         3.0f, 5.0f, 1.0f, 1.0f,
+                         1.0f, 1.0f, 1.0f, 1.0f });
+
+    set_values(input_low,  { 0.0f, 1.0f, 2.0f, 3.0f,
+                             4.0f, 5.0f, 6.0f, 7.0f,
+                             7.0f, 6.0f, 5.0f, 4.0f,
+                             3.0f, 2.0f, 1.0f, 0.0f });
+    set_values(input_high, { 10.0f, 21.0f, 32.0f, 43.0f,
+                             54.0f, 65.0f, 76.0f, 87.0f,
+                             87.0f, 76.0f, 65.0f, 54.0f,
+                             43.0f, 32.0f, 21.0f, 10.0f });
+
+    set_values(output_low,  { 0.0f });
+    set_values(output_high, { 255.0f });
+
+    std::vector<uint8_t> ref_data = {
+            0, 54, 77, 102,
+            51, 13, 13, 26,
+            17, 34, 8, 8,
+            0, 13, 0, 0,
+
+            0, 0, 0, 0,
+            0, 4, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 4, 0, 0,
+            0, 5, 0, 0,
+
+            0, 0, 0, 0,
+            17, 34, 8, 8,
+            26, 51, 0, 0,
+            26, 26, 26, 26
+    };
+
+    topology topology;
+    topology.add(
+        input_layout("input", in_dyn_layout),
+        data("input_low", input_low),
+        data("input_high", input_high),
+        data("output_low", output_low),
+        data("output_high", output_high),
+        reorder("reorder", input_info("input"), format::b_fs_yx_fsv16, data_types::f32),
+        quantize("quantize", input_info("reorder"), input_info("input_low"), input_info("input_high"), input_info("output_low"), input_info("output_high"), 255, data_types::u8),
+        reorder("output_reorder", input_info("quantize"), format::bfyx, data_types::u8)
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+
+    auto inst = network.get_primitive("quantize");
+    auto impl = inst->get_impl();
+    ASSERT_TRUE(impl != nullptr);
+    ASSERT_TRUE(impl->is_dynamic());
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("output_reorder").get_memory();
+    cldnn::mem_lock<uint8_t> output_ptr(output, get_test_stream());
+
+    // Check that layout and memory contains logical size of tensor
+    ASSERT_EQ(output->count(), (size_t)64);
+    ASSERT_EQ(output->get_layout().count(), (size_t)64);
+
+    ASSERT_EQ(output->size(), ref_data.size() * sizeof(uint8_t));
+
+    for (size_t i = 0; i < ref_data.size(); ++i) {
+        ASSERT_NEAR(output_ptr[i], ref_data[i], 1) << " index = " << i;
+    }
+}
+
 struct quantize_random_test_params {
     data_types  input_type;
     data_types  output_type;


### PR DESCRIPTION
### Details:
 - Currently, b_fs_yx_fsv16 blocked format is enabled for convolution operations, but the lack of it for reorder and quantize operations causes runtime static version kernel recompilation. This change enables support for the b_fs_yx_fsv16 format to allow shape-agnostic kernel selection.

### Tickets:
 - [CVS-145296](https://jira.devtools.intel.com/browse/CVS-145296)
