### PR TITLE
[GPU] Support different input and output data type in convolution ref

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.cpp
@@ -123,13 +123,8 @@ bool ConvolutionKernel_Ref::Validate(const Params& params) const {
 
     // int8/uint8 inputs (quantization case) require additional checks
     // require some additional checks.
-    if (input_type == output_type && input_type != Datatype::UINT8 && input_type != Datatype::INT8)
-        return true;
-
-    // For fp model, some convolutions may not be compressed to fp16 depending on the transformation policy,
-    // and those convolutions may have the fused nodes which is of fp16.
-    // Convolution needs to support for this case.
-    if (input_type == Datatype::F32 && output_type == Datatype::F16)
+    if (input_type != Datatype::UINT8 && input_type != Datatype::INT8 &&
+        output_type != Datatype::UINT8 && output_type != Datatype::INT8)
         return true;
 
     // (u)int8 input + fp weights

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_ref.cpp
@@ -126,6 +126,12 @@ bool ConvolutionKernel_Ref::Validate(const Params& params) const {
     if (input_type == output_type && input_type != Datatype::UINT8 && input_type != Datatype::INT8)
         return true;
 
+    // For fp model, some convolutions may not be compressed to fp16 depending on the transformation policy,
+    // and those convolutions may have the fused nodes which is of fp16.
+    // Convolution needs to support for this case.
+    if (input_type == Datatype::F32 && output_type == Datatype::F16)
+        return true;
+
     // (u)int8 input + fp weights
     if (weights_type == WeightsType::F32 || weights_type == WeightsType::F16)
         return true;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -12,6 +12,7 @@
 #include <intel_gpu/primitives/crop.hpp>
 #include <intel_gpu/primitives/reorder.hpp>
 #include <intel_gpu/primitives/reshape.hpp>
+#include <intel_gpu/primitives/permute.hpp>
 
 #include <algorithm>
 #include <array>
@@ -1637,6 +1638,47 @@ TEST(convolution_f32_fw_gpu, basic_convolution) {
             ASSERT_EQ(output_vec[y][x], output_ptr[y * x_size + x]);
         }
     }
+}
+
+TEST(convolution_f32_fw_gpu, input_f32_output_f16_dynamic_ref_kernel) {
+    auto& engine = get_test_engine();
+
+    auto in_layout = layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx};
+    auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 5, 4 } });
+    auto weights = engine.allocate_memory({ data_types::i8, format::bfyx, { 1, 1, 3, 2 } });
+    auto biases = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 1, 1 } });
+    auto eltwise_data = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 1, 1, 1 } });
+
+    set_values(input, {
+        1.0f, 2.0f, 3.0f, 4.0f,
+        5.0f, 2.0f, 2.0f, 3.0f,
+        4.0f, 6.0f, 3.0f, 3.0f,
+        3.0f, 5.0f, 1.0f, 1.0f,
+        1.0f, 1.0f, 1.0f, 1.0f }
+    );
+
+    topology topology(
+        input_layout("input", in_layout),
+        data("weights", weights),
+        data("biases", biases),
+        data("eltwise_data", eltwise_data),
+        convolution( "conv", input_info("input"), "weights", "biases", 1, {2, 1}, {1, 1}, {0, 0}, {0, 0}, false),
+        eltwise("eltwise", { input_info("conv"), input_info("eltwise_data") }, eltwise_mode::prod, data_types::f16),
+        permute("permute", input_info("eltwise"), {0, 1, 2, 3}));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc conv_impl_ref = { format::bfyx, "convolution_gpu_ref", impl_types::ocl };
+    config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl_ref } }));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
+    network.set_input_data("input", input);
+
+    auto outputs = network.execute();
+
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_FALSE(has_node(*network.get_program(), "eltwise"));
+    ASSERT_EQ(outputs.at("permute").get_layout().data_type, data_types::f16);
 }
 
 TEST(convolution_f32_fw_gpu, convolution_big_size_weights) {


### PR DESCRIPTION
### Details:
 - For fp model, some convolutions may not be compressed to fp16 depending on the transformation policy and those convolutions may have the fused node which is of fp16. Then convolution node input data type will be fp32 while output data type fp16. Convolution needs to support  this case.

### Tickets:
 - 147689
