### PR TITLE
[JAX FE] Add Support for jax.lax.gather Operation

### DIFF
--- a/src/frontends/jax/src/op/translate_reshape.cpp
+++ b/src/frontends/jax/src/op/translate_reshape.cpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/jax/node_context.hpp"
+#include "openvino/op/power.hpp"
+#include "utils.hpp"
+
+using namespace std;
+using namespace ov;
+using namespace ov::op;
+
+namespace ov {
+namespace frontend {
+namespace jax {
+namespace op {
+
+OutputVector translate_gather(const NodeContext& context) {
+    num_inputs_check(context, 2, 2); 
+    Output<Node> input = context.get_input(0);
+    Output<Node> indices = context.get_input(1);
+
+    auto axis = context.const_named_param<int64_t>("axis");
+    auto axis_node = std::make_shared<v0::Constant>(element::i64, Shape{}, axis);
+
+    // the gather operation using OpenVINO Gather node
+    Output<Node> res = std::make_shared<v1::Gather>(input, indices, axis_node);
+
+    return {res};
+}
+
+
+} 
+} 
+} 
+}  

--- a/src/frontends/jax/src/op_table.cpp
+++ b/src/frontends/jax/src/op_table.cpp
@@ -48,6 +48,8 @@ OP_CONVERTER(translate_rsqrt);
 OP_CONVERTER(translate_slice);
 OP_CONVERTER(translate_squeeze);
 OP_CONVERTER(translate_transpose);
+OP_CONVERTER(translate_gather);
+
 
 }  // namespace op
 
@@ -82,7 +84,9 @@ const std::map<std::string, CreatorFunction> get_supported_ops_jaxpr() {
             {"squeeze", op::translate_squeeze},
             {"stop_gradient", op::skip_node},
             {"sub", op::translate_1to1_match_2_inputs<v1::Subtract>},
-            {"tanh", op::translate_1to1_match_1_input<v0::Tanh>}};
+            {"tanh", op::translate_1to1_match_1_input<v0::Tanh>}},
+            {"gather", op::translate_gather};
+
 };
 
 }  // namespace jax

--- a/tests/layer_tests/jax_tests/test_gather.py
+++ b/tests/layer_tests/jax_tests/test_gather.py
@@ -1,0 +1,11 @@
+import pytest
+from openvino.tests.layer_tests.jax_tests.utils import run_layer_test
+
+@pytest.mark.parametrize("input_data, indices, axis, expected", [
+  
+    ([[1, 2, 3], [4, 5, 6]], [0, 2], 1, [[1, 3], [4, 6]]),
+  
+])
+def test_gather(input_data, indices, axis, expected):
+    result = run_layer_test("jax.lax.gather", input_data=input_data, indices=indices, axis=axis)
+    assert result == expected


### PR DESCRIPTION
Added support for jax.lax.gather operation in the OpenVINO JAX frontend.
Implemented the corresponding loader in the JAX FE operation directory.
Registered the jax.lax.gather operation in the op_table.cpp file.
Added relevant test cases in test_gather.py.

Notes:

I am new to open-source contributions and this is my first time contributing to this repository. Please let me know if any changes or improvements are required.
I would appreciate any feedback to help me improve and better understand the contribution process.