### PR TITLE
[CPU] change Eltwise layout selection logic for x86 non-CNN ModelType

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2574,6 +2574,14 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
         return;
     }
 #endif
+    // To make attention_mask process align with SDPA layout
+    if (getAlgorithm() == Algorithm::EltwiseClamp) {
+        auto parentNode = getParentEdgeAt(0)->getParent();
+        if (Config::ModelType::LLM == context->getConfig().modelType && "Ceiling" == parentNode->getTypeStr() &&
+            Algorithm::MathCeiling == parentNode->getAlgorithm()) {
+            isChannelsFirstApplicable = false;
+        }
+    }
 
 #if defined(OV_CPU_WITH_SHL)
     eltwiseAttrs = {algorithm, alpha, beta, gamma};

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2574,14 +2574,6 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
         return;
     }
 #endif
-    // To make attention_mask process align with SDPA layout
-    if (getAlgorithm() == Algorithm::EltwiseClamp) {
-        auto parentNode = getParentEdgeAt(0)->getParent();
-        if (Config::ModelType::LLM == context->getConfig().modelType && "Ceiling" == parentNode->getTypeStr() &&
-            Algorithm::MathCeiling == parentNode->getAlgorithm()) {
-            isChannelsFirstApplicable = false;
-        }
-    }
 
 #if defined(OV_CPU_WITH_SHL)
     eltwiseAttrs = {algorithm, alpha, beta, gamma};
@@ -2599,11 +2591,19 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
         return;
 #endif
 
-    if (isChannelsFirstApplicable)
-        supportedPrimitiveDescriptors.emplace_back(initDesc(ChannelsFirst));
-    if (isBlockedApplicable)
-        supportedPrimitiveDescriptors.emplace_back(initDesc(Blocked));
-    supportedPrimitiveDescriptors.emplace_back(initDesc(Planar));
+    if (context->getConfig().modelType == Config::ModelType::CNN) {
+        if (isChannelsFirstApplicable)
+            supportedPrimitiveDescriptors.emplace_back(initDesc(ChannelsFirst));
+        if (isBlockedApplicable)
+            supportedPrimitiveDescriptors.emplace_back(initDesc(Blocked));
+        supportedPrimitiveDescriptors.emplace_back(initDesc(Planar));
+    } else {
+        supportedPrimitiveDescriptors.emplace_back(initDesc(Planar));
+        if (isChannelsFirstApplicable)
+            supportedPrimitiveDescriptors.emplace_back(initDesc(ChannelsFirst));
+        if (isBlockedApplicable)
+            supportedPrimitiveDescriptors.emplace_back(initDesc(Blocked));
+    }
 }
 
 void Eltwise::createPrimitive() {


### PR DESCRIPTION

### Details:
 - *change Eltwise layout selection logic for x86 non-CNN ModelType, several llm models gain performance benefits from this change since additional reorder operators have been avoided, e.g. phi3 and bloomz*
 - *details can be found in the [ticket discussion](https://jira.devtools.intel.com/browse/CVS-148780).)*


### Tickets:
 - *148780*
