### PR TITLE
[DOCS] Removing IOT Devkit references

### DIFF
--- a/docs/articles_en/documentation/legacy-features/install-dev-tools.rst
+++ b/docs/articles_en/documentation/legacy-features/install-dev-tools.rst
@@ -257,7 +257,3 @@ Additional Resources
 ####################
 
 - `Intel® Distribution of OpenVINO™ toolkit home page <https://software.intel.com/en-us/openvino-toolkit>`__
-- For IoT Libraries & Code Samples, see `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__ .
-
-
-

--- a/docs/articles_en/documentation/openvino-security.rst
+++ b/docs/articles_en/documentation/openvino-security.rst
@@ -72,4 +72,3 @@ Additional Resources
 - :doc:`Convert a Model <legacy-features/transition-legacy-conversion-api/legacy-conversion-api>`.
 - :doc:`OpenVINO™ Runtime User Guide <../openvino-workflow/running-inference>`.
 - For more information on Sample Applications, see the :doc:`OpenVINO Samples Overview <../learn-openvino/openvino-samples>`
-- For IoT Libraries and Code Samples, see the `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__.

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-linux.rst
@@ -328,8 +328,3 @@ Additional Resources
 * Writing your own OpenVINO™ applications: :doc:`OpenVINO™ Runtime User Guide <../../../openvino-workflow/running-inference>`
 * Sample applications: :doc:`OpenVINO™ Toolkit Samples Overview <../../../learn-openvino/openvino-samples>`
 * Pre-trained deep learning models: :doc:`Overview of OpenVINO™ Toolkit Pre-Trained Models <../../../documentation/legacy-features/model-zoo>`
-* IoT libraries and code samples in the GitHub repository: `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__
-
-
-
-

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-macos.rst
@@ -205,7 +205,3 @@ Additional Resources
 * :doc:`Write your own OpenVINO™ applications <../../../openvino-workflow/running-inference/integrate-openvino-with-your-application>`
 * Sample applications: :doc:`OpenVINO™ Toolkit Samples Overview <../../../learn-openvino/openvino-samples>`
 * Pre-trained deep learning models: :doc:`Overview of OpenVINO™ Toolkit Pre-Trained Models <../../../documentation/legacy-features/model-zoo>`
-* IoT libraries and code samples in the GitHUB repository: `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__
-
-
-

--- a/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-archive-windows.rst
@@ -249,5 +249,3 @@ Additional Resources
 * :doc:`Write your own OpenVINO™ applications <../../../openvino-workflow/running-inference/integrate-openvino-with-your-application>`
 * Sample applications: :doc:`OpenVINO™ Toolkit Samples Overview <../../../learn-openvino/openvino-samples>`
 * Pre-trained deep learning models: :doc:`Overview of OpenVINO™ Toolkit Pre-Trained Models <../../../documentation/legacy-features/model-zoo>`
-* IoT libraries and code samples in the GitHUB repository: `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__
-

--- a/docs/articles_en/get-started/install-openvino/install-openvino-npm.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-npm.rst
@@ -56,4 +56,3 @@ Additional Resources
 ####################
 
 - Intel® Distribution of OpenVINO™ toolkit home page: https://software.intel.com/en-us/openvino-toolkit
-- For IoT Libraries & Code Samples, see `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__.

--- a/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-pip.rst
@@ -149,5 +149,3 @@ Additional Resources
 ####################
 
 - Intel® Distribution of OpenVINO™ `toolkit home page <https://software.intel.com/en-us/openvino-toolkit>`__
-- For IoT Libraries & Code Samples, see `Intel® IoT Developer Kit <https://github.com/intel-iot-devkit>`__.
-

--- a/docs/articles_en/learn-openvino/openvino-samples/get-started-demos.rst
+++ b/docs/articles_en/learn-openvino/openvino-samples/get-started-demos.rst
@@ -272,7 +272,6 @@ Download a Media to use
 Most of the samples require you to provide an image or a video as input for the model. OpenVINO provides several sample images and videos for you to run code samples and demo applications:
 
 - `Sample images and video <https://storage.openvinotoolkit.org/data/test_data/>`__
-- `Sample videos <https://github.com/intel-iot-devkit/sample-videos>`__
 
 To run the sample applications, you can use images and videos from the media files collection available `here <https://storage.openvinotoolkit.org/data/test_data>`__ . As an alternative, you can get them from sites like `Pexels <https://pexels.com>`__ or `Google Images <https://images.google.com>`__ .
 


### PR DESCRIPTION
Removing references to internal resources of IoT Devkit found in OpenVINO documentation. This PR addresses the following JIRA ticket: 105801
