### PR TITLE
[CVS-149644] Fixed ONNX FE debug build

### DIFF
--- a/thirdparty/onnx/CMakeLists.txt
+++ b/thirdparty/onnx/CMakeLists.txt
@@ -50,7 +50,7 @@ if(MINGW)
 endif()
 
 # from onnx==1.13.1 it requires C++17 when compiling on Windows, and since onnx==1.16.0 on Linux
-target_compile_features(onnx PRIVATE cxx_std_17)
+target_compile_features(onnx_proto PUBLIC cxx_std_17)
 
 ov_disable_all_warnings(onnx onnx_proto)
 


### PR DESCRIPTION
### Details:
 - Fixed ONNX FE debug build
 - ONNX proto is base library and must be compiled with newer standard, otherwise onnx and onnx_proto are compiled with different C++ standard.

### Tickets:
 - CVS-149644
