### PR TITLE
Disabled LTO for gcc older than 9.0

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -11,7 +11,7 @@ else()
     set (CPACK_GENERATOR "TGZ" CACHE STRING "Cpack generator for OpenVINO")
 endif()
 
-ov_dependent_option (ENABLE_LTO "Enable Link Time Optimization" OFF "LINUX;NOT ARM;CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9" OFF)
+ov_dependent_option (ENABLE_LTO "Enable Link Time Optimization" OFF "LINUX;NOT ARM;CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0" OFF)
 
 ov_option (OS_FOLDER "create OS dedicated folder in output" OFF)
 


### PR DESCRIPTION
### Details:
 - Gcc 8.x has multiple bug for LTO
 - Let's have 9.x and higher as required for LTO

### Tickets:
 - CVS-150950
