### PR TITLE
Limit metrics workflow to openvino repository only

### DIFF
--- a/.github/workflows/send_workflows_to_opentelemetry.yml
+++ b/.github/workflows/send_workflows_to_opentelemetry.yml
@@ -37,6 +37,7 @@ jobs:
   otel-export-trace:
     name: Export finished workflow metrics
     runs-on: aks-linux-2-cores-8gb
+    if: github.repository == 'openvinotoolkit/openvino'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Details:
This will prevents the metrics workflow from begin run on openvinotoolkit/openvino forks.
