### PR TITLE
[GPU] Optimize fc_bf_tiled kernel for large N + small K case

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/format.hpp
@@ -150,6 +150,7 @@ struct format {
         os_is_zyx_osv32_isv16,
         os_is_yx_osv32_isv2,                          ///< format used only for fully connected weights compressed for i4
         os_is_zyx_osv64_isv16,
+        os_is_yx_osv64_isv2,                          ///< format used only for fully connected weights compressed for i4
         os_zyxi_osv16,                                ///< format used for weights for 3D convolution
         os_is_yx_isv16_osv16,                         ///< format used for blocked convolution
         os_is_zyx_isv16_osv16,                        ///< format used for weights for blocked 3D convolution

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.cpp
@@ -558,6 +558,8 @@ kernel_selector::weights_layout to_weights_layout(format f, bool is_grouped) {
             return kernel_selector::weights_layout::os_i_osv16;
         case format::os_is_yx_osv32_isv2:
             return kernel_selector::weights_layout::os_is_yx_osv32_isv2;
+        case format::os_is_yx_osv64_isv2:
+            return kernel_selector::weights_layout::os_is_yx_osv64_isv2;
         case format::os_is_zyx_isv16_osv16:
             return kernel_selector::weights_layout::os_is_zyx_isv16_osv16;
         case format::is_os_zyx_isv16_osv16:
@@ -682,6 +684,8 @@ cldnn::format::type from_weights_layout(kernel_selector::weights_layout l) {
             return cldnn::format::os_i_osv16;
         case kernel_selector::weights_layout::os_is_yx_osv32_isv2:
             return cldnn::format::os_is_yx_osv32_isv2;
+        case kernel_selector::weights_layout::os_is_yx_osv64_isv2:
+            return cldnn::format::os_is_yx_osv64_isv2;
         case kernel_selector::weights_layout::os_i_osv8__ai8:
             return cldnn::format::os_i_osv8__ai8;
         case kernel_selector::weights_layout::os_i_osv16__ai8:

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/fully_connected_gpu_bf_tiled.cl
@@ -198,7 +198,7 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
     // full dispatch pipeline.
     uint feature_mini_block = gid % DISPATCH_FSV;
     uint batch_mini_block = gid / DISPATCH_FSV % DISPATCH_BSV;
-     uint feature_mega_block = gid / (DISPATCH_FSV * DISPATCH_BSV) % (CEIL_DIV(TILE_OUT_F_NUM, OUTER_OFM * TILE_OFM * SIMD) / DISPATCH_FSV);
+    uint feature_mega_block = gid / (DISPATCH_FSV * DISPATCH_BSV) % (CEIL_DIV(TILE_OUT_F_NUM, OUTER_OFM * TILE_OFM * SIMD) / DISPATCH_FSV);
     uint batch_mega_block = gid / (DISPATCH_FSV * DISPATCH_BSV * CEIL_DIV(TILE_OUT_F_NUM, OUTER_OFM* TILE_OFM * SIMD) / DISPATCH_FSV);
 
 #if USE_SLM
@@ -650,6 +650,9 @@ inline void FUNC(fc_bf_tiled_kernel_default)(
     ACTIVATION_VEC_TYPE activated[TILE_B] = { };
     for (uint bi = 0; bi < TILE_B; ++bi) {
         activated[bi] = TO_ACTIVATION_VEC_TYPE(acc[bi]);
+#if OUTER_OFM > 1
+        acc[bi] = 0;
+#endif
     }
 
 #if BIAS_TERM
@@ -1035,9 +1038,6 @@ inline void FUNC(fc_bf_tiled_kernel_dyn_quan)(
     ACTIVATION_VEC_TYPE activated[TILE_B] = { };
     for (uint bi = 0; bi < TILE_B; ++bi) {
         activated[bi] = TO_ACTIVATION_VEC_TYPE(acc[bi]);
-#if OUTER_OFM > 1
-        acc[bi] = 0;
-#endif
     }
 
 #if BIAS_TERM

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/reorder_weights_int4.cl
@@ -49,9 +49,6 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
 
     const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 16); // Calculate offset as osv16 due to packing
     output[output_idx] = packed_out_channels;
-
-
-
 #elif defined(OUTPUT_LAYOUT_OS_IYX_OSV32)
     // os_iyx osv32 layout for int4 packed weight
     // k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k1_f0f16 | k1_f1f17 | ... | k1_f15f31
@@ -76,7 +73,6 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
 
     const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX(OUTPUT, o, i, 0, 0, 32 / 2); // Calculate offset as osv16 due to packing
     output[output_idx] = packed_out_channels;
-
 #elif defined(OUTPUT_LAYOUT_OS_IS_YX_OSV32_ISV2)
     // osv32_isv2 layout for int4 packed weight
     // f0_k0k1 | f1_k0k1 | ....  | f15_k0k1|| f16_k0k1 | f17_k0k1 | ... | f31_k0k1
@@ -92,6 +88,36 @@ KERNEL(reorder_weights_int4)(const __global INPUT0_TYPE* input, __global OUTPUT_
     INPUT0_TYPE packed_out_channels = in1;
 
     const uint output_idx = GET_FILTER_OS_IS_YX_OSV_ISV_INDEX_INT4_PACKED(OUTPUT, o, i/2, 0, 0, 32); // Calculate offset as osv16 due to packing
+    output[output_idx] = packed_out_channels;
+#elif defined(OUTPUT_LAYOUT_OS_IYX_OSV64)
+    // os_iyx_osv64 layout for int4 packed weight
+    // k0_f0f16 | k0_f1f17 | .... | k0_f15f31 || k0_f32f48 | k0_f33f49 | .... | k0_f47f63 || k1_f0f16 | k1_f1f17 | .... | k1_f15f31 || k1_f32f48 | k1_f33f49 | .... | k1_f47f63 ||
+    // k2_f0f16 | k2_f1f17 | .... | k2_f15f31 || k2_f32f48 | k2_f33f49 | .... | k2_f47f63 || k3_f0f16 | k3_f1f17 | .... | k3_f15f31 || k3_f32f48 | k3_f33f49 | .... | k3_f47f63 ||
+    // ...
+    const unsigned o = (uint)get_global_id(0);
+    const unsigned i = (uint)get_global_id(1);
+
+    // Calculate offsets for 2 contiguous values in the 8-bit packed format
+    const unsigned o0 = (o / 16) * 32 + (o % 16);
+    const unsigned o1 = (o / 16) * 32 + (o % 16) + 16;
+
+    // Calculate the input buffer offests
+    const uint input0_offset = GET_FILTER_INDEX(INPUT0, 0, o0, i, 0, 0);
+    const uint input1_offset = GET_FILTER_INDEX(INPUT0, 0, o1, i, 0, 0);
+
+    // Determine the bit position within each 8-bit value
+    const uint input0_idx = input0_offset % 2;
+    const uint input1_idx = input1_offset % 2;
+
+    // Extract 4-bit values from the input buffer
+    INPUT0_TYPE in0 = (input[input0_offset / 2] >> input0_idx*4) & 0x0F;
+    INPUT0_TYPE in1 = (input[input1_offset / 2] >> input1_idx*4) & 0x0F;
+
+    // Combine the 4-bit values into a single 8-bit value
+    INPUT0_TYPE packed_out_channels = in0 | (in1 << 4);
+
+    // Calculate the output buffer index for the packed 8-bit data
+    const uint output_idx = GET_FILTER_OS_IYX_OSV_INDEX(OUTPUT, o, i, 0, 0, 64 / 2);
     output[output_idx] = packed_out_channels;
 #else
 #error "reorder_weights_int4: unsupported layouts combination"

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_common.cpp
@@ -351,6 +351,7 @@ std::string toString(WeightsLayout layout) {
         case WeightsLayout::os_is_yx_osv32_isv4_swizzled_by_2:           return "OS_IS_YX_OSV32_ISV4_SWIZZLED_BY_2";
         case WeightsLayout::os_is_yx_osv32_isv4:                         return "OS_IS_YX_OSV32_ISV4";
         case WeightsLayout::os_is_yx_osv32_isv2:                         return "OS_IS_YX_OSV32_ISV2";
+        case WeightsLayout::os_is_yx_osv64_isv2:                         return "OS_IS_YX_OSV64_ISV2";
         case WeightsLayout::os_is_zyx_osv32_isv4:                        return "OS_IS_ZYX_OSV32_ISV4";
         case WeightsLayout::oizyx:                                       return "OIZYX";
         case WeightsLayout::iozyx:                                       return "IOZYX";

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_base.h
@@ -34,6 +34,7 @@ public:
         uint32_t rg_count = 0;
 
         bool use_slm = false;
+        uint32_t outer_n = 0;
 
         // Gemm style params
         uint32_t tile_m = 0;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -747,7 +747,7 @@ KernelsData FullyConnected_bf_tiled::GetTunedKernelsDataByIndex(const Params &pa
 
     WeightsLayout weights_layout = WeightsLayout::os_iyx_osv16;
     if (fc_params.compressed && fc_params.inputs[0].GetDType() == Datatype::F16
-        && !is_weight_with_small_ofm(fc_params, output_f) && !is_weight_with_large_ifm(fc_params)
+        && output_f >= 10240 && !is_weight_with_large_ifm(fc_params)
         && (fc_params.weights.GetLayout() == WeightsLayout::oiyx || fc_params.weights.GetLayout() == WeightsLayout::os_iyx_osv64)
         && (fc_params.weights.GetDType() == WeightsType::INT4 || fc_params.weights.GetDType() == WeightsType::UINT4)) {
         // Large N + Small K case to use [osv64] + TILE_OFM 4 for batch 1

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -551,6 +551,16 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
         jit.AddConstant(MakeJitConstant("W_IDX", "kii * TILE_OFM + fi"));
     }
 
+    if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16 && dispatchData.tile_n == 2) {
+        jit.AddConstant(MakeJitConstant("TILE_OFM_PER_OSV_SIZE", 0.5f));
+    } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2 && dispatchData.tile_n == 1) {
+        jit.AddConstant(MakeJitConstant("TILE_OFM_PER_OSV_SIZE", 2));
+    } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2 && dispatchData.tile_n == 2) {
+        jit.AddConstant(MakeJitConstant("TILE_OFM_PER_OSV_SIZE", 2));
+    } else {
+        jit.AddConstant(MakeJitConstant("TILE_OFM_PER_OSV_SIZE", 1));
+    }
+
     jit.AddConstant(MakeJitConstant("W_DYN_QUAN_IDX", "fi * TILE_K + kii"));
 
     if (dispatchData.use_slm) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -768,7 +768,8 @@ KernelsData FullyConnected_bf_tiled::GetTunedKernelsDataByIndex(const Params &pa
     auto output_f = get_output_aligned_bf_size(fc_params, false).second;
 
     WeightsLayout weights_layout = WeightsLayout::os_iyx_osv16;
-    if (fc_params.compressed && fc_params.inputs[0].GetDType() == Datatype::F16
+    // TODO: Update may also be required to fc_bf_tiled_kernel_dyn_quan kernel to support os_is_yx_osv64_isv2 format as needed
+    if (!should_dynamic_quantize(fc_params) && fc_params.compressed && fc_params.inputs[0].GetDType() == Datatype::F16
         && is_weight_with_large_ofm(fc_params, output_f) && !is_weight_with_large_ifm(fc_params)
         && (fc_params.weights.GetLayout() == WeightsLayout::oiyx || fc_params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
         && (fc_params.weights.GetDType() == WeightsType::INT4 || fc_params.weights.GetDType() == WeightsType::UINT4)) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -573,6 +573,9 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
         if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
             jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size / 2));
             jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load / 2));
+        } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
+            jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size / 2));
+            jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load / 2));
         } else {
             jit.AddConstant(MakeJitConstant("FILTER_ACTUAL_LOAD_BLOCK_SIZE", block_read_size));
             jit.Merge(make_int4_packed_type_jit_constant("INT4_PACKED_TYPE_PRELOAD", params.weights.GetDType(), weights_elements_per_load));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -389,6 +389,8 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
             }
             if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16)
                 return selector.Default(tune_params(8, 1, 1, 4, 1, 1, 1, EXE_MODE_DEFAULT));
+            else if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv64)
+                return selector.Default(tune_params(8, 4, 1, 2, 1, 1, 1, EXE_MODE_DEFAULT));
             else
                 return selector.Default(tune_params(8, 2, 1, 4, 1, 1, 1, EXE_MODE_DEFAULT));
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -371,7 +371,7 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
             } else {
                 if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
                     return selector.Default(tune_params(1, 1, 4, 4, 1, 1, 1, EXE_MODE_DEFAULT));
-                } else if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv64) {
+                } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
                     return selector.Default(tune_params(1, 4, 4, 2, 2, 1, 1, EXE_MODE_DEFAULT));
                 } else {
                     return selector.Default(tune_params(1, 2, 4, 2, 1, 1, 1, EXE_MODE_DEFAULT));
@@ -389,7 +389,7 @@ FullyConnected_bf_tiled::GetAutoTuneParams(const fully_connected_params& params,
             }
             if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16)
                 return selector.Default(tune_params(8, 1, 1, 4, 1, 1, 1, EXE_MODE_DEFAULT));
-            else if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv64)
+            else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
                 return selector.Default(tune_params(8, 4, 1, 2, 1, 1, 1, EXE_MODE_DEFAULT));
             else
                 return selector.Default(tune_params(8, 2, 1, 4, 1, 1, 1, EXE_MODE_DEFAULT));
@@ -532,6 +532,8 @@ JitConstants FullyConnected_bf_tiled::GetJitConstants(const fully_connected_para
     if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2) {
         jit.AddConstant(MakeJitConstant("W_IDX", "fi * TILE_K + kii"));
     } else if (params.weights.GetLayout() == WeightsLayout::os_iyx_osv16) {
+        jit.AddConstant(MakeJitConstant("W_IDX", "fi * TILE_K + kii"));
+    } else if (params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
         jit.AddConstant(MakeJitConstant("W_IDX", "fi * TILE_K + kii"));
     } else {
         jit.AddConstant(MakeJitConstant("W_IDX", "kii * TILE_OFM + fi"));
@@ -753,10 +755,10 @@ KernelsData FullyConnected_bf_tiled::GetTunedKernelsDataByIndex(const Params &pa
     WeightsLayout weights_layout = WeightsLayout::os_iyx_osv16;
     if (fc_params.compressed && fc_params.inputs[0].GetDType() == Datatype::F16
         && output_f >= 10240 && !is_weight_with_large_ifm(fc_params)
-        && (fc_params.weights.GetLayout() == WeightsLayout::oiyx || fc_params.weights.GetLayout() == WeightsLayout::os_iyx_osv64)
+        && (fc_params.weights.GetLayout() == WeightsLayout::oiyx || fc_params.weights.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2)
         && (fc_params.weights.GetDType() == WeightsType::INT4 || fc_params.weights.GetDType() == WeightsType::UINT4)) {
-        // Large N + Small K case to use [osv64] + TILE_OFM 4 for batch 1
-        weights_layout = WeightsLayout::os_iyx_osv64;
+        // Large N + Small K case to use [osv64_isv2] + TILE_OFM 4 for batch 1
+        weights_layout = WeightsLayout::os_is_yx_osv64_isv2;
     } else if (fc_params.compressed && fc_params.inputs[0].GetDType() == Datatype::F16
         && (fc_params.weights.GetDType() == WeightsType::INT4 || fc_params.weights.GetDType() == WeightsType::UINT4)
         && is_weight_with_small_ofm(fc_params, output_f) && is_weight_with_large_ifm(fc_params)

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.h
@@ -42,6 +42,7 @@ public:
                     unsigned tile_ofm,
                     unsigned tile_ifm,
                     unsigned tile_k,
+                    unsigned outer_ofm,
                     unsigned dispatch_bsv,
                     unsigned dispatch_fsv,
                     std::string exec_options,
@@ -50,6 +51,7 @@ public:
             , tile_ofm(tile_ofm)
             , tile_ifm(tile_ifm)
             , tile_k(tile_k)
+            , outer_ofm(outer_ofm)
             , dispatch_bsv(dispatch_bsv)
             , dispatch_fsv(dispatch_fsv)
             , exec_options(exec_options)
@@ -62,6 +64,7 @@ public:
         unsigned tile_ofm;
         unsigned tile_ifm;
         unsigned tile_k;
+        unsigned outer_ofm;
         unsigned dispatch_bsv;
         unsigned dispatch_fsv;
         std::string exec_options;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
@@ -21,6 +21,7 @@ ParamsKey ReorderWeightsKernelInt4::GetSupportedKey() const {
     k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv16);
     k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv32);
     k.EnableOutputWeightsLayout(WeightsLayout::os_is_yx_osv32_isv2);
+    k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv64);
     k.EnableOutputWeightsLayout(WeightsLayout::oiyx);
     k.EnableTensorOffset();
     k.EnableTensorPitches();
@@ -44,6 +45,8 @@ ReorderWeightsKernelInt4::DispatchData ReorderWeightsKernelInt4::SetDefault(cons
         dispatchData.gws = { Align(output.OFM().v, 32), output.IFM().v / 2, 1 };
     } else if (output.GetLayout() == WeightsLayout::os_iyx_osv16) {
         dispatchData.gws = { Align(output.OFM().v, 16), output.IFM().v / 2, 1 };
+    } else if (output.GetLayout() == WeightsLayout::os_iyx_osv64) {
+        dispatchData.gws = { Align(output.OFM().v, 64) / 2, output.IFM().v, 1 };
     } else {
         dispatchData.gws = { CeilDiv(output.LogicalSize(), 2), 1, 1 };
     }
@@ -65,6 +68,7 @@ bool ReorderWeightsKernelInt4::Validate(const Params& params) const {
     bool supported_case = input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2;
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv16;
+    supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv64;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::oiyx;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
     return supported_case;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_weights_int4.cpp
@@ -22,6 +22,7 @@ ParamsKey ReorderWeightsKernelInt4::GetSupportedKey() const {
     k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv32);
     k.EnableOutputWeightsLayout(WeightsLayout::os_is_yx_osv32_isv2);
     k.EnableOutputWeightsLayout(WeightsLayout::os_iyx_osv64);
+    k.EnableOutputWeightsLayout(WeightsLayout::os_is_yx_osv64_isv2);
     k.EnableOutputWeightsLayout(WeightsLayout::oiyx);
     k.EnableTensorOffset();
     k.EnableTensorPitches();
@@ -47,6 +48,8 @@ ReorderWeightsKernelInt4::DispatchData ReorderWeightsKernelInt4::SetDefault(cons
         dispatchData.gws = { Align(output.OFM().v, 16), output.IFM().v / 2, 1 };
     } else if (output.GetLayout() == WeightsLayout::os_iyx_osv64) {
         dispatchData.gws = { Align(output.OFM().v, 64) / 2, output.IFM().v, 1 };
+    } else if (output.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2) {
+        dispatchData.gws = { Align(output.OFM().v, 64), output.IFM().v / 2, 1 };
     } else {
         dispatchData.gws = { CeilDiv(output.LogicalSize(), 2), 1, 1 };
     }
@@ -69,6 +72,7 @@ bool ReorderWeightsKernelInt4::Validate(const Params& params) const {
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_is_yx_osv32_isv2;
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv16;
     supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_iyx_osv64;
+    supported_case |= input.GetLayout() == WeightsLayout::oiyx && output.GetLayout() == WeightsLayout::os_is_yx_osv64_isv2;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::oiyx;
     supported_case |= input.GetLayout() == WeightsLayout::ioyx && output.GetLayout() == WeightsLayout::os_iyx_osv32;
     return supported_case;

--- a/src/plugins/intel_gpu/src/kernel_selector/tensor_type.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/tensor_type.cpp
@@ -118,6 +118,7 @@ WeightsTensor::WeightsChannelArray WeightsTensor::weightsChannelArray {{
     { WeightsLayout::os_is_yx_osv32_isv4_swizzled_by_2,           {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::os_is_yx_osv32_isv4,                         {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::os_is_yx_osv32_isv2,                         {  0,  1, -1,   2,   3, -1 } },
+    { WeightsLayout::os_is_yx_osv64_isv2,                         {  0,  1, -1,   2,   3, -1 } },
     { WeightsLayout::os_is_zyx_osv32_isv4,                        {  0,  1,  2,   3,   4, -1 } },
     { WeightsLayout::oizyx,                                       {  0,  1,  2,   3,   4, -1 } },
     { WeightsLayout::iozyx,                                       {  0,  1,  2,   4,   3, -1 } },

--- a/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/tensor_type.h
@@ -113,6 +113,7 @@ enum WeightsLayout {
     os_i_osv16,
     os_is_yx_osv16_isv16,           // weights for int8 blocked conv
     os_is_yx_osv32_isv2,            // weights for fully connected kernels with int4 compressed data type
+    os_is_yx_osv64_isv2,            // weights for fully connected kernels with int4 compressed data type
     os_is_zyx_osv16_isv16,
     os_is_zyx_osv32_isv16,
     os_is_zyx_osv64_isv16,

--- a/src/plugins/intel_gpu/src/runtime/format.cpp
+++ b/src/plugins/intel_gpu/src/runtime/format.cpp
@@ -124,6 +124,7 @@ static const std::map<format::type, format_traits> format_traits_map {
         FMT_TRAITS(os_is_yx_isv8_osv16_isv2,                     1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{1, 8}, {0, 16}, {1, 2}},         {{1, 8}, {0, 16}, {1, 2}}),  // NOLINT
         FMT_TRAITS(os_is_yx_osv16_isv16,                         1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 16}, {1, 16}},                {{0, 16}, {1, 16}}),  // NOLINT
         FMT_TRAITS(os_is_yx_osv32_isv2,                          1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 32}},                         {{0, 32}}),  // NOLINT
+        FMT_TRAITS(os_is_yx_osv64_isv2,                          1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 64}},                         {{0, 64}}),  // NOLINT
         FMT_TRAITS(os_is_zyx_osv32_isv16,                        1, 1, 3, 0, {0, 1, 2, 3, 4}, "oizyx",  "oixyz", {{0, 32}, {1, 16}},                {{0, 32}, {1, 16}}),  // NOLINT
         FMT_TRAITS(os_is_zyx_osv64_isv16,                        1, 1, 3, 0, {0, 1, 2, 3, 4}, "oizyx",  "oixyz", {{0, 64}, {1, 16}},                {{0, 64}, {1, 16}}),  // NOLINT
         FMT_TRAITS(os_iyx_osv8,                                  1, 1, 2, 0, {0, 1, 2, 3},    "oiyx",   "oixy",  {{0, 8}},                          {{0, 8}}),  // NOLINT

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1513,6 +1513,10 @@ public:
     void test_compressed_int4_scale_large_n(bool is_caching_test, bool is_dynamic, long int batch_num, bool is_dyn_quan = false) {
         tests::random_generator rg(GET_SUITE_NAME);
         auto& engine = get_test_engine();
+
+        if (engine.get_device_info().dev_type == device_type::discrete_gpu)
+            GTEST_SKIP();
+
         auto supports_immad = engine.get_device_info().supports_immad;
 
         long int ifm_num = 4096;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1681,89 +1681,6 @@ public:
         }
     }
 
-    void test_compressed_int4_scale_andrew(bool is_caching_test, bool is_dynamic, long int batch_num, long int ifm_num, long int ofm_num, long int scales_group_size = 128, bool is_wei_dyn = false) {
-        tests::random_generator rg(GET_SUITE_NAME);
-        auto& engine = get_test_engine();
-        auto supports_immad = engine.get_device_info().supports_immad;
-
-        auto input_mem_host = engine.allocate_memory({ { batch_num, 1, ifm_num}, data_types::f32, format::bfyx });
-        auto weights_mem_host = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
-        auto weights_mem_dev = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx }, cldnn::allocation_type::usm_device);
-        auto scale_mem_host = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
-        auto scale_mem_dev = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx }, cldnn::allocation_type::usm_device);
-        auto dcomp_zp_mem_host = engine.allocate_memory({ {1, 1, 1, 1}, data_types::u8, format::bfyx });
-
-        set_values(dcomp_zp_mem_host, {8});
-
-        auto input_data = rg.generate_random_1d<float>(batch_num * ifm_num, -2.0f, 2.0f);
-        set_values(input_mem_host, input_data);
-
-        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
-        set_values(weights_mem_host, weigths_data);
-        weights_mem_dev->copy_from(engine.get_service_stream(), weights_mem_host->buffer_ptr(), true);
-
-        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -4.0f, 4.0f);
-        set_values(scale_mem_host, scale_data);
-        scale_mem_dev->copy_from(engine.get_service_stream(), scale_mem_host->buffer_ptr(), true);
-
-        auto in_layout = is_dynamic ? layout{ {-1, 1, ifm_num}, data_types::f32, format::bfyx }
-                                    : layout{ {batch_num, 1, ifm_num}, data_types::f32, format::bfyx };
-
-        auto in_layout_half = is_dynamic ? layout{ {-1, 1, ifm_num}, data_types::f16, format::bfyx }
-                                         : layout{ {batch_num, 1, ifm_num}, data_types::f16, format::bfyx };
-
-        if (is_dynamic && is_wei_dyn) {
-            // ifm_num is dynamic
-            in_layout = layout{ {-1, 1, -1}, data_types::f16, format::bfyx };
-        }
-
-        auto dcomp_zp_name = supports_immad ? "dcomp_zp" : "";
-
-        auto fc_prim = fully_connected("fc_prim", input_info("input_dev"), "weights", "", "scale", dcomp_zp_name, data_types::f16, 3, 2);
-
-        fc_prim.decompression_zero_point_scalar = 8;
-
-        topology topology(
-            input_layout("input", in_layout),
-            reorder("input_dev", input_info("input"), in_layout_half),
-            data("weights", weights_mem_dev),
-            data("scale", scale_mem_dev),
-            data("dcomp_zp", dcomp_zp_mem_host),
-            fc_prim,
-            reorder("output", input_info("fc_prim"), layout { {1, ofm_num}, data_types::f32, format::bfyx})
-        );
-
-        auto config = get_test_default_config(engine);
-        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
-        config.set_property(ov::intel_gpu::optimize_data(true));
-
-        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
-
-        // Impl is selected only when it is running from cldnn
-        if (is_dynamic && !engine.get_device_info().supports_immad) {
-            auto inst = network->get_primitive("fc_prim");
-            auto impl = inst->get_impl();
-            ASSERT_TRUE(impl != NULL);
-            ASSERT_EQ(impl->get_kernels().size(), 2);
-        }
-        int num_exec = 200;
-        for (auto exec = 0; exec < num_exec; exec++) {
-            network->set_input_data("input", input_mem_host);
-
-            auto outputs = network->execute();
-            ASSERT_EQ(outputs.size(), size_t(1));
-            ASSERT_EQ(outputs.begin()->first, "output");
-
-            auto output_mem = outputs.begin()->second.get_memory();
-            cldnn::mem_lock<float> output_ptr (output_mem, get_test_stream());
-
-            if (exec == num_exec - 1) {
-               std::cout << output_ptr[0] << std::endl;
-               std::cout << output_ptr[10] << std::endl;
-            }
-        }
-    }
-
     void test_compressed_int8_scale_zp_bias(bool is_caching_test) {
         auto& engine = get_test_engine();
 
@@ -3706,38 +3623,6 @@ TEST_F(fully_connected_gpu_tests, compressed_int4_scale_b1g64) {
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_b1g128) {
     this->test_compressed_int4_scale(false, false, 1, 128);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_andrew) {
-    this->test_compressed_int4_scale_andrew(false, false, 1, 4096, 27392, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_dyn_andrew) {
-    this->test_compressed_int4_scale_andrew(false, true, 1, 4096, 27392, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_batch_andrew) {
-    this->test_compressed_int4_scale_andrew(false, false, 1024, 4096, 27392, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_batch_dyn_andrew) {
-    this->test_compressed_int4_scale_andrew(false, true, 1024, 4096, 27392, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_llama3_andrew) {
-    this->test_compressed_int4_scale_andrew(false, false, 1, 4096, 14336, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_llama3_dyn_andrew) {
-    this->test_compressed_int4_scale_andrew(false, true, 1, 4096, 14336, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_qwen2_andrew) {
-    this->test_compressed_int4_scale_andrew(false, false, 1, 3584, 18944, 32);
-}
-
-TEST_F(fully_connected_gpu_tests, compressed_int4_scale_qwen2_dyn_andrew) {
-    this->test_compressed_int4_scale_andrew(false, true, 1, 3584, 18944, 32);
 }
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_dyn_quan_single_batch) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3716,6 +3716,14 @@ TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_dyn_andrew) {
     this->test_compressed_int4_scale_andrew(false, true, 1, 4096, 27392, 32);
 }
 
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_batch_andrew) {
+    this->test_compressed_int4_scale_andrew(false, false, 1024, 4096, 27392, 32);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_chatglm3_batch_dyn_andrew) {
+    this->test_compressed_int4_scale_andrew(false, true, 1024, 4096, 27392, 32);
+}
+
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale_llama3_andrew) {
     this->test_compressed_int4_scale_andrew(false, false, 1, 4096, 14336, 32);
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -1510,6 +1510,116 @@ public:
             ASSERT_NEAR(output_ptr_ref[i], output_ptr[i], 9.0) << "i = " << i;
     }
 
+    void test_compressed_int4_scale_large_n(bool is_caching_test, bool is_dynamic, long int batch_num, bool is_dyn_quan = false) {
+        tests::random_generator rg(GET_SUITE_NAME);
+        auto& engine = get_test_engine();
+        auto supports_immad = engine.get_device_info().supports_immad;
+
+        long int ifm_num = 4096;
+        long int ofm_num = 14336;
+        long int scales_group_size = 32;
+
+        auto input_mem = engine.allocate_memory({ { batch_num, 1, ifm_num}, data_types::f16, format::bfyx });
+        auto weights_mem = engine.allocate_memory({ {ofm_num, ifm_num}, data_types::u4, format::bfyx });
+        auto scale_mem = engine.allocate_memory({ {ofm_num, ifm_num / scales_group_size}, data_types::f16, format::bfyx });
+        auto dcomp_zp_mem = engine.allocate_memory({ {1, 1, 1, 1}, data_types::u8, format::bfyx });
+
+        set_values(dcomp_zp_mem, {8});
+
+        auto input_data = rg.generate_random_1d<ov::float16>(batch_num * ifm_num, -1.0f, 1.0f);
+        set_values(input_mem, input_data);
+
+        auto weigths_data = rg.generate_random_1d<uint8_t>(ofm_num * ifm_num / 2, 0, 10);
+        set_values(weights_mem, weigths_data);
+
+        auto scale_data = rg.generate_random_1d<ov::float16>(ofm_num * ifm_num / scales_group_size, -1.0f, 1.0f);
+        set_values(scale_mem, scale_data);
+
+        auto in_layout = is_dynamic ? layout{ {-1, 1, ifm_num}, data_types::f16, format::bfyx }
+                                    : layout{ {batch_num, 1, ifm_num}, data_types::f16, format::bfyx };
+
+        if (is_dynamic) {
+            // ifm_num is dynamic
+            in_layout = layout{ {-1, -1, -1}, data_types::f16, format::bfyx };
+        }
+
+        auto dcomp_zp_name = supports_immad ? "dcomp_zp" : "";
+
+        auto fc_prim = fully_connected("fc_prim", input_info("input"), "weights", "", "scale", dcomp_zp_name, data_types::f16, 3, 2);
+
+        fc_prim.decompression_zero_point_scalar = 8;
+
+        auto get_ref_results = [&]() {
+            topology topology(
+                input_layout("input", in_layout),
+                data("weights", weights_mem),
+                data("scale", scale_mem),
+                data("dcomp_zp", dcomp_zp_mem),
+                fc_prim
+            );
+
+            auto config = get_test_default_config(engine);
+            config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+            ov::intel_gpu::ImplementationDesc fc_impl_desc = { format::bfyx, "fully_connected_gpu_bfyx_ref", impl_types::ocl };
+            config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"fc_prim", fc_impl_desc} }));
+            if (is_dyn_quan) {
+                config.set_property(ov::hint::dynamic_quantization_group_size(0));
+            }
+
+            network network(engine, topology, config);
+            network.set_input_data("input", input_mem);
+
+            auto outputs = network.execute();
+            OPENVINO_ASSERT(outputs.size() == 1);
+            OPENVINO_ASSERT(outputs.begin()->first == "fc_prim");
+
+            auto output_layout = outputs.begin()->second.get_layout();
+            auto output_mem = outputs.begin()->second.get_memory();
+
+            return engine.reinterpret_buffer(*output_mem, output_layout);
+        };
+
+        topology topology(
+            input_layout("input", in_layout),
+            data("weights", weights_mem),
+            data("scale", scale_mem),
+            data("dcomp_zp", dcomp_zp_mem),
+            fc_prim
+        );
+
+        auto config = get_test_default_config(engine);
+        config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+        config.set_property(ov::intel_gpu::optimize_data(true));
+        if (is_dyn_quan) {
+            config.set_property(ov::hint::dynamic_quantization_group_size(32));
+        }
+
+        network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
+
+        // Impl is selected only when it is running from cldnn
+        if (is_dynamic && !engine.get_device_info().supports_immad) {
+            auto inst = network->get_primitive("fc_prim");
+            auto impl = inst->get_impl();
+            ASSERT_TRUE(impl != NULL);
+            ASSERT_EQ(impl->get_kernels().size(), 2);
+        }
+
+        network->set_input_data("input", input_mem);
+
+        auto outputs = network->execute();
+        ASSERT_EQ(outputs.size(), size_t(1));
+        ASSERT_EQ(outputs.begin()->first, "fc_prim");
+
+        auto output_mem = outputs.begin()->second.get_memory();
+        cldnn::mem_lock<ov::float16> output_ptr (output_mem, get_test_stream());
+
+        auto ref_output_mem = get_ref_results();
+        cldnn::mem_lock<ov::float16> output_ptr_ref (ref_output_mem, get_test_stream());
+
+        for (size_t i = 0; i < output_ptr_ref.size(); i++)
+            ASSERT_NEAR(output_ptr_ref[i], output_ptr[i], 12.0) << "i = " << i;
+    }
+
     void test_compressed_int4_accumulation(bool is_caching_test, bool is_dynamic, long int batch_num) {
         auto& engine = get_test_engine();
 
@@ -3575,6 +3685,30 @@ TEST_F(fully_connected_gpu_tests, compressed_scale_zp_bias_cached) {
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_scale) {
     this->test_compressed_int4_scale(false, false, 256);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_large_n) {
+    this->test_compressed_int4_scale_large_n(false, false, 1);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_large_n_cached) {
+    this->test_compressed_int4_scale_large_n(true, false, 1);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_large_n_dynamic) {
+    this->test_compressed_int4_scale_large_n(false, true, 1);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_large_n_dynamic_cached) {
+    this->test_compressed_int4_scale_large_n(true, true, 1);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_large_n_dyn_quan) {
+    this->test_compressed_int4_scale_large_n(false, false, 1, true);
+}
+
+TEST_F(fully_connected_gpu_tests, compressed_int4_scale_large_n_dyn_quan_dynamic) {
+    this->test_compressed_int4_scale_large_n(true, false, 1, true);
 }
 
 TEST_F(fully_connected_gpu_tests, compressed_int4_reuse_scale) {


### PR DESCRIPTION
### Details:
 - Optimize fc_bf_tiled kernel for large N + small K case by setting TILE_OFM=4 w/ os_is_yx_osv64_isv2 weight format
 - Perf gain on MTL (U7 155H + 32G RAM + driver 31.0.101.5522)
![image](https://github.com/user-attachments/assets/4139cf1b-db67-4a46-93ae-204058db3739)

### Tickets:
 - 148076
