### PR TITLE
[GPU] Fix accuracy issue for StableDiffusion3

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reshape_inst.h
@@ -8,6 +8,7 @@
 #include "openvino/core/partial_shape.hpp"
 #include "crop_inst.h"
 #include "rope_inst.h"
+#include "mvn_inst.h"
 #include "primitive_inst.h"
 
 #include <string>
@@ -42,8 +43,12 @@ public:
         if (!input().is_type<crop>())
             return false;
 
-        // TODO: If user is RoPE and dynamic padding exists, ouput padding propagation is not supported in the base mode
-        if (get_users().size() == 1 && get_users().front()->is_type<rope>())
+        // oneDNN supports padded input of outer axis only for buffer fusing on static shape
+        if (!has_outer_padding_offset() && get_users().front()->get_preferred_impl_type() == impl_types::onednn)
+            return false;
+
+        // TODO: If user is RoPE or MVN and dynamic padding exists, ouput padding propagation is not supported in the base mode
+        if (get_users().size() == 1 && (get_users().front()->is_type<rope>() || get_users().front()->is_type<mvn>()))
             return false;
 
         auto axis = input().as<crop>().get_primitive()->axis;

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -20,6 +20,7 @@
 #include "shape_of_inst.h"
 #include "gather_inst.h"
 #include "strided_slice_inst.h"
+#include "mvn_inst.h"
 #include "intel_gpu/graph/network.hpp"
 #include "pass_manager.h"
 #include "to_string_utils.h"
@@ -933,6 +934,87 @@ TEST(prepare_buffer_fusing, in_place_crop_dynamic_split_lengths) {
 
     for (size_t i = 0; i < out2.size(); i++)
         ASSERT_EQ(output_ptr_2[i], out2[i]);
+
+    auto output_3 = outputs.at("output3").get_memory();
+    cldnn::mem_lock<float> output_ptr_3(output_3, get_test_stream());
+
+    for (size_t i = 0; i < out3.size(); i++)
+        ASSERT_EQ(output_ptr_3[i], out3[i]);
+}
+
+TEST(prepare_buffer_fusing, in_place_crop_dynamic_mvn) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ ov::PartialShape{-1, -1, 4}, data_types::f32, format::bfyx};
+    auto input_mem = engine.allocate_memory({ {1, 2, 4}, data_types::f32, format::bfyx });
+    auto weights_mem = engine.allocate_memory({ {8, 4}, data_types::u8, format::bfyx });
+    auto bias_mem = engine.allocate_memory({ {1, 1, 8}, data_types::f32, format::bfyx });
+    auto scale_mem = engine.allocate_memory({ {8, 1}, data_types::f32, format::bfyx });
+    auto zp_mem = engine.allocate_memory({ {8, 1}, data_types::f32, format::bfyx });
+    auto axis_mem = engine.allocate_memory({ {}, data_types::i64, format::bfyx });
+    auto splits_length_mem = engine.allocate_memory({ {2}, data_types::i64, format::bfyx });
+
+    int64_t axis = 2;
+    set_values(input_mem, { -0.5f,  2.0f,  0.5f,  1.0f,
+                             0.5f, -2.0f, -0.5f, -1.0f });
+    set_values<int64_t>(axis_mem, {axis});
+    set_values<int64_t>(splits_length_mem, { 2, 6 });
+    set_values<uint8_t>(weights_mem, { 1,  2,  3,  4,
+                                       5,  6,  7,  8,
+                                       9, 10, 11, 12,
+                                      13, 14, 15,  0,
+                                      15, 14, 13, 12,
+                                      11, 10,  9,  8,
+                                       7,  6,  5,  4,
+                                       3,  2,  1,  0});
+    set_values(bias_mem, { 1.0f, -2.0f, 3.0f, -4.0f, 5.0f, -6.0f, 7.0f, 2.0f });
+    set_values(scale_mem, { 2.0f, 4.0f, -2.0f, -4.0f, 0.5f, -0.5f, 2.0f, 2.0f });
+    set_values(zp_mem, { 1.0f, 2.0f, 2.0f, 1.0f, 4.0f, 1.0f, 6.0f, 2.0f });
+
+    std::vector<float> out1 = { 13.f, 58.f, -11.f, -62.f };
+    std::vector<float> out2 = { -24.0833f, -81.0833f, 45.4167f, 8.91667f, 27.9167f, 22.9167f, 27.75f, 70.75f, -37.75f, -23.25f, -16.25f, -21.25f };
+    std::vector<float> out3 = { 13.f, 58.f, -51.f, -108.f, 18.5f, -18.f, 1.f, -4.f, -11.f, -62.f, 57.f, 100.f, -8.5f, 6.f, 13.f, 8.f };
+
+    cldnn::crop_ngraph_op_mode op_mode = cldnn::crop_ngraph_op_mode::variadic_split;
+    topology topology(
+        input_layout("input", in_layout),
+        data("axis", axis_mem),
+        data("splits_length", splits_length_mem),
+        data("weights", weights_mem),
+        data("bias", bias_mem),
+        data("scale", scale_mem),
+        data("zp", zp_mem),
+        fully_connected("fc", input_info("input"), "weights", "bias", "scale", "zp", data_types::f32, 3, 2),
+        crop("crop1", { input_info("fc"), input_info("axis"), input_info("splits_length") }, cldnn::tensor(1), cldnn::tensor(0), op_mode, 0, axis),
+        reorder("output1", input_info("crop1"), format::bfyx, data_types::f32),
+        crop("crop2", { input_info("fc"), input_info("axis"), input_info("splits_length") }, cldnn::tensor(1), cldnn::tensor(0), op_mode, 1, axis),
+        reshape("reshape", input_info("crop2"), true, std::vector<int64_t>{0, 0, 3, 2}, ov::PartialShape{-1, -1, 3, 2}, cldnn::reshape::reshape_mode::base),
+        mvn("mvn", input_info("reshape"), false, 1e-10f, false, {2, 3}),
+        reorder("output2", input_info("mvn"), format::bfyx, data_types::f32, std::vector<float>(), reorder_mean_mode::subtract, padding(), true),
+        reorder("output3", input_info("fc"), format::bfyx, data_types::f32)
+    );
+
+    auto config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    network network(engine, topology, config);
+
+    network.set_input_data("input", input_mem);
+
+    auto outputs = network.execute();
+
+    auto output = outputs.at("output1").get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+
+    for (size_t i = 0; i < out1.size(); i++)
+        ASSERT_EQ(output_ptr[i], out1[i]);
+
+    auto output_2 = outputs.at("output2").get_memory();
+    cldnn::mem_lock<float> output_ptr_2(output_2, get_test_stream());
+
+    for (size_t i = 0; i < out2.size(); i++) {
+        ASSERT_NEAR(output_ptr_2[i], out2[i], 0.0001);
+    }
 
     auto output_3 = outputs.at("output3").get_memory();
     cldnn::mem_lock<float> output_ptr_3(output_3, get_test_stream());


### PR DESCRIPTION
### Details:
 - Fix accuracy issue from runtime buffer fusing for crop(https://github.com/openvinotoolkit/openvino/pull/25060)
 - If user is MVN and dynamic padding exists, output padding propagation is not supported in the base mode reshape
 - oneDNN supports padded input of outer axis only for buffer fusing on static shape

### Tickets:
 - [CVS-149472](https://jira.devtools.intel.com/browse/CVS-149472)
