### PR TITLE
[GPU] Add Validate pass call after IncreasePositionIdsPrecision to ensure proper data type propagation

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -857,6 +857,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         pass_config->disable<ov::pass::RoPEShareCosSin>();
 
         manager.register_pass<ov::intel_gpu::IncreasePositionIdsPrecision>();
+        // This Validate is needed for proper data type propagation after applying IncreasePositionIdsPrecision pass
+        manager.register_pass<ov::pass::Validate>();
 
         auto dynamic_quantization_group_size = config.get_property(ov::hint::dynamic_quantization_group_size);
         if (device_info.supports_immad) { // XXX: 1048576 is considered per-token


### PR DESCRIPTION
### Details:
This patch adds Validate pass call after IncreasePositionIdsPrecision to ensure proper data type propagation

With this change the accuracy of llama-3-8b INT8 (and other LLMs probably) can be restored to expected level
Before:
```
| Tasks  |Version|Filter|n-shot|    Metric     |   |Value |   |Stderr|
|--------|------:|------|-----:|---------------|---|-----:|---|------|
|wikitext|      2|none  |     0|bits_per_byte  |↓  |0.6030|±  |N/A   |
|        |       |none  |     0|byte_perplexity|↓  |1.5189|±  |N/A   |
|        |       |none  |     0|word_perplexity|↓  |9.3472|±  |N/A   |
```

After:
```
| Tasks  |Version|Filter|n-shot|    Metric     |   |Value |   |Stderr|
|--------|------:|------|-----:|---------------|---|-----:|---|------|
|wikitext|      2|none  |     0|bits_per_byte  |↓  |0.5351|±  |N/A   |
|        |       |none  |     0|byte_perplexity|↓  |1.4490|±  |N/A   |
|        |       |none  |     0|word_perplexity|↓  |7.2664|±  |N/A   |
```

### Tickets:
 - [CVS-147653](https://jira.devtools.intel.com/browse/CVS-147653)
