### PR TITLE
[EISW-136980][NPU] Remove use_elf_compiler_backend option

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/compiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/compiler.hpp
@@ -16,7 +16,6 @@ namespace ov {
 namespace intel_npu {
 
 std::string_view stringifyEnum(CompilerType val);
-std::string_view stringifyEnum(ElfCompilerBackend val);
 
 }  // namespace intel_npu
 
@@ -306,34 +305,6 @@ struct DMA_ENGINES final : OptionBase<DMA_ENGINES, int64_t> {
         return "IE_NPU_DMA_ENGINES";
     }
 #endif
-};
-
-//
-// USE_ELF_COMPILER_BACKEND
-//
-
-struct USE_ELF_COMPILER_BACKEND final : OptionBase<USE_ELF_COMPILER_BACKEND, ov::intel_npu::ElfCompilerBackend> {
-    static std::string_view key() {
-        return ov::intel_npu::use_elf_compiler_backend.name();
-    }
-
-    static constexpr std::string_view getTypeName() {
-        return "ov::intel_npu::ElfCompilerBackend";
-    }
-
-#ifdef NPU_PLUGIN_DEVELOPER_BUILD
-    static std::string_view envVar() {
-        return "IE_NPU_USE_ELF_COMPILER_BACKEND";
-    }
-#endif
-
-    static ov::intel_npu::ElfCompilerBackend defaultValue() {
-        return ov::intel_npu::ElfCompilerBackend::AUTO;
-    }
-
-    static ov::intel_npu::ElfCompilerBackend parse(std::string_view val);
-
-    static std::string toString(const ov::intel_npu::ElfCompilerBackend& val);
 };
 
 //

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npu_private_properties.hpp
@@ -116,44 +116,6 @@ inline std::ostream& operator<<(std::ostream& out, const CompilerType& fmt) {
 /**
  * @brief [Only for NPU Plugin]
  * Type: String. Default is "AUTO".
- * This option is added for enabling ELF backend.
- * Possible values: "AUTO", "YES", "NO".
- */
-
-enum class ElfCompilerBackend {
-    AUTO = 0,
-    NO = 1,
-    YES = 2,
-};
-
-/**
- * @brief Prints a string representation of ov::intel_npu::ElfCompilerBackend to a stream
- * @param out An output stream to send to
- * @param fmt A elf compiler backend value to print to a stream
- * @return A reference to the `out` stream
- * @note Configuration API v 2.0
- */
-inline std::ostream& operator<<(std::ostream& out, const ElfCompilerBackend& fmt) {
-    switch (fmt) {
-    case ElfCompilerBackend::AUTO: {
-        out << "AUTO";
-    } break;
-    case ElfCompilerBackend::NO: {
-        out << "NO";
-    } break;
-    case ElfCompilerBackend::YES: {
-        out << "YES";
-    } break;
-    default:
-        out << static_cast<uint32_t>(fmt);
-        break;
-    }
-    return out;
-}
-
-/**
- * @brief [Only for NPU Plugin]
- * Type: String. Default is "AUTO".
  * This option is added for enabling batching on plugin.
  * Possible values: "AUTO", "COMPILER", "PLUGIN".
  */
@@ -327,14 +289,6 @@ static constexpr ov::Property<std::string> dynamic_shape_to_static{"NPU_DYNAMIC_
  * Model layers profiling are used if this string is empty
  */
 static constexpr ov::Property<ProfilingType> profiling_type{"NPU_PROFILING_TYPE"};
-
-/**
- * @brief
- * Type: String. Default is "AUTO".
- * Sets the format in which the compiled model is stored.
- * Possible values: "AUTO", "YES", "NO".
- */
-static constexpr ov::Property<ElfCompilerBackend> use_elf_compiler_backend{"NPU_USE_ELF_COMPILER_BACKEND"};
 
 /**
  * @brief [Only for NPU Plugin]

--- a/src/plugins/intel_npu/src/al/src/config/compiler.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/compiler.cpp
@@ -22,7 +22,6 @@ void intel_npu::registerCompilerOptions(OptionsDesc& desc) {
     desc.add<STEPPING>();
     desc.add<MAX_TILES>();
     desc.add<DMA_ENGINES>();
-    desc.add<USE_ELF_COMPILER_BACKEND>();
     desc.add<DYNAMIC_SHAPE_TO_STATIC>();
     desc.add<EXECUTION_MODE_HINT>();
 }
@@ -72,50 +71,6 @@ std::string intel_npu::COMPILER_TYPE::toString(const ov::intel_npu::CompilerType
         strStream << "DRIVER";
     } else {
         OPENVINO_THROW("No valid string for current LOG_LEVEL option");
-    }
-
-    return strStream.str();
-}
-
-//
-// USE_ELF_COMPILER_BACKEND
-//
-
-std::string_view ov::intel_npu::stringifyEnum(ov::intel_npu::ElfCompilerBackend val) {
-    switch (val) {
-    case ov::intel_npu::ElfCompilerBackend::AUTO:
-        return "AUTO";
-    case ov::intel_npu::ElfCompilerBackend::NO:
-        return "NO";
-    case ov::intel_npu::ElfCompilerBackend::YES:
-        return "YES";
-    default:
-        return "<UNKNOWN>";
-    }
-}
-
-ov::intel_npu::ElfCompilerBackend intel_npu::USE_ELF_COMPILER_BACKEND::parse(std::string_view val) {
-    if (val == stringifyEnum(ov::intel_npu::ElfCompilerBackend::AUTO)) {
-        return ov::intel_npu::ElfCompilerBackend::AUTO;
-    } else if (val == stringifyEnum(ov::intel_npu::ElfCompilerBackend::NO)) {
-        return ov::intel_npu::ElfCompilerBackend::NO;
-    } else if (val == stringifyEnum(ov::intel_npu::ElfCompilerBackend::YES)) {
-        return ov::intel_npu::ElfCompilerBackend::YES;
-    }
-
-    OPENVINO_THROW("Value '", val, "' is not a valid USE_ELF_COMPILER_BACKEND option");
-}
-
-std::string intel_npu::USE_ELF_COMPILER_BACKEND::toString(const ov::intel_npu::ElfCompilerBackend& val) {
-    std::stringstream strStream;
-    if (val == ov::intel_npu::ElfCompilerBackend::AUTO) {
-        strStream << "AUTO";
-    } else if (val == ov::intel_npu::ElfCompilerBackend::NO) {
-        strStream << "NO";
-    } else if (val == ov::intel_npu::ElfCompilerBackend::YES) {
-        strStream << "YES";
-    } else {
-        OPENVINO_THROW("No valid string for current USE_ELF_COMPILER_BACKEND option");
     }
 
     return strStream.str();

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -64,7 +64,6 @@ private:
                                                               ov::intel_npu::compilation_mode.name(),
                                                               ov::intel_npu::driver_version.name(),
                                                               ov::intel_npu::compiler_type.name(),
-                                                              ov::intel_npu::use_elf_compiler_backend.name(),
                                                               ov::intel_npu::batch_mode.name(),
                                                               ov::hint::execution_mode.name()};
 

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -293,12 +293,6 @@ void CompiledModel::initialize_properties() {
           [](const Config& config) {
               return config.getString<DYNAMIC_SHAPE_TO_STATIC>();
           }}},
-        {ov::intel_npu::use_elf_compiler_backend.name(),
-         {false,
-          ov::PropertyMutability::RO,
-          [](const Config& config) {
-              return config.getString<USE_ELF_COMPILER_BACKEND>();
-          }}},
         {ov::intel_npu::create_executor.name(),
          {false,
           ov::PropertyMutability::RO,

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -538,12 +538,6 @@ Plugin::Plugin()
           [&](const Config&) {
               return _metrics->GetBackendName();
           }}},
-        {ov::intel_npu::use_elf_compiler_backend.name(),
-         {false,
-          ov::PropertyMutability::RW,
-          [](const Config& config) {
-              return config.getString<USE_ELF_COMPILER_BACKEND>();
-          }}},
         {ov::intel_npu::create_executor.name(),
          {false,
           ov::PropertyMutability::RW,

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -146,14 +146,11 @@ const std::vector<ov::AnyMap> CorrectPluginMutableProperties = {
       removeDeviceNameOnlyID(
           ov::test::utils::getTestsDeviceNameFromEnvironmentOr(std::string(ov::intel_npu::Platform::AUTO_DETECT)))}},
     {{ov::intel_npu::stepping.name(), 0}},
-    {{ov::intel_npu::use_elf_compiler_backend.name(), ov::intel_npu::ElfCompilerBackend::NO}},
     {{ov::intel_npu::profiling_type.name(), ov::intel_npu::ProfilingType::INFER}}};
 
 const std::vector<ov::AnyMap> IncorrectMutablePropertiesWrongValueTypes = {
     {{ov::intel_npu::compilation_mode.name(), -3.6}},
-    {{ov::intel_npu::compiler_type.name(), ov::intel_npu::ElfCompilerBackend::NO}},
     {{ov::intel_npu::stepping.name(), "V1"}},
-    {{ov::intel_npu::use_elf_compiler_backend.name(), "N"}},
     {{ov::intel_npu::profiling_type.name(), 10}},
     {{ov::intel_npu::dma_engines.name(), false}},
 };

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
@@ -129,7 +129,6 @@ std::vector<std::pair<std::string, ov::Any>> plugin_internal_mutable_properties 
     {ov::intel_npu::max_tiles.name(), ov::Any(8)},
     {ov::intel_npu::stepping.name(), ov::Any(4)},
     {ov::intel_npu::dpu_groups.name(), ov::Any(2)},
-    {ov::intel_npu::use_elf_compiler_backend.name(), ov::Any(ov::intel_npu::ElfCompilerBackend::YES)},
     {ov::intel_npu::defer_weights_load.name(), ov::Any(true)},
 };
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
@@ -47,7 +47,6 @@ const std::vector<std::pair<std::string, ov::Any>> compiledModelProperties = {
     {ov::hint::model_priority.name(), ov::Any(ov::hint::Priority::HIGH)},
     {ov::intel_npu::tiles.name(), ov::Any(2)},
     {ov::intel_npu::profiling_type.name(), ov::Any(ov::intel_npu::ProfilingType::INFER)},
-    {ov::intel_npu::use_elf_compiler_backend.name(), ov::Any(ov::intel_npu::ElfCompilerBackend::NO)},
     {ov::intel_npu::defer_weights_load.name(), ov::Any(false)}};
 
 const std::string& expectedModelName = []() -> std::string {

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
@@ -98,17 +98,6 @@ const std::vector<ov::AnyMap> NPULoadFromFileConfigs = {
     {ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)}};
 
 const std::vector<std::pair<ov::AnyMap, std::string>> NPUCompiledKernelsCacheTest = {
-    std::make_pair<ov::AnyMap, std::string>(
-        {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT),
-         ov::intel_npu::use_elf_compiler_backend(ov::intel_npu::ElfCompilerBackend::NO)},
-        "blob"),
-    std::make_pair<ov::AnyMap, std::string>(
-        {ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY),
-         ov::intel_npu::use_elf_compiler_backend(ov::intel_npu::ElfCompilerBackend::NO)},
-        "blob"),
-    std::make_pair<ov::AnyMap, std::string>(
-        {ov::intel_npu::use_elf_compiler_backend(ov::intel_npu::ElfCompilerBackend::NO)},
-        "blob"),
     std::make_pair<ov::AnyMap, std::string>({ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},
                                             "blob"),
     std::make_pair<ov::AnyMap, std::string>({ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)}, "blob")};

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -481,13 +481,6 @@ std::vector<std::string> disabledTestPatterns() {
                 // [Tracking number: E#111369]
                 ".*OVInferRequestMultithreadingTests.canRun3SyncRequestsConsistently.*"
         });
-
-        // [Tracking number: E#107154]
-        _skipRegistry.addPatterns(
-                "Can't disable ELF Backend since Graphfile does not work on linux", {
-                ".*NPU_USE_ELF_COMPILER_BACKEND:NO.*",
-                ".*USE_ELF_COMPILER_BACKEND_NO.*"
-        });
 #endif
 
         _skipRegistry.addPatterns(backendName.isIMD(), "IMD/Simics do not support the tests",


### PR DESCRIPTION
### Details:
 - After GF schema removal https://jira.devtools.intel.com/browse/EISW-129562 there is no need to have use_elf_compiler_backend option as ELF backend set by default.

### Tickets:
 - https://jira.devtools.intel.com/browse/EISW-136980
