### PR TITLE
Fix path to generated ov_plugins.hpp

### DIFF
--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -330,10 +330,11 @@ function(ov_generate_plugins_hpp)
         ov_target_link_plugins(openvino_runtime_s)
     endif()
 
+    get_target_property(OV_RUNTIME_OBJ_BINARY_DIR openvino_runtime_obj BINARY_DIR)
     if(OV_GENERATOR_MULTI_CONFIG AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)
-        set(ov_plugins_hpp "${CMAKE_BINARY_DIR}/src/inference/$<CONFIG>/ov_plugins.hpp")
+        set(ov_plugins_hpp "${OV_RUNTIME_OBJ_BINARY_DIR}/$<CONFIG>/ov_plugins.hpp")
     else()
-        set(ov_plugins_hpp "${CMAKE_BINARY_DIR}/src/inference/ov_plugins.hpp")
+        set(ov_plugins_hpp "${OV_RUNTIME_OBJ_BINARY_DIR}/ov_plugins.hpp")
     endif()
     set(plugins_hpp_in "${OpenVINODeveloperScripts_DIR}/plugins/plugins.hpp.in")
 


### PR DESCRIPTION
OpenVino fails to compile if it's used as a subdirectory in CMakeLists.txt. For example, below scenario:
```
$ git clone https://github.com/openvinotoolkit/openvino --recursive
$ cat CMakeLists.txt
project(testing)
add_subdirectory(openvino)
$ mkdir build
$ cmake -B build -S .
$ make -C build openvino_runtime_obj
```

ends with compilation error:
```
core_impl.cpp:32:10: fatal error: ov_plugins.hpp: No such file or directory
   32 | #include "ov_plugins.hpp"
      |          ^~~~~~~~~~~~~~~~
```
because of incorrect include path.
openvino_runtime_obj target expects ov_plugins.hpp to be present in ${CMAKE_CURRENT_BINARY_DIR} (which is build/openvino/src/inference in this case), but ov_plugins.hpp is generated to ${CMAKE_BINARY_DIR}/src/inference (which is build/src/inference). To fix that, ov_generate_plugins_hpp can use BINARY_DIR property of openvino_runtime_obj instead of ${CMAKE_BINARY_DIR}/src/inference.