### PR TITLE
[DOCS] Fixes in Plugin API articles for 24.3

### DIFF
--- a/docs/articles_en/documentation/openvino-extensibility/openvino-plugin-library/advanced-guides/quantized-models.rst
+++ b/docs/articles_en/documentation/openvino-extensibility/openvino-plugin-library/advanced-guides/quantized-models.rst
@@ -1,12 +1,5 @@
-.. {#openvino_docs_ov_plugin_dg_quantized_models}
-
 Quantized models compute and restrictions
 =========================================
-
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
 
 .. meta::
    :description: Learn about the support for quantized models with different

--- a/docs/articles_en/documentation/openvino-extensibility/openvino-plugin-library/plugin-api-references.rst
+++ b/docs/articles_en/documentation/openvino-extensibility/openvino-plugin-library/plugin-api-references.rst
@@ -1,5 +1,3 @@
-.. {#openvino_docs_ie_plugin_api_references}
-
 Plugin API Reference
 ====================
 

--- a/src/inference/dev_api/openvino/runtime/exec_model_info.hpp
+++ b/src/inference/dev_api/openvino/runtime/exec_model_info.hpp
@@ -44,7 +44,7 @@ static const char OUTPUT_PRECISIONS[] = "outputPrecisions";
 
 /**
  * @ingroup ov_dev_exec_model
- * @brief Used to get a value of execution time of the executable primitive.
+ * @brief Used to get a value of execution time of the executable primitive, where Mcs = Microseconds.
  */
 static const char PERF_COUNTER[] = "execTimeMcs";
 


### PR DESCRIPTION
Port: https://github.com/openvinotoolkit/openvino/pull/26129

* Removed unused toctree.
* Added explanation of Microseconds (JIRA: 149717)
