### PR TITLE
[GPU] Skip to match concat inputs for output format for blocked output format

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -945,7 +945,7 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
             const auto& input = dep.first;
             auto input_layout = input->get_output_layout();
             // Change input data type of concat node from input format to output format
-            if (input_layout.format != output_layout.format) {
+            if (concat_node.get_preferred_impl_type() != cldnn::impl_types::onednn && output_layout.format != input_layout.format) {
                 auto new_layout = input_layout;
                 new_layout.format = output_layout.format;
                 auto new_input = rf.get_reorder(input->id(), dep.second, input_layout, new_layout);


### PR DESCRIPTION
### Details:
 - *Fix previous pr of "make the input format of concatenation same as output format" in case of onednn impl type*

### Tickets:
 - *149462*
