### PR TITLE
[LPT] Handle scale with convert in MatMulTransformation

### DIFF
--- a/src/common/low_precision_transformations/src/mat_mul.cpp
+++ b/src/common/low_precision_transformations/src/mat_mul.cpp
@@ -222,6 +222,19 @@ bool MatMulTransformation::canBeTransformed(const TransformationContext& context
         return false;
     }
 
+    // WA: LPT don't expect Convert on dequantization scale: the convert is usually folded at the previous transformation pipeline steps.
+    // However, such subgraphs may arise on Matmul weights since decompression handling logic keeps these subgraphs unchanged
+    // TODO: remove this logic when
+    //       1. CompressedMatmul is implemented
+    //       2. Or convert on scales is supported across the whole LPT pipeline
+    if (auto mul = ov::as_type_ptr<ov::op::v1::Multiply>(layer->get_input_node_shared_ptr(1))) {
+        if (auto convert = ov::as_type_ptr<ov::op::v0::Convert>(mul->get_input_node_shared_ptr(1))) {
+            if (auto constant = ov::as_type_ptr<ov::op::v0::Constant>(convert->get_input_node_shared_ptr(0))) {
+                auto new_constant = foldConvert(constant, convert->get_destination_type());
+                ov::replace_node_update_name(convert, new_constant);
+            }
+        }
+    }
     const auto dequantization2 = NetworkHelper::getDequantization(layer, defaultPrecisions, 1);
     if (!dequantization2.empty()) {
         if ((updatePrecisions && !dequantization2.isLowPrecision())) {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -65,6 +65,22 @@ std::vector<MatMulWithConstantTransformationTestValues> testValues = {
         "FullyConnected",
         "u8"
     },
+    // 4D with Dq on weights, with convert on scales
+    {
+        { 1, 1, 3, 4 },
+        { 256ul, {{1, 1, 1}, {1, 1, 1}, {1, 3, 1}, {1, 3, 1}}, {0.f}, {255.f}, {0.f, 0.f, 0.f}, {255.f, 25.5f, 255.f} },
+        { std::vector<float>(4 * 2, 2.f), ov::element::i8, ov::Shape{ 2, 4 } },
+        {},
+        {
+            ov::element::f32,
+            {},
+            ov::builder::subgraph::DequantizationOperations::Multiply({0.1f, 0.01f}, ov::element::f32, ov::Shape{ 2, 1 })
+                .setConstantPrecision(ov::element::f16)
+                .setAddConvert(true)
+        },
+        "FullyConnected",
+        "u8"
+    },
     // 3D with the same values
     {
         { 1, 3, 4 },

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/dequantization_operations.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/common/dequantization_operations.hpp
@@ -54,6 +54,7 @@ public:
             isEmpty = true;
         }
         Subtract& setConstantPrecision(const ov::element::Type& precision);
+        Subtract& setAddConvert(bool value);
 
         std::vector<float> values;
         ov::element::Type outPrecision = ov::element::undefined;
@@ -81,13 +82,15 @@ public:
             const ov::Shape& constantShape,
             const bool toRemove = false,
             const size_t constantIndex = 1ul,
-            const ov::element::Type constantPrecision = ov::element::undefined);
+            const ov::element::Type constantPrecision = ov::element::undefined,
+            const bool addConvert = false);
         bool empty() const noexcept;
         bool equal(const DequantizationOperations::Multiply& value) const noexcept;
         bool operator==(const Multiply& value) const noexcept {
             return equal(value);
         }
         Multiply& setConstantPrecision(const ov::element::Type& precision);
+        Multiply& setAddConvert(bool value);
 
         std::vector<float> values;
         ov::element::Type outPrecision = ov::element::undefined;
@@ -95,6 +98,7 @@ public:
         bool constantShapeIsDefined = false;
         size_t constantIndex = 1ul;
         ov::element::Type constantPrecision = ov::element::undefined;
+        bool addConvert = false;
 
     private:
         bool isEmpty;

--- a/src/tests/ov_helpers/ov_lpt_models/src/common/dequantization_operations.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/common/dequantization_operations.cpp
@@ -96,6 +96,11 @@ DequantizationOperations::Subtract& DequantizationOperations::Subtract::setConst
     return *this;
 }
 
+DequantizationOperations::Subtract& DequantizationOperations::Subtract::setAddConvert(bool value) {
+    addConvert = value;
+    return *this;
+}
+
 DequantizationOperations::Multiply::Multiply() :
     isEmpty(true),
     outPrecision(ov::element::undefined),
@@ -129,13 +134,15 @@ DequantizationOperations::Multiply::Multiply(
     const ov::Shape& constantShape,
     const bool toRemove,
     const size_t constantIndex,
-    ov::element::Type constantPrecision) :
+    ov::element::Type constantPrecision,
+    const bool addConvert) :
     isEmpty(false),
     values(values),
     outPrecision(outPrecision),
     constantShape(constantShape),
     constantIndex(constantIndex),
     constantPrecision(constantPrecision),
+    addConvert(addConvert),
     constantShapeIsDefined(true) {
 }
 
@@ -166,6 +173,11 @@ DequantizationOperations::Multiply& DequantizationOperations::Multiply::setConst
     return *this;
 }
 
+DequantizationOperations::Multiply& DequantizationOperations::Multiply::setAddConvert(bool value) {
+    addConvert = value;
+    return *this;
+}
+
 DequantizationOperations::DequantizationOperations() {}
 
 DequantizationOperations::DequantizationOperations(
@@ -179,9 +191,11 @@ DequantizationOperations::DequantizationOperations(
 
 void DequantizationOperations::setPrecision(const ov::element::Type& type) noexcept {
     convert.outPrecision = type;
-    subtract.constantPrecision = type;
+    if (!subtract.addConvert)
+        subtract.constantPrecision = type;
     subtract.outPrecision = type;
-    multiply.constantPrecision = type;
+    if (!multiply.addConvert)
+        multiply.constantPrecision = type;
     multiply.outPrecision = type;
 }
 


### PR DESCRIPTION
### Details:
This PR handles Matmul dequantization subgraphs with convert on scales.

In general, LPT don't expect Convert on dequantization scale: the convert is usually folded at the previous transformation pipeline steps. However, such subgraphs may arise on Matmul weights (in CPU plugin) since decompression handling logic keeps these subgraphs unchanged. Since decompression handling logic concerns only MatMuls, the changes in MatMul LPT is enough.

### Tickets:
 - *CVS-151589*
