### PR TITLE
[TF FE] Switch on SparseTensorDenseAdd test on GPU

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_SparseTensorDenseAdd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SparseTensorDenseAdd.py
@@ -78,8 +78,6 @@ class TestSparseTensorDenseAdd(CommonTFLayerTest):
                                     a_shape, b_shape, nnz,
                                     ie_device, precision, ir_version, temp_dir,
                                     use_legacy_frontend):
-        if ie_device == 'GPU':
-            pytest.skip("149830: ScatterNDUpdate-15 is not supported on GPU")
         self._test(*self.create_sparse_tensor_dense_add_net(data_type, indices_type,
                                                             a_shape, b_shape, nnz),
                    ie_device, precision, ir_version, temp_dir=temp_dir,


### PR DESCRIPTION
**Details:** Switch on SparseTensorDenseAdd test on GPU. It was fixed since downgrading transformation for ScatterNDUpdate was merged https://github.com/openvinotoolkit/openvino/pull/26113

**Ticket:** TBD
