### PR TITLE
[NPUW] Use OpenVINO-provided flags to enable AVX2

### DIFF
--- a/src/plugins/intel_npu/src/plugin/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/plugin/CMakeLists.txt
@@ -66,12 +66,9 @@ target_include_directories(${TARGET_NAME}
         ${NPU_PLUGIN_SOURCE_DIR}/thirdparty/level-zero-ext
 )
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR OV_COMPILER_IS_INTEL_LLVM)
-  target_compile_options(${TARGET_NAME} PRIVATE -mavx2 -mf16c)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  target_compile_options(${TARGET_NAME} PRIVATE /arch:AVX2)
-else()
-  message(AUTHOR_WARNING "Unknown compiler, may miss the AVX2 baseline setting")
+if(ENABLE_AVX2)
+    ov_avx2_optimization_flags(avx2_flags)
+    target_compile_options(${TARGET_NAME} PRIVATE "${avx2_flags}")
 endif()
 
 ov_add_api_validator_post_build_step(TARGET ${NPU_PLUGIN_TARGET})


### PR DESCRIPTION
### Details:
 - Use OpenVINO-provided flags to enable AVX2 for NPUW

### Tickets:
 - 136004
