### PR TITLE
[GPU] Fix segmentation fault during remote tensor destruction in the Python API

### DIFF
--- a/src/inference/src/cpp/remote_context.cpp
+++ b/src/inference/src/cpp/remote_context.cpp
@@ -67,6 +67,8 @@ std::string RemoteContext::get_device_name() const {
 RemoteTensor RemoteContext::create_tensor(const element::Type& type, const Shape& shape, const AnyMap& params) {
     OV_REMOTE_CONTEXT_STATEMENT({
         auto tensor = _impl->create_tensor(type, shape, params);
+        if (!tensor._so)
+            tensor._so = _so;
         return make_tensor(tensor).as<ov::RemoteTensor>();
     });
 }
@@ -74,6 +76,8 @@ RemoteTensor RemoteContext::create_tensor(const element::Type& type, const Shape
 Tensor RemoteContext::create_host_tensor(const element::Type element_type, const Shape& shape) {
     OV_REMOTE_CONTEXT_STATEMENT({
         auto tensor = _impl->create_host_tensor(element_type, shape);
+        if (!tensor._so)
+            tensor._so = _so;
         return make_tensor(tensor);
     });
 }


### PR DESCRIPTION
### Details:
This patch updates `create_host_tensor()` and `create_tensor()` of `RemoteContext` to update _so to std::shared_ptr of the created remote tensor, preventing the dynamically loaded library from unloading before all remote tensors are destroyed