### PR TITLE
[Snippets] Fix sporadic issue in MHAParallelWAOptimizer

### DIFF
--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -179,13 +179,13 @@ protected:
         static std::unordered_set<size_t> find_unsqueezed_params(
             const ov::snippets::lowered::LinearIRCPtr& linear_ir,
             const std::unordered_set<snippets::lowered::ExpressionPtr>& brgemms);
-        static std::unordered_set<ov::snippets::lowered::ExpandedLoopInfoPtr> find_loops_to_split(
+        static std::vector<ov::snippets::lowered::ExpandedLoopInfoPtr> find_loops_to_split(
             const ov::snippets::lowered::LinearIRCPtr& linear_ir,
             const std::unordered_set<size_t>& unsqueezed_params);
 
         RuntimeConfigurator* configurator = nullptr;
 
-        std::unordered_set<ov::snippets::lowered::ExpandedLoopInfoPtr> loops_to_split{};
+        std::vector<ov::snippets::lowered::ExpandedLoopInfoPtr> loops_to_split{};
         std::unordered_set<size_t> unsqueezed_params{};
         std::vector<std::vector<size_t>> optimized_layouts{};
         std::vector<size_t> m_dim_idces{};

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -85,8 +85,12 @@ size_t InsertSpecificIterations::get_decomposed_loop_work_amount(const UnifiedLo
             return is_dynamic ? remaining_work_amount : increment;
         case (SpecificLoopIterType::MAIN_BODY):
             return is_dynamic ? remaining_work_amount : (remaining_work_amount / increment) * increment;
-        case (SpecificLoopIterType::LAST_ITER):
+        case (SpecificLoopIterType::LAST_ITER): {
+            OPENVINO_ASSERT(is_dynamic || remaining_work_amount < unified_loop_info->get_increment(),
+                            "Last iter work amount (", remaining_work_amount,
+                            ") must be less than the UnifiedLoopInfo's increment: ", unified_loop_info->get_increment());
             return remaining_work_amount;
+        }
         default:
             OPENVINO_THROW("Unknown SpecificLoopIterType!");
     }

--- a/src/common/snippets/src/runtime_configurator.cpp
+++ b/src/common/snippets/src/runtime_configurator.cpp
@@ -510,11 +510,8 @@ std::vector<ExpandedLoopInfoPtr> RuntimeConfigurator::MHAParallelWAOptimizer::fi
 
     const auto& loops_map = linear_ir->get_loop_manager()->get_map();
     std::vector<ExpandedLoopInfoPtr> loops_to_split;
-    for (const auto& id : loop_idces_to_split) {
-        const auto expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loops_map.at(id));
-        OPENVINO_ASSERT(expanded_loop_info, "Loop info to split must be ExpandedLoopInfo");
-        loops_to_split.push_back(expanded_loop_info);
-    }
+    for (const auto& id : loop_idces_to_split)
+        loops_to_split.push_back(ov::as_type_ptr<ExpandedLoopInfo>(loops_map.at(id)));
     return loops_to_split;
 }
 


### PR DESCRIPTION
### Details:
 - *Currently, `loops_to_split` in `MHAParallelWAOptimizer` are stored in unordered_map, so elements order is not determined. This sporadically leads to the situation when loop last iteration has work_amount more than main body's increment. This might lead to failures*
 - *In this PR, 'loops_to_split' are stored in vector, so loop information updates are always called for expanded loop infos in determined order: FIRST_ITER->MAIN_BODY->LAST_ITER*
 - *Also, the corresponding assert is added to `InsertSpecificIterations::get_decomposed_loop_work_amount` in order to throw an exception on early stage in case of incorrect configuration. This assert also allows to cover the changes by the existing tests (some of them fail if assert is added but the fix is not applied)*

### Tickets:
 - *N/A*
