### PR TITLE
[NPUW] Enhance weights sharing

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
@@ -72,8 +72,6 @@ private:
 
     void implement_properties();
 
-    void fill_weights_bank(const std::size_t idx);
-
     std::shared_ptr<::intel_npu::OptionsDesc> m_options_desc;
     ::intel_npu::Config m_cfg;
     GetPropertiesMap m_prop_to_opt;

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.hpp
@@ -9,6 +9,7 @@
 #include <variant>
 #include <vector>
 
+#include "../weights_bank.hpp"
 #include "intel_npu/al/config/config.hpp"
 #include "openvino/openvino.hpp"
 
@@ -105,7 +106,9 @@ struct Partitioning {
     float total_gflops = 0.f;
 };
 
-Partitioning getPartitioning(const std::shared_ptr<ov::Model>& model, ::intel_npu::Config& config);
+Partitioning getPartitioning(const std::shared_ptr<ov::Model>& model,
+                             ::intel_npu::Config& config,
+                             const std::shared_ptr<weights::Bank>& bank);
 
 }  // namespace npuw
 }  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/dcoff.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/dcoff.cpp
@@ -47,7 +47,9 @@ namespace opp = ov::pass::pattern;
 //      Const tensor will be taken from [i-base]'th closure in the
 //      updated closure tensor.
 
-ClosureRemap build_remap(const Function& fbody, const DCOFFParams& params_to) {
+ClosureRemap build_remap(const Function& fbody,
+                         const DCOFFParams& params_to,
+                         const std::shared_ptr<ov::npuw::weights::Bank>& bank) {
     LOG_DEBUG("Creating a closure remap for " << fbody._model->get_friendly_name());
     LOG_BLOCK();
 
@@ -100,7 +102,7 @@ ClosureRemap build_remap(const Function& fbody, const DCOFFParams& params_to) {
         auto zerop_iter = params_to.zerops.find(param);
         if (zerop_iter != params_to.zerops.end()) {
             LOG_DEBUG("This parameter requires zero point: " << zerop_iter->second);
-            m.zero_points.push_back(ov::npuw::util::tensor_from_const(zerop_iter->second));
+            m.zero_points.push_back(bank->update(zerop_iter->second));
         } else {
             m.zero_points.push_back(ov::Tensor());
         }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/dcoff.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/dcoff.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <vector>
 
+#include "../../weights_bank.hpp"
 #include "openvino/openvino.hpp"
 #include "openvino/pass/graph_rewrite.hpp"
 
@@ -44,7 +45,7 @@ struct ClosureRemap {
     std::vector<ov::Tensor> zero_points;  // zero points for closures, if needed
 };
 
-ClosureRemap build_remap(const Function& fbody, const DCOFFParams& p);
+ClosureRemap build_remap(const Function& fbody, const DCOFFParams& p, const std::shared_ptr<weights::Bank>& bank);
 void apply_remap(Subgraph& fcall, const ClosureRemap& m);
 void finalize_remap(Function& fbody, const ClosureRemap& m);
 

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
@@ -23,14 +23,17 @@ public:
     explicit Bank(const std::shared_ptr<const ov::ICore>& core) : m_core(core) {}
 
     // Capture CPU version of the tensor
-    ov::Tensor update(const ov::Tensor& tensor);
+    ov::Tensor update(const std::shared_ptr<ov::Node>& tensor);
 
     // Based on previously captured tensor allocate a new tensor (if needed) on a specified device
     ov::Tensor get(const ov::Tensor& tensor, const std::string& device);
 
 private:
+    // After get() allocates device memory, remove reference to the CPU Node
+    void drop(const ov::Tensor& tensor);
+
     // Default CPU bank. Filled by update()
-    std::unordered_map<void*, ov::Tensor> m_bank;
+    std::unordered_map<void*, std::shared_ptr<ov::Node>> m_bank;
     // Bank for specified device and their allocated memory
     std::unordered_map<std::string, std::unordered_map<void*, ov::Tensor>> m_device_bank;
     std::mutex m_mutex;


### PR DESCRIPTION
1) Fill weights bank during partitioning processing stage
2) Keep ownership of `ov::Node`s required for `closure`s and `zerop`s
3) Drop `ov::Node` reference from bank if non-CPU memory has been captured

NOTE: not tested on NPU yet, CPU works

NEW PR: https://github.com/openvinotoolkit/openvino/pull/26623
