### PR TITLE
[GPU] Fix network c-tor to avoid config mismatch

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -67,7 +67,8 @@ struct network {
 public:
     using ptr = std::shared_ptr<network>;
 
-    explicit network(program::ptr program, const ExecutionConfig& config, stream::ptr stream, bool is_internal = false, bool is_primary_stream = true);
+    network(program::ptr program, stream::ptr stream, bool is_internal, bool is_primary_stream);
+    network(program::ptr program, bool is_internal, bool is_primary_stream);
     network(engine& engine,
             const topology& topo,
             const ExecutionConfig& config = {},

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -153,7 +153,7 @@ program::program(engine& engine_ref,
       _compilation_context(compilation_context) {
     _config.apply_user_properties(_engine.get_device_info());
     init_primitives();
-    GPU_DEBUG_INFO << "Program config\n" << config.to_string();
+    GPU_DEBUG_INFO << "Program config\n" << _config.to_string();
     init_program();
     prepare_nodes(topology);
     program_node::reset_unique_id();
@@ -202,8 +202,7 @@ program::program(engine& engine_ref,
     build_program(is_internal);
 }
 
-program::program(engine& engine,
-        const ExecutionConfig& config)
+program::program(engine& engine, const ExecutionConfig& config)
     : _engine(engine),
       _stream(_engine.create_stream({})),
       _config(config),
@@ -211,6 +210,7 @@ program::program(engine& engine,
     init_primitives();
     _config.apply_user_properties(_engine.get_device_info());
     new_shape_infer = _config.get_property(ov::intel_gpu::allow_new_shape_infer);
+    _layout_optimizer = cldnn::make_unique<layout_optimizer>();
 }
 
 program::~program() {


### PR DESCRIPTION
### Details:
 - Network class c-tor had version with both program and config parameters, and this config parameter was actually used which caused mismatch between program and network config values as inside the program we call apply_user_properties() method.
 - This PR removes Config from this c-tor and get it from program class
