### PR TITLE
[GPU] Optimize fc_bf_tiled kernel for large K + small N case

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1013,7 +1013,7 @@ bool primitive_inst::update_impl(bool use_async_compilation) {
             }
         }
         if (!cached_impl) {
-            if (!_node->is_type<fully_connected>() && (_dynamic_impl || is_current_impl_dynamic)) {
+            if (_dynamic_impl || is_current_impl_dynamic) {
                 if (use_async_compilation) {
                     auto& compilation_context = prog->get_compilation_context();
                     compilation_context.push_task(updated_params, [this, &compilation_context, updated_params]() {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1013,7 +1013,7 @@ bool primitive_inst::update_impl(bool use_async_compilation) {
             }
         }
         if (!cached_impl) {
-            if (_dynamic_impl || is_current_impl_dynamic) {
+            if (!_node->is_type<fully_connected>() && (_dynamic_impl || is_current_impl_dynamic)) {
                 if (use_async_compilation) {
                     auto& compilation_context = prog->get_compilation_context();
                     compilation_context.push_task(updated_params, [this, &compilation_context, updated_params]() {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -307,9 +307,9 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
         ACCUMULATOR_VEC_TYPE acc_tmp[TILE_B] = { };
 
         #if USE_SLM && COMPRESSED_WEIGHTS_INT4
-//            #if TILE_OFM != 2
-//            #error "FC bf_tiled kernel: can't use SLM optimization with TILE_OFM != 2"
-//            #endif
+            #if TILE_OFM != 2
+            #error "FC bf_tiled kernel: can't use SLM optimization with TILE_OFM != 2"
+            #endif
 
             // Skip first barrier synchronization if there is only single outer loop iteration.
             #if MAIN_LOOP_ELEMENTS_COUNT / (TILE_IFM * SIMD) > 1
@@ -321,20 +321,12 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
             uint weights_idx = weights_offset + local_id * SIMD * FILTER_LOAD_ITERS * FILTER_LOAD_BLOCK_SIZE;
             uint wei_local_idx = local_id * SIMD * FILTER_LOAD_ITERS * FILTER_LOAD_BLOCK_SIZE + sglid;
 
-            #if TILE_OFM == 1
-            unroll_for(uint load_iter = 0; load_iter < (TILE_IFM * SIMD) / TILE_K; ++load_iter) {
-            #else
             unroll_for(uint load_iter = 0; load_iter < FILTER_LOAD_ITERS; ++load_iter) {
-            #endif
                 SLM_FILTER_PACKED_VEC wei_packed = BLOCK_READN(FILTER_TYPE, FILTER_LOAD_BLOCK_SIZE, weights, weights_idx);
                 SLM_FILTER_UNPACKED_VEC wei_unpacked = UNPACK_INT4(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE_PRELOAD*)&wei_packed));
                 ACCUMULATOR_TYPE* w = (ACCUMULATOR_TYPE*)(&wei_unpacked);
                 unroll_for(uint fi = 0; fi < TILE_OFM; ++fi) {
-                    #if TILE_OFM == 1
-                    unroll_for(uint kii = 0; kii < TILE_K; ++kii) {
-                    #else
                     unroll_for(uint kii = 0; kii < FILTER_LOAD_BLOCK_SIZE; ++kii) {
-                    #endif
                         const uint offset_ofm = out_f + fi*SIMD + sglid;
                         const uint offset_ifm = ni * TILE_IFM * SIMD + local_id * FILTER_LOAD_ITERS * FILTER_LOAD_BLOCK_SIZE + load_iter * FILTER_LOAD_BLOCK_SIZE + kii;
                         #if !DECOMPRESSION_SCALE_POST_OP
@@ -366,43 +358,30 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                     }
                 }
 
-                #if TILE_OFM == 1
-                    #define STORE_TO_SLM(vec2) slm_wei_vec[wei_local_idx] = vec2; wei_local_idx += SIMD;
-                    #if FILTER_LOAD_BLOCK_SIZE == 2
-                        STORE_TO_SLM(wei_unpacked.s0);
-                        STORE_TO_SLM(wei_unpacked.s1);
-                        STORE_TO_SLM(wei_unpacked.s2);
-                        STORE_TO_SLM(wei_unpacked.s3);
-                    #else
-                        #error "FC bf_tiled kernel: unsupported FILTER_LOAD_BLOCK_SIZE for SLM kernel"
-                    #endif
-                    #undef STORE_TO_SLM
-                #elif TILE_OFM == 2
-                    #define STORE_TO_SLM(vec2) slm_wei_vec[wei_local_idx] = vec2; wei_local_idx += SIMD;
-                    #if FILTER_LOAD_BLOCK_SIZE == 2
-                        STORE_TO_SLM(wei_unpacked.s01);
-                        STORE_TO_SLM(wei_unpacked.s23);
-                    #elif FILTER_LOAD_BLOCK_SIZE == 4
-                        STORE_TO_SLM(wei_unpacked.s01);
-                        STORE_TO_SLM(wei_unpacked.s23);
-                        STORE_TO_SLM(wei_unpacked.s45);
-                        STORE_TO_SLM(wei_unpacked.s67);
-                    #elif FILTER_LOAD_BLOCK_SIZE == 8
-                        STORE_TO_SLM(wei_unpacked.s01);
-                        STORE_TO_SLM(wei_unpacked.s23);
-                        STORE_TO_SLM(wei_unpacked.s45);
-                        STORE_TO_SLM(wei_unpacked.s67);
-                        STORE_TO_SLM(wei_unpacked.s89);
-                        STORE_TO_SLM(wei_unpacked.sab);
-                        STORE_TO_SLM(wei_unpacked.scd);
-                        STORE_TO_SLM(wei_unpacked.sef);
-                    #else
-                        #error "FC bf_tiled kernel: unsupported FILTER_LOAD_BLOCK_SIZE for SLM kernel"
-                    #endif
-                    #undef STORE_TO_SLM
+                #define STORE_TO_SLM(vec2) slm_wei_vec[wei_local_idx] = vec2; wei_local_idx += SIMD;
+
+                #if FILTER_LOAD_BLOCK_SIZE == 2
+                    STORE_TO_SLM(wei_unpacked.s01);
+                    STORE_TO_SLM(wei_unpacked.s23);
+                #elif FILTER_LOAD_BLOCK_SIZE == 4
+                    STORE_TO_SLM(wei_unpacked.s01);
+                    STORE_TO_SLM(wei_unpacked.s23);
+                    STORE_TO_SLM(wei_unpacked.s45);
+                    STORE_TO_SLM(wei_unpacked.s67);
+                #elif FILTER_LOAD_BLOCK_SIZE == 8
+                    STORE_TO_SLM(wei_unpacked.s01);
+                    STORE_TO_SLM(wei_unpacked.s23);
+                    STORE_TO_SLM(wei_unpacked.s45);
+                    STORE_TO_SLM(wei_unpacked.s67);
+                    STORE_TO_SLM(wei_unpacked.s89);
+                    STORE_TO_SLM(wei_unpacked.sab);
+                    STORE_TO_SLM(wei_unpacked.scd);
+                    STORE_TO_SLM(wei_unpacked.sef);
                 #else
-                    #error "FC bf_tiled kernel: unsupported TILE_OFM size for SLM kernel"
+                    #error "FC bf_tiled kernel: unsupported FILTER_LOAD_BLOCK_SIZE for SLM kernel"
                 #endif
+
+                #undef STORE_TO_SLM
 
                 weights_idx += SIMD * FILTER_LOAD_BLOCK_SIZE;
             }
@@ -414,19 +393,6 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
         unroll_for(uint ki = 0; ki < (TILE_IFM * SIMD) / TILE_K; ++ki) {
             #if COMPRESSED_WEIGHTS_INT4
                 #if USE_SLM
-                    #if TILE_OFM == 1
-                    FILTER_VEC_TYPE wei = 0;
-                    #define LOAD_FROM_SLM(vec) vec = slm_wei_vec[wei_local_idx]; wei_local_idx += SIMD;
-                    #if TILE_K == 4
-                        LOAD_FROM_SLM(wei.s0);
-                        LOAD_FROM_SLM(wei.s1);
-                        LOAD_FROM_SLM(wei.s2);
-                        LOAD_FROM_SLM(wei.s3);
-                    #else
-                    #error "FC bf_tiled kernel: unsupported TILE_K size for SLM kernel"
-                    #endif
-                    #undef LOAD_FROM_SLM
-                    #else
                     FILTER_VEC_TYPE wei = 0;
                     #define LOAD_FROM_SLM(vec2) vec2 = slm_wei_vec[wei_local_idx]; wei_local_idx += SIMD;
                     #if TILE_K == 1
@@ -443,7 +409,6 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                     #error "FC bf_tiled kernel: unsupported TILE_K size for SLM kernel"
                     #endif
                     #undef LOAD_FROM_SLM
-                    #endif
                 #else
                     FILTER_PACKED_VEC_TYPE wei_packed = FILTER_BLOCK_READ(weights, weights_offset);
                     wei = UNPACK_INT4(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE*)&wei_packed));

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -318,15 +318,29 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
 
             __local SLM_FILTER_VEC* slm_wei_vec = (__local SLM_FILTER_VEC*)wei_local_mem;
 
+            #if FILTER_LAYOUT_OS_IYX_OSV16
+            uint weights_idx = weights_offset + local_id * SIMD * FILTER_LOAD_ITERS * 2;
+            #else
             uint weights_idx = weights_offset + local_id * SIMD * FILTER_LOAD_ITERS * FILTER_LOAD_BLOCK_SIZE;
+            #endif
             uint wei_local_idx = local_id * SIMD * FILTER_LOAD_ITERS * FILTER_LOAD_BLOCK_SIZE + sglid;
-
             unroll_for(uint load_iter = 0; load_iter < FILTER_LOAD_ITERS; ++load_iter) {
-                SLM_FILTER_PACKED_VEC wei_packed = BLOCK_READN(FILTER_TYPE, FILTER_LOAD_BLOCK_SIZE, weights, weights_idx);
+                // BLOCK_READN(type, vector_size, ptr, offset) AS_TYPE(MAKE_VECTOR_TYPE(type, vector_size), BLOCK_READN_RAW(TYPE_SIZE(type), vector_size, __global, ptr, offset))
+                #if FILTER_LAYOUT_OS_IYX_OSV16
+                uchar2 wei_packed0 = as_uchar2(_sub_group_block_read_uc2((const __global uchar*)(weights) + (weights_idx)));
+                uchar2 wei_packed1 = as_uchar2(_sub_group_block_read_uc2((const __global uchar*)(weights) + (weights_idx) + ((IFM_SIZE >> 1) << 4 )));
+                half4 wei_unpacked0 = unpack_to_half(*((uint4x4_t*)&wei_packed0));
+                half4 wei_unpacked1 = unpack_to_half(*((uint4x4_t*)&wei_packed1));
+                half8 wei_unpacked = { wei_unpacked0.s0, wei_unpacked0.s1, wei_unpacked0.s2, wei_unpacked0.s3, wei_unpacked1.s0, wei_unpacked1.s1, wei_unpacked1.s2, wei_unpacked1.s3};
+                #else
+                //uchar4 wei_packed = as_uchar4(_sub_group_block_read_uc4((const __global uchar*)(weights) + (weights_idx)));
+                SLM_FILTER_PACKED_VEC wei_packed = BLOCK_READN(FILTER_TYPE, FILTER_LOAD_BLOCK_SIZE/*4*/, weights, weights_idx);
+                // half8 wei_unpacked = unpack_to_half_osv32_isv2(*((uint4x8_t*)&wei_packed));
                 SLM_FILTER_UNPACKED_VEC wei_unpacked = UNPACK_INT4(ACCUMULATOR_TYPE, *((INT4_PACKED_TYPE_PRELOAD*)&wei_packed));
+                #endif
                 ACCUMULATOR_TYPE* w = (ACCUMULATOR_TYPE*)(&wei_unpacked);
                 unroll_for(uint fi = 0; fi < TILE_OFM; ++fi) {
-                    unroll_for(uint kii = 0; kii < FILTER_LOAD_BLOCK_SIZE; ++kii) {
+                    unroll_for(uint kii = 0; kii < FILTER_LOAD_BLOCK_SIZE/*4*/; ++kii) {
                         const uint offset_ofm = out_f + fi*SIMD + sglid;
                         const uint offset_ifm = ni * TILE_IFM * SIMD + local_id * FILTER_LOAD_ITERS * FILTER_LOAD_BLOCK_SIZE + load_iter * FILTER_LOAD_BLOCK_SIZE + kii;
                         #if !DECOMPRESSION_SCALE_POST_OP
@@ -354,6 +368,7 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                         #else
                             ACCUMULATOR_TYPE dzp = ACCUMULATOR_VAL_ZERO;
                         #endif
+                        //W_IDX kii * TILE_OFM + fi
                         w[W_IDX] = (w[W_IDX] - dzp) * ds;
                     }
                 }
@@ -382,8 +397,11 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
                 #endif
 
                 #undef STORE_TO_SLM
-
+                #if FILTER_LAYOUT_OS_IYX_OSV16
+                weights_idx += SIMD * 2;
+                #else
                 weights_idx += SIMD * FILTER_LOAD_BLOCK_SIZE;
+                #endif
             }
 
             wei_local_idx = sglid;
@@ -477,6 +495,8 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
             }
             #if TILE_OFM == 1 && FILTER_LAYOUT_OS_IS_YX_OSV32_ISV2
             weights_offset += TILE_K_OFM_PACKED * 2 * SIMD;
+            #elif FILTER_LAYOUT_OS_IYX_OSV16 && TILE_OFM == 2 && USE_SLM == 1
+            weights_offset += TILE_K_OFM_PACKED / 2 * SIMD;
             #else
             weights_offset += TILE_K_OFM_PACKED * SIMD;
             #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/fetch_weights.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/fetch_weights.cl
@@ -405,6 +405,16 @@ inline uint get_os_zyxi_osv16_index(uint o, uint i, uint z, uint y, uint x, uint
         ((o) / (sub_group_size))*CAT(prefix, _OFM_PITCH)                 \
     )
 
+#define GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(prefix, o, i, y, x, sub_group_size) \
+    CAT(prefix, _OFFSET) +                                               \
+    ((o) % (sub_group_size)) +                                           \
+    (sub_group_size)*(                                                   \
+        (x)*CAT(prefix, _X_PITCH) +                                      \
+        (y)*CAT(prefix, _Y_PITCH) +                                      \
+        (i)*CAT(prefix, _IFM_PITCH) +                                    \
+        ((o) / (sub_group_size))*(CAT(prefix, _OFM_PITCH)/2)             \
+    )
+
 #define GET_FILTER_OS_IS_YX_OSV_ISV_INDEX_INT4_PACKED(prefix, o, i, y, x, sub_group_size) \
     CAT(prefix, _OFFSET) +                                               \
     ((o) % (sub_group_size)) +                                           \

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int4_utils.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/batch_headers/int4_utils.cl
@@ -147,7 +147,19 @@ inline half4 unpack_to_half(uint4x4_t v) __attribute__((overloadable)) {
     return (half4)(f0.s0, f0.s1, f1.s0, f1.s1);
 }
 
+inline half4 unpack_to_half_osv32_isv2(uint4x4_t v) __attribute__((overloadable)) {
+    half2 f0 = unpack_to_half(v.s0);
+    half2 f1 = unpack_to_half(v.s1);
+    return (half4)(f0.s0, f0.s1, f1.s0, f1.s1);
+}
+
 inline half4 unpack_to_half(int4x4_t v) __attribute__((overloadable)) {
+    half2 f0 = unpack_to_half(v.s0);
+    half2 f1 = unpack_to_half(v.s1);
+    return (half4)(f0.s0, f0.s1, f1.s0, f1.s1);
+}
+
+inline half4 unpack_to_half_osv32_isv2(int4x4_t v) __attribute__((overloadable)) {
     half2 f0 = unpack_to_half(v.s0);
     half2 f1 = unpack_to_half(v.s1);
     return (half4)(f0.s0, f0.s1, f1.s0, f1.s1);
@@ -207,5 +219,6 @@ inline uchar8 unpack_to_uchar_osv32_isv2(uint4x8_t v) __attribute__((overloadabl
 
 #define UNPACK_INT4x2(target_type, value) CAT(unpack_to_, target_type)(value)
 #define UNPACK_INT4x2_OSV32_ISV2(target_type, value) CAT(CAT(unpack_to_, target_type), _osv32_isv2)(value)
+#define UNPACK_INT4x4_OSV32_ISV2(target_type, value) CAT(CAT(unpack_to_, target_type), _osv32_isv2)(value)
 #define UNPACK_TRANSPOSED_INT4x2(target_type, value) CAT(unpack_transposed_to_, target_type)(value)
 #define UNPACK_TRANSPOSED_INT4x2_OSV32_ISV2(target_type, value) CAT(CAT(unpack_transposed_to_, target_type), _osv32_isv2)(value)

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
@@ -28,6 +28,31 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
 
     OUTPUT_TYPE out = in0 | (in1 << 4);
     output[out_byte_offset] = out;
+#elif defined(OUTPUT_LAYOUT_OS_IYX_OSV16)
+    // osv32_isv2 layout for int4 packed weight
+    // f0_k0k1 | f1_k0k1 | ....  | f15_k0k1
+    // f0_k2k3 | f1_k2k3 | ....  | f15_k2k3
+    // f0_k3k4 | f1_k3k4 | ....  | f15_k3k4
+    // ...
+    // f0_k(K/2-2)k(K/2-1) | f1_k(K/2-2)k(K/2-1) | ....f15_k(K/2-2)k(K/2-1)
+    // -------------------------------------
+    // f16_k2k3 | f17_k2k3 | ... | f31_k2k3
+    // ...
+    const unsigned o = (uint)get_global_id(0);
+    const unsigned i = (uint)get_global_id(1) * 2;
+
+    const uint input0_offset = GET_FILTER_INDEX(INPUT0, 0, o, i, 0, 0);
+
+    INPUT0_TYPE in1 = input[input0_offset / 2] & 0xFF;
+
+    INPUT0_TYPE packed_out_channels = in1;
+
+    const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 16); // Calculate offset as osv16 due to packing
+    //printf("OUTPUT_OFM_PITCH:%d k:%d n:%d => %d\n", OUTPUT_OFM_PITCH, i, o, output_idx);
+    output[output_idx] = packed_out_channels;
+
+
+
 #elif defined(OUTPUT_LAYOUT_OS_IYX_OSV32)
     // os_iyx osv32 layout for int4 packed weight
     // k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k1_f0f16 | k1_f1f17 | ... | k1_f15f31

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
@@ -48,7 +48,6 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
     INPUT0_TYPE packed_out_channels = in1;
 
     const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 16); // Calculate offset as osv16 due to packing
-    //printf("OUTPUT_OFM_PITCH:%d k:%d n:%d => %d\n", OUTPUT_OFM_PITCH, i, o, output_idx);
     output[output_idx] = packed_out_channels;
 
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -325,7 +325,8 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
         if (!params.is_shape_agnostic && batch == 1) {
             // Tuning for Meteor Lake
             size_t min_num_threads = params.engineInfo.computeUnitsCount * simd;
-            if (output_f / 2 <= min_num_threads && params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
+//            if (output_f / 2 <= min_num_threads && params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
+            if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
                 GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: Set ofm_tile 1. (output_f : " << output_f
                     << ", computeUnitsCount : " << params.engineInfo.computeUnitsCount
                     << " min_num_threads : " << min_num_threads << ")" << std::endl;
@@ -693,6 +694,8 @@ KernelsData FullyConnected_bf_tiled::GetTunedKernelsDataByIndex(const Params &pa
         weights_layout = WeightsLayout::os_iyx_osv64;
     }
 
+    if (fc_params.weights.IFM().v == 13696 && fc_params.weights.OFM().v == 4096)
+        weights_layout = WeightsLayout::os_iyx_osv16;
     KernelsData kernels_data;
     if (should_dynamic_quantize(fc_params)) {
         // Use seperate 2 kernels for dynamic quantizing : quantizing_kernel + fc_kernel

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -329,7 +329,12 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
                 GPU_DEBUG_TRACE_DETAIL << "FC bf tiled: Set ofm_tile 1. (output_f : " << output_f
                     << ", computeUnitsCount : " << params.engineInfo.computeUnitsCount
                     << " min_num_threads : " << min_num_threads << ")" << std::endl;
-                return selector.Default(tune_params(1, 1, 4, 2, 1, 1, EXE_MODE_DEFAULT));
+                if (params.weights.IFM().v >= params.weights.OFM().v * 3 && params.weights.OFM().v <= 4096) {
+                    GPU_DEBUG_TRACE_DETAIL << "K: " << params.weights.IFM().v << " N: " << params.weights.OFM().v << " => set TILE_K_SIZE 4" << std::endl;
+                    return selector.Default(tune_params(1, 1, 4, 4, 1, 1, EXE_MODE_DEFAULT));
+                } else {
+                    return selector.Default(tune_params(1, 1, 4, 2, 1, 1, EXE_MODE_DEFAULT));
+                }
             } else {
                 return selector.Default(tune_params(1, 2, 4, 2, 1, 1, EXE_MODE_DEFAULT));
             }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -242,20 +242,23 @@ bool TuneParamsSelector::VerifyTuneParams(const fully_connected_params& params, 
     size_t output_b = bf_size.first;
     size_t output_f = bf_size.second;
 
-    if (params.compressed &&
-        (params.weights.GetDType() == WeightsType::INT4 || params.weights.GetDType() == WeightsType::UINT4) &&
-        tparams.tile_ofm != 2)
-        return false;
+//    if (params.compressed &&
+//        (params.weights.GetDType() == WeightsType::INT4 || params.weights.GetDType() == WeightsType::UINT4) &&
+//        tparams.tile_ofm != 2) {
+//        std::cout << " return 0" << std::endl;
+//        return false;
+//    }
 
     auto batch_size = params.is_shape_agnostic ? Align(output_b, tparams.tile_b) : output_b;
     if (batch_size % (tparams.tile_b * tparams.dispatch_bsv) != 0)
         return false;
+
     if (CeilDiv(output_f, tparams.tile_ofm * simd) % tparams.dispatch_fsv != 0)
         return false;
 
     // Same result can be achieved with smaller tile_ofm.
-    if (output_f <= (tparams.tile_ofm / 2) * simd)
-        return false;
+//    if (output_f <= (tparams.tile_ofm / 2) * simd)
+//        return false;
     // No weights layout for such huge tile ofm.
     if (tparams.tile_ofm * simd > 64)
         return false;
@@ -270,9 +273,9 @@ bool TuneParamsSelector::VerifyTuneParams(const fully_connected_params& params, 
         if ((tparams.tile_b != required_tile_b) && !is_i4_u4)
             return false;
 
-        const auto required_tile_ofm = 2;
-        if (tparams.tile_ofm != required_tile_ofm)
-            return false;
+//        const auto required_tile_ofm = 2;
+//        if (tparams.tile_ofm != required_tile_ofm)
+//            return false;
 
         if (params.weights.GetDType() != WeightsType::INT4 && params.weights.GetDType() != WeightsType::UINT4)
             return false;
@@ -501,7 +504,7 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
 
 
     if (dispatchData.use_slm) {
-        OPENVINO_ASSERT(dispatchData.tile_n == 2, "[GPU] Unsupported TILE_OFM size for SLM kernel configuration");
+//        OPENVINO_ASSERT(dispatchData.tile_n == 2, "[GPU] Unsupported TILE_OFM size for SLM kernel configuration");
         OPENVINO_ASSERT(weights_dt == WeightsType::INT4 || weights_dt == WeightsType::UINT4, "[GPU] Unsupported FC weights type for SLM kernel configuration");
 
         auto lws_batches = dispatchData.lws[2];

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -341,7 +341,7 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
             if (preferred_kernel_type != KernelType::DEFAULT) {
                 if (params.is_shape_agnostic && !should_dynamic_quantize(params)) {
                     if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
-                        selector.Case(tune_params(16, 1, 2, 4, 1, 1, EXE_MODE_DEFAULT, KernelType::SLM))
+                        selector.Case(tune_params(16, 2, 2, 4, 1, 1, EXE_MODE_DEFAULT, KernelType::SLM))
                                 .Case(tune_params(16, 1, 1, 4, 1, 1, EXE_MODE_DEFAULT, KernelType::SLM));
                     } else {
                         selector.Case(tune_params(16, 2, 2, 4, 1, 1, EXE_MODE_DEFAULT, KernelType::SLM))
@@ -495,6 +495,8 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
             jit.AddConstant(MakeJitConstant("DECOMPRESSION_SCALE_POST_OP", 1));
     }
     if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2)
+        jit.AddConstant(MakeJitConstant("W_IDX", "fi * TILE_K + kii"));
+    else if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16 && dispatchData.use_slm)
         jit.AddConstant(MakeJitConstant("W_IDX", "fi * TILE_K + kii"));
     else
         jit.AddConstant(MakeJitConstant("W_IDX", "kii * TILE_OFM + fi"));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -242,23 +242,20 @@ bool TuneParamsSelector::VerifyTuneParams(const fully_connected_params& params, 
     size_t output_b = bf_size.first;
     size_t output_f = bf_size.second;
 
-//    if (params.compressed &&
-//        (params.weights.GetDType() == WeightsType::INT4 || params.weights.GetDType() == WeightsType::UINT4) &&
-//        tparams.tile_ofm != 2) {
-//        std::cout << " return 0" << std::endl;
-//        return false;
-//    }
+    if (params.compressed &&
+        (params.weights.GetDType() == WeightsType::INT4 || params.weights.GetDType() == WeightsType::UINT4) &&
+        tparams.tile_ofm != 2)
+        return false;
 
     auto batch_size = params.is_shape_agnostic ? Align(output_b, tparams.tile_b) : output_b;
     if (batch_size % (tparams.tile_b * tparams.dispatch_bsv) != 0)
         return false;
-
     if (CeilDiv(output_f, tparams.tile_ofm * simd) % tparams.dispatch_fsv != 0)
         return false;
 
     // Same result can be achieved with smaller tile_ofm.
-//    if (output_f <= (tparams.tile_ofm / 2) * simd)
-//        return false;
+    if (output_f <= (tparams.tile_ofm / 2) * simd)
+        return false;
     // No weights layout for such huge tile ofm.
     if (tparams.tile_ofm * simd > 64)
         return false;
@@ -273,9 +270,9 @@ bool TuneParamsSelector::VerifyTuneParams(const fully_connected_params& params, 
         if ((tparams.tile_b != required_tile_b) && !is_i4_u4)
             return false;
 
-//        const auto required_tile_ofm = 2;
-//        if (tparams.tile_ofm != required_tile_ofm)
-//            return false;
+        const auto required_tile_ofm = 2;
+        if (tparams.tile_ofm != required_tile_ofm)
+            return false;
 
         if (params.weights.GetDType() != WeightsType::INT4 && params.weights.GetDType() != WeightsType::UINT4)
             return false;
@@ -504,7 +501,7 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
 
 
     if (dispatchData.use_slm) {
-//        OPENVINO_ASSERT(dispatchData.tile_n == 2, "[GPU] Unsupported TILE_OFM size for SLM kernel configuration");
+        OPENVINO_ASSERT(dispatchData.tile_n == 2, "[GPU] Unsupported TILE_OFM size for SLM kernel configuration");
         OPENVINO_ASSERT(weights_dt == WeightsType::INT4 || weights_dt == WeightsType::UINT4, "[GPU] Unsupported FC weights type for SLM kernel configuration");
 
         auto lws_batches = dispatchData.lws[2];

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
@@ -67,8 +67,6 @@ bool ReorderWeightsKernelInt4::Validate(const Params& params) const {
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv16;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::oiyx;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
-    if (!supported_case)
-        std::cout << "x" << std::endl;
     return supported_case;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
@@ -6,6 +6,7 @@
 #include "kernel_selector_common.h"
 #include "kernel_selector_params.h"
 #include "kernel_selector_utils.h"
+#include "common_types.h"
 
 namespace kernel_selector {
 
@@ -17,6 +18,7 @@ ParamsKey ReorderWeightsKernelInt4::GetSupportedKey() const {
     k.EnableOutputWeightsType(WeightsType::INT4);
     k.EnableInputWeightsLayout(WeightsLayout::oiyx);
     k.EnableInputWeightsLayout(WeightsLayout::ioyx);
+    k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv16);
     k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv32);
     k.EnableOutputWeightsLayout(WeightsLayout::os_is_yx_osv32_isv2);
     k.EnableOutputWeightsLayout(WeightsLayout::oiyx);
@@ -40,6 +42,8 @@ ReorderWeightsKernelInt4::DispatchData ReorderWeightsKernelInt4::SetDefault(cons
         dispatchData.gws = { Align(output.OFM().v, 32) / 2, output.IFM().v, 1 };
     } else if (output.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
         dispatchData.gws = { Align(output.OFM().v, 32), output.IFM().v / 2, 1 };
+    } else if (output.GetLayout() == WeightsLayout::os_iyx_osv16) {
+        dispatchData.gws = { Align(output.OFM().v, 16), output.IFM().v / 2, 1 };
     } else {
         dispatchData.gws = { CeilDiv(output.LogicalSize(), 2), 1, 1 };
     }
@@ -60,8 +64,11 @@ bool ReorderWeightsKernelInt4::Validate(const Params& params) const {
 
     bool supported_case = input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2;
+    supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv16;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::oiyx;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
+    if (!supported_case)
+        std::cout << "x" << std::endl;
     return supported_case;
 }
 


### PR DESCRIPTION
### Details:
 - Optimize fc_bf_tiled kernel for large K + small N case by setting K_TILE_SIZE 4
- Perf gain on MTL (U7 155H +  32GB RAM + driver 31.0.101.5333)
![image](https://github.com/user-attachments/assets/2e6537fe-90d4-47e1-8d56-f816d3471559)
(No regression and on par on llama3 INT4 default and phi-3 mini INT4 default)
### Tickets:
 - 149212

