### PR TITLE
[NPU] Add compile interface with custom allocator

### DIFF
--- a/src/plugins/intel_npu/src/al/src/icompiler.cpp
+++ b/src/plugins/intel_npu/src/al/src/icompiler.cpp
@@ -64,4 +64,10 @@ void NetworkMetadata::bindRelatedDescriptors() {
     }
 }
 
+BlobView::BlobView(uint8_t* _ptr, uint64_t _size) : ptr(_ptr), size(_size) {}
+
+AllocatedCompiledNetwork::AllocatedCompiledNetwork(BlobView blob, NetworkMetadata&& meta)
+    : compiledNetwork(std::move(blob)),
+      metadata(std::move(meta)) {}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -26,6 +26,10 @@ public:
     NetworkDescription compile(const std::shared_ptr<const ov::Model>& model,
                                const Config& config) const override final;
 
+    AllocatedCompiledNetwork compile(const std::shared_ptr<const ov::Model>& model,
+                                     const Config& config,
+                                     BlobAllocator& allocator) const override final;
+
     ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const override final;
 
     NetworkMetadata parse(const std::vector<uint8_t>& network, const Config& config) const override final;

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -69,6 +69,12 @@ public:
     NetworkDescription compile(const std::shared_ptr<const ov::Model>& model,
                                const Config& config) const override final;
 
+    AllocatedCompiledNetwork compile(const std::shared_ptr<const ov::Model>& model,
+                                     const Config& config,
+                                     BlobAllocator& allocator) const override final {
+        OPENVINO_THROW("Compilation with allocator is not implemented");
+    }
+
     ze_result_t seriazlideIRModelAndCreateGraph(const std::shared_ptr<const ov::Model>& model,
                                                 const Config& config,
                                                 ze_device_graph_properties_t deviceGraphProperties,

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -93,6 +93,12 @@ NetworkDescription LevelZeroCompilerAdapter::compile(const std::shared_ptr<const
     return apiAdapter->compile(model, config);
 }
 
+AllocatedCompiledNetwork LevelZeroCompilerAdapter::compile(const std::shared_ptr<const ov::Model>& model,
+                                                           const Config& config,
+                                                           BlobAllocator& allocator) const {
+    OPENVINO_THROW("Compilation with allocator is not implemented");
+}
+
 ov::SupportedOpsMap LevelZeroCompilerAdapter::query(const std::shared_ptr<const ov::Model>& model,
                                                     const Config& config) const {
     _logger.debug("query start");


### PR DESCRIPTION
### Details:
New API method allows to compile an OV model with blob storage allocated via given interface. It allows to save extra memory consumption on copying a blob from compiler to the caller (UMD at the moment). With new method blob could be allocated directly at desired location (e.g. cache) and used afterwards without any copy of the data.

Note that compiler does not own blob storage and it is responsibility of the caller to deallocate memory after compilation.

### Tickets:
 - [EISW-139919](https://jira.devtools.intel.com/browse/EISW-139919)
