### PR TITLE
[GPU] Fix lack of support for 3D (and smaller) shapes in TransposeFusion pass

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -52,6 +52,13 @@ bool has_optimized_version(const ov::Output<ov::Node>& output, bool supports_imm
         {3, 0, 1, 2},
     };
 
+    const auto expected_dims_num = 4;
+    const auto original_dims_num = transpose_order.size();
+    if (original_dims_num < expected_dims_num) {
+        transpose_order.resize(expected_dims_num);
+        std::iota(transpose_order.begin() + original_dims_num, transpose_order.end(), original_dims_num);
+    }
+
     if (!cldnn::one_of(transpose_order, allowed_orders))
         return false;
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_position_ids_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_position_ids_precision_test.cpp
@@ -130,3 +130,49 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionWithUnsqueeze) {
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
+
+TEST_F(TransformationTestsF, IncreasePositionIdsMatmulWithoutUnsqueeze) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ -1, -1 });
+        auto input_convert = std::make_shared<ov::op::v0::Convert>(input, ov::element::i32);
+        auto input_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(input_convert, std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
+        auto input_convert_fp = std::make_shared<ov::op::v0::Convert>(input_unsqueeze, ov::element::f16);
+        auto rotary_embd_const = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 64, 1});
+
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input_convert_fp, rotary_embd_const);
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{matmul, matmul}, 2);
+
+        auto cos = std::make_shared<ov::op::v0::Cos>(concat);
+        auto sin = std::make_shared<ov::op::v0::Sin>(concat);
+
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        manager.register_pass<IncreasePositionIdsPrecision>();
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::PartialShape{ -1, -1 });
+        auto input_convert = std::make_shared<ov::op::v0::Convert>(input, ov::element::i32);
+        auto input_unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(input_convert, std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{1}));
+        auto rotary_embd_const = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{1, 64, 1});
+
+        auto input_convert_f32 = std::make_shared<ov::op::v0::Convert>(input_unsqueeze, ov::element::f32);
+        auto rotary_embd_const_convert_f32 = std::make_shared<ov::op::v0::Convert>(rotary_embd_const, ov::element::f32);
+
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input_convert_f32, rotary_embd_const_convert_f32);
+        auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{matmul, matmul}, 2);
+
+        auto cos = std::make_shared<ov::op::v0::Cos>(concat);
+        auto sin = std::make_shared<ov::op::v0::Sin>(concat);
+
+        auto cos_convert = std::make_shared<ov::op::v0::Convert>(cos, ov::element::f16);
+        auto sin_convert = std::make_shared<ov::op::v0::Convert>(sin, ov::element::f16);
+
+        auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
+        auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_convert, sin_convert}, ov::op::internal::RoPE::Config());
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+    }
+    comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+}

--- a/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
@@ -124,6 +124,64 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion4) {
     }
 }
 
+TEST_F(TransformationTestsF, TranposeMatmulFusion5) {
+    {
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
+        auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
+        auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+
+        const auto supports_immad = false;
+        manager.register_pass<TransposeFusion>(supports_immad);
+    }
+    {
+        std::vector<int64_t> order_a = {0, 1, 2};
+        std::vector<int64_t> order_b = {0, 1, 2};
+        std::vector<int64_t> order_c = {0, 2, 1};
+        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
+        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
+        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a, input_b, order_a, order_b, order_c, ov::element::undefined);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, TranposeMatmulFusion6) {
+    auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(2));
+    auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(2));
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
+    auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
+    auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
+
+    model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+
+    const auto supports_immad = false;
+    manager.register_pass<TransposeFusion>(supports_immad);
+
+    model_ref = model->clone();
+    comparator.enable(FunctionsComparator::ATTRIBUTES);
+}
+
+TEST_F(TransformationTestsF, TranposeMatmulFusion7) {
+    auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 4});
+    auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{4, 2});
+    auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
+    auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
+    auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
+
+    model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+
+    const auto supports_immad = false;
+    manager.register_pass<TransposeFusion>(supports_immad);
+
+    model_ref = model->clone();
+    comparator.enable(FunctionsComparator::ATTRIBUTES);
+}
+
 TEST_F(TransformationTestsF, TranposeMatmulFusion_Illegal_1) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{10, 20});


### PR DESCRIPTION
### Details:
 - Fix lack of support for 3D (and smaller) shapes in TransposeFusion pass
 - Update IncreasePositionIdsPrecision to support both MatMul and Gemm operations
 - Copy of https://github.com/openvinotoolkit/openvino/pull/26440

### Tickets:
 - [CVS-146889](https://jira.devtools.intel.com/browse/CVS-146889)
