### PR TITLE
[PyOV] return back testing of PyAPI tests for py3.12

### DIFF
--- a/.github/workflows/job_python_unit_tests.yml
+++ b/.github/workflows/job_python_unit_tests.yml
@@ -299,7 +299,7 @@ jobs:
           python3 ${OPENVINO_REPO}/docs/articles_en/assets/snippets/main.py
 
       - name: Python API Tests -- numpy>=2.0.0
-        if: ${{ fromJSON(inputs.affected-components).Python_API.test && inputs.python-version != '3.12' }} # Ticket: 152242
+        if: ${{ fromJSON(inputs.affected-components).Python_API.test }}
         run: |
           python3 -m pip uninstall -y numpy
           python3 -m pip install "numpy>=2.0.0,<2.1.0"

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -65,6 +65,7 @@ if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ] ; then
         python3-venv \
         python3-setuptools \
         libpython3-dev \
+        pybind11-dev \
         libffi-dev \
         `# spell checking for MO sources` \
         python3-enchant \

--- a/install_build_dependencies.sh
+++ b/install_build_dependencies.sh
@@ -65,7 +65,6 @@ if [ -f /etc/lsb-release ] || [ -f /etc/debian_version ] ; then
         python3-venv \
         python3-setuptools \
         libpython3-dev \
-        pybind11-dev \
         libffi-dev \
         `# spell checking for MO sources` \
         python3-enchant \

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -189,7 +189,7 @@ endif()
 if(CMAKE_CROSSCOMPILING)
     set(pybind11_min_version 2.12.0)
 else()
-    set(pybind11_min_version 2.10.0)
+    set(pybind11_min_version 2.12.0)
 endif()
 # search for FindPython3.cmake instead of legacy modules
 set(PYBIND11_FINDPYTHON ON)

--- a/tools/mo/unit_tests/mock_mo_frontend/mock_mo_python_api/CMakeLists.txt
+++ b/tools/mo/unit_tests/mock_mo_frontend/mock_mo_python_api/CMakeLists.txt
@@ -28,7 +28,7 @@ source_group("src" FILES ${PYBIND_FE_SRC})
 if(CMAKE_CROSSCOMPILING)
     set(pybind11_min_version 2.12.0)
 else()
-    set(pybind11_min_version 2.10.0)
+    set(pybind11_min_version 2.12.0)
 endif()
 # search for FindPython3.cmake instead of legacy modules
 set(PYBIND11_FINDPYTHON ON)


### PR DESCRIPTION
### Details:
 - problem with tests was caused due-to old pybind11 version is installed ((2.11.1-2)). 

### Tickets:
 - CVS-152242
