### PR TITLE
[NPU] Fix ze_loader dependency

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_remote_tensor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_remote_tensor.cpp
@@ -7,6 +7,7 @@
 #include <ze_api.h>
 
 #include "intel_npu/al/config/common.hpp"
+#include "intel_npu/utils/zero/zero_api.hpp"
 #include "openvino/core/type/element_iterator.hpp"
 #include "zero_utils.hpp"
 


### PR DESCRIPTION
### Details:
Commit ad4eb09 introduced dynamic loading of ze_loader so that it is loaded only when really needed.
Recent changes in `ZeroRemoteTensor` caused NPU plugin binary to import from ze_loader directly.

This commit should fix that and the NPU binary should have no longer dependency on ze_loader.

### Tickets:
 - None
