### PR TITLE
[GPU] Fix Interpolate 11 axes reading

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -128,7 +128,7 @@ struct resample : public primitive_base<resample> {
     tensor output_size;
     /// @param num_filter Input filter. Only used by bilinear sample_type.
     uint32_t num_filter = 0;
-    /// @param num_filter Input filter. Only used by bilinear sample_type.
+    /// @param num_filter Port number of scales.
     uint32_t scales_port;
     /// @param sizes Describing output shape for spatial axes.
     std::vector<int64_t> sizes;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -96,38 +96,12 @@ struct resample : public primitive_base<resample> {
              InterpolateOp::InterpolateMode operation_type = InterpolateOp::InterpolateMode::LINEAR,
              InterpolateOp::ShapeCalcMode shape_calc_mode = InterpolateOp::ShapeCalcMode::SIZES,
              InterpolateOp::CoordinateTransformMode ctm = InterpolateOp::CoordinateTransformMode::HALF_PIXEL,
-             InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR)
+             InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR,
+	     const int scales_port = 2)
         : primitive_base(id, {input, sizes_id, scales_id}),
           output_size(tensor()),
           num_filter(0),
-          sizes({}),
-          scales({}),
-          axes(axes),
-          pads_begin(pads_begin),
-          pads_end(pads_end),
-          operation_type(operation_type),
-          shape_calc_mode(shape_calc_mode),
-          antialias(antialias),
-          cube_coeff(cube_coeff),
-          coord_trans_mode(ctm),
-          round_mode(nm) {}
-
-    /// @brief resample with dynamic sizes/scales
-    resample(const primitive_id& id,
-             const input_info& input,
-             const input_info& sizes_or_scales_id,
-             const std::vector<int64_t>& axes,
-             const std::vector<size_t>& pads_begin = {},
-             const std::vector<size_t>& pads_end = {},
-             int32_t antialias = 0,
-             float cube_coeff = -0.75f,
-             InterpolateOp::InterpolateMode operation_type = InterpolateOp::InterpolateMode::LINEAR,
-             InterpolateOp::ShapeCalcMode shape_calc_mode = InterpolateOp::ShapeCalcMode::SIZES,
-             InterpolateOp::CoordinateTransformMode ctm = InterpolateOp::CoordinateTransformMode::HALF_PIXEL,
-             InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR)
-        : primitive_base(id, {input, sizes_or_scales_id}),
-          output_size(tensor()),
-          num_filter(0),
+          scales_port(scales_port),
           sizes({}),
           scales({}),
           axes(axes),
@@ -154,6 +128,8 @@ struct resample : public primitive_base<resample> {
     tensor output_size;
     /// @param num_filter Input filter. Only used by bilinear sample_type.
     uint32_t num_filter = 0;
+    /// @param num_filter Input filter. Only used by bilinear sample_type.
+    uint32_t scales_port;
     /// @param sizes Describing output shape for spatial axes.
     std::vector<int64_t> sizes;
     /// @param scales Scales of spatial axes, i.e. output_shape / input_shape

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -112,6 +112,36 @@ struct resample : public primitive_base<resample> {
           coord_trans_mode(ctm),
           round_mode(nm) {}
 
+    /// @brief resample with dynamic sizes/scales
+    resample(const primitive_id& id,
+             const input_info& input,
+             const input_info& sizes_or_scales_id,
+             const std::vector<int64_t>& axes,
+             const std::vector<size_t>& pads_begin = {},
+             const std::vector<size_t>& pads_end = {},
+             int32_t antialias = 0,
+             float cube_coeff = -0.75f,
+             InterpolateOp::InterpolateMode operation_type = InterpolateOp::InterpolateMode::LINEAR,
+             InterpolateOp::ShapeCalcMode shape_calc_mode = InterpolateOp::ShapeCalcMode::SIZES,
+             InterpolateOp::CoordinateTransformMode ctm = InterpolateOp::CoordinateTransformMode::HALF_PIXEL,
+             InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR)
+        : primitive_base(id, {input, sizes_or_scales_id}),
+          output_size(tensor()),
+          num_filter(0),
+          sizes({}),
+          scales({}),
+          axes(axes),
+          pads_begin(pads_begin),
+          pads_end(pads_end),
+          operation_type(operation_type),
+          shape_calc_mode(shape_calc_mode),
+          antialias(antialias),
+          cube_coeff(cube_coeff),
+          coord_trans_mode(ctm),
+          round_mode(nm) {}
+
+
+
     InterpolateOp::InterpolateAttrs get_attrs() const {
         return InterpolateOp::InterpolateAttrs(this->operation_type,
                                                this->shape_calc_mode,

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -97,7 +97,7 @@ struct resample : public primitive_base<resample> {
              InterpolateOp::ShapeCalcMode shape_calc_mode = InterpolateOp::ShapeCalcMode::SIZES,
              InterpolateOp::CoordinateTransformMode ctm = InterpolateOp::CoordinateTransformMode::HALF_PIXEL,
              InterpolateOp::NearestMode nm = InterpolateOp::NearestMode::ROUND_PREFER_FLOOR,
-	     const int scales_port = 2)
+             const int scales_port = 2)
         : primitive_base(id, {input, sizes_id, scales_id}),
           output_size(tensor()),
           num_filter(0),

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -140,8 +140,6 @@ struct resample : public primitive_base<resample> {
           coord_trans_mode(ctm),
           round_mode(nm) {}
 
-
-
     InterpolateOp::InterpolateAttrs get_attrs() const {
         return InterpolateOp::InterpolateAttrs(this->operation_type,
                                                this->shape_calc_mode,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -156,9 +156,10 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
         params.pads_end = convert_pads(primitive->pads_end, dimsNum);
 
         auto scales = primitive->scales;
+        auto scales_port = primitive->scales_port;
         bool scales_calc_mod = primitive->shape_calc_mode == resample::InterpolateOp::ShapeCalcMode::SCALES;
         if (scales_calc_mod && impl_param.input_layouts.size() > 1 && scales.empty()) {
-            auto mem = impl_param.memory_deps.at(2);
+            auto mem = impl_param.memory_deps.at(scales_port);
             scales = read_vector<float>(std::move(mem), impl_param.get_stream());
         }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -201,7 +201,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                              attrs.shape_calculation_mode,
                                                              attrs.coordinate_transformation_mode,
                                                              attrs.nearest_mode,
-							     1);
+                                                             1);
         }
     } else {
         auto outShape = op->get_output_shape(0);

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -191,7 +191,6 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
             resamplePrim = std::make_shared<cldnn::resample>(layerName,
                                                              inputs[0],
                                                              inputs[eScalesOrSizesIndex],
-                                                             inputs[eScalesOrSizesIndex],
                                                              axes,
                                                              attrs.pads_begin,
                                                              attrs.pads_end,

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -191,6 +191,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
             resamplePrim = std::make_shared<cldnn::resample>(layerName,
                                                              inputs[0],
                                                              inputs[eScalesOrSizesIndex],
+                                                             inputs[eAxesIndex],
                                                              axes,
                                                              attrs.pads_begin,
                                                              attrs.pads_end,
@@ -199,7 +200,8 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
                                                              attrs.mode,
                                                              attrs.shape_calculation_mode,
                                                              attrs.coordinate_transformation_mode,
-                                                             attrs.nearest_mode);
+                                                             attrs.nearest_mode,
+							     1);
         }
     } else {
         auto outShape = op->get_output_shape(0);


### PR DESCRIPTION
### Details:
 - Fix interpolate 11 op case when sizes or scales are not constant. The additional argument shadowed TensorAccessor underlying tensor on port 2 and therefore shape inference was reading wrong values

### Tickets:
 - 146022
