### PR TITLE
Add USE_TBBBIND_2_5 before the definition of binding_observer

### DIFF
--- a/src/inference/src/dev/threading/parallel_custom_arena.cpp
+++ b/src/inference/src/dev/threading/parallel_custom_arena.cpp
@@ -229,8 +229,13 @@ static binding_oberver_ptr construct_binding_observer(tbb::task_arena& ta, int n
 task_arena::task_arena(int max_concurrency_, unsigned reserved_for_masters)
     : my_task_arena{max_concurrency_, reserved_for_masters},
       my_initialization_state{},
-      my_constraints{},
-      my_binding_observer{} {}
+      my_constraints{}
+#    if USE_TBBBIND_2_5
+      ,
+      my_binding_observer{}
+#    endif
+{
+}
 
 task_arena::task_arena(const constraints& constraints_, unsigned reserved_for_masters)
 #    if USE_TBBBIND_2_5
@@ -242,15 +247,24 @@ task_arena::task_arena(const constraints& constraints_, unsigned reserved_for_ma
 #    endif
       ,
       my_initialization_state{},
-      my_constraints{constraints_},
-      my_binding_observer{} {
+      my_constraints{constraints_}
+#    if USE_TBBBIND_2_5
+      ,
+      my_binding_observer{}
+#    endif
+{
 }
 
 task_arena::task_arena(const task_arena& s)
     : my_task_arena{s.my_task_arena},
       my_initialization_state{},
-      my_constraints{s.my_constraints},
-      my_binding_observer{} {}
+      my_constraints{s.my_constraints}
+#    if USE_TBBBIND_2_5
+      ,
+      my_binding_observer{}
+#    endif
+{
+}
 
 void task_arena::initialize() {
     my_task_arena.initialize();

--- a/src/inference/src/dev/threading/parallel_custom_arena.hpp
+++ b/src/inference/src/dev/threading/parallel_custom_arena.hpp
@@ -69,8 +69,8 @@ struct constraints {
     int max_threads_per_core = tbb::task_arena::automatic;
 };
 
+#if USE_TBBBIND_2_5
 class binding_handler;
-
 class binding_observer : public tbb::task_scheduler_observer {
     binding_handler* my_binding_handler;
 
@@ -90,14 +90,16 @@ struct binding_observer_deleter {
 };
 
 using binding_oberver_ptr = std::unique_ptr<binding_observer, binding_observer_deleter>;
-
+#endif
 }  // namespace detail
 
 class task_arena {
     tbb::task_arena my_task_arena;
     std::once_flag my_initialization_state;
     detail::constraints my_constraints;
+#if USE_TBBBIND_2_5
     detail::binding_oberver_ptr my_binding_observer;
+#endif
 
 public:
     using constraints = detail::constraints;


### PR DESCRIPTION
### Details:
 - *`binding_observer` is defined but not implemented when USE_TBBBIND_2_5 is not defined. So add `USE_TBBBIND_2_5` before the definition of `binding_observer`*

### Tickets:
 - *151706*
