### PR TITLE
[ARM] Use OpenMP in ACL build if `THREADING=OMP`

### DIFF
--- a/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
+++ b/src/plugins/intel_cpu/thirdparty/ACLConfig.cmake
@@ -131,8 +131,6 @@ elseif(NOT TARGET arm_compute::arm_compute)
     set(ARM_COMPUTE_OPTIONS
         neon=1
         opencl=0
-        openmp=0
-        cppthreads=1
         examples=0
         Werror=0
         gemm_tuner=0
@@ -145,6 +143,14 @@ elseif(NOT TARGET arm_compute::arm_compute)
         data_layout_support=all
         arch=${OV_CPU_ARM_TARGET_ARCH}
     )
+
+    if(THREADING STREQUAL "OMP")
+        list(APPEND ARM_COMPUTE_OPTIONS openmp=1
+                                        cppthreads=0)
+    else()
+        list(APPEND ARM_COMPUTE_OPTIONS openmp=0
+                                        cppthreads=1)
+    endif()
 
     if(ARM)
         list(APPEND ARM_COMPUTE_OPTIONS estate=32)


### PR DESCRIPTION
### Details:
 - ACL should use OpenMP scheduler if OpenVINO is built with `THREADING=OMP` option

### Tickets:
 - *ticket-id*
