### PR TITLE
[LPT] separateInStandaloneBranch fix

### DIFF
--- a/src/common/low_precision_transformations/src/add.cpp
+++ b/src/common/low_precision_transformations/src/add.cpp
@@ -108,9 +108,6 @@ bool AddTransformation::transform(TransformationContext& context, ov::pass::patt
         return false;
     }
 
-    NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(op, defaultPrecisions, 0));
-    NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(op, defaultPrecisions, 1));
-
     std::shared_ptr<Node> addNode = NetworkHelper::separateInStandaloneBranch(op, defaultPrecisions);
     std::shared_ptr<ov::opset1::Add> add = ov::as_type_ptr<ov::opset1::Add>(addNode);
 

--- a/src/common/low_precision_transformations/src/concat.cpp
+++ b/src/common/low_precision_transformations/src/concat.cpp
@@ -40,11 +40,11 @@ ConcatTransformation::ConcatTransformation(const Params& params) : LayerTransfor
 }
 
 bool ConcatTransformation::transform(TransformationContext& context, ov::pass::pattern::Matcher &m) {
-    std::shared_ptr<ov::opset1::Concat> concat = ov::as_type_ptr<ov::opset1::Concat>(m.get_match_root());
-    if (!canBeTransformed(context, concat)) {
+    if (!canBeTransformed(context, m.get_match_root())) {
         return false;
     }
 
+    const auto concat = ov::as_type_ptr<ov::opset1::Concat>(NetworkHelper::separateInStandaloneBranch(m.get_match_root(), defaultPrecisions));
     std::vector<FakeQuantizeDequantization> layerDequantizations;
     layerDequantizations.reserve(concat->get_input_size());
     for (size_t parentIndex = 0ul; parentIndex < concat->get_input_size(); parentIndex++) {

--- a/src/common/low_precision_transformations/src/multiply.cpp
+++ b/src/common/low_precision_transformations/src/multiply.cpp
@@ -49,9 +49,6 @@ bool MultiplyTransformation::transform(TransformationContext& context, ov::pass:
     multiply = NetworkHelper::separateInStandaloneBranch(multiply, defaultPrecisions);
     decomposeFakeQuantizeForWeightsPath(multiply);
 
-    NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(multiply, defaultPrecisions, 0));
-    NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(multiply, defaultPrecisions, 1));
-
     const auto dequantization1 = NetworkHelper::getDequantization(multiply, defaultPrecisions, 0);
     const auto dequantization2 = NetworkHelper::getDequantization(multiply, defaultPrecisions, 1);
 

--- a/src/common/low_precision_transformations/src/multiply_partial.cpp
+++ b/src/common/low_precision_transformations/src/multiply_partial.cpp
@@ -45,9 +45,6 @@ bool MultiplyPartialTransformation::transform(TransformationContext& context, ov
         return false;
     }
 
-    NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(multiply, defaultPrecisions, 0));
-    NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(multiply, defaultPrecisions, 1));
-
     multiply = NetworkHelper::separateInStandaloneBranch(multiply, defaultPrecisions);
     auto newMultiply = multiply;
 

--- a/src/common/low_precision_transformations/src/mvn.cpp
+++ b/src/common/low_precision_transformations/src/mvn.cpp
@@ -123,11 +123,7 @@ bool MVNTransformation::transform(TransformationContext &context, ov::pass::patt
         return false;
     }
 
-    std::shared_ptr<Node> mvn = ov::as_type_ptr<op::v0::MVN>(operation);
-    if (!mvn) {
-        mvn = ov::as_type_ptr<opset6::MVN>(operation);
-    }
-
+    const auto mvn = NetworkHelper::separateInStandaloneBranch(operation, defaultPrecisions);
     bool normalizeVariance;
     if (ov::is_type<op::v0::MVN>(mvn)) {
         normalizeVariance = ov::as_type_ptr<op::v0::MVN>(mvn)->get_normalize_variance();

--- a/src/common/low_precision_transformations/src/reduce_base_transformation.cpp
+++ b/src/common/low_precision_transformations/src/reduce_base_transformation.cpp
@@ -22,7 +22,7 @@ bool ReduceBaseTransformation::transform(TransformationContext& context, ov::pas
     }
 
     const auto reduce = NetworkHelper::separateInStandaloneBranch(m.get_match_root(), defaultPrecisions);
-    auto dequantization = NetworkHelper::normalizeDequantization(NetworkHelper::getDequantization(reduce, defaultPrecisions));
+    auto dequantization = NetworkHelper::getDequantization(reduce, defaultPrecisions);
 
     // prepare dequantization to propagate
     changeDequantizationValues(reduce, dequantization);

--- a/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
@@ -85,7 +85,13 @@ public:
         const auto createReferenceFunction = [](
             const ov::element::Type precision,
             const ov::Shape& inputShape,
-            const ov::builder::subgraph::DequantizationOperations& dequantization) -> std::shared_ptr<ov::Model> {
+            ov::builder::subgraph::DequantizationOperations dequantization) -> std::shared_ptr<ov::Model> {
+            // Note: separateInStandaloneBranch normalizes dequantization so constant indexes become equal to 1
+            if (!dequantization.subtract.empty())
+                dequantization.subtract.constantIndex = 1;
+            if (!dequantization.multiply.empty())
+                dequantization.multiply.constantIndex = 1;
+
             const std::shared_ptr<ov::op::v0::Parameter> input = std::make_shared<ov::op::v0::Parameter>(precision, inputShape);
             const auto relu = std::make_shared<ov::op::v0::Relu>(input);
 
@@ -118,7 +124,7 @@ public:
         std::tie(shapes, testValues) = obj.param;
 
         std::stringstream ss;
-        ss << shapes << "_" << "_" << testValues;
+        ss << shapes << "_" << testValues;
         return ss.str();
     }
 };
@@ -133,7 +139,6 @@ TEST_P(SeparateInStandaloneBranchTransformation, CompareFunctions) {
 
 const std::vector<ov::Shape> shapes = {
     { 1, 3, 9, 9 },
-    { 4, 3, 9, 9 }
 };
 
 std::vector<SeparateInStandaloneBranchTransformationTestValues> testValues = {
@@ -155,7 +160,16 @@ std::vector<SeparateInStandaloneBranchTransformationTestValues> testValues = {
             { {127.f}, ov::element::f32, {}, true, 1ul, ov::element::u8, true},
             { 0.02f }
         }
-    }
+    },
+    {
+        LayerTransformation::createParamsU8U8(),
+        ov::element::u8,
+        {
+            ov::element::f32,
+            { {127.f}, ov::element::f32, {}, false, 0ul},
+            { {0.02f}, ov::element::f32, {}, false, 0ul }
+        }
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
### Details:
 - *Added `normalizeDequantization` in `separateInStandaloneBranch`: it is needed since `separateInStandaloneBranch` works correctly only with normalized dequantization*
 - *Handle all inputs (not only 0's as before) in `separateInStandaloneBranch`*
 - *Removed `normalizeDequantization` in transformations since this logic is placed inside `separateInStandaloneBranch` now*

### Tickets:
 - *CVS-150001*
