### PR TITLE
Support bfyx and fsv32 input formats for concat

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -924,35 +924,14 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
         }
     };
 
-    const auto reorder_input_concat = [&p, &rf](typed_program_node<concatenation>& concat_node) {
-        auto output_layout = concat_node.get_output_layout();
-        // Iterate over all dependencies of the concat node
-        for (size_t i = 0; i < concat_node.get_dependencies().size(); ++i) {
-            auto dep = concat_node.get_dependency_with_port(i);
-            const auto& input = dep.first;
-            auto input_layout = input->get_output_layout();
-            // Change input data type of concat node from input format to output format
-            if (concat_node.get_preferred_impl_type() != cldnn::impl_types::onednn && output_layout.format != input_layout.format) {
-                auto new_layout = input_layout;
-                new_layout.format = output_layout.format;
-                auto new_input = rf.get_reorder(input->id(), dep.second, input_layout, new_layout);
-                if (new_input.first) {
-                    p.add_intermediate(new_input.first, concat_node, i);
-                    concat_node.get_dependency_with_port(i).first->recalc_output_layout();
-                }
-            }
-        }
-    };
-
     for (auto& prim : p.get_processing_order()) {
-        program_helpers::do_for_types<detection_output, deconvolution, convolution, fully_connected, pooling, concatenation>(
+        program_helpers::do_for_types<detection_output, deconvolution, convolution, fully_connected, pooling>(
             *prim,
             reorder_input_detection_output,
             reorder_input_and_weights_deconvolution,
             reorder_convolution,
             reorder_input_fully_connected,
-            reorder_input_pooling,
-            reorder_input_concat);
+            reorder_input_pooling);
     }
 
     for (auto n : p.get_processing_order()) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -932,7 +932,7 @@ void reorder_inputs::run(program& p, layout_optimizer& lo, reorder_factory& rf) 
             const auto& input = dep.first;
             auto input_layout = input->get_output_layout();
             // Change input data type of concat node from input format to output format
-            if (input_layout.format != output_layout.format) {
+            if (concat_node.get_preferred_impl_type() != cldnn::impl_types::onednn && output_layout.format != input_layout.format) {
                 auto new_layout = input_layout;
                 new_layout.format = output_layout.format;
                 auto new_input = rf.get_reorder(input->id(), dep.second, input_layout, new_layout);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/concatenation_gpu_ref.cl
@@ -6,11 +6,13 @@
 
 #define GET_INDEX(prefix, ORDER) CAT(prefix, _GET_INDEX)(ORDER)
 
-KERNEL(concatenation_gpu_ref)(__global INPUT0_TYPE* input,
-                              __global OUTPUT_TYPE* output,
-                              uint output_offset_in_concat_axis
+KERNEL(concatenation_gpu_ref)(
+    OPTIONAL_SHAPE_INFO_ARG
+    __global INPUT0_TYPE* input,
+    __global OUTPUT_TYPE* output,
+    uint output_offset_in_concat_axis
 #if HAS_FUSED_OPS_DECLS
-                              , FUSED_OPS_DECLS
+    , FUSED_OPS_DECLS
 #endif
 )
 {
@@ -22,7 +24,7 @@ KERNEL(concatenation_gpu_ref)(__global INPUT0_TYPE* input,
 #endif
     const uint d3 = (uint)get_global_id(2); // B
 
-    for (size_t d0 = 0; d0 < INPUT0_SIZES[INPUT_DIM_0]; ++d0) // X
+    for (size_t d0 = 0; d0 < INPUT0_SIZE_X; ++d0) // X
     {
         uint input_offset = GET_INDEX(INPUT0, INPUT_DIMS_ORDER);
         uint output_offset = GET_INDEX(OUTPUT, OUTPUT_DIMS_ORDER);

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -364,7 +364,7 @@ JitDefinitions DataTensorJitConstant::GetDefinitions() const {
         if (_tensor.GetLayout() == DataLayout::bf || _tensor.GetLayout() == DataLayout::bfyx ||
             _tensor.GetLayout() == DataLayout::bfzyx || _tensor.GetLayout() == DataLayout::bfwzyx ||
             _tensor.GetLayout() == DataLayout::bfuwzyx || _tensor.GetLayout() == DataLayout::bfvuwzyx ||
-            _tensor.GetLayout() == DataLayout::b_fs_yx_fsv16) {
+            _tensor.GetLayout() == DataLayout::b_fs_yx_fsv16 || _tensor.GetLayout() == DataLayout::b_fs_yx_fsv32) {
             definitions.push_back({_name + "_X_PITCH", "1"});
             definitions.push_back({_name + "_Y_PITCH", dims_padded.x()});
             definitions.push_back({_name + "_Z_PITCH", toVectorMulString({dims_padded.x(), dims_padded.y()})});

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/concatenation/concatenation_kernel_ref.cpp
@@ -58,6 +58,7 @@ ParamsKey ConcatenationKernelRef::GetSupportedKey() const {
     k.EnableConcatAxis(ConcatAxis::BATCH);
     k.EnableConcatKernelPerInput();
     k.EnableDifferentTypes();
+    k.EnableDynamicShapesSupport();
     return k;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -209,6 +209,59 @@ TEST(concat_cpu_impl, dynamic_4d_f) {
     start_concat_test_dynamic(impl_types::cpu);
 }
 
+TEST(concat_gpu, dynamic_4d_bfyx_and_b_fs_yx_fsv32) {
+    auto& engine = get_test_engine();
+
+    topology topology(
+            input_layout("input0", { {  2, 4 }, data_types::f32, format::bfyx }),
+            input_layout("input1", { { -1, 1 }, data_types::f32, format::bfyx }),
+            reorder("reorder_input1", input_info("input1"), { { -1, 1 }, data_types::f16, format::b_fs_yx_fsv32 }),
+            concatenation("concat",
+                          { input_info("input0"), input_info("reorder_input1") },
+                          1,
+                          data_types::f32)
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(false));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ov::intel_gpu::ImplementationDesc impl = { format::bfyx, "", impl_types::ocl };
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "concat", impl } }));
+
+    auto network = cldnn::network::build_network(engine, topology, config);
+
+    layout layout0 = { { 2, 4 }, data_types::f32, format::bfyx };
+    layout layout1 = { { 2, 1 }, data_types::f32, format::bfyx };
+
+    auto input0 = engine.allocate_memory(layout0);
+    auto input1 = engine.allocate_memory(layout1);
+
+    set_values<float>(input0, { 0, 1, 2, 3, 4, 5, 6, 7 });
+    set_values<float>(input1, { 8, 9 });
+    VF<float> expected_out = { 0, 1, 2, 3, 8, 4, 5, 6, 7, 9 };
+
+    network->set_input_data("input0", input0);
+    network->set_input_data("input1", input1);
+
+    auto outputs = network->execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "concat");
+
+    auto output_memory = outputs.at("concat").get_memory();
+    auto output_layout = outputs.at("concat").get_layout();
+    cldnn::mem_lock<float> output_ptr(output_memory, get_test_stream());
+
+    ov::PartialShape expected_shape = layout0.get_partial_shape();
+    expected_shape[1] = layout0.get_partial_shape()[1] +
+                        layout1.get_partial_shape()[1];
+
+    ASSERT_EQ(output_layout.get_partial_shape(), expected_shape);
+
+    for (size_t i = 0; i < output_layout.count(); ++i) {
+        ASSERT_EQ(expected_out[i], output_ptr[i]) << " i = " << i;
+    }
+}
+
 TEST(concat_gpu, dynamic_6d_f) {
     auto& engine = get_test_engine();
 


### PR DESCRIPTION
### Details:
 - *Implement shape agnostic concat ref kernel*
 - *The shape agnostic concat ref kernel supports bfyx and fsv32 input formats*

### Tickets:
 - *149462*
