### PR TITLE
[GPU] Fix lockable requirement check for shape_of consumer

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -528,7 +528,7 @@ bool program_node::is_fused_dep(size_t dep_idx) const {
 std::set<size_t> program_node::get_lockable_input_ids() const {
     const auto impl = get_selected_impl();
     const bool has_cpu_impl = get_preferred_impl_type() == impl_types::cpu || (impl && impl->is_cpu());
-    if (has_cpu_impl) {
+    if (has_cpu_impl && !is_type<shape_of>()) {
         std::set<size_t> dependencies_indexes;
         for (size_t i = 0; i < get_dependencies().size(); i++)
             dependencies_indexes.insert(i);


### PR DESCRIPTION
### Details:
 - We had an exception on attempt to set remote tensor if input had multiple GPU users and ShapeOf node with CPU impl. This patch adds special handling for shape_of node to avoid it's requirement for lockable inputs as it doesn't touch tensor.
 - Note: Likely it will still fail for other CPU node types, so need to investigate that further.
