### PR TITLE
[CPU][ARM] Fix ACL version detection

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
+++ b/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
@@ -391,5 +391,5 @@ elseif(NOT TARGET arm_compute::arm_compute)
     endforeach()
 
     # required by oneDNN to attempt to parse ACL version
-    set(ENV{ACL_ROOT_DIR} "${ARM_COMPUTE_SOURCE_DIR}")
+    set(ACL_INCLUDE_DIR "${ARM_COMPUTE_SOURCE_DIR}")
 endif()

--- a/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_cpu/thirdparty/CMakeLists.txt
@@ -15,6 +15,17 @@ if(ENABLE_LTO)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
 endif()
 
+function(create_acl_version_file)
+    set(ACL_ROOT_DIR "${intel_cpu_thirdparty_SOURCE_DIR}/ComputeLibrary")
+    set(ACL_SCONSCRIPT_FILE_PATH "${ACL_ROOT_DIR}/SConscript")
+    file(READ ${ACL_SCONSCRIPT_FILE_PATH} ACL_SCONSCRIPT_FILE_CONTENT)
+    string(REGEX MATCH "v([0-9]+\\.[0-9]+\\.?[0-9]*)" ACL_VERSION "${ACL_SCONSCRIPT_FILE_CONTENT}")
+    set(ACL_VERSION "${CMAKE_MATCH_1}")
+
+    set(ACL_VERSION_FILE_PATH "${ACL_ROOT_DIR}/build/src/core/arm_compute_version.embed")
+    file(WRITE ${ACL_VERSION_FILE_PATH} "\"arm_compute_version=v${ACL_VERSION}\"")
+endfunction()
+
 function(ov_add_onednn)
     set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
     set(CMAKE_DISABLE_FIND_PACKAGE_PythonInterp ON)
@@ -120,6 +131,7 @@ function(ov_add_onednn)
     # to find our FindACL.cmake
     if(DNNL_USE_ACL)
         list(APPEND CMAKE_MODULE_PATH "${intel_cpu_thirdparty_SOURCE_DIR}")
+        create_acl_version_file()
     endif()
 
     add_subdirectory(onednn EXCLUDE_FROM_ALL)


### PR DESCRIPTION
### Details:
 - oneDNN commit https://github.com/openvinotoolkit/oneDNN/commit/2829997861b317d13af62c029d20e3c3fb3504a7 has been reverted to be aligned with oneDNN upstream
 - New cmake function was created to generate `arm_compute_version.embed` which is used by oneDNN to detect ACL version

