### PR TITLE
[DOCS] D3D11 surface sharing support

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/gpu-device/remote-tensor-api-gpu-plugin.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/gpu-device/remote-tensor-api-gpu-plugin.rst
@@ -452,6 +452,11 @@ pointers or the ``VASurfaceID`` handle, as shown in the examples below:
          infer_request.wait();
 
 
+.. important::
+
+   Currently, only sharing of D3D11 surfaces is supported via the
+   `cl_intel_d3d11_nv12_media_sharing <https://github.com/KhronosGroup/OpenCL-Registry/blob/main/extensions/intel/cl_intel_d3d11_nv12_media_sharing.txt>`__
+   extension, which provides interoperability between OpenCL and DirectX.
 
 
 Direct NV12 Video Surface Input


### PR DESCRIPTION
Adding info on support for sharing of D3D11 surfaces in `Remote Tensor API of GPU Plugin`. Addressing JIRA Ticket: 120077
