### PR TITLE
[dGPU] fix FullyConnectedCompressed output precision issue in dynamic…

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -70,7 +70,7 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
                                                                      m_fc->get_input_node_shared_ptr(3),
                                                                      optional_w_zp,
                                                                      dyn_quan->output(1),
-                                                                     m_fc->get_output_type());
+                                                                     m_fc->get_output_element_type(0));
         ov::replace_node(m_fc, new_fc);
 
         new_fc->set_friendly_name(m_fc->get_friendly_name());


### PR DESCRIPTION
Fixed FullyConnectedCompressed precision issue if dynamic quantize group size is set UINT64:

### Details:
 - FC output precision is set to s8, which causes onednn kernel fallback to ocl::ref 
    onednn_verbose,primitive,exec,gpu:0,matmul,ocl:ref:any,undef,src_s8::blocked:ab::f0 wei_s8::blocked:ba::f0 dst_s8::blocked:ab::f0,attr-scratchpad:user attr-fpmath:f16:true attr-scales:src0:3:f16:1x896+wei:2:f16,,1024x896:896x1152,89.301

- After apply this fixing:
onednn_verbose,primitive,exec,gpu:0,matmul,jit:gemm:any,undef,src_s8::blocked:ab::f0 wei_s8::blocked:ba::f0 dst_f16::blocked:ab::f0,attr-scratchpad:user attr-fpmath:f16:true attr-scales:src0:3:f16:1x896+wei:2:f16,,8192x896:896x1152,0.207031

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-149663
