### PR TITLE
[GPU] Enable activation fusing for softmax_gpu_bf kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/softmax/softmax_kernel_base.cpp
@@ -82,10 +82,6 @@ bool SoftmaxKernelBaseBF::Validate(const Params& p) const {
     const softmax_params& params = static_cast<const softmax_params&>(p);
     const auto& input = params.inputs[0];
 
-    if (!params.activations.empty()) {
-        return false;
-    }
-
     if (input.GetLayout() == DataLayout::bf || input.GetLayout() == DataLayout::fb) {
         return true;
     }


### PR DESCRIPTION
### Details:
 - *Significantly speed up LogSoftmax operation*

### Tickets:
 - *[148550](https://jira.devtools.intel.com/browse/CVS-148550)*
