### PR TITLE
[`intel_npu`] [`releases/2024/4`] [`reduce memory consumption`] Avoid creating a blob copy while exporting a compiled model

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -203,8 +203,8 @@ public:
     // Driver compiler can use this to release graphHandle, if we do not have executor
     virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
-    virtual std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
-        return networkDescription->compiledNetwork;
+    virtual std::pair<const uint8_t*, size_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
+        return {networkDescription->compiledNetwork.data(), networkDescription->compiledNetwork.size()};
     }
 
 protected:

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -216,7 +216,9 @@ public:
     virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
     virtual CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
-        return CompiledNetwork{networkDescription->compiledNetwork.data(), networkDescription->compiledNetwork.size(), networkDescription->compiledNetwork};
+        return CompiledNetwork{networkDescription->compiledNetwork.data(),
+                               networkDescription->compiledNetwork.size(),
+                               networkDescription->compiledNetwork};
     }
 
 protected:

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -168,13 +168,13 @@ struct NetworkDescription final {
 struct CompiledNetwork {
     const uint8_t* data;
     size_t size;
-    CompiledNetwork(const uint8_t* data, size_t size, const std::vector<uint8_t>&& storage)
+    CompiledNetwork(const uint8_t* data, size_t size, std::vector<uint8_t> storage)
         : data(data),
           size(size),
           ownedStorage(std::move(storage)) {}
 
 private:
-    const std::vector<uint8_t> ownedStorage;
+    std::vector<uint8_t> ownedStorage;
 };
 
 /**
@@ -229,10 +229,10 @@ public:
     // Driver compiler can use this to release graphHandle, if we do not have executor
     virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
-    virtual CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
-        return CompiledNetwork(networkDescription->compiledNetwork.data(),
-                               networkDescription->compiledNetwork.size(),
-                               std::move(networkDescription->compiledNetwork));
+    virtual CompiledNetwork getCompiledNetwork(const NetworkDescription& networkDescription) {
+        return CompiledNetwork(networkDescription.compiledNetwork.data(),
+                               networkDescription.compiledNetwork.size(),
+                               networkDescription.compiledNetwork);
     }
 
 protected:

--- a/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/al/icompiler.hpp
@@ -152,6 +152,18 @@ struct NetworkDescription final {
 };
 
 /**
+ * @struct CompiledNetwork
+ * @brief Custom container for compiled model, used for model export
+ * Underlying container will be empty for optimized memory consumption
+ */
+
+struct CompiledNetwork {
+    const uint8_t* data;
+    size_t size;
+    std::vector<uint8_t> container;
+};
+
+/**
  * @interface ICompiler
  * @brief An interface to be implemented by a concrete compiler to provide
  * methods for preparing a network for execution on a NPU device
@@ -203,8 +215,8 @@ public:
     // Driver compiler can use this to release graphHandle, if we do not have executor
     virtual void release([[maybe_unused]] std::shared_ptr<const NetworkDescription> networkDescription){};
 
-    virtual std::pair<const uint8_t*, size_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
-        return {networkDescription->compiledNetwork.data(), networkDescription->compiledNetwork.size()};
+    virtual CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) {
+        return CompiledNetwork{networkDescription->compiledNetwork.data(), networkDescription->compiledNetwork.size(), networkDescription->compiledNetwork};
     }
 
 protected:

--- a/src/plugins/intel_npu/src/backend/include/zero_types.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_types.hpp
@@ -75,6 +75,7 @@ public:
         // wrappers replace pointers
 
         // version 1.7
+        pfnGetNativeBinary2 = _impl->pfnGetNativeBinary2;
     }
     ~ze_graph_dditable_ext_decorator() = default;
 

--- a/src/plugins/intel_npu/src/backend/include/zero_types.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_types.hpp
@@ -134,8 +134,7 @@ public:
     }
 
     // version 1.7
-    ze_result_t ZE_APICALL pfnGetNativeBinary2(ze_graph_handle_t hGraph,
-                                                        size_t* pSize, uint8_t** pGraphNativeBinary) {
+    ze_result_t ZE_APICALL pfnGetNativeBinary2(ze_graph_handle_t hGraph, size_t* pSize, uint8_t** pGraphNativeBinary) {
         throwWhenUnsupported("pfnGetNativeBinary2", ZE_GRAPH_EXT_VERSION_1_7);
         return _impl->pfnGetNativeBinary2(hGraph, pSize, pGraphNativeBinary);
     }

--- a/src/plugins/intel_npu/src/backend/include/zero_types.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_types.hpp
@@ -73,9 +73,6 @@ public:
 
         // version 1.5
         // wrappers replace pointers
-
-        // version 1.7
-        pfnGetNativeBinary2 = _impl->pfnGetNativeBinary2;
     }
     ~ze_graph_dditable_ext_decorator() = default;
 
@@ -137,7 +134,11 @@ public:
     }
 
     // version 1.7
-    ze_pfnGraphGetNativeBinary_ext_2_t pfnGetNativeBinary2;
+    ze_result_t ZE_APICALL pfnGetNativeBinary2(ze_graph_handle_t hGraph,
+                                                        size_t* pSize, uint8_t** pGraphNativeBinary) {
+        throwWhenUnsupported("pfnGetNativeBinary2", ZE_GRAPH_EXT_VERSION_1_7);
+        return _impl->pfnGetNativeBinary2(hGraph, pSize, pGraphNativeBinary);
+    }
 };
 
 using ze_graph_dditable_ext_curr_t = ze_graph_dditable_ext_decorator;

--- a/src/plugins/intel_npu/src/backend/include/zero_types.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_types.hpp
@@ -13,7 +13,7 @@
 /**
  * @brief Last version of Table of Graph Extension functions used within plugin
  */
-using ze_graph_dditable_ext_last_t = ze_graph_dditable_ext_1_6_t;
+using ze_graph_dditable_ext_last_t = ze_graph_dditable_ext_1_7_t;
 
 /**
  * @brief Table of Graph Extension functions pointers and function wrappers
@@ -73,6 +73,8 @@ public:
 
         // version 1.5
         // wrappers replace pointers
+
+        // version 1.7
     }
     ~ze_graph_dditable_ext_decorator() = default;
 
@@ -132,6 +134,9 @@ public:
         throwWhenUnsupported("pfnDeviceGetGraphProperties2", ZE_GRAPH_EXT_VERSION_1_6);
         return _impl->pfnDeviceGetGraphProperties2(hDevice, pDeviceGraphProperties);
     }
+
+    // version 1.7
+    ze_pfnGraphGetNativeBinary_ext_2_t pfnGetNativeBinary2;
 };
 
 using ze_graph_dditable_ext_curr_t = ze_graph_dditable_ext_decorator;

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -36,7 +36,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    CompiledNetwork getCompiledNetwork(const NetworkDescription& networkDescription) override;
 
 private:
     /**

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -36,7 +36,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    std::pair<const uint8_t*, size_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
 private:
     /**

--- a/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/driver_compiler_adapter.hpp
@@ -36,7 +36,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    std::pair<const uint8_t*, size_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
 private:
     /**

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -129,12 +129,12 @@ private:
                      std::vector<IODescriptor>& outputs) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<UseCopyForNativeBinary(T), bool> = true>
-    void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
+    void getNativeBinary(TableExtension* graphDdiTableExt,
                          ze_graph_handle_t graphHandle, std::vector<uint8_t>& blob,
                          uint8_t** blobPtr, size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<!UseCopyForNativeBinary(T), bool> = true>
-    void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
+    void getNativeBinary(TableExtension* graphDdiTableExt,
                          ze_graph_handle_t graphHandle, std::vector<uint8_t>& /* unusedBlob */,
                          uint8_t** blobPtr, size_t* blobSize) const;
 

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -43,6 +43,11 @@ using SerializedIR = std::pair<size_t, std::shared_ptr<uint8_t>>;
     (std::is_same<T, ze_graph_dditable_ext_1_2_t>::value || std::is_same<T, ze_graph_dditable_ext_1_3_t>::value || \
      std::is_same<T, ze_graph_dditable_ext_1_4_t>::value || std::is_same<T, ze_graph_dditable_ext_1_5_t>::value)
 
+#define UseCopyForNativeBinary(T)                                                                                  \
+    (std::is_same<T, ze_graph_dditable_ext_1_2_t>::value || std::is_same<T, ze_graph_dditable_ext_1_3_t>::value || \
+     std::is_same<T, ze_graph_dditable_ext_1_4_t>::value || std::is_same<T, ze_graph_dditable_ext_1_5_t>::value || \
+     std::is_same<T, ze_graph_dditable_ext_1_6_t>::value)
+
 /**
  * Adapter to use CiD through ZeroAPI
  */
@@ -122,6 +127,16 @@ private:
                      uint32_t index,
                      std::vector<IODescriptor>& inputs,
                      std::vector<IODescriptor>& outputs) const;
+
+    template <typename T = TableExtension, typename std::enable_if_t<UseCopyForNativeBinary(T), bool> = true>
+    void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
+                         ze_graph_handle_t graphHandle,
+                         std::vector<uint8_t>& blob) const;
+
+    template <typename T = TableExtension, typename std::enable_if_t<!UseCopyForNativeBinary(T), bool> = true>
+    void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
+                         ze_graph_handle_t graphHandle,
+                         std::vector<uint8_t>& blob) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<SupportAPIGraphQueryNetworkV2(T), bool> = true>
     ze_result_t seriazlideIRModelAndQueryNetworkCreateV2(const std::shared_ptr<const ov::Model>& model,

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -105,7 +105,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    std::vector<uint8_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    std::pair<const uint8_t*, size_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
 private:
     NetworkMetadata getNetworkMeta(ze_graph_handle_t graphHandle) const;
@@ -131,12 +131,14 @@ private:
     template <typename T = TableExtension, typename std::enable_if_t<UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
                          ze_graph_handle_t graphHandle,
-                         std::vector<uint8_t>& blob) const;
+                         std::shared_ptr<const NetworkDescription> networkDescription,
+                         uint8_t** blobPtr, size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<!UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
                          ze_graph_handle_t graphHandle,
-                         std::vector<uint8_t>& blob) const;
+                         std::shared_ptr<const NetworkDescription>,
+                         uint8_t** blobPtr, size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<SupportAPIGraphQueryNetworkV2(T), bool> = true>
     ze_result_t seriazlideIRModelAndQueryNetworkCreateV2(const std::shared_ptr<const ov::Model>& model,

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -105,7 +105,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    CompiledNetwork getCompiledNetwork(const NetworkDescription& networkDescription) override;
 
 private:
     NetworkMetadata getNetworkMeta(ze_graph_handle_t graphHandle) const;
@@ -132,15 +132,15 @@ private:
     void getNativeBinary(TableExtension* graphDdiTableExt,
                          ze_graph_handle_t graphHandle,
                          std::vector<uint8_t>& blob,
-                         uint8_t** blobPtr,
-                         size_t* blobSize) const;
+                         uint8_t*& blobPtr,
+                         size_t& blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<!UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(TableExtension* graphDdiTableExt,
                          ze_graph_handle_t graphHandle,
                          std::vector<uint8_t>& /* unusedBlob */,
-                         uint8_t** blobPtr,
-                         size_t* blobSize) const;
+                         uint8_t*& blobPtr,
+                         size_t& blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<SupportAPIGraphQueryNetworkV2(T), bool> = true>
     ze_result_t seriazlideIRModelAndQueryNetworkCreateV2(const std::shared_ptr<const ov::Model>& model,

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -105,7 +105,7 @@ public:
 
     void release(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
-    std::pair<const uint8_t*, size_t> getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
+    CompiledNetwork getCompiledNetwork(std::shared_ptr<const NetworkDescription> networkDescription) override;
 
 private:
     NetworkMetadata getNetworkMeta(ze_graph_handle_t graphHandle) const;
@@ -130,14 +130,12 @@ private:
 
     template <typename T = TableExtension, typename std::enable_if_t<UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
-                         ze_graph_handle_t graphHandle,
-                         std::shared_ptr<const NetworkDescription> networkDescription,
+                         ze_graph_handle_t graphHandle, std::vector<uint8_t>& blob,
                          uint8_t** blobPtr, size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<!UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
-                         ze_graph_handle_t graphHandle,
-                         std::shared_ptr<const NetworkDescription>,
+                         ze_graph_handle_t graphHandle, std::vector<uint8_t>& /* unusedBlob */,
                          uint8_t** blobPtr, size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<SupportAPIGraphQueryNetworkV2(T), bool> = true>

--- a/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
+++ b/src/plugins/intel_npu/src/compiler/include/zero_compiler_in_driver.hpp
@@ -130,13 +130,17 @@ private:
 
     template <typename T = TableExtension, typename std::enable_if_t<UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(TableExtension* graphDdiTableExt,
-                         ze_graph_handle_t graphHandle, std::vector<uint8_t>& blob,
-                         uint8_t** blobPtr, size_t* blobSize) const;
+                         ze_graph_handle_t graphHandle,
+                         std::vector<uint8_t>& blob,
+                         uint8_t** blobPtr,
+                         size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<!UseCopyForNativeBinary(T), bool> = true>
     void getNativeBinary(TableExtension* graphDdiTableExt,
-                         ze_graph_handle_t graphHandle, std::vector<uint8_t>& /* unusedBlob */,
-                         uint8_t** blobPtr, size_t* blobSize) const;
+                         ze_graph_handle_t graphHandle,
+                         std::vector<uint8_t>& /* unusedBlob */,
+                         uint8_t** blobPtr,
+                         size_t* blobSize) const;
 
     template <typename T = TableExtension, typename std::enable_if_t<SupportAPIGraphQueryNetworkV2(T), bool> = true>
     ze_result_t seriazlideIRModelAndQueryNetworkCreateV2(const std::shared_ptr<const ov::Model>& model,

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -64,6 +64,12 @@ LevelZeroCompilerAdapter::LevelZeroCompilerAdapter(std::shared_ptr<IEngineBacken
                                                                                               zeContext,
                                                                                               graph_ddi_table_ext);
         break;
+    case ZE_GRAPH_EXT_VERSION_1_7:
+        apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_7_t>>(driverHandle,
+                                                                                              deviceHandle,
+                                                                                              zeContext,
+                                                                                              graph_ddi_table_ext);
+        break;
     default:
         apiAdapter = std::make_shared<LevelZeroCompilerInDriver<ze_graph_dditable_ext_1_2_t>>(driverHandle,
                                                                                               deviceHandle,

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -115,7 +115,7 @@ void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription>
     apiAdapter->release(std::move(networkDescription));
 }
 
-std::pair<const uint8_t*, size_t> LevelZeroCompilerAdapter::getCompiledNetwork(
+CompiledNetwork LevelZeroCompilerAdapter::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
     _logger.info("getCompiledNetwork - using adapter to perform getCompiledNetwork(networkDescription)");
     return apiAdapter->getCompiledNetwork(std::move(networkDescription));

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -115,8 +115,7 @@ void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription>
     apiAdapter->release(std::move(networkDescription));
 }
 
-CompiledNetwork LevelZeroCompilerAdapter::getCompiledNetwork(
-    std::shared_ptr<const NetworkDescription> networkDescription) {
+CompiledNetwork LevelZeroCompilerAdapter::getCompiledNetwork(const NetworkDescription& networkDescription) {
     _logger.info("getCompiledNetwork - using adapter to perform getCompiledNetwork(networkDescription)");
     return apiAdapter->getCompiledNetwork(std::move(networkDescription));
 }

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -115,7 +115,7 @@ void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription>
     apiAdapter->release(std::move(networkDescription));
 }
 
-std::vector<uint8_t> LevelZeroCompilerAdapter::getCompiledNetwork(
+std::pair<const uint8_t*, size_t> LevelZeroCompilerAdapter::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
     _logger.info("getCompiledNetwork - using adapter to perform getCompiledNetwork(networkDescription)");
     return apiAdapter->getCompiledNetwork(std::move(networkDescription));

--- a/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/driver_compiler_adapter.cpp
@@ -117,7 +117,7 @@ void LevelZeroCompilerAdapter::release(std::shared_ptr<const NetworkDescription>
 
 CompiledNetwork LevelZeroCompilerAdapter::getCompiledNetwork(const NetworkDescription& networkDescription) {
     _logger.info("getCompiledNetwork - using adapter to perform getCompiledNetwork(networkDescription)");
-    return apiAdapter->getCompiledNetwork(std::move(networkDescription));
+    return apiAdapter->getCompiledNetwork(networkDescription);
 }
 
 }  // namespace driverCompilerAdapter

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -366,11 +366,10 @@ template <typename TableExtension>
 template <typename T, std::enable_if_t<UseCopyForNativeBinary(T), bool>>
 void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
                                                                 ze_graph_handle_t graphHandle,
-                                                                std::vector<uint8_t>& blob) const {
+                                                                std::shared_ptr<const NetworkDescription> networkDescription,
+                                                                uint8_t** blobPtr, size_t* blobSize) const {
         // Get blob size first
-        size_t blobSize = -1;
-
-        auto result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, &blobSize, nullptr);
+        auto result = _graphDdiTableExt.pfnGetNativeBinary(graphHandle, blobSize, nullptr);
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
                         "Failed to compile network. L0 pfnGetNativeBinary get blob size",
@@ -382,9 +381,8 @@ void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditabl
                         ". ",
                         getLatestBuildError());
 
-        blob.resize(blobSize);
         // Get blob data
-        result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, &blobSize, blob.data());
+        result = _graphDdiTableExt.pfnGetNativeBinary(graphHandle, blobSize, std::const_pointer_cast<NetworkDescription>(networkDescription)->compiledNetwork.data());
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
                         "Failed to compile network. L0 pfnGetNativeBinary get blob data",
@@ -395,18 +393,18 @@ void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditabl
                         uint64_t(result),
                         ". ",
                         getLatestBuildError());
+
+        *blobPtr = std::const_pointer_cast<NetworkDescription>(networkDescription)->compiledNetwork.data();
 }
 
 template <typename TableExtension>
 template <typename T, std::enable_if_t<!UseCopyForNativeBinary(T), bool>>
 void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
                                                                 ze_graph_handle_t graphHandle,
-                                                                std::vector<uint8_t>& blob) const {
+                                                                std::shared_ptr<const NetworkDescription>,
+                                                                uint8_t** blobPtr, size_t* blobSize) const {
         // Get blob ptr and size
-        uint8_t* blobPtr;
-        size_t blobSize = -1;
-
-        auto result = _graphDdiTableExt.pfnGetNativeBinary2(graphHandle, &blobSize, &blobPtr);
+        auto result = _graphDdiTableExt.pfnGetNativeBinary2(graphHandle, blobSize, blobPtr);
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
                         "Failed to compile network. L0 pfnGetNativeBinary get blob size",
@@ -417,26 +415,25 @@ void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditabl
                         uint64_t(result),
                         ". ",
                         getLatestBuildError());
-
-        blob.assign(blobPtr, blobPtr + blobSize);
 }
 
 template <typename TableExtension>
-std::vector<uint8_t> LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
+std::pair<const uint8_t*, size_t> LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
     std::shared_ptr<const NetworkDescription> networkDescription) {
     if (networkDescription->metadata.graphHandle != nullptr && networkDescription->compiledNetwork.size() == 0) {
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork get blob from graphHandle");
         ze_graph_handle_t graphHandle = static_cast<ze_graph_handle_t>(networkDescription->metadata.graphHandle);
 
-        std::vector<uint8_t> blob;
+        uint8_t* blobPtr;
+        size_t blobSize = -1;
 
-        getNativeBinary(_graphDdiTableExt, graphHandle, blob);
+        getNativeBinary(_graphDdiTableExt, graphHandle, networkDescription, &blobPtr, &blobSize);
 
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork returning blob");
-        return blob;
+        return {blobPtr, blobSize};
     } else {
         _logger.info("return the blob from network description");
-        return networkDescription->compiledNetwork;
+        return {networkDescription->compiledNetwork.data(), networkDescription->compiledNetwork.size()};
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -364,12 +364,12 @@ void LevelZeroCompilerInDriver<TableExtension>::release(std::shared_ptr<const Ne
 
 template <typename TableExtension>
 template <typename T, std::enable_if_t<UseCopyForNativeBinary(T), bool>>
-void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
+void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(TableExtension* graphDdiTableExt,
                                                                 ze_graph_handle_t graphHandle,
                                                                 std::vector<uint8_t>& blob,
                                                                 uint8_t** blobPtr, size_t* blobSize) const {
         // Get blob size first
-        auto result = _graphDdiTableExt.pfnGetNativeBinary(graphHandle, blobSize, nullptr);
+        auto result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, blobSize, nullptr);
         blob.resize(*blobSize);
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
@@ -383,7 +383,7 @@ void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditabl
                         getLatestBuildError());
 
         // Get blob data
-        result = _graphDdiTableExt.pfnGetNativeBinary(graphHandle, blobSize, blob.data());
+        result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, blobSize, blob.data());
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
                         "Failed to compile network. L0 pfnGetNativeBinary get blob data",
@@ -400,12 +400,12 @@ void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditabl
 
 template <typename TableExtension>
 template <typename T, std::enable_if_t<!UseCopyForNativeBinary(T), bool>>
-void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(ze_graph_dditable_ext_curr_t& graphDdiTableExt,
+void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(TableExtension* graphDdiTableExt,
                                                                 ze_graph_handle_t graphHandle,
                                                                 std::vector<uint8_t>& /* unusedBlob */,
                                                                 uint8_t** blobPtr, size_t* blobSize) const {
         // Get blob ptr and size
-        auto result = _graphDdiTableExt.pfnGetNativeBinary2(graphHandle, blobSize, blobPtr);
+        auto result = _graphDdiTableExt->pfnGetNativeBinary2(graphHandle, blobSize, blobPtr);
 
         OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
                         "Failed to compile network. L0 pfnGetNativeBinary get blob size",
@@ -425,7 +425,7 @@ CompiledNetwork LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork get blob from graphHandle");
         ze_graph_handle_t graphHandle = static_cast<ze_graph_handle_t>(networkDescription->metadata.graphHandle);
 
-        uint8_t* blobPtr;
+        uint8_t* blobPtr = nullptr;
         size_t blobSize = -1;
         std::vector<uint8_t> blob;
 

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -434,12 +434,12 @@ CompiledNetwork LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
         getNativeBinary(_graphDdiTableExt, graphHandle, blob, &blobPtr, &blobSize);
 
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork returning blob");
-        return CompiledNetwork{blobPtr, blobSize, std::move(blob)};
+        return CompiledNetwork(blobPtr, blobSize, std::move(blob));
     }
     _logger.info("return the blob from network description");
-    return CompiledNetwork{networkDescription->compiledNetwork.data(),
+    return CompiledNetwork(networkDescription->compiledNetwork.data(),
                            networkDescription->compiledNetwork.size(),
-                           networkDescription->compiledNetwork};
+                           std::move(networkDescription->compiledNetwork));
 }
 
 template <typename TableExtension>

--- a/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
+++ b/src/plugins/intel_npu/src/compiler/src/zero_compiler_in_driver.cpp
@@ -367,35 +367,36 @@ template <typename T, std::enable_if_t<UseCopyForNativeBinary(T), bool>>
 void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(TableExtension* graphDdiTableExt,
                                                                 ze_graph_handle_t graphHandle,
                                                                 std::vector<uint8_t>& blob,
-                                                                uint8_t** blobPtr, size_t* blobSize) const {
-        // Get blob size first
-        auto result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, blobSize, nullptr);
-        blob.resize(*blobSize);
+                                                                uint8_t** blobPtr,
+                                                                size_t* blobSize) const {
+    // Get blob size first
+    auto result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, blobSize, nullptr);
+    blob.resize(*blobSize);
 
-        OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
-                        "Failed to compile network. L0 pfnGetNativeBinary get blob size",
-                        " result: ",
-                        ze_result_to_string(result),
-                        ", code 0x",
-                        std::hex,
-                        uint64_t(result),
-                        ". ",
-                        getLatestBuildError());
+    OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
+                    "Failed to compile network. L0 pfnGetNativeBinary get blob size",
+                    " result: ",
+                    ze_result_to_string(result),
+                    ", code 0x",
+                    std::hex,
+                    uint64_t(result),
+                    ". ",
+                    getLatestBuildError());
 
-        // Get blob data
-        result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, blobSize, blob.data());
+    // Get blob data
+    result = _graphDdiTableExt->pfnGetNativeBinary(graphHandle, blobSize, blob.data());
 
-        OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
-                        "Failed to compile network. L0 pfnGetNativeBinary get blob data",
-                        " result: ",
-                        ze_result_to_string(result),
-                        ", code 0x",
-                        std::hex,
-                        uint64_t(result),
-                        ". ",
-                        getLatestBuildError());
+    OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
+                    "Failed to compile network. L0 pfnGetNativeBinary get blob data",
+                    " result: ",
+                    ze_result_to_string(result),
+                    ", code 0x",
+                    std::hex,
+                    uint64_t(result),
+                    ". ",
+                    getLatestBuildError());
 
-        *blobPtr = blob.data();
+    *blobPtr = blob.data();
 }
 
 template <typename TableExtension>
@@ -403,19 +404,20 @@ template <typename T, std::enable_if_t<!UseCopyForNativeBinary(T), bool>>
 void LevelZeroCompilerInDriver<TableExtension>::getNativeBinary(TableExtension* graphDdiTableExt,
                                                                 ze_graph_handle_t graphHandle,
                                                                 std::vector<uint8_t>& /* unusedBlob */,
-                                                                uint8_t** blobPtr, size_t* blobSize) const {
-        // Get blob ptr and size
-        auto result = _graphDdiTableExt->pfnGetNativeBinary2(graphHandle, blobSize, blobPtr);
+                                                                uint8_t** blobPtr,
+                                                                size_t* blobSize) const {
+    // Get blob ptr and size
+    auto result = _graphDdiTableExt->pfnGetNativeBinary2(graphHandle, blobSize, blobPtr);
 
-        OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
-                        "Failed to compile network. L0 pfnGetNativeBinary get blob size",
-                        " result: ",
-                        ze_result_to_string(result),
-                        ", code 0x",
-                        std::hex,
-                        uint64_t(result),
-                        ". ",
-                        getLatestBuildError());
+    OPENVINO_ASSERT(result == ZE_RESULT_SUCCESS,
+                    "Failed to compile network. L0 pfnGetNativeBinary get blob size",
+                    " result: ",
+                    ze_result_to_string(result),
+                    ", code 0x",
+                    std::hex,
+                    uint64_t(result),
+                    ". ",
+                    getLatestBuildError());
 }
 
 template <typename TableExtension>
@@ -433,10 +435,11 @@ CompiledNetwork LevelZeroCompilerInDriver<TableExtension>::getCompiledNetwork(
 
         _logger.info("LevelZeroCompilerInDriver getCompiledNetwork returning blob");
         return CompiledNetwork{blobPtr, blobSize, std::move(blob)};
-    } else {
-        _logger.info("return the blob from network description");
-        return CompiledNetwork{networkDescription->compiledNetwork.data(), networkDescription->compiledNetwork.size(), networkDescription->compiledNetwork};
     }
+    _logger.info("return the blob from network description");
+    return CompiledNetwork{networkDescription->compiledNetwork.data(),
+                           networkDescription->compiledNetwork.size(),
+                           networkDescription->compiledNetwork};
 }
 
 template <typename TableExtension>

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -27,9 +27,9 @@ constexpr std::string_view NO_EXECUTOR_FOR_INFERENCE =
     "Can't create infer request!\n"
     "Please make sure that the device is available. Only exports can be made.";
 
-std::uint32_t hash(std::pair<const uint8_t*, size_t> blob) {
+std::uint32_t hash(const intel_npu::CompiledNetwork& blob) {
     std::uint32_t result = 1171117u;
-    for (const uint8_t* it = blob.first; it != blob.first + blob.second; ++it) {
+    for (const uint8_t* it = blob.data; it != blob.data + blob.size; ++it) {
         result = ((result << 7) + result) + static_cast<uint32_t>(*it);
     }
     return result;
@@ -141,11 +141,11 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
 void CompiledModel::export_model(std::ostream& stream) const {
     _logger.debug("CompiledModel::export_model");
     const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
-    stream.write(reinterpret_cast<const char*>(blob.first), blob.second);
+    stream.write(reinterpret_cast<const char*>(blob.data), blob.size);
 
     if (_logger.level() == ov::log::Level::INFO) {
         std::stringstream str;
-        str << "Blob size: " << blob.second << ", hash: " << std::hex << hash(blob);
+        str << "Blob size: " << blob.size << ", hash: " << std::hex << hash(blob);
         _logger.info(str.str().c_str());
 
         if (!stream) {

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -140,7 +140,7 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
 
 void CompiledModel::export_model(std::ostream& stream) const {
     _logger.debug("CompiledModel::export_model");
-    const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
+    const auto blob = _compiler->getCompiledNetwork(*_networkPtr);
     stream.write(reinterpret_cast<const char*>(blob.data), blob.size);
 
     if (!stream) {

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -141,14 +141,17 @@ void CompiledModel::export_model(std::ostream& stream) const {
     _logger.debug("CompiledModel::export_model");
     const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
     stream.write(reinterpret_cast<const char*>(blob.data()), blob.size());
-    std::stringstream str;
-    str << "Blob size: " << blob.size() << ", hash: " << std::hex << hash(blob);
-    _logger.info(str.str().c_str());
 
-    if (!stream) {
-        _logger.error("Write blob to stream failed. Blob is broken!");
-    } else {
-        _logger.info("Write blob to stream successfully.");
+    if (_logger.level() == ov::log::Level::INFO) {
+        std::stringstream str;
+        str << "Blob size: " << blob.size() << ", hash: " << std::hex << hash(blob);
+        _logger.info(str.str().c_str());
+
+        if (!stream) {
+            _logger.error("Write blob to stream failed. Blob is broken!");
+        } else {
+            _logger.info("Write blob to stream successfully.");
+        }
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -143,16 +143,15 @@ void CompiledModel::export_model(std::ostream& stream) const {
     const auto&& blob = _compiler->getCompiledNetwork(_networkPtr);
     stream.write(reinterpret_cast<const char*>(blob.data), blob.size);
 
-    if (_logger.level() == ov::log::Level::INFO) {
-        std::stringstream str;
-        str << "Blob size: " << blob.size << ", hash: " << std::hex << hash(blob);
-        _logger.info(str.str().c_str());
-
-        if (!stream) {
-            _logger.error("Write blob to stream failed. Blob is broken!");
-        } else {
-            _logger.info("Write blob to stream successfully.");
+    if (!stream) {
+        _logger.error("Write blob to stream failed. Blob is broken!");
+    } else {
+        if (_logger.level() >= ov::log::Level::INFO) {
+            std::stringstream str;
+            str << "Blob size: " << blob.size << ", hash: " << std::hex << hash(blob);
+            _logger.info(str.str().c_str());
         }
+        _logger.info("Write blob to stream successfully.");
     }
 }
 


### PR DESCRIPTION
### Details:
 - *Add support for new L0 API 1.7*
 - *Change return type of `getCompiledNetwork` to new custom `CompiledNetwork` container*

### Tickets:
 - *[151912](https://jira.devtools.intel.com/browse/CVS-151912)*
