### PR TITLE
[core] Fix regression in performance of model compile

### DIFF
--- a/src/core/src/bound_evaluate.cpp
+++ b/src/core/src/bound_evaluate.cpp
@@ -424,11 +424,7 @@ bool ov::could_propagate(const Output<Node>& output, std::vector<Node*>& result)
                 }
             }
             if (can_add) {
-                if (is_type<op::v0::Constant>(node)) {
-                    propagate_rt_info(node, output);
-                } else {
-                    result.push_back(node);
-                }
+                result.push_back(node);
                 nodes_to_do.pop();
                 nodes_done.insert(node);
             }

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -542,11 +542,6 @@ void Constant::update_identical_flags(bool is_checked, bool identical_value) con
 
 void Constant::validate_and_infer_types() {
     set_output_type(0, m_element_type, m_shape);
-    if (const auto tensor = get_tensor_view()) {
-        auto& output_tensor = get_output_tensor(0);
-        output_tensor.set_lower_value(tensor);
-        output_tensor.set_upper_value(tensor);
-    }
 }
 
 bool Constant::visit_attributes(AttributeVisitor& visitor) {


### PR DESCRIPTION
### Details:
 - Fix regression in compile model to set bounds for Constant nodes during bound evaluation.

### Tickets:
 - CVS-148842
