### PR TITLE
[Snippets] Fixed aux GPR using in Loop emitters

### DIFF
--- a/src/common/snippets/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/src/pass/mha_tokenization.cpp
@@ -387,8 +387,8 @@ ov::snippets::pass::TokenizeMHASnippets::TokenizeMHASnippets(const SnippetsToken
             parent = parent->get_input_node_shared_ptr(0);
             has_matmul0_has_ops_on_input = true;
         }
-        // If there are ops on second input of MatMul0 -> there always will be unique Buffer
-        if (has_matmul0_has_ops_on_input) {
+        // If there are ops on second input of MatMul0 and only one unique Buffer between MatMuls - there must be one more unique Buffer
+        if (has_matmul0_has_ops_on_input && uniqie_buffer_reg_group_count < 2) {
             uniqie_buffer_reg_group_count++;
         }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
@@ -14,6 +14,52 @@ using namespace dnnl::impl::cpu::x64;
 namespace ov {
 namespace intel_cpu {
 
+namespace {
+class jit_aux_gpr_holder {
+public:
+    jit_aux_gpr_holder(dnnl::impl::cpu::x64::jit_generator* host, std::vector<size_t>& pool_gpr_idxs, const std::vector<size_t>& used_gpr_idxs)
+        : m_h(host), m_pool_gpr_idxs(pool_gpr_idxs) {
+        // If the pool is empty, let's manualy allocate the gpr and push original vlaue on stack
+        if (m_pool_gpr_idxs.empty()) {
+            m_aux_gpr_idx = Reg64(static_cast<int>(allocate_aux_gpr(used_gpr_idxs)));
+            m_is_preserved = true;
+            m_h->push(m_aux_gpr_idx);
+        } else {
+            m_aux_gpr_idx = Reg64(static_cast<int>(m_pool_gpr_idxs.back()));
+            m_pool_gpr_idxs.pop_back();
+        }
+    }
+
+    ~jit_aux_gpr_holder() {
+        if (m_is_preserved) {
+            m_h->pop(m_aux_gpr_idx);
+        } else {
+            m_pool_gpr_idxs.push_back(m_aux_gpr_idx.getIdx());
+        }
+    }
+
+    const Reg64& get_reg() const { return m_aux_gpr_idx; }
+
+private:
+    size_t allocate_aux_gpr(const std::vector<size_t>& used_gpr_idxs) const {
+        // RSP, RBP - stack-related registers, abi_param1 - runtime parameter register in the kernel
+        static std::set<size_t> blakclist_gpr_idxs = { Operand::RSP, Operand::RBP, static_cast<size_t>(abi_param1.getIdx()) };
+        for (size_t gpr_idx = 0; gpr_idx <= Operand::R15; ++gpr_idx) {
+            size_t _idx = Operand::R15 - gpr_idx; // we allocate from the end
+            if (std::find(used_gpr_idxs.cbegin(), used_gpr_idxs.cend(), _idx) != used_gpr_idxs.cend()) continue;
+            if (std::find(blakclist_gpr_idxs.cbegin(), blakclist_gpr_idxs.cend(), _idx) != blakclist_gpr_idxs.cend()) continue;
+            return _idx;
+        }
+        OV_CPU_JIT_EMITTER_THROW("Failed to allocate aux GPR");
+    }
+
+    dnnl::impl::cpu::x64::jit_generator* m_h;
+    std::vector<size_t>& m_pool_gpr_idxs;
+    Reg64 m_aux_gpr_idx {};
+    bool m_is_preserved = false;
+};
+}  // namespace
+
 /* ================== jit_loop_begin_emitter ====================== */
 
 jit_loop_begin_emitter::jit_loop_begin_emitter(dnnl::impl::cpu::x64::jit_generator* h, dnnl::impl::cpu::x64::cpu_isa_t isa,
@@ -28,12 +74,6 @@ jit_loop_begin_emitter::jit_loop_begin_emitter(dnnl::impl::cpu::x64::jit_generat
     loop_id = loop_end->get_id();
     is_work_amount_dynamic = ov::snippets::utils::is_dynamic_value(work_amount);
     in_out_type_ = emitter_in_out_map::gpr_to_gpr;
-}
-
-size_t jit_loop_begin_emitter::aux_gprs_count() const {
-    // We should have aux GPR to store Loop arguments from `runtime_args`
-    // where we will take all needed information about the current loop: work amount
-    return is_work_amount_dynamic ? 1 : 0;
 }
 
 void jit_loop_begin_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {
@@ -59,10 +99,10 @@ void jit_loop_begin_emitter::emit_impl(const std::vector<size_t>& in, const std:
 
     Reg64 reg_work_amount = Reg64(static_cast<int>(out.back()));
     if (is_work_amount_dynamic) {
-        Reg64 reg_runtime_params = abi_param1;  // defined by jit_kernel_emitter
-        Reg64 reg_loop_args_ptr = Reg64(static_cast<int>(aux_gpr_idxs[0]));
+        jit_aux_gpr_holder gpr_holder(h, aux_gpr_idxs, out); // loop_begin has only output registers
+        Reg64 reg_loop_args_ptr = gpr_holder.get_reg();
         const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
-        h->mov(reg_loop_args_ptr, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);
+        h->mov(reg_loop_args_ptr, h->ptr[abi_param1 + GET_OFF(loop_args)]);
         h->mov(reg_work_amount, h->ptr[reg_loop_args_ptr + id_offset + GET_OFF_LOOP_ARGS(m_work_amount)]);
     } else {
         h->mov(reg_work_amount, work_amount);
@@ -141,37 +181,37 @@ void jit_loop_end_emitter::emit_code(const std::vector<size_t> &in, const std::v
     jit_emitter::emit_code(in, out, pool_vec_idxs, pool_gpr_idxs);
 }
 
-size_t jit_loop_end_emitter::aux_gprs_count() const {
-    // We should have aux GPR to store Loop arguments from `runtime_args`
-    // where we will take all needed information about the current loop: data pointer shifts
-    return are_ptr_shifts_dynamic ? 1 : 0;
-}
-
 void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     std::vector<size_t> data_ptr_reg_idxs;
     // the last input is actually a work_amount reg
     data_ptr_reg_idxs.reserve(num_inputs + num_outputs);
     std::copy(in.begin(), in.end() - 1, std::back_inserter(data_ptr_reg_idxs));
 
-    const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
-    Reg64 reg_increments = are_ptr_shifts_dynamic ? Reg64(static_cast<int>(aux_gpr_idxs[0])) : Reg64();
-
     auto apply_increments = [&](bool use_runtime_args, size_t field_offset, const std::vector<int64_t>& increments, size_t scale) {
-        if (use_runtime_args) {
-            Reg64 reg_runtime_params = abi_param1; /* defined by jit_kernel_emitter */
-            h->mov(reg_increments, h->ptr[reg_runtime_params + GET_OFF(loop_args)]);
-            h->mov(reg_increments, h->ptr[reg_increments + id_offset + field_offset]);
-        }
-        for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
-            const auto& increment = increments[idx];
-            if (is_incremented[idx] && increment != 0) {
-                if (ov::snippets::utils::is_dynamic_value(increment)) {
-                    OV_CPU_JIT_EMITTER_ASSERT(use_runtime_args, "Loop argument structure cannot be pushed to aux GPR");
-                    h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), h->ptr[reg_increments + idx * sizeof(int64_t)]);
-                } else {
-                    h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), increment * scale * data_sizes[idx]);
+        Reg64 reg_increments;
+        auto add_increments = [&]() {
+            for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
+                const auto& increment = increments[idx];
+                if (is_incremented[idx] && increment != 0) {
+                    if (ov::snippets::utils::is_dynamic_value(increment)) {
+                        OV_CPU_JIT_EMITTER_ASSERT(use_runtime_args, "Loop argument structure cannot be pushed to aux GPR");
+                        h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), h->ptr[reg_increments + idx * sizeof(int64_t)]);
+                    } else {
+                        h->add(Reg64(static_cast<int>(data_ptr_reg_idxs[idx])), increment * scale * data_sizes[idx]);
+                    }
                 }
             }
+        };
+
+        const auto id_offset = loop_id * sizeof(jit_snippets_call_args::loop_args_t);
+        if (use_runtime_args) {
+            jit_aux_gpr_holder gpr_holder(h, aux_gpr_idxs, in); // loop_end has only input registers
+            reg_increments = gpr_holder.get_reg();
+            h->mov(reg_increments, h->ptr[abi_param1 + GET_OFF(loop_args)]);
+            h->mov(reg_increments, h->ptr[reg_increments + id_offset + field_offset]);
+            add_increments();
+        } else {
+            add_increments();
         }
     };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
@@ -31,7 +31,8 @@ protected:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
-    size_t aux_gprs_count() const override;
+    // `jit_loop_begin_emitter` handles manually aux_gpr allocation using `jit_aux_gpr_holder`
+    size_t aux_gprs_count() const override { return 0; }
 
     std::shared_ptr<Xbyak::Label> loop_begin_label = nullptr;
     std::shared_ptr<const Xbyak::Label> loop_end_label = nullptr;
@@ -61,7 +62,8 @@ protected:
     void validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
-    size_t aux_gprs_count() const override;
+    // `jit_loop_end_emitter` handles manually aux_gpr allocation using `jit_aux_gpr_holder`
+    size_t aux_gprs_count() const override { return 0; }
 
     static ov::snippets::lowered::ExpressionPtr get_loop_begin_expr(const ov::snippets::lowered::ExpressionPtr& expr);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -527,6 +527,35 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(CPUTestUtils::empty_plugin_config)),
     MHA::getTestCaseName);
 
+std::vector<std::vector<ov::test::InputShape>> inputShapes_4D_WithMul_dynamic{
+        {
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 70, 3, 19}, {1, 128, 3, 64}, {1, 68, 6, 87}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 1, 64}, {2, 49, 1, 19}, {1, 128, 1, 64}, {2, 13, 6, 87}}},
+            {PartialShape{1},              {{1},             {1},            {1},             {1} }},
+            {PartialShape{-1, -1, -1, -1}, {{2, 1, 128, 128}, {1, 1, 70, 49}, {2, 1, 128, 128}, {1, 1, 68, 13}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 49, 3, 19}, {1, 128, 3, 64}, {2, 13, 6, 87}}},
+        },
+        {
+            {PartialShape{-1, -1, 12, 64}, {{1, 70, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 70, 12, 64}}},
+            {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {2, 10, 12, 64}, {2, 1, 12, 64},  {2, 10, 12, 64}, {1, 35, 12, 64}}},
+            {PartialShape{-1, 12, 64, -1}, {{1, 12, 64, 35}, {1, 12, 64, 10}, {1, 12, 64, 10}, {1, 12, 64, 1},  {1, 12, 64, 35}}},
+            {PartialShape{-1, 12, -1, -1}, {{2, 12, 70, 35}, {1, 12, 20, 10}, {1, 12, 20, 10}, {1, 12, 20, 1},  {2, 12, 70, 35}}},
+            {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 35, 12, 64}}},
+        }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_DynMHA_4D_WithMul,
+                         MHAWithDynamicMul,
+                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D_WithMul_dynamic),
+                                            ::testing::ValuesIn(precision_f32(5)),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::Values(MHA::default_thread_count),
+                                            ::testing::Values(1),
+                                            ::testing::Values(1),
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
+                         MHAWithDynamicMul::getTestCaseName);
+
 }  // namespace
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -11,7 +11,7 @@ namespace ov {
 namespace test {
 namespace snippets {
 
-typedef std::tuple<std::vector<InputShape>,   // Input shapes
+typedef std::tuple<std::vector<InputShape>,         // Input shapes
                    std::vector<ov::element::Type>,  // Input Element types
                    ov::element::Type,               // Inference precision
                    bool,                            // With Multiply
@@ -23,72 +23,101 @@ typedef std::tuple<std::vector<InputShape>,   // Input shapes
                    >
     MHAParams;
 
-class MHA : public testing::WithParamInterface<ov::test::snippets::MHAParams>,
-            virtual public ov::test::SnippetsTestsCommon {
-public:
-    static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj);
+typedef std::tuple<std::vector<InputShape>,         // Input shapes
+                   std::vector<ov::element::Type>,  // Input Element types
+                   ov::element::Type,               // Inference precision
+                   size_t,                          // Thread count
+                   size_t,                          // Expected num nodes
+                   size_t,                          // Expected num subgraphs
+                   std::string,                     // Target Device
+                   ov::AnyMap                       // Config
+                   >
+MHAWithDynamicMulParams;
 
+class MHABase :  virtual public ov::test::SnippetsTestsCommon {
+public:
     constexpr static size_t default_thread_count = 0;
 
 protected:
     void SetUp() override;
-
     void compile_model() override;
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
-    virtual std::shared_ptr<SnippetsFunctionBase> get_subgraph();
+    virtual std::shared_ptr<SnippetsFunctionBase> get_subgraph() const = 0;
+    virtual void init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) = 0;
 
-    bool m_with_mul = false;
     size_t m_thread_count;
     std::vector<ov::element::Type> m_input_types;
+};
+
+class MHA : public testing::WithParamInterface<ov::test::snippets::MHAParams>,
+            virtual public MHABase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj);
+
+protected:
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
+    void init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) override;
+
+    bool m_with_mul = false;
 };
 
 class MHASelect : public MHA {
 protected:
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAWOTransposeOnInputs : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAWOTranspose : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAMulAdd : public MHA {
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHATransposedB : public MHA {
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAINT8MatMul : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAQuantMatMul0 : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAFQAfterMatMul : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAFQ : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
 };
 
 class MHAWithExtractedReshape : public MHA {
 protected:
-    std::shared_ptr<SnippetsFunctionBase> get_subgraph() override;
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
+};
+
+class MHAWithDynamicMul : public testing::WithParamInterface<ov::test::snippets::MHAWithDynamicMulParams>,
+                          virtual public MHABase {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAWithDynamicMulParams> obj);
+
+protected:
+    std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
+    void init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) override;
 };
 
 }  // namespace snippets

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -14,6 +14,51 @@ namespace ov {
 namespace test {
 namespace snippets {
 
+void MHABase::compile_model() {
+    if (m_thread_count != default_thread_count)
+        core->set_property(targetDevice, ov::inference_num_threads(m_thread_count));
+    SubgraphBaseTest::compile_model();
+}
+
+void MHABase::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
+    inputs.clear();
+    const auto& model_inputs = function->inputs();
+
+    for (int i = 0; i < model_inputs.size(); ++i) {
+        const auto& model_input = model_inputs[i];
+        ov::Tensor tensor;
+        ov::test::utils::InputGenerateData in_data;
+        // To avoid big relative errors in the vicinity of zero, only positive values are generated for bf16 precision
+        in_data.start_from = model_input.get_element_type() == ov::element::bf16 ? 0 : -1;
+        in_data.range = 2;
+        in_data.resolution = 256;
+        tensor =
+            ov::test::utils::create_and_fill_tensor(model_input.get_element_type(), targetInputStaticShapes[i], in_data);
+        inputs.insert({model_input.get_node_shared_ptr(), tensor});
+    }
+}
+
+void MHABase::SetUp() {
+    std::vector<InputShape> input_shapes;
+    ov::element::Type prc;
+    ov::AnyMap additional_config;
+    init_params(input_shapes, prc, additional_config);
+    init_input_shapes(input_shapes);
+
+    const auto subgraph_model = get_subgraph();
+    function = subgraph_model->getOriginal();
+
+    configuration.insert(additional_config.begin(), additional_config.end());
+    if (!configuration.count("SNIPPETS_MODE")) {
+        configuration.insert({"SNIPPETS_MODE", "IGNORE_CALLBACK"});
+    }
+
+    setInferenceType(prc);
+    inType = outType = prc;
+    if (prc == ov::element::bf16)
+        rel_threshold = 0.05f;
+}
+
 std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj) {
     std::vector<InputShape> input_shapes;
     std::vector<ov::element::Type> elem_types;
@@ -54,60 +99,46 @@ std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAP
     return result.str();
 }
 
-void MHA::SetUp() {
+std::string MHAWithDynamicMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAWithDynamicMulParams> obj) {
     std::vector<InputShape> input_shapes;
+    std::vector<ov::element::Type> elem_types;
     ov::element::Type prc;
+    size_t thread_count;
+    std::string target_device;
+    size_t num_nodes, num_subgraphs;
     ov::AnyMap additional_config;
-    std::tie(input_shapes,
-             m_input_types,
-             prc,
-             m_with_mul,
-             m_thread_count,
-             ref_num_nodes,
-             ref_num_subgraphs,
-             targetDevice,
-             additional_config) = this->GetParam();
-    init_input_shapes(input_shapes);
+    std::tie(input_shapes, elem_types, prc, thread_count, num_nodes, num_subgraphs, target_device, additional_config) = obj.param;
 
-    const auto subgraph_model = get_subgraph();
-    function = subgraph_model->getOriginal();
+    std::ostringstream result;
+    for (size_t i = 0; i < input_shapes.size(); i++)
+        result << "IS[" << i << "]=" << input_shapes[i] << "_";
+    for (size_t i = 0; i < elem_types.size(); i++)
+        result << "T[" << i << "]=" << elem_types[i] << "_";
+    result << "ThreadNum=" << thread_count << "_";
+    result << "PRC=" << prc << "_";
+    result << "#N=" << num_nodes << "_";
+    result << "#S=" << num_subgraphs << "_";
+    result << "targetDevice=" << target_device << "_";
 
-    configuration.insert(additional_config.begin(), additional_config.end());
-    if (!configuration.count("SNIPPETS_MODE")) {
-        configuration.insert({"SNIPPETS_MODE", "IGNORE_CALLBACK"});
+    if (!additional_config.empty()) {
+        result << "_PluginConf";
+        for (auto& item : additional_config) {
+            result << "_" << item.first << "=" << item.second.as<std::string>();
+        }
     }
-
-    setInferenceType(prc);
-    inType = outType = prc;
-    if (prc == ov::element::bf16)
-        rel_threshold = 0.05f;
+    return result.str();
 }
 
-void MHA::compile_model() {
-    if (m_thread_count != default_thread_count)
-        core->set_property(targetDevice, ov::inference_num_threads(m_thread_count));
-    SubgraphBaseTest::compile_model();
+void MHA::init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) {
+    std::tie(input_shapes, m_input_types, prc, m_with_mul, m_thread_count, ref_num_nodes, ref_num_subgraphs,
+             targetDevice, additional_config) = this->GetParam();
 }
 
-void MHA::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
-    inputs.clear();
-    const auto& model_inputs = function->inputs();
-
-    for (int i = 0; i < model_inputs.size(); ++i) {
-        const auto& model_input = model_inputs[i];
-        ov::Tensor tensor;
-        ov::test::utils::InputGenerateData in_data;
-        // To avoid big relative errors in the vicinity of zero, only positive values are generated for bf16 precision
-        in_data.start_from = model_input.get_element_type() == ov::element::bf16 ? 0 : -1;
-        in_data.range = 2;
-        in_data.resolution = 256;
-        tensor =
-            ov::test::utils::create_and_fill_tensor(model_input.get_element_type(), targetInputStaticShapes[i], in_data);
-        inputs.insert({model_input.get_node_shared_ptr(), tensor});
-    }
+void MHAWithDynamicMul::init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) {
+    std::tie(input_shapes, m_input_types, prc, m_thread_count, ref_num_nodes, ref_num_subgraphs, targetDevice, additional_config) = this->GetParam();
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHA::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHA::get_subgraph() const {
     bool is_with_reshape = std::all_of(inputDynamicShapes.begin(), inputDynamicShapes.end(), [](const PartialShape& ps){ return ps.is_static(); });
     return std::make_shared<ov::test::snippets::MHAFunction>(inputDynamicShapes, m_input_types, m_with_mul, is_with_reshape);
 }
@@ -143,44 +174,48 @@ void MHASelect::generate_inputs(const std::vector<ov::Shape>& targetInputStaticS
     }
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHASelect::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHASelect::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHASelectFunction>(inputDynamicShapes, m_input_types);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAWOTransposeOnInputs::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAWOTransposeOnInputs::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAWOTransposeOnInputsFunction>(inputDynamicShapes);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAWOTranspose::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAWOTranspose::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAWOTransposeFunction>(inputDynamicShapes, m_input_types);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAINT8MatMul::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAINT8MatMul::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAINT8MatMulFunction>(inputDynamicShapes);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAQuantMatMul0::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAQuantMatMul0::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAQuantMatMul0Function>(inputDynamicShapes);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAFQAfterMatMul::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAFQAfterMatMul::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAFQAfterMatMulFunction>(inputDynamicShapes);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAFQ::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAFQ::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAFQFunction>(inputDynamicShapes);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAMulAdd::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAMulAdd::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAMulAddFunction>(inputDynamicShapes);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHATransposedB::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHATransposedB::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHATransposedInputFunction>(inputDynamicShapes, true);
 }
 
-std::shared_ptr<SnippetsFunctionBase> MHAWithExtractedReshape::get_subgraph() {
+std::shared_ptr<SnippetsFunctionBase> MHAWithExtractedReshape::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAWithExtractedReshapeFunction>(inputDynamicShapes, false);
+}
+
+std::shared_ptr<SnippetsFunctionBase> MHAWithDynamicMul::get_subgraph() const {
+    return std::make_shared<ov::test::snippets::MHAWithDynamicMulFunction>(inputDynamicShapes, m_input_types);
 }
 
 TEST_P(MHA, CompareWithRefImpl) {
@@ -245,6 +280,12 @@ TEST_P(MHAFQ, CompareWithRefImpl) {
 }
 
 TEST_P(MHAWithExtractedReshape, CompareWithRefImpl) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    run();
+    validateNumSubgraphs();
+}
+
+TEST_P(MHAWithDynamicMul, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
     run();
     validateNumSubgraphs();

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
@@ -71,6 +71,32 @@ protected:
 };
 
 /* Graph:
+ *       Transpose1[0,2,3,1]  Parameter
+ *                     \       /
+ * Transpose0[0,2,1,3] Multiply
+ *              \     /
+ *              MatMul0
+ *                 \   /
+ *                  Add
+ *                Softmax  Transpose2[0,2,1,3]
+ *                    \      /
+ *                     MatMul1
+ *                   Transpose3[0,2,1,3]
+ */
+class MHAWithDynamicMulFunction : public SnippetsFunctionBase {
+public:
+    explicit MHAWithDynamicMulFunction(const std::vector<PartialShape>& inputShapes, const std::vector<ov::element::Type>& precisions)
+        : SnippetsFunctionBase(inputShapes), precisions(precisions) {
+        OPENVINO_ASSERT(input_shapes.size() == 5, "Got invalid number of input shapes");
+        OPENVINO_ASSERT(precisions.size() == 5, "Got invalid number of input precisions");
+    }
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+
+    const std::vector<ov::element::Type> precisions;
+};
+
+/* Graph:
  *       Transpose1[0,2,1,3]  Constant
  *                     \       /
  * Transpose0[0,2,1,3] Multiply

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -231,6 +231,37 @@ std::shared_ptr<ov::Model> MHASplitMFunction::initReference() const {
     return std::make_shared<ov::Model>(results, ngraphParams, "mha");
 }
 
+std::shared_ptr<ov::Model> MHAWithDynamicMulFunction::initOriginal() const {
+    auto transpose0Param = std::make_shared<ov::opset1::Parameter>(precisions[0], input_shapes[0]);
+    auto transpose1Param = std::make_shared<ov::opset1::Parameter>(precisions[1], input_shapes[1]);
+    auto mulParam = std::make_shared<ov::opset1::Parameter>(precisions[2], input_shapes[2]);
+    auto addParam = std::make_shared<ov::opset1::Parameter>(precisions[3], input_shapes[3]);
+    auto transpose2Param = std::make_shared<ov::opset1::Parameter>(precisions[4], input_shapes[4]);
+    ov::ParameterVector ngraphParam = {transpose0Param, transpose1Param, mulParam, addParam, transpose2Param};
+
+    const auto rank = input_shapes[0].size();
+    const auto fusion_order = get_fusion_order(rank);
+    const auto decomposed_order = get_decomposed_order(rank);
+
+    const auto transpose0Const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{rank}, fusion_order);
+    const auto transpose1Const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{rank}, decomposed_order);
+    const auto transpose2Const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{rank}, fusion_order);
+    const auto transpose3Const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{rank}, fusion_order);
+
+    const auto transpose0 = std::make_shared<ov::op::v1::Transpose>(transpose0Param, transpose0Const);
+    const auto transpose1 = std::make_shared<ov::op::v1::Transpose>(transpose1Param, transpose1Const);
+    const auto mul = std::make_shared<ov::op::v1::Multiply>(transpose1, mulParam);
+    const auto matMul0 = std::make_shared<ov::op::v0::MatMul>(transpose0, mul);
+    const auto add = std::make_shared<ov::op::v1::Add>(matMul0, addParam);
+    const auto softMax = std::make_shared<ov::opset1::Softmax>(add, rank - 1);
+    const auto transpose2 = std::make_shared<ov::op::v1::Transpose>(transpose2Param, transpose2Const);
+    const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(softMax, transpose2);
+    const auto transpose3 = std::make_shared<ov::op::v1::Transpose>(matMul1, transpose3Const);
+
+    ov::ResultVector results{std::make_shared<ov::opset1::Result>(transpose3)};
+    return std::make_shared<ov::Model>(results, ngraphParam, "mha");
+}
+
 std::shared_ptr<ov::Model> MHAMatMul0TransposeFunction::initOriginal() const {
     auto transpose0Param = std::make_shared<ov::opset1::Parameter>(precisions[0], input_shapes[0]);
     auto transpose1Param = std::make_shared<ov::opset1::Parameter>(precisions[1], input_shapes[1]);


### PR DESCRIPTION
### Details:
 - *If Loop emitters need aux GPR and have empty `aux_gpr_pool`, now we take any (unused by this emitter) GPR, push on stack before using and pop it from stack explicitly  after using*

### Tickets:
 - *N/A*

### Prerequisites:
- [x] https://github.com/openvinotoolkit/openvino/pull/25500