### PR TITLE
[GHA] Add ov_wheel_source output for ov provider

### DIFF
--- a/.github/actions/openvino_provider/action.yml
+++ b/.github/actions/openvino_provider/action.yml
@@ -44,6 +44,9 @@ outputs:
   ov_wheel_input:
     description: "Input for pip to install OpenVINO python wheel"
     value: ${{ steps.openvino_nightly_wheel.outputs.ov_wheel_input || steps.openvino_commit_wheel.outputs.ov_wheel_input }}
+  ov_wheel_source:
+    description: "Pip option for custom OV wheel location (--find-links or --extra-index-url)"
+    value: ${{ steps.openvino_nightly_wheel.outputs.ov_wheel_source || steps.openvino_commit_wheel.outputs.ov_wheel_source }}
 
 runs:
   using: "composite"
@@ -113,9 +116,11 @@ runs:
         cd ${{ steps.openvino_commit_download.outputs.artifacts_workspace_path }}
         version=$(yq eval '.components.dldt.custom_params.wheel_product_version' manifest.yml)
         wheel_path=${{ steps.openvino_commit_output.outputs.ov_package_path }}/tools
-        find_links_cmd=$([[ -n "$PIP_FIND_LINKS" ]] && echo "" || echo "--find-links=./$wheel_path")
+        default_find_links_cmd="--find-links=./$wheel_path"
+        find_links_cmd=$([[ -n "$PIP_FIND_LINKS" ]] && echo "" || echo "$default_find_links_cmd")
         wheel_input="$find_links_cmd openvino==$version"
         echo "ov_wheel_input=$wheel_input" >> $GITHUB_OUTPUT
+        echo "ov_wheel_source=$default_find_links_cmd" >> $GITHUB_OUTPUT
 
 
     # --- Nightly case ---
@@ -155,5 +160,7 @@ runs:
       run: |
         version=$(echo ${{ steps.openvino_nightly_download.outputs.ov_package_path }} |
           grep -oP '(?<=_)\d{4}\.\d\.\d\.dev\d{8}(?=_)')
-        wheel_input="--pre --extra-index-url ${{ inputs.nightly_pip_extra_url }} openvino==$version"
+        extra_index="--pre --extra-index-url ${{ inputs.nightly_pip_extra_url }}"
+        wheel_input="$extra_index openvino==$version"
         echo "ov_wheel_input=$wheel_input" >> $GITHUB_OUTPUT
+        echo "ov_wheel_source=$extra_index" >> $GITHUB_OUTPUT


### PR DESCRIPTION
For some cases (e.g. during tokenizers build via pip wheel) we need only wheel source argument, not the input for pip install

