### PR TITLE
[NPU] Only use zero utils when ENABLE_ZEROAPI_BACKEND be ON

### DIFF
--- a/src/plugins/intel_npu/cmake/features.cmake
+++ b/src/plugins/intel_npu/cmake/features.cmake
@@ -6,13 +6,17 @@ ov_option(ENABLE_MLIR_COMPILER "Enable compilation of npu_mlir_compiler librarie
 
 ov_option(BUILD_COMPILER_FOR_DRIVER "Enable build of npu_driver_compiler" OFF)
 
-ov_dependent_option(ENABLE_DRIVER_COMPILER_ADAPTER "Enable NPU Compiler inside driver" ON "NOT BUILD_COMPILER_FOR_DRIVER" OFF)
+# if ENABLE_ZEROAPI_BACKEND=ON, it adds the ze_loader dependency for driver compiler
+ov_dependent_option(ENABLE_ZEROAPI_BACKEND "Enable zero-api as a plugin backend" ON "NOT BUILD_COMPILER_FOR_DRIVER" OFF)
+
+ov_dependent_option(ENABLE_DRIVER_COMPILER_ADAPTER "Enable NPU Compiler inside driver" ON "NOT BUILD_COMPILER_FOR_DRIVER;ENABLE_ZEROAPI_BACKEND" OFF)
+
+if(NOT ENABLE_ZEROAPI_BACKEND AND ENABLE_DRIVER_COMPILER_ADAPTER)
+    message(FATAL_ERROR "Compiler adapter depends on zero backend to use same context!")
+endif()
 
 if(NOT BUILD_SHARED_LIBS AND NOT ENABLE_MLIR_COMPILER AND NOT ENABLE_DRIVER_COMPILER_ADAPTER)
     message(FATAL_ERROR "No compiler found for static build!")
 endif()
-
-# if ENABLE_ZEROAPI_BACKEND=ON, it adds the ze_loader dependency for driver compiler
-ov_dependent_option(ENABLE_ZEROAPI_BACKEND "Enable zero-api as a plugin backend" ON "NOT BUILD_COMPILER_FOR_DRIVER" OFF)
 
 ov_dependent_option(ENABLE_IMD_BACKEND "Enable InferenceManagerDemo based NPU AL backend" OFF "NOT WIN32;NOT CMAKE_CROSSCOMPILING" OFF)

--- a/src/plugins/intel_npu/src/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/CMakeLists.txt
@@ -9,7 +9,7 @@ add_subdirectory(utils)
 
 add_subdirectory(al)
 
-if(ENABLE_DRIVER_COMPILER_ADAPTER)
+if(ENABLE_DRIVER_COMPILER_ADAPTER AND ENABLE_ZEROAPI_BACKEND)
     add_subdirectory(compiler)
 endif()
 

--- a/src/plugins/intel_npu/src/utils/src/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/CMakeLists.txt
@@ -3,4 +3,6 @@
 #
 
 add_subdirectory(logger)
-add_subdirectory(zero)
+if(ENABLE_ZEROAPI_BACKEND)
+    add_subdirectory(zero)
+endif()


### PR DESCRIPTION
### Details:
 - *zero utils depend on level-zero-ext, the target only open if we set ENABLE_ZEROAPI_BACKEND to ON now*
 - "Add check of ENABLE_ZEROAPI_BACKEND and ENABLE_DRIVER_COMPILER_ADAPTER"

### Tickets:
 - *153228*
