### PR TITLE
[RISC-V][Tests] Fixed ov_cpu_unit_tests linking with SHL

### DIFF
--- a/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
+++ b/src/plugins/intel_cpu/tests/unit/CMakeLists.txt
@@ -34,6 +34,10 @@ else()
     set(MLAS_LIBRARY "mlas")
 endif()
 
+if (ENABLE_SHL_FOR_CPU)
+    set(SHL_LIBRARY "shl")
+endif()
+
 ov_add_test_target(
         NAME ${TARGET_NAME}
         ROOT ${CMAKE_CURRENT_SOURCE_DIR}
@@ -61,6 +65,7 @@ ov_add_test_target(
             ov_snippets_models
             snippets_test_utils
             ${MLAS_LIBRARY}
+            ${SHL_LIBRARY}
         ADD_CPPLINT
         LABELS
             OV UNIT CPU


### PR DESCRIPTION
### Details:
 - *Fixed "ov_cpu_unit_tests" linking with SHL for RISC-V devices*
 - *Before the changes:*
 ```
[build] [100%] Linking CXX executable /openvino/bin/riscv64/Release/ov_cpu_unit_tests
[build] /Xuantie-900-gcc-linux-5.15.0-glibc-x86_64-V2.8.1/lib/gcc/riscv64-unknown-linux-gnu/10.4.0/../../../../riscv64-unknown-linux-gnu/bin/ld: ../../CMakeFiles/openvino_intel_cpu_plugin_obj.dir/src/nodes/executors/shl/shl_eltwise.cpp.o:(.text._ZN2ov9intel_cpu18ShlStructureTraitsIP13csinn_sessionE10destructorES3_[_ZN2ov9intel_cpu18ShlStructureTraitsIP13csinn_sessionE10destructorES3_]+0x0): undefined reference to `csinn_free_session'
[build] /Xuantie-900-gcc-linux-5.15.0-glibc-x86_64-V2.8.1/lib/gcc/riscv64-unknown-linux-gnu/10.4.0/../../../../riscv64-unknown-linux-gnu/bin/ld: ../../CMakeFiles/openvino_intel_cpu_plugin_obj.dir/src/nodes/executors/shl/shl_fullyconnected.cpp.o: in function `.LEHE110':
[build] shl_fullyconnected.cpp:(.text._ZN2ov9intel_cpu13ShlFCExecutor6updateERKSt13unordered_mapIiSt10shared_ptrINS0_7IMemoryEESt4hashIiESt8equal_toIiESaISt4pairIKiS5_EEE+0x24a): undefined reference to `csinn_tensor_copy' 
  ```
  - *After the changes:*
  ```
[build] [ 94%] Linking CXX executable /openvino/bin/riscv64/Release/ov_cpu_unit_tests
[build] [100%] Built target ov_cpu_unit_tests
  ```

### Tickets:
 - *N/A*
