### PR TITLE
[GPU] Extend RemoteTensor API

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/remote_tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/remote_tensor.cpp
@@ -19,7 +19,17 @@ void regclass_RemoteTensor(py::module m) {
             }),
             py::arg("remote_tensor"),
             py::arg("begin"),
-            py::arg("end"));
+            py::arg("end"),
+            R"(
+        Constructs a RoiRemoteTensor object using a specified range of coordinates on an existing RemoteTensor.
+
+        :param remote_tensor: The RemoteTensor object on which the RoiRemoteTensor will be based.
+        :type remote_tensor: openvino.RemoteTensor
+        :param begin: The starting coordinates for the tensor bound.
+        :type begin: openvino.runtime.Coordinate
+        :param end: The ending coordinates for the tensor bound.
+        :type end: openvino.runtime.Coordinate
+        )");
 
     cls.def(
         "get_device_name",
@@ -54,9 +64,13 @@ void regclass_RemoteTensor(py::module m) {
         [](RemoteTensorWrapper& self, RemoteTensorWrapper& dst) {
             self.tensor.copy_to(dst.tensor);
         },
+        py::arg("target_tensor"),
         R"(
-        Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+        Copy tensor's data to a destination remote tensor. The destination tensor should have the same element type.
         In case of RoiTensor, the destination tensor should also have the same shape.
+
+        :param target_tensor: The destination remote tensor to which the data will be copied.
+        :type target_tensor: openvino.RemoteTensor
     )");
 
     cls.def(
@@ -64,9 +78,13 @@ void regclass_RemoteTensor(py::module m) {
         [](RemoteTensorWrapper& self, ov::Tensor& dst) {
             self.tensor.copy_to(dst);
         },
+        py::arg("target_tensor"),
         R"(
-        Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+        Copy tensor's data to a destination tensor. The destination tensor should have the same element type.
         In case of RoiTensor, the destination tensor should also have the same shape.
+
+        :param target_tensor: The destination tensor to which the data will be copied.
+        :type target_tensor: openvino.Tensor
     )");
 
     cls.def(
@@ -74,9 +92,13 @@ void regclass_RemoteTensor(py::module m) {
         [](RemoteTensorWrapper& self, RemoteTensorWrapper& src) {
             self.tensor.copy_from(src.tensor);
         },
+        py::arg("source_tensor"),
         R"(
-        Copy source tensor's data to this tensor. Tensors should have the same element type.
+        Copy source remote tensor's data to this tensor. Tensors should have the same element type.
         In case of RoiTensor, tensors should also have the same shape.
+
+        :param source_tensor: The source remote tensor from which the data will be copied.
+        :type source_tensor: openvino.RemoteTensor
     )");
 
     cls.def(
@@ -84,9 +106,13 @@ void regclass_RemoteTensor(py::module m) {
         [](RemoteTensorWrapper& self, ov::Tensor& src) {
             self.tensor.copy_from(src);
         },
+        py::arg("source_tensor"),
         R"(
         Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
         In case of RoiTensor, tensors should also have the same shape.
+
+        :param source_tensor: The source tensor from which the data will be copied.
+        :type source_tensor: openvino.Tensor
     )");
 
     cls.def(
@@ -97,7 +123,7 @@ void regclass_RemoteTensor(py::module m) {
         R"(
         Gets Tensor's shape.
 
-        :rtype: openvino.runtime.Shape
+        :rtype: openvino.Shape
     )");
 
     cls.def(

--- a/src/bindings/python/src/pyopenvino/core/remote_tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/remote_tensor.cpp
@@ -56,6 +56,7 @@ void regclass_RemoteTensor(py::module m) {
         },
         R"(
         Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+        In case of RoiTensor, the destination tensor should also have the same shape.
     )");
 
     cls.def(
@@ -65,6 +66,7 @@ void regclass_RemoteTensor(py::module m) {
         },
         R"(
         Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+        In case of RoiTensor, the destination tensor should also have the same shape.
     )");
 
     cls.def(
@@ -73,7 +75,8 @@ void regclass_RemoteTensor(py::module m) {
             self.tensor.copy_from(src.tensor);
         },
         R"(
-        Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+        Copy source tensor's data to this tensor. Tensors should have the same element type.
+        In case of RoiTensor, tensors should also have the same shape.
     )");
 
     cls.def(
@@ -83,6 +86,7 @@ void regclass_RemoteTensor(py::module m) {
         },
         R"(
         Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+        In case of RoiTensor, tensors should also have the same shape.
     )");
 
     cls.def(

--- a/src/bindings/python/src/pyopenvino/core/remote_tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/remote_tensor.cpp
@@ -14,6 +14,13 @@ namespace py = pybind11;
 void regclass_RemoteTensor(py::module m) {
     py::class_<RemoteTensorWrapper, std::shared_ptr<RemoteTensorWrapper>> cls(m, "RemoteTensor");
 
+    cls.def(py::init([](RemoteTensorWrapper& tensor_wrapper, ov::Coordinate& begin, ov::Coordinate& end) {
+                return RemoteTensorWrapper(ov::RemoteTensor(tensor_wrapper.tensor, begin, end));
+            }),
+            py::arg("remote_tensor"),
+            py::arg("begin"),
+            py::arg("end"));
+
     cls.def(
         "get_device_name",
         [](RemoteTensorWrapper& self) {
@@ -44,12 +51,61 @@ void regclass_RemoteTensor(py::module m) {
 
     cls.def(
         "copy_to",
-        [](RemoteTensorWrapper& self, py::object& dst) {
-            Common::utils::raise_not_implemented();
+        [](RemoteTensorWrapper& self, RemoteTensorWrapper& dst) {
+            self.tensor.copy_to(dst.tensor);
         },
         R"(
-        This method is not implemented.
+        Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
     )");
+
+    cls.def(
+        "copy_to",
+        [](RemoteTensorWrapper& self, ov::Tensor& dst) {
+            self.tensor.copy_to(dst);
+        },
+        R"(
+        Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+    )");
+
+    cls.def(
+        "copy_from",
+        [](RemoteTensorWrapper& self, RemoteTensorWrapper& src) {
+            self.tensor.copy_from(src.tensor);
+        },
+        R"(
+        Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+    )");
+
+    cls.def(
+        "copy_from",
+        [](RemoteTensorWrapper& self, ov::Tensor& src) {
+            self.tensor.copy_from(src);
+        },
+        R"(
+        Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+    )");
+
+    cls.def(
+        "get_shape",
+        [](RemoteTensorWrapper& self) {
+            return self.tensor.get_shape();
+        },
+        R"(
+        Gets Tensor's shape.
+
+        :rtype: openvino.runtime.Shape
+    )");
+
+    cls.def(
+        "get_byte_size",
+        [](RemoteTensorWrapper& self) {
+            return self.tensor.get_byte_size();
+        },
+        R"(
+        Gets Tensor's size in bytes.
+
+        :rtype: int
+        )");
 
     cls.def_property_readonly(
         "data",

--- a/src/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -390,6 +390,9 @@ void regclass_Tensor(py::module m) {
         py::arg("target_tensor"),
         R"(
         Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+
+        :param target_tensor: The destination tensor to which the data will be copied.
+        :type target_tensor: openvino.Tensor
     )");
 
     cls.def(
@@ -399,7 +402,11 @@ void regclass_Tensor(py::module m) {
         },
         py::arg("target_tensor"),
         R"(
-        Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+        Copy tensor's data to a destination remote tensor. The destination remote tensor should have the same element type.
+        In case of RoiRemoteTensor, the destination tensor should also have the same shape.
+
+        :param target_tensor: The destination remote tensor to which the data will be copied.
+        :type target_tensor: openvino.RemoteTensor
     )");
 
     cls.def(
@@ -407,9 +414,12 @@ void regclass_Tensor(py::module m) {
         [](ov::Tensor& self, ov::Tensor& source) {
             return source.copy_to(self);
         },
-        py::arg("source"),
+        py::arg("source_tensor"),
         R"(
         Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+
+        :param source_tensor: The source tensor from which the data will be copied.
+        :type source_tensor: openvino.Tensor
     )");
 
     cls.def(
@@ -417,9 +427,13 @@ void regclass_Tensor(py::module m) {
         [](ov::Tensor& self, RemoteTensorWrapper& source) {
             return source.tensor.copy_to(self);
         },
-        py::arg("source"),
+        py::arg("source_tensor"),
         R"(
-        Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+        Copy source remote tensor's data to this tensor. Tensors should have the same element type.
+        In case of RoiTensor, tensors should also have the same shape.
+
+        :param source_tensor: The source remote tensor from which the data will be copied.
+        :type source_tensor: openvino.RemoteTensor
     )");
 
     cls.def(

--- a/src/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -9,6 +9,7 @@
 
 #include "openvino/runtime/tensor.hpp"
 #include "pyopenvino/core/common.hpp"
+#include "pyopenvino/core/remote_tensor.hpp"
 
 namespace py = pybind11;
 
@@ -156,7 +157,7 @@ void regclass_Tensor(py::module m) {
             R"(
                 Constructs Tensor using port from node.
                 Type and shape will be taken from the port.
-     
+
                 :param port: Output port from a node.
                 :type param: openvino.runtime.Output
              )");
@@ -185,7 +186,7 @@ void regclass_Tensor(py::module m) {
             R"(
             Constructs Tensor using port from node.
             Type and shape will be taken from the port.
-    
+
             :param port: Output port from a node.
             :type param: openvino.runtime.ConstOutput
             )");
@@ -392,9 +393,29 @@ void regclass_Tensor(py::module m) {
     )");
 
     cls.def(
+        "copy_to",
+        [](ov::Tensor& self, RemoteTensorWrapper& dst) {
+            return self.copy_to(dst.tensor);
+        },
+        py::arg("target_tensor"),
+        R"(
+        Copy tensor's data to a destination tensor. The destination tensor should have the same element type and shape.
+    )");
+
+    cls.def(
         "copy_from",
         [](ov::Tensor& self, ov::Tensor& source) {
             return source.copy_to(self);
+        },
+        py::arg("source"),
+        R"(
+        Copy source tensor's data to this tensor. Tensors should have the same element type and shape.
+    )");
+
+    cls.def(
+        "copy_from",
+        [](ov::Tensor& self, RemoteTensorWrapper& source) {
+            return source.tensor.copy_to(self);
         },
         py::arg("source"),
         R"(
@@ -436,7 +457,7 @@ void regclass_Tensor(py::module m) {
             &ov::Tensor::is_continuous,
             R"(
         Reports whether the tensor is continuous or not.
-        :return: True if the tensor is continuous, otherwise False. 
+        :return: True if the tensor is continuous, otherwise False.
         :rtype: bool
     )");
 

--- a/src/bindings/python/tests/test_runtime/test_remote_api.py
+++ b/src/bindings/python/tests/test_runtime/test_remote_api.py
@@ -91,10 +91,6 @@ def test_create_device_tensor_gpu():
         _ = ov.RemoteTensor(np.ones((1, 2, 3)))
     assert "No constructor defined!" in str(constructor_error.value)
 
-    with pytest.raises(RuntimeError) as copy_to_error:
-        _ = tensor.copy_to(None)
-    assert "This function is not implemented." in str(copy_to_error.value)
-
     with pytest.raises(RuntimeError) as data_error:
         _ = tensor.data
     assert "This function is not implemented." in str(data_error.value)
@@ -129,3 +125,145 @@ def test_va_context():
     with pytest.raises(RuntimeError) as context_error:
         _ = ov.VAContext(core, None)
     assert "user handle is nullptr!" in str(context_error.value)
+
+
+@pytest.mark.skipif(
+    "GPU" not in os.environ.get("TEST_DEVICE", ""),
+    reason="Test can be only performed on GPU device!",
+)
+def test_copy_host_to_device_gpu():
+    core = ov.Core()
+    context = core.get_default_context("GPU")
+    assert isinstance(context, ov.RemoteContext)
+    assert "GPU" in context.get_device_name()
+
+    host_tensor_ref = ov.Tensor(ov.Type.f32, ov.Shape([1, 2, 3]))
+
+    random_arr = np.random.rand(*host_tensor_ref.shape).astype(np.float32)
+    host_tensor_ref.data[:] = random_arr
+
+    # allocate remote tensor with smaller shape and expect proper reallocation
+    device_tensor = context.create_tensor(ov.Type.f32, ov.Shape([1, 1, 1]), {})
+
+    # copy to device tensor from host tensor
+    host_tensor_ref.copy_to(device_tensor)
+
+    assert host_tensor_ref.get_shape() == device_tensor.get_shape()
+    assert host_tensor_ref.get_byte_size() == device_tensor.get_byte_size()
+
+    host_tensor_res = ov.Tensor(ov.Type.f32, ov.Shape([1, 2, 3]))
+
+    # copy from device tensor from host tensor
+    host_tensor_res.copy_from(device_tensor)
+
+    assert np.array_equal(host_tensor_res.data, host_tensor_ref.data)
+
+
+@pytest.mark.skipif(
+    "GPU" not in os.environ.get("TEST_DEVICE", ""),
+    reason="Test can be only performed on GPU device!",
+)
+def test_copy_device_to_host_gpu():
+    core = ov.Core()
+    context = core.get_default_context("GPU")
+    assert isinstance(context, ov.RemoteContext)
+    assert "GPU" in context.get_device_name()
+
+    host_tensor_ref = ov.Tensor(ov.Type.f32, ov.Shape([1, 2, 3]))
+
+    random_arr = np.random.rand(*host_tensor_ref.shape).astype(np.float32)
+    host_tensor_ref.data[:] = random_arr
+
+    # allocate remote tensor with smaller shape and expect proper reallocation
+    device_tensor = context.create_tensor(ov.Type.f32, ov.Shape([1, 1, 1]), {})
+
+    # copy from host tensor to  device tensor
+    device_tensor.copy_from(host_tensor_ref)
+
+    assert host_tensor_ref.get_shape() == device_tensor.get_shape()
+    assert host_tensor_ref.get_byte_size() == device_tensor.get_byte_size()
+
+    host_tensor_res = ov.Tensor(ov.Type.f32, ov.Shape([1, 2, 3]))
+
+    # copy to host tensor from device tensor
+    device_tensor.copy_to(host_tensor_res)
+
+    assert np.array_equal(host_tensor_res.data, host_tensor_ref.data)
+
+
+@pytest.mark.skipif(
+    "GPU" not in os.environ.get("TEST_DEVICE", ""),
+    reason="Test can be only performed on GPU device!",
+)
+def test_roi_copy_host_to_device_gpu():
+    core = ov.Core()
+    context = core.get_default_context("GPU")
+    assert isinstance(context, ov.RemoteContext)
+    assert "GPU" in context.get_device_name()
+
+    host_tensor_ref = ov.Tensor(ov.Type.f32, ov.Shape([4, 4, 4]))
+
+    random_arr = np.random.rand(*host_tensor_ref.shape).astype(np.float32)
+    host_tensor_ref.data[:] = random_arr
+
+    begin_roi = ov.runtime.Coordinate([0, 0, 0])
+    end_roi = ov.runtime.Coordinate([3, 4, 4])
+    roi_host_tensor_ref = ov.Tensor(host_tensor_ref, begin_roi, end_roi)
+
+    device_tensor = context.create_tensor(ov.Type.f32, ov.Shape([4, 4, 4]), {})
+    roi_device_tensor = ov.RemoteTensor(device_tensor, begin_roi, end_roi)
+
+    # copy to roi device tensor from roi host tensor
+    roi_host_tensor_ref.copy_to(roi_device_tensor)
+
+    assert roi_host_tensor_ref.get_shape() == roi_device_tensor.get_shape()
+    assert roi_host_tensor_ref.get_byte_size() == roi_device_tensor.get_byte_size()
+
+    host_tensor_res = ov.Tensor(ov.Type.f32, roi_host_tensor_ref.get_shape())
+
+    # copy from roi device tensor from roi host tensor
+    host_tensor_res.copy_from(roi_device_tensor)
+
+    host_tensor_wo_roi = ov.Tensor(ov.Type.f32, roi_host_tensor_ref.get_shape())
+    host_tensor_wo_roi.copy_from(roi_host_tensor_ref)
+
+    assert np.array_equal(host_tensor_res.data, host_tensor_wo_roi.data)
+
+
+@pytest.mark.skipif(
+    "GPU" not in os.environ.get("TEST_DEVICE", ""),
+    reason="Test can be only performed on GPU device!",
+)
+def test_roi_copy_device_to_host_gpu():
+    core = ov.Core()
+    context = core.get_default_context("GPU")
+    assert isinstance(context, ov.RemoteContext)
+    assert "GPU" in context.get_device_name()
+
+    host_tensor_ref = ov.Tensor(ov.Type.f32, ov.Shape([4, 4, 4]))
+
+    random_arr = np.random.rand(*host_tensor_ref.shape).astype(np.float32)
+    host_tensor_ref.data[:] = random_arr
+
+    begin_roi = ov.runtime.Coordinate([1, 2, 1])
+    end_roi = ov.runtime.Coordinate([3, 4, 4])
+    roi_host_tensor_ref = ov.Tensor(host_tensor_ref, begin_roi, end_roi)
+
+    device_tensor = context.create_tensor(ov.Type.f32, ov.Shape([4, 4, 4]), {})
+    roi_device_tensor = ov.RemoteTensor(device_tensor, begin_roi, end_roi)
+
+    # copy from roi host tensor to roi device tensor
+    roi_device_tensor.copy_from(roi_host_tensor_ref)
+
+    assert roi_host_tensor_ref.get_shape() == roi_device_tensor.get_shape()
+    assert roi_host_tensor_ref.get_byte_size() == roi_device_tensor.get_byte_size()
+
+    host_tensor_res = ov.Tensor(ov.Type.f32, roi_host_tensor_ref.get_shape())
+
+    # copy to roi host tensor from roi remote tensor
+    host_tensor_res.copy_from(roi_device_tensor)
+
+    host_tensor_wo_roi = ov.Tensor(ov.Type.f32, roi_host_tensor_ref.get_shape())
+    host_tensor_wo_roi.copy_from(roi_host_tensor_ref)
+
+    assert np.array_equal(host_tensor_res.data, host_tensor_wo_roi.data)

--- a/src/core/dev_api/openvino/runtime/itensor.hpp
+++ b/src/core/dev_api/openvino/runtime/itensor.hpp
@@ -81,7 +81,7 @@ public:
      *
      * @param dst destination tensor
      */
-    void copy_to(const std::shared_ptr<ov::ITensor>& dst) const;
+    virtual void copy_to(const std::shared_ptr<ov::ITensor>& dst) const;
 
 protected:
     virtual ~ITensor();

--- a/src/core/src/runtime/itensor.cpp
+++ b/src/core/src/runtime/itensor.cpp
@@ -56,8 +56,6 @@ void ITensor::copy_to(const std::shared_ptr<ov::ITensor>& dst) const {
     OPENVINO_ASSERT(dst, "Destination tensor was not initialized.");
     OPENVINO_ASSERT(!dynamic_cast<const ov::IRemoteTensor*>(this),
                     "Default copy to doesn't support copy from remote tensor.");
-    OPENVINO_ASSERT(!std::dynamic_pointer_cast<ov::IRemoteTensor>(dst),
-                    "Default copy to doesn't support copy to remote tensor.");
     OPENVINO_ASSERT(dst->get_element_type() == get_element_type(),
                     "Tensor element types are not equal. (src: ",
                     get_element_type(),
@@ -68,6 +66,12 @@ void ITensor::copy_to(const std::shared_ptr<ov::ITensor>& dst) const {
     const auto& shape = get_shape();
     if (shape != dst->get_shape()) {
         dst->set_shape(shape);
+    }
+
+    if (std::dynamic_pointer_cast<ov::IRemoteTensor>(dst)) {
+        auto remote_tensor_dst = std::dynamic_pointer_cast<ov::IRemoteTensor>(dst);
+        remote_tensor_dst->copy_from(shared_from_this());
+        return;
     }
 
     auto* src_data = static_cast<const uint8_t*>(data());

--- a/src/inference/dev_api/openvino/runtime/iremote_tensor.hpp
+++ b/src/inference/dev_api/openvino/runtime/iremote_tensor.hpp
@@ -33,5 +33,23 @@ public:
      * @return Device name
      */
     virtual const std::string& get_device_name() const = 0;
+
+    void copy_to(const std::shared_ptr<ov::ITensor>& dst) const override {
+        const auto zero_offset = 0;
+        copy_to(dst, zero_offset, zero_offset, this->get_shape());
+    }
+
+    virtual void copy_from(const std::shared_ptr<const ov::ITensor>& src) {
+        const auto zero_offset = 0;
+        copy_from(src, zero_offset, zero_offset, this->get_shape());
+    }
+
+    virtual void copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) const {
+        OPENVINO_NOT_IMPLEMENTED;
+    };
+
+    virtual void copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) {
+        OPENVINO_NOT_IMPLEMENTED;
+    };
 };
 }  // namespace ov

--- a/src/inference/dev_api/openvino/runtime/iremote_tensor.hpp
+++ b/src/inference/dev_api/openvino/runtime/iremote_tensor.hpp
@@ -36,19 +36,19 @@ public:
 
     void copy_to(const std::shared_ptr<ov::ITensor>& dst) const override {
         const auto zero_offset = 0;
-        copy_to(dst, zero_offset, zero_offset, this->get_shape());
+        copy_to(dst, zero_offset, zero_offset, {});
     }
 
     virtual void copy_from(const std::shared_ptr<const ov::ITensor>& src) {
         const auto zero_offset = 0;
-        copy_from(src, zero_offset, zero_offset, this->get_shape());
+        copy_from(src, zero_offset, zero_offset, {});
     }
 
-    virtual void copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) const {
+    virtual void copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, const ov::Shape& roi_shape) const {
         OPENVINO_NOT_IMPLEMENTED;
     };
 
-    virtual void copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) {
+    virtual void copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, const ov::Shape& roi_shape) {
         OPENVINO_NOT_IMPLEMENTED;
     };
 };

--- a/src/inference/include/openvino/runtime/remote_tensor.hpp
+++ b/src/inference/include/openvino/runtime/remote_tensor.hpp
@@ -24,6 +24,19 @@ class OPENVINO_RUNTIME_API RemoteTensor : public Tensor {
     using Tensor::Tensor;
 
 public:
+    /// @brief Default constructor
+    RemoteTensor() = default;
+
+    /**
+     * @brief Constructs region of interest (ROI) tensor from another remote tensor.
+     * @note Does not perform memory allocation internally
+     * @param other original tensor
+     * @param begin start coordinate of ROI object inside of the original object.
+     * @param end end coordinate of ROI object inside of the original object.
+     * @note A Number of dimensions in `begin` and `end` must match number of dimensions in `other.get_shape()`
+     */
+    RemoteTensor(const RemoteTensor& other, const Coordinate& begin, const Coordinate& end);
+
     /**
      * @brief Checks OpenVINO remote type.
      * @param tensor Tensor which type is checked.
@@ -43,7 +56,17 @@ public:
     template <typename T>
     T* data() = delete;
 
-    void copy_to(ov::Tensor& dst) const = delete;
+    /**
+     * @brief Copies data from this RemoteTensor to the specified destination tensor.
+     * @param dst The destination tensor to which data will be copied.
+     */
+    void copy_to(ov::Tensor& dst) const;
+
+    /**
+     * @brief Copies data from the specified source tensor to this RemoteTensor.
+     * @param src The source tensor from which data will be copied.
+     */
+    void copy_from(const ov::Tensor& src);
 
     /**
      * @brief Returns a map of device-specific parameters required for low-level

--- a/src/inference/src/cpp/remote_tensor.cpp
+++ b/src/inference/src/cpp/remote_tensor.cpp
@@ -13,6 +13,11 @@
 
 namespace ov {
 
+RemoteTensor::RemoteTensor(const RemoteTensor& owner, const Coordinate& begin, const Coordinate& end) {
+    _impl = make_tensor(std::dynamic_pointer_cast<ov::IRemoteTensor>(owner._impl), begin, end);
+    _so = owner._so;
+}
+
 void RemoteTensor::type_check(const Tensor& tensor, const std::map<std::string, std::vector<std::string>>& type_info) {
     OPENVINO_ASSERT(tensor, "Could not check empty tensor type");
     auto remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(get_tensor_impl(tensor)._ptr);
@@ -53,6 +58,16 @@ AnyMap RemoteTensor::get_params() const {
     } catch (...) {
         OPENVINO_THROW("Unexpected exception");
     }
+}
+
+void RemoteTensor::copy_to(ov::Tensor& dst) const {
+    auto remote_tensor_impl = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl);
+    remote_tensor_impl->copy_to(get_tensor_impl(dst)._ptr);
+}
+
+void RemoteTensor::copy_from(const ov::Tensor& src) {
+    auto remote_tensor_impl = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl);
+    remote_tensor_impl->copy_from(get_tensor_impl(src)._ptr);
 }
 
 std::string RemoteTensor::get_device_name() const {

--- a/src/inference/src/cpp/remote_tensor.cpp
+++ b/src/inference/src/cpp/remote_tensor.cpp
@@ -13,7 +13,20 @@
 
 namespace ov {
 
+#define OV_REMOTE_TENSOR_STATEMENT(remote_tensor, ...)                        \
+    OPENVINO_ASSERT(_impl != nullptr, "Tensor was not initialized.");         \
+    auto remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl); \
+    OPENVINO_ASSERT(remote_tensor, "Tensor is not remote.");                  \
+    try {                                                                     \
+        __VA_ARGS__;                                                          \
+    } catch (const std::exception& ex) {                                      \
+        OPENVINO_THROW(ex.what());                                            \
+    } catch (...) {                                                           \
+        OPENVINO_THROW("Unexpected exception");                               \
+    }
+
 RemoteTensor::RemoteTensor(const RemoteTensor& owner, const Coordinate& begin, const Coordinate& end) {
+    OPENVINO_ASSERT(get_tensor_impl(owner)._ptr, "Cannot create RoiRemoteTensor on top of empty tensor");
     _impl = make_tensor(std::dynamic_pointer_cast<ov::IRemoteTensor>(owner._impl), begin, end);
     _so = owner._so;
 }
@@ -44,43 +57,27 @@ void RemoteTensor::type_check(const Tensor& tensor, const std::map<std::string, 
 }
 
 AnyMap RemoteTensor::get_params() const {
-    OPENVINO_ASSERT(_impl != nullptr, "Tensor was not initialized.");
-    type_check(*this);
-    auto remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl);
-    try {
-        AnyMap paramMap;
+    auto get_params_impl = [](const std::shared_ptr<ov::IRemoteTensor>& remote_tensor,
+                              const std::shared_ptr<void>& so) {
+        ov::AnyMap params_map;
         for (auto&& param : remote_tensor->get_properties()) {
-            paramMap.emplace(param.first, Any{param.second, _so});
+            params_map.emplace(param.first, Any{param.second, so});
         }
-        return paramMap;
-    } catch (const std::exception& ex) {
-        OPENVINO_THROW(ex.what());
-    } catch (...) {
-        OPENVINO_THROW("Unexpected exception");
-    }
+        return params_map;
+    };
+
+    OV_REMOTE_TENSOR_STATEMENT(remote_tensor, return get_params_impl(remote_tensor, _so));
 }
 
 void RemoteTensor::copy_to(ov::Tensor& dst) const {
-    auto remote_tensor_impl = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl);
-    remote_tensor_impl->copy_to(get_tensor_impl(dst)._ptr);
+    OV_REMOTE_TENSOR_STATEMENT(remote_tensor, remote_tensor->copy_to(get_tensor_impl(dst)._ptr));
 }
 
 void RemoteTensor::copy_from(const ov::Tensor& src) {
-    auto remote_tensor_impl = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl);
-    remote_tensor_impl->copy_from(get_tensor_impl(src)._ptr);
+    OV_REMOTE_TENSOR_STATEMENT(remote_tensor, remote_tensor->copy_from(get_tensor_impl(src)._ptr));
 }
 
 std::string RemoteTensor::get_device_name() const {
-    OPENVINO_ASSERT(_impl != nullptr, "Tensor was not initialized.");
-    auto remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(_impl);
-    OPENVINO_ASSERT(remote_tensor, "Tensor is not remote.");
-    type_check(*this);
-    try {
-        return remote_tensor->get_device_name();
-    } catch (const std::exception& ex) {
-        OPENVINO_THROW(ex.what());
-    } catch (...) {
-        OPENVINO_THROW("Unexpected exception");
-    }
+    OV_REMOTE_TENSOR_STATEMENT(remote_tensor, return remote_tensor->get_device_name());
 }
 }  // namespace ov

--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -284,34 +284,23 @@ std::shared_ptr<ITensor> make_tensor(const element::Type element_type, const Sha
 }
 
 /**
- * @brief ROI tensor on other tensor
+ * @brief Base class for representing a Region of Interest (ROI) on another tensor
  * ROI tensor holds the owner
  */
-class RoiTensor : public ITensor {
+class BaseRoiTensor {
 public:
-    RoiTensor(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end)
+    BaseRoiTensor(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end)
         : m_owner{owner},
           m_shape{make_roi_shape(owner->get_shape(), begin, end)},
           m_capacity{m_shape},
-          m_offset{std::inner_product(begin.begin(), begin.end(), get_strides().begin(), static_cast<size_t>(0))} {
-        OPENVINO_ASSERT(get_element_type().bitwidth() >= 8,
-                        "ROI Tensor for types with bitwidths less then 8 bit is not implemented. Tensor type: ",
-                        get_element_type());
+          m_offset{
+              std::inner_product(begin.begin(), begin.end(), m_owner->get_strides().begin(), static_cast<size_t>(0))} {
+        OPENVINO_ASSERT(m_owner->get_element_type().bitwidth() >= 8,
+                        "ROI Tensor for types with bitwidths less than 8 bit is not implemented. Tensor type: ",
+                        m_owner->get_element_type());
     }
 
-    const element::Type& get_element_type() const override {
-        return m_owner->get_element_type();
-    }
-
-    const Strides& get_strides() const override {
-        return m_owner->get_strides();
-    }
-
-    const Shape& get_shape() const override {
-        return m_shape;
-    }
-
-    void set_shape(ov::Shape new_shape) override {
+    void set_shape(ov::Shape new_shape) {
         OPENVINO_ASSERT(new_shape.size() == m_shape.size());
         for (auto new_dim = new_shape.cbegin(), max_dim = m_capacity.cbegin(); new_dim != new_shape.cend();
              ++max_dim, ++new_dim) {
@@ -326,12 +315,7 @@ public:
         m_shape = std::move(new_shape);
     }
 
-    void* data(const element::Type& element_type) const override {
-        auto owner_data = m_owner->data(element_type);
-        return static_cast<uint8_t*>(owner_data) + m_offset;
-    }
-
-private:
+protected:
     std::shared_ptr<ITensor> m_owner;
     Shape m_shape;
     const Shape m_capacity;
@@ -339,7 +323,103 @@ private:
 };
 
 /**
+ * @brief Tensor representing a Region of Interest (ROI) on another host tensor
+ * ROI tensor holds the owner
+ */
+class RoiTensor : public BaseRoiTensor, public ITensor {
+public:
+    RoiTensor(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end)
+        : BaseRoiTensor(owner, begin, end) {}
+
+    const element::Type& get_element_type() const override {
+        return m_owner->get_element_type();
+    }
+
+    const Strides& get_strides() const override {
+        return m_owner->get_strides();
+    }
+
+    const Shape& get_shape() const override {
+        return m_shape;
+    }
+
+    void set_shape(ov::Shape new_shape) override {
+        BaseRoiTensor::set_shape(new_shape);
+    }
+
+    void* data(const element::Type& element_type) const override {
+        auto owner_data = m_owner->data(element_type);
+        return static_cast<uint8_t*>(owner_data) + m_offset;
+    }
+};
+
+/**
+ * @brief Tensor representing a Region of Interest (ROI) on another device tensor
+ * ROI tensor holds the owner
+ */
+class RoiRemoteTensor : public BaseRoiTensor, public IRemoteTensor {
+public:
+    RoiRemoteTensor(const std::shared_ptr<ITensor>& owner, const Coordinate& begin, const Coordinate& end)
+        : BaseRoiTensor(owner, begin, end) {}
+
+    const element::Type& get_element_type() const override {
+        return m_owner->get_element_type();
+    }
+
+    const Strides& get_strides() const override {
+        return m_owner->get_strides();
+    }
+
+    const Shape& get_shape() const override {
+        return m_shape;
+    }
+
+    void set_shape(ov::Shape new_shape) override {
+        BaseRoiTensor::set_shape(new_shape);
+    }
+
+    void copy_to(const std::shared_ptr<ov::ITensor>& dst) const override {
+        auto owner_remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(m_owner);
+
+        if (std::dynamic_pointer_cast<RoiRemoteTensor>(dst)) {
+            auto dst_roi_remote_tensor = std::dynamic_pointer_cast<RoiRemoteTensor>(dst);
+            owner_remote_tensor->copy_to(dst_roi_remote_tensor->m_owner,
+                                         m_offset,
+                                         dst_roi_remote_tensor->m_offset,
+                                         m_shape);
+        } else {
+            owner_remote_tensor->copy_to(dst, m_offset, 0, m_shape);
+        }
+    };
+
+    void copy_from(const std::shared_ptr<const ov::ITensor>& src) override {
+        auto owner_remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(m_owner);
+
+        if (std::dynamic_pointer_cast<const RoiRemoteTensor>(src)) {
+            const auto src_roi_remote_tensor = std::dynamic_pointer_cast<const RoiRemoteTensor>(src);
+            owner_remote_tensor->copy_from(src_roi_remote_tensor->m_owner,
+                                           src_roi_remote_tensor->m_offset,
+                                           m_offset,
+                                           m_shape);
+        } else {
+            owner_remote_tensor->copy_from(src, 0, m_offset, m_shape);
+        }
+    };
+
+    const AnyMap& get_properties() const override {
+        auto remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(m_owner);
+        return remote_tensor->get_properties();
+    };
+
+    const std::string& get_device_name() const override {
+        auto remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(m_owner);
+        return remote_tensor->get_device_name();
+    }
+};
+
+/**
  * @brief Creates ROI tensor
+ * It determines whether the tensor is remote tensor or regular tensor and returns the appropriate ROI tensor type
  *
  * @param other Tensor what owns the memory
  * @param begin Begin coordinates
@@ -350,7 +430,11 @@ private:
 std::shared_ptr<ITensor> make_tensor(const std::shared_ptr<ITensor>& other,
                                      const Coordinate& begin,
                                      const Coordinate& end) {
-    return std::make_shared<RoiTensor>(other, begin, end);
+    if (std::dynamic_pointer_cast<IRemoteTensor>(other)) {
+        return std::make_shared<RoiRemoteTensor>(other, begin, end);
+    } else {
+        return std::make_shared<RoiTensor>(other, begin, end);
+    }
 }
 
 namespace util {

--- a/src/inference/src/dev/make_tensor.cpp
+++ b/src/inference/src/dev/make_tensor.cpp
@@ -382,6 +382,13 @@ public:
         auto owner_remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(m_owner);
 
         if (std::dynamic_pointer_cast<RoiRemoteTensor>(dst)) {
+            OPENVINO_ASSERT(get_shape() == dst->get_shape(),
+                            "Cannot copy to RoiRemoteTensor. Shapes are not equal. (src: ",
+                            get_shape(),
+                            " != dst: ",
+                            dst->get_shape(),
+                            ")");
+
             auto dst_roi_remote_tensor = std::dynamic_pointer_cast<RoiRemoteTensor>(dst);
             owner_remote_tensor->copy_to(dst_roi_remote_tensor->m_owner,
                                          m_offset,
@@ -394,6 +401,13 @@ public:
 
     void copy_from(const std::shared_ptr<const ov::ITensor>& src) override {
         auto owner_remote_tensor = std::dynamic_pointer_cast<ov::IRemoteTensor>(m_owner);
+
+        OPENVINO_ASSERT(src->get_shape() == get_shape(),
+                        "Cannot copy to RoiRemoteTensor. Shapes are not equal. (src: ",
+                        src->get_shape(),
+                        " != dst: ",
+                        get_shape(),
+                        ")");
 
         if (std::dynamic_pointer_cast<const RoiRemoteTensor>(src)) {
             const auto src_roi_remote_tensor = std::dynamic_pointer_cast<const RoiRemoteTensor>(src);

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -143,7 +143,7 @@ void convert_and_copy(const ov::ITensor* src,
                       cldnn::stream& stream,
                       const cldnn::layout& src_layout = cldnn::layout({}, ov::element::undefined, cldnn::format::bfyx, cldnn::padding()));
 void convert_and_copy(const cldnn::memory::ptr src, ov::ITensor const* dst, const cldnn::stream& stream);
-void convert_and_copy(const ov::ITensor* src, ov::ITensor const* dst, const cldnn::stream& stream);
+void convert_and_copy(const ov::ITensor* src, ov::ITensor* dst, const cldnn::stream& stream);
 void convert_and_copy(const cldnn::memory::ptr src, cldnn::memory::ptr dst, cldnn::stream& stream);
 
 }  // namespace intel_gpu

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -37,7 +37,6 @@ public:
     ov::SoPtr<ov::ITensor> create_host_tensor(const ov::element::Type type, const ov::Shape& shape) override;
     ov::SoPtr<ov::IRemoteTensor> create_tensor(const ov::element::Type& type, const ov::Shape& shape, const ov::AnyMap& params) override;
 
-
     cldnn::engine& get_engine() { return *m_engine; }
     ov::intel_gpu::gpu_handle_param get_external_queue() const { return m_external_queue; }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_tensor.hpp
@@ -48,6 +48,9 @@ public:
     const ov::Shape& get_shape() const override;
     const ov::Strides& get_strides() const override;
 
+    void copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) const override;
+    void copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) override;
+
     void allocate();
     bool deallocate() noexcept;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_tensor.hpp
@@ -48,8 +48,8 @@ public:
     const ov::Shape& get_shape() const override;
     const ov::Strides& get_strides() const override;
 
-    void copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) const override;
-    void copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, ov::Shape roi_shape) override;
+    void copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, const ov::Shape& roi_shape) const override;
+    void copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, const ov::Shape& roi_shape) override;
 
     void allocate();
     bool deallocate() noexcept;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -89,6 +89,8 @@ struct data : public primitive_base<data> {
 
                 size_t dst_offset = 0;
                 while (dst_offset < data_size) {
+                    const bool is_blocking = false;
+                    const size_t src_offset = 0;
                     size_t copy_size = (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
                     if (buf_flag) {
                         ib >> make_data(_buf1.data(), copy_size);
@@ -96,14 +98,14 @@ struct data : public primitive_base<data> {
                             ev2->wait();
                             ev2 = nullptr;
                         }
-                        ev1 = mem->copy_from(strm, _buf1.data(), false, dst_offset, copy_size);
+                        ev1 = mem->copy_from(strm, _buf1.data(), src_offset, dst_offset, copy_size, is_blocking);
                     } else {
                         ib >> make_data(_buf2.data(), copy_size);
                         if (ev1 != nullptr) {
                             ev1->wait();
                             ev1 = nullptr;
                         }
-                        ev2 = mem->copy_from(strm, _buf2.data(), false, dst_offset, copy_size);
+                        ev2 = mem->copy_from(strm, _buf2.data(), src_offset, dst_offset, copy_size, is_blocking);
                     }
                     dst_offset += DATA_BLOCK_SIZE;
                     buf_flag = !buf_flag;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -81,11 +81,44 @@ struct memory {
 
         return true;
     }
-    virtual event::ptr copy_from(stream& /* stream */, const memory& /* other */, bool blocking = true) = 0;
-    virtual event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool blocking = true, size_t dst_offset = 0, size_t data_size = 0) = 0;
 
-    virtual event::ptr copy_to(stream& stream, memory& other, bool blocking = true) { return other.copy_from(stream, *this, blocking); }
-    virtual event::ptr copy_to(stream& /* stream */, void* /* host_ptr */, bool blocking = true) = 0;
+    // Device <== Host
+    virtual event::ptr copy_from(stream& stream, const void* src_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) = 0;
+
+    // Device <== Device
+    virtual event::ptr copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) = 0;
+
+    // Device ==> Host
+    virtual event::ptr copy_to(stream& stream, void* dst_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const = 0;
+
+    // Device ==> Device
+    virtual event::ptr copy_to(stream& stream, memory& dst_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const {
+        return dst_mem.copy_from(stream, *this, src_offset, dst_offset, size, blocking);
+    }
+
+    virtual event::ptr copy_from(stream& stream, const memory& src_mem, bool blocking = true) {
+        const auto zero_offset = 0;
+        const auto data_size = src_mem._bytes_count;
+        return copy_from(stream, src_mem, zero_offset, zero_offset, data_size, blocking);
+    }
+
+    virtual event::ptr copy_from(stream& stream, const void* src_ptr, bool blocking = true) {
+        const auto zero_offset = 0;
+        const auto data_size = _bytes_count;
+        return copy_from(stream, src_ptr, zero_offset, zero_offset, data_size, blocking);
+    }
+
+    virtual event::ptr copy_to(stream& stream, memory& other, bool blocking = true) const {
+        const auto zero_offset = 0;
+        const auto data_size = other._bytes_count;
+        return copy_to(stream, other, zero_offset, zero_offset, data_size, blocking);
+    }
+
+    virtual event::ptr copy_to(stream& stream, void* dst_ptr, bool blocking = true) const {
+        const auto zero_offset = 0;
+        const auto data_size = _bytes_count;
+        return copy_to(stream, dst_ptr, zero_offset, zero_offset, data_size, blocking);
+    }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     virtual dnnl::memory get_onednn_memory(dnnl::memory::desc /* desc */, int64_t offset = 0) const {
@@ -124,17 +157,14 @@ struct simple_attached_memory : memory {
 #endif
         0}; };
 
-    event::ptr copy_from(stream& /* stream */, const memory& /* other */, bool /* blocking */) override {
-        OPENVINO_THROW("[GPU] copy_from is not implemented for simple_attached_memory");
+    event::ptr copy_from(stream& stream, const void* src_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override {
+        OPENVINO_NOT_IMPLEMENTED;
     }
-    event::ptr copy_from(stream& /* stream */, const void* /* host_ptr */, bool /* blocking */, size_t /* dst_offset */, size_t /* data_size */) override {
-        OPENVINO_THROW("[GPU] copy_from is not implemented for simple_attached_memory");
+    event::ptr copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override {
+        OPENVINO_NOT_IMPLEMENTED;
     }
-    event::ptr copy_to(stream& /* stream */, memory& /* other */, bool /* blocking */) override {
-        OPENVINO_THROW("[GPU] copy_to is not implemented for simple_attached_memory");
-    }
-    event::ptr copy_to(stream& /* stream */, void* /* host_ptr */, bool /* blocking */) override {
-        OPENVINO_THROW("[GPU] copy_to is not implemented for simple_attached_memory");
+    event::ptr copy_to(stream& stream, void* dst_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const override {
+        OPENVINO_NOT_IMPLEMENTED;
     }
 
 private:

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -17,8 +17,24 @@
 #include <oneapi/dnnl/dnnl_ocl.hpp>
 #endif
 
+#define TRY_CATCH_CL_ERROR(command)           \
+    try {                                     \
+        command;                              \
+    } catch (cl::Error const& err) {          \
+        OPENVINO_THROW(OCL_ERR_MSG_FMT(err)); \
+    }
+
 namespace cldnn {
 namespace ocl {
+
+static inline cldnn::event::ptr create_event(stream& stream, size_t bytes_count, bool need_user_event) {
+    if (bytes_count == 0) {
+        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
+        return stream.create_user_event(true);
+    }
+
+    return need_user_event ? stream.create_user_event(true) : stream.create_base_event();
+}
 
 static int get_cl_map_type(mem_lock_type type) {
     switch (type) {
@@ -112,75 +128,66 @@ shared_mem_params gpu_buffer::get_internal_params() const {
         0};
 }
 
-event::ptr gpu_buffer::copy_from(stream& stream, const memory& other, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    switch (other.get_allocation_type()) {
-    case allocation_type::usm_host:
-    case allocation_type::usm_shared:
-        {
+event::ptr gpu_buffer::copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
+
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
+
+    TRY_CATCH_CL_ERROR(cl_stream->get_cl_queue().enqueueWriteBuffer(_buffer, blocking, dst_offset, size, src_ptr, nullptr, cl_event))
+
+    return result_event;
+}
+
+event::ptr gpu_buffer::copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {
+    auto result_event = create_event(stream, size, false);
+    if (size == 0)
+        return result_event;
+
+    switch (src_mem.get_allocation_type()) {
+        case allocation_type::usm_host:
+        case allocation_type::usm_shared: {
             // If other is gpu_usm, down cast to gpu_buffer is not possible.
             // But it can read as host ptr if it's allocation type is either usm_host or usm_shared.
-            auto& mem_inst = downcast<const gpu_usm>(other);
-            return copy_from(stream, mem_inst.buffer_ptr(), blocking, 0, 0);
+            auto usm_mem = downcast<const gpu_usm>(&src_mem);
+            return copy_from(stream, usm_mem->buffer_ptr(), src_offset, dst_offset, size, blocking);
         }
-    case allocation_type::cl_mem:
-        {
-            auto& cl_stream = downcast<ocl_stream>(stream);
-            auto& mem_inst = downcast<const gpu_buffer>(other);
-            auto ev = stream.create_base_event();
-            cl::Event& ev_ocl = downcast<ocl_event>(ev.get())->get();
-            try {
-                cl_stream.get_cl_queue().enqueueCopyBuffer(mem_inst.get_buffer(), get_buffer(), 0, 0, other.size(), nullptr, &ev_ocl);
-            } catch (cl::Error const& err) {
-                OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-            }
+        case allocation_type::cl_mem: {
+            OPENVINO_ASSERT(!src_mem.get_layout().format.is_image_2d());
+
+            auto cl_stream = downcast<ocl_stream>(&stream);
+            auto cl_mem_buffer = downcast<const gpu_buffer>(&src_mem);
+            auto ev_ocl = &downcast<ocl_event>(result_event.get())->get();
+
+            TRY_CATCH_CL_ERROR(
+                cl_stream->get_cl_queue().enqueueCopyBuffer(cl_mem_buffer->get_buffer(), get_buffer(), src_offset, dst_offset, size, nullptr, ev_ocl));
+
             if (blocking)
-                ev->wait();
+                result_event->wait();
 
-            return ev;
+            return result_event;
         }
-    case allocation_type::usm_device:
-    default:
-        throw std::runtime_error("Unsupported allocation_type.");
+        case allocation_type::usm_device:
+        default:
+            OPENVINO_THROW("[GPU] Unsupported buffer type for gpu_buffer::copy_from() function");
     }
 }
 
-event::ptr gpu_buffer::copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<ocl_stream>(stream);
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    data_size = (data_size == 0) ? size() : data_size;
-    try {
-        cl_stream.get_cl_queue().enqueueWriteBuffer(_buffer, blocking, dst_offset, data_size, host_ptr, nullptr, ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
+event::ptr gpu_buffer::copy_to(stream& stream, void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
 
-    return ev;
-}
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
 
-event::ptr gpu_buffer::copy_to(stream& stream, void* host_ptr, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<ocl_stream>(stream);
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    try {
-        cl_stream.get_cl_queue().enqueueReadBuffer(_buffer, blocking, 0, size(), host_ptr, nullptr, ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
+    TRY_CATCH_CL_ERROR(cl_stream->get_cl_queue().enqueueReadBuffer(_buffer, blocking, src_offset, size, dst_ptr, nullptr, cl_event));
 
-    return ev;
+    return result_event;
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -341,89 +348,63 @@ shared_mem_params gpu_image2d::get_internal_params() const {
         0};
 }
 
-event::ptr gpu_image2d::copy_from(stream& stream, const memory& other, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<const ocl_stream>(stream);
-    auto& casted = downcast<const gpu_image2d>(other);
-    auto ev = stream.create_base_event();
-    cl::Event* ev_ocl = &downcast<ocl_event>(ev.get())->get();
-    try {
-        cl_stream.get_cl_queue().enqueueCopyImage(casted.get_buffer(), get_buffer(),
-                                                {0, 0, 0}, {0, 0, 0}, {_width, _height, 1},
-                                                nullptr, ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
+event::ptr gpu_image2d::copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
+
+    OPENVINO_ASSERT(dst_offset == 0, "[GPU] Unsupported dst_offset value for gpu_image2d::copy_from() function");
+    OPENVINO_ASSERT(size == _bytes_count, "[GPU] Unsupported data_size value for gpu_image2d::copy_from() function");
+
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
+
+    TRY_CATCH_CL_ERROR(
+        cl_stream->get_cl_queue().enqueueWriteImage(_buffer, blocking, {0, 0, 0}, {_width, _height, 1}, _row_pitch, _slice_pitch, src_ptr, nullptr, cl_event));
+
+    return result_event;
+}
+
+event::ptr gpu_image2d::copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {
+    auto result_event = create_event(stream, size, false);
+    if (size == 0)
+        return result_event;
+
+    OPENVINO_ASSERT(src_mem.get_layout().format.is_image_2d(), "Unsupported buffer type for gpu_image2d::copy_from() function");
+    OPENVINO_ASSERT(src_offset == 0, "[GPU] Unsupported dst_offset value for gpu_image2d::copy_from() function");
+    OPENVINO_ASSERT(dst_offset == 0, "[GPU] Unsupported dst_offset value for gpu_image2d::copy_from() function");
+    OPENVINO_ASSERT(size == _bytes_count, "[GPU] Unsupported data_size value for gpu_image2d::copy_from() function");
+
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = &downcast<ocl_event>(result_event.get())->get();
+    auto cl_image_mem = downcast<const gpu_image2d>(&src_mem);
+
+    TRY_CATCH_CL_ERROR(
+        cl_stream->get_cl_queue().enqueueCopyImage(cl_image_mem->get_buffer(), get_buffer(), {0, 0, 0}, {0, 0, 0}, {_width, _height, 1}, nullptr, cl_event));
 
     if (blocking)
-        ev->wait();
+        cl_event->wait();
 
-    return ev;
+    return result_event;
 }
 
-event::ptr gpu_image2d::copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    OPENVINO_ASSERT(dst_offset == 0, "[GPU] dst_offset should be zero for gpu_image2d::copy_from.");
-    OPENVINO_ASSERT(data_size == 0, "[GPU] data_size should be zero for gpu_image2d::copy_from.");
-    auto& cl_stream = downcast<ocl_stream>(stream);
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    try {
-        cl_stream.get_cl_queue().enqueueWriteImage(_buffer, blocking, {0, 0, 0}, {_width, _height, 1},
-                                                    _row_pitch, _slice_pitch, host_ptr, nullptr, ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
+event::ptr gpu_image2d::copy_to(stream& stream, void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
 
-    return ev;
-}
+    OPENVINO_ASSERT(src_offset == 0, "[GPU] Unsupported src_offset value for gpu_image2d::copy_from() function");
+    OPENVINO_ASSERT(size == _bytes_count, "[GPU] Unsupported data_size value for gpu_image2d::copy_from() function");
 
-event::ptr gpu_image2d::copy_to(stream& stream, memory& other, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<const ocl_stream>(stream);
-    auto& casted = downcast<const gpu_image2d>(other);
-    auto ev = stream.create_base_event();
-    cl::Event* ev_ocl = &downcast<ocl_event>(ev.get())->get();
-    try {
-        cl_stream.get_cl_queue().enqueueCopyImage(get_buffer(), casted.get_buffer(),
-                                                {0, 0, 0}, {0, 0, 0}, {_width, _height, 1},
-                                                nullptr, ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
 
+    TRY_CATCH_CL_ERROR(
+        cl_stream->get_cl_queue().enqueueReadImage(_buffer, blocking, {0, 0, 0}, {_width, _height, 1}, _row_pitch, _slice_pitch, dst_ptr, nullptr, cl_event));
 
-    if (blocking)
-        ev->wait();
-
-    return ev;
-}
-
-event::ptr gpu_image2d::copy_to(stream& stream, void* host_ptr, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<ocl_stream>(stream);
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    try {
-        cl_stream.get_cl_queue().enqueueReadImage(_buffer, blocking, {0, 0, 0}, {_width, _height, 1},
-                                                _row_pitch, _slice_pitch, host_ptr, nullptr, ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
-
-    return ev;
+    return result_event;
 }
 
 gpu_media_buffer::gpu_media_buffer(ocl_engine* engine,
@@ -565,91 +546,62 @@ event::ptr gpu_usm::fill(stream& stream) {
     return fill(stream, 0);
 }
 
-event::ptr gpu_usm::copy_from(stream& stream, const memory& other, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<const ocl_stream>(stream);
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    if (other.get_allocation_type() == allocation_type::cl_mem) {
-        // Copy cl_mem to usm_memory by cl::CommandQueue::enqueueReadBuffer()
-        auto& mem_inst = downcast<const gpu_buffer>(other);
-        try {
-            cl_stream.get_cl_queue().enqueueReadBuffer(mem_inst.get_buffer(), blocking, 0, size(), this->buffer_ptr(), nullptr, ev_ocl);
-        } catch (cl::Error const& err) {
-            OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-        }
+event::ptr gpu_usm::copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
+
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto src_ptr = reinterpret_cast<const char*>(data_ptr) + src_offset;
+    auto dst_ptr = reinterpret_cast<char*>(buffer_ptr()) + dst_offset;
+
+    TRY_CATCH_CL_ERROR(cl_stream->get_usm_helper().enqueue_memcpy(cl_stream->get_cl_queue(), dst_ptr, src_ptr, size, blocking, nullptr, cl_event));
+
+    return result_event;
+}
+
+event::ptr gpu_usm::copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
+
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+
+    if (src_mem.get_allocation_type() == allocation_type::cl_mem) {
+        OPENVINO_ASSERT(get_allocation_type() != allocation_type::usm_device, "[GPU] Unsupported allocation type for gpu_usm::copy_from() function");
+
+        auto cl_mem_buffer = downcast<const gpu_buffer>(&src_mem);
+        auto dst_ptr = reinterpret_cast<char*>(buffer_ptr());
+
+        return cl_mem_buffer->copy_to(stream, dst_ptr, src_offset, dst_offset, size, blocking);
+    } else if (memory_capabilities::is_usm_type(src_mem.get_allocation_type())) {
+        auto usm_mem = downcast<const gpu_usm>(&src_mem);
+        auto src_ptr = reinterpret_cast<const char*>(usm_mem->buffer_ptr()) + src_offset;
+        auto dst_ptr = reinterpret_cast<char*>(buffer_ptr()) + dst_offset;
+
+        TRY_CATCH_CL_ERROR(cl_stream->get_usm_helper().enqueue_memcpy(cl_stream->get_cl_queue(), dst_ptr, src_ptr, size, blocking, nullptr, cl_event));
     } else {
-        auto& casted = downcast<const gpu_usm>(other);
-        auto dst_ptr = get_buffer().get();
-        auto src_ptr = casted.get_buffer().get();
-        try {
-            cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(),
-                                                    dst_ptr,
-                                                    src_ptr,
-                                                    _bytes_count,
-                                                    blocking,
-                                                    nullptr,
-                                                    ev_ocl);
-        } catch (cl::Error const& err) {
-            OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-        }
+        OPENVINO_THROW("[GPU] Unsupported allocation type for gpu_usm::copy_from() function");
     }
-    return ev;
+
+    return result_event;
 }
 
-event::ptr gpu_usm::copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<ocl_stream>(stream);
-    auto dst_ptr = get_buffer().get();
-    if (dst_offset > 0) {
-        auto tmp_dst_ptr = reinterpret_cast<char*>(dst_ptr);
-        tmp_dst_ptr += dst_offset;
-        dst_ptr = reinterpret_cast<void*>(tmp_dst_ptr);
-    }
-    data_size = (data_size == 0) ? _bytes_count : data_size;
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    try {
-        cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(),
-                                                dst_ptr,
-                                                host_ptr,
-                                                data_size,
-                                                blocking,
-                                                nullptr,
-                                                ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
-    return ev;
-}
+event::ptr gpu_usm::copy_to(stream& stream, void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const {
+    auto result_event = create_event(stream, size, blocking);
+    if (size == 0)
+        return result_event;
 
-event::ptr gpu_usm::copy_to(stream& stream, void* host_ptr, bool blocking) {
-    if (_bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
-        return stream.create_user_event(true);
-    }
-    auto& cl_stream = downcast<ocl_stream>(stream);
-    auto ev = blocking ? stream.create_user_event(true) : stream.create_base_event();
-    cl::Event* ev_ocl = blocking ? nullptr : &downcast<ocl_event>(ev.get())->get();
-    auto src_ptr = get_buffer().get();
-    try {
-        cl_stream.get_usm_helper().enqueue_memcpy(cl_stream.get_cl_queue(),
-                                                host_ptr,
-                                                src_ptr,
-                                                _bytes_count,
-                                                blocking,
-                                                nullptr,
-                                                ev_ocl);
-    } catch (cl::Error const& err) {
-        OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
-    }
-    return ev;
+    auto cl_stream = downcast<ocl_stream>(&stream);
+    auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
+    auto src_ptr = reinterpret_cast<const char*>(buffer_ptr()) + src_offset;
+    auto dst_ptr = reinterpret_cast<char*>(data_ptr) + dst_offset;
+
+    TRY_CATCH_CL_ERROR(cl_stream->get_usm_helper().enqueue_memcpy(cl_stream->get_cl_queue(), dst_ptr, src_ptr, size, blocking, nullptr, cl_event));
+
+    return result_event;
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -17,9 +17,9 @@
 #include <oneapi/dnnl/dnnl_ocl.hpp>
 #endif
 
-#define TRY_CATCH_CL_ERROR(command)           \
+#define TRY_CATCH_CL_ERROR(...)               \
     try {                                     \
-        command;                              \
+        __VA_ARGS__;                          \
     } catch (cl::Error const& err) {          \
         OPENVINO_THROW(OCL_ERR_MSG_FMT(err)); \
     }
@@ -29,7 +29,7 @@ namespace ocl {
 
 static inline cldnn::event::ptr create_event(stream& stream, size_t bytes_count, bool need_user_event) {
     if (bytes_count == 0) {
-        GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
+        GPU_DEBUG_TRACE_DETAIL << "Skip memory operation for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
     }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
@@ -40,10 +40,9 @@ struct gpu_buffer : public lockable_gpu_mem, public memory {
         return _buffer;
     }
 
-    event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
-    event::ptr copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) override;
-
-    event::ptr copy_to(stream& stream, void* other , bool blocking) override;
+    event::ptr copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override;
+    event::ptr copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override;
+    event::ptr copy_to(stream& stream, void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const override;
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
     dnnl::memory get_onednn_memory(dnnl::memory::desc /* desc */, int64_t offset = 0) const override;
@@ -67,11 +66,9 @@ struct gpu_image2d : public lockable_gpu_mem, public memory {
         return _buffer;
     }
 
-    event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
-    event::ptr copy_from(stream& stream, const void* other, bool blocking, size_t dst_offset, size_t data_size) override;
-
-    event::ptr copy_to(stream& stream, memory& other, bool blocking) override;
-    event::ptr copy_to(stream& stream, void* other, bool blocking) override;
+    event::ptr copy_from(stream& stream, const void* data_ptr, size_t src_offset = 0, size_t dst_offset = 0, size_t size = 0, bool blocking = true) override;
+    event::ptr copy_from(stream& stream, const memory& src_mem, size_t src_offset = 0, size_t dst_offset = 0, size_t size = 0, bool blocking = true) override;
+    event::ptr copy_to(stream& stream, void* data_ptr, size_t src_offset = 0, size_t dst_offset = 0, size_t size = 0, bool blocking = true) const override;
 
 protected:
     cl::Image2D _buffer;
@@ -119,10 +116,10 @@ struct gpu_usm : public lockable_gpu_mem, public memory {
     event::ptr fill(stream& stream) override;
     shared_mem_params get_internal_params() const override;
 
-    event::ptr copy_from(stream& stream, const memory& other, bool blocking) override;
-    event::ptr copy_from(stream& stream, const void* host_ptr, bool blocking, size_t dst_offset, size_t data_size) override;
+    event::ptr copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override;
+    event::ptr copy_from(stream& stream, const memory& src_mem, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override;
+    event::ptr copy_to(stream& stream, void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) const override;
 
-    event::ptr copy_to(stream& stream, void* host_ptr, bool blocking) override;
 #ifdef ENABLE_ONEDNN_FOR_GPU
     dnnl::memory get_onednn_memory(dnnl::memory::desc /* desc */, int64_t offset = 0) const override;
 #endif

--- a/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_gpu/tests/functional/CMakeLists.txt
@@ -30,6 +30,7 @@ ov_add_test_target(
         DEPENDENCIES
             openvino_intel_gpu_plugin
         LINK_LIBRARIES
+            openvino::reference
             funcSharedTests
             OpenCL::NewHeaders # should come before OpenCL::OpenCL
             OpenCL::OpenCL

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -14,6 +14,7 @@
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
 #include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/convert_transpose.hpp"
+#include "openvino/reference/utils/coordinate_transform.hpp"
 
 class OVRemoteTensor_Test : public ov::test::TestsCommon {
 protected:
@@ -2496,98 +2497,312 @@ TEST(OVRemoteContextGPU, smoke_RemoteTensorSetShape) {
     OV_ASSERT_NO_THROW(remote_tensor.set_shape({3, 3, 4, 5}));
 }
 
-TEST(OVRemoteTensorGPU, smoke_RoiRemoteTensor) {
+TEST(RemoteTensor, smoke_CopyToEmptyTensor) {
 #if defined(ANDROID)
     GTEST_SKIP();
 #endif
     auto core = ov::Core();
     auto context = core.get_default_context(ov::test::utils::DEVICE_GPU);
 
-    auto host_tensor_ref = ov::Tensor(ov::element::f32, ov::Shape{3, 2, 3, 4});
-    for (size_t i = 0; i < host_tensor_ref.get_size(); i++) {
-        auto data_ptr = host_tensor_ref.data<float>();
-        data_ptr[i] = i + 0.0;
+    auto empty_remote_tensor = ov::RemoteTensor();
+    auto remote_tensor = context.create_tensor(ov::element::f32, ov::Shape{1, 2, 3, 4});
+
+    OV_EXPECT_THROW_HAS_SUBSTRING(empty_remote_tensor.copy_to(remote_tensor),
+                                  ov::Exception,
+                                  "Check '_impl != nullptr' failed");
+}
+
+TEST(RemoteTensor, smoke_EmptyRoiTensor) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+
+    auto empty_remote_tensor = ov::RemoteTensor();
+
+    OV_EXPECT_THROW_HAS_SUBSTRING(ov::RemoteTensor(empty_remote_tensor, ov::Coordinate{}, ov::Coordinate{}),
+                                  ov::Exception,
+                                  "Cannot create RoiRemoteTensor on top of empty tensor");
+}
+
+struct TestParams {
+    ov::Shape src_shape;
+    ov::Shape dst_shape;
+    ov::Coordinate begin;
+    ov::Coordinate end;
+};
+
+struct RemoteTensor : ::testing::TestWithParam<std::tuple<ov::element::Type, RemoteTensorSharingType, TestParams>> {};
+
+namespace {
+template <class T>
+std::vector<T> fill_data(const ov::Tensor& tensor) {
+    std::vector<T> actual;
+    const T* data = tensor.data<T>();
+    auto strides = tensor.get_strides();
+    for (auto&& c : ov::CoordinateTransformBasic{tensor.get_shape()}) {
+        size_t offset = 0;
+        for (size_t i = 0; i < strides.size(); i++)
+            offset += c[i] * strides[i];
+        actual.emplace_back(*(data + offset / tensor.get_element_type().size()));
     }
+    return actual;
+}
 
-    // Host Tensor to Remote Tensor
-    auto remote_tensor = context.create_tensor(ov::element::f32, ov::Shape{3, 2, 3, 4});
-    remote_tensor.copy_from(host_tensor_ref);
+template <class T>
+void compare_data(const ov::Tensor& src, const ov::Tensor& dst) {
+    auto source_vec = fill_data<T>(src);
+    auto dest_vec = fill_data<T>(dst);
 
+    ASSERT_EQ(source_vec.size(), dest_vec.size());
+
+    for (size_t i = 0; i < source_vec.size(); i++) {
+        ASSERT_EQ(source_vec[i], dest_vec[i]);
+    }
+}
+
+template <ov::element::Type_t ET,
+          typename T = typename ov::element_type_traits<ET>::value_type>
+void init_tensor(const ov::Tensor& tensor) {
+    const auto origPtr = tensor.data<T>();
+    ASSERT_NE(nullptr, origPtr);
+    for (size_t i = 0; i < tensor.get_size(); ++i) {
+        origPtr[i] = static_cast<T>(i);
+    }
+}
+
+void init_tensor(const ov::Tensor& tensor) {
+    switch (tensor.get_element_type()) {
+    case ov::element::f32:
+        init_tensor<ov::element::f32>(tensor);
+        break;
+    case ov::element::u8:
+        init_tensor<ov::element::u8>(tensor);
+        break;
+    default:
+        OPENVINO_THROW("Unsupported data type");
+    }
+}
+
+void compare_tensors(const ov::Tensor& src, const ov::Tensor& dst) {
+    ASSERT_EQ(src.get_byte_size(), dst.get_byte_size());
+    ASSERT_EQ(src.get_size(), dst.get_size());
+    ASSERT_EQ(src.get_element_type(), dst.get_element_type());
+    switch (src.get_element_type()) {
+    case ov::element::f32:
+        compare_data<ov::element_type_traits<ov::element::f32>::value_type>(src, dst);
+        break;
+    case ov::element::u8:
+        compare_data<ov::element_type_traits<ov::element::u8>::value_type>(src, dst);
+        break;
+    default:
+        OPENVINO_THROW("Unsupported data type");
+    }
+}
+
+ov::RemoteTensor create_tensor(ov::intel_gpu::ocl::ClContext context,
+                               RemoteTensorSharingType sharing_type,
+                               const ov::element::Type& type,
+                               const ov::Shape& shape) {
+    switch (sharing_type) {
+        case RemoteTensorSharingType::PLUGIN_CL_TENSOR:
+            return context.create_tensor(type, shape);
+        case RemoteTensorSharingType::PLUGIN_HOST_TENSOR:
+            return context.create_usm_host_tensor(type, shape);
+        case  RemoteTensorSharingType::PLUGIN_USM_DEVICE_TENSOR:
+            return context.create_usm_device_tensor(type, shape);
+        default:
+            OPENVINO_THROW("Unsupported tensor allocation type");
+    }
+}
+}  // namespace
+
+TEST_P(RemoteTensor, smoke_CopyFrom) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    ov::element::Type type;
+    TestParams p;
+    RemoteTensorSharingType sharing_type;
+    std::tie(type, sharing_type, p) = GetParam();
+
+    auto core = ov::Core();
+    auto remote_context = core.get_default_context(ov::test::utils::DEVICE_GPU);
+    auto gpu_context = remote_context.as<ov::intel_gpu::ocl::ClContext>();
+    bool use_roi = p.begin != ov::Coordinate{} && p.end != ov::Coordinate{};
+
+    auto host_tensor_ref = ov::Tensor(type, p.src_shape);
+    init_tensor(host_tensor_ref);
+
+    auto first_remote_tensor = create_tensor(gpu_context, sharing_type, type, p.src_shape);
+    auto second_remote_tensor = create_tensor(gpu_context, sharing_type, type, p.dst_shape);
+
+    // Copy from remote tensor to remote tensor
+    second_remote_tensor.copy_from(first_remote_tensor);
+
+    // Copy from host tensor to remote tensor
+    if (use_roi) {
+        auto roi_host_tensor_ref = ov::Tensor(host_tensor_ref, p.begin, p.end);
+        auto roi_second_remote_tensor = ov::RemoteTensor(second_remote_tensor, p.begin, p.end);
+
+        roi_second_remote_tensor.copy_from(roi_host_tensor_ref);
+
+        auto result_host_tensor = ov::Tensor(type, roi_second_remote_tensor.get_shape());
+        roi_second_remote_tensor.copy_to(result_host_tensor);
+
+        compare_tensors(roi_host_tensor_ref, result_host_tensor);
+    } else {
+        second_remote_tensor.copy_from(host_tensor_ref);
+
+        auto result_host_tensor = ov::Tensor(type, p.src_shape);
+        second_remote_tensor.copy_to(result_host_tensor);
+
+        compare_tensors(host_tensor_ref, result_host_tensor);
+    }
+}
+
+TEST_P(RemoteTensor, smoke_CopyTo) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    ov::element::Type type;
+    TestParams p;
+    RemoteTensorSharingType sharing_type;
+    std::tie(type, sharing_type, p) = GetParam();
+
+    auto core = ov::Core();
+    auto remote_context = core.get_default_context(ov::test::utils::DEVICE_GPU);
+    auto gpu_context = remote_context.as<ov::intel_gpu::ocl::ClContext>();
+    bool use_roi = p.begin != ov::Coordinate{} && p.end != ov::Coordinate{};
+
+    auto host_tensor_ref = ov::Tensor(type, p.src_shape);
+    init_tensor(host_tensor_ref);
+
+    auto first_remote_tensor = create_tensor(gpu_context, sharing_type, type, p.src_shape);
+    auto second_remote_tensor = create_tensor(gpu_context, sharing_type, type, p.dst_shape);
+
+    // Copy to remote tensor from remote tensor
+    first_remote_tensor.copy_to(second_remote_tensor);
+
+    // Copy to remote tensor from host tensor
+    if (use_roi) {
+        auto roi_host_tensor_ref = ov::Tensor(host_tensor_ref, p.begin, p.end);
+        auto roi_second_remote_tensor = ov::RemoteTensor(second_remote_tensor, p.begin, p.end);
+
+        roi_host_tensor_ref.copy_to(roi_second_remote_tensor);
+
+        auto result_host_tensor = ov::Tensor(type, roi_second_remote_tensor.get_shape());
+        roi_second_remote_tensor.copy_to(result_host_tensor);
+
+        compare_tensors(roi_host_tensor_ref, result_host_tensor);
+    } else {
+        host_tensor_ref.copy_to(second_remote_tensor);
+
+        auto host_tensor = ov::Tensor(type, p.src_shape);
+        second_remote_tensor.copy_to(host_tensor);
+
+        compare_tensors(host_tensor_ref, host_tensor);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(copy_tests,
+                         RemoteTensor,
+                         ::testing::Combine(::testing::Values(ov::element::u8,
+                                                              ov::element::f32),
+                                            ::testing::Values(RemoteTensorSharingType::PLUGIN_CL_TENSOR,
+                                                              RemoteTensorSharingType::PLUGIN_USM_DEVICE_TENSOR,
+                                                              RemoteTensorSharingType::PLUGIN_HOST_TENSOR),
+                                            ::testing::Values(TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
+                                                                  ov::Coordinate{}, ov::Coordinate{}
+                                                              },
+                                                              TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{1, 3, 2, 5},
+                                                                  ov::Coordinate{}, ov::Coordinate{}
+                                                              },
+                                                              TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
+                                                                  ov::Coordinate{0, 0, 0, 0}, ov::Coordinate{2, 3, 2, 5}
+                                                              },
+                                                              TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
+                                                                  ov::Coordinate{0, 0, 0, 4}, ov::Coordinate{2, 3, 2, 5}
+                                                              },
+                                                              TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
+                                                                  ov::Coordinate{2, 1, 1, 4}, ov::Coordinate{4, 3, 2, 5}
+                                                              })));
+
+TEST(RemoteTensor, smoke_CanSetRoiRemoteTensor) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    auto core = ov::Core();
+    auto model = ov::test::behavior::getDefaultNGraphFunctionForTheDevice();
+
+    auto compiled_model = core.compile_model(model, ov::test::utils::DEVICE_GPU);
+
+    auto input = model->get_parameters().at(0);
+    auto output = model->get_results().at(0);
+
+    auto input_shape = input->get_shape();
+    auto output_shape = output->get_shape();
+
+    auto gpu_context = compiled_model.get_context().as<ov::intel_gpu::ocl::ClContext>();
+    cl_context ctx = gpu_context;
+    auto ocl_instance = std::make_shared<OpenCL>(ctx);
+
+    auto host_tensor = ov::Tensor(input->get_element_type(), input_shape);
+    init_tensor(host_tensor);
+
+    auto output_tensor_copy_0 = ov::Tensor(output->get_element_type(), output_shape);
+    auto output_tensor_copy_1 = ov::Tensor(output->get_element_type(), output_shape);
+
+    auto infer_request = compiled_model.create_infer_request();
     {
-        auto host_tensor = ov::Tensor(ov::element::f32, ov::Shape{3, 2, 3, 4});
-        remote_tensor.copy_to(host_tensor);
+        auto user_input_tensor = gpu_context.create_tensor(input->get_element_type(), input_shape);
+        auto user_output_tensor = gpu_context.create_tensor(output->get_element_type(), output_shape);
 
-        for (size_t i = 0; i < host_tensor.get_size(); i++) {
-            auto data_ptr_ref = host_tensor_ref.data<float>();
-            auto data_ptr = host_tensor.data<float>();
-            ASSERT_EQ(data_ptr_ref[i], data_ptr[i]);
-        }
+        user_input_tensor.copy_from(host_tensor);
+
+        infer_request.set_tensor(input, user_input_tensor);
+        infer_request.set_tensor(output, user_output_tensor);
+
+        OV_ASSERT_NO_THROW(infer_request.infer());
+
+        auto output_tensor = infer_request.get_tensor(output);
+        ASSERT_EQ(output_tensor.get_shape(), output_shape);
+
+        output_tensor.copy_to(output_tensor_copy_0);
     }
-
-    // Remote Tensor to Remote Tensor
-    auto new_remote_tensor = context.create_tensor(ov::element::f32, ov::Shape{3, 2, 3, 4});
-    remote_tensor.copy_to(new_remote_tensor);
-
     {
-        auto host_tensor = ov::Tensor(ov::element::f32, ov::Shape{3, 2, 3, 4});
-        new_remote_tensor.copy_to(host_tensor);
+        auto larger_input_shape = input_shape;
+        for (size_t i = 0; i < input_shape.size(); i++)
+            larger_input_shape[i] += 2;
 
-        for (size_t i = 0; i < host_tensor.get_size(); i++) {
-            auto data_ptr_ref = host_tensor_ref.data<float>();
-            auto data_ptr = host_tensor.data<float>();
-            ASSERT_EQ(data_ptr_ref[i], data_ptr[i]);
-        }
+        auto larger_output_shape = input_shape;
+        for (size_t i = 0; i < input_shape.size(); i++)
+            larger_output_shape[i] += 2;
+
+        auto roi_begin = ov::Coordinate(input_shape.size(), 2);
+        auto roi_end = ov::Coordinate(larger_input_shape);
+
+        auto user_input_tensor = gpu_context.create_tensor(input->get_element_type(), larger_input_shape);
+        auto user_input_tensor_roi = ov::RemoteTensor(user_input_tensor, roi_begin, roi_end);
+        auto user_output_tensor = gpu_context.create_tensor(output->get_element_type(), larger_output_shape);
+        auto user_output_tensor_roi = ov::RemoteTensor(user_output_tensor, roi_begin, roi_end);
+
+        user_input_tensor_roi.copy_from(host_tensor);
+
+        infer_request.set_tensor(input, user_input_tensor_roi);
+        infer_request.set_tensor(output, user_output_tensor_roi);
+
+        OV_ASSERT_NO_THROW(infer_request.infer());
+
+        auto output_tensor = infer_request.get_tensor(output);
+        ASSERT_EQ(output_tensor.get_shape(), output_shape);
+
+        output_tensor.copy_to(output_tensor_copy_1);
     }
 
-    // Update reference values
-    for (size_t i = 0; i < host_tensor_ref.get_size(); i++) {
-        auto data_ptr = host_tensor_ref.data<float>();
-        data_ptr[i] = i + 0.1;
-    }
-
-    auto roi_host_tensor_ref = ov::Tensor(host_tensor_ref, {1, 0, 0, 0}, {3, 2, 3, 4});
-    auto roi_remote_tensor = ov::RemoteTensor(remote_tensor, {1, 0, 0, 0}, {3, 2, 3, 4});
-
-    // Host ROI Tensor to Remote ROI Tensor
-    roi_host_tensor_ref.copy_to(roi_remote_tensor);
-
-    {
-        auto host_tensor = ov::Tensor(ov::element::f32, ov::Shape{2, 2, 3, 4});
-        roi_remote_tensor.copy_to(host_tensor);
-
-        auto host_tensor_ref_new = ov::Tensor(ov::element::f32, ov::Shape{2, 2, 3, 4});
-        roi_host_tensor_ref.copy_to(host_tensor_ref_new);
-
-        for (size_t i = 0; i < host_tensor.get_size(); i++) {
-            auto data_ptr_ref = host_tensor_ref_new.data<float>();
-            auto data_ptr = host_tensor.data<float>();
-            ASSERT_EQ(data_ptr_ref[i], data_ptr[i]) << i;
-        }
-    }
-
-    // Update reference values
-    for (size_t i = 0; i < host_tensor_ref.get_size(); i++) {
-        auto data_ptr = host_tensor_ref.data<float>();
-        data_ptr[i] = i + 0.2;
-    }
-
-    roi_host_tensor_ref = ov::Tensor(host_tensor_ref, {1, 0, 0, 2}, {3, 2, 3, 4});
-    roi_remote_tensor = ov::RemoteTensor(remote_tensor, {1, 0, 0, 2}, {3, 2, 3, 4});
-
-    // Host ROI Tensor to Remote ROI Tensor
-    roi_remote_tensor.copy_from(roi_host_tensor_ref);
-
-    {
-        auto host_tensor = ov::Tensor(ov::element::f32, ov::Shape{2, 2, 3, 2});
-        roi_remote_tensor.copy_to(host_tensor);
-
-        auto host_tensor_ref_new = ov::Tensor(ov::element::f32, ov::Shape{2, 2, 3, 2});
-        roi_host_tensor_ref.copy_to(host_tensor_ref_new);
-
-        for (size_t i = 0; i < host_tensor.get_size(); i++) {
-            auto data_ptr_ref = host_tensor_ref_new.data<float>();
-            auto data_ptr = host_tensor.data<float>();
-            ASSERT_EQ(data_ptr_ref[i], data_ptr[i]) << i;
-        }
-    }
+    compare_tensors(output_tensor_copy_0, output_tensor_copy_1);
 }

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -2639,12 +2639,20 @@ TEST_P(RemoteTensor, smoke_CopyFrom) {
     // Copy from remote tensor to remote tensor
     second_remote_tensor.copy_from(first_remote_tensor);
 
+    // Check updated shape after copy_from call
+    ASSERT_EQ(second_remote_tensor.get_shape(), first_remote_tensor.get_shape());
+
     // Copy from host tensor to remote tensor
     if (use_roi) {
         auto roi_host_tensor_ref = ov::Tensor(host_tensor_ref, p.begin, p.end);
         auto roi_second_remote_tensor = ov::RemoteTensor(second_remote_tensor, p.begin, p.end);
+        auto second_remote_tensor_shape = second_remote_tensor.get_shape();
 
         roi_second_remote_tensor.copy_from(roi_host_tensor_ref);
+
+        // Ensure that the shape of the underlying RemoteTensor of RoiRemoteTensor remains unchanged
+        ASSERT_EQ(second_remote_tensor.get_shape(), second_remote_tensor_shape);
+        ASSERT_EQ(roi_second_remote_tensor.get_shape(), roi_host_tensor_ref.get_shape());
 
         auto result_host_tensor = ov::Tensor(type, roi_second_remote_tensor.get_shape());
         roi_second_remote_tensor.copy_to(result_host_tensor);
@@ -2683,12 +2691,20 @@ TEST_P(RemoteTensor, smoke_CopyTo) {
     // Copy to remote tensor from remote tensor
     first_remote_tensor.copy_to(second_remote_tensor);
 
+    // Check updated shape after copy_to call
+    ASSERT_EQ(second_remote_tensor.get_shape(), first_remote_tensor.get_shape());
+
     // Copy to remote tensor from host tensor
     if (use_roi) {
         auto roi_host_tensor_ref = ov::Tensor(host_tensor_ref, p.begin, p.end);
         auto roi_second_remote_tensor = ov::RemoteTensor(second_remote_tensor, p.begin, p.end);
+        auto second_remote_tensor_shape = second_remote_tensor.get_shape();
 
         roi_host_tensor_ref.copy_to(roi_second_remote_tensor);
+
+        // Ensure that the shape of the underlying RemoteTensor of RoiRemoteTensor remains unchanged
+        ASSERT_EQ(second_remote_tensor.get_shape(), second_remote_tensor_shape);
+        ASSERT_EQ(roi_second_remote_tensor.get_shape(), roi_host_tensor_ref.get_shape());
 
         auto result_host_tensor = ov::Tensor(type, roi_second_remote_tensor.get_shape());
         roi_second_remote_tensor.copy_to(result_host_tensor);
@@ -2730,6 +2746,14 @@ INSTANTIATE_TEST_SUITE_P(copy_tests,
                                                               TestParams {
                                                                   ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
                                                                   ov::Coordinate{2, 1, 1, 4}, ov::Coordinate{4, 3, 2, 5}
+                                                              },
+                                                              TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
+                                                                  ov::Coordinate{2, 0, 1, 0}, ov::Coordinate{4, 3, 2, 5}
+                                                              },
+                                                              TestParams {
+                                                                  ov::Shape{4, 3, 2, 5}, ov::Shape{4, 3, 2, 5},
+                                                                  ov::Coordinate{0, 1, 1, 0}, ov::Coordinate{4, 2, 2, 3}
                                                               })));
 
 TEST(RemoteTensor, smoke_CanSetRoiRemoteTensor) {

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -24,6 +24,7 @@
 #include "program_wrapper.h"
 
 #include <memory>
+#include <tuple>
 
 using namespace cldnn;
 using namespace ::tests;
@@ -40,6 +41,23 @@ struct usm_test_params{
     allocation_type type;
 };
 
+static void init_device_and_engine(std::shared_ptr<ocl::ocl_device>& device,
+                                   std::shared_ptr<ocl::ocl_engine>& engine,
+                                   bool& supports_usm) {
+    // Find device, which supports USMs.
+    device_query query(engine_types::ocl, runtime_types::ocl);
+    auto devices = query.get_available_devices();
+    for (const auto& d : devices) {
+        if (d.second->get_mem_caps().supports_usm()) {
+            device = std::dynamic_pointer_cast<ocl::ocl_device>(d.second);
+            supports_usm = true;
+            break;
+        }
+    }
+
+    engine = std::dynamic_pointer_cast<ocl::ocl_engine>(engine::create(engine_types::ocl, runtime_types::ocl, device));
+}
+
 class BaseUSMTest : public ::testing::TestWithParam<usm_test_params> {
 protected:
     std::shared_ptr<ocl::ocl_device> _device = nullptr;
@@ -47,20 +65,11 @@ protected:
     bool _supports_usm = false;
 public:
     void SetUp() override {
-        // Find device, which supports USMs.
-        device_query query(engine_types::ocl, runtime_types::ocl);
-        auto devices = query.get_available_devices();
-        for (const auto& d : devices) {
-            if (d.second->get_mem_caps().supports_usm()) {
-                _device = std::dynamic_pointer_cast<ocl::ocl_device>(d.second);
-                break;
-            }
+        init_device_and_engine(_device, _engine, _supports_usm);
+
+        if (!_device || !_engine || !_supports_usm) {
+            GTEST_SKIP();
         }
-        if (!_device) {
-            GTEST_SUCCEED();
-        }
-        _engine = std::dynamic_pointer_cast<ocl::ocl_engine>(engine::create(engine_types::ocl, runtime_types::ocl, _device));
-        _supports_usm = true;
     }
 
     bool supports_usm() const { return _supports_usm; }
@@ -339,80 +348,153 @@ INSTANTIATE_TEST_SUITE_P(cldnn_usm, copy_between_gpu_buffer_and_gpu_usm, ::testi
     usm_test_params{ allocation_type::usm_device },
 }));
 
-class offset_usm_copy : public BaseUSMTest {};
-TEST_P(offset_usm_copy, basic) {
-    auto p = GetParam();
-    if (!supports_usm()) {
-        return;
+struct mem_test_params {
+    size_t src_offset;
+    size_t dst_offset;
+    size_t size;
+};
+
+class offset_copy_host : public ::testing::TestWithParam<std::tuple<allocation_type, mem_test_params, bool>> {
+protected:
+    std::shared_ptr<ocl::ocl_device> _device = nullptr;
+    std::shared_ptr<ocl::ocl_engine> _engine = nullptr;
+    bool _supports_usm = false;
+public:
+    void SetUp() override {
+        init_device_and_engine(_device, _engine, _supports_usm);
+
+        if (!_device || !_engine || !_supports_usm) {
+            GTEST_SKIP();
+        }
     }
-    try {
-        ocl::ocl_stream stream(*_engine, {});
 
-        size_t values_count = 100;
-        size_t values_bytes_count = values_count * sizeof(float);
-        std::vector<float> src_buffer(values_count);
-        std::iota(src_buffer.begin(), src_buffer.end(), 0.0f);
+    bool supports_usm() const { return _supports_usm; }
+};
 
-        cldnn::layout linear_layout = cldnn::layout(cldnn::data_types::f32, cldnn::format::bfyx, cldnn::tensor(1, 1, int32_t(values_count), 1));
-        auto usm_host_src = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
+class offset_copy : public ::testing::TestWithParam<std::tuple<allocation_type, allocation_type, mem_test_params, bool>> {
+protected:
+    std::shared_ptr<ocl::ocl_device> _device = nullptr;
+    std::shared_ptr<ocl::ocl_engine> _engine = nullptr;
+    bool _supports_usm = false;
+public:
+    void SetUp() override {
+        init_device_and_engine(_device, _engine, _supports_usm);
 
-        // Fill usm_host_src memory.
-        cldnn::mem_lock<float> lock(usm_host_src, stream);
-        std::copy(src_buffer.begin(), src_buffer.end(), lock.data());
+        if (!_device || !_engine || !_supports_usm) {
+            GTEST_SKIP();
+        }
+    }
 
-        // Create dst memory
-        auto mem_dst = _engine->allocate_memory(linear_layout, p.type);
+    bool supports_usm() const { return _supports_usm; }
+};
 
-        // Fill dst memory
-        switch (p.type) {
-        case allocation_type::usm_host:
-        case allocation_type::usm_shared:
-        case allocation_type::usm_device:
-        {
-            auto ev = mem_dst->copy_from(stream, usm_host_src->buffer_ptr(), 0, 32, mem_dst->size(), true);
-            ev->wait();
-            break;
-        }
-        case allocation_type::cl_mem: {
-            auto ev = mem_dst->copy_from(stream, usm_host_src->buffer_ptr(), 0, 32, mem_dst->size(), true);
-            ev->wait();
-            break;
-        }
-        default:
-            FAIL() << "Not supported allocation type!";
-        }
+TEST_P(offset_copy, basic) {
+    allocation_type src_allocation_type;
+    allocation_type dst_allocation_type;
+    mem_test_params params;
+    bool use_copy_to;
+    std::tie(src_allocation_type, dst_allocation_type, params, use_copy_to) = GetParam();
 
-        // Read from dst mem
-        std::vector<float> dst_buffer(values_count);
-        switch (p.type) {
-        case allocation_type::usm_host:
-        case allocation_type::usm_shared: {
-            cldnn::mem_lock<float> lock(mem_dst, stream);
-            std::memcpy(dst_buffer.data(), lock.data(), values_bytes_count);
-            break;
-        }
-        case allocation_type::usm_device:
-        case allocation_type::cl_mem: {
-            auto host_buf = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
-            host_buf->copy_from(stream, *mem_dst);
-            {
-                cldnn::mem_lock<float> lock(host_buf, stream);
-                std::memcpy(dst_buffer.data(), lock.data(), values_bytes_count);
-            }
-            break;
-        }
-        default:
-            FAIL() << "Not supported allocation type!";
-        }
-        bool are_equal = std::equal(src_buffer.begin(), src_buffer.begin() + 8, dst_buffer.begin() + 8);
-        ASSERT_EQ(true, are_equal);
-    } catch (const char* msg) {
-        FAIL() << msg;
+    bool skip_test = false;
+    skip_test |= src_allocation_type == allocation_type::unknown && use_copy_to;
+    skip_test |= dst_allocation_type == allocation_type::unknown && !use_copy_to;
+
+    if (skip_test) {
+        GTEST_SKIP();
+    }
+
+    const auto copy_size = params.size;
+    const auto src_size = params.src_offset + copy_size;
+    const auto dst_size = params.dst_offset + copy_size;
+
+    auto stream = ocl::ocl_stream(*_engine, {});
+    const auto src_layout = cldnn::layout({static_cast<int64_t>(src_size)}, cldnn::data_types::u8, cldnn::format::bfyx);
+    const auto dst_layout = cldnn::layout({static_cast<int64_t>(dst_size)}, cldnn::data_types::u8, cldnn::format::bfyx);
+
+    std::vector<uint8_t> src_buffer(src_size);
+    for (size_t i = 0; i < src_size; i++)
+        src_buffer[i] = i % 64;
+
+    // Allocate and fill src memory
+    auto src_memory = _engine->allocate_memory(src_layout, src_allocation_type);
+
+    {
+        const auto src_offset = 0;
+        const auto dst_offset = 0;
+        src_memory->copy_from(stream, src_buffer.data(), src_offset, dst_offset, src_size, true);
+    }
+
+    // Create dst memory and copy data
+    auto dst_memory = _engine->allocate_memory(dst_layout, dst_allocation_type);
+
+    if (use_copy_to) {
+        src_memory->copy_to(stream, *dst_memory, params.src_offset, params.dst_offset, copy_size, true);
+    } else {
+        dst_memory->copy_from(stream, *src_memory, params.src_offset, params.dst_offset, copy_size, true);
+    }
+
+    // Read from dst mem
+    std::vector<uint8_t> dst_buffer(copy_size);
+
+    {
+        const auto src_offset = params.dst_offset;
+        const auto dst_offset = 0;
+        dst_memory->copy_to(stream, dst_buffer.data(), src_offset, dst_offset, copy_size, true);
+    }
+
+    for (size_t i = 0; i < copy_size; i++) {
+        ASSERT_EQ(src_buffer[i + params.src_offset], dst_buffer[i]) << i << "\n";
     }
 }
 
-INSTANTIATE_TEST_SUITE_P(cldnn_usm, offset_usm_copy, ::testing::ValuesIn(std::vector<usm_test_params>{
-    usm_test_params{ allocation_type::cl_mem },
-    usm_test_params{ allocation_type::usm_host },
-    usm_test_params{ allocation_type::usm_device },
-}));
+TEST_P(offset_copy_host, basic) {
+    allocation_type allocation_type;
+    mem_test_params params;
+    bool use_copy_to;
+    std::tie(allocation_type, params, use_copy_to) = GetParam();
+
+    const auto copy_size = params.size;
+    const auto src_size = params.src_offset + copy_size;
+    const auto mem_size = params.dst_offset + copy_size;
+
+    auto stream = ocl::ocl_stream(*_engine, {});
+    const auto mem_layout = cldnn::layout({static_cast<int64_t>(mem_size)}, cldnn::data_types::u8, cldnn::format::bfyx);
+
+    std::vector<uint8_t> src_buffer(src_size);
+    std::vector<uint8_t> dst_buffer(src_size);
+    for (size_t i = 0; i < src_size; i++)
+        src_buffer[i] = i % 64;
+
+    auto memory = _engine->allocate_memory(mem_layout, allocation_type);
+    memory->copy_from(stream, src_buffer.data(), params.src_offset, params.dst_offset, copy_size, true);
+    memory->copy_to(stream, dst_buffer.data(), params.dst_offset, params.src_offset, copy_size, true);
+
+    for (size_t i = 0; i < copy_size; i++) {
+        ASSERT_EQ(src_buffer[i + params.src_offset], dst_buffer[i + params.src_offset]) << i << "\n";
+    }
+}
+
+static std::vector<allocation_type> test_memory_types { allocation_type::cl_mem,
+                                                        allocation_type::usm_host,
+                                                        allocation_type::usm_device };
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(mem_test,
+                         offset_copy,
+                         ::testing::Combine(::testing::ValuesIn(test_memory_types),
+                                            ::testing::ValuesIn(test_memory_types),
+                                            ::testing::Values(mem_test_params{0, 0, 381},
+                                                              mem_test_params{100, 0, 381},
+                                                              mem_test_params{0, 79, 381},
+                                                              mem_test_params{100, 79, 381}),
+                                            ::testing::Values(false, true)));
+
+// clang-format off
+INSTANTIATE_TEST_SUITE_P(mem_test,
+                         offset_copy_host,
+                         ::testing::Combine(::testing::ValuesIn(test_memory_types),
+                                            ::testing::Values(mem_test_params{0, 0, 381},
+                                                              mem_test_params{100, 0, 381},
+                                                              mem_test_params{0, 79, 381},
+                                                              mem_test_params{100, 79, 381}),
+                                            ::testing::Values(false, true)));

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -129,13 +129,12 @@ TEST_P(copy_and_read_buffer, basic) {
             break;
         }
         case allocation_type::usm_device: {
-            auto casted = std::dynamic_pointer_cast<ocl::gpu_usm>(cldnn_mem_src);
             auto host_buf = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
             {
                 cldnn::mem_lock<float> lock(host_buf, stream);
                 std::copy(src_buffer.begin(), src_buffer.end(), lock.data());
             }
-            casted->copy_from(stream, *host_buf, true);
+            cldnn_mem_src->copy_from(stream, *host_buf, true);
             break;
         }
         default:
@@ -288,17 +287,15 @@ TEST_P(copy_between_gpu_buffer_and_gpu_usm, basic) {
         // Fill dst memory
         switch (p.type) {
         case allocation_type::usm_host:
-        case allocation_type::usm_shared: 
+        case allocation_type::usm_shared:
         case allocation_type::usm_device:
         {
-            auto casted = std::dynamic_pointer_cast<ocl::gpu_usm>(mem_dst);
-            auto ev = casted->copy_from(stream, *usm_host_src, true);
+            auto ev = mem_dst->copy_from(stream, *usm_host_src, true);
             ev->wait();
             break;
         }
         case allocation_type::cl_mem: {
-            auto casted = std::dynamic_pointer_cast<ocl::gpu_buffer>(mem_dst);
-            auto ev = casted->copy_from(stream, *usm_host_src, true);
+            auto ev = mem_dst->copy_from(stream, *usm_host_src, true);
             ev->wait();
             break;
         }
@@ -315,7 +312,7 @@ TEST_P(copy_between_gpu_buffer_and_gpu_usm, basic) {
             std::memcpy(dst_buffer.data(), lock.data(), values_bytes_count);
             break;
         }
-        case allocation_type::usm_device: 
+        case allocation_type::usm_device:
         case allocation_type::cl_mem: {
             auto host_buf = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
             host_buf->copy_from(stream, *mem_dst);
@@ -369,17 +366,15 @@ TEST_P(offset_usm_copy, basic) {
         // Fill dst memory
         switch (p.type) {
         case allocation_type::usm_host:
-        case allocation_type::usm_shared: 
+        case allocation_type::usm_shared:
         case allocation_type::usm_device:
         {
-            auto casted = std::dynamic_pointer_cast<ocl::gpu_usm>(mem_dst);
-            auto ev = casted->copy_from(stream, usm_host_src->buffer_ptr(), true, 32, 32);
+            auto ev = mem_dst->copy_from(stream, usm_host_src->buffer_ptr(), 0, 32, mem_dst->size(), true);
             ev->wait();
             break;
         }
         case allocation_type::cl_mem: {
-            auto casted = std::dynamic_pointer_cast<ocl::gpu_buffer>(mem_dst);
-            auto ev = casted->copy_from(stream, usm_host_src->buffer_ptr(), true, 32, 32);
+            auto ev = mem_dst->copy_from(stream, usm_host_src->buffer_ptr(), 0, 32, mem_dst->size(), true);
             ev->wait();
             break;
         }
@@ -396,7 +391,7 @@ TEST_P(offset_usm_copy, basic) {
             std::memcpy(dst_buffer.data(), lock.data(), values_bytes_count);
             break;
         }
-        case allocation_type::usm_device: 
+        case allocation_type::usm_device:
         case allocation_type::cl_mem: {
             auto host_buf = _engine->allocate_memory(linear_layout, allocation_type::usm_host);
             host_buf->copy_from(stream, *mem_dst);

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -395,14 +395,6 @@ TEST_P(offset_copy, basic) {
     bool use_copy_to;
     std::tie(src_allocation_type, dst_allocation_type, params, use_copy_to) = GetParam();
 
-    bool skip_test = false;
-    skip_test |= src_allocation_type == allocation_type::unknown && use_copy_to;
-    skip_test |= dst_allocation_type == allocation_type::unknown && !use_copy_to;
-
-    if (skip_test) {
-        GTEST_SKIP();
-    }
-
     const auto copy_size = params.size;
     const auto src_size = params.src_offset + copy_size;
     const auto dst_size = params.dst_offset + copy_size;


### PR DESCRIPTION
The idea of these changes is to allow more flexible interaction between remote tensors and host tensors, enabling the implementation of features like swap_blocks in vLLM

### Details:
- Made `ITensor::copy_to()` function virtual to allow proper underlying implementation call of `copy_to()` for ov::Tensor
- Added `copy_to(const std::shared_ptr<ov::ITensor>& dst)` and `copy_from(const std::shared_ptr<const ov::ITensor>& src)` functions to `IRemoteTensor` class, and pure virtual functions `copy_to(const std::shared_ptr<ov::ITensor>& dst, size_t src_offset, size_t dst_offset, ov::Shape roi_shape)` and `copy_from(const std::shared_ptr<const ov::ITensor>& src, size_t src_offset, size_t dst_offset, ov::Shape roi_shape)`, which are supposed to be defined in the RemoteTensor implementation itself
- Allowed RemoteTensor as dst argument for `ITensor::copy_to()` with a corresponding redirecting `IRemoteTensor::copy_from()` call
- Added `RoiRemoteTensor` to implement region-specific copying for remote tensors
- Added `copy_to(ov::Tensor& dst)` and `copy_from(ov::Tensor& src)` to `ov::RemoteTensor` class, allowing to interact with any host tensors, remote tensors, ROI remote tensors
- Refactored `copy_to()` / `copy_from()` methods of `ocl_memory` class

### Tickets:
 - *ticket-id*
