### PR TITLE
[Common] MarkDequantizationSubgraph: avoid modification of RT Info for fold_multiply_const=true option

### DIFF
--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -24,7 +24,7 @@ public:
     OPENVINO_RTTI("MarkDequantizationSubgraph", "0");
     MarkDequantizationSubgraph(const element::TypeVector& precisions,
                                const bool fold_subtract_const = false,
-                               const bool fold_multiply_const = true);
+                               const bool disable_fold_multiply_const = false);
 };
 }  // namespace pass
 }  // namespace ov

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -15,7 +15,7 @@
 
 ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::TypeVector& precisions,
                                                                  const bool fold_subtract_const,
-                                                                 const bool fold_multiply_const) {
+                                                                 const bool disable_fold_multiply_const) {
     // Dequantization subgraph may have two forms: with and without Subtract
     //
     //    Input                                 Input
@@ -103,13 +103,10 @@ ov::pass::MarkDequantizationSubgraph::MarkDequantizationSubgraph(const element::
         auto scale = multiply->get_input_node_shared_ptr(1);
         if (ov::is_type<ov::op::v0::Convert>(scale) &&
             ov::is_type<ov::op::v0::Constant>(scale->get_input_node_ptr(0))) {
-            if (!fold_multiply_const) {
+            if (disable_fold_multiply_const) {
                 ov::disable_constant_folding(scale);
                 ov::unmark_as_decompression(scale);
                 ov::enable_keep_const_precision(scale->get_input_node_shared_ptr(0));
-            } else {
-                ov::enable_constant_folding(scale);
-                ov::disable_keep_const_precision(scale->get_input_node_shared_ptr(0));
             }
         }
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -326,7 +326,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
                                                      ov::element::i4,
                                                      ov::element::nf4,
                                                      ov::element::f4e2m1};
-    CPU_REGISTER_PASS_X64(decompression_handling_manager, ov::pass::MarkDequantizationSubgraph, decompression_precisions, false, false);
+    CPU_REGISTER_PASS_X64(decompression_handling_manager, ov::pass::MarkDequantizationSubgraph, decompression_precisions, false, true);
     CPU_SET_CALLBACK_X64(decompression_handling_manager, [&](const_node_ptr &node) -> bool {
         return !is_decompression_multiply(node);
     }, ov::pass::MarkDequantizationSubgraph);


### PR DESCRIPTION
### Details:
 - The PR restores MarkDequantizationSubgraph transformation behavior to the state before https://github.com/openvinotoolkit/openvino/pull/25783. This is required to avoid compressed zero-points constant folding during model conversion. 

### Tickets:
 - *[CVS-150686](https://jira.devtools.intel.com/browse/CVS-150686)*
