### PR TITLE
[intel-npu] Publishing properties NPU_TILES (RW) and NPU_MAX_TILES

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -140,6 +140,8 @@ offer a limited set of supported OpenVINO features.
          ov::workload_type
          ov::intel_npu::compilation_mode_params
          ov::intel_npu::turbo
+         ov::intel_npu::tiles
+         ov::intel_nou::max_tiles
 
    .. tab-item:: Read-only properties
 

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -72,5 +72,20 @@ static constexpr ov::Property<std::string> compilation_mode_params{"NPU_COMPILAT
  */
 static constexpr ov::Property<bool> turbo{"NPU_TURBO"};
 
+/**
+ * @brief [Only for NPU Compiler]
+ * Type: integer, default is -1
+ * Sets the number of npu tiles to compile the model for.
+ */
+static constexpr ov::Property<int64_t> tiles{"NPU_TILES"};
+
+/**
+ * @brief
+ * Type: integer, default is -1
+ * Maximum number of tiles supported by the device we compile for. Can be set for offline compilation. If not set, it
+ * will be populated by driver.
+ */
+static constexpr ov::Property<int64_t> max_tiles{"NPU_MAX_TILES"};
+
 }  // namespace intel_npu
 }  // namespace ov

--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -174,6 +174,8 @@ The following properties are supported:
 | `ov::intel_npu::driver_version`/</br>`NPU_DRIVER_VERSION` | RO | NPU driver version (for both discrete/integrated NPU devices). | `N/A` | `N/A` |
 | `ov::intel_npu::compilation_mode_params`/</br>`NPU_COMPILATION_MODE_PARAMS` | RW | Set various parameters supported by the NPU compiler. (See bellow) | `<std::string>`| `N/A` |
 | `ov::intel_npu::turbo`/</br>`NPU_TURBO` | RW | Set Turbo mode on/off | `YES`/ `NO`| `NO` |
+| `ov::intel_npu::tiles`/</br>`NPU_TILES` | RW | Sets the number of npu tiles to compile the model for | `[0-]` | `-1` |
+| `ov::intel_npu::max_tiles`/</br>`NPU_MAX_TILES` | RW | Maximum number of tiles supported by the device we compile for. Can be set for offline compilation. If not set, it will be populated by driver.| `[0-]` | `[1-6] depends on npu platform` |
 
 &nbsp;
 ### Performance Hint: Default Number of DPU Groups / DMA Engines

--- a/src/plugins/intel_npu/src/al/include/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/npu_private_properties.hpp
@@ -302,20 +302,6 @@ static constexpr ov::Property<std::string> compilation_mode{"NPU_COMPILATION_MOD
 static constexpr ov::Property<int64_t> dpu_groups{"NPU_DPU_GROUPS"};
 
 /**
- * @brief [Only for NPU Compiler]
- * Type: integer, default is -1
- * Sets the number of npu tiles that will be used to execute the model. (Replaces NPU_DPU_GROUPS)
- */
-static constexpr ov::Property<int64_t> tiles{"NPU_TILES"};
-
-/**
- * @brief
- * Type: integer, default is -1
- * Maximum number of tiles supported by the device. If unset, it will be automatically obtained from driver
- */
-static constexpr ov::Property<int64_t> max_tiles{"NPU_MAX_TILES"};
-
-/**
  * @brief [Only for NPU Plugin]
  * Type: integer, default is -1
  * Sets the number of DMA engines that will be used to execute the model.

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -138,8 +138,11 @@ size_t getFileSize(std::istream& stream) {
     log.debug("Read blob size: streamStart=%zu, streamEnd=%zu", streamStart, streamEnd);
 
     if (streamEnd < streamStart) {
-        OPENVINO_THROW("Invalid stream size: streamEnd (", streamEnd,
-                       ") is not larger than streamStart (", streamStart, ")!");
+        OPENVINO_THROW("Invalid stream size: streamEnd (",
+                       streamEnd,
+                       ") is not larger than streamStart (",
+                       streamStart,
+                       ")!");
     }
 
     return streamEnd - streamStart;
@@ -449,6 +452,23 @@ Plugin::Plugin()
           [](const Config& config) {
               return config.get<TURBO>();
           }}},
+        {ov::intel_npu::tiles.name(),
+         {true,
+          ov::PropertyMutability::RW,
+          [](const Config& config) {
+              return config.get<TILES>();
+          }}},
+        {ov::intel_npu::max_tiles.name(),
+         {true,
+          ov::PropertyMutability::RW,
+          [&](const Config& config) {
+              if (!config.has<MAX_TILES>()) {
+                  const auto specifiedDeviceName = get_specified_device_name(config);
+                  return static_cast<int64_t>(_metrics->GetMaxTiles(specifiedDeviceName));
+              } else {
+                  return config.get<MAX_TILES>();
+              }
+          }}},
         // NPU Private
         // =========
         {ov::intel_npu::dma_engines.name(),
@@ -456,12 +476,6 @@ Plugin::Plugin()
           ov::PropertyMutability::RW,
           [](const Config& config) {
               return config.get<DMA_ENGINES>();
-          }}},
-        {ov::intel_npu::tiles.name(),
-         {false,
-          ov::PropertyMutability::RW,
-          [](const Config& config) {
-              return config.get<TILES>();
           }}},
         {ov::intel_npu::dpu_groups.name(),
          {false,
@@ -478,17 +492,6 @@ Plugin::Plugin()
                   return static_cast<int64_t>(_metrics->GetSteppingNumber(specifiedDeviceName));
               } else {
                   return config.get<STEPPING>();
-              }
-          }}},
-        {ov::intel_npu::max_tiles.name(),
-         {false,
-          ov::PropertyMutability::RW,
-          [&](const Config& config) {
-              if (!config.has<MAX_TILES>()) {
-                  const auto specifiedDeviceName = get_specified_device_name(config);
-                  return static_cast<int64_t>(_metrics->GetMaxTiles(specifiedDeviceName));
-              } else {
-                  return config.get<MAX_TILES>();
               }
           }}},
         {ov::intel_npu::compilation_mode.name(),

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -465,9 +465,8 @@ Plugin::Plugin()
               if (!config.has<MAX_TILES>()) {
                   const auto specifiedDeviceName = get_specified_device_name(config);
                   return static_cast<int64_t>(_metrics->GetMaxTiles(specifiedDeviceName));
-              } else {
-                  return config.get<MAX_TILES>();
               }
+              return config.get<MAX_TILES>();
           }}},
         // NPU Private
         // =========


### PR DESCRIPTION
### Details:
 - publishing NPU_TILES (RW) property to enable setting the number of npu tiles to compile the model for.
 - publishing NPU_MAX_TILES (RW) property to set (in case of offline compilation) or get (from current device) the maximum number of tiles the hardware we compile for supports.

### Tickets:
 - [*ticket-id*](https://jira.devtools.intel.com/browse/CVS-147058)
