### PR TITLE
[GPU] pass::FullyConnectedConvertFusion support symmetric quantized FC.

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_convert_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_convert_fusion.cpp
@@ -22,7 +22,9 @@ FullyConnectedConvertFusion::FullyConnectedConvertFusion() {
     auto weights = any_input();
     auto bias = any_input();
     auto fully_connected = wrap_type<op::FullyConnected>({data, weights, bias}, consumers_count(1));
-    auto fully_connected_compressed = wrap_type<op::FullyConnectedCompressed>({data, weights, bias, any_input(), any_input()}, consumers_count(1));
+    auto fully_connected_compressed1 = wrap_type<op::FullyConnectedCompressed>({data, weights, bias, any_input()}, consumers_count(1));
+    auto fully_connected_compressed2 = wrap_type<op::FullyConnectedCompressed>({data, weights, bias, any_input(), any_input()}, consumers_count(1));
+    auto fully_connected_compressed = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{fully_connected_compressed1, fully_connected_compressed2});
     auto fc = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{fully_connected, fully_connected_compressed});
     auto convert = wrap_type<ov::op::v0::Convert>({fc}, type_matches(element::f32));
 
@@ -43,12 +45,19 @@ FullyConnectedConvertFusion::FullyConnectedConvertFusion() {
             new_fc = std::make_shared<op::FullyConnected>(m_data, m_weights, m_bias, output_type);
         } else {
             m_fc = pattern_map.at(fully_connected_compressed).get_node_shared_ptr();
-            new_fc = std::make_shared<op::FullyConnectedCompressed>(m_data,
-                                                                    m_weights,
-                                                                    m_bias,
-                                                                    m_fc->input_value(3),
-                                                                    m_fc->input_value(4),
-                                                                    output_type);
+            if (m_fc->input_values().size() == 4)
+                new_fc = std::make_shared<op::FullyConnectedCompressed>(m_data,
+                                                                        m_weights,
+                                                                        m_bias,
+                                                                        m_fc->input_value(3),
+                                                                        output_type);
+            else
+                new_fc = std::make_shared<op::FullyConnectedCompressed>(m_data,
+                                                                        m_weights,
+                                                                        m_bias,
+                                                                        m_fc->input_value(3),
+                                                                        m_fc->input_value(4),
+                                                                        output_type);
         }
         new_fc->set_friendly_name(m_convert->get_friendly_name());
         copy_runtime_info(m.get_matched_nodes(), new_fc);


### PR DESCRIPTION
### Details:
 - *pass::FullyConnectedConvertFusion support symmetric quantized FC... This removes a bunch of type-converting Reorder nodes that follows FullyConnectedCompress node in QWen decoder layers.*

### Tickets:
 - *143169*
