### PR TITLE
[CPU] fix QKVProjection fake-matching for accuracy with bert models

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/qkv_proj.cpp
@@ -16,6 +16,7 @@ void QKVProjectionNode::validate_and_infer_types() {
     const auto& ishape = get_input_partial_shape(0);
     const auto& itype = get_input_element_type(0);
     NODE_VALIDATION_CHECK(this, ishape.rank().is_static() && ishape.rank() == 3, "feature shape rank must be 3");
+    NODE_VALIDATION_CHECK(this, itype.is_real(), "feature data type must be real");
 
     set_output_size(3);
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
@@ -52,6 +52,10 @@ ov::intel_cpu::QKVProjFusion::QKVProjFusion() {
             return false;
         }
 
+        if (!src.get_element_type().is_real()) {
+            return false;
+        }
+
         OutputVector args = {src};
         OutputVector outputs;
         size_t hidden_size = 0;


### PR DESCRIPTION
### Details:
 - prevent QKVProjFusion from mistakenly fusing patterns with integer input (happens in bert-INT8 models with smooth-quant)


### Tickets:
 - *CVS-151213*