### PR TITLE
[Docs]Fix OV pass manager API doc

### DIFF
--- a/src/core/include/openvino/pass/manager.hpp
+++ b/src/core/include/openvino/pass/manager.hpp
@@ -33,7 +33,7 @@ public:
     /// Example below show the basic usage of pass::Manager
     ///
     ///     pass::Manager manager;
-    ///     manager.register_pass<MyTransformation>(/* transformation constructor arg */);
+    ///     manager.register_pass<MyTransformation>(/* transformation constructor args */);
     ///     manager.run_passes(f);
     ///
     /// For some purposes transformation can be registered and disabled by default.

--- a/src/core/include/openvino/pass/manager.hpp
+++ b/src/core/include/openvino/pass/manager.hpp
@@ -33,7 +33,7 @@ public:
     /// Example below show the basic usage of pass::Manager
     ///
     ///     pass::Manager manager;
-    ///     manager.register_pass<MyTransformation>(/*transformation constructor ars*/);
+    ///     manager.register_pass<MyTransformation>(/* transformation constructor arg */);
     ///     manager.run_passes(f);
     ///
     /// For some purposes transformation can be registered and disabled by default.


### PR DESCRIPTION
### Details:
- Fix format and typo for ov::pass::Manager register_pass() function:
Original link for OV 24.5 nightly
https://docs.openvino.ai/nightly/api/c_cpp_api/classov_1_1pass_1_1_manager.html#_CPPv4I0_bDpEN2ov4pass7Manager13register_passENSt10shared_ptrI1TEEDpRR4Args
<img width="676" alt="OV24 5_nightly" src="https://github.com/user-attachments/assets/c70f5da1-f511-4c13-9da4-e1ed7240462c">


- Reference: https://github.com/openvinotoolkit/openvino/blob/77dfb1de59debe9c59cb45c44de520bb781db81c/src/plugins/template/backend/executable.cpp#L70