### PR TITLE
[GPU] Fix qwen run failure regression.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -511,7 +511,9 @@ static void optimize_weights_decompression_parameters(fully_connected_node& fc_n
     auto need_reorder = [&](size_t dep_id) {
         auto dep_layout = fc_node.get_input_layout(dep_id);
         auto dep_pshape = dep_layout.get_partial_shape();
-        auto groups_count = dep_pshape[1].get_length();
+        // Group for scale_idx is always 1, whereas zero_point_idx is 0.
+        auto groups_idx = (dep_pshape.size() > 1) ? 1 : 0;
+        auto groups_count = dep_pshape[groups_idx].get_length();
 
         return groups_count > 1;
     };


### PR DESCRIPTION
Recently fixed FC bad groups size bug PR(https://github.com/openvinotoolkit/openvino/pull/26145) has the regression in qwen.


need_reorder function is used both decompression_scale and zero_point, but only consider scale NOT ZP.


### Tickets:
 - *150515*
