### PR TITLE
[INSTALL] Fix setupvars.sh corrupted installation directory

### DIFF
--- a/scripts/setupvars/setupvars.sh
+++ b/scripts/setupvars/setupvars.sh
@@ -6,7 +6,7 @@
 abs_path () {
     script_path=$(eval echo "$1")
     directory=$(dirname "$script_path")
-    builtin cd "$directory" || exit
+    builtin cd "$directory" >/dev/null 2>&1 || exit
     pwd -P
 }
 


### PR DESCRIPTION
Both 'cd' and 'pwd -P' print the directory name
Installation directory should be printed only once