### PR TITLE
[CPU][ARM] Fix output detection in `ConvertReduceMultiAxisBase` transformation

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.cpp
@@ -36,6 +36,7 @@ ov::matcher_pass_callback ov::intel_cpu::ConvertReduceMultiAxisBase::convert_red
 
         ov::NodeVector new_ops;
         std::shared_ptr<ov::Node> node = input0.get_node_shared_ptr();
+        auto output = input0;
         bool keepDims = reduce->get_keep_dims();
         //axes should be sorted in descending order if keepDims is false to be keep axis within data shape
         if (!keepDims) {
@@ -43,7 +44,8 @@ ov::matcher_pass_callback ov::intel_cpu::ConvertReduceMultiAxisBase::convert_red
         }
         for (auto axis : axes) {
             auto reduction_axis = ov::opset8::Constant::create<int64_t>(ov::element::i64, ov::Shape{}, {axis});
-            node = std::make_shared<T>(node, reduction_axis, keepDims);
+            node = std::make_shared<T>(output, reduction_axis, keepDims);
+            output = node->output(0);
             new_ops.push_back(node);
         }
 


### PR DESCRIPTION
### Details:
 - The fix of https://github.com/openvinotoolkit/nncf/issues/2943 
 - The error `Default output not supported` could be raised in `ConvertReduceMultiAxisBase` transformation because output of Reduce input node was not specified. It works well if the node has default output, but for some nodes (like `VariadicSplit`) it leads to the error.
 - The fix is to explicitly specify needed output. 

### Tickets:
 - *ticket-id*
