### PR TITLE
[CPU][ARM] Do not run SLT Deconvolution tests with blocked layout on ARM

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/arm/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/arm/convolution_backprop_data.cpp
@@ -81,48 +81,4 @@ INSTANTIATE_TEST_SUITE_P(nightly_arm_Deconv_2D_Planar_FP32,
                                             ::testing::ValuesIn(filterCPUInfo({conv_gemm_2D, conv_gemm_acl_2D, conv_gemm_acl_2D_nspc})),
                                             ::testing::Values(empty_plugin_config)),
                          DeconvolutionLayerCPUTest::getTestCaseName);
-
-/* ============= Deconvolution auto padding tests ============= */
-const std::vector<DeconvInputData> inputs_2D_AutoPadding = {
-        DeconvInputData{InputShape{{}, {{2, 67, 7, 7}}}, ov::test::utils::InputLayerType::CONSTANT, {}},
-        DeconvInputData{InputShape{{-1, 67, -1, -1}, {{1, 67, 9, 4}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
-                        ov::test::utils::InputLayerType::CONSTANT,
-                        {}},
-        DeconvInputData{InputShape{{-1, 67, -1, -1}, {{2, 67, 7, 7}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
-                        ov::test::utils::InputLayerType::CONSTANT,
-                        {}},
-        DeconvInputData{InputShape{{-1, 67, -1, -1}, {{1, 67, 9, 4}, {2, 67, 5, 7}, {1, 67, 9, 4}}},
-                        ov::test::utils::InputLayerType::PARAMETER,
-                        {}}};
-
-const auto deconvParams_AutoPadding_2D =
-        ::testing::Combine(::testing::ValuesIn(kernels2d),
-                           ::testing::ValuesIn(strides2d),
-                           ::testing::ValuesIn(padBegins2d),
-                           ::testing::ValuesIn(padEnds2d),
-                           ::testing::ValuesIn(dilations2d),
-                           ::testing::ValuesIn(numOutChannels_Blocked),
-                           ::testing::Values(ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER),
-                           ::testing::ValuesIn(emptyOutputPadding));
-
-INSTANTIATE_TEST_SUITE_P(smoke_arm_Deconv_2D_AutoPadding_FP16,
-                         DeconvolutionLayerCPUTest,
-                         ::testing::Combine(deconvParams_AutoPadding_2D,
-                                            ::testing::ValuesIn(inputs_2D_AutoPadding),
-                                            ::testing::Values(ElementType::f16),
-                                            ::testing::Values(emptyFusingSpec),
-                                            ::testing::ValuesIn(filterCPUInfo({conv_gemm_2D, conv_gemm_acl_2D, conv_gemm_acl_2D_nspc, conv_avx512_2D})),
-                                            ::testing::Values(cpu_f16_plugin_config)),
-                         DeconvolutionLayerCPUTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_arm_Deconv_2D_AutoPadding_FP32,
-                         DeconvolutionLayerCPUTest,
-                         ::testing::Combine(deconvParams_AutoPadding_2D,
-                                            ::testing::ValuesIn(inputs_2D_AutoPadding),
-                                            ::testing::Values(ElementType::f32),
-                                            ::testing::Values(emptyFusingSpec),
-                                            ::testing::ValuesIn(filterCPUInfo({conv_gemm_2D, conv_gemm_acl_2D, conv_gemm_acl_2D_nspc, conv_avx512_2D})),
-                                            ::testing::Values(empty_plugin_config)),
-                         DeconvolutionLayerCPUTest::getTestCaseName);
-
 } // namespace


### PR DESCRIPTION
### Details:
 - There were 2 SLT Deconvolution tests (`smoke_arm_Deconv_2D_AutoPadding_FP16`, `smoke_arm_Deconv_2D_AutoPadding_FP32`) that test blocked layouts on ARM.
 - ARM does not support blocked layout, so these tests were removed
 - It was verified that removed tests are already presented in `x64` directory, so no need to add these tests in `x64`.
 - It was discussed with @allnes that tests with planar layout are splited as well, @allnes is going to verify the possibility to move planar tests into `common` directory. Planar tests refactoring is not part of this PR.

### Tickets:
 - *ticket-id*
