### PR TITLE
[CPU] Introduce additional OV_CPU_VERBOSE levels

### DIFF
--- a/src/plugins/intel_cpu/docs/debug_capabilities/verbose.md
+++ b/src/plugins/intel_cpu/docs/debug_capabilities/verbose.md
@@ -29,7 +29,10 @@ To turn on verbose mode the following environment variable should be used:
     OV_CPU_VERBOSE=<level> binary ...
 ```
 
-Currently verbose mode has only one level, any digit can be used for activation.
+Levels enable printing of:
+  - 1 - executable nodes only
+  - 2 - same as `1` plus `Input` and `Output` nodes
+  - 3 - same as `2` plus constant path nodes (executed in scope of `compile_model()`)
 
 To have colored verbose output just duplicate level's digit, for example:
 ```sh

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -495,6 +495,8 @@ void Graph::CreatePrimitivesAndExecConstants() const {
             continue;
         }
 
+        VERBOSE(node, getConfig().debugCaps.verbose);
+
         if (context->getWeightsCache()) {
             auto sharedOutputs = acquireSharedOutputs(node);
 

--- a/src/plugins/intel_cpu/src/utils/verbose.cpp
+++ b/src/plugins/intel_cpu/src/utils/verbose.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#include "utils/general_utils.h"
 #ifdef CPU_DEBUG_CAPS
 
 #include "verbose.h"
@@ -25,11 +26,15 @@ bool Verbose::shouldBePrinted() const {
     if (lvl < 1)
         return false;
 
-    if (node->isConstant() ||
-        node->getType() == Type::Input || node->getType() == Type::Output)
+    if (lvl < 2 && one_of(node->getType(), Type::Input, Type::Output))
         return false;
+
+    if (lvl < 3 && node->isConstant())
+        return false;
+
     return true;
 }
+
 /**
  * Print node verbose execution information to cout.
  * Similiar to DNNL_VERBOSE output
@@ -37,10 +42,6 @@ bool Verbose::shouldBePrinted() const {
  * Can be rewritten in pure C++ if necessary
  */
 void Verbose::printInfo() {
-    /* 1,  2,  3,  etc -> no color
-     * 11, 22, 33, etc -> colorize */
-    bool colorUp = lvl / 10 > 0 ? true : false;
-
     enum Color {
         RED,
         GREEN,

--- a/src/plugins/intel_cpu/src/utils/verbose.h
+++ b/src/plugins/intel_cpu/src/utils/verbose.h
@@ -17,7 +17,10 @@ namespace intel_cpu {
 class Verbose {
 public:
     Verbose(const NodePtr& _node, const std::string& _lvl)
-        : node(_node), lvl(atoi(_lvl.c_str())) {
+        : node(_node),
+          lvl(atoi(_lvl.c_str()) % 10),
+          /* 1,  2,  3,  etc -> no color. 11, 22, 33, etc -> colorize */
+          colorUp(atoi(_lvl.c_str()) / 10) {
         if (!shouldBePrinted())
             return;
         printInfo();
@@ -34,6 +37,7 @@ public:
 private:
     const NodePtr& node;
     const int lvl;
+    const bool colorUp;
     std::stringstream stream;
 
     bool shouldBePrinted() const;


### PR DESCRIPTION
Levels enable printing of:
  - 1 - executable nodes only
  - 2 - same as `1` plus `Input` and `Output` nodes
  - 3 - same as `2` plus constant path nodes (executed in scope of `compile_model()`)