### PR TITLE
[TFLite-FE] Move GraphIterator destructor to header file

### DIFF
--- a/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/graph_iterator.hpp
+++ b/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/graph_iterator.hpp
@@ -41,7 +41,7 @@ public:
     virtual std::shared_ptr<GraphIterator> get_subgraph(size_t idx) const = 0;
 
     /// \brief Destructor
-    virtual ~GraphIterator();
+    virtual ~GraphIterator() = default;
 };
 
 }  // namespace tensorflow_lite

--- a/src/frontends/tensorflow_lite/src/graph_iterator.cpp
+++ b/src/frontends/tensorflow_lite/src/graph_iterator.cpp
@@ -1,9 +1,0 @@
-// Copyright (C) 2018-2024 Intel Corporation
-// SPDX-License-Identifier: Apache-2.0
-//
-
-#include "openvino/frontend/tensorflow_lite/graph_iterator.hpp"
-
-using namespace ov::frontend::tensorflow_lite;
-
-GraphIterator::~GraphIterator() = default;


### PR DESCRIPTION
When tensorflow Lite delegate links against OpenVINO the definition to the ~GraphIterator cannot be found. As graph_iterator.cpp has no other definitions delete it, and move destructor definition to graph_iterator.hpp.

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
