### PR TITLE
[GPU] i8_u8 fc can support eltwise fusion always, do not unfuse it

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2400,7 +2400,8 @@ bool primitive_inst::is_valid_fusion() const {
         // TODO: Only fc_bf_tiled_kernel & ref kernel are verified for fused eltwise. To support more fc kernels for eltwise fusion
         if (!_node->get_selected_impl())
             return false;
-        if ((_node->get_selected_impl()->get_kernel_name().find("fully_connected_gpu_bf_tiled") == std::string::npos)
+        if (!data_type_traits::is_i8_u8(_node->get_input_layout(0).data_type)
+            && (_node->get_selected_impl()->get_kernel_name().find("fully_connected_gpu_bf_tiled") == std::string::npos)
             && (_node->get_selected_impl()->get_kernel_name().find("fully_connected_gpu_bfyx_ref") == std::string::npos)) {
             return false;
         }


### PR DESCRIPTION
### Details:
 - A quick fix to preventing u8_i8 FCs from unfusion

### Tickets:
 - *ticket-id*
