### PR TITLE
Allow `numpy==1.26` in MO for Python 3.12 enablement

### DIFF
--- a/tools/mo/requirements_caffe.txt
+++ b/tools/mo/requirements_caffe.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-numpy>=1.16.6,<1.26
+numpy>=1.16.6,<1.27
 networkx
 protobuf
 defusedxml

--- a/tools/mo/requirements_kaldi.txt
+++ b/tools/mo/requirements_kaldi.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-numpy>=1.16.6,<1.26
+numpy>=1.16.6,<1.27
 networkx
 defusedxml
 requests

--- a/tools/mo/requirements_mxnet.txt
+++ b/tools/mo/requirements_mxnet.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-numpy>=1.16.6,<1.24
+numpy>=1.16.6,<1.27
 mxnet
 networkx
 defusedxml

--- a/tools/mo/requirements_onnx.txt
+++ b/tools/mo/requirements_onnx.txt
@@ -1,5 +1,5 @@
 -c ../constraints.txt
-numpy>=1.16.6,<1.26
+numpy>=1.16.6,<1.27
 onnx
 networkx
 defusedxml

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,7 +1,7 @@
 -c ../constraints.txt
 h5py
 tensorflow>=1.15.5,<2.17.0
-numpy>=1.16.6,<1.26
+numpy>=1.16.6,<1.27
 networkx
 defusedxml
 requests

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,7 +1,7 @@
 -c ../constraints.txt
 h5py
 tensorflow>=2.5,<2.17.0
-numpy>=1.16.6,<1.26
+numpy>=1.16.6,<1.27
 networkx
 defusedxml
 requests


### PR DESCRIPTION
### Details:
 - `numpy==1.27` is the first version to support Python 3.12
 - kaldi, mxnet and caffee will most likely fail with Python 3.12, TBD how to handle it
 - cc @culhatsker 

### Tickets:
 - CVS-150017
