### PR TITLE
[conformance] Mark DEVICE_ID mandatory for HW plugin

### DIFF
--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_plugin/properties.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_plugin/properties.cpp
@@ -83,7 +83,7 @@ INSTANTIATE_TEST_SUITE_P(ov_plugin, OVCheckSetIncorrectRWMetricsPropsTests,
         OVCheckSetIncorrectRWMetricsPropsTests::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    ov_plugin_mandatory,
+    ov_plugin,
     OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
     ::testing::Combine(::testing::Values(ov::test::utils::target_device), ::testing::Values(ov::AnyMap({}))),
     MARK_MANDATORY_PROPERTY_FOR_HW_DEVICE(OVCheckChangePropComplieModleGetPropTests_DEVICE_ID::getTestCaseName));

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_plugin/properties.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_plugin/properties.cpp
@@ -82,11 +82,11 @@ INSTANTIATE_TEST_SUITE_P(ov_plugin, OVCheckSetIncorrectRWMetricsPropsTests,
                                 {}, sw_plugin_in_target_device(ov::test::utils::target_device)))),
         OVCheckSetIncorrectRWMetricsPropsTests::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(ov_plugin_mandatory, OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
-        ::testing::Combine(
-                ::testing::Values(ov::test::utils::target_device),
-                ::testing::Values(ov::AnyMap({}))),
-        OVCheckChangePropComplieModleGetPropTests_DEVICE_ID::getTestCaseName);
+INSTANTIATE_TEST_SUITE_P(
+    ov_plugin_mandatory,
+    OVCheckChangePropComplieModleGetPropTests_DEVICE_ID,
+    ::testing::Combine(::testing::Values(ov::test::utils::target_device), ::testing::Values(ov::AnyMap({}))),
+    MARK_MANDATORY_PROPERTY_FOR_HW_DEVICE(OVCheckChangePropComplieModleGetPropTests_DEVICE_ID::getTestCaseName));
 
 /* Add prefix mandatory_ to suffix (getTestCaseName) of HW plugin test cases */
 INSTANTIATE_TEST_SUITE_P(

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/properties_tests.cpp
@@ -479,9 +479,6 @@ TEST_P(OVCheckGetSupportedROMetricsPropsTests, ChangeCorrectProperties) {
 }
 
 TEST_P(OVCheckChangePropComplieModleGetPropTests_DEVICE_ID, ChangeCorrectDeviceProperties) {
-    if (sw_plugin_in_target_device(target_device)) {
-        return;
-    }
     std::vector<ov::PropertyName> supported_properties;
     OV_ASSERT_NO_THROW(supported_properties = core->get_property(target_device, ov::supported_properties));
     auto supported = util::contains(supported_properties, ov::device::id);


### PR DESCRIPTION
### Details:
 - *DEVICE_ID is optional for SW plugin and mandatory for HW plugin*

### Tickets:
 - *N/A*
