### PR TITLE
[GPU] Update gpu passes to keep valid layouts more often

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/handle_reshape.cpp
@@ -181,6 +181,8 @@ void handle_reshape::run(program& p) {
                         }
 
                         reorder_reshape_nodes.push_back(&new_reshape_node);
+                        new_reshape_node.recalc_output_layouts(false);
+                        node->recalc_output_layouts(false);
                     }
                 }
 
@@ -208,7 +210,8 @@ void handle_reshape::run(program& p) {
                                        0,
                                        reshape_input_node.get_dependencies().empty());
                     reshape_reorder_id++;
-                    reshape_input_node.recalc_output_layout();
+                    reshape_input_node.recalc_output_layouts(false);
+                    node->recalc_output_layouts(false);
                 }
             }
 
@@ -233,7 +236,8 @@ void handle_reshape::run(program& p) {
                         << " input_info : " << reshape_input->dependencies().front().to_string() << std::endl;
                     auto& reshape_input_node = p.get_or_create(reshape_input);
                     p.add_intermediate(reshape_input_node, *node, 0, reshape_input_node.get_dependencies().empty());
-                    reshape_input_node.recalc_output_layout();
+                    reshape_input_node.recalc_output_layouts(false);
+                    node->recalc_output_layouts(false);
                 }
 
                 // Check whether output reorder is required for format change
@@ -251,9 +255,9 @@ void handle_reshape::run(program& p) {
                                         *user,
                                         *node,
                                         reshape_output_node.get_dependencies().empty());
-                        reshape_output_node.recalc_output_layout();
+                        reshape_output_node.recalc_output_layouts(false);
                     }
-                    node->recalc_output_layout();
+                    node->recalc_output_layouts(false);
                 }
             }
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -41,6 +41,7 @@ void prepare_padding::run(program& p) {
                     auto new_reorder = std::make_shared<reorder>(node.id() + "_padding_reorder_for_" + input.id(), input.id(), input.get_output_layout());
                     auto& new_reorder_node = p.get_or_create(new_reorder);
                     p.add_intermediate(new_reorder_node, node, input);
+                    new_reorder_node.recalc_output_layouts(false);
                 }
 
                 p.apply_needed_padding(node, node.get_dependency(0), needed_padding);
@@ -209,6 +210,7 @@ void prepare_padding::run(program& p) {
             auto new_reorder = std::make_shared<reorder>(node.id() + "_padding_reorder_for_" + input.id(), input.id(), input.get_output_layout());
             auto& new_reorder_node = p.get_or_create(new_reorder);
             p.add_intermediate(new_reorder_node, node, input);
+            new_reorder_node.recalc_output_layouts(false);
         }
 
         p.apply_needed_padding(node, node.get_dependency(0), needed_padding);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -756,6 +756,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
 
                 if (new_input.first) {
                     p.add_intermediate(new_input.first, detection_output_node, i, !new_input.second);
+                    detection_output_node.recalc_output_layouts();
                 }
             }
         }
@@ -770,6 +771,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
                 layout{ input_layout.get_partial_shape(), input_layout.data_type, new_format });
             if (reorder.first) {
                 p.add_intermediate(reorder.first, deconv_node, 0, !reorder.second);
+                deconv_node.recalc_output_layouts();
             }
         }
 
@@ -893,6 +895,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
             auto new_input = rf.get_reorder(input.id(), input_layout, new_layout);
             if (new_input.first) {
                p.add_intermediate(new_input.first, fc_node, 0, !new_input.second);
+               fc_node.recalc_output_layouts();
             }
         }
 
@@ -919,6 +922,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
             auto new_input = rf.get_reorder(input->id(), dep.second, input_layout, new_layout);
             if (new_input.first) {
                p.add_intermediate(new_input.first, pooling_node, 0);
+               pooling_node.recalc_output_layouts();
             }
         }
     };

--- a/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
+++ b/src/plugins/intel_gpu/src/graph/include/layout_optimizer.h
@@ -186,7 +186,6 @@ public:
     static bool onednn_check_data_types_for_convolution(data_types in_dt, data_types wei_dt, data_types out_dt);
     static bool onednn_check_data_types_for_deconvolution(data_types in_dt, data_types wei_dt, data_types out_dt);
     static bool onednn_check_data_types_for_fc_gemm(data_types in_dt, data_types wei_dt, data_types out_dt);
-    static bool onednn_check_preferred_impl_type_of_users(program_node& node);
     bool is_primitive_implemented_for_onednn(program_node& node);
     bool is_format_supported(program_node& node, format::type fmt);
 

--- a/src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/paged_attention_inst.h
@@ -66,8 +66,6 @@ public:
 
 protected:
     void on_execute() override;
-
-    void update_shape_info_tensor(const kernel_impl_params& params) override;
 };
 
 using paged_attention_inst = typed_primitive_inst<paged_attention>;

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -386,6 +386,7 @@ protected:
                                               bool reset_mem = true,
                                               bool runtime_alloc = false);
     memory::ptr allocate_internal_buffer(size_t idx, bool reset = true);
+    void allocate_shape_info_memory();
     static std::vector<primitive_inst*> build_exec_deps(
         std::vector<std::pair<primitive_inst*, int32_t>> const& mem_deps);
     int32_t get_index_in_deps(memory::cptr arg) const;

--- a/src/plugins/intel_gpu/src/graph/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/kv_cache.cpp
@@ -83,6 +83,9 @@ int32_t kv_cache_inst::get_prealloc_iter_num() {
 }
 
 void kv_cache_inst::update_shape_info_tensor(const kernel_impl_params& params) {
+    if (!_shape_info_memory) {
+        allocate_shape_info_memory();
+    }
     mem_lock<int32_t> lock(_shape_info_memory, _network.get_stream());
     auto shape_info_ptr = lock.data();
     size_t offset = 0;

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1434,18 +1434,6 @@ bool layout_optimizer::is_primitive_implemented_for_onednn(program_node& node) {
     return false;
 }
 
-bool layout_optimizer::onednn_check_preferred_impl_type_of_users(program_node& node) {
-    if (node.get_users().size() == 0)
-        return false;
-
-    for (auto& user : node.get_users()) {
-        if (user->get_preferred_impl_type() == impl_types::onednn)
-            return true;
-    }
-
-    return false;
-}
-
 impl_types layout_optimizer::get_forced_impl_type_by_config(program_node& node) {
 #ifdef GPU_DEBUG_CONFIG
     GPU_DEBUG_GET_INSTANCE(debug_config);

--- a/src/plugins/intel_gpu/src/graph/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/paged_attention.cpp
@@ -143,10 +143,6 @@ void paged_attention_inst::on_execute() {
     }
 }
 
-void paged_attention_inst::update_shape_info_tensor(const kernel_impl_params& params) {
-    parent::update_shape_info_tensor(params);
-}
-
 paged_attention_inst::typed_primitive_inst(network& network, const paged_attention_node& node)
     : parent(network, node) {
     const auto desc = node.get_primitive();

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -813,6 +813,7 @@ void program::apply_needed_padding(program_node& node, program_node& prev_node, 
 
         auto r_prim = std::make_shared<reorder>("reorder_input_" + node.id(), prev_node.id(), target_layout);
         add_intermediate(r_prim, node, 0);
+        get_or_create(r_prim).recalc_output_layouts(false);
         return;
     }
 

--- a/src/plugins/intel_gpu/src/graph/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/slice.cpp
@@ -96,6 +96,10 @@ std::string slice_inst::to_string(slice_node const& node) {
 }
 
 void slice_inst::update_shape_info_tensor(const kernel_impl_params& params) {
+    if (!_shape_info_memory) {
+        allocate_shape_info_memory();
+    }
+
     mem_lock<int32_t> lock(_shape_info_memory, _network.get_stream());
     auto shape_info_ptr = lock.data();
     size_t offset = 0;

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
@@ -2,20 +2,45 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <vector>
 #include "single_op_tests/gru_sequence.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "common_test_utils/test_enums.hpp"
+
+using ov::test::GRUSequenceTest;
+using ov::test::utils::InputLayerType;
+using ov::test::utils::SequenceTestsMode;
 
 namespace {
-    using ov::test::GRUSequenceTest;
-
-    std::vector<ov::test::utils::SequenceTestsMode> mode{ov::test::utils::SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
-                                                         ov::test::utils::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST,
-                                                         ov::test::utils::SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM,
-                                                         ov::test::utils::SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_CONST,
-                                                         ov::test::utils::SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_PARAM,
-                                                         ov::test::utils::SequenceTestsMode::PURE_SEQ};
+    std::vector<SequenceTestsMode> mode{SequenceTestsMode::CONVERT_TO_TI_MAX_SEQ_LEN_CONST,
+                                        SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_CONST,
+                                        SequenceTestsMode::CONVERT_TO_TI_RAND_SEQ_LEN_PARAM,
+                                        SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_PARAM,
+                                        SequenceTestsMode::PURE_SEQ_RAND_SEQ_LEN_CONST,
+                                        SequenceTestsMode::PURE_SEQ};
     // output values increase rapidly without clip, so use only seq_lengths = 2
-    std::vector<ov::test::InputShape> seq_lengths_zero_clip{2};
-    std::vector<ov::test::InputShape> seq_lengths_clip_non_zero{20};
+
+    const std::vector<std::vector<ov::Shape>> input_shapes_zero_clip_static = {
+    // {batch, seq_lengths, input_size}, {batch, num_directions, hidden_size}, {batch},
+        {{ 10, 2, 1}, { 10, 1, 1 }, { 10 }},
+        {{ 10, 2, 1}, { 10, 1, 10 }, { 10 }},
+    };
+    const std::vector<std::vector<ov::Shape>> input_shapes_bidirect_zero_clip_static = {
+        {{ 10, 2, 1}, { 10, 2, 1 }, { 10 }},
+        {{ 10, 2, 1}, { 10, 2, 10 }, { 10 }},
+    };
+    const std::vector<std::vector<ov::Shape>> input_shapes_non_zero_clip_static = {
+        {{ 10, 20, 1}, { 10, 1, 1 }, { 10 }},
+        {{ 10, 20, 1}, { 10, 1, 10 }, { 10 }},
+    };
+    const std::vector<std::vector<ov::Shape>> input_shapes_bidirect_non_zero_clip_static = {
+        {{ 10, 20, 1}, { 10, 2, 1 }, { 10 }},
+        {{ 10, 20, 1}, { 10, 2, 10 }, { 10 }},
+    };
+    std::vector<size_t> seq_lengths_zero_clip{2};
+    std::vector<size_t> seq_lengths_clip_non_zero{20};
+    std::vector<size_t> batch{10};
+    std::vector<size_t> hidden_size{1, 10};
     // std::vector<size_t> input_size{10};
     std::vector<std::vector<std::string>> activations = {{"relu", "tanh"}, {"tanh", "sigmoid"}, {"sigmoid", "tanh"},
                                                          {"tanh", "relu"}};
@@ -23,50 +48,64 @@ namespace {
     std::vector<float> clip{0.f};
     std::vector<float> clip_non_zeros{0.7f};
     std::vector<ov::op::RecurrentSequenceDirection> direction = {ov::op::RecurrentSequenceDirection::FORWARD,
-                                                                 ov::op::RecurrentSequenceDirection::REVERSE,
-                                                                 ov::op::RecurrentSequenceDirection::BIDIRECTIONAL
-    };
+                                                                 ov::op::RecurrentSequenceDirection::REVERSE};
+    std::vector<ov::op::RecurrentSequenceDirection> direction_bi = {ov::op::RecurrentSequenceDirection::BIDIRECTIONAL};
+
     std::vector<ov::element::Type> netPrecisions = {ov::element::f32,
                                                     ov::element::f16};
 
-    INSTANTIATE_TEST_SUITE_P(GRUSequenceCommonZeroClip, GRUSequenceTest,
+    INSTANTIATE_TEST_SUITE_P(smoke_GRUSequenceCommonZeroClip, GRUSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(mode),
-                                    ::testing::Values(seq_lengths_zero_clip),
+                                    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_zero_clip_static)),
                                     // ::testing::ValuesIn(input_size), // hardcoded to 10 due to Combine supports up to 10 args
                                     ::testing::ValuesIn(activations),
                                     ::testing::ValuesIn(clip),
                                     ::testing::ValuesIn(linear_before_reset),
                                     ::testing::ValuesIn(direction),
-                                    ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                    ::testing::Values(InputLayerType::CONSTANT),
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(ov::test::utils::DEVICE_GPU)),
                             GRUSequenceTest::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(GRUSequenceCommonZeroClipNonConstantWRB, GRUSequenceTest,
+    INSTANTIATE_TEST_SUITE_P(smoke_GRUSequenceCommonZeroClipBidirect, GRUSequenceTest,
                             ::testing::Combine(
-                                    ::testing::Values(ov::test::utils::SequenceTestsMode::PURE_SEQ),
-                                    ::testing::Values(seq_lengths_zero_clip),
+                                    ::testing::ValuesIn(mode),
+                                    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_bidirect_zero_clip_static)),
                                     // ::testing::ValuesIn(input_size), // hardcoded to 10 due to Combine supports up to 10 args
                                     ::testing::ValuesIn(activations),
                                     ::testing::ValuesIn(clip),
                                     ::testing::ValuesIn(linear_before_reset),
-                                    ::testing::ValuesIn(direction),
-                                    ::testing::Values(ov::test::utils::InputLayerType::PARAMETER),
+                                    ::testing::ValuesIn(direction_bi),
+                                    ::testing::Values(InputLayerType::CONSTANT),
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(ov::test::utils::DEVICE_GPU)),
                             GRUSequenceTest::getTestCaseName);
 
-    INSTANTIATE_TEST_SUITE_P(GRUSequenceCommonClip, GRUSequenceTest,
+    INSTANTIATE_TEST_SUITE_P(smoke_GRUSequenceCommonClip, GRUSequenceTest,
                             ::testing::Combine(
                                     ::testing::ValuesIn(mode),
-                                    ::testing::Values(seq_lengths_clip_non_zero),
+                                    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_non_zero_clip_static)),
                                     // ::testing::ValuesIn(input_size),  // hardcoded to 10 due to Combine supports up to 10 args
                                     ::testing::ValuesIn(activations),
                                     ::testing::ValuesIn(clip_non_zeros),
                                     ::testing::ValuesIn(linear_before_reset),
                                     ::testing::ValuesIn(direction),
-                                    ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                    ::testing::Values(InputLayerType::CONSTANT),
+                                    ::testing::ValuesIn(netPrecisions),
+                                    ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                            GRUSequenceTest::getTestCaseName);
+
+    INSTANTIATE_TEST_SUITE_P(smoke_GRUSequenceCommonClipBidirect, GRUSequenceTest,
+                            ::testing::Combine(
+                                    ::testing::ValuesIn(mode),
+                                    ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(input_shapes_bidirect_non_zero_clip_static)),
+                                    // ::testing::ValuesIn(input_size),  // hardcoded to 10 due to Combine supports up to 10 args
+                                    ::testing::ValuesIn(activations),
+                                    ::testing::ValuesIn(clip_non_zeros),
+                                    ::testing::ValuesIn(linear_before_reset),
+                                    ::testing::ValuesIn(direction_bi),
+                                    ::testing::Values(InputLayerType::CONSTANT),
                                     ::testing::ValuesIn(netPrecisions),
                                     ::testing::Values(ov::test::utils::DEVICE_GPU)),
                             GRUSequenceTest::getTestCaseName);

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -350,9 +350,7 @@ public:
     }
 
     layout get_input_layout(convolution_test_params& p) {
-        auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
-        return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
+        return layout{ p.in_shape, p.data_type, p.input_format };
     }
 
     layout get_output_layout(convolution_test_params& p) {
@@ -408,9 +406,7 @@ public:
     }
 
     layout get_input_layout(conv_activation_onednn_test_params& p) {
-        auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
-        return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
+        return layout{ p.in_shape, p.data_type, p.input_format };
     }
 
     layout get_output_layout(conv_activation_onednn_test_params& p) {
@@ -1034,7 +1030,7 @@ TEST_P(conv_fp32_prelu_eltwise, vector_ops) {
         reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     tolerance = default_tolerance(p.data_type);
@@ -1055,7 +1051,7 @@ TEST_P(conv_fp32_prelu_eltwise, vector_ops_slope_2) {
         reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     tolerance = default_tolerance(p.data_type);
@@ -1077,7 +1073,7 @@ TEST_P(conv_fp32_prelu_eltwise, vector_ops_mixed_types) {
         reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     tolerance = default_tolerance(p.data_type);
@@ -1099,7 +1095,7 @@ TEST_P(conv_fp32_prelu_eltwise, vector_ops_mixed_types_slope_2) {
         reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv16, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     tolerance = default_tolerance(p.data_type);
@@ -2762,7 +2758,7 @@ TEST_P(conv_int8_scale_prelu_quantize_i8_eltwise_fp32_quantize_i8_vec, vector_op
         reorder("reorder_bfyx", input_info("quantize_1"), p.default_format, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv4, "convolution_gpu_b_fs_yx_fsv4_1x1" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv4, "convolution_gpu_b_fs_yx_fsv4_1x1", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     tolerance = 1.f;
@@ -2797,7 +2793,7 @@ TEST_P(conv_int8_scale_prelu_quantize_i8_eltwise_fp32_quantize_i8_vec, vector_op
         reorder("reorder_bfyx", input_info("quantize_1"), p.default_format, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv4, "convolution_gpu_b_fs_yx_fsv4_1x1" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::b_fs_yx_fsv4, "convolution_gpu_b_fs_yx_fsv4_1x1", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     tolerance = 1.f;
@@ -2930,7 +2926,7 @@ TEST_P(conv_fp32_reorder_bfyx_to_fsv32_conv_basic, basic) {
         reorder("reorder_out", input_info("activation"), format::bfyx, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     execute(p);
@@ -2955,7 +2951,7 @@ TEST_P(conv_fp32_reorder_bfyx_to_fsv32_conv_mean, have_mean) {
         activation("activation", input_info("conv_prim"), activation_func::abs)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     execute(p);
@@ -2987,7 +2983,7 @@ TEST_P(conv_fp32_reorder_bfyx_to_fsv32_conv_subtract, have_subtract_per_feature)
         convolution("conv_output", input_info("reorder_fsv32"), "weights_dw", "", p.out_shape[1].get_length(), dw_stride, p.dilation, p.pad, p.pad, true)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim", conv_impl } }));
 
     execute(p);
@@ -3016,7 +3012,7 @@ TEST_P(conv_fp32_reorder_bfyx_to_fsv32_conv_fused_activation, have_fused_activat
         activation("activation", input_info("conv_prim2"), activation_func::abs)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim2", conv_impl } }));
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "activation", conv_impl } }));
 
@@ -3046,7 +3042,7 @@ TEST_P(conv_fp32_reorder_bfyx_to_fsv32_conv_fused_through_activation, have_fused
         activation("activation", input_info("conv_prim2"), activation_func::abs)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim2", conv_impl } }));
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "activation", conv_impl } }));
 
@@ -3075,7 +3071,7 @@ TEST_P(conv_fp32_reorder_bfyx_to_fsv32_conv_data_padding, have_data_padding) {
         reorder("reorder_out", input_info("conv_prim2"), format::fs_b_yx_fsv32, data_types::f32)
     );
 
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "", impl_types::ocl };
     cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_prim2", conv_impl } }));
 
     execute(p);
@@ -3943,9 +3939,7 @@ public:
     }
 
     layout get_input_layout(convolution_eltw_sum_test_params& p) {
-        auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[0]), static_cast<int>(pad[1]) };
-        return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
+        return layout{ p.in_shape, p.data_type, p.input_format };
     }
 
     layout get_per_channel_layout(convolution_eltw_sum_test_params& p) {
@@ -4074,9 +4068,7 @@ public:
     }
 
     layout get_input_layout(implicit_crop_concat_convolution_test_params& p) {
-        auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[0]), static_cast<int>(pad[1]) };
-        return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
+        return layout{ p.in_shape, p.data_type, p.input_format };
     }
 
     layout get_per_channel_layout(implicit_crop_concat_convolution_test_params& p) {
@@ -4189,9 +4181,7 @@ public:
     }
 
     layout get_input_layout(convolution_test_params& p) {
-        auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
-        return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
+        return layout{ p.in_shape, p.data_type, p.input_format };
     }
 
     layout get_per_channel_layout(convolution_test_params& p) {
@@ -4320,9 +4310,7 @@ public:
     }
 
     layout get_input_layout(convolution_eltw_sum_test_params& p) {
-        auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[0]), static_cast<int>(pad[1]) };
-        return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
+        return layout{ p.in_shape, p.data_type, p.input_format };
     }
 
     layout get_weights_layout(convolution_eltw_sum_test_params& p) {

--- a/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
@@ -826,6 +826,9 @@ TEST_P(deconv_scale_activation_quantize_i8_eltwise_quantize_u8, basic) {
         reorder("reorder_bfyx", input_info("quant2"), p.default_format, data_types::f32)
     );
 
+    ov::intel_gpu::ImplementationDesc gemmv_impl = { cldnn::format::type::any, "", impl_types::ocl };
+    cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "deconv_prim", gemmv_impl } }));
+
     tolerance = 1.f;
     execute(p);
 }

--- a/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
@@ -53,8 +53,8 @@ public:
         auto input1_prim = get_mem(get_input_layout(p, 1));
 
         if (!p.kernel_name.empty()) {
-            ov::intel_gpu::ImplementationDesc gemm_ref_impl = { format::bfyx, "gemm_ref" };
-            ov::intel_gpu::ImplementationDesc gemm_target_impl = { format::bfyx, p.kernel_name };
+            ov::intel_gpu::ImplementationDesc gemm_ref_impl = { format::bfyx, "gemm_ref", impl_types::ocl  };
+            ov::intel_gpu::ImplementationDesc gemm_target_impl = { format::bfyx, p.kernel_name, impl_types::ocl  };
             cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"gemm_prim", gemm_target_impl} }));
             cfg_not_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"gemm_prim", gemm_ref_impl} }));
         }
@@ -197,6 +197,9 @@ TEST_P(gemm_2in_quantize_u8, basic) {
                  input_info("out_lo"), input_info("out_hi"), 256, data_types::u8),
         reorder("reorder_bfyx", input_info("quantize"), p.default_format, data_types::f32)
     );
+
+    ov::intel_gpu::ImplementationDesc gemm_impl = { format::bfyx, "", impl_types::ocl };
+    cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"gemm_prim", gemm_impl} }));
 
     tolerance = default_tolerance(data_types::u8);
     execute(p, false);
@@ -568,6 +571,10 @@ TEST_P(gemm_2in_act_scale_eltwise, broadcast_eltwise) {
         eltwise("sum", { input_info("activation"), input_info("eltwise_data") }, eltwise_mode::sum,  data_types::f32),
         reorder("reorder_bfyx", input_info("sum"), p.default_format, data_types::f32)
     );
+
+    // Onednn impl gives different results for some reason (looks like missing saturation somewhere)
+    ov::intel_gpu::ImplementationDesc gemm_impl = { format::bfyx, "", impl_types::ocl };
+    cfg_fused.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "gemm_prim", gemm_impl } }));
 
     tolerance = default_tolerance(p.default_type);
     if (p.default_type == data_types::f16 && p.kernel_name == "gemm_tiled_opt") {

--- a/src/plugins/intel_gpu/tests/unit/module_tests/graph_manipulation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/graph_manipulation_gpu_test.cpp
@@ -155,7 +155,6 @@ TEST(add_intermediate_gpu, test2)
 
     prog->add_intermediate(new_conv, prog->get_node("conv2a"), 0, true, true);
     program_wrapper::add_connection(*prog, prog->get_or_create(weights_node), prog->get_or_create(new_conv));
-    prog->dump_program("custom_dump", true);
 
     program_wrapper::build(*prog);
 

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -408,6 +408,12 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     ExecutionConfig config;
     config.set_property(ov::intel_gpu::optimize_data(true));
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ov::intel_gpu::ImplForcingMap forcing_map = {
+        {"reorder1", ov::intel_gpu::ImplementationDesc{format::any, "", impl_types::onednn}},
+        {"reorder2", ov::intel_gpu::ImplementationDesc{format::any, "", impl_types::onednn}}
+    };
+    config.set_property(ov::intel_gpu::force_implementations(forcing_map));
+
     auto prog = program::build_program(engine, topology, config, false, false);
     ASSERT_NE(prog, nullptr);
     auto& concat_node_p = prog->get_node("concat");

--- a/src/plugins/intel_gpu/tests/unit/passes/select_preferred_formats_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/select_preferred_formats_test.cpp
@@ -39,6 +39,9 @@ TEST(test_select_preferred_formats, setting_target_conv_format) {
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv1", impl} }));
 
     auto prog = program::build_program(engine, topology, config, false, true);
+    if (engine.get_device_info().supports_immad) {
+        prog->get_layout_optimizer().set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, 1);
+    }
 
     // It initializes output_layout.
     // It's necessary because this test runs select_preferred_formats pass alone.
@@ -85,6 +88,9 @@ TEST(test_select_preferred_formats, fsv2_fallback_to_byxf) {
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv1", impl} }));
 
     auto prog = program::build_program(engine, topology, config, false, true);
+    if (engine.get_device_info().supports_immad) {
+        prog->get_layout_optimizer().set_optimization_attribute(layout_optimizer::optimization_attributes_type::use_onednn_impls, 1);
+    }
 
     // It initializes output_layout.
     // It's necessary because this test runs select_preferred_formats pass alone.

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -1752,6 +1752,8 @@ TEST(convolution_f16_fw_gpu, convolution_big_size_weights) {
 
         ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::optimize_data(true));
+        ov::intel_gpu::ImplementationDesc conv_impl = {format::any, "", impl_types::ocl};
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", conv_impl} }));
 
         network network(engine, topology, config);
 
@@ -5722,7 +5724,7 @@ TEST_P(convolution_gpu_fs_byx_fsv32_crop, fs_byx_fsv32_crop)
     }
 
     ExecutionConfig config = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "convolution_gpu_bfyx_to_fs_byx_fsv32" };
+    ov::intel_gpu::ImplementationDesc conv_impl = { format::fs_b_yx_fsv32, "convolution_gpu_bfyx_to_fs_byx_fsv32", impl_types::ocl };
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv_fsv", conv_impl } }));
     config.set_property(ov::intel_gpu::optimize_data(true));
     network network(engine, topology, config);
@@ -10648,6 +10650,9 @@ TEST_P(conv_dyn_test, convolution_gpu_fsv16_1x1_no_bias) {
             input_layout("input", in_layout),
             data("weights", weights),
             convolution("conv", input_info("input"), "weights", no_bias, groups_num, p.stride, p.dilation, p.pad_begin, p.pad_end, is_grouped));
+
+        ov::intel_gpu::ImplementationDesc conv_impl = { in_layout.format, "convolution_gpu_ref", impl_types::ocl };
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl } }));
 
         network network_ref(engine, topology_ref, config);
         network_ref.set_input_data("input", input);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1620,6 +1620,8 @@ public:
 
             auto config = get_test_default_config(engine);
             config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+            ov::intel_gpu::ImplementationDesc fc_impl = { in_layout.format, "", impl_types::ocl };
+            config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "fc_prim1", fc_impl }, { "fc_prim2", fc_impl }  }));
 
             network network(engine, topology, config);
             network.set_input_data("input", input_mem);
@@ -1856,7 +1858,7 @@ public:
         auto input_mem = engine.allocate_memory({ {1, 2, 4}, data_types::f32, format::bfyx });
         auto weights_mem = engine.allocate_memory({ {8, 4}, data_types::u8, format::bfyx });
         auto bias_mem = engine.allocate_memory({ {1, 1, 8}, data_types::f32, format::bfyx });
-        auto scale_mem = engine.allocate_memory({ {1, 1, 8}, data_types::f32, format::bfyx });
+        auto scale_mem = engine.allocate_memory({ {8, 1}, data_types::f32, format::bfyx });
 
         set_values(input_mem, { -0.5f, 2.0f, 0.5f, 1.0f,
                                 0.5f, -2.0f, -0.5f, -1.0f });
@@ -1897,7 +1899,7 @@ public:
         ov::PartialShape expected_shape{1, 2, 8};
         ASSERT_EQ(expected_shape, output_mem->get_layout().get_partial_shape());
 
-        std::vector<float> expected_result = {19.f, 40.f, 69.f, 54.f, 83.f, 48.f, 37.f, -2.f, -17.f, -44.f, -63.f, -62.f, -73.f, -60.f, -23.f, -14.f };
+        std::vector<float> expected_result = {19.f, 82.f, -63.f, -120.f, 24.5f, -19.5f, 37.f, -5.f, -17.f, -86.f, 69.f, 112.f, -14.5f, 7.5f, -23.f, -11.f };
 
         for (size_t i = 0; i < expected_result.size(); i++) {
             ASSERT_EQ(expected_result[i], output_ptr[i]) << "i = " << i;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/pooling_gpu_test.cpp
@@ -1944,7 +1944,7 @@ public:
             pad.insert(pad.begin(), offset_z());
         }
 
-        topo.add(pooling("pool", input_info("input"), pool_mode(), kernel, stride, pad));
+        topo.add(pooling("pool", input_info("input"), pool_mode(), kernel, stride, pad, pad));
         return topo;
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reduce_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reduce_gpu_test.cpp
@@ -1936,7 +1936,7 @@ public:
             topology.add(red);
             ExecutionConfig config = get_test_default_config(engine);
             config.set_property(ov::intel_gpu::optimize_data(true));
-            ov::intel_gpu::ImplementationDesc reduce_impl = {input_format, kernel_name};
+            ov::intel_gpu::ImplementationDesc reduce_impl = {input_format, kernel_name, impl_types::ocl};
             config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"reduce", reduce_impl}}));
             cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
             network->set_input_data("input", input_mem);


### PR DESCRIPTION
### Details:
 - Added explicit layout recalc after some graph modifications to avoid full invalidation of layouts later on random attempt to call `get_output_layout()`
 - Remove i64 data type handling in add_required_reorder pass as ConvertPrecision is supposed to convert everything into i32.
 - Move shape info tensor alloc to `update_shape_info_tensor` call to avoid allocation in case if the buffer is not needed for selected impl
- Fixed impl forcing in some unit tests  + other minor test changes
