### PR TITLE
Switched to use of reference to fix minor coverity issue

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -912,7 +912,7 @@ void Snapshot::afterUniques() {
 
     for (const auto& nh : m_graph->sorted()) {
         Group::GPtr group = m_graph->meta(nh).get<Group::GPtr>();
-        auto tag = group->isolatedTag();
+        const auto& tag = group->isolatedTag();
 
         // Not expecting thousands of tags here, thus std::find on a vector
         if (!tag.empty() && std::find(m_ctx.nofolds.begin(), m_ctx.nofolds.end(), tag) != m_ctx.nofolds.end()) {


### PR DESCRIPTION
### Details:
 - This PR fixes minor coverity issue in NPUW component: switches usage of copy to reference

### Tickets:
 - *ticket-id*
