### PR TITLE
[CPU][ARM] Disable ACL MVN executor for NHWC and `across_channels` = false

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.cpp
@@ -72,5 +72,44 @@ void AclMVNExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<
     dstTensor.allocator()->free();
 }
 
+bool AclMVNExecutorBuilder::isSupported(const MVNAttrs& mvnAttrs,
+                                        const std::vector<MemoryDescPtr>& srcDescs,
+                                        const std::vector<MemoryDescPtr>& dstDescs) const {
+        if ((srcDescs[0]->getPrecision() != ov::element::f32 &&
+             srcDescs[0]->getPrecision() != ov::element::f16) ||
+             srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
+            DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",
+                      " src[0]=", srcDescs[0]->getPrecision(),
+                      " dst[0]=", dstDescs[0]->getPrecision());
+            return false;
+        }
+
+        if (!(srcDescs[0]->hasLayoutType(LayoutType::ncsp) &&
+              dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&
+            !(srcDescs[0]->hasLayoutType(LayoutType::nspc) &&
+              dstDescs[0]->hasLayoutType(LayoutType::nspc))) {
+            DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support layout:",
+                      " src: ", srcDescs[0]->serializeFormat(),
+                      " dst: ", dstDescs[0]->serializeFormat());
+            return false;
+        }
+
+        if (mvnAttrs.epsMode_ == MVNEpsMode::OUTSIDE_SQRT) {
+            DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support OUTSIDE_SQRT mode");
+            return false;
+        }
+        if (!mvnAttrs.normalizeVariance_) {
+            DEBUG_LOG("NEMeanStdDevNormalizationLayer supports normalize_variance=true only");
+            return false;
+        }
+        if (!mvnAttrs.initAcrossChannels_ &&
+            srcDescs[0]->hasLayoutType(LayoutType::nspc)) {
+            DEBUG_LOG("initAcrossChannels = false is not supported by ACL for NHWC layout");
+            return false;
+        }
+
+        return true;
+    }
+
 }   // namespace intel_cpu
 }   // namespace ov

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.hpp
@@ -40,37 +40,7 @@ class AclMVNExecutorBuilder : public MVNExecutorBuilder {
 public:
     bool isSupported(const MVNAttrs& mvnAttrs,
                      const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
-        if ((srcDescs[0]->getPrecision() != ov::element::f32 &&
-             srcDescs[0]->getPrecision() != ov::element::f16) ||
-             srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision()) {
-            DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support precisions:",
-                      " src[0]=", srcDescs[0]->getPrecision(),
-                      " dst[0]=", dstDescs[0]->getPrecision());
-            return false;
-        }
-
-        if (!(srcDescs[0]->hasLayoutType(LayoutType::ncsp) &&
-              dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&
-            !(srcDescs[0]->hasLayoutType(LayoutType::nspc) &&
-              dstDescs[0]->hasLayoutType(LayoutType::nspc))) {
-            DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support layout:",
-                      " src: ", srcDescs[0]->serializeFormat(),
-                      " dst: ", dstDescs[0]->serializeFormat());
-            return false;
-        }
-
-        if (mvnAttrs.epsMode_ == MVNEpsMode::OUTSIDE_SQRT) {
-            DEBUG_LOG("NEMeanStdDevNormalizationLayer does not support OUTSIDE_SQRT mode");
-            return false;
-        }
-        if (!mvnAttrs.normalizeVariance_) {
-            DEBUG_LOG("NEMeanStdDevNormalizationLayer supports normalize_variance=true only");
-            return false;
-        }
-
-        return true;
-    }
+                     const std::vector<MemoryDescPtr>& dstDescs) const override;
 
     MVNExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<AclMVNExecutor>(context);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/mvn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/mvn.cpp
@@ -61,17 +61,6 @@ std::string MvnLayerCPUTest::getTestCaseName(testing::TestParamInfo<MvnLayerCPUT
     return result.str();
 }
 
-bool MvnLayerCPUTest::isSupportedTestCase() {
-#if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
-    // "initAcrossChannels = false" is not supported by ACL for NHWC layout
-    if (!inFmts.empty() && (inFmts.front() == nwc ||
-                            inFmts.front() == nhwc ||
-                            inFmts.front() == ndhwc) &&
-        !acrossChanels) return false;
-#endif
-    return true;
-}
-
 void MvnLayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -92,10 +81,6 @@ void MvnLayerCPUTest::SetUp() {
     bool normalizeVariance;
     double eps;
     std::tie(inputShapes, netPrecision, axes, acrossChanels, normalizeVariance, eps) = basicParamsSet;
-
-    if (!isSupportedTestCase()) {
-        GTEST_SKIP() << "Skip MVN test since such combination of parameters is not supported." << std::endl;
-    }
 
     init_input_shapes({inputShapes});
 
@@ -365,6 +350,43 @@ const std::vector<double>& epsilon() {
     return epsilon;
 }
 
+const std::vector<CPUSpecificParams>& cpuParams_4D() {
+    static const std::vector<CPUSpecificParams> cpuParams_4D = {
+        CPUSpecificParams({nchw}, {nchw}, {}, {}),
+        CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
+    };
+    return cpuParams_4D;
+}
+
+const std::vector<CPUSpecificParams>& cpuParams_5D() {
+    static const std::vector<CPUSpecificParams> cpuParams_5D = {
+            CPUSpecificParams({ncdhw}, {ncdhw}, {}, {}),
+            CPUSpecificParams({ndhwc}, {ndhwc}, {}, {}),
+    };
+    return cpuParams_5D;
+}
+
+const std::vector<ElementType>& inpPrc() {
+    static const std::vector<ElementType> inpPrc = {
+            ElementType::i8,
+            ElementType::f32,
+    };
+    return inpPrc;
+}
+
+const std::vector<ElementType>& outPrc() {
+    static const std::vector<ElementType> outPrc = {
+            ElementType::f32,
+    };
+    return outPrc;
+}
+
+const std::vector<fusingSpecificParams>& fusingParamsSet() {
+    static const std::vector<fusingSpecificParams> fusingParamsSet = {
+            emptyFusingSpec,
+    };
+    return fusingParamsSet;
+}
 }  // namespace MVN
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/mvn.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/mvn.hpp
@@ -35,7 +35,6 @@ class MvnLayerCPUTest : public testing::WithParamInterface<MvnLayerCPUTestParamS
                        virtual public SubgraphBaseTest, public CpuTestWithFusing {
 public:
    static std::string getTestCaseName(testing::TestParamInfo<MvnLayerCPUTestParamSet> obj);
-   bool isSupportedTestCase();
 protected:
    void SetUp() override;
 private:
@@ -58,6 +57,13 @@ namespace MVN {
    const std::vector<bool>& acrossChannels();
    const std::vector<double>& epsilon();
 
+   const std::vector<CPUSpecificParams>& cpuParams_4D();
+   const std::vector<CPUSpecificParams>& cpuParams_5D();
+
+   const std::vector<ElementType>& inpPrc();
+   const std::vector<ElementType>& outPrc();
+
+   const std::vector<fusingSpecificParams>& fusingParamsSet();
    const std::vector<ov::AnyMap>& additionalConfig();
 }  // namespace MVN
 }  // namespace test

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/mvn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/mvn.cpp
@@ -17,26 +17,12 @@ const std::vector<bool> normalizeVariance = {
        true
 };
 
-std::vector<ElementType> inpPrc = {
-        ElementType::i8,
-        ElementType::f32,
-};
-std::vector<ElementType> outPrc = {
-        ElementType::f32,
+const std::vector<CPUSpecificParams> cpuParams_4D_ncsp = {
+    CPUSpecificParams({nchw}, {nchw}, {}, {})
 };
 
-std::vector<CPUSpecificParams> cpuParams_4D = {
-        CPUSpecificParams({nchw}, {nchw}, {}, {}),
-        CPUSpecificParams({nhwc}, {nhwc}, {}, {}),
-};
-
-std::vector<CPUSpecificParams> cpuParams_5D = {
-        CPUSpecificParams({ncdhw}, {ncdhw}, {}, {}),
-        CPUSpecificParams({ndhwc}, {ndhwc}, {}, {}),
-};
-
-std::vector<fusingSpecificParams> fusingParamsSet {
-        emptyFusingSpec,
+const std::vector<CPUSpecificParams> cpuParams_5D_ncsp = {
+    CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})
 };
 
 std::vector<fusingSpecificParams> fusingParamsSetStaticShape {
@@ -52,44 +38,76 @@ const auto Mvn3D = ::testing::Combine(
            ::testing::ValuesIn(normalizeVariance),
            ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
-       ::testing::ValuesIn(fusingParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(fusingParamsSet()),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn3D, MvnLayerCPUTest, Mvn3D, MvnLayerCPUTest::getTestCaseName);
 
-const auto Mvn4D = ::testing::Combine(
+const auto Mvn4D_across_channels = ::testing::Combine(
        ::testing::Combine(
                ::testing::ValuesIn(inputShapes_4D()),
                ::testing::Values(ElementType::f32),
                ::testing::ValuesIn(emptyReductionAxes()),
-               ::testing::ValuesIn(acrossChannels()),
+               ::testing::Values(true),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
-       ::testing::ValuesIn(fusingParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D())),
+       ::testing::ValuesIn(fusingParamsSet()),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn4D, MvnLayerCPUTest, Mvn4D, MvnLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn4D_across_channels, MvnLayerCPUTest, Mvn4D_across_channels, MvnLayerCPUTest::getTestCaseName);
 
-const auto Mvn5D = ::testing::Combine(
+const auto Mvn4D_no_across_channels_ncsp = ::testing::Combine(
+       ::testing::Combine(
+               ::testing::ValuesIn(inputShapes_4D()),
+               ::testing::Values(ElementType::f32),
+               ::testing::ValuesIn(emptyReductionAxes()),
+               ::testing::Values(false),
+               ::testing::Values(true),
+               ::testing::ValuesIn(epsilon())),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D_ncsp)),
+       ::testing::ValuesIn(fusingParamsSet()),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
+       ::testing::ValuesIn(additionalConfig()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn4D_no_across_channels_ncsp, MvnLayerCPUTest, Mvn4D_no_across_channels_ncsp, MvnLayerCPUTest::getTestCaseName);
+
+const auto Mvn5D_across_channels = ::testing::Combine(
        ::testing::Combine(
                ::testing::ValuesIn(inputShapes_5D()),
                ::testing::Values(ElementType::f32),
                ::testing::ValuesIn(emptyReductionAxes()),
-               ::testing::ValuesIn(acrossChannels()),
+               ::testing::Values(true),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
-       ::testing::ValuesIn(fusingParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D())),
+       ::testing::ValuesIn(fusingParamsSet()),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
-INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn5D, MvnLayerCPUTest, Mvn5D, MvnLayerCPUTest::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn5D_across_channels, MvnLayerCPUTest, Mvn5D_across_channels, MvnLayerCPUTest::getTestCaseName);
+
+const auto Mvn5D_no_across_channels_ncsp = ::testing::Combine(
+       ::testing::Combine(
+               ::testing::ValuesIn(inputShapes_5D()),
+               ::testing::Values(ElementType::f32),
+               ::testing::ValuesIn(emptyReductionAxes()),
+               ::testing::Values(false),
+               ::testing::Values(true),
+               ::testing::ValuesIn(epsilon())),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D_ncsp)),
+       ::testing::ValuesIn(fusingParamsSet()),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
+       ::testing::ValuesIn(additionalConfig()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn5D_no_across_channels_ncsp, MvnLayerCPUTest, Mvn5D_no_across_channels_ncsp, MvnLayerCPUTest::getTestCaseName);
 
 // 1D 2D case
 std::vector<fusingSpecificParams> fusingUnaryEltwiseParamsSet {
@@ -106,8 +124,8 @@ const auto Mvn1D = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingUnaryEltwiseParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn1D, MvnLayerCPUTest, Mvn1D, MvnLayerCPUTest::getTestCaseName);
@@ -122,9 +140,9 @@ const auto Mvn2D = ::testing::Combine(
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
-       ::testing::ValuesIn(fusingParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(fusingParamsSet()),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn2D, MvnLayerCPUTest, Mvn2D, MvnLayerCPUTest::getTestCaseName);
@@ -140,8 +158,8 @@ const auto Mvn2DTrans = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingUnaryEltwiseParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn2DTrans, MvnLayerCPUTest, Mvn2DTrans, MvnLayerCPUTest::getTestCaseName);
@@ -156,8 +174,8 @@ const auto Mvn2DStatic = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 const auto Mvn3DStatic = ::testing::Combine(
@@ -170,8 +188,8 @@ const auto Mvn3DStatic = ::testing::Combine(
            ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn3D_Static, MvnLayerCPUTest, Mvn3DStatic, MvnLayerCPUTest::getTestCaseName);
@@ -184,10 +202,10 @@ const auto Mvn4DStatic = ::testing::Combine(
                ::testing::Values(true),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D())),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn4D_Static, MvnLayerCPUTest, Mvn4DStatic, MvnLayerCPUTest::getTestCaseName);
@@ -200,10 +218,10 @@ const auto Mvn5DStatic = ::testing::Combine(
                ::testing::Values(true),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D())),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn5D_Static, MvnLayerCPUTest, Mvn5DStatic, MvnLayerCPUTest::getTestCaseName);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/mvn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/mvn.cpp
@@ -19,18 +19,11 @@ const std::vector<bool> normalizeVariance = {
        false
 };
 
-std::vector<ElementType> inpPrc = {
-        ElementType::bf16
-};
-std::vector<ElementType> outPrc = {
-        ElementType::bf16
-};
-
-std::vector<CPUSpecificParams> cpuParams_4D = {
+std::vector<CPUSpecificParams> cpuParams_4D_blocked = {
         CPUSpecificParams({nChw16c}, {nChw16c}, {}, {})
 };
 
-std::vector<CPUSpecificParams> cpuParams_5D = {
+std::vector<CPUSpecificParams> cpuParams_5D_blocked = {
         CPUSpecificParams({nCdhw16c}, {nCdhw16c}, {}, {})
 };
 
@@ -64,8 +57,8 @@ const auto Mvn3D = ::testing::Combine(
            ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn3D, MvnLayerCPUTest, Mvn3D, MvnLayerCPUTest::getTestCaseName);
@@ -89,8 +82,8 @@ const auto Mvn1D = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingUnaryEltwiseParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn1D, MvnLayerCPUTest, Mvn1D, MvnLayerCPUTest::getTestCaseName);
@@ -106,8 +99,8 @@ const auto Mvn2D = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn2D, MvnLayerCPUTest, Mvn2D, MvnLayerCPUTest::getTestCaseName);
@@ -123,8 +116,8 @@ const auto Mvn2DTrans = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingUnaryEltwiseParamsSet),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn2DTrans, MvnLayerCPUTest, Mvn2DTrans, MvnLayerCPUTest::getTestCaseName);
@@ -139,8 +132,8 @@ const auto Mvn2DStatic = ::testing::Combine(
                ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 const auto Mvn3DStatic = ::testing::Combine(
@@ -153,8 +146,8 @@ const auto Mvn3DStatic = ::testing::Combine(
            ::testing::ValuesIn(epsilon())),
        ::testing::Values(emptyCPUSpec),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn3D_Static, MvnLayerCPUTest, Mvn3DStatic, MvnLayerCPUTest::getTestCaseName);
@@ -167,10 +160,10 @@ const auto Mvn4DStatic = ::testing::Combine(
                ::testing::Values(false),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D_blocked)),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn4D_Static, MvnLayerCPUTest, Mvn4DStatic, MvnLayerCPUTest::getTestCaseName);
@@ -198,7 +191,7 @@ const auto Mvn4DStaticCTails = ::testing::Combine(
                ::testing::Values(false),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D)),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D_blocked)),
        ::testing::Values(emptyFusingSpec),
        ::testing::Values(ElementType::f32),
        ::testing::Values(ElementType::f32),
@@ -215,10 +208,10 @@ const auto Mvn5DStatic = ::testing::Combine(
                ::testing::Values(false),
                ::testing::ValuesIn(normalizeVariance),
                ::testing::ValuesIn(epsilon())),
-       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D)),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D_blocked)),
        ::testing::ValuesIn(fusingParamsSetStaticShape),
-       ::testing::ValuesIn(inpPrc),
-       ::testing::ValuesIn(outPrc),
+       ::testing::Values(ElementType::bf16),
+       ::testing::Values(ElementType::bf16),
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn5D_Static, MvnLayerCPUTest, Mvn5DStatic, MvnLayerCPUTest::getTestCaseName);
@@ -246,6 +239,46 @@ const auto MvnSmallSpatial = ::testing::Combine(
        ::testing::ValuesIn(additionalConfig()));
 
 INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_MvnSmallSpatial, MvnLayerCPUTest, MvnSmallSpatial, MvnLayerCPUTest::getTestCaseName);
+
+const std::vector<CPUSpecificParams> cpuParams_4D_nspc = {
+    CPUSpecificParams({nhwc}, {nhwc}, {}, {})
+};
+
+const std::vector<CPUSpecificParams> cpuParams_5D_nspc = {
+    CPUSpecificParams({ndhwc}, {ndhwc}, {}, {})
+};
+
+const auto Mvn4D_no_across_channels_nspc = ::testing::Combine(
+       ::testing::Combine(
+               ::testing::ValuesIn(inputShapes_4D()),
+               ::testing::Values(ElementType::f32),
+               ::testing::ValuesIn(emptyReductionAxes()),
+               ::testing::Values(false),
+               ::testing::ValuesIn(normalizeVariance),
+               ::testing::ValuesIn(epsilon())),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_4D_nspc)),
+       ::testing::Values(emptyFusingSpec),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
+       ::testing::ValuesIn(additionalConfig()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn4D_no_across_channels_nspc, MvnLayerCPUTest, Mvn4D_no_across_channels_nspc, MvnLayerCPUTest::getTestCaseName);
+
+const auto Mvn5D_no_across_channels_nspc = ::testing::Combine(
+       ::testing::Combine(
+               ::testing::ValuesIn(inputShapes_5D()),
+               ::testing::Values(ElementType::f32),
+               ::testing::ValuesIn(emptyReductionAxes()),
+               ::testing::Values(false),
+               ::testing::ValuesIn(normalizeVariance),
+               ::testing::ValuesIn(epsilon())),
+       ::testing::ValuesIn(filterCPUSpecificParams(cpuParams_5D_nspc)),
+       ::testing::Values(emptyFusingSpec),
+       ::testing::ValuesIn(inpPrc()),
+       ::testing::ValuesIn(outPrc()),
+       ::testing::ValuesIn(additionalConfig()));
+
+INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Mvn5D_no_across_channels_nspc, MvnLayerCPUTest, Mvn5D_no_across_channels_nspc, MvnLayerCPUTest::getTestCaseName);
 
 }  // namespace
 }  // namespace MVN


### PR DESCRIPTION
### Details:
 - Reverts PR https://github.com/openvinotoolkit/openvino/pull/25905
 - Fixed layout check in `isSupported` method to cover both 4D and 5D cases
 - Removed workaround that skips unsupported cases (NHWC\NDHWC + `across_channels` = false) on ARM
 - Moved tests with unsupported cases from common to x64 dir

### Tickets:
 - *ticket-id*
