### PR TITLE
Append input index to input names

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -1395,7 +1395,7 @@ void nameIOTensors(std::shared_ptr<ov::Model> model) {
     for (std::size_t id = 0ul; id < inputInfo.size(); ++id) {
         auto ii = inputInfo[id];
         if (ii.get_names().empty()) {
-            ii.add_names({"input_" + std::to_string(ii.get_index())});
+            ii.add_names({"input_" + std::to_string(ii.get_index()) + "_" + std::to_string(id)});
         }
     }
 
@@ -1403,7 +1403,7 @@ void nameIOTensors(std::shared_ptr<ov::Model> model) {
     for (std::size_t id = 0ul; id < outputInfo.size(); ++id) {
         auto oi = outputInfo[id];
         if (oi.get_names().empty()) {
-            oi.add_names({"output_" + std::to_string(oi.get_index())});
+            oi.add_names({"output_" + std::to_string(oi.get_index()) + "_" + std::to_string(id)});
         }
     }
 }


### PR DESCRIPTION
### Details:
 - `ii.get_index` can return same index for different inputs:
```
(gdb) p inputInfo
$1 = std::vector of length 2, capacity 2 = {{
    m_node = std::shared_ptr<ov::Node> (use count 3, weak count 2) = {get() = 0x555555872860}, m_index = 0}, {
    m_node = std::shared_ptr<ov::Node> (use count 3, weak count 2) = {get() = 0x555555873fa0}, m_index = 0}}
```
 - This may result in the collision of names.
 - When different inputs are referred by the same name, single image test will populate only one such input.
 - Append `id` to the name to assure its uniqueness.

### Tickets:
 - E-137973
