### PR TITLE
[GPU] Fix accuracy loss in Range due to high value generation for attention mask

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -560,7 +560,7 @@ bool fuse_type_to_range_v4(const std::shared_ptr<ov::Node>& node, const precisio
         return false;
     const auto& to = it->second;
     if (auto range = ov::as_type_ptr<ov::op::v4::Range>(node)) {
-        if (to.is_integral_number() || to.is_real()) {
+        if (!fp16_compression_is_disabled(node) && (to.is_integral_number() || to.is_real())) {
             range->set_output_type(to);
             return true;
         }

--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -13,13 +13,18 @@
 #include "openvino/op/divide.hpp"
 #include "openvino/op/exp.hpp"
 #include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/greater.hpp"
+#include "openvino/op/greater_eq.hpp"
 #include "openvino/op/interpolate.hpp"
+#include "openvino/op/less.hpp"
+#include "openvino/op/less_eq.hpp"
 #include "openvino/op/max_pool.hpp"
 #include "openvino/op/maximum.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/mvn.hpp"
 #include "openvino/op/normalize_l2.hpp"
 #include "openvino/op/power.hpp"
+#include "openvino/op/range.hpp"
 #include "openvino/op/reduce_max.hpp"
 #include "openvino/op/reduce_mean.hpp"
 #include "openvino/op/reduce_min.hpp"
@@ -76,6 +81,19 @@ bool is_fq_path(const std::shared_ptr<const Node>& node) {
 void erase_fq_path(const std::shared_ptr<Node>& node) {
     auto& rt_info = node->get_rt_info();
     rt_info.erase("fq_path");
+}
+
+void mark_range_path(const std::shared_ptr<Node>& node) {
+    node->get_rt_info().emplace("range_path", true);
+}
+
+bool is_range_path(const std::shared_ptr<const Node>& node) {
+    return node->get_rt_info().count("range_path");
+}
+
+void erase_range_path(const std::shared_ptr<Node>& node) {
+    auto& rt_info = node->get_rt_info();
+    rt_info.erase("range_path");
 }
 
 // Marking continues to propagate through these ops.
@@ -205,6 +223,58 @@ public:
             return true;
         };
         auto m = make_shared<pattern::Matcher>(reduce_ops, matcher_name);
+        register_matcher(m, callback);
+    }
+};
+
+/* MarkFloatingPointRange marks paths that involve Range operations with floating point output data types,
+ * as well as their users allowed for propagation. This pass is needed to prevent accuracy data loss
+ * in cases of high range generation, which could suffer due to lowered precision.
+ */
+class MarkFloatingPointRange : public pass::MatcherPass {
+public:
+    OPENVINO_RTTI("MarkFloatingPointRange", "0");
+    MarkFloatingPointRange() {
+        MATCHER_SCOPE(MarkFloatingPointRange);
+        auto exp_pattern = pattern::wrap_type<ov::op::v4::Range>();
+
+        // through this nodes
+        const std::shared_ptr<Node> range_propagating_nodes = pattern::wrap_type<ov::op::v0::Convert,
+                                                                                 ov::op::v1::Greater,
+                                                                                 ov::op::v1::GreaterEqual,
+                                                                                 ov::op::v1::Less,
+                                                                                 ov::op::v1::LessEqual,
+                                                                                 ov::op::v1::Reshape,
+                                                                                 ov::op::v4::Range,
+                                                                                 ov::op::v0::Squeeze,
+                                                                                 ov::op::v0::Unsqueeze>();
+
+        matcher_pass_callback callback = [=](pattern::Matcher& m) {
+            const auto& node = m.get_match_root();
+            if (!node)
+                return false;
+
+            auto range = as_type_ptr<ov::op::v4::Range>(node);
+            if (range && range->get_output_type().is_real()) {
+                mark_range_path(node);
+                disable_fp16_compression(node);
+                return true;
+            }
+
+            bool is_changed = false;
+
+            for (const auto& in_node_output : node->input_values()) {
+                auto input_node = in_node_output.get_node_shared_ptr();
+                if (is_range_path(input_node)) {
+                    mark_range_path(node);
+                    disable_fp16_compression(node);
+                    is_changed = true;
+                }
+            }
+
+            return is_changed;
+        };
+        auto m = make_shared<pattern::Matcher>(range_propagating_nodes, matcher_name);
         register_matcher(m, callback);
     }
 };
@@ -426,6 +496,7 @@ bool MarkSugraphsToKeepInMixedPrecision::run_on_model(const shared_ptr<ov::Model
     Manager manager(get_pass_config(), "MarkSugraphsToKeepInMixedPrecision");
     manager.set_per_pass_validation(false);
     // Mark root of Division with eps pattern to keep in FP32
+    REGISTER_PASS(manager, MarkFloatingPointRange)
     REGISTER_PASS(manager, MarkDivWithEps)
     REGISTER_PASS(manager, MarkExpInReduceOpPath)
     REGISTER_PASS(manager, PropagateDownDisableSensitivityForQuantized)
@@ -444,6 +515,7 @@ bool MarkSugraphsToKeepInMixedPrecision::run_on_model(const shared_ptr<ov::Model
     for (auto& node : m->get_ops()) {
         erase_reduceop_path(node);
         erase_fq_path(node);
+        erase_range_path(node);
     }
 
     return false;  // no need to revalidate

--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -236,18 +236,17 @@ public:
     OPENVINO_RTTI("MarkFloatingPointRange", "0");
     MarkFloatingPointRange() {
         MATCHER_SCOPE(MarkFloatingPointRange);
-        auto exp_pattern = pattern::wrap_type<ov::op::v4::Range>();
 
-        // through this nodes
-        const std::shared_ptr<Node> range_propagating_nodes = pattern::wrap_type<ov::op::v0::Convert,
-                                                                                 ov::op::v1::Greater,
-                                                                                 ov::op::v1::GreaterEqual,
-                                                                                 ov::op::v1::Less,
-                                                                                 ov::op::v1::LessEqual,
-                                                                                 ov::op::v1::Reshape,
-                                                                                 ov::op::v4::Range,
-                                                                                 ov::op::v0::Squeeze,
-                                                                                 ov::op::v0::Unsqueeze>();
+        // through these nodes
+        const auto range_propagating_nodes = pattern::wrap_type<ov::op::v0::Convert,
+                                                                ov::op::v1::Greater,
+                                                                ov::op::v1::GreaterEqual,
+                                                                ov::op::v1::Less,
+                                                                ov::op::v1::LessEqual,
+                                                                ov::op::v1::Reshape,
+                                                                ov::op::v4::Range,
+                                                                ov::op::v0::Squeeze,
+                                                                ov::op::v0::Unsqueeze>();
 
         matcher_pass_callback callback = [=](pattern::Matcher& m) {
             const auto& node = m.get_match_root();


### PR DESCRIPTION
### Details:
 - Fixed accuracy loss in the Range operation due to high value generation for the attention mask in cases of long input sequences

### Tickets:
 - [CVS-146283](https://jira.devtools.intel.com/browse/CVS-146283)
