### PR TITLE
[NPU] Disabling AVX optimizations for NPU plugin.cpp

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
@@ -358,8 +358,8 @@ public:
     void walk(std::function<void(const details::OptionConcept&)> cb) const;
 
 private:
-    std::map<std::string, details::OptionConcept> _impl;
-    std::map<std::string, std::string> _deprecated;
+    std::unordered_map<std::string, details::OptionConcept> _impl;
+    std::unordered_map<std::string, std::string> _deprecated;
 };
 
 template <class Opt>
@@ -383,7 +383,7 @@ void OptionsDesc::add() {
 class Config final {
 public:
     using ConfigMap = std::map<std::string, std::string>;
-    using ImplMap = std::map<std::string, std::shared_ptr<details::OptionValue>>;
+    using ImplMap = std::unordered_map<std::string, std::shared_ptr<details::OptionValue>>;
 
     explicit Config(const std::shared_ptr<const OptionsDesc>& desc);
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
@@ -15,6 +15,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/config/config.hpp
@@ -15,7 +15,6 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -33,11 +32,15 @@ struct TypePrinter {
     static constexpr const char* name();
 };
 
-#define TYPE_PRINTER(type)                                    \
-    template <>                                               \
-    struct TypePrinter<type> {                                \
-        static constexpr bool hasName() { return true; }      \
-        static constexpr const char* name() { return #type; } \
+#define TYPE_PRINTER(type)                    \
+    template <>                               \
+    struct TypePrinter<type> {                \
+        static constexpr bool hasName() {     \
+            return true;                      \
+        }                                     \
+        static constexpr const char* name() { \
+            return #type;                     \
+        }                                     \
     };
 
 TYPE_PRINTER(bool)
@@ -355,8 +358,8 @@ public:
     void walk(std::function<void(const details::OptionConcept&)> cb) const;
 
 private:
-    std::unordered_map<std::string, details::OptionConcept> _impl;
-    std::unordered_map<std::string, std::string> _deprecated;
+    std::map<std::string, details::OptionConcept> _impl;
+    std::map<std::string, std::string> _deprecated;
 };
 
 template <class Opt>
@@ -380,7 +383,7 @@ void OptionsDesc::add() {
 class Config final {
 public:
     using ConfigMap = std::map<std::string, std::string>;
-    using ImplMap = std::unordered_map<std::string, std::shared_ptr<details::OptionValue>>;
+    using ImplMap = std::map<std::string, std::shared_ptr<details::OptionValue>>;
 
     explicit Config(const std::shared_ptr<const OptionsDesc>& desc);
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#pragma GCC target("no-avx")
+#if defined(__GNUC__) || defined(__clang__)
+#    pragma GCC target("no-avx")
+#elif defined(_MSC_VER)
+#    pragma optimize("t", off)
+#endif
+
 #include "plugin.hpp"
 
 #include <fstream>
@@ -829,3 +834,7 @@ static const ov::Version version = {CI_BUILD_NUMBER, NPU_PLUGIN_LIB_NAME};
 OV_DEFINE_PLUGIN_CREATE_FUNCTION(Plugin, version)
 
 }  // namespace intel_npu
+
+#if defined(_MSC_VER)
+#    pragma optimize("t", on)
+#endif

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#pragma GCC target("no-avx")
 #include "plugin.hpp"
 
 #include <fstream>


### PR DESCRIPTION
### Details:
 - AVX optimization will propagate to standard library containers (unordered_map) and they will cause an illegal instruction core dump on processors that don't support AVX. This PR disable AVX optimizations for the npu plugin.cpp file. If there are AVX optimizations in plugin.cpp, there is a risk of a crash when checking for available plugins.

### Tickets:
 - CVS-147126
