### PR TITLE
[GPU] Do not preallocate memory if desired size reaches the maximum supported buffer size

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/shape_predictor.cpp
+++ b/src/plugins/intel_gpu/src/runtime/shape_predictor.cpp
@@ -53,6 +53,9 @@ bool ShapePredictor::can_preallocate(size_t desired_buffer_size) {
     const auto memory_threshold = 0.90f;
     auto device_mem_usage = _engine->get_used_device_memory(cldnn::allocation_type::usm_device);
 
+    if (desired_buffer_size > _engine->get_device_info().max_alloc_mem_size)
+        return false;
+
     return device_mem_usage + desired_buffer_size < _engine->get_device_info().max_global_mem_size * memory_threshold;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/module_tests/shape_predictor_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/shape_predictor_test.cpp
@@ -117,3 +117,23 @@ INSTANTIATE_TEST_SUITE_P(smoke, shape_predictor_tests_b_fs_yx_fsv16,
         {{{1,1}, {1,128}, {1,256}}, {}, 1.1f, true},
         {{{1,3,128}, {1,3,112}, {1,3,418}, {1,3,512}}, {}, 1.1f, true},
     }));
+
+TEST(shape_predictor_tests, check_max_buffer_size) {
+    auto& engine = get_test_engine();
+
+    const auto& buffers_preallocation_ratio = 1.1;
+    ShapePredictor sp(&engine, buffers_preallocation_ratio);
+
+    const auto max_alloc_mem_size = engine.get_device_info().max_alloc_mem_size;
+    auto layout = cldnn::layout({static_cast<int64_t>(max_alloc_mem_size)}, ov::element::u8, format::bfyx);
+
+    std::pair<bool, ov::Shape> result;
+
+    // Perform 3 iteration to trigger shape preallocation
+    result = sp.predict_preallocation_shape("dummy_name", layout, false);
+    result = sp.predict_preallocation_shape("dummy_name", layout, false);
+    result = sp.predict_preallocation_shape("dummy_name", layout, false);
+
+    const auto bytes_count = ov::shape_size(result.second);
+    ASSERT_FALSE(sp.can_preallocate(bytes_count));
+}


### PR DESCRIPTION
### Details:
 - This patch fixes an issue where requested buffer meets the requirements of the maximum buffer allocation size, but applying preallocation causes the limits to be reached, resulting in an OpenCL error
