### PR TITLE
[PyOV] Add set_tensor binding for RemoteTensor

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/infer_request.cpp
+++ b/src/bindings/python/src/pyopenvino/core/infer_request.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "pyopenvino/core/common.hpp"
+#include "pyopenvino/core/remote_tensor.hpp"
 #include "pyopenvino/utils/utils.hpp"
 
 namespace py = pybind11;
@@ -464,10 +465,27 @@ void regclass_InferRequest(py::module m) {
         },
         R"(
             Gets output tensor of InferRequest.
-            
+
             :return: An output Tensor for the model.
                      If model has several outputs, an exception is thrown.
             :rtype: openvino.runtime.Tensor
+        )");
+
+    cls.def(
+        "set_tensor",
+        [](InferRequestWrapper& self, const std::string& name, const RemoteTensorWrapper& tensor) {
+            self.m_request->set_tensor(name, tensor.tensor);
+        },
+        py::arg("name"),
+        py::arg("tensor"),
+        R"(
+            Sets input/output tensor of InferRequest.
+
+            :param name: Name of input/output tensor.
+            :type name: str
+            :param tensor: RemoteTensor object. The element_type and shape of a tensor
+                           must match the model's input/output element_type and shape.
+            :type tensor: openvino.runtime.RemoteTensor
         )");
 
     cls.def(


### PR DESCRIPTION
### Details:
 - Add binding for set_tensor with RemoteTensorWrapper arg to have a way to set remote tensors in python API.
 - This solution may be changes in the future, but currently it's impossible to set remote tensor from python and this patch enables it.
