### PR TITLE
[CI] [GHA] Do not checkout latest oneDNN on U22 in nightly

### DIFF
--- a/.github/workflows/job_build_linux.yml
+++ b/.github/workflows/job_build_linux.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Ticket: 139627
       - name: Checkout the latest OneDNN for GPU in nightly
-        if: ${{ inputs.event-name == 'schedule' }}
+        if: ${{ inputs.event-name == 'schedule' && inputs.os == 'ubuntu_20_04' }} # GPU tests are enabled only on U20
         working-directory: ${{ env.OPENVINO_REPO }}/src/plugins/intel_gpu/thirdparty/onednn_gpu
         run: |
           git fetch origin


### PR DESCRIPTION
### Details:
 - GPU tests are only enabled for U20. Checking out the latest oneDNN via https://github.com/openvinotoolkit/openvino/blob/0b8eb87e0efa9030be47d661fe94b3c8beb655fd/.github/workflows/job_build_linux.yml#L71 breaks the build on U22: [like this one](https://github.com/openvinotoolkit/openvino/actions/runs/10481070002/job/29030046664) and prevents other nightly tests from executing.
 - This PR limits the checkout of the latest oneDNN to U20 only. This will unblock the nightly tests that run on U22 for now.
 - Later, it might be better to separate the builds for GPU/other test jobs.

### Tickets:
 - *149805*
