### PR TITLE
Fixed extensions (tokenizers) loading on Android

### DIFF
--- a/src/core/dev_api/openvino/core/so_extension.hpp
+++ b/src/core/dev_api/openvino/core/so_extension.hpp
@@ -13,9 +13,7 @@ namespace detail {
 
 class OPENVINO_API SOExtension : public Extension {
 public:
-    ~SOExtension() {
-        m_ext = {};
-    }
+    virtual ~SOExtension() override;
 
     SOExtension(const Extension::Ptr& ext, const std::shared_ptr<void>& so) : m_ext(ext), m_so(so) {}
 

--- a/src/core/include/openvino/core/op_extension.hpp
+++ b/src/core/include/openvino/core/op_extension.hpp
@@ -46,7 +46,7 @@ public:
     /**
      * @brief Destructor
      */
-    ~BaseOpExtension() override;
+    virtual ~BaseOpExtension() override;
 };
 
 namespace detail {

--- a/src/core/src/so_extension.cpp
+++ b/src/core/src/so_extension.cpp
@@ -4,6 +4,10 @@
 
 #include "openvino/core/so_extension.hpp"
 
+ov::detail::SOExtension::~SOExtension() {
+    m_ext.reset();
+}
+
 const ov::Extension::Ptr& ov::detail::SOExtension::extension() const {
     return m_ext;
 }


### PR DESCRIPTION
### Details:
 - Android 's clang has issues with RTTI. So, we need to expose virtual methods from the class to ensure dynamic cast is working.
