### PR TITLE
[CPU] Fix BatchToSpace size_t underflow for the second dimension

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
@@ -180,8 +180,10 @@ void BatchToSpace::batchToSpaceKernel() {
                 oAdd.push_back(oAdd[1]);
                 oAdd.erase(oAdd.begin() + 1);
             }
-            begin[1] = (blockShape[1] - 1 - oAdd[1]) / blockShape[1] / blockSize;
-            finish[1] = (outShape5D[1] - 1 - oAdd[1]) / blockShape[1] / blockSize;
+
+            const auto numBlockElements = blockShape[1] * blockSize;
+            begin[1] = (blockShape[1] - 1 - oAdd[1]) / numBlockElements;
+            finish[1] = (outShape5D[1] + numBlockElements - 1 - oAdd[1]) / numBlockElements;
             begin[2] = (blockShape[2] - 1 - oAdd[2]) / blockShape[2];
             finish[2] = (outShape5D[2] + blockShape[2] - 1 - oAdd[2]) / blockShape[2];
             begin[3] = (blockShape[3] - 1 - oAdd[3]) / blockShape[3];
@@ -190,12 +192,14 @@ void BatchToSpace::batchToSpaceKernel() {
             finish[4] = (outShape5D[4] + blockShape[4] - 1 - oAdd[4]) / blockShape[4];
             const int64_t addTmpOC = blocked ? 0lu : oAdd[1];
             const int64_t addTmpOc = blocked ? oAdd[1] : 0lu;
-            indxStart[1] = begin[1] > indxStart[1] ? begin[1] : indxStart[1];
-            const size_t lastI1 = i0 == indxEnd[0] ? (indxEnd[1] > finish[1] ? finish[1] : indxEnd[1]) : finish[1];
-            for (; indxStart[1] < lastI1 + 1; ++indxStart[1]) {
-                const size_t block = indxStart[1] == finish[1] ? lastBlock : blockSize;
-                const int64_t tmpOC = indxStart[1] * blockShape[1] + addTmpOC;
-                const size_t srcIdx1 = srcIdx0 + indxStart[1] * inSpatialStep * blockSize;
+
+            const size_t firstI1 = i0 == 0 ?          std::max(begin[1], indxStart[1])    : begin[1];
+            const size_t lastI1  = i0 == indxEnd[0] ? std::min(indxEnd[1] + 1, finish[1]) : finish[1];
+
+            for (size_t i1 = firstI1; i1 < lastI1; ++i1) {
+                const size_t block = i1 == finish[1] ? lastBlock : blockSize;
+                const int64_t tmpOC = i1 * blockShape[1] + addTmpOC;
+                const size_t srcIdx1 = srcIdx0 + i1 * inSpatialStep * blockSize;
                 const size_t dstIdx1 = dstIdx0 + tmpOC * outSpatialStep * blockSize;
                 const size_t itEnd = blocked ? ((block - 1) * blockShape[1] + oAdd[1]) / blockSize : 0lu;
                 for (size_t i2 = begin[2]; i2 < finish[2]; ++i2) {
@@ -225,7 +229,6 @@ void BatchToSpace::batchToSpaceKernel() {
                     }
                 }
             }
-            indxStart[1] = 0lu;
         }
     });
 }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/batch_to_space.cpp
@@ -418,11 +418,11 @@ const std::vector<int64_t> cropsBeginZeroDimOutput = {0, 0, 0, 0, 0};
 const std::vector<int64_t> cropsEndZeroDimOutput = {0, 0, 2, 0, 0};
 
 const auto dynamicBatchToSpaceParamsSetZeroDimOutput = ::testing::Combine(::testing::Values(dynamicInputShapesZeroDimOutput),
-                                                                  ::testing::Values(blockShapeZeroDimOutput),
-                                                                  ::testing::Values(cropsBeginZeroDimOutput),
-                                                                  ::testing::Values(cropsEndZeroDimOutput),
-                                                                  ::testing::Values(ov::element::Type_t::f32),
-                                                                  ::testing::Values(CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})));
+                                                                          ::testing::Values(blockShapeZeroDimOutput),
+                                                                          ::testing::Values(cropsBeginZeroDimOutput),
+                                                                          ::testing::Values(cropsEndZeroDimOutput),
+                                                                          ::testing::Values(ov::element::Type_t::f32),
+                                                                          ::testing::ValuesIn(cpuParams_5D));
 
 INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchToSpaceCPULayerTestCaseZeroDimOutput,
                          BatchToSpaceCPULayerTest,
@@ -441,11 +441,11 @@ const std::vector<int64_t> cropsBeginOutputDimOne = {0, 0, 0, 0, 0};
 const std::vector<int64_t> cropsEndOutputDimOne = {0, 0, 1, 0, 0};
 
 const auto dynamicBatchToSpaceParamsSetOutputDimOne = ::testing::Combine(::testing::Values(dynamicInputShapesOutputDimOne),
-                                                                  ::testing::Values(blockShapeOutputDimOne),
-                                                                  ::testing::Values(cropsBeginOutputDimOne),
-                                                                  ::testing::Values(cropsEndOutputDimOne),
-                                                                  ::testing::Values(ov::element::Type_t::f32),
-                                                                  ::testing::Values(CPUSpecificParams({ncdhw}, {ncdhw}, {}, {})));
+                                                                         ::testing::Values(blockShapeOutputDimOne),
+                                                                         ::testing::Values(cropsBeginOutputDimOne),
+                                                                         ::testing::Values(cropsEndOutputDimOne),
+                                                                         ::testing::Values(ov::element::Type_t::f32),
+                                                                         ::testing::ValuesIn(cpuParams_5D));
 
 INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchToSpaceCPULayerTestCaseOutputDimOne,
                          BatchToSpaceCPULayerTest,


### PR DESCRIPTION
size_t underflow might happen for the second dimension as well, for example when layout is ndhwc.
New test cases extended for `ndhwc` layout as well

### Tickets:
 - 14877