### PR TITLE
Update clone_with_new_inputs

### DIFF
--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -301,7 +301,7 @@ std::shared_ptr<Node> TypeRelaxed<BaseOp>::clone_with_new_inputs(const OutputVec
         if (origin_input_type == element::undefined)
             origin_input_type = BaseOp::get_input_element_type(i);
         fake_new_inputs.push_back(
-            std::make_shared<v0::Parameter>(origin_input_type, BaseOp::get_input_partial_shape(i)));
+            std::make_shared<v0::Parameter>(origin_input_type, new_args[i].get_partial_shape()));
     }
     auto base_op = BaseOp::clone_with_new_inputs(fake_new_inputs);
     // since originally TypeRelaxed was copying everything from the original node, we continue doing the same

--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -300,8 +300,7 @@ std::shared_ptr<Node> TypeRelaxed<BaseOp>::clone_with_new_inputs(const OutputVec
         auto origin_input_type = get_origin_input_type(i);
         if (origin_input_type == element::undefined)
             origin_input_type = BaseOp::get_input_element_type(i);
-        fake_new_inputs.push_back(
-            std::make_shared<v0::Parameter>(origin_input_type, new_args[i].get_partial_shape()));
+        fake_new_inputs.push_back(std::make_shared<v0::Parameter>(origin_input_type, new_args[i].get_partial_shape()));
     }
     auto base_op = BaseOp::clone_with_new_inputs(fake_new_inputs);
     // since originally TypeRelaxed was copying everything from the original node, we continue doing the same


### PR DESCRIPTION
### Details:
 - In current `clone_with_new_inputs`, `fake_new_inputs` gets shapes from `BaseOp` instead of `new_args`.
 - If shapes of `BaseOp` and `new_args` are different, we meet error while executing new_node->validate_and_infer_types().
   - This situation could occur in `MoveEltwiseUpThroughDataMovPerChannel`.
 - This PR updates `fake_new_inputs` to get shapes from `new_args` instead of `BaseOp`.

### Tickets:
 - 147082