### PR TITLE
[Snippets][CPU] Enabled dynamic INT8|BF16 MHA tokenization on non AMX-platforms

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -978,9 +978,6 @@ void Transformations::MainSnippets(void) {
             return false;
         if (is_fp32)
             return true;
-        // Only FP32 dynamic MHA is supported
-        if (matmul->is_dynamic())
-            return false;
         // [114487] brgemm kernel in oneDNN requires brgemm_copy_b kernel if MatMul node has transposed_b=True
         // The current solution with ExtractExplicitMatMulTranspose pass is slower for non-f32 cases than using of brgemm_copy_b kernel
         if (matmul->get_transpose_a() || matmul->get_transpose_b())

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -237,7 +237,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_FakeQuantize.*/FakeQuantizeLayerTest.Inference.*TS=.*3.4.2.5.*LEVELS=255.*)",
         R"(.*smoke_FakeQuantizePerChannel.*/FakeQuantizeLayerTest.Inference.*TS=.*11.10.22.19.*LEVELS=(255|256).*netPRC=f32.*)",
         R"(.*smoke_MVN_5D/Mvn6LayerTest.Inference.*TS=.*3.4.2.5.*LEVELS=255.*netPRC=f16.*)",
-        R"(.*smoke_Snippets_MHAINT8MatMul/MHAINT8MatMul.*)",
         R"(.*smoke_static/ConvertFqRnnToQuantizedRnn.*2.1.5.*2.1.1.*2.1.1.*)",
         R"(.*smoke_InterpolateBicubicPillow_Layout_Test/InterpolateLayerCPUTest.CompareWithRefs/ShapeCalcMode=sizes_IS=\[?.2..20.?.?\]_TS.*1.17.4.4.*2.3.10.12.*1.17.4.4.*Sizes.*4.4.*10.20.*10.4.*PARAMETER.*0.0.0.0.*0.0.1.1.*2.3.*)",
         R"(.*smoke_LoopForCommon/LoopLayerCPUTest.CompareWithRefs/.*_netType=bf16.*)",
@@ -560,7 +559,7 @@ std::vector<std::string> disabledTestPatterns() {
         // ignored for not supported bf16 platforms
         retVector.emplace_back(R"(.*smoke_Snippets_EnforcePrecision_bf16.*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MHAWOTransposeEnforceBF16.*)");
-        retVector.emplace_back(R"(.*smoke_Snippets_MHAEnforceBF16.*)");
+        retVector.emplace_back(R"(.*smoke_Snippets_MHA.*EnforceBF16.*)");
     }
     // [150842] Need to support dynamic K dimension of BF16|INT8 MatMul on AMX systems
     if (ov::with_cpu_x86_avx512_core_amx()) {
@@ -568,6 +567,10 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(.*smoke_Snippets_MatMul/MatMul.CompareWithRefImpl/.*IS\[0\]=\[\?.\?.\?.\?\].*T\[0\]=(u8|i8|bf16)_T\[1\]=(i8|bf16).*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MatMulTransposeB.*IS\[0\]=\[\?.\?.\?.\?\].*T\[0\]=(u8|i8|bf16)_T\[1\]=(i8|bf16).*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MatMulBias.*IS\[0\]=\[\?.\?.\?.\?\].*T\[0\]=(u8|i8|bf16)_T\[1\]=(i8|bf16).*)");
+
+        retVector.emplace_back(R"(.*smoke_Snippets_MHA.*BF16.*/MHA.*IS\[0\]=\[(\?|1).(\?|4).(\?|12).(\?|64)\].*)");
+        retVector.emplace_back(R"(.*smoke_Snippets_MHA.*BF16.*/MHA.*IS\[0\]=\[\?.\?.\?\].*)");
+        retVector.emplace_back(R"(.*smoke_Snippets_(MHAINT8MatMul|MHAQuantMatMul0|MHAFQAfterMatMul_4D|smoke_Snippets_MHAFQ).*IS\[0\]=\[\?.\?.\?\.\?].*)");
     }
 #ifdef SNIPPETS_LIBXSMM_TPP
     // GN in TPP requires exposing tmp Buffer results outside the loop (ticket: 151234)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha.cpp
@@ -16,18 +16,6 @@ namespace snippets {
 #define STATIC_SHAPES(...) static_shapes_to_test_representation(std::vector<std::vector<ov::Shape>>{__VA_ARGS__})
 namespace {
 
-const auto& inputShapes_4D = STATIC_SHAPES(
-    {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}},
-    {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 16, 1, 1}, {1, 128, 16, 64}},
-    {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 1, 1, 128}, {1, 128, 16, 64}},
-    {{2, 68, 6, 92}, {2, 68, 6, 92}, {1, 1, 68, 68}, {2, 68, 6, 92}},
-    {{1, 58, 16, 34}, {1, 58, 16, 34}, {1, 1, 1, 58}, {1, 58, 16, 34}});
-
-const auto& inputShapes_3D = STATIC_SHAPES(
-    {{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
-    {{68, 6, 92}, {68, 6, 92}, {1, 68, 68}, {68, 6, 92}},
-    {{16, 2, 92}, {68, 2, 92}, {1, 16, 68}, {68, 2, 92}});
-
 static inline bool is_bf16_supported() {
     return ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx512_core_amx_bf16();
 }
@@ -49,40 +37,61 @@ static ov::AnyMap enable_callback() {
     return ov::AnyMap({ov::intel_cpu::snippets_mode(ov::intel_cpu::SnippetsMode::ENABLE)});
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_4D,
-                         MHA,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D),
-                                            ::testing::ValuesIn(precision_f32(4)),
-                                            ::testing::Values(ov::element::f32),
-                                            ::testing::ValuesIn({false, true}),
-                                            ::testing::Values(MHA::default_thread_count),
-                                            ::testing::Values(1),
-                                            ::testing::Values(1),
-                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
-                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
-                         MHA::getTestCaseName);
+namespace MHADefaultInstances {
 
-std::vector<std::vector<ov::test::InputShape>> inputShapes_4D_dynamic{
+std::vector<std::vector<InputShape>> transposedShape_4D(bool with_dynamic = true) {
+    auto shapes = STATIC_SHAPES(
+        {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}},
+        {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 16, 1, 1}, {1, 128, 16, 64}},
+        {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 1, 1, 128}, {1, 128, 16, 64}},
+        {{2, 68, 6, 92}, {2, 68, 6, 92}, {1, 1, 68, 68}, {2, 68, 6, 92}},
+        {{1, 58, 16, 34}, {1, 58, 16, 34}, {1, 1, 1, 58}, {1, 58, 16, 34}});
+    if (with_dynamic) {
+        std::vector<std::vector<ov::test::InputShape>> dynamic_shapes = {{
+            {PartialShape{-1, -1, -1, 100},  {{1, 64, 4, 100},  {2, 16, 2, 100},  {1, 72, 4, 100}}},
+            {PartialShape{-1, 128, -1, 100}, {{1, 128, 4, 100}, {2, 128, 2, 100}, {1, 128, 4, 100}}},
+            {PartialShape{-1, -1, -1, 128},  {{1, 4, 64, 128},  {2, 2, 16, 128},  {1, 4, 72, 128}}},
+            {PartialShape{-1, 128, -1, 100}, {{1, 128, 4, 100}, {2, 128, 2, 100}, {1, 128, 4, 100}}},
+        },
         {
-            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 70, 3, 19}, {1, 128, 3, 64}, {1, 68, 6, 87}}},
-            {PartialShape{-1, -1, -1, -1}, {{1, 128, 1, 64}, {2, 49, 1, 19}, {1, 128, 1, 64}, {2, 13, 6, 87}}},
-            {PartialShape{-1, -1, -1, -1}, {{2, 1, 128, 128}, {1, 1, 70, 49}, {2, 1, 128, 128}, {1, 1, 68, 13}}},
-            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 49, 3, 19}, {1, 128, 3, 64}, {2, 13, 6, 87}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64},  {2, 16, 2, 100},  {1, 128, 3, 64}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 1, 64},  {2, 128, 2, 100}, {1, 128, 1, 64}}},
+            {PartialShape{-1, -1, -1, -1}, {{2, 1, 128, 128}, {2, 2, 16, 128},  {2, 1, 128, 128}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64},  {2, 128, 2, 100}, {1, 128, 3, 64}}},
         },
         {
             {PartialShape{-1, -1, 12, 64}, {{1, 70, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 70, 12, 64}}},
             {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {2, 10, 12, 64}, {2, 1, 12, 64}, {2, 10, 12, 64}, {1, 35, 12, 64}}},
             {PartialShape{-1, 12, -1, -1}, {{2, 12, 70, 35}, {1, 12, 20, 10}, {1, 12, 20, 10}, {1, 12, 20, 1},  {2, 12, 70, 35}}},
             {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 35, 12, 64}}},
-        }
-};
+        }};
+        shapes.insert(shapes.end(), dynamic_shapes.begin(), dynamic_shapes.end());
+    }
+    return shapes;
+}
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_DynMHA_4D,
+std::vector<std::vector<InputShape>> transposedShape_3D(bool with_dynamic = true) {
+    auto shapes = STATIC_SHAPES(
+        {{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
+        {{68, 6, 92}, {68, 6, 92}, {1, 68, 68}, {68, 6, 92}},
+        {{16, 2, 92}, {68, 2, 92}, {1, 16, 68}, {68, 2, 92}});
+    if (with_dynamic) {
+        shapes.push_back({
+            {PartialShape{-1, -1, -1}, {{128, 3, 64},  {128, 3, 64},  {68, 6, 87}}},
+            {PartialShape{-1, -1, -1}, {{128, 1, 64},  {128, 1, 64},  {13, 6, 87}}},
+            {PartialShape{-1, -1, -1}, {{1, 128, 128}, {1, 128, 128}, {1, 68, 13}}},
+            {PartialShape{-1, -1, -1}, {{128, 3, 64},  {128, 3, 64},  {13, 6, 87}}},
+        });
+    }
+    return shapes;
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_4D,
                          MHA,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D_dynamic),
+                         ::testing::Combine(::testing::ValuesIn(transposedShape_4D()),
                                             ::testing::ValuesIn(precision_f32(4)),
                                             ::testing::Values(ov::element::f32),
-                                            ::testing::ValuesIn({false}),
+                                            ::testing::Values(false),
                                             ::testing::Values(MHA::default_thread_count),
                                             ::testing::Values(1),
                                             ::testing::Values(1),
@@ -90,13 +99,25 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_DynMHA_4D,
                                             ::testing::Values(CPUTestUtils::empty_plugin_config)),
                          MHA::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_4D_WithScalarMul,
+                         MHA,
+                         ::testing::Combine(::testing::ValuesIn(transposedShape_4D(false)),
+                                            ::testing::ValuesIn(precision_f32(4)),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::Values(true),
+                                            ::testing::Values(MHA::default_thread_count),
+                                            ::testing::Values(1),
+                                            ::testing::Values(1),
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
+                         MHA::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D,
                          MHA,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_3D),
+                         ::testing::Combine(::testing::ValuesIn(transposedShape_3D()),
                                             ::testing::ValuesIn(precision_f32(4)),
                                             ::testing::Values(ov::element::f32),
-                                            ::testing::ValuesIn({false, true}),
+                                            ::testing::Values(false),
                                             ::testing::Values(MHA::default_thread_count),
                                             ::testing::Values(5),  // [122706]: Subgraph + 4 Transpose
                                             ::testing::Values(2),  // decomposed Transpose + MHA
@@ -104,12 +125,421 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D,
                                             ::testing::Values(CPUTestUtils::empty_plugin_config)),
                          MHA::getTestCaseName);
 
-const auto& splitm_static_shapes = STATIC_SHAPES({{1, 128, 2, 64}, {1, 128, 2, 64}, {1, 1, 1, 1}, {1, 128, 2, 64}});
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHA_3D_WithScalarMul,
+                         MHA,
+                         ::testing::Combine(::testing::ValuesIn(transposedShape_3D(false)),
+                                            ::testing::ValuesIn(precision_f32(4)),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::Values(true),
+                                            ::testing::Values(MHA::default_thread_count),
+                                            ::testing::Values(5),  // [122706]: Subgraph + 4 Transpose
+                                            ::testing::Values(2),  // decomposed Transpose + MHA
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
+                         MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16_4D,
+                         MHA,
+                         ::testing::Combine(::testing::ValuesIn(transposedShape_4D()),
+                                            ::testing::ValuesIn(precision_bf16(4)),
+                                            ::testing::Values(ov::element::f32),
+                                            ::testing::ValuesIn({false, true}),
+                                            ::testing::Values(MHA::default_thread_count),
+                                            ::testing::Values(7),  // MHA + 5 Converts + 1 Transpose on output
+                                            ::testing::Values(6),  // MHA + 5 Converts on inputs and output
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
+                         MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAEnforceBF16,
+                         MHA,
+                         ::testing::Combine(::testing::ValuesIn(transposedShape_4D()),
+                                            ::testing::ValuesIn(precision_f32(4)),
+                                            ::testing::Values(ov::element::bf16),
+                                            ::testing::ValuesIn({false}),
+                                            ::testing::Values(MHA::default_thread_count),
+                                            ::testing::Values(7),
+                                            ::testing::Values(6),
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                            ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
+                         MHA::getTestCaseName);
+
+}  // namespace MHADefaultInstances
+
+namespace MHAWOTransposeInstances {
+
+std::vector<std::vector<ov::test::InputShape>> originalShape_4D {
+    { {{}, {{1, 12, 197, 64}}}, {{}, {{1, 12, 64, 197}}}, {{}, {{1, 12, 197, 64}}} },
+    { {{}, {{1, 12, 12, 64}}},  {{}, {{1, 12, 64, 48}}},  {{}, {{1, 12, 48, 64}}} },
+    {
+        {PartialShape{-1, -1, -1, -1}, {{1, 3, 128, 64}, {1, 12, 197, 100}, {1, 3, 128, 64}, {1, 12, 197, 600}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 3, 64, 128}, {1, 12, 100, 197}, {1, 3, 64, 128}, {1, 12, 600, 197}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 3, 128, 64}, {1, 12, 197, 100}, {1, 3, 128, 64}, {1, 12, 197, 600}}},
+    },
+    {
+        {PartialShape{1, 4, -1, -1}, {{1, 4, 384, 64}, {1, 4, 197, 64}, {1, 4, 384, 560}}},
+        {PartialShape{1, 4, -1, -1}, {{1, 4, 64, 128}, {1, 4, 64, 197}, {1, 4, 560, 384}}},
+        {PartialShape{1, 4, -1, 64}, {{1, 4, 128, 64}, {1, 4, 197, 64}, {1, 4, 384, 64}}},
+    }
+};
+
+std::vector<std::vector<ov::test::InputShape>> originalShape_3D {
+    { {{}, {{12, 197, 64}}},  {{}, {{12, 64, 197}}},  {{}, {{12, 197, 64}}} },
+    { {{}, {{12, 128, 100}}}, {{}, {{12, 100, 128}}}, {{}, {{12, 128, 100}}} },
+    {
+        {PartialShape{-1, -1, 64},  {{2, 9, 64},   {1, 64, 64},  {2, 64, 64}}},
+        {PartialShape{-1, 64, 124}, {{2, 64, 124}, {1, 64, 124}, {2, 64, 124}}},
+        {PartialShape{-1, 124, 64}, {{2, 124, 64}, {1, 124, 64}, {2, 124, 64}}},
+    },
+    {
+        {PartialShape{-1, -1, -1}, {{12, 19, 85}, {1, 40, 36}}},
+        {PartialShape{-1, -1, -1}, {{1, 85, 19}, {2, 36, 40}}},
+        {PartialShape{-1, -1, -1}, {{12, 19, 85}, {1, 40, 36}}},
+    },
+    {
+        {PartialShape{2, -1, 64}, {{2, 9, 64}, {2, 4, 64}, {2, 9, 64}}},
+        {PartialShape{2, 64, -1}, {{2, 64, 9}, {2, 64, 4}, {2, 64, 9}}},
+        {PartialShape{2, -1, 64}, {{2, 9, 64}, {2, 4, 64}, {2, 9, 64}}},
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTransposeOnInputs_4D,
+    MHAWOTransposeOnInputs,
+    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+                       ::testing::Values(std::vector<ov::element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(1),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTranspose_4D,
+    MHAWOTranspose,
+    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+                       ::testing::ValuesIn(precision_f32(3)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(1),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTranspose_3D,
+    MHAWOTranspose,
+    ::testing::Combine(::testing::ValuesIn(originalShape_3D),
+                       ::testing::ValuesIn(precision_f32(3)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(1),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTransposeBF16_4D,
+    MHAWOTranspose,
+    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+                       ::testing::ValuesIn(precision_bf16(3)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTransposeBF16_3D,
+    MHAWOTranspose,
+    ::testing::Combine(::testing::ValuesIn(originalShape_3D),
+                       ::testing::ValuesIn(precision_bf16(3)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTransposeEnforceBF16_4D,
+    MHAWOTranspose,
+    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+                       ::testing::ValuesIn(precision_f32(3)),
+                       ::testing::Values(ov::element::bf16),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWOTransposeEnforceBF16_3D,
+    MHAWOTranspose,
+    ::testing::Combine(::testing::ValuesIn(originalShape_3D),
+                       ::testing::ValuesIn(precision_f32(3)),
+                       ::testing::Values(ov::element::bf16),
+                       ::testing::Values(true),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
+    MHA::getTestCaseName);
+
+}  // namespace MHAWOTransposeInstances
+
+namespace MHAQuantInstances {
+
+std::vector<std::vector<InputShape>> quantizedShape_4D(bool with_dynamic = true) {
+    auto shapes = STATIC_SHAPES(
+        {{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 16, 1, 1}, {1, 128, 16, 64}},
+        {{2, 68, 6, 92}, {2, 68, 6, 92}, {1, 1, 68, 68}, {2, 68, 6, 92}});
+    if (with_dynamic) {
+        std::vector<std::vector<ov::test::InputShape>> dynamic_shapes = {
+        // K, N are static
+        {
+            {PartialShape{-1, -1, -1, 100},  {{1, 64, 4, 100},  {2, 16, 2, 100},  {1, 72, 4, 100}}},
+            {PartialShape{-1, 128, -1, 100}, {{1, 128, 4, 100}, {2, 128, 2, 100}, {1, 128, 4, 100}}},
+            {PartialShape{-1, -1, -1, 128},  {{1, 4, 64, 128},  {2, 2, 16, 128},  {1, 4, 72, 128}}},
+            {PartialShape{-1, 128, -1, 100}, {{1, 128, 4, 100}, {2, 128, 2, 100}, {1, 128, 4, 100}}},
+        },
+        {
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64},  {2, 16, 2, 100},  {1, 128, 3, 64},  {1, 128, 12, 600}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 1, 64},  {2, 128, 2, 100}, {1, 128, 1, 64},  {1, 128, 12, 600}}},
+            {PartialShape{-1, -1, -1, -1}, {{2, 1, 128, 128}, {1, 1, 1, 128},   {2, 1, 128, 128}, {1, 12, 1, 1}}},
+            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64},  {2, 128, 2, 100}, {1, 128, 3, 64},  {1, 128, 12, 600}}},
+        }};
+        shapes.insert(shapes.end(), dynamic_shapes.begin(), dynamic_shapes.end());
+    }
+    return shapes;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAINT8MatMul,
+    MHAINT8MatMul,
+    ::testing::Combine(::testing::ValuesIn(quantizedShape_4D()),
+                       ::testing::Values(std::vector<element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),  // The graph doesn't contain Multiply
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(6),  // FQx3 on inputs + MHA + Transpose on output + Deq Mul
+                       ::testing::Values(5),  // FQx3 on inputs + MHA + Deq Mul
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAQuantMatMul0,
+    MHAQuantMatMul0,
+    ::testing::Combine(
+        ::testing::ValuesIn(quantizedShape_4D()),
+        ::testing::Values(std::vector<element::Type>{}),
+        ::testing::Values(ov::element::f32),
+        ::testing::Values(false),  // The graph doesn't contain Multiply
+        ::testing::Values(MHA::default_thread_count),
+        ::testing::Values(5),  // FQx2 on inputs + MHA + Transpose on output + Deq Mul
+        ::testing::Values(4),  // FQx2 on inputs + MHA + Deq Mul
+        ::testing::Values(ov::test::utils::DEVICE_CPU),
+        ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAFQAfterMatMul_4D,
+    MHAFQAfterMatMul,
+    ::testing::Combine(::testing::ValuesIn(quantizedShape_4D()),
+                       ::testing::Values(std::vector<element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),  // The graph doesn't contain Multiply
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(3),  // MHA + Transpose on output + Deq Mul
+                       ::testing::Values(2),  // MHA + Deq Mul
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAFQ,
+    MHAFQ,
+    ::testing::Combine(::testing::ValuesIn(quantizedShape_4D()),
+                       ::testing::Values(std::vector<element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),  // The graph doesn't contain Multiply
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(7),  // Transposex2 + Subgraphsx5
+                       ::testing::Values(5),  // MHA + Deq Mul on output + Deqs on inputs + 2 xFQ on inputs
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+}  // namespace MHAQuantInstances
+
+namespace MHACornerCasesInstances {
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAMulAdd,
+    MHAMulAdd,
+    ::testing::Combine(
+        ::testing::ValuesIn(STATIC_SHAPES({{1, 10, 12, 16}, {1, 10, 12, 16}, {1, 10, 12, 16}})),
+        ::testing::ValuesIn(precision_f32(3)),
+        ::testing::Values(ov::element::f32),
+        ::testing::ValuesIn({false}),  // Need to support True for graph builder in tests
+        ::testing::Values(MHA::default_thread_count),
+        ::testing::Values(1),
+        ::testing::Values(1),
+        ::testing::Values(ov::test::utils::DEVICE_CPU),
+        ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+const auto& inputShapeSelect = STATIC_SHAPES(
+    // without broadcast
+    {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 12, 128, 128}, {1, 12, 128, 128}, {1, 128, 12, 64}},
+    {{1, 94, 12, 54}, {1, 94, 12, 54}, {1, 12, 94, 94}, {1, 12, 94, 94}, {1, 12, 94, 94}, {1, 94, 12, 54}},
+    // with broadcast
+    {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 12, 1, 1}, {1, 12, 1, 1}, {1, 128, 12, 64}},
+    {{2, 52, 6, 102}, {2, 52, 6, 102}, {1, 6, 52, 52}, {1, 6, 1, 1}, {1, 6, 1, 1}, {2, 52, 6, 102}}
+);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHA,
+    MHASelect,
+    ::testing::Combine(::testing::ValuesIn(inputShapeSelect),
+                       ::testing::ValuesIn(precision_f32(6)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(false),  // Need to support True for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(2),  // Less + MHA
+                       ::testing::Values(2),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+const auto& inputShapesExtractedReshape = STATIC_SHAPES(
+    {{2, 196, 64}, {2, 64, 196}, {2, 14, 14, 14, 1}, {2, 14, 14, 1, 14}, {2, 196, 64}},
+    {{1, 16, 10}, {1, 10, 16}, {1, 4, 4, 4, 1}, {1, 4, 4, 1, 4}, {1, 16, 10}},
+    {{1, 16, 10}, {1, 10, 16}, {1, 1, 1, 1, 1}, {1, 4, 4, 4, 4}, {1, 16, 10}},
+    {{1, 16, 10}, {1, 10, 16}, {1, 4, 4, 4, 4}, {1, 1, 1, 1, 1}, {1, 16, 10}},
+    {{1, 4, 16, 10}, {1, 4, 10, 16}, {1, 4, 256}, {1, 4, 256}, {1, 4, 16, 10}},
+    {{1, 4, 16, 10}, {1, 4, 10, 16}, {1, 1, 256}, {1, 4, 1}, {1, 4, 16, 10}});
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHAWithExtractedReshape,
+    MHAWithExtractedReshape,
+    ::testing::Combine(::testing::ValuesIn(inputShapesExtractedReshape),
+                       ::testing::Values(std::vector<element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn({true}),  // False is not supported for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(3),  // Extracted Add + Extracted Reshape + MHA
+                       ::testing::Values(2),  // Extracted Add + MHA
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+std::vector<std::vector<ov::test::InputShape>> transposedShape_4D_WithMul {
+    {
+        {PartialShape{-1, -1, -1, 100},  {{1, 64, 4, 100},  {2, 16, 2, 100},  {1, 72, 4, 100}}},
+        {PartialShape{-1, 200, -1, 100}, {{1, 200, 4, 100}, {2, 200, 2, 100}, {1, 200, 4, 100}}},
+        {PartialShape{-1, -1, 100, 200}, {{1, 4, 100, 200}, {2, 2, 100, 200}, {1, 4, 100, 200}}},
+        {PartialShape{-1, -1, -1, 200},  {{1, 4, 64, 200},  {2, 2, 16, 200},  {1, 4, 72, 200}}},
+        {PartialShape{-1, 200, -1, 100}, {{1, 200, 4, 100}, {2, 200, 2, 100}, {1, 200, 4, 100}}},
+    },
+    {
+        {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 70, 3, 19}, {1, 128, 3, 64}, {1, 68, 6, 87}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 128, 1, 64}, {2, 49, 1, 19}, {1, 128, 1, 64}, {2, 13, 6, 87}}},
+        {PartialShape{1},              {{1},             {1},            {1},             {1} }},
+        {PartialShape{-1, -1, -1, -1}, {{2, 1, 128, 128}, {1, 1, 70, 49}, {2, 1, 128, 128}, {1, 1, 68, 13}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 49, 3, 19}, {1, 128, 3, 64}, {2, 13, 6, 87}}},
+    },
+    {
+        {PartialShape{-1, -1, 12, 64}, {{1, 70, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 70, 12, 64}}},
+        {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {2, 10, 12, 64}, {2, 1, 12, 64},  {2, 10, 12, 64}, {1, 35, 12, 64}}},
+        {PartialShape{-1, 12, 64, -1}, {{1, 12, 64, 35}, {1, 12, 64, 10}, {1, 12, 64, 10}, {1, 12, 64, 1},  {1, 12, 64, 35}}},
+        {PartialShape{-1, 12, -1, -1}, {{2, 12, 70, 35}, {1, 12, 20, 10}, {1, 12, 20, 10}, {1, 12, 20, 1},  {2, 12, 70, 35}}},
+        {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 35, 12, 64}}},
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHA_4D_WithDynamicMul,
+    MHAWithDynamicMul,
+    ::testing::Combine(::testing::ValuesIn(transposedShape_4D_WithMul),
+                       ::testing::ValuesIn(precision_f32(5)),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(1),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHAWithDynamicMul::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHA_4D_WithDynamicMul_EnforceBF16,
+    MHAWithDynamicMul,
+    ::testing::Combine(::testing::ValuesIn(transposedShape_4D_WithMul),
+                       ::testing::ValuesIn(precision_f32(5)),
+                       ::testing::Values(ov::element::bf16),
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(8),  // MHA + 1 Transpose on output + 6 Converts around
+                       ::testing::Values(7),  // MHA + 6 Converts around
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHAWithDynamicMul::getTestCaseName);
+
+std::vector<std::vector<ov::test::InputShape>> inputShapesTransposedB {
+    {
+        {{}, {{1, 12, 12, 64}}},
+        {{}, {{1, 12, 48, 64}}},
+        {{}, {{1, 12, 48, 64}}}
+    },
+    {
+        {PartialShape{-1, 3, -1, 64}, {{1, 3, 12, 64}, {2, 3, 36, 64}}},
+        {PartialShape{-1, 3, -1, 64}, {{1, 3, 14, 64}, {2, 3, 42, 64}}},
+        {PartialShape{-1, 3, -1, -1}, {{1, 3, 14, 36}, {2, 3, 42, 36}}},
+    },
+    {
+        {PartialShape{2, -1, 32, -1}, {{2, 1, 32, 70}, {2, 2, 32, 96}}},
+        {PartialShape{2, -1, 49, -1}, {{2, 3, 49, 70}, {2, 1, 49, 96}}},
+        {PartialShape{2, -1, 49, -1}, {{2, 1, 49, 17}, {2, 2, 49, 81}}},
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    smoke_Snippets_MHATransposedB,
+    MHATransposedB,
+    ::testing::Combine(::testing::ValuesIn(inputShapesTransposedB),
+                       ::testing::Values(std::vector<element::Type>{}),
+                       ::testing::Values(ov::element::f32),
+                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
+                       ::testing::Values(MHA::default_thread_count),
+                       ::testing::Values(1),
+                       ::testing::Values(1),
+                       ::testing::Values(ov::test::utils::DEVICE_CPU),
+                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
+    MHA::getTestCaseName);
+
+}  // namespace MHACornerCasesInstances
+
+namespace MHASplitDimensionMInstances {
 
 INSTANTIATE_TEST_SUITE_P(
     smoke_Snippets_MHA_4D_SplitDimensionM_static,
     MHA,
-    ::testing::Combine(::testing::ValuesIn(splitm_static_shapes),
+    ::testing::Combine(::testing::ValuesIn(STATIC_SHAPES({{1, 128, 2, 64}, {1, 128, 2, 64}, {1, 1, 1, 1}, {1, 128, 2, 64}})),
                        ::testing::ValuesIn(precision_f32(4)),
                        ::testing::Values(ov::element::f32),
                        ::testing::Values(true),
@@ -205,346 +635,7 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(CPUTestUtils::empty_plugin_config)),
     MHA::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHABF16_4D,
-                         MHA,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D),
-                                            ::testing::ValuesIn(precision_bf16(4)),
-                                            ::testing::Values(ov::element::f32),
-                                            ::testing::ValuesIn({false, true}),
-                                            ::testing::Values(MHA::default_thread_count),
-                                            ::testing::Values(7),  // MHA + 5 Converts + 1 Transpose on output
-                                            ::testing::Values(6),  // MHA + 5 Converts on inputs and output
-                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
-                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
-                         MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAEnforceBF16,
-                         MHA,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D),
-                                            ::testing::ValuesIn(precision_f32(4)),
-                                            ::testing::Values(ov::element::bf16),
-                                            ::testing::ValuesIn({false}),
-                                            ::testing::Values(MHA::default_thread_count),
-                                            ::testing::Values(7),
-                                            ::testing::Values(6),
-                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
-                                            ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
-                         MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAMulAdd,
-    MHAMulAdd,
-    ::testing::Combine(
-        ::testing::ValuesIn(STATIC_SHAPES({{1, 10, 12, 16}, {1, 10, 12, 16}, {1, 10, 12, 16}})),
-        ::testing::ValuesIn(precision_f32(3)),
-        ::testing::Values(ov::element::f32),
-        ::testing::ValuesIn({false}),  // Need to support True for graph builder in tests
-        ::testing::Values(MHA::default_thread_count),
-        ::testing::Values(1),
-        ::testing::Values(1),
-        ::testing::Values(ov::test::utils::DEVICE_CPU),
-        ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-const auto& inputShapeSelect = STATIC_SHAPES(
-    // without broadcast
-    {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 12, 128, 128}, {1, 12, 128, 128}, {1, 128, 12, 64}},
-    {{1, 94, 12, 54}, {1, 94, 12, 54}, {1, 12, 94, 94}, {1, 12, 94, 94}, {1, 12, 94, 94}, {1, 94, 12, 54}},
-    // with broadcast
-    {{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 12, 1, 1}, {1, 12, 1, 1}, {1, 128, 12, 64}},
-    {{2, 52, 6, 102}, {2, 52, 6, 102}, {1, 6, 52, 52}, {1, 6, 1, 1}, {1, 6, 1, 1}, {2, 52, 6, 102}}
-);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHA,
-    MHASelect,
-    ::testing::Combine(::testing::ValuesIn(inputShapeSelect),
-                       ::testing::ValuesIn(precision_f32(6)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::Values(false),  // Need to support True for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(2),  // Less + MHA
-                       ::testing::Values(2),
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-const auto& inputShapesWOTranspose_4D = STATIC_SHAPES(
-    {{1, 12, 197, 64}, {1, 12, 64, 197}, {1, 12, 197, 64}},
-    {{1, 12, 12, 64}, {1, 12, 64, 48}, {1, 12, 48, 64}});
-const auto& inputShapesWOTranspose_3D = STATIC_SHAPES(
-    {{12, 197, 64}, {12, 64, 197}, {12, 197, 64}},
-    {{12, 128, 100}, {12, 100, 128}, {12, 128, 100}});
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeOnInputs_4D,
-    MHAWOTransposeOnInputs,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_4D),
-                       ::testing::Values(std::vector<ov::element::Type>{}),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::Values(true),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(1),
-                       ::testing::Values(1),
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTranspose_4D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_4D),
-                       ::testing::ValuesIn(precision_f32(3)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(1),
-                       ::testing::Values(1),
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTranspose_3D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_3D),
-                       ::testing::ValuesIn(precision_f32(3)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(1),
-                       ::testing::Values(1),
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-std::vector<std::vector<ov::test::InputShape>> inputShapesWOTranspose_3D_dynamic{
-        {
-                {PartialShape{-1, -1, -1}, {{12, 19, 85}, {1, 40, 36}}},
-                {PartialShape{-1, -1, -1}, {{1, 85, 19}, {2, 36, 40}}},
-                {PartialShape{-1, -1, -1}, {{12, 19, 85}, {1, 40, 36}}},
-        },
-        {
-                {PartialShape{2, -1, 64}, {{2, 9, 64}, {2, 2, 64}, {2, 9, 64}}},
-                {PartialShape{2, 64, -1}, {{2, 64, 9}, {2, 64, 2}, {2, 64, 9}}},
-                {PartialShape{2, -1, 64}, {{2, 9, 64}, {2, 2, 64}, {2, 9, 64}}},
-        },
-};
-
-
-
-INSTANTIATE_TEST_SUITE_P(
-        smoke_Snippets_DynMHAWOTranspose_3D,
-        MHAWOTranspose,
-        ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_3D_dynamic),
-                           ::testing::ValuesIn(precision_f32(3)),
-                           ::testing::Values(ov::element::f32),
-                           ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                           ::testing::Values(MHA::default_thread_count),
-                           ::testing::Values(1),
-                           ::testing::Values(1),
-                           ::testing::Values(ov::test::utils::DEVICE_CPU),
-                           ::testing::Values(CPUTestUtils::empty_plugin_config)),
-        MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeBF16_4D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_4D),
-                       ::testing::ValuesIn(precision_bf16(3)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeBF16_3D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_3D),
-                       ::testing::ValuesIn(precision_bf16(3)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeEnforceBF16_4D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_4D),
-                       ::testing::ValuesIn(precision_f32(3)),
-                       ::testing::Values(ov::element::bf16),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeEnforceBF16_3D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(inputShapesWOTranspose_3D),
-                       ::testing::ValuesIn(precision_f32(3)),
-                       ::testing::Values(ov::element::bf16),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAINT8MatMul,
-    MHAINT8MatMul,
-    ::testing::Combine(::testing::ValuesIn(std::vector<std::vector<InputShape>>(inputShapes_4D.begin(),
-                                                                                      inputShapes_4D.begin() + 2)),
-                       ::testing::Values(std::vector<element::Type>{}),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::Values(false),  // The graph doesn't contain Multiply
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(6),  // FQx3 on inputs + MHA + Transpose on output + Deq Mul
-                       ::testing::Values(5),  // FQx3 on inputs + MHA + Deq Mul
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAQuantMatMul0,
-    MHAQuantMatMul0,
-    ::testing::Combine(
-        ::testing::ValuesIn(STATIC_SHAPES({{1, 128, 768}, {1, 128, 768}, {1, 1, 1, 128}, {1, 128, 768}})),
-        ::testing::Values(std::vector<element::Type>{}),
-        ::testing::Values(ov::element::f32),
-        ::testing::Values(false),  // The graph doesn't contain Multiply
-        ::testing::Values(MHA::default_thread_count),
-        ::testing::Values(9),  // FQx2 on inputs + MHA + Transpose on output + 4 Reshapes + Deq Mul
-        ::testing::Values(4),  // FQx2 on inputs + MHA + Deq Mul
-        ::testing::Values(ov::test::utils::DEVICE_CPU),
-        ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MHAFQAfterMatMul_4D,
-                         MHAFQAfterMatMul,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D),
-                                            ::testing::Values(std::vector<element::Type>{}),
-                                            ::testing::Values(ov::element::f32),
-                                            ::testing::Values(false),  // The graph doesn't contain Multiply
-                                            ::testing::Values(MHA::default_thread_count),
-                                            ::testing::Values(3),  // MHA + Transpose on output + Deq Mul
-                                            ::testing::Values(2),  // MHA + Deq Mul
-                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
-                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
-                         MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAFQ,
-    MHAFQ,
-    ::testing::Combine(::testing::ValuesIn(STATIC_SHAPES({{1, 64, 12, 64},
-                                                          {1, 64, 12, 64},
-                                                          {1, 1, 1, 64},
-                                                          {1, 64, 12, 64}})),
-                       ::testing::Values(std::vector<element::Type>{}),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::Values(false),  // The graph doesn't contain Multiply
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(7),  // Transposex2 + Subgraphsx5
-                       ::testing::Values(5),  // MHA + Deq Mul on output + Deqs on inputs + 2 xFQ on inputs
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-std::vector<std::vector<ov::test::InputShape>> inputShapesTransposedB {
-    {
-        {{}, {{1, 12, 12, 64}}},
-        {{}, {{1, 12, 48, 64}}},
-        {{}, {{1, 12, 48, 64}}}
-    },
-    {
-        {PartialShape{-1, 3, -1, 64}, {{1, 3, 12, 64}, {2, 3, 36, 64}}},
-        {PartialShape{-1, 3, -1, 64}, {{1, 3, 14, 64}, {2, 3, 42, 64}}},
-        {PartialShape{-1, 3, -1, -1}, {{1, 3, 14, 36}, {2, 3, 42, 36}}},
-    },
-    {
-        {PartialShape{2, -1, 32, -1}, {{2, 1, 32, 70}, {2, 2, 32, 96}}},
-        {PartialShape{2, -1, 49, -1}, {{2, 3, 49, 70}, {2, 1, 49, 96}}},
-        {PartialShape{2, -1, 49, -1}, {{2, 1, 49, 17}, {2, 2, 49, 81}}},
-    },
-};
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHATransposedB,
-    MHATransposedB,
-    ::testing::Combine(::testing::ValuesIn(inputShapesTransposedB),
-                       ::testing::Values(std::vector<element::Type>{}),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn({true}),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(1),
-                       ::testing::Values(1),
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-const auto& inputShapesExtractedReshape = STATIC_SHAPES(
-    {{2, 196, 64}, {2, 64, 196}, {2, 14, 14, 14, 1}, {2, 14, 14, 1, 14}, {2, 196, 64}},
-    {{1, 16, 10}, {1, 10, 16}, {1, 4, 4, 4, 1}, {1, 4, 4, 1, 4}, {1, 16, 10}},
-    {{1, 16, 10}, {1, 10, 16}, {1, 1, 1, 1, 1}, {1, 4, 4, 4, 4}, {1, 16, 10}},
-    {{1, 16, 10}, {1, 10, 16}, {1, 4, 4, 4, 4}, {1, 1, 1, 1, 1}, {1, 16, 10}},
-    {{1, 4, 16, 10}, {1, 4, 10, 16}, {1, 4, 256}, {1, 4, 256}, {1, 4, 16, 10}},
-    {{1, 4, 16, 10}, {1, 4, 10, 16}, {1, 1, 256}, {1, 4, 1}, {1, 4, 16, 10}});
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWithExtractedReshape,
-    MHAWithExtractedReshape,
-    ::testing::Combine(::testing::ValuesIn(inputShapesExtractedReshape),
-                       ::testing::Values(std::vector<element::Type>{}),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::ValuesIn({true}),  // False is not supported for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(3),  // Extracted Add + Extracted Reshape + MHA
-                       ::testing::Values(2),  // Extracted Add + MHA
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-std::vector<std::vector<ov::test::InputShape>> inputShapes_4D_WithMul_dynamic{
-        {
-            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 70, 3, 19}, {1, 128, 3, 64}, {1, 68, 6, 87}}},
-            {PartialShape{-1, -1, -1, -1}, {{1, 128, 1, 64}, {2, 49, 1, 19}, {1, 128, 1, 64}, {2, 13, 6, 87}}},
-            {PartialShape{1},              {{1},             {1},            {1},             {1} }},
-            {PartialShape{-1, -1, -1, -1}, {{2, 1, 128, 128}, {1, 1, 70, 49}, {2, 1, 128, 128}, {1, 1, 68, 13}}},
-            {PartialShape{-1, -1, -1, -1}, {{1, 128, 3, 64}, {1, 49, 3, 19}, {1, 128, 3, 64}, {2, 13, 6, 87}}},
-        },
-        {
-            {PartialShape{-1, -1, 12, 64}, {{1, 70, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 20, 12, 64}, {1, 70, 12, 64}}},
-            {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {2, 10, 12, 64}, {2, 1, 12, 64},  {2, 10, 12, 64}, {1, 35, 12, 64}}},
-            {PartialShape{-1, 12, 64, -1}, {{1, 12, 64, 35}, {1, 12, 64, 10}, {1, 12, 64, 10}, {1, 12, 64, 1},  {1, 12, 64, 35}}},
-            {PartialShape{-1, 12, -1, -1}, {{2, 12, 70, 35}, {1, 12, 20, 10}, {1, 12, 20, 10}, {1, 12, 20, 1},  {2, 12, 70, 35}}},
-            {PartialShape{-1, -1, 12, 64}, {{1, 35, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 10, 12, 64}, {1, 35, 12, 64}}},
-        }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_Snippets_DynMHA_4D_WithMul,
-                         MHAWithDynamicMul,
-                         ::testing::Combine(::testing::ValuesIn(inputShapes_4D_WithMul_dynamic),
-                                            ::testing::ValuesIn(precision_f32(5)),
-                                            ::testing::Values(ov::element::f32),
-                                            ::testing::Values(MHA::default_thread_count),
-                                            ::testing::Values(1),
-                                            ::testing::Values(1),
-                                            ::testing::Values(ov::test::utils::DEVICE_CPU),
-                                            ::testing::Values(CPUTestUtils::empty_plugin_config)),
-                         MHAWithDynamicMul::getTestCaseName);
+}  // namespace MHASplitDimensionMInstances
 
 }  // namespace
 }  // namespace snippets

--- a/src/tests/functional/plugin/shared/include/snippets/mha.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/mha.hpp
@@ -44,6 +44,7 @@ protected:
     void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
     virtual std::shared_ptr<SnippetsFunctionBase> get_subgraph() const = 0;
     virtual void init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) = 0;
+    virtual void init_thresholds();
 
     size_t m_thread_count;
     std::vector<ov::element::Type> m_input_types;
@@ -88,6 +89,7 @@ class MHATransposedB : public MHA {
 class MHAINT8MatMul : public MHA {
 protected:
     std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
+    void init_thresholds() override;
 };
 
 class MHAQuantMatMul0 : public MHA {
@@ -103,6 +105,7 @@ protected:
 class MHAFQ : public MHA {
 protected:
     std::shared_ptr<SnippetsFunctionBase> get_subgraph() const override;
+    void init_thresholds() override;
 };
 
 class MHAWithExtractedReshape : public MHA {

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -53,15 +53,19 @@ void MHABase::SetUp() {
         configuration.insert({"SNIPPETS_MODE", "IGNORE_CALLBACK"});
     }
 
-    setInferenceType(prc);
     inType = outType = prc;
+    setInferenceType(prc);
+    init_thresholds();
+}
+
+ void MHABase::init_thresholds() {
     // Note: Libxsmm calculates Exp in a slightly different way, so the abs values might differ a bit. Ticket: 130699
 #ifdef SNIPPETS_LIBXSMM_TPP
     abs_threshold = 1e-6;
 #endif
-    if (prc == ov::element::bf16)
+    if (inType == ov::element::bf16)
         rel_threshold = 0.05f;
-}
+ }
 
 std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj) {
     std::vector<InputShape> input_shapes;
@@ -194,6 +198,11 @@ std::shared_ptr<SnippetsFunctionBase> MHAINT8MatMul::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAINT8MatMulFunction>(inputDynamicShapes);
 }
 
+void MHAINT8MatMul::init_thresholds() {
+    MHABase::init_thresholds();
+    abs_threshold = 4e-6;
+}
+
 std::shared_ptr<SnippetsFunctionBase> MHAQuantMatMul0::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAQuantMatMul0Function>(inputDynamicShapes);
 }
@@ -204,6 +213,11 @@ std::shared_ptr<SnippetsFunctionBase> MHAFQAfterMatMul::get_subgraph() const {
 
 std::shared_ptr<SnippetsFunctionBase> MHAFQ::get_subgraph() const {
     return std::make_shared<ov::test::snippets::MHAFQFunction>(inputDynamicShapes);
+}
+
+void MHAFQ::init_thresholds() {
+    MHABase::init_thresholds();
+    abs_threshold = 0.016;
 }
 
 std::shared_ptr<SnippetsFunctionBase> MHAMulAdd::get_subgraph() const {

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_mha.hpp
@@ -235,9 +235,7 @@ protected:
  *            FakeQuantize i8
  *                 \   /
  *                  Add
- *                Reshape0
- *                Softmax
- *                Reshape1  Transpose2[0,2,1,3]
+ *                Softmax   Transpose2[0,2,1,3]
  *                    \      /
  *                     MatMul1
  *                   FakeQuantize i8
@@ -261,9 +259,7 @@ protected:
  *            FakeQuantize i8
  *                 \   /
  *                  Add
- *                Reshape0
- *                Softmax
- *                Reshape1   FakeQuantize i8
+ *                Softmax    FakeQuantize i8
  *            FakeQuantize u8 Transpose2[0,2,1,3]
  *                    \      /
  *                     MatMul1
@@ -281,20 +277,17 @@ protected:
 };
 
 /* Graph:
- *   FakeQuantize i8      Reshape1
- *       Reshape0       Transpose1[0,2,3,1]
+ *   FakeQuantize i8      Transpose1[0,2,3,1]
  * Transpose0[0,2,1,3] FakeQuantize i8
  *              \     /
  *              MatMul0
  *                 \   /
- *                  Add        Reshape2
+ *                  Add
  *                Softmax   Transpose2[0,2,1,3]
  *                    \      /
  *                     MatMul1
  *                  FakeQuantize i8
  *                  Transpose3[0,2,1,3]
- *                    Reshape3
- * Note: Reshapes are tosplit Tokenization between FQs and deq Mul and MHA since Snippets::Ignore_Callback may be enabled
  */
 class MHAQuantMatMul0Function : public SnippetsFunctionBase {
 public:


### PR DESCRIPTION
### Details:
 - *Refactored CPU MHA tests - added more dynamic tests for INT8/BF16*
 - *Enabled dynamic INT8|BF16 MHA tokenization on non AMX-platforms*

### Tickets:
 - *150840*

### Prerequisites:
- [x] https://github.com/openvinotoolkit/openvino/pull/26413
- [x] https://github.com/openvinotoolkit/openvino/pull/26493