### PR TITLE
[JAX FE] Update JAX version to latest one for testing

### DIFF
--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -22,8 +22,8 @@ pytest>=5.0,<8.4
 pytest-dependency==0.5.1
 pytest-html==4.1.1
 pytest-timeout==2.2.0
-jax<=0.4.14
-jaxlib<=0.4.14
+jax~=0.4.31
+jaxlib~=0.4.31
 kornia==0.7.0
 networkx<=3.3
 timm==1.0.8

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -22,8 +22,8 @@ pytest>=5.0,<8.4
 pytest-dependency==0.5.1
 pytest-html==4.1.1
 pytest-timeout==2.2.0
-jax~=0.4.31
-jaxlib~=0.4.31
+jax<=0.4.31
+jaxlib<=0.4.31
 kornia==0.7.0
 networkx<=3.3
 timm==1.0.8


### PR DESCRIPTION
**Details:** It is required for validation of Python 3.12 support.

**Tickets:** 150860
