### PR TITLE
[Snippets][CPU] Added avx2_vnni_2 support for Quantized MHA

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
@@ -72,7 +72,6 @@ std::set<std::vector<element::Type>> jit_brgemm_emitter::get_supported_precision
     const auto brgemm = as_type_ptr<ov::intel_cpu::BrgemmCPU>(node);
     OV_CPU_JIT_EMITTER_ASSERT(brgemm, "get_supported_precisions() expects BrgemmCPU node");
     using brgemm_utils::BRGEMM_TYPE;
-    std::set<std::vector<element::Type>> supported_types;
     if (brgemm->get_type() == BRGEMM_TYPE::STAND_ALONE) {
         return {{element::f32, element::f32}};
     } else if (brgemm->get_type() == BRGEMM_TYPE::REPACKING_ONLY) {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
@@ -72,22 +72,24 @@ std::set<std::vector<element::Type>> jit_brgemm_emitter::get_supported_precision
     const auto brgemm = as_type_ptr<ov::intel_cpu::BrgemmCPU>(node);
     OV_CPU_JIT_EMITTER_ASSERT(brgemm, "get_supported_precisions() expects BrgemmCPU node");
     using brgemm_utils::BRGEMM_TYPE;
-    switch (brgemm->get_type()) {
-        case BRGEMM_TYPE::STAND_ALONE:
-            return {{element::f32, element::f32}};
-        case BRGEMM_TYPE::REPACKING_ONLY:
-            return {{element::u8, element::i8},
-                    {element::bf16, element::bf16},
-                    {element::f32, element::f32}};
-        case BRGEMM_TYPE::WITH_COMPENSATIONS:
-            return {{element::i8, element::i8, element::f32}};
-        case BRGEMM_TYPE::WITH_AMX:
-            return {{element::i8, element::i8, element::u8},
-                    {element::u8, element::i8, element::u8},
-                    {element::bf16, element::bf16, element::u8}};
-        default:
-            OV_CPU_JIT_EMITTER_THROW("got BrgemmCPU node with unsupported type");
+    std::set<std::vector<element::Type>> supported_types;
+    if (brgemm->get_type() == BRGEMM_TYPE::STAND_ALONE) {
+        return {{element::f32, element::f32}};
+    } else if (brgemm->get_type() == BRGEMM_TYPE::REPACKING_ONLY) {
+        std::set<std::vector<element::Type>> supported_types = {{element::u8, element::i8},
+                                                                {element::bf16, element::bf16},
+                                                                {element::f32, element::f32}};
+        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2))
+            supported_types.insert({element::i8, element::i8});
+        return supported_types;
+    } else if (brgemm->get_type() == BRGEMM_TYPE::WITH_COMPENSATIONS) {
+        return {{element::i8, element::i8, element::f32}};
+    } else if (brgemm->get_type() == BRGEMM_TYPE::WITH_AMX) {
+        return {{element::i8, element::i8, element::u8},
+                {element::u8, element::i8, element::u8},
+                {element::bf16, element::bf16, element::u8}};
     }
+    OV_CPU_JIT_EMITTER_THROW("got BrgemmCPU node with unsupported type");
 }
 
 void jit_brgemm_emitter::validate_arguments(const std::vector<size_t> &in, const std::vector<size_t> &out) const {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.cpp
@@ -24,6 +24,7 @@ cpu_isa_t get_primitive_isa(const ov::element::Type& dt_in0, bool is_with_amx) {
 #define SUPPORT(X, Y) if (mayiuse(X)) { isa = X; } else { Y }
 #define SUPPORT_ONE(X, MESSAGE) SUPPORT(X, OV_CPU_JIT_EMITTER_THROW(MESSAGE);)
 #define SUPPORT_TWO(X, Y, MESSAGE) SUPPORT(X, SUPPORT_ONE(Y, MESSAGE))
+#define SUPPORT_THREE(X, Y, Z, MESSAGE) SUPPORT(X, SUPPORT_TWO(Y, Z, MESSAGE))
 
     // Note: AMX might be not used even if it's supported by the hardware, check the BrgemmToBrgemmCPU pass for details
     if (is_with_amx) {
@@ -31,7 +32,7 @@ cpu_isa_t get_primitive_isa(const ov::element::Type& dt_in0, bool is_with_amx) {
     } else if (dt_in0 == ov::element::bf16) {
         SUPPORT_ONE(avx512_core_bf16, "Unsupported hardware configuration: bf16 is supported only on avx512 platforms")
     } else if (one_of(dt_in0, ov::element::u8, ov::element::i8)) {
-        SUPPORT_TWO(avx512_core_vnni, avx2_vnni, "Unsupported hardware configuration: int8 is supported only on vnni platforms")
+        SUPPORT_THREE(avx512_core_vnni, avx2_vnni_2, avx2_vnni, "Unsupported hardware configuration: int8 is supported only on vnni platforms")
     } else {
         SUPPORT_TWO(avx512_core, cpu::x64::avx2, "Unsupported hardware configuration: brgemm requires at least avx2 isa")
     }
@@ -56,9 +57,8 @@ BRGEMM_TYPE get_brgemm_type(const ov::element::Type& element_type_a, const Dimen
         return BRGEMM_TYPE::WITH_AMX;
     // Note: this condition reproduces logic from the OneDNN Brgemm implementation. This is needed to align with the
     // backend requirements. More details in onednn/src/cpu/x64/brgemm/brgemm_utils.cpp
-    if (element_type_a == ov::element::i8 &&
-       !dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2))
-       return BRGEMM_TYPE::WITH_COMPENSATIONS;
+    if (element_type_a == ov::element::i8)
+       return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2) ? BRGEMM_TYPE::REPACKING_ONLY : BRGEMM_TYPE::WITH_COMPENSATIONS;
 
     if (one_of(element_type_a, element::u8, ov::element::bf16))
         return BRGEMM_TYPE::REPACKING_ONLY;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp
@@ -15,11 +15,11 @@ namespace pass {
  * @brief The pass decompose Snippets Brgemm to specific subgraph that depends on ISA and input precisions:
  *        - f32|f32 without transpose_b:
  *                   BrgemmCPU
- *        - u8|i8 or bf16|bf16 (non-AMX system):
+ *        - u8|i8 or bf16|bf16 (non-AMX system) or i8|i8 (with avx2_vnni_2 support):
  *                 \       BrgemmCopyB (the operation for data repacking)
  *                  \        Buffer
  *                   BrgemmCPU
- *        - i8|i8 (non-AMX system) - needs compensations:
+ *        - i8|i8 (non-AMX system and without avx2_vnni_2) - needs compensations:
  *                \                              BrgemmCopyB
  *                 \                            /          \
  *                  \        Buffer (with repacked data)  Buffer (with compensations)

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp
@@ -15,7 +15,7 @@ namespace pass {
  * @brief The pass decompose Snippets Brgemm to specific subgraph that depends on ISA and input precisions:
  *        - f32|f32 without transpose_b:
  *                   BrgemmCPU
- *        - u8|i8 or bf16|bf16 (non-AMX system) or i8|i8 (with avx2_vnni_2 support):
+ *        - u8|i8 or bf16|bf16 (non-AMX system) or i8|i8 (with avx2_vnni_2 support) or with `transpose_b=True`:
  *                 \       BrgemmCopyB (the operation for data repacking)
  *                  \        Buffer
  *                   BrgemmCPU

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -963,13 +963,9 @@ void Transformations::MainSnippets(void) {
         // The current solution with ExtractExplicitMatMulTranspose pass is slower for non-f32 cases than using of brgemm_copy_b kernel
         if (matmul->get_transpose_a() || matmul->get_transpose_b())
             return false;
-        if (in_type0 == ov::element::i8) {
-            // [150531] AVX2_VNNI_2 is not fully supported yet
-            if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2))
-                return false;
+        if (in_type0 == ov::element::i8)
             return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni) ||
                    dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni);
-        }
         if ((in_type0 == ov::element::bf16 && in_type1 == ov::element::bf16) ||
             ((in_type0 == element::f32 && in_type1 == ov::element::f32 && inferencePrecision == ov::element::bf16))) {
             // Implementation calls AMX BF16 brgemm only for tensors with K and N aligned on 2, otherwise fallbacks on vector impl


### PR DESCRIPTION
### Details:
 - *Added  Quantized MHA tokenization support on `avx2_vnni_2` platforms. `i8|i8` Brgemms don't need to have compensations on archs with this ISA*
 - *PR to oneDNN: https://github.com/openvinotoolkit/oneDNN/pull/262*

### Tickets:
 - *150531*
