### PR TITLE
[GPU]: Temp fix for failing i16 elementwise func test.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -63,9 +63,11 @@ inline cldnn::layout make_layout(const ov::element::Type type, const ov::Shape& 
 
 inline ov::element::Type convert_to_supported_device_type(ov::element::Type et) {
     switch (et) {
-        case ov::element::f64:
         case ov::element::i16:
+            return ov::element::i16;
         case ov::element::u16:
+            return ov::element::u16;
+        case ov::element::f64:
             return ov::element::f32;
         case ov::element::u64:
         case ov::element::u32:

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -114,7 +114,9 @@ inline ::std::ostream& operator<<(::std::ostream& os, const data_types& dt) {
 inline data_types element_type_to_data_type(ov::element::Type t) {
     switch (t) {
     case ov::element::Type_t::i16:
+        return data_types::i16;
     case ov::element::Type_t::u16:
+        return data_types::u16;
     case ov::element::Type_t::f64:
         return cldnn::data_types::f32;
     case ov::element::Type_t::u32:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
@@ -11,6 +11,8 @@ ParamsKey ReorderKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::INT16);
+    k.EnableInputDataType(Datatype::UINT16);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
     k.EnableInputDataType(Datatype::F16);
@@ -18,6 +20,8 @@ ParamsKey ReorderKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT8);
+    k.EnableOutputDataType(Datatype::INT16);
+    k.EnableOutputDataType(Datatype::UINT16);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::UINT8);

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -85,6 +85,7 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
     if (std::accumulate(const_shape.begin(), const_shape.end(), size_t(1), std::multiplies<size_t>()) == 0)
         constTensor = cldnn::tensor{1};
 
+    // Here where problem starts for gpu func i16 elementwise tests(i16 wrongly converted to f32).
     cldnn::data_types out_dtype = cldnn::element_type_to_data_type(op->get_output_element_type(0));
     cldnn::layout constLayout = p.use_new_shape_infer() ? cldnn::layout(const_shape, out_dtype, constFormat) :
                                                           cldnn::layout(out_dtype, constFormat, constTensor);

--- a/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
@@ -29,6 +29,7 @@ static void CreateParameterOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v
     }
 
     cldnn::format input_format = cldnn::format::get_default_format(input_pshape.size());
+    // Here where problem starts for gpu func i16 elementwise tests(i16 wrongly converted to f32).
     auto element_type = cldnn::element_type_to_data_type(convert_to_supported_device_type(op->get_output_element_type(0)));
 
     // look at the expected color format of this input

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/eltwise.cpp
@@ -73,6 +73,7 @@ std::vector<EltwiseTypes> smoke_intOnly_eltwiseOpTypes = {
 
 std::vector<ov::test::ElementType> intOnly_netPrecisions = {
         ov::element::i32,
+        ov::element::i16,
         ov::element::u16
 };
 


### PR DESCRIPTION
### Details:
 - Temp fix for failing GPU functional i16 test. The problem is that i16 input is wrongly converted to f32 in constant and parameter op. This is rather to show a problem, not a final solution(yet)..

### Tickets:
 - *ticket-id*
