### PR TITLE
[GPU] Add prefix support for PagedAttention operation

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/paged_attention.cpp
@@ -84,7 +84,7 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         };
 
         std::vector<layout> layouts;
-        add_internal_buffers(layouts, _kernels_data[Stage::SDPA]);
+        add_internal_buffers(layouts, _kernels_data[Stage::KV_CACHE_UPDATE]);
         add_internal_buffers(layouts, _kernels_data[Stage::PA_SDPA]);
 
         return layouts;
@@ -94,7 +94,7 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         const auto desc = instance.get_node().as<paged_attention>().get_primitive();
 
         kernel_arguments_data args;
-        if (stage == Stage::KV_CACHE_UPDATE || stage == Stage::SDPA || (stage == Stage::PA_SDPA && kernel_idx == 0))
+        if (stage == Stage::KV_CACHE_UPDATE || stage == Stage::SDPA)
             args.shape_info = instance.shape_info_memory_ptr();
 
         if (stage == Stage::KV_CACHE_UPDATE) {
@@ -102,7 +102,8 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
                              instance.value_memory_ptr(),
                              instance.past_lens_memory_ptr(),
                              instance.block_indices_memory_ptr(),
-                             instance.block_indices_begins_memory_ptr() };
+                             instance.block_indices_begins_memory_ptr(),
+                             instance.subsequence_begins_memory_ptr() };
 
             args.outputs = { instance.key_cache_memory_ptr(),
                              instance.value_cache_memory_ptr() };
@@ -118,7 +119,9 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
 
             args.outputs = { instance.output_memory_ptr(0) };
         } else if (stage == Stage::PA_SDPA) {
-            if (kernel_idx == 0) {
+            if (kernel_idx == 0 || kernel_idx == 1) {
+                args.shape_info = instance.shape_info_memory_ptr();
+
                 args.inputs = { instance.input_memory_ptr(0),
                                 instance.key_cache_memory_ptr(),
                                 instance.value_cache_memory_ptr(),
@@ -126,11 +129,17 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
                                 instance.block_indices_memory_ptr(),
                                 instance.block_indices_begins_memory_ptr() };
 
+                if (kernel_idx == 1) {
+                    // Multi tokens kernel version has additional subsequence_begins_memory memory
+                    // dependency
+                    args.inputs.push_back(instance.subsequence_begins_memory_ptr());
+                }
+
                 if (desc->has_alibi) {
                     args.inputs.push_back(instance.alibi_memory_ptr());
                 }
             } else {
-                args.inputs = { instance.past_lens_memory_ptr(), };
+                args.inputs = { instance.past_lens_memory_ptr() };
             }
 
             args.outputs = { instance.output_memory_ptr(0) };
@@ -140,7 +149,8 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
     }
 
     std::set<size_t> get_lockable_internal_buffers() const override {
-        return std::set<size_t>{ 0, 1, 2 }; /* SDPA and KV_CACHE_UPDATE indexes configuration */
+        return std::set<size_t>{ 0, 1, 2, /* SDPA and KV_CACHE_UPDATE indexes configuration */
+                                 6, /* PA_SDPA multiple tokens mode */ };
     };
 
     void execute_stage(const std::vector<event::ptr>& events, paged_attention_inst& instance, std::vector<event::ptr>& all_events, size_t stage) {
@@ -155,10 +165,10 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         size_t internal_buffers_offset = 0;
         size_t internal_buffers_count = 0;
         if (stage == Stage::PA_SDPA) {
-            internal_buffers_offset = _kernels_data[Stage::SDPA].internalBufferSizes.size();
+            internal_buffers_offset = _kernels_data[Stage::KV_CACHE_UPDATE].internalBufferSizes.size();
             internal_buffers_count = _kernels_data[Stage::PA_SDPA].internalBufferSizes.size();
         } else {
-            internal_buffers_count = _kernels_data[Stage::SDPA].internalBufferSizes.size();
+            internal_buffers_count = _kernels_data[Stage::KV_CACHE_UPDATE].internalBufferSizes.size();
         }
 
         for (size_t kd_idx = 0; kd_idx < _kernels_data[stage].kernels.size(); ++kd_idx) {
@@ -184,7 +194,8 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
             const auto& gws = params.workGroups.global;
             const auto& lws = params.workGroups.local;
 
-            GPU_DEBUG_TRACE_DETAIL << "Enqueue stage " << stage << " kernel " << idx_final << ": gws=[" << gws[0] << ", " << gws[1] << ", " << gws[2] << "] "
+            GPU_DEBUG_TRACE_DETAIL << "Enqueue stage " << stage << " kernel " << idx_final << " (kd_idx=" << kd_idx << "): "
+                                   << "gws=[" << gws[0] << ", " << gws[1] << ", " << gws[2] << "] "
                                    << "lws=[" << lws[0] << ", " << lws[1] << ", " << lws[2] << "]"
                                    << (needs_completion_event ? " has_completion_event=true" : "") << std::endl;
 
@@ -199,17 +210,68 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
 
     event::ptr execute_impl(const std::vector<event::ptr>& events, paged_attention_inst& instance) override {
         std::vector<event::ptr> res_events;
+        const auto stage = get_paged_attention_stage(*instance.get_impl_params());
 
         execute_stage(events, instance, res_events, Stage::KV_CACHE_UPDATE);
 
         std::vector<event::ptr> dep_events(res_events.begin(), res_events.end());
-        if (is_prefill_stage(*instance.get_impl_params())) {
+        if (stage == PagedAttentionStage::PREFILL) {
             execute_stage(dep_events, instance, res_events, Stage::SDPA);
-        } else {
+        } else if (stage == PagedAttentionStage::GENERATE || stage == PagedAttentionStage::MIXED) {
             execute_stage(dep_events, instance, res_events, Stage::PA_SDPA);
         }
 
         return aggregate_events(res_events, instance.get_network().get_stream(), res_events.size() > 1);
+    }
+
+    static int64_t get_aligned_seq_len(const kernel_impl_params& impl_param, const PagedAttentionStage& stage, int64_t target_seq_len_block_size = 16) {
+        // Since at prefill stage Q, K, V inputs may contain multiple sequences with arbitrary
+        // target sequence lengths each (shape is [sequences_num * target_seq_len, num_heads * head_size]),
+        // to apply blocking to the first dimension (target_seq_len of each sequence), we need to calculate aligned total
+        // target sequence length for proper kernel dispatching
+        // For instance, if input contains two sequences with 35 and 28 sequence lengths each,
+        // the Q, K, V inputs at prefill stage will have shapes [35 + 28, num_heads * head_size]; considering kernel's
+        // target_seq_len_block_size equals 16, we need to launch kernel instances for the following ranges:
+        // [0, 15], [16, 31], [32, 34], [35, 50], [51, 62], so aligned target_seq_len_block_size should be 5 * 16 = 80,
+        // and 5 kernels instances should be launched (for each range, some of them containing leftovers)
+        //
+        // In general, to obtain length for each sequence, we have to parse subsequence_begins input,
+        // which contains begin and end indexes for each sequence (for above example it will contain three values: {0, 35, 63})
+        // However, as long as kernel's target_seq_len_block_size matches with vLLM's block_size,
+        // we can reuse block_indices_shape[0] size to determine total aligned sequences length size, avoiding
+        // memory access at runtime, because vLLM internally uses similar logic to configure blocks for KV cache
+
+        auto calculate_aligned_seq_len = [&]() {
+            const auto& input_mem = impl_param.memory_deps;
+            const auto subsequence_begins_input_idx = 6;
+            const auto subsequence_begins_mem = input_mem.at(subsequence_begins_input_idx);
+            mem_lock<int32_t, mem_lock_type::read> subsequence_begins_mem_lock(subsequence_begins_mem, *impl_param.strm);
+
+            auto aligned_seq_len = 0;
+            for (size_t i = 0; i < subsequence_begins_mem_lock.size() - 1; i++) {
+                auto prompt_length = subsequence_begins_mem_lock[i + 1] - subsequence_begins_mem_lock[i];
+                aligned_seq_len += align_to(prompt_length, target_seq_len_block_size);
+            }
+
+            return aligned_seq_len;
+        };
+
+        int64_t aligned_seq_len = 0;
+        if (stage == PagedAttentionStage::PREFILL) {
+            const auto desc = impl_param.typed_desc<paged_attention>();
+            if (static_cast<int64_t>(paged_attention::block_size) == target_seq_len_block_size) {
+                const auto block_indices_input_idx = 7;
+                const auto& block_indices_ps = impl_param.get_input_layout(block_indices_input_idx).get_partial_shape();
+
+                aligned_seq_len = block_indices_ps[0].get_length() * target_seq_len_block_size;
+            } else {
+                aligned_seq_len = calculate_aligned_seq_len();
+            }
+        } else {
+            aligned_seq_len = calculate_aligned_seq_len();
+        }
+
+        return aligned_seq_len;
     }
 
     static kernel_selector::sdpa_configuration get_sdpa_configuration(const kernel_impl_params& impl_param) {
@@ -237,7 +299,9 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         return config;
     }
 
-    static kv_cache_update_kernel_params_t get_kv_cache_update_kernel_params(const kernel_impl_params& impl_param, bool is_dynamic = false) {
+    static kv_cache_update_kernel_params_t get_kv_cache_update_kernel_params(const kernel_impl_params& impl_param,
+                                                                             const PagedAttentionStage& stage,
+                                                                             bool is_dynamic = false) {
         auto params = get_default_params<kv_cache_update_kernel_params_t>(impl_param, is_dynamic);
 
         const auto& key_layout = impl_param.get_input_layout(1);
@@ -247,8 +311,9 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         const auto& past_lens_layout = impl_param.get_input_layout(5);
         const auto& block_indices_layout = impl_param.get_input_layout(7);
         const auto& block_indices_begins_layout = impl_param.get_input_layout(8);
+        const auto& subsequence_begins_layout = impl_param.get_input_layout(6);
 
-        const auto inputs_number = 5;
+        const auto inputs_number = 6;
         const auto outputs_number = 2;
         params.inputs.resize(inputs_number);
         params.outputs.resize(outputs_number);
@@ -257,10 +322,16 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         params.inputs[2] = convert_data_tensor(past_lens_layout);
         params.inputs[3] = convert_data_tensor(block_indices_layout);
         params.inputs[4] = convert_data_tensor(block_indices_begins_layout);
+        params.inputs[5] = convert_data_tensor(subsequence_begins_layout);
         params.outputs[0] = convert_data_tensor(key_cache_layout);
         params.outputs[1] = convert_data_tensor(value_cache_layout);
 
         params.conf = get_sdpa_configuration(impl_param);
+
+        params.is_prefill = stage == PagedAttentionStage::PREFILL || stage == PagedAttentionStage::MIXED;
+
+        if ((stage == PagedAttentionStage::PREFILL || stage == PagedAttentionStage::MIXED) && !is_dynamic)
+            params.conf.paged_attention_aligned_seq_len = get_aligned_seq_len(impl_param, stage);
 
         const auto& in_offsets_map = impl_param.in_port_to_shape_info_offset;
         std::map<size_t, size_t> in_tensor_to_offset_map = {
@@ -269,6 +340,7 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
             {2, in_offsets_map.at(5)},
             {3, in_offsets_map.at(7)},
             {4, in_offsets_map.at(8)},
+            {5, in_offsets_map.at(6)},
         };
         std::map<size_t, size_t> out_tensor_to_offset_map = {
             {0, in_offsets_map.at(3)},
@@ -280,7 +352,7 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         return params;
     }
 
-    static sdpa_kernel_params_t get_sdpa_kernel_params(const kernel_impl_params& impl_param, bool is_dynamic = false) {
+    static sdpa_kernel_params_t get_sdpa_kernel_params(const kernel_impl_params& impl_param, const PagedAttentionStage& stage, bool is_dynamic = false) {
         auto params = get_default_params<sdpa_kernel_params_t>(impl_param, is_dynamic);
 
         const auto& query_layout = impl_param.get_input_layout(0);
@@ -321,54 +393,15 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         if (has_alibi)
             in_tensor_to_offset_map.insert({4, in_offsets_map.at(11)});
 
-        if (is_prefill_stage(impl_param) && !is_dynamic) {
-            auto get_aligned_seq_len = [&](int64_t target_seq_len_block_size = 16) {
-                // Since at prefill stage Q, K, V inputs may contain multiple sequences with arbitrary
-                // target sequence lengths each (shape is [sequences_num * target_seq_len, num_heads * head_size]),
-                // to apply blocking to the first dimension (target_seq_len of each sequence), we need to calculate aligned total
-                // target sequence length for proper kernel dispatching
-                // For instance, if input contains two sequences with 35 and 28 sequence lengths each,
-                // the Q, K, V inputs at prefill stage will have shapes [35 + 28, num_heads * head_size]; considering kernel's
-                // target_seq_len_block_size equals 16, we need to launch kernel instances for the following ranges:
-                // [0, 15], [16, 31], [32, 34], [35, 50], [51, 62], so aligned target_seq_len_block_size should be 5 * 16 = 80,
-                // and 5 kernels instances should be launched (for each range, some of them containing leftovers)
-                //
-                // In general, to obtain length for each sequence, we have to parse subsequence_begins input,
-                // which contains begin and end indexes for each sequence (for above example it will contain three values: {0, 35, 63})
-                // However, as long as kernel's target_seq_len_block_size matches with vLLM's block_size,
-                // we can reuse block_indices_shape[0] size to determine total aligned sequences length size, avoiding
-                // memory access at runtime, because vLLM internally uses similar logic to configure blocks for KV cache
-
-                int64_t aligned_seq_len = 0;
-                const auto desc = impl_param.typed_desc<paged_attention>();
-                if (static_cast<int64_t>(paged_attention::block_size) == target_seq_len_block_size) {
-                    const auto block_indices_input_idx = 7;
-                    const auto& block_indices_ps = impl_param.get_input_layout(block_indices_input_idx).get_partial_shape();
-
-                    aligned_seq_len = block_indices_ps[0].get_length() * target_seq_len_block_size;
-                } else {
-                    const auto& input_mem = impl_param.memory_deps;
-                    const auto subsequence_begins_mem = input_mem.at(6);
-                    mem_lock<int32_t, mem_lock_type::read> subsequence_begins_mem_lock(subsequence_begins_mem, *impl_param.strm);
-
-                    for (size_t i = 0; i < subsequence_begins_mem_lock.size() - 1; i++) {
-                        auto prompt_length = subsequence_begins_mem_lock[i + 1] - subsequence_begins_mem_lock[i];
-                        aligned_seq_len += align_to(prompt_length, target_seq_len_block_size);
-                    }
-                }
-
-                return aligned_seq_len;
-            };
-
-            params.conf.paged_attention_aligned_seq_len = get_aligned_seq_len();
-        }
+        if ((stage == PagedAttentionStage::PREFILL || stage == PagedAttentionStage::MIXED) && !is_dynamic)
+            params.conf.paged_attention_aligned_seq_len = get_aligned_seq_len(impl_param, stage);
 
         params.set_dynamic_shape_offsets(in_tensor_to_offset_map, out_tensor_to_offset_map);
 
         return params;
     }
 
-    static pa_sdpa_kernel_params_t get_pa_sdpa_params(const kernel_impl_params& impl_param, bool is_dynamic = false) {
+    static pa_sdpa_kernel_params_t get_pa_sdpa_params(const kernel_impl_params& impl_param, const PagedAttentionStage& stage, bool is_dynamic = false) {
         auto params = get_default_params<pa_sdpa_kernel_params_t>(impl_param, is_dynamic);
 
         const auto& query_layout = impl_param.get_input_layout(0);
@@ -377,10 +410,11 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         const auto& past_lens_layout = impl_param.get_input_layout(5);
         const auto& block_indices_layout = impl_param.get_input_layout(7);
         const auto& block_indices_begins_layout = impl_param.get_input_layout(8);
+        const auto& subsequence_begins_layout = impl_param.get_input_layout(6);
         const auto& alibi_layout = impl_param.get_input_layout(11);
         const auto has_alibi = alibi_layout.count() > 0;
 
-        auto inputs_number = 6;
+        auto inputs_number = 7;
         if (has_alibi)
             inputs_number++;
 
@@ -392,12 +426,15 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         params.inputs[input_idx++] = convert_data_tensor(past_lens_layout);
         params.inputs[input_idx++] = convert_data_tensor(block_indices_layout);
         params.inputs[input_idx++] = convert_data_tensor(block_indices_begins_layout);
+        params.inputs[input_idx++] = convert_data_tensor(subsequence_begins_layout);
         params.conf = get_sdpa_configuration(impl_param);
 
         if (has_alibi)
             params.inputs[input_idx++] = convert_data_tensor(alibi_layout);
 
-        if (!is_prefill_stage(impl_param) && !is_dynamic) {
+        params.multi_tokens_mode = stage == PagedAttentionStage::MIXED;
+
+        if ((stage == PagedAttentionStage::GENERATE || stage == PagedAttentionStage::MIXED) && !is_dynamic) {
             const auto& input_mem = impl_param.memory_deps;
             const auto max_context_len = input_mem.at(12);
             mem_lock<int32_t, mem_lock_type::read> max_context_len_mem_lock(max_context_len, *impl_param.strm);
@@ -414,13 +451,14 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
             {3, in_offsets_map.at(5)},
             {4, in_offsets_map.at(7)},
             {5, in_offsets_map.at(8)},
+            {6, in_offsets_map.at(6)},
         };
         std::map<size_t, size_t> out_tensor_to_offset_map = {
             {0, out_offsets_map.at(0)},
         };
 
         if (has_alibi)
-            in_tensor_to_offset_map.insert({6, in_offsets_map.at(11)});
+            in_tensor_to_offset_map.insert({7, in_offsets_map.at(11)});
 
         params.set_dynamic_shape_offsets(in_tensor_to_offset_map, out_tensor_to_offset_map);
 
@@ -428,30 +466,33 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
     }
 
     void update_dispatch_data(const kernel_impl_params& impl_param) override {
-        auto kv_cache_update_kernel_params = get_kv_cache_update_kernel_params(impl_param, impl_param.is_dynamic());
+        const auto stage = get_paged_attention_stage(impl_param);
+
+        auto kv_cache_update_kernel_params = get_kv_cache_update_kernel_params(impl_param, stage, impl_param.is_dynamic());
         (_kernels_data[Stage::KV_CACHE_UPDATE].update_dispatch_data_func)(kv_cache_update_kernel_params, _kernels_data[Stage::KV_CACHE_UPDATE]);
 
-        if (is_prefill_stage(impl_param)) {
-            auto sdpa_kernel_params = get_sdpa_kernel_params(impl_param, impl_param.is_dynamic());
+        if (stage == PagedAttentionStage::PREFILL) {
+            auto sdpa_kernel_params = get_sdpa_kernel_params(impl_param, stage, impl_param.is_dynamic());
             (_kernels_data[Stage::SDPA].update_dispatch_data_func)(sdpa_kernel_params, _kernels_data[Stage::SDPA]);
-        } else {
-            auto pa_sdpa_kernel_params = get_pa_sdpa_params(impl_param, impl_param.is_dynamic());
+        } else if (stage == PagedAttentionStage::GENERATE || stage == PagedAttentionStage::MIXED) {
+            auto pa_sdpa_kernel_params = get_pa_sdpa_params(impl_param, stage, impl_param.is_dynamic());
             (_kernels_data[Stage::PA_SDPA].update_dispatch_data_func)(pa_sdpa_kernel_params, _kernels_data[Stage::PA_SDPA]);
         }
     }
 
     static std::unique_ptr<primitive_impl> create(const typed_program_node<paged_attention>& arg, const kernel_impl_params& impl_param) {
         std::vector<kernel_selector::kernel_data> kernels_data;
+        const auto stage = PagedAttentionStage::UNKNOWN;
 
-        auto kv_cache_update_kernel_params = get_kv_cache_update_kernel_params(impl_param, impl_param.is_dynamic());
+        auto kv_cache_update_kernel_params = get_kv_cache_update_kernel_params(impl_param, stage, impl_param.is_dynamic());
         auto& kv_cache_update_kernel_selector = kv_cache_update_kernel_selector_t::Instance();
         kernels_data.push_back(kv_cache_update_kernel_selector.get_best_kernel(kv_cache_update_kernel_params));
 
-        auto sdpa_kernel_params = get_sdpa_kernel_params(impl_param, impl_param.is_dynamic());
+        auto sdpa_kernel_params = get_sdpa_kernel_params(impl_param, stage, impl_param.is_dynamic());
         auto& sdpa_kernel_selector = sdpa_kernel_selector_t::Instance();
         kernels_data.push_back(sdpa_kernel_selector.get_best_kernel(sdpa_kernel_params));
 
-        auto pa_sdpa_kernel_params = get_pa_sdpa_params(impl_param, impl_param.is_dynamic());
+        auto pa_sdpa_kernel_params = get_pa_sdpa_params(impl_param, stage, impl_param.is_dynamic());
         auto& pa_sdpa_kernel_selector = pa_sdpa_kernel_selector_t::Instance();
         kernels_data.push_back(pa_sdpa_kernel_selector.get_best_kernel(pa_sdpa_kernel_params));
 

--- a/src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h
@@ -9,7 +9,14 @@
 
 namespace cldnn {
 
-bool is_prefill_stage(const kernel_impl_params& impl_param);
+enum PagedAttentionStage {
+    GENERATE = 0,
+    PREFILL = 1,
+    MIXED = 2,
+    UNKNOWN = 3
+};
+
+PagedAttentionStage get_paged_attention_stage(const kernel_impl_params& impl_param);
 
 template <>
 struct typed_program_node<paged_attention> : public typed_program_node_base<paged_attention> {
@@ -20,11 +27,11 @@ public:
     using parent::parent;
 
     std::set<size_t> get_lockable_input_ids() const override {
-        return { 6 /* subsequence_begins */, 12 /* max_context_len */ };
+        return { 5 /* past_lens */, 6 /* subsequence_begins */, 12 /* max_context_len */ };
     }
 
     std::vector<size_t> get_shape_infer_dependencies() const override {
-        return { 6 /* subsequence_begins */, 12 /* max_context_len */ };
+        return { 5 /* past_lens */, 6 /* subsequence_begins */, 12 /* max_context_len */ };
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/paged_attention.cpp
@@ -13,14 +13,31 @@ GPU_DEFINE_PRIMITIVE_TYPE_ID(paged_attention)
 
 constexpr size_t paged_attention::block_size;
 
-bool is_prefill_stage(const kernel_impl_params& impl_param) {
+PagedAttentionStage get_paged_attention_stage(const kernel_impl_params& impl_param) {
     const auto& query_shape = impl_param.get_input_layout(0).get_partial_shape();
     const auto& past_lens_shape = impl_param.get_input_layout(5).get_partial_shape();
 
-    if (query_shape.is_static() && past_lens_shape.is_static())
-        return query_shape[0].get_length() != past_lens_shape[0].get_length();
+    if (query_shape.is_static() && past_lens_shape.is_static()) {
+        if (query_shape[0].get_length() == past_lens_shape[0].get_length()) {
+            return PagedAttentionStage::GENERATE;
+        }
 
-    return false;
+        const auto past_lens_idx = 5;
+        const auto& memory_deps = impl_param.memory_deps;
+        const auto past_lens_mem = memory_deps.at(past_lens_idx);
+        mem_lock<int32_t, mem_lock_type::read> past_lens_mem_lock(past_lens_mem, *impl_param.strm);
+
+        const auto past_lens_size = past_lens_mem_lock.size();
+        for (size_t i = 0; i < past_lens_size; i++) {
+            if (past_lens_mem_lock[i] != 0) {
+                return PagedAttentionStage::MIXED;
+            }
+        }
+
+        return PagedAttentionStage::PREFILL;
+    }
+
+    return PagedAttentionStage::UNKNOWN;
 }
 
 layout paged_attention_inst::calc_output_layout(const paged_attention_node& /*node*/, kernel_impl_params const& impl_param) {
@@ -64,19 +81,22 @@ std::string paged_attention_inst::to_string(const paged_attention_node& node) {
 }
 
 void paged_attention_inst::on_execute() {
-    if (!is_prefill_stage(*_impl_params))
+    auto stage = get_paged_attention_stage(*_impl_params);
+
+    if (stage == PagedAttentionStage::UNKNOWN ||
+        stage == PagedAttentionStage::GENERATE)
         return;
 
     OPENVINO_ASSERT(_intermediates_memory.size() >= 3, "Unexpected number of intermediates buffers for Paged Attention at prefill stage");
 
     const auto blocks_indexes_start_idx = 0;
     const auto blocks_indexes_end_idx = 1;
-    const auto gws_seq_indexes_correspondence_idx = 2;
+    const auto blocked_gws_subseq_mapping_idx = 2;
 
     auto subsequence_begins_mem = subsequence_begins_memory_ptr();
     auto blocks_indexes_start_mem = _intermediates_memory[blocks_indexes_start_idx];
     auto blocks_indexes_end_mem = _intermediates_memory[blocks_indexes_end_idx];
-    auto gws_seq_indexes_correspondence_mem = _intermediates_memory[gws_seq_indexes_correspondence_idx];
+    auto blocked_gws_subseq_mapping_mem = _intermediates_memory[blocked_gws_subseq_mapping_idx];
 
     OPENVINO_ASSERT(subsequence_begins_mem->get_layout().data_type == data_types::i32);
 
@@ -84,7 +104,18 @@ void paged_attention_inst::on_execute() {
     mem_lock<int32_t, mem_lock_type::read> subsequence_begins_mem_lock(subsequence_begins_mem, stream);
     mem_lock<int32_t, mem_lock_type::write> blocks_indexes_start_lock(blocks_indexes_start_mem, stream);
     mem_lock<int32_t, mem_lock_type::write> blocks_indexes_end_lock(blocks_indexes_end_mem, stream);
-    mem_lock<int32_t, mem_lock_type::write> gws_seq_indexes_correspondence_lock(gws_seq_indexes_correspondence_mem, stream);
+    mem_lock<int32_t, mem_lock_type::write> blocked_gws_subseq_mapping_mem_lock(blocked_gws_subseq_mapping_mem, stream);
+    std::unique_ptr<mem_lock<int32_t, mem_lock_type::write>> sequential_gws_subseq_mapping_lock = nullptr;
+
+    if (stage == PagedAttentionStage::MIXED) {
+        const auto sequential_gws_subseq_mapping_idx = 6;
+
+        OPENVINO_ASSERT(_intermediates_memory.size() > sequential_gws_subseq_mapping_idx,
+                        "Unexpected number of intermediates buffers for Paged Attention for mixed stage");
+
+        auto sequential_gws_subseq_mapping_mem = _intermediates_memory[sequential_gws_subseq_mapping_idx];
+        sequential_gws_subseq_mapping_lock.reset(new mem_lock<int32_t, mem_lock_type::write>(sequential_gws_subseq_mapping_mem, stream));
+    }
 
     size_t index = 0;
     const auto target_seq_len_block_size = 16; // TODO: Get block size from the impl
@@ -99,9 +130,15 @@ void paged_attention_inst::on_execute() {
 
             blocks_indexes_start_lock[index] = block_start_pos;
             blocks_indexes_end_lock[index] = block_end_pos;
-            gws_seq_indexes_correspondence_lock[index] = static_cast<int32_t>(i);
+            blocked_gws_subseq_mapping_mem_lock[index] = static_cast<int32_t>(i);
 
             index++;
+        }
+
+        if (stage == PagedAttentionStage::MIXED) {
+            for (int32_t idx = seq_start; idx < seq_end; idx++) {
+                sequential_gws_subseq_mapping_lock->operator[](idx) = static_cast<int32_t>(i);
+            }
         }
     }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
@@ -34,13 +34,19 @@ KERNEL(pa_sdpa_opt)(
     const __global INPUT3_TYPE* past_lens,
     const __global INPUT4_TYPE* block_indices,
     const __global INPUT5_TYPE* block_indices_begins,
+#if MULTI_TOKENS_PROCESSING
+    const __global INPUT6_TYPE* subsequence_begins,
+#endif
 #if HAS_ALIBI
-    const __global INPUT6_TYPE* alibi_slopes,
+    const __global INPUT7_TYPE* alibi_slopes,
 #endif
     __global OUTPUT_TYPE* output,
     __global SOFTMAX_ACCUMULATOR_TYPE* exp_sums,
     __global SOFTMAX_ACCUMULATOR_TYPE* max_logits,
     __global OUTPUT_TYPE* tmp_out
+#if MULTI_TOKENS_PROCESSING
+    , __global const int* gws_subseq_mapping
+#endif
 ) {
     // Input shapes:
     // query: [sequences_num, HEADS_NUM * HEAD_SIZE]
@@ -66,7 +72,15 @@ KERNEL(pa_sdpa_opt)(
 
     const uint batch_idx = seq_idx;
 
+#if MULTI_TOKENS_PROCESSING
+    const int subsequence_idx = gws_subseq_mapping[seq_idx];
+    const int subsequence_begin = subsequence_begins[subsequence_idx];
+    const int subsequence_end = subsequence_begins[subsequence_idx + 1];
+    const uint seq_len = past_lens[subsequence_idx] + 1 + (seq_idx - subsequence_begin);
+#else
+    const uint subsequence_idx = seq_idx;
     const uint seq_len = past_lens[seq_idx] + 1;
+#endif
 
     const uint partition_idx = get_group_id(2);
     const uint block_start_idx = partition_idx * SEQ_LEN_PARTITION_SIZE / PAGED_ATTENTION_BLOCK_SIZE;
@@ -79,7 +93,7 @@ KERNEL(pa_sdpa_opt)(
 
 #ifdef STORE_QUERY_TO_SLM
     // SLM buffer for query inputs
-    __local INPUT0_TYPE slm_query[HEAD_SIZE * TARGET_SEQ_LEN_BLOCK_SIZE];
+    __local INPUT0_TYPE slm_query[HEAD_SIZE];
 #endif
 
     // SLM for intermediate QK results
@@ -117,7 +131,7 @@ KERNEL(pa_sdpa_opt)(
         if (sgid < blocks_num_per_partition % SUBGROUPS_PER_WG)
             blocks_num++;
 
-        const uint start_block_idx = block_indices_begins[seq_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION + sgid;
+        const uint start_block_idx = block_indices_begins[subsequence_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION + sgid;
         for (uint block_num = 0; block_num < blocks_num; block_num++) {
 #ifdef BROADCAST_GROUP_SIZE
             const uint head_idx = head_num_idx / BROADCAST_GROUP_SIZE;
@@ -255,7 +269,7 @@ KERNEL(pa_sdpa_opt)(
             blocks_num_per_partition = blocks_num_per_partition - 1;
         }
 
-        const uint start_block_idx = block_indices_begins[seq_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION;
+        const uint start_block_idx = block_indices_begins[subsequence_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION;
 
         for (uint block_num = 0; block_num < blocks_num_per_partition; block_num++) {
 #ifdef BROADCAST_GROUP_SIZE

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/pa_kv_cache_update_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/pa_kv_cache_update_kernel_ref.h
@@ -12,6 +12,7 @@ namespace kernel_selector {
 struct kv_cache_update_params : base_params {
     kv_cache_update_params() : base_params(KernelType::PA_KV_CACHE_UPDATE) {}
 
+    bool is_prefill = false;
     sdpa_configuration conf;
 };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/pa_sdpa_kernel_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/pa_sdpa_kernel_opt.h
@@ -12,8 +12,9 @@ namespace kernel_selector {
 struct pa_sdpa_params : base_params {
     pa_sdpa_params() : base_params(KernelType::PA_SDPA) {}
 
-    sdpa_configuration conf;
+    bool multi_tokens_mode = false;
     size_t max_context_len = 0;
+    sdpa_configuration conf;
 };
 
 class PagedAttentionSDPAKernelOpt : public KernelBaseOpenCL {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_opt.cpp
@@ -314,13 +314,7 @@ KernelsData SDPAKernelOpt::GetKernelsData(const Params& params) const {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 2});
 
         const auto buf_sizes = get_internal_buffer_sizes(prim_params, kernel_idx);
-        if (prim_params.conf.is_paged_attention) {
-            kd.internalBufferSizes.clear();
-            kd.internalBufferSizes.push_back(buf_sizes[0]);
-            kd.internalBufferSizes.push_back(buf_sizes[0]);
-            kd.internalBufferSizes.push_back(buf_sizes[0]);
-            kd.internalBufferDataType = Datatype::INT32;
-        } else {
+        if (!prim_params.conf.is_paged_attention) {
             kd.internalBufferSizes.clear();
             kd.internalBufferSizes.push_back(buf_sizes[0]);
             kd.internalBufferSizes.push_back(buf_sizes[0]);
@@ -359,15 +353,6 @@ void SDPAKernelOpt::GetUpdateDispatchDataFunc(KernelData& kd) const {
             kernel_data.kernels[0].params.workGroups.global = dispatch_data.gws;
             kernel_data.kernels[0].params.workGroups.local = dispatch_data.lws;
             kernel_data.kernels[0].skip_execution = false;
-
-            const auto blocks_indexes_dt = Datatype::INT32;
-            const auto buf_sizes = get_internal_buffer_sizes(prim_params, KernelsTypes::MULTI_TOKENS);
-
-            kernel_data.internalBufferSizes.clear();
-            kernel_data.internalBufferSizes.push_back(buf_sizes[0]);
-            kernel_data.internalBufferSizes.push_back(buf_sizes[0]);
-            kernel_data.internalBufferSizes.push_back(buf_sizes[0]);
-            kernel_data.internalBufferDataType = blocks_indexes_dt;
         } else {
             const auto num_of_partitions = get_partitions_num(prim_params, KernelsTypes::SINGLE_TOKEN);
             const auto buf_sizes = get_internal_buffer_sizes(prim_params, KernelsTypes::SINGLE_TOKEN);


### PR DESCRIPTION
### Details:
 - Add prefix support for PagedAttention operation via existing pa_sdpa_opt kernel by processing subsequence's tokens in sequential mode, one by one for
 - Moved responsibility for intermediate buffers reallocation from the sdpa_opt kernel to kv_cache_update kernel (they both use the same data, but now one of these buffers can be reused by the pa_sdpa_opt kernel, so everything was moved to one place)

