### PR TITLE
[intel-npu] Adding property to optionally bypass UMD caching  (default: disabled)

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -85,6 +85,9 @@ may be summarized in three stages:
 3. All subsequent requests to compile the same IR model with the same arguments
    use the pre-compiled model, reading it from the cache instead of recompiling.
 
+UMD Dynamic Model Caching can be bypassed for given model by setting boolean property
+ov::intel_npu::bypass_umd_caching (NPU_BYPASS_UMD_CACHE) to true at compilation. (default value is false)
+
 
 OpenVINO Model Caching
 +++++++++++++++++++++++++++++

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -164,7 +164,7 @@ offer a limited set of supported OpenVINO features.
          ov::intel_npu::device_alloc_mem_size
          ov::intel_npu::device_total_mem_size
          ov::intel_npu::driver_version
-         ov::intel_npu::umd_caching
+         ov::intel_npu::bypass_umd_caching
 
 
 .. note::

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -141,7 +141,7 @@ offer a limited set of supported OpenVINO features.
          ov::intel_npu::compilation_mode_params
          ov::intel_npu::turbo
          ov::intel_npu::tiles
-         ov::intel_nou::max_tiles
+         ov::intel_npu::max_tiles
 
    .. tab-item:: Read-only properties
 
@@ -164,6 +164,7 @@ offer a limited set of supported OpenVINO features.
          ov::intel_npu::device_alloc_mem_size
          ov::intel_npu::device_total_mem_size
          ov::intel_npu::driver_version
+         ov::intel_npu::umd_caching
 
 
 .. note::

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -87,5 +87,14 @@ static constexpr ov::Property<int64_t> tiles{"NPU_TILES"};
  */
 static constexpr ov::Property<int64_t> max_tiles{"NPU_MAX_TILES"};
 
+/**
+ * @brief [Only for NPU plugin]
+ * Type: std::bool
+ * Set caching of compiled models in UMD on or off.
+ * UMD Caching is enabled by default, and disabled automatically if OV caching is enabled
+ * @ingroup ov_runtime_npu_prop_cpp_api
+ */
+static constexpr ov::Property<bool> umd_caching{"NPU_UMD_CACHING"};
+
 }  // namespace intel_npu
 }  // namespace ov

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -90,11 +90,10 @@ static constexpr ov::Property<int64_t> max_tiles{"NPU_MAX_TILES"};
 /**
  * @brief [Only for NPU plugin]
  * Type: std::bool
- * Set caching of compiled models in UMD on or off.
- * UMD Caching is enabled by default, and disabled automatically if OV caching is enabled
+ * Bypass caching of the compiled model by UMD cache.
  * @ingroup ov_runtime_npu_prop_cpp_api
  */
-static constexpr ov::Property<bool> umd_caching{"NPU_UMD_CACHING"};
+static constexpr ov::Property<bool> bypass_umd_caching{"NPU_BYPASS_UMD_CACHING"};
 
 }  // namespace intel_npu
 }  // namespace ov

--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -176,7 +176,7 @@ The following properties are supported:
 | `ov::intel_npu::turbo`/</br>`NPU_TURBO` | RW | Set Turbo mode on/off | `YES`/ `NO`| `NO` |
 | `ov::intel_npu::tiles`/</br>`NPU_TILES` | RW | Sets the number of npu tiles to compile the model for | `[0-]` | `-1` |
 | `ov::intel_npu::max_tiles`/</br>`NPU_MAX_TILES` | RW | Maximum number of tiles supported by the device we compile for. Can be set for offline compilation. If not set, it will be populated by driver.| `[0-]` | `[1-6] depends on npu platform` |
-| `ov::intel_npu::umd_caching`/</br>`NPU_UMD_CACHING` | RW | Set caching of compiled models in UMD on or off.</br> UMD Caching is enabled by default, and disabled automatically if OV caching is enabled | `YES`/ `NO`| `YES` |
+| `ov::intel_npu::bypass_umd_caching`/</br>`NPU_BYPASS_UMD_CACHING` | RW | Bypass the caching of compiled models in UMD. | `YES`/ `NO`| `NO` |
 
 &nbsp;
 ### Performance Hint: Default Number of DPU Groups / DMA Engines

--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -176,6 +176,7 @@ The following properties are supported:
 | `ov::intel_npu::turbo`/</br>`NPU_TURBO` | RW | Set Turbo mode on/off | `YES`/ `NO`| `NO` |
 | `ov::intel_npu::tiles`/</br>`NPU_TILES` | RW | Sets the number of npu tiles to compile the model for | `[0-]` | `-1` |
 | `ov::intel_npu::max_tiles`/</br>`NPU_MAX_TILES` | RW | Maximum number of tiles supported by the device we compile for. Can be set for offline compilation. If not set, it will be populated by driver.| `[0-]` | `[1-6] depends on npu platform` |
+| `ov::intel_npu::umd_caching`/</br>`NPU_UMD_CACHING` | RW | Set caching of compiled models in UMD on or off.</br> UMD Caching is enabled by default, and disabled automatically if OV caching is enabled | `YES`/ `NO`| `YES` |
 
 &nbsp;
 ### Performance Hint: Default Number of DPU Groups / DMA Engines

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/runtime.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/runtime.hpp
@@ -221,4 +221,21 @@ struct TURBO final : OptionBase<TURBO, bool> {
         return OptionMode::RunTime;
     }
 };
+
+//
+// UMD_CACHING
+//
+struct UMD_CACHING final : OptionBase<UMD_CACHING, bool> {
+    static std::string_view key() {
+        return ov::intel_npu::umd_caching.name();
+    }
+
+    static bool defaultValue() {
+        return true;
+    }
+
+    static OptionMode mode() {
+        return OptionMode::RunTime;
+    }
+};
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/runtime.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/runtime.hpp
@@ -223,15 +223,15 @@ struct TURBO final : OptionBase<TURBO, bool> {
 };
 
 //
-// UMD_CACHING
+// BYPASS_UMD_CACHING
 //
-struct UMD_CACHING final : OptionBase<UMD_CACHING, bool> {
+struct BYPASS_UMD_CACHING final : OptionBase<BYPASS_UMD_CACHING, bool> {
     static std::string_view key() {
-        return ov::intel_npu::umd_caching.name();
+        return ov::intel_npu::bypass_umd_caching.name();
     }
 
     static bool defaultValue() {
-        return true;
+        return false;
     }
 
     static OptionMode mode() {

--- a/src/plugins/intel_npu/src/al/src/config/runtime.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/runtime.cpp
@@ -25,7 +25,7 @@ void intel_npu::registerRunTimeOptions(OptionsDesc& desc) {
     desc.add<ENABLE_CPU_PINNING>();
     desc.add<WORKLOAD_TYPE>();
     desc.add<TURBO>();
-    desc.add<UMD_CACHING>();
+    desc.add<BYPASS_UMD_CACHING>();
 }
 
 // Heuristically obtained number. Varies depending on the values of PLATFORM and PERFORMANCE_HINT

--- a/src/plugins/intel_npu/src/al/src/config/runtime.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/runtime.cpp
@@ -25,6 +25,7 @@ void intel_npu::registerRunTimeOptions(OptionsDesc& desc) {
     desc.add<ENABLE_CPU_PINNING>();
     desc.add<WORKLOAD_TYPE>();
     desc.add<TURBO>();
+    desc.add<UMD_CACHING>();
 }
 
 // Heuristically obtained number. Varies depending on the values of PLATFORM and PERFORMANCE_HINT

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -483,9 +483,9 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
     std::ostringstream turbostring;
     turbostring << ov::intel_npu::turbo.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+" << VALUE_DELIMITER;
     content = std::regex_replace(content, std::regex(turbostring.str()), "");
-    // Remove UMD Caching propery
+    // Remove Bypass UMD Caching propery
     std::ostringstream umdcachestring;
-    umdcachestring << ov::intel_npu::umd_caching.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
+    umdcachestring << ov::intel_npu::bypass_umd_caching.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
                    << VALUE_DELIMITER;
     content = std::regex_replace(content, std::regex(umdcachestring.str()), "");
 
@@ -788,10 +788,10 @@ ze_result_t LevelZeroCompilerInDriver<TableExtension>::seriazlideIRModelAndCreat
 
     _logger.debug("compileIR Build flags : %s", buildFlags.c_str());
 
-    // If UMD Caching is requested to be disabled or if OV cache is enabled, disable driver caching
+    // If UMD Caching is requested to be bypassed or if OV cache is enabled, disable driver caching
     uint32_t flags = ZE_GRAPH_FLAG_NONE;
     const auto set_cache_dir = config.get<CACHE_DIR>();
-    if (!set_cache_dir.empty() || !config.get<UMD_CACHING>()) {
+    if (!set_cache_dir.empty() || config.get<BYPASS_UMD_CACHING>()) {
         flags = flags | ZE_GRAPH_FLAG_DISABLE_CACHING;
     }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -483,6 +483,11 @@ std::string LevelZeroCompilerInDriver<TableExtension>::serializeConfig(
     std::ostringstream turbostring;
     turbostring << ov::intel_npu::turbo.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+" << VALUE_DELIMITER;
     content = std::regex_replace(content, std::regex(turbostring.str()), "");
+    // Remove UMD Caching propery
+    std::ostringstream umdcachestring;
+    umdcachestring << ov::intel_npu::umd_caching.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
+                   << VALUE_DELIMITER;
+    content = std::regex_replace(content, std::regex(umdcachestring.str()), "");
 
     // FINAL step to convert prefixes of remaining params, to ensure backwards compatibility
     // From 5.0.0, driver compiler start to use NPU_ prefix, the old version uses VPU_ prefix
@@ -783,10 +788,10 @@ ze_result_t LevelZeroCompilerInDriver<TableExtension>::seriazlideIRModelAndCreat
 
     _logger.debug("compileIR Build flags : %s", buildFlags.c_str());
 
-    // If OV cache is enabled, disable driver caching
+    // If UMD Caching is requested to be disabled or if OV cache is enabled, disable driver caching
     uint32_t flags = ZE_GRAPH_FLAG_NONE;
     const auto set_cache_dir = config.get<CACHE_DIR>();
-    if (!set_cache_dir.empty()) {
+    if (!set_cache_dir.empty() || !config.get<UMD_CACHING>()) {
         flags = flags | ZE_GRAPH_FLAG_DISABLE_CACHING;
     }
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -468,11 +468,11 @@ Plugin::Plugin()
               }
               return config.get<MAX_TILES>();
           }}},
-        {ov::intel_npu::umd_caching.name(),
+        {ov::intel_npu::bypass_umd_caching.name(),
          {true,
           ov::PropertyMutability::RW,
           [](const Config& config) {
-              return config.get<UMD_CACHING>();
+              return config.get<BYPASS_UMD_CACHING>();
           }}},
         // NPU Private
         // =========

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -468,6 +468,12 @@ Plugin::Plugin()
               }
               return config.get<MAX_TILES>();
           }}},
+        {ov::intel_npu::umd_caching.name(),
+         {true,
+          ov::PropertyMutability::RW,
+          [](const Config& config) {
+              return config.get<UMD_CACHING>();
+          }}},
         // NPU Private
         // =========
         {ov::intel_npu::dma_engines.name(),

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -146,7 +146,6 @@ const std::vector<ov::AnyMap> CorrectPluginMutableProperties = {
       removeDeviceNameOnlyID(
           ov::test::utils::getTestsDeviceNameFromEnvironmentOr(std::string(ov::intel_npu::Platform::AUTO_DETECT)))}},
     {{ov::intel_npu::stepping.name(), 0}},
-    {{ov::intel_npu::max_tiles.name(), 2}},
     {{ov::intel_npu::use_elf_compiler_backend.name(), ov::intel_npu::ElfCompilerBackend::NO}},
     {{ov::intel_npu::profiling_type.name(), ov::intel_npu::ProfilingType::INFER}}};
 
@@ -154,10 +153,8 @@ const std::vector<ov::AnyMap> IncorrectMutablePropertiesWrongValueTypes = {
     {{ov::intel_npu::compilation_mode.name(), -3.6}},
     {{ov::intel_npu::compiler_type.name(), ov::intel_npu::ElfCompilerBackend::NO}},
     {{ov::intel_npu::stepping.name(), "V1"}},
-    {{ov::intel_npu::max_tiles.name(), "two"}},
     {{ov::intel_npu::use_elf_compiler_backend.name(), "N"}},
     {{ov::intel_npu::profiling_type.name(), 10}},
-    {{ov::intel_npu::tiles.name(), "none"}},
     {{ov::intel_npu::dma_engines.name(), false}},
 };
 


### PR DESCRIPTION
### Details:
 - Adding new intel-npu plugin specific property to optionally bypass driver caching of compiled models (on/off, default:off)
- piggybacking a quickfix for private properties tests broken by PR #26161 

### Tickets:
 - *EISW-135607*
