### PR TITLE
[PyOV] Exclude a specific `tensorflow` version which does not support Python 3.8 on MacOS

### DIFF
--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,7 +1,7 @@
 -c ../constraints.txt
 h5py
-tensorflow>=1.15.5,<2.18.0; platform_system != 'darwin'
-tensorflow>=1.15.5,<2.18.0,!=2.13.1; platform_system == 'darwin'  # Explanation: 151865
+tensorflow>=1.15.5,<2.18.0; platform_system != 'darwin' or python_version != '3.8'
+tensorflow>=1.15.5,<2.18.0,!=2.13.1; platform_system == 'darwin' and python_version == '3.8'  # Explanation: 151865
 numpy>=1.16.6,<1.27
 networkx
 defusedxml

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,6 +1,7 @@
 -c ../constraints.txt
 h5py
-tensorflow>=1.15.5,<2.18.0
+tensorflow>=1.15.5,<2.18.0; platform_system != 'Darwin'
+tensorflow>=1.15.5,<2.18.0,!=2.13.1; platform_system == 'Darwin'  # Explanation: 151865
 numpy>=1.16.6,<1.27
 networkx
 defusedxml

--- a/tools/mo/requirements_tf.txt
+++ b/tools/mo/requirements_tf.txt
@@ -1,7 +1,7 @@
 -c ../constraints.txt
 h5py
-tensorflow>=1.15.5,<2.18.0; platform_system != 'Darwin'
-tensorflow>=1.15.5,<2.18.0,!=2.13.1; platform_system == 'Darwin'  # Explanation: 151865
+tensorflow>=1.15.5,<2.18.0; platform_system != 'darwin'
+tensorflow>=1.15.5,<2.18.0,!=2.13.1; platform_system == 'darwin'  # Explanation: 151865
 numpy>=1.16.6,<1.27
 networkx
 defusedxml

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,6 +1,7 @@
 -c ../constraints.txt
 h5py
-tensorflow>=2.5,<2.18.0
+tensorflow>=2.5,<2.18.0; platform_system != 'Darwin'
+tensorflow>=2.5,<2.18.0,!=2.13.1; platform_system == 'Darwin'  # Explanation: 151865
 numpy>=1.16.6,<1.27
 networkx
 defusedxml

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,7 +1,7 @@
 -c ../constraints.txt
 h5py
-tensorflow>=2.5,<2.18.0; platform_system != 'Darwin'
-tensorflow>=2.5,<2.18.0,!=2.13.1; platform_system == 'Darwin'  # Explanation: 151865
+tensorflow>=2.5,<2.18.0; platform_system != 'darwin'
+tensorflow>=2.5,<2.18.0,!=2.13.1; platform_system == 'darwin'  # Explanation: 151865
 numpy>=1.16.6,<1.27
 networkx
 defusedxml

--- a/tools/mo/requirements_tf2.txt
+++ b/tools/mo/requirements_tf2.txt
@@ -1,7 +1,7 @@
 -c ../constraints.txt
 h5py
-tensorflow>=2.5,<2.18.0; platform_system != 'darwin'
-tensorflow>=2.5,<2.18.0,!=2.13.1; platform_system == 'darwin'  # Explanation: 151865
+tensorflow>=2.5,<2.18.0; platform_system != 'darwin' or python_version != '3.8'
+tensorflow>=2.5,<2.18.0,!=2.13.1; platform_system == 'darwin' and python_version == '3.8'  # Explanation: 151865
 numpy>=1.16.6,<1.27
 networkx
 defusedxml


### PR DESCRIPTION
### Details:
 - Fixes MacOS CI on Python 3.8
 - Full investigation in the ticket
 - Related PR to OMZ: https://github.com/openvinotoolkit/open_model_zoo/pull/3974

### Tickets:
 - CVS-151865
