### PR TITLE
[OVJS] Avoid of usage global variables in tests

### DIFF
--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -9,15 +9,16 @@ const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov basic tests.', () => {
 
-  before(async () => {
-    await isModelAvailable(testModels.testModelFP32);
-  });
-
-  const testXml = getModelPath().xml;
+  let testXml = null; 
   let core = null;
   let model = null;
   let compiledModel = null;
   let modelLike = null;
+
+  before(async () => {
+    await isModelAvailable(testModels.testModelFP32);
+    testXml = getModelPath().xml;
+  });
 
   beforeEach(() => {
     core = new ov.Core();

--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -6,6 +6,7 @@ const { addon: ov } = require('../..');
 const assert = require('assert');
 const { describe, it, before, beforeEach } = require('node:test');
 const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
+const epsilon = 0.5;
 
 describe('ov basic tests.', () => {
 
@@ -228,12 +229,12 @@ describe('ov basic tests.', () => {
   });
 
   describe('Test exportModel()/importModel()', () => {
-    const epsilon = 0.5;
-    const tensor = Float32Array.from({ length: 3072 }, () => (Math.random() + epsilon));
+    let tensor = null;
     let userStream = null;
     let res1 = null;
 
     before(() => {
+      tensor = Float32Array.from({ length: 3072 }, () => (Math.random() + epsilon));
       const core = new ov.Core();
       const model = core.readModelSync(testXml);
       const compiledModel = core.compileModelSync(model, 'CPU');

--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -24,8 +24,7 @@ describe('ov basic tests.', () => {
     core = new ov.Core();
     model = core.readModelSync(testXml);
     compiledModel = core.compileModelSync(model, 'CPU');
-    modelLike = [model,
-      compiledModel];
+    modelLike = [model, compiledModel];
   });
 
   it('Core.getAvailableDevices()', () => {
@@ -234,7 +233,7 @@ describe('ov basic tests.', () => {
     let userStream = null;
     let res1 = null;
 
-    before( () => {
+    before(() => {
       const core = new ov.Core();
       const model = core.readModelSync(testXml);
       const compiledModel = core.compileModelSync(model, 'CPU');

--- a/src/bindings/js/node/tests/unit/compiled_model.test.js
+++ b/src/bindings/js/node/tests/unit/compiled_model.test.js
@@ -9,14 +9,17 @@ const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov.CompiledModel tests', () => {
 
-  before(async () => {
-    await isModelAvailable(testModels.testModelFP32);
-  });
 
-  const testXml = getModelPath().xml;
-  const core = new ov.Core();
+  let testXml = null;
+  let core = null;
   let compiledModel = null;
 
+  before(async () => {
+    await isModelAvailable(testModels.testModelFP32);
+    testXml = getModelPath().xml;
+    core = new ov.Core();
+  });
+  
   beforeEach( () => {
     const properties = {
       'AUTO_BATCH_TIMEOUT': '1',

--- a/src/bindings/js/node/tests/unit/compiled_model.test.js
+++ b/src/bindings/js/node/tests/unit/compiled_model.test.js
@@ -20,7 +20,7 @@ describe('ov.CompiledModel tests', () => {
     core = new ov.Core();
   });
   
-  beforeEach( () => {
+  beforeEach(() => {
     const properties = {
       'AUTO_BATCH_TIMEOUT': '1',
     };

--- a/src/bindings/js/node/tests/unit/compiled_model.test.js
+++ b/src/bindings/js/node/tests/unit/compiled_model.test.js
@@ -4,7 +4,7 @@
 
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { describe, it, before } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov.CompiledModel tests', () => {
@@ -15,10 +15,14 @@ describe('ov.CompiledModel tests', () => {
 
   const testXml = getModelPath().xml;
   const core = new ov.Core();
-  const properties = {
-    'AUTO_BATCH_TIMEOUT': '1',
-  };
-  const compiledModel = core.compileModelSync(testXml, 'BATCH:CPU', properties);
+  let compiledModel = null;
+
+  beforeEach( () => {
+    const properties = {
+      'AUTO_BATCH_TIMEOUT': '1',
+    };
+    compiledModel = core.compileModelSync(testXml, 'BATCH:CPU', properties);
+  });
 
   describe('getProperty()', () => {
     it('returns the value of property from compiled model', () => {
@@ -39,7 +43,7 @@ describe('ov.CompiledModel tests', () => {
 
   describe('setProperty()', () => {
     it('sets a properties for compiled model', () => {
-      properties['AUTO_BATCH_TIMEOUT'] = '1000';
+      const properties = {'AUTO_BATCH_TIMEOUT': '1000'};
       assert.doesNotThrow(() => compiledModel.setProperty(properties));
     });
 
@@ -64,7 +68,7 @@ describe('ov.CompiledModel tests', () => {
     });
 
     it('returns the set property of the compiled model', () => {
-      properties['AUTO_BATCH_TIMEOUT'] = '123';
+      const properties = {'AUTO_BATCH_TIMEOUT': '123'};
       compiledModel.setProperty(properties);
       assert.strictEqual(compiledModel.getProperty('AUTO_BATCH_TIMEOUT'), 123);
     });

--- a/src/bindings/js/node/tests/unit/core.test.js
+++ b/src/bindings/js/node/tests/unit/core.test.js
@@ -4,11 +4,14 @@
 
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { describe, it } = require('node:test');
+const { describe, it, beforeEach } = require('node:test');
 
 describe('ov.Core tests', () => {
 
-  const core = new ov.Core();
+  let core = null;
+  beforeEach(() => {
+    core = new ov.Core();
+  });
 
   it('Core.setProperty()', () => {
     const tmpDir = '/tmp';

--- a/src/bindings/js/node/tests/unit/infer_request.test.js
+++ b/src/bindings/js/node/tests/unit/infer_request.test.js
@@ -81,11 +81,11 @@ describe('ov.InferRequest tests', () => {
 
         assert.throws(
           () => inferRequest.infer([tl]),
-          {message: new RegExp(msg)}, 'infer([data]) throws');
+          { message: new RegExp(msg) }, 'infer([data]) throws');
 
         assert.throws(
           () => inferRequest.infer({data: tl}),
-          {message: new RegExp(msg)}, 'infer({ data: tl}) throws');
+          { message: new RegExp(msg) }, 'infer({ data: tl}) throws');
 
       });
 

--- a/src/bindings/js/node/tests/unit/infer_request.test.js
+++ b/src/bindings/js/node/tests/unit/infer_request.test.js
@@ -36,8 +36,7 @@ describe('ov.InferRequest tests', () => {
       [1, 10],
       tensorData.slice(-10),
     );
-    tensorLike = [[tensor],
-      [tensorData]];
+    tensorLike = [tensor, tensorData];
   });
 
   describe('infer() method', () => {
@@ -47,7 +46,7 @@ describe('ov.InferRequest tests', () => {
     });
 
     it('Test infer(inputData: {inputName: string]: Tensor[]/TypedArray[]}', () => {
-      tensorLike.forEach(([tl]) => {
+      tensorLike.forEach((tl) => {
         const result = inferRequest.infer({ data: tl });
         assert.deepStrictEqual(Object.keys(result), ['fc_out']);
         assert.deepStrictEqual(result['fc_out'].data.length, 10);
@@ -55,7 +54,7 @@ describe('ov.InferRequest tests', () => {
     });
 
     it('Test infer(inputData: Tensor[]/TypedArray[])', () => {
-      tensorLike.forEach(([tl]) => {
+      tensorLike.forEach((tl) => {
         const result = inferRequest.infer([tl]);
         assert.deepStrictEqual(Object.keys(result), ['fc_out']);
         assert.deepStrictEqual(result['fc_out'].data.length, 10);

--- a/src/bindings/js/node/tests/unit/infer_request.test.js
+++ b/src/bindings/js/node/tests/unit/infer_request.test.js
@@ -4,7 +4,7 @@
 
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { describe, it, before } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const { testModels, isModelAvailable, getModelPath } = require('./utils.js');
 
 const epsilon = 0.5; // To avoid very small numbers
@@ -20,9 +20,6 @@ describe('ov.InferRequest tests', () => {
   const model = core.readModelSync(testXml);
   const compiledModel = core.compileModelSync(model, 'CPU');
 
-  const inferRequest = compiledModel.createInferRequest();
-  const inferRequestAsync = compiledModel.createInferRequest();
-
   const tensorData = Float32Array.from({ length: 3072 }, () => (Math.random() + epsilon));
   const tensor = new ov.Tensor(
     ov.element.f32,
@@ -34,29 +31,30 @@ describe('ov.InferRequest tests', () => {
     [1, 10],
     tensorData.slice(-10),
   );
-
   const tensorLike = [[tensor],
     [tensorData]];
+    
 
-  describe('InferRequest', () => {
+  describe('infer() method', () => {
+    let inferRequest = null;
+    beforeEach(() => {
+      inferRequest = compiledModel.createInferRequest();
+    });
 
-    tensorLike.forEach(([tl]) => {
-      const result = inferRequest.infer({ data: tl });
-      const label = tl instanceof Float32Array ? 'TypedArray[]' : 'Tensor[]';
-      it(`Test infer(inputData: { [inputName: string]: ${label} })`, () => {
+    it('Test infer(inputData: {inputName: string]: Tensor[]/TypedArray[]}', () => {
+      tensorLike.forEach(([tl]) => {
+        const result = inferRequest.infer({ data: tl });
         assert.deepStrictEqual(Object.keys(result), ['fc_out']);
         assert.deepStrictEqual(result['fc_out'].data.length, 10);
       });
     });
 
-    tensorLike.forEach(([tl]) => {
-      const result = inferRequest.infer([tl]);
-      const label = tl instanceof Float32Array ? 'TypedArray[]' : 'Tensor[]';
-      it(`Test infer(inputData: ${label})`, () => {
+    it('Test infer(inputData: Tensor[]/TypedArray[])', () => {
+      tensorLike.forEach(([tl]) => {
+        const result = inferRequest.infer([tl]);
         assert.deepStrictEqual(Object.keys(result), ['fc_out']);
         assert.deepStrictEqual(result['fc_out'].data.length, 10);
       });
-
     });
 
     it('Test infer(TypedArray) throws', () => {
@@ -86,8 +84,16 @@ describe('ov.InferRequest tests', () => {
       });
     });
 
+  });
+
+  describe('inferAsync() method', () => {
+    let inferRequest = null;
+    before( () => {
+      inferRequest = compiledModel.createInferRequest();
+    });
+
     it('Test inferAsync(inputData: { [inputName: string]: Tensor })', () => {
-      inferRequestAsync.inferAsync({ data: tensor }).then(result => {
+      inferRequest.inferAsync({ data: tensor }).then(result => {
         assert.ok(result['fc_out'] instanceof ov.Tensor);
         assert.deepStrictEqual(Object.keys(result), ['fc_out']);
         assert.deepStrictEqual(result['fc_out'].data.length, 10);}
@@ -95,7 +101,7 @@ describe('ov.InferRequest tests', () => {
     });
 
     it('Test inferAsync(inputData: Tensor[])', () => {
-      inferRequestAsync.inferAsync([ tensor ]).then(result => {
+      inferRequest.inferAsync([ tensor ]).then(result => {
         assert.ok(result['fc_out'] instanceof ov.Tensor);
         assert.deepStrictEqual(Object.keys(result), ['fc_out']);
         assert.deepStrictEqual(result['fc_out'].data.length, 10);
@@ -104,16 +110,24 @@ describe('ov.InferRequest tests', () => {
 
     it('Test inferAsync([data]) throws: Cannot create a tensor from the passed Napi::Value.', () => {
       assert.throws(
-        () => inferRequestAsync.inferAsync(['string']).then(),
+        () => inferRequest.inferAsync(['string']).then(),
         /Cannot create a tensor from the passed Napi::Value./
       );
     });
 
     it('Test inferAsync({ data: "string"}) throws: Cannot create a tensor from the passed Napi::Value.', () => {
       assert.throws(
-        () => inferRequestAsync.inferAsync({data: 'string'}).then(),
+        () => inferRequest.inferAsync({data: 'string'}).then(),
         /Cannot create a tensor from the passed Napi::Value./
       );
+    });
+
+  });
+
+  describe('setters', () => {
+    let inferRequest = null;
+    beforeEach(() => {
+      inferRequest = compiledModel.createInferRequest();
     });
 
     it('Test setInputTensor(tensor)', () => {
@@ -238,38 +252,44 @@ describe('ov.InferRequest tests', () => {
       );
     });
 
-    const irGetters = compiledModel.createInferRequest();
-    irGetters.setInputTensor(tensor);
-    irGetters.infer();
+  });
+
+  describe('getters', () => {
+    let inferRequest = null;
+    beforeEach(() => {
+      inferRequest = compiledModel.createInferRequest();
+      inferRequest.setInputTensor(tensor);
+      inferRequest.infer();
+    });
 
     it('Test getTensor(tensorName)', () => {
-      const t1 = irGetters.getTensor('data');
+      const t1 = inferRequest.getTensor('data');
       assert.ok(t1 instanceof ov.Tensor);
       assert.deepStrictEqual(tensor.data[0], t1.data[0]);
     });
 
     it('Test getTensor(Output)', () => {
-      const input = irGetters.getCompiledModel().input();
-      const t1 = irGetters.getTensor(input);
+      const input = inferRequest.getCompiledModel().input();
+      const t1 = inferRequest.getTensor(input);
       assert.ok(t1 instanceof ov.Tensor);
       assert.deepStrictEqual(tensor.data[0], t1.data[0]);
     });
 
     it('Test getInputTensor()', () => {
-      const t1 = irGetters.getInputTensor();
+      const t1 = inferRequest.getInputTensor();
       assert.ok(t1 instanceof ov.Tensor);
       assert.deepStrictEqual(tensor.data[0], t1.data[0]);
     });
 
     it('Test getInputTensor(idx)', () => {
-      const t1 = irGetters.getInputTensor(0);
+      const t1 = inferRequest.getInputTensor(0);
       assert.ok(t1 instanceof ov.Tensor);
       assert.deepStrictEqual(tensor.data[0], t1.data[0]);
     });
 
     it('Test getOutputTensor(idx?)', () => {
-      const res1 = irGetters.getOutputTensor();
-      const res2 = irGetters.getOutputTensor(0);
+      const res1 = inferRequest.getOutputTensor();
+      const res2 = inferRequest.getOutputTensor(0);
       assert.ok(res1 instanceof ov.Tensor);
       assert.ok(res2 instanceof ov.Tensor);
       assert.deepStrictEqual(res1.data[0], res2.data[0]);
@@ -284,6 +304,6 @@ describe('ov.InferRequest tests', () => {
       const res1 = ir.infer([tensorData]);
       assert.deepStrictEqual(res1['fc_out'].data[0], res2['fc_out'].data[0]);
     });
-  });
 
+  });
 });

--- a/src/bindings/js/node/tests/unit/model.test.js
+++ b/src/bindings/js/node/tests/unit/model.test.js
@@ -9,13 +9,16 @@ const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov.Model tests', () => {
 
+  let testXml = null;
+  let core = null;
+  let model = null;
+
   before(async () => {
     await isModelAvailable(testModels.testModelFP32);
+    testXml = getModelPath().xml;
+    core = new ov.Core();
   });
 
-  const testXml = getModelPath().xml;
-  const core = new ov.Core();
-  let model = null;
   beforeEach(() => {
     model = core.readModelSync(testXml);
   });

--- a/src/bindings/js/node/tests/unit/model.test.js
+++ b/src/bindings/js/node/tests/unit/model.test.js
@@ -4,7 +4,7 @@
 
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { describe, it, before } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov.Model tests', () => {
@@ -15,8 +15,10 @@ describe('ov.Model tests', () => {
 
   const testXml = getModelPath().xml;
   const core = new ov.Core();
-  const model = core.readModelSync(testXml);
-  const clonedModel = model.clone();
+  let model = null;
+  beforeEach(() => {
+    model = core.readModelSync(testXml);
+  });
 
   describe('Model.isDynamic()', () => {
     it('should return a boolean value indicating if the model is dynamic', () => {
@@ -61,10 +63,6 @@ describe('ov.Model tests', () => {
     });
   });
   describe('Model.setFriendlyName()', () => {
-    it('sets a friendly name for the model', () => {
-      assert.doesNotThrow(() => model.setFriendlyName('MyFriendlyName'));
-    });
-
     it('throws an error when called without a string argument', () => {
       assert.throws(
         () => model.setFriendlyName(),
@@ -97,7 +95,7 @@ describe('ov.Model tests', () => {
 
     it('handles setting an empty string as a friendly name', () => {
       assert.doesNotThrow(() => model.setFriendlyName(''));
-      assert.strictEqual(model.getFriendlyName(), 'Model1');
+      assert.strictEqual(model.getFriendlyName(), model.getName());
     });
   });
 
@@ -166,10 +164,12 @@ describe('ov.Model tests', () => {
 
   describe('Model.clone()', () => {
     it('should return an object of type model', () => {
+      const clonedModel = model.clone();
       assert.ok(clonedModel instanceof ov.Model, 'clone() should return a model');
     });
 
     it('should return a model that is a clone of the calling model', () => {
+      const clonedModel = model.clone();
       assert.deepStrictEqual(clonedModel, model, 'Cloned Model should be exactly equal to the calling model');
     });
 

--- a/src/bindings/js/node/tests/unit/pre_post_processor.test.js
+++ b/src/bindings/js/node/tests/unit/pre_post_processor.test.js
@@ -9,13 +9,17 @@ const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov.preprocess.PrePostProcessor tests', () => {
 
+  let testXml = null;
+  let core = null;
+  let model = null;
+
   before(async () => {
     await isModelAvailable(testModels.testModelFP32);
+    testXml = getModelPath().xml;
+    core = new ov.Core();
+
   });
 
-  const testXml = getModelPath().xml;
-  const core = new ov.Core();
-  let model = null;
   beforeEach(() => {
     model = core.readModelSync(testXml);
   });

--- a/src/bindings/js/node/tests/unit/pre_post_processor.test.js
+++ b/src/bindings/js/node/tests/unit/pre_post_processor.test.js
@@ -4,7 +4,7 @@
 
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { describe, it, before } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const { testModels, getModelPath, isModelAvailable } = require('./utils.js');
 
 describe('ov.preprocess.PrePostProcessor tests', () => {
@@ -15,7 +15,10 @@ describe('ov.preprocess.PrePostProcessor tests', () => {
 
   const testXml = getModelPath().xml;
   const core = new ov.Core();
-  const model = core.readModelSync(testXml);
+  let model = null;
+  beforeEach(() => {
+    model = core.readModelSync(testXml);
+  });
 
   describe('PrePostProcess', () => {
 

--- a/src/bindings/js/node/tests/unit/read_model.test.js
+++ b/src/bindings/js/node/tests/unit/read_model.test.js
@@ -5,7 +5,7 @@
 const fs = require('node:fs');
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { describe, it, before } = require('node:test');
+const { describe, it, before, beforeEach } = require('node:test');
 const { testModels, isModelAvailable, getModelPath } = require('./utils.js');
 
 const { xml: modelPath, bin: weightsPath } = getModelPath();
@@ -19,9 +19,12 @@ describe('Tests for reading model.', () => {
   const modelFile = fs.readFileSync(modelPath);
   const modelStr = fs.readFileSync(modelPath, 'utf8');
   const weightsFile = fs.readFileSync(weightsPath);
-  const weightsTensor = new ov.Tensor(ov.element.u8, [weightsFile.buffer.byteLength], new Uint8Array(weightsFile.buffer));
-
-  const core = new ov.Core();
+  let core = null;
+  let weightsTensor= null;
+  beforeEach(() => {
+    core = new ov.Core();
+    weightsTensor = new ov.Tensor(ov.element.u8, [weightsFile.buffer.byteLength], new Uint8Array(weightsFile.buffer));
+  });
 
   describe('Core.readModeSync', () => {
     it('readModeSync(xmlPath) ', () => {

--- a/src/bindings/js/node/tests/unit/read_model.test.js
+++ b/src/bindings/js/node/tests/unit/read_model.test.js
@@ -12,15 +12,19 @@ const { xml: modelPath, bin: weightsPath } = getModelPath();
 
 describe('Tests for reading model.', () => {
 
+  let modelFile = null;
+  let modelStr = null;
+  let weightsFile = null;
+  let weightsTensor= null;
+  let core = null;
+
   before(async () => {
     await isModelAvailable(testModels.testModelFP32);
+    modelFile = fs.readFileSync(modelPath);
+    modelStr = fs.readFileSync(modelPath, 'utf8');
+    weightsFile = fs.readFileSync(weightsPath);
   });
 
-  const modelFile = fs.readFileSync(modelPath);
-  const modelStr = fs.readFileSync(modelPath, 'utf8');
-  const weightsFile = fs.readFileSync(weightsPath);
-  let core = null;
-  let weightsTensor= null;
   beforeEach(() => {
     core = new ov.Core();
     weightsTensor = new ov.Tensor(ov.element.u8, [weightsFile.buffer.byteLength], new Uint8Array(weightsFile.buffer));

--- a/src/bindings/js/node/tests/unit/tensor.test.js
+++ b/src/bindings/js/node/tests/unit/tensor.test.js
@@ -4,26 +4,33 @@
 
 const { addon: ov } = require('../..');
 const assert = require('assert');
-const { test, describe, it } = require('node:test');
+const { test, describe, it, before } = require('node:test');
 const getRandomBigInt = require('random-bigint');
 
 describe('ov.Tensor tests', () => {
 
-  const shape = [1, 3, 224, 224];
-  const elemNum = 1 * 3 * 224 * 224;
-  const data = Float32Array.from({ length: elemNum }, () => Math.random() );
-  const params = [
-    [ov.element.i8, 'i8', Int8Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.u8, 'u8', Uint8Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.i16, 'i16', Int16Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.u16, 'u16', Uint16Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.i32, 'i32', Int32Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.u32, 'u32', Uint32Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.f32, 'f32', Float32Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.f64, 'f64', Float64Array.from({ length: elemNum }, () => Math.random() )],
-    [ov.element.i64, 'i64', BigInt64Array.from({ length: elemNum }, () => getRandomBigInt(10) )],
-    [ov.element.u64, 'u64', BigUint64Array.from({ length: elemNum }, () => getRandomBigInt(10) )],
-  ];
+  let shape = null;
+  let elemNum = null;
+  let data = null;
+  let params =null;
+
+  before(() => {
+    shape = [1, 3, 224, 224];
+    elemNum = 1 * 3 * 224 * 224;
+    data = Float32Array.from({ length: elemNum }, () => Math.random() );
+    params = [
+      [ov.element.i8, 'i8', Int8Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.u8, 'u8', Uint8Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.i16, 'i16', Int16Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.u16, 'u16', Uint16Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.i32, 'i32', Int32Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.u32, 'u32', Uint32Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.f32, 'f32', Float32Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.f64, 'f64', Float64Array.from({ length: elemNum }, () => Math.random() )],
+      [ov.element.i64, 'i64', BigInt64Array.from({ length: elemNum }, () => getRandomBigInt(10) )],
+      [ov.element.u64, 'u64', BigUint64Array.from({ length: elemNum }, () => getRandomBigInt(10) )],
+    ];
+  });
 
   test('Test for number of arguments in tensor', () => {
     assert.throws( () => new ov.Tensor(ov.element.f32, shape, data, params),
@@ -38,9 +45,8 @@ describe('ov.Tensor tests', () => {
   });
 
   describe('Tensor data', () => {
-
-    params.forEach(([type, stringType, data]) => {
-      it(`set tensor data with ${stringType} element type`, () => {
+    it('set tensor data with element type', () => {
+      params.forEach(([type, stringType, data]) => {
         const tensor = new ov.Tensor(type, shape, data);
         assert.deepStrictEqual(tensor.data, data);
       });
@@ -192,14 +198,16 @@ describe('ov.Tensor tests', () => {
   });
 
   describe('Tensor element type', () => {
-    params.forEach(([elemType, val]) => {
-      it(`comparison of ov.element.${elemType} to string ${val}`, () => {
+    it('comparisons of ov.element to string', () => {
+      params.forEach(([elemType, val]) => {
+
         assert.strictEqual(elemType, val);
       });
     });
 
-    params.forEach(([elemType, , data]) => {
-      it(`comparison of ov.element ${elemType} got from Tensor object`, () => {
+    it('comparisons of ov.element got from Tensor object', () => {
+      params.forEach(([elemType, , data]) => {
+
         const tensor = new ov.Tensor(elemType, shape, data);
         assert.strictEqual(tensor.getElementType(), elemType);
       });


### PR DESCRIPTION
### Details:
 - Avoid dependencies between tests and unexpected behaviours
 - Add `beforeEach`

### Tickets:
 - [CVS-146340](https://jira.devtools.intel.com/browse/CVS-146340)
