### PR TITLE
[CI] [GHA] Fix `CCACHE_REMOTE_DIR` value if in merge group

### DIFF
--- a/.github/workflows/job_build_windows.yml
+++ b/.github/workflows/job_build_windows.yml
@@ -32,7 +32,7 @@ jobs:
       CMAKE_GENERATOR: 'Ninja Multi-Config'
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
       CMAKE_C_COMPILER_LAUNCHER: ccache
-      CCACHE_REMOTE_DIR: "C:\\mount\\caches\\ccache\\windows2022_x86_64_${{ inputs.build-type }}\\${{ github.base_ref || github.event.merge_group.base_ref || github.ref_name }}"
+      CCACHE_REMOTE_DIR: ""
       CCACHE_DIR: ${{ github.workspace }}\\ccache
       CCACHE_MAXSIZE: 3G
       OPENVINO_REPO: "${{ github.workspace }}\\openvino"
@@ -57,6 +57,21 @@ jobs:
           repository: 'openvinotoolkit/openvino_contrib'
           path: 'openvino_contrib'
           ref: 'master'
+
+      - name: Set CCACHE_REMOTE_DIR based on event
+        shell: bash
+        run: |
+          final_dir=""
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            branch_ref="${{ github.event.merge_group.base_ref }}" # Resolves into "refs/heads/master"
+            final_dir="${branch_ref##*/}" # Resolves into "master"
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            final_dir="${{ github.base_ref }}" # Resolves into "master"
+          else
+            final_dir="${{ github.ref_name }}" # Resolves into "master"
+          fi
+          
+          echo "CCACHE_REMOTE_DIR=C:\\\mount\\\caches\\\ccache\\\windows2022_x86_64_${{ inputs.build-type }}\\\$final_dir" >> $GITHUB_ENV
 
       - name: Setup Python ${{ env.PYTHON_VERSION }}
         uses: ./openvino/.github/actions/setup_python


### PR DESCRIPTION
### Details:
 - Apparently, `github.event.merge_group.base_ref` for merge group checks does not resolve into the same thing as `github.base_ref` for pull request checks.
 - `github.event.merge_group.base_ref` resolves into `refs/heads/master` while we need only the `master` part to construct the cache remote directory.

### Tickets:
 - *150744*
