### PR TITLE
[TRANSFORMATIONS] Fix Alibi slopes handling for Jais-13b model

### DIFF
--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
@@ -357,9 +357,9 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
                             v0::Constant::create(alibi_slopes->get_element_type(), {}, {-1}));
                     }
                 } else {
-                        alibi_slopes = std::make_shared<v1::Multiply>(
-                            alibi_slopes,
-                            v0::Constant::create(alibi_slopes->get_element_type(), {}, {-1}));
+                    alibi_slopes = std::make_shared<v1::Multiply>(
+                        alibi_slopes,
+                        v0::Constant::create(alibi_slopes->get_element_type(), {}, {-1}));
                 }
             }
 

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
@@ -7,6 +7,8 @@
 #include <tuple>
 
 #include "openvino/cc/pass/itt.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/add.hpp"
 #include "openvino/op/broadcast.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/divide.hpp"
@@ -145,6 +147,14 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
     sdpa_mask = pattern::wrap_type<v1::Reshape>({sdpa_mask, pattern::any_input()});
     sdpa_mask = pattern::wrap_type<v1::Select>({pattern::any_input(), pattern::any_input(), sdpa_mask});
 
+    // For Jais (Jais-13b has a different pattern and handling of alibi slopes)
+    auto mirroring_abs = pattern::wrap_type<v0::Abs>({pattern::any_input()});
+    auto unsqueeze = pattern::wrap_type<v0::Unsqueeze>({mirroring_abs, pattern::any_input()});
+    auto alibi_mask = pattern::wrap_type<v1::Multiply>({alibi, unsqueeze});
+    alibi_mask = pattern::wrap_type<v3::Broadcast>({alibi_mask, pattern::any_input()});
+    alibi_mask = pattern::wrap_type<v0::Unsqueeze>({alibi_mask, pattern::any_input()});
+    alibi_mask = pattern::wrap_type<v1::Add>({pattern::any_input(), alibi_mask});
+
     auto q = pattern::any_input();
     auto scale_input = pattern::any_input();
 
@@ -152,7 +162,7 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
         std::make_shared<pattern::op::Or>(OutputVector{k_concat, k_shaped, k_shaped_transposed, k_simply_shaped});
     auto v_to_sdpa =
         std::make_shared<pattern::op::Or>(OutputVector{v_concat, v_shaped, v_shaped_transposed, v_simply_shaped});
-    auto mask_to_sdpa = std::make_shared<pattern::op::Or>(OutputVector{sdpa_mask, pattern::any_input()});
+    auto mask_to_sdpa = std::make_shared<pattern::op::Or>(OutputVector{sdpa_mask, alibi_mask, pattern::any_input()});
 
     auto sdpa_with_4_inputs =
         pattern::wrap_type<v13::ScaledDotProductAttention>({q, k_to_sdpa, v_to_sdpa, mask_to_sdpa});
@@ -324,6 +334,24 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
             if (alibi_slopes->get_element_type() == element::f32) {
                 alibi_slopes = std::make_shared<v0::Convert>(alibi_slopes, element::f32);
             }
+
+            // Jais-13b case
+            if (auto alibi_constant = std::dynamic_pointer_cast<v0::Constant>(pattern_map.at(alibi).get_node_shared_ptr())) {
+                auto alibi_constant_values = alibi_constant->cast_vector<float>();
+                bool all_values_nagative = std::all_of(alibi_constant_values.begin(),
+                                                       alibi_constant_values.end(),
+                                                       [&](float value) {
+                                                            return value < 0.0;
+                                                                        });
+
+                if (all_values_nagative && pattern_map.find(mirroring_abs) != pattern_map.end()) {
+                    alibi_slopes = std::make_shared<v1::Multiply>(alibi_slopes,
+                                                                  v0::Constant::create(alibi_slopes->get_element_type(),
+                                                                  {},
+                                                                  {-1}));
+                }
+            }
+
         } else {
             alibi_slopes = v0::Constant::create(element::f32, Shape{0}, {});
         }

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
@@ -341,8 +341,8 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
                 auto alibi_constant_values = alibi_constant->cast_vector<float>();
                 bool all_values_nagative =
                     std::all_of(alibi_constant_values.begin(), alibi_constant_values.end(), [&](float value) {
-                                                                                                return value < 0.0;
-                                                                                                             });
+                        return value < 0.0;
+                        });
 
                 if (all_values_nagative && pattern_map.find(mirroring_abs) != pattern_map.end()) {
                     alibi_slopes = std::make_shared<v1::Multiply>(

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
@@ -342,7 +342,7 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
                 bool all_values_nagative =
                     std::all_of(alibi_constant_values.begin(), alibi_constant_values.end(), [&](float value) {
                         return value < 0.0;
-                        });
+                    });
 
                 if (all_values_nagative && pattern_map.find(mirroring_abs) != pattern_map.end()) {
                     alibi_slopes = std::make_shared<v1::Multiply>(

--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/state_management_pattern.cpp
@@ -336,19 +336,18 @@ ov::pass::StateManagementPattern::StateManagementPattern(ParameterVector& kv_par
             }
 
             // Jais-13b case
-            if (auto alibi_constant = std::dynamic_pointer_cast<v0::Constant>(pattern_map.at(alibi).get_node_shared_ptr())) {
+            if (auto alibi_constant =
+                    std::dynamic_pointer_cast<v0::Constant>(pattern_map.at(alibi).get_node_shared_ptr())) {
                 auto alibi_constant_values = alibi_constant->cast_vector<float>();
-                bool all_values_nagative = std::all_of(alibi_constant_values.begin(),
-                                                       alibi_constant_values.end(),
-                                                       [&](float value) {
-                                                            return value < 0.0;
-                                                                        });
+                bool all_values_nagative =
+                    std::all_of(alibi_constant_values.begin(), alibi_constant_values.end(), [&](float value) {
+                                                                                                return value < 0.0;
+                                                                                                             });
 
                 if (all_values_nagative && pattern_map.find(mirroring_abs) != pattern_map.end()) {
-                    alibi_slopes = std::make_shared<v1::Multiply>(alibi_slopes,
-                                                                  v0::Constant::create(alibi_slopes->get_element_type(),
-                                                                  {},
-                                                                  {-1}));
+                    alibi_slopes = std::make_shared<v1::Multiply>(
+                        alibi_slopes,
+                        v0::Constant::create(alibi_slopes->get_element_type(), {}, {-1}));
                 }
             }
 


### PR DESCRIPTION
[TRANSFORMATIONS] Fix Alibi slopes handling for Jais-13b model

The Jais-13b model uses different approach for forming the attention mask using negative values of Alibi slopes for positional embedding. The current implementation of extracting the Alibi slopes and inserting it to PA results into model producing incorrect output.

Detect the Jais-13b-like pattern with the negative Alibi constant and multiply it by -1 to use the "raw" (positive) Alibi values before inserting into PA.

### Tickets:
 - CVS-142320

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
