### PR TITLE
[GHA] Enable parallel execution of TensorFlow Lite Layer python tests

### DIFF
--- a/.github/workflows/job_python_unit_tests.yml
+++ b/.github/workflows/job_python_unit_tests.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: TensorFlow Lite Layer Tests - TFL FE
         if: fromJSON(inputs.affected-components).TFL_FE.test
-        run: python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow_lite_tests/ --junitxml=${INSTALL_TEST_DIR}/TEST-tfl_fe.xml
+        run: python3 -m pytest ${LAYER_TESTS_INSTALL_DIR}/tensorflow_lite_tests/ -n logical --junitxml=${INSTALL_TEST_DIR}/TEST-tfl_fe.xml
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16

--- a/.github/workflows/windows_vs2019_release.yml
+++ b/.github/workflows/windows_vs2019_release.yml
@@ -340,7 +340,7 @@ jobs:
         if: fromJSON(needs.smart_ci.outputs.affected_components).TFL_FE.test
         shell: cmd
         run: |
-          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow_lite_tests/ --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tfl_fe.xml
+          python3 -m pytest ${{ env.LAYER_TESTS_INSTALL_DIR }}/tensorflow_lite_tests/ -n logical --junitxml=${{ env.INSTALL_TEST_DIR }}/TEST-tfl_fe.xml
         env:
           TEST_DEVICE: CPU
           TEST_PRECISION: FP16

--- a/tests/layer_tests/common/tflite_layer_test_class.py
+++ b/tests/layer_tests/common/tflite_layer_test_class.py
@@ -34,7 +34,7 @@ class TFLiteLayerTest(CommonLayerTest):
                                                          input_tensors=input_tensors,
                                                          output_tensors=output_tensors).convert()
 
-        tflite_model_path = os.path.join(os.path.dirname(save_path), 'model.tflite')
+        tflite_model_path = os.path.join(save_path, 'model.tflite')
         with tf.io.gfile.GFile(tflite_model_path, 'wb') as f:
             f.write(tflite_model)
         return tflite_model_path

--- a/tests/layer_tests/common/utils/tflite_utils.py
+++ b/tests/layer_tests/common/utils/tflite_utils.py
@@ -54,13 +54,13 @@ additional_test_params = [
     ],
     [
         {'activation': None},
-        {'activation': tf.nn.relu},
-        {'activation': tf.nn.relu6},
+        {'activation': 'tf.nn.relu'},
+        {'activation': 'tf.nn.relu6'},
         # skip tanh and signbit since tflite doesn't fuse such activations
         # https://github.com/tensorflow/tensorflow/blob/77d8c333405a080c57850c45531dbbf077b2bd0e/tensorflow/compiler/mlir/lite/transforms/optimize_patterns.td#L86:L89
         # {'activation': tf.math.tanh},
         # {'activation': lambda x, name: tf.identity(tf.experimental.numpy.signbit(x), name=name)},
-        {'activation': lambda x, name: tf.math.minimum(tf.math.maximum(-1., x), 1., name=name)}
+        {'activation': 'lambda x, name: tf.math.minimum(tf.math.maximum(-1., x), 1., name=name)'}
     ]
 ]
 

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_ArgValue.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_ArgValue.py
@@ -6,8 +6,8 @@ from common.utils.tflite_utils import additional_test_params
 from common.utils.tflite_utils import parametrize_tests
 
 test_ops = [
-    {'op_name': 'ARG_MAX', 'op_func': tf.math.argmax},
-    {'op_name': 'ARG_MIN', 'op_func': tf.math.argmin},
+    {'op_name': 'ARG_MAX', 'op_func': 'tf.math.argmax'},
+    {'op_name': 'ARG_MIN', 'op_func': 'tf.math.argmin'},
 ]
 
 test_params = [
@@ -31,7 +31,7 @@ class TestTFLiteArgValueLayerTest(TFLiteLayerTest):
         with tf.compat.v1.Session() as sess:
             place_holder = tf.compat.v1.placeholder(params.get('dtype', tf.float32), params['shape'],
                                                     name=self.inputs[0])
-            params['op_func'](place_holder, axis=params['axis'], name=self.outputs[0])
+            eval(params['op_func'])(place_holder, axis=params['axis'], name=self.outputs[0])
             net = sess.graph_def
         return net
 

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_Binary.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_Binary.py
@@ -6,20 +6,20 @@ from common.tflite_layer_test_class import TFLiteLayerTest
 from common.utils.tflite_utils import parametrize_tests
 
 test_ops = [
-    {'op_name': 'EQUAL', 'op_func': tf.math.equal},
-    {'op_name': 'FLOOR_MOD', 'op_func': tf.math.floormod, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'FLOOR_DIV', 'op_func': tf.math.floordiv, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'GREATER', 'op_func': tf.math.greater},
-    {'op_name': 'GREATER_EQUAL', 'op_func': tf.math.greater_equal},
-    {'op_name': 'LESS', 'op_func': tf.math.less},
-    {'op_name': 'LESS_EQUAL', 'op_func': tf.math.less_equal},
-    {'op_name': 'LOGICAL_AND', 'op_func': tf.math.logical_and, 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
-    {'op_name': 'LOGICAL_OR', 'op_func': tf.math.logical_or, 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
-    {'op_name': 'MAXIMUM', 'op_func': tf.math.maximum},
-    {'op_name': 'MINIMUM', 'op_func': tf.math.minimum},
-    {'op_name': 'NOT_EQUAL', 'op_func': tf.math.not_equal},
-    {'op_name': 'POW', 'op_func': tf.math.pow, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'SQUARED_DIFFERENCE', 'op_func': tf.math.squared_difference},
+    {'op_name': 'EQUAL', 'op_func': 'tf.math.equal'},
+    {'op_name': 'FLOOR_MOD', 'op_func': 'tf.math.floormod', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'FLOOR_DIV', 'op_func': 'tf.math.floordiv', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'GREATER', 'op_func': 'tf.math.greater'},
+    {'op_name': 'GREATER_EQUAL', 'op_func': 'tf.math.greater_equal'},
+    {'op_name': 'LESS', 'op_func': 'tf.math.less'},
+    {'op_name': 'LESS_EQUAL', 'op_func': 'tf.math.less_equal'},
+    {'op_name': 'LOGICAL_AND', 'op_func': 'tf.math.logical_and', 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
+    {'op_name': 'LOGICAL_OR', 'op_func': 'tf.math.logical_or', 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
+    {'op_name': 'MAXIMUM', 'op_func': 'tf.math.maximum'},
+    {'op_name': 'MINIMUM', 'op_func': 'tf.math.minimum'},
+    {'op_name': 'NOT_EQUAL', 'op_func': 'tf.math.not_equal'},
+    {'op_name': 'POW', 'op_func': 'tf.math.pow', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'SQUARED_DIFFERENCE', 'op_func': 'tf.math.squared_difference'},
 ]
 
 test_params = [
@@ -44,7 +44,7 @@ class TestTFLiteBinaryLayerTest(TFLiteLayerTest):
                                                      name=self.inputs[0])
             place_holder1 = tf.compat.v1.placeholder(params.get('dtype', tf.float32), params['shape'],
                                                      name=self.inputs[1])
-            params['op_func'](place_holder0, place_holder1, name=self.outputs[0])
+            eval(params['op_func'])(place_holder0, place_holder1, name=self.outputs[0])
             net = sess.graph_def
         return net
 

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_BinaryWithActivation.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_BinaryWithActivation.py
@@ -6,10 +6,10 @@ from common.utils.tflite_utils import additional_test_params, activation_helper
 from common.utils.tflite_utils import parametrize_tests
 
 test_ops = [
-    {'op_name': 'ADD', 'op_func': tf.math.add},
-    {'op_name': 'DIV', 'op_func': tf.math.divide, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'MUL', 'op_func': tf.math.multiply},
-    {'op_name': 'SUB', 'op_func': tf.math.subtract},
+    {'op_name': 'ADD', 'op_func': 'tf.math.add'},
+    {'op_name': 'DIV', 'op_func': 'tf.math.divide', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'MUL', 'op_func': 'tf.math.multiply'},
+    {'op_name': 'SUB', 'op_func': 'tf.math.subtract'},
 ]
 
 test_params = [
@@ -35,8 +35,8 @@ class TestTFLiteBinaryWithActivationLayerTest(TFLiteLayerTest):
             in1 = tf.compat.v1.placeholder(params.get('dtype', tf.float32), params['shape'], name=self.inputs[1])
             bin_op_name = self.outputs[0] if not params['activation'] else \
                 self.outputs[0] + "/op"
-            op = params['op_func'](in0, in1, name=bin_op_name)
-            op = activation_helper(op, params['activation'], self.outputs[0])
+            op = eval(params['op_func'])(in0, in1, name=bin_op_name)
+            op = activation_helper(op, eval(params['activation']) if params['activation'] else None, self.outputs[0])
 
             net = sess.graph_def
         return net

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_Pool.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_Pool.py
@@ -5,8 +5,8 @@ from common.tflite_layer_test_class import TFLiteLayerTest
 from common.utils.tflite_utils import parametrize_tests
 
 test_ops = [
-    {'op_name': 'AVERAGE_POOL_2D', 'op_func': tf.nn.avg_pool2d},
-    {'op_name': 'MAX_POOL_2D', 'op_func': tf.nn.max_pool2d},
+    {'op_name': 'AVERAGE_POOL_2D', 'op_func': 'tf.nn.avg_pool2d'},
+    {'op_name': 'MAX_POOL_2D', 'op_func': 'tf.nn.max_pool2d'},
 ]
 
 test_params = [
@@ -32,7 +32,7 @@ class TestTFLitePoolLayerTest(TFLiteLayerTest):
         with tf.compat.v1.Session() as sess:
             place_holder = tf.compat.v1.placeholder(params.get('dtype', tf.float32), params['shape'],
                                                     name=self.inputs[0])
-            params['op_func'](place_holder, params['ksize'], params['strides'],
+            eval(params['op_func'])(place_holder, params['ksize'], params['strides'],
                               params['padding'], 'NHWC', name=self.outputs[0])
             net = sess.graph_def
         return net

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_Reduce.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_Reduce.py
@@ -6,13 +6,13 @@ from common.utils.tflite_utils import additional_test_params
 from common.utils.tflite_utils import parametrize_tests
 
 test_ops = [
-    {'op_name': 'MEAN', 'op_func': tf.math.reduce_mean},
-    {'op_name': 'REDUCE_ALL', 'op_func': tf.math.reduce_all, 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
-    {'op_name': 'REDUCE_ANY', 'op_func': tf.math.reduce_any, 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
-    {'op_name': 'REDUCE_MAX', 'op_func': tf.math.reduce_max},
-    {'op_name': 'REDUCE_MIN', 'op_func': tf.math.reduce_min},
-    {'op_name': 'REDUCE_PROD', 'op_func': tf.math.reduce_prod, 'kwargs_to_prepare_input': 'short_range'},
-    {'op_name': 'SUM', 'op_func': tf.math.reduce_sum},
+    {'op_name': 'MEAN', 'op_func': 'tf.math.reduce_mean'},
+    {'op_name': 'REDUCE_ALL', 'op_func': 'tf.math.reduce_all', 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
+    {'op_name': 'REDUCE_ANY', 'op_func': 'tf.math.reduce_any', 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
+    {'op_name': 'REDUCE_MAX', 'op_func': 'tf.math.reduce_max'},
+    {'op_name': 'REDUCE_MIN', 'op_func': 'tf.math.reduce_min'},
+    {'op_name': 'REDUCE_PROD', 'op_func': 'tf.math.reduce_prod', 'kwargs_to_prepare_input': 'short_range'},
+    {'op_name': 'SUM', 'op_func': 'tf.math.reduce_sum'},
 ]
 
 test_params = [
@@ -36,7 +36,7 @@ class TestTFLiteReduceLayerTest(TFLiteLayerTest):
         with tf.compat.v1.Session() as sess:
             place_holder = tf.compat.v1.placeholder(params.get('dtype', tf.float32), params['shape'],
                                                     name=self.inputs[0])
-            params['op_func'](place_holder, axis=params['axis'], name=self.outputs[0])
+            eval(params['op_func'])(place_holder, axis=params['axis'], name=self.outputs[0])
             net = sess.graph_def
         return net
 

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_Resize.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_Resize.py
@@ -5,8 +5,8 @@ from common.tflite_layer_test_class import TFLiteLayerTest
 from common.utils.tflite_utils import parametrize_tests
 
 test_ops = [
-    {'op_name': ['RESIZE_BILINEAR'], 'op_func': tf.compat.v1.image.resize_bilinear},
-    {'op_name': ['RESIZE_NEAREST_NEIGHBOR'], 'op_func': tf.compat.v1.image.resize_nearest_neighbor},
+    {'op_name': ['RESIZE_BILINEAR'], 'op_func': 'tf.compat.v1.image.resize_bilinear'},
+    {'op_name': ['RESIZE_NEAREST_NEIGHBOR'], 'op_func': 'tf.compat.v1.image.resize_nearest_neighbor'},
 ]
 
 test_params = [
@@ -35,7 +35,7 @@ class TestTFLiteResizeLayerTest(TFLiteLayerTest):
         with tf.compat.v1.Session() as sess:
             placeholder = tf.compat.v1.placeholder(params.get("dtype", tf.float32), params["shape"],
                                                    name=self.inputs[0])
-            params['op_func'](placeholder, size=params['size'],
+            eval(params['op_func'])(placeholder, size=params['size'],
                               align_corners=params['align_corners'],
                               half_pixel_centers=params['half_pixel_centers'],
                               name=self.outputs[0])

--- a/tests/layer_tests/tensorflow_lite_tests/test_tfl_Unary.py
+++ b/tests/layer_tests/tensorflow_lite_tests/test_tfl_Unary.py
@@ -12,28 +12,28 @@ from common.utils.tflite_utils import parametrize_tests
 np.random.seed(42)
 
 test_ops = [
-    {'op_name': 'ABS', 'op_func': tf.math.abs},
-    {'op_name': 'CAST', 'op_func': partial(tf.cast, dtype=tf.int32)},
-    {'op_name': 'CEIL', 'op_func': tf.math.ceil},
-    {'op_name': 'COS', 'op_func': tf.math.cos},
-    {'op_name': 'ELU', 'op_func': tf.nn.elu},
-    {'op_name': 'EXP', 'op_func': tf.math.exp, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'FLOOR', 'op_func': tf.math.floor},
-    {'op_name': 'LEAKY_RELU', 'op_func': partial(tf.nn.leaky_relu, alpha=-0.5)},
-    {'op_name': 'LOG', 'op_func': tf.math.log, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'LOG_SOFTMAX', 'op_func': partial(tf.nn.log_softmax, axis=-1)},
-    {'op_name': 'LOGICAL_NOT', 'op_func': tf.math.logical_not, 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
-    {'op_name': 'LOGISTIC', 'op_func': tf.math.sigmoid},
-    {'op_name': 'NEG', 'op_func': tf.math.negative},
-    {'op_name': 'RELU6', 'op_func': tf.nn.relu6},
-    {'op_name': 'RELU', 'op_func': tf.nn.relu},
-    {'op_name': 'ROUND', 'op_func': tf.math.round},
-    {'op_name': 'RSQRT', 'op_func': tf.math.rsqrt, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'SIN', 'op_func': tf.math.sin},
-    {'op_name': 'SOFTMAX', 'op_func': partial(tf.nn.softmax, axis=-1)},  # additionally test with alpha
-    {'op_name': 'SQRT', 'op_func': tf.math.sqrt, 'kwargs_to_prepare_input': 'positive'},
-    {'op_name': 'SQUARE', 'op_func': tf.math.square},
-    {'op_name': 'TANH', 'op_func': tf.math.tanh},
+    {'op_name': 'ABS', 'op_func': 'tf.math.abs'},
+    {'op_name': 'CAST', 'op_func': 'partial(tf.cast, dtype=tf.int32)'},
+    {'op_name': 'CEIL', 'op_func': 'tf.math.ceil'},
+    {'op_name': 'COS', 'op_func': 'tf.math.cos'},
+    {'op_name': 'ELU', 'op_func': 'tf.nn.elu'},
+    {'op_name': 'EXP', 'op_func': 'tf.math.exp', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'FLOOR', 'op_func': 'tf.math.floor'},
+    {'op_name': 'LEAKY_RELU', 'op_func': 'partial(tf.nn.leaky_relu, alpha=-0.5)'},
+    {'op_name': 'LOG', 'op_func': 'tf.math.log', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'LOG_SOFTMAX', 'op_func': 'partial(tf.nn.log_softmax, axis=-1)'},
+    {'op_name': 'LOGICAL_NOT', 'op_func': 'tf.math.logical_not', 'kwargs_to_prepare_input': 'boolean', 'dtype': tf.bool},
+    {'op_name': 'LOGISTIC', 'op_func': 'tf.math.sigmoid'},
+    {'op_name': 'NEG', 'op_func': 'tf.math.negative'},
+    {'op_name': 'RELU6', 'op_func': 'tf.nn.relu6'},
+    {'op_name': 'RELU', 'op_func': 'tf.nn.relu'},
+    {'op_name': 'ROUND', 'op_func': 'tf.math.round'},
+    {'op_name': 'RSQRT', 'op_func': 'tf.math.rsqrt', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'SIN', 'op_func': 'tf.math.sin'},
+    {'op_name': 'SOFTMAX', 'op_func': 'partial(tf.nn.softmax, axis=-1)'},  # additionally test with alpha
+    {'op_name': 'SQRT', 'op_func': 'tf.math.sqrt', 'kwargs_to_prepare_input': 'positive'},
+    {'op_name': 'SQUARE', 'op_func': 'tf.math.square'},
+    {'op_name': 'TANH', 'op_func': 'tf.math.tanh'},
 
     # These operations are getting optimized out by tflite aka empty tfl model
     # {'op_name': 'RANK', 'op_func': tf.rank},
@@ -63,7 +63,7 @@ class TestTFLiteUnaryLayerTest(TFLiteLayerTest):
         with tf.compat.v1.Session() as sess:
             place_holder = tf.compat.v1.placeholder(params.get('dtype', tf.float32), params['shape'],
                                                     name=self.inputs[0])
-            params['op_func'](place_holder, name=self.outputs[0])
+            eval(params['op_func'])(place_holder, name=self.outputs[0])
             net = sess.graph_def
         return net
 


### PR DESCRIPTION
### Details:
 - Enabled parallel call
 - Fixed tests to be compatible with pytest-xdist plugin (pass function name instead of reference)
 - `os.path.dirname` caused saving model in `/out` directory instead of `/out/{temp_dir}` beacause it didn't have '/' char at the end and it treated `temp_dir` like a file

### Tickets:
 - [None](https://github.com/openvinotoolkit/openvino/issues/20920)
 
Without parallel execution
![Screenshot from 2024-09-18 14-15-16](https://github.com/user-attachments/assets/f1b00954-de59-445a-904f-5b13819c0971)

With parallel execution (8 cpu cores)
![Screenshot from 2024-09-18 14-32-48](https://github.com/user-attachments/assets/2fc144cc-f771-43aa-909b-f41dedc1ccca)
