### PR TITLE
[Transformations] Extend LSTMSequenceFusion transformation with multiply-by-one pattern

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -24,6 +24,7 @@
 #include "openvino/op/loop.hpp"
 #include "openvino/op/lstm_cell.hpp"
 #include "openvino/op/lstm_sequence.hpp"
+#include "openvino/op/multiply.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/op/range.hpp"
 #include "openvino/op/reshape.hpp"
@@ -361,6 +362,38 @@ bool check_condition_true_pattern(const std::shared_ptr<op::v0::Result>& cond_re
     return true;
 }
 
+void create_mul_by_one_pattern(std::shared_ptr<Node>& param,
+                               std::shared_ptr<Node>& broadcast_value,
+                               std::shared_ptr<Node>& mul,
+                               bool with_first_squeeze = false) {
+    param = pattern::wrap_type<op::v0::Parameter>();
+    auto shape_of_input = param;
+    if (with_first_squeeze) {
+        auto first_squeeze_axes = pattern::wrap_type<op::v0::Constant>();
+        shape_of_input = pattern::wrap_type<op::v0::Squeeze>({param, first_squeeze_axes});
+    }
+    auto shape_of = pattern::wrap_type<op::v3::ShapeOf>({shape_of_input});
+    auto concat_value = pattern::wrap_type<op::v0::Constant>();
+    auto concat = pattern::wrap_type<op::v0::Concat>({concat_value, shape_of});
+    broadcast_value = pattern::wrap_type<op::v0::Constant>();
+    auto broadcast = pattern::wrap_type<op::v3::Broadcast>({broadcast_value, concat});
+    auto squeeze_axes = pattern::wrap_type<op::v0::Constant>();
+    auto squeeze = pattern::wrap_type<op::v0::Squeeze>({broadcast, squeeze_axes});
+    mul = pattern::wrap_type<op::v1::Multiply>({shape_of_input, squeeze});
+}
+
+bool check_const_one(const std::shared_ptr<Node>& node) {
+    auto const_node = ov::as_type_ptr<op::v0::Constant>(node);
+    if (!const_node) {
+        return false;
+    }
+    auto const_values = const_node->get_vector<float>();
+    if (const_values.size() != 1 || const_values[0] != 1) {
+        return false;
+    }
+    return true;
+}
+
 bool check_lstm_cell_pattern(
     const std::shared_ptr<op::v5::Loop>& loop,
     const ov::ParameterVector& body_params,
@@ -386,8 +419,19 @@ bool check_lstm_cell_pattern(
     auto R_label = pattern::wrap_type<op::v0::Constant>();
     auto B_label = pattern::wrap_type<op::v0::Constant>();
 
+    // TODO: 152648 - remove this WA
+    // create multiply by one pattern for x input
+    std::shared_ptr<Node> x_param, x_broadcast_value, x_mul;
+    create_mul_by_one_pattern(x_param, x_broadcast_value, x_mul, true);
+    // create multiply by one pattern for hidden state input
+    std::shared_ptr<Node> h_param, h_broadcast_value, h_mul;
+    create_mul_by_one_pattern(h_param, h_broadcast_value, h_mul, false);
+
+    auto xi_common_label = std::make_shared<pattern::op::Or>(OutputVector{xi_reshape_label, x_mul});
+    auto hidden_common_label = std::make_shared<pattern::op::Or>(OutputVector{init_hidden_state_i_label, h_mul});
+
     auto lstm_cell_label = pattern::wrap_type<op::v4::LSTMCell>(
-        {xi_reshape_label, init_hidden_state_i_label, init_cell_state_i_label, W_label, R_label, B_label});
+        {xi_common_label, hidden_common_label, init_cell_state_i_label, W_label, R_label, B_label});
     auto unsqueeze_axis_label = pattern::wrap_type<op::v0::Constant>();
     auto unsqueeze_hidden_state_label = pattern::wrap_type<op::v0::Unsqueeze>({lstm_cell_label, unsqueeze_axis_label});
     auto result_hidden_state_label = pattern::wrap_type<op::v0::Result>({unsqueeze_hidden_state_label});
@@ -420,6 +464,23 @@ bool check_lstm_cell_pattern(
     if (!result_hidden_state) {
         return false;
     }
+
+    // re-assign keys for pattern if multiply-by-one pattern was applied
+    if (lstm_cell_map.count(h_param)) {
+        // check that broadcasted value is equal to one
+        if (!check_const_one(lstm_cell_map.at(h_broadcast_value).get_node_shared_ptr())) {
+            return false;
+        }
+        init_hidden_state_i_label = h_param;
+    }
+    if (lstm_cell_map.count(x_param)) {
+        // check that broadcasted value is equal to one
+        if (!check_const_one(lstm_cell_map.at(x_broadcast_value).get_node_shared_ptr())) {
+            return false;
+        }
+        xi_label = x_param;
+    }
+
     for (const auto& input_desc : input_descriptions) {
         auto param_idx = input_desc->m_body_parameter_index;
         auto input_idx = input_desc->m_input_index;

--- a/src/common/transformations/tests/op_conversions/convert_ti_to_sequences_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_ti_to_sequences_test.cpp
@@ -1271,7 +1271,8 @@ using LoopWithLSTMCellToLSTMSequenceFusionParam = std::tuple<std::string,  // f 
                                                              std::string,  // g activation function
                                                              std::string,  // h activation function
                                                              size_t,       // input size
-                                                             size_t>;      // hidden size
+                                                             size_t,       // hidden size
+                                                             bool>;        // with mul-by-one pattern
 
 class LoopWithLSTMCellToLSTMSequenceFusionTest
     : public testing::WithParamInterface<LoopWithLSTMCellToLSTMSequenceFusionParam>,
@@ -1286,6 +1287,17 @@ void generate_weights_value(std::vector<float>& weights_value, const Shape& weig
         weights_value[i] = distribution(rng);
     }
 }
+
+std::shared_ptr<Node> stitch_mul_by_one_pattern(const std::shared_ptr<Node>& in_node) {
+    auto shape_of = std::make_shared<op::v3::ShapeOf>(in_node);
+    auto concat_value = std::make_shared<op::v0::Constant>(element::i64, Shape{1}, 1);
+    auto concat = std::make_shared<op::v0::Concat>(OutputVector{concat_value, shape_of}, 0);
+    auto broadcast_value = std::make_shared<op::v0::Constant>(element::f32, Shape{1}, 1);
+    auto broadcast = std::make_shared<op::v3::Broadcast>(broadcast_value, concat);
+    auto squeeze_axes = std::make_shared<op::v0::Constant>(element::i64, Shape{1}, 0);
+    auto squeeze = std::make_shared<op::v0::Squeeze>(broadcast, squeeze_axes);
+    return std::make_shared<op::v1::Multiply>(in_node, squeeze);
+}
 }  // namespace
 
 TEST_P(LoopWithLSTMCellToLSTMSequenceFusionTest, FusionTest) {
@@ -1295,6 +1307,7 @@ TEST_P(LoopWithLSTMCellToLSTMSequenceFusionTest, FusionTest) {
     const std::string& h_activation = std::get<2>(param);
     size_t input_size = std::get<3>(param);
     size_t hidden_size = std::get<4>(param);
+    bool with_mul_by_one_pattern = std::get<5>(param);
     size_t batch_size = 2;
     size_t time_len = 10;
 
@@ -1314,15 +1327,22 @@ TEST_P(LoopWithLSTMCellToLSTMSequenceFusionTest, FusionTest) {
         // create body graph with LSTMCell
         auto xi = std::make_shared<op::v0::Parameter>(element::f32, Shape{1, batch_size, input_size});
         auto squeeze_axis = std::make_shared<op::v0::Constant>(element::i64, Shape{}, 0);
-        auto xi_squeeze = std::make_shared<op::v0::Squeeze>(xi, squeeze_axis);
+        std::shared_ptr<ov::Node> xi_squeeze = std::make_shared<op::v0::Squeeze>(xi, squeeze_axis);
+        if (with_mul_by_one_pattern) {
+            xi_squeeze = stitch_mul_by_one_pattern(xi_squeeze);
+        }
         auto init_hidden_state = std::make_shared<op::v0::Parameter>(element::f32, Shape{batch_size, hidden_size});
+        std::shared_ptr<ov::Node> hidden_state_to_lstm_cell = init_hidden_state;
+        if (with_mul_by_one_pattern) {
+            hidden_state_to_lstm_cell = stitch_mul_by_one_pattern(init_hidden_state);
+        }
         auto init_cell_state = std::make_shared<op::v0::Parameter>(element::f32, Shape{batch_size, hidden_size});
         auto w_const = op::v0::Constant::create(element::f32, w_shape, w);
         auto r_const = op::v0::Constant::create(element::f32, r_shape, r);
         auto b_const = op::v0::Constant::create(element::f32, b_shape, b);
         auto lstm_cell =
             std::make_shared<op::v4::LSTMCell>(xi_squeeze,
-                                               init_hidden_state,
+                                               hidden_state_to_lstm_cell,
                                                init_cell_state,
                                                w_const,
                                                r_const,
@@ -1459,4 +1479,5 @@ INSTANTIATE_TEST_SUITE_P(LoopWithLSTMCellToLSTMSequenceFusion,
                                           testing::Values("sigmoid", "relu"),
                                           testing::Values("tanh", "relu"),
                                           testing::Values(2, 3),
-                                          testing::Values(3, 4)));
+                                          testing::Values(3, 4),
+                                          testing::Values(true, false)));


### PR DESCRIPTION
**Details:** In customer model, there is a sub-graph under ShapeOf that is equivalent to multiplication by one. It can be eliminated and make LSTMSequence fusion possible

**Ticket:** 149687
