### PR TITLE
[NPU] Adding support for the set_tensors method

### DIFF
--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -164,7 +164,7 @@ protected:
     mutable std::vector<std::shared_ptr<ov::ITensor>> _userInputTensors;
     mutable std::vector<std::shared_ptr<ov::ITensor>> _userOutputTensors;
 
-    mutable std::unordered_map<size_t, std::vector<ov::SoPtr<ov::ITensor>>> _userBatchedTensors;
+    std::unordered_map<size_t, std::vector<ov::SoPtr<ov::ITensor>>> _userBatchedTensors;
 
     mutable std::vector<ov::SoPtr<ov::IVariableState>> _variableStates;
 

--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -44,14 +44,14 @@ public:
      * @brief Currently there is no support implemented for batches of tensors, thus this call is a simple redirection
      * to the "get_tensor" one.
      */
-    std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& port) const override;
+    virtual std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& port) const override;
 
     /**
      * @brief Currently there is no support implemented for batches of tensors, thus this call is a simple redirection
      * to the "set_tensor" one.
      */
-    void set_tensors(const ov::Output<const ov::Node>& port,
-                     const std::vector<ov::SoPtr<ov::ITensor>>& tensors) override;
+    virtual void set_tensors(const ov::Output<const ov::Node>& port,
+                             const std::vector<ov::SoPtr<ov::ITensor>>& tensors) override;
 
     /**
      * @brief Gets inputs for infer request
@@ -153,6 +153,8 @@ protected:
                                                  const ov::Allocator& allocator = {},
                                                  const std::optional<std::size_t> batchSize = std::nullopt) const;
 
+    bool is_batched_input(size_t idx) const;
+
     // This is intel_npu::ICompiledModel pointer, but need to use OV base class because
     // ov::IInferRequest::get_compiled_model returns a refernce to shared_ptr!
     std::shared_ptr<const ov::ICompiledModel> _compiledModel;
@@ -161,6 +163,8 @@ protected:
 
     mutable std::vector<std::shared_ptr<ov::ITensor>> _userInputTensors;
     mutable std::vector<std::shared_ptr<ov::ITensor>> _userOutputTensors;
+
+    mutable std::unordered_map<size_t, std::vector<ov::SoPtr<ov::ITensor>>> _userBatchedTensors;
 
     mutable std::vector<ov::SoPtr<ov::IVariableState>> _variableStates;
 

--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -161,10 +161,9 @@ protected:
 
     NetworkMetadata _metadata;
 
-    mutable std::vector<std::shared_ptr<ov::ITensor>> _userInputTensors;
+    // In case set_tensors is called, we receive a vector with N tensors otherwise only 1 tensor is needed
+    mutable std::vector<std::vector<std::shared_ptr<ov::ITensor>>> _userInputTensors;
     mutable std::vector<std::shared_ptr<ov::ITensor>> _userOutputTensors;
-
-    std::unordered_map<size_t, std::vector<ov::SoPtr<ov::ITensor>>> _userBatchedTensors;
 
     mutable std::vector<ov::SoPtr<ov::IVariableState>> _variableStates;
 

--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -22,7 +22,7 @@ namespace intel_npu {
  */
 class SyncInferRequest : public ov::IInferRequest {
 public:
-    explicit SyncInferRequest(const std::shared_ptr<const ICompiledModel>& compiledModel);
+    explicit SyncInferRequest(const std::shared_ptr<const ICompiledModel>& compiledModel, const Config& config);
 
     /**
      * @brief Gets an input/output tensor for inference.
@@ -127,6 +127,15 @@ protected:
     void check_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) const;
 
     /**
+     * @brief Basic checks for input tensors
+     *
+     * @param port Input port
+     * @param tensors Input tensors
+     */
+    void check_batched_tensors(const ov::Output<const ov::Node>& port,
+                               const std::vector<ov::SoPtr<ov::ITensor>>& tensors) const;
+
+    /**
      * @brief Check that all tensors are valid. Throws an exception if it's not.
      */
     void check_tensors() const override;
@@ -163,6 +172,8 @@ protected:
     std::shared_ptr<const ov::ICompiledModel> _compiledModel;
 
     NetworkMetadata _metadata;
+
+    Logger _logger;
 
     // In case set_tensors is called, we receive a vector with N tensors otherwise only 1 tensor is needed
     mutable std::vector<std::vector<ov::SoPtr<ov::ITensor>>> _userInputTensors;

--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -155,6 +155,9 @@ protected:
 
     bool is_batched_input(size_t idx) const;
 
+    ov::SoPtr<ov::ITensor>& get_user_input(size_t index) const;
+    std::vector<ov::SoPtr<ov::ITensor>>& get_user_inputs(size_t index) const;
+
     // This is intel_npu::ICompiledModel pointer, but need to use OV base class because
     // ov::IInferRequest::get_compiled_model returns a refernce to shared_ptr!
     std::shared_ptr<const ov::ICompiledModel> _compiledModel;

--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -162,8 +162,8 @@ protected:
     NetworkMetadata _metadata;
 
     // In case set_tensors is called, we receive a vector with N tensors otherwise only 1 tensor is needed
-    mutable std::vector<std::vector<std::shared_ptr<ov::ITensor>>> _userInputTensors;
-    mutable std::vector<std::shared_ptr<ov::ITensor>> _userOutputTensors;
+    mutable std::vector<std::vector<ov::SoPtr<ov::ITensor>>> _userInputTensors;
+    mutable std::vector<ov::SoPtr<ov::ITensor>> _userOutputTensors;
 
     mutable std::vector<ov::SoPtr<ov::IVariableState>> _variableStates;
 

--- a/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
+++ b/src/plugins/intel_npu/src/al/include/sync_infer_request.hpp
@@ -44,7 +44,7 @@ public:
      * @brief Currently there is no support implemented for batches of tensors, thus this call is a simple redirection
      * to the "get_tensor" one.
      */
-    virtual std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& port) const override;
+    std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& port) const override;
 
     /**
      * @brief Currently there is no support implemented for batches of tensors, thus this call is a simple redirection

--- a/src/plugins/intel_npu/src/al/src/sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/al/src/sync_infer_request.cpp
@@ -195,6 +195,9 @@ void SyncInferRequest::check_tensor(const ov::Output<const ov::Node>& port,
 void SyncInferRequest::check_tensors() const {
     const auto& inputs = _compiledModel->inputs();
     for (size_t i = 0; i < inputs.size(); i++) {
+        if (is_batched_input(i)) {
+            continue;
+        }
         if (_userInputTensors.at(i)) {
             check_tensor(inputs[i], _userInputTensors.at(i));
         }
@@ -250,4 +253,9 @@ std::shared_ptr<ov::ITensor> SyncInferRequest::allocate_tensor(const IODescripto
 
     return tensor;
 }
+
+bool SyncInferRequest::is_batched_input(size_t idx) const {
+    return _userBatchedTensors.count(idx) > 0;
+}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/al/src/sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/al/src/sync_infer_request.cpp
@@ -201,6 +201,7 @@ void SyncInferRequest::check_tensors() const {
     const auto& inputs = _compiledModel->inputs();
     for (size_t i = 0; i < inputs.size(); i++) {
         if (is_batched_input(i)) {
+            // in case of batched input, user tensor is not set
             continue;
         }
         if (_userInputTensors.at(i)) {

--- a/src/plugins/intel_npu/src/al/src/sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/al/src/sync_infer_request.cpp
@@ -144,11 +144,16 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
     }
 }
 
-std::vector<ov::SoPtr<ov::ITensor>> SyncInferRequest::get_tensors(const ov::Output<const ov::Node>& /*port*/) const {
+std::vector<ov::SoPtr<ov::ITensor>> SyncInferRequest::get_tensors(const ov::Output<const ov::Node>& port) const {
     OV_ITT_SCOPED_TASK(ov::itt::domains::Plugin, "get_tensors");
 
-    // Using batches of tensors is currently not supported by the NPU plugin. In this scenario, the OpenVINO API demands
-    // returning an empty vector.
+    auto foundPort = find_port(port);
+    OPENVINO_ASSERT(foundPort.found(), "Cannot find input tensors for port ", port);
+
+    if (foundPort.is_input() && is_batched_input(foundPort.idx)) {
+        return _userBatchedTensors.at(foundPort.idx);
+    }
+
     return {};
 }
 

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -26,7 +26,10 @@ public:
                               const Config& config);
 
     ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
+    std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& port) const override;
     void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
+    void set_tensors(const ov::Output<const ov::Node>& port,
+                     const std::vector<ov::SoPtr<ov::ITensor>>& tensors) override;
 
     void infer() override;
     void infer_async() override;
@@ -72,6 +75,8 @@ private:
      */
     void set_remote_tensor_data(const std::shared_ptr<ZeroRemoteTensor> tensor, const size_t index, const bool isInput);
 
+    void check_batched_tensors(const ov::Output<const ov::Node>& input,
+                               const std::vector<ov::SoPtr<ov::ITensor>>& tensors);
     void check_network_precision(const ov::element::Type_t precision) const override;
     void create_pipeline();
 
@@ -115,6 +120,10 @@ private:
     std::optional<std::size_t> _batchSize = std::nullopt;
 
     bool _pipelineIsCreated = false;
+
+    std::unordered_map<size_t, std::vector<ov::SoPtr<ov::ITensor>>> _levelZeroBatchedTensors;
+
+    std::unordered_map<size_t, std::vector<std::optional<TensorData>>> _batchedTensorsData;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -79,6 +79,12 @@ private:
     void check_network_precision(const ov::element::Type_t precision) const override;
     void create_pipeline();
 
+    std::shared_ptr<ov::ITensor>& get_level_zero_input(size_t index, size_t tensorNo = 0) const;
+    std::vector<std::shared_ptr<ov::ITensor>>& get_level_zero_inputs(size_t index) const;
+
+    std::optional<TensorData>& get_input_tensor_data(size_t index, size_t tensorNo = 0) const;
+    std::vector<std::optional<TensorData>>& get_input_tensors_data(size_t index) const;
+
     const std::shared_ptr<ZeroInitStructsHolder> _initStructs;
     const std::shared_ptr<const IExecutor> _executorPtr;
     const ZeroExecutor* _executor;

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -56,7 +56,7 @@ private:
      * @returns The batch size deduced by the algorithm or the default value of 1 if batching cannot be performed inside
      * the plugin.
      */
-    std::optional<size_t> getBatchSize(const NetworkMetadata& metadata);
+    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata);
 
     /**
      * @brief Check the received tensor and set the Level Zero tensor accordingly
@@ -87,10 +87,10 @@ private:
 
     // A copy of each tensor is needed to maintain the original L0 memory allocation in case the user provides another
     // memory area for the tensor.
-    mutable std::vector<std::shared_ptr<ov::ITensor>> _levelZeroInputTensors;
+    mutable std::vector<std::vector<std::shared_ptr<ov::ITensor>>> _levelZeroInputTensors;
     mutable std::vector<std::shared_ptr<ov::ITensor>> _levelZeroOutputTensors;
 
-    mutable std::vector<std::optional<TensorData>> _inputTensorsData;
+    mutable std::vector<std::vector<std::optional<TensorData>>> _inputTensorsData;
     mutable std::vector<std::optional<TensorData>> _outputTensorsData;
 
     ze_device_properties_t _properties = {};
@@ -119,10 +119,6 @@ private:
     std::optional<std::size_t> _batchSize = std::nullopt;
 
     bool _pipelineIsCreated = false;
-
-    std::unordered_map<size_t, std::vector<ov::SoPtr<ov::ITensor>>> _levelZeroBatchedTensors;
-
-    std::unordered_map<size_t, std::vector<std::optional<TensorData>>> _batchedTensorsData;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -74,8 +74,6 @@ private:
      */
     void set_remote_tensor_data(const std::shared_ptr<ZeroRemoteTensor> tensor, const size_t index, const bool isInput);
 
-    void check_batched_tensors(const ov::Output<const ov::Node>& input,
-                               const std::vector<ov::SoPtr<ov::ITensor>>& tensors);
     void check_network_precision(const ov::element::Type_t precision) const override;
     void create_pipeline();
 

--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -26,7 +26,6 @@ public:
                               const Config& config);
 
     ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
-    std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& port) const override;
     void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
     void set_tensors(const ov::Output<const ov::Node>& port,
                      const std::vector<ov::SoPtr<ov::ITensor>>& tensors) override;

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -27,6 +27,7 @@ public:
              std::shared_ptr<zeroProfiling::NpuInferProfiling> npu_profiling,
              const std::vector<std::optional<TensorData>>& inputTensorsData,
              const std::vector<std::optional<TensorData>>& outputTensorsData,
+             const std::unordered_map<size_t, std::vector<std::optional<TensorData>>>& batchedTensorsData,
              const size_t numberOfCommandLists);
 
     Pipeline(const Pipeline&) = delete;
@@ -37,7 +38,10 @@ public:
     void pull();
     void reset() const;
 
-    void updateCommandList(const TensorData& tensorsData, const uint32_t index);
+    void updateCommandList(const TensorData& tensorsData,
+                           uint32_t index,
+                           bool batchedInput = false,
+                           size_t commandListIndex = 0);
 
 protected:
     const Config _config;

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -37,10 +37,8 @@ public:
     void pull();
     void reset() const;
 
-    void updateCommandList(const TensorData& tensorsData,
-                           uint32_t index,
-                           bool batchedInput = false,
-                           size_t commandListIndex = 0);
+    void updateCommandList(const TensorData& tensorsData, uint32_t index);
+    void updateCommandList(const TensorData& tensorsData, uint32_t index, size_t commandListIndex);
 
 protected:
     const Config _config;

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -25,9 +25,8 @@ public:
              zeroProfiling::ProfilingPool& profiling_pool,
              zeroProfiling::ProfilingQuery& profiling_query,
              std::shared_ptr<zeroProfiling::NpuInferProfiling> npu_profiling,
-             const std::vector<std::optional<TensorData>>& inputTensorsData,
+             const std::vector<std::vector<std::optional<TensorData>>>& inputTensorsData,
              const std::vector<std::optional<TensorData>>& outputTensorsData,
-             const std::unordered_map<size_t, std::vector<std::optional<TensorData>>>& batchedTensorsData,
              const size_t numberOfCommandLists);
 
     Pipeline(const Pipeline&) = delete;

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -422,7 +422,7 @@ void ZeroInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
 
 void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                                    const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
-    OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "set_tensors");
+    OV_ITT_TASK_CHAIN(SET_TENSORS, itt::domains::LevelZeroBackend, "set_tensors", "set_tensors");
     if (tensors.size() == 1) {
         set_tensor(port, tensors[0]);
         return;
@@ -450,6 +450,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                 if (remoteTensor == nullptr) {
                     bool tensorHasSameL0Context = false;
 
+                    OV_ITT_TASK_NEXT(SET_TENSORS, "check_data_allocation");
                     if (memory_was_allocated_in_the_same_l0_context(_initStructs->getContext(), tensors[i]->data())) {
                         _logger.debug("ZeroInferRequest::set_tensors - tensor was created in the same L0 context");
 
@@ -481,9 +482,9 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                 }
 
                 if (_pipelineIsCreated) {
+                    OV_ITT_TASK_NEXT(SET_TENSORS, "updateCommandList");
                     _pipeline->updateCommandList(*get_input_tensor_data(foundPort.idx, i),
                                                  _executor->get_input_descriptors().at(foundPort.idx).idx,
-                                                 true,
                                                  i);
                 }
             }

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -85,16 +85,9 @@ bool memory_was_allocated_in_the_same_l0_context(ze_context_handle_t hContext, c
     auto res = intel_npu::zeMemGetAllocProperties(hContext, ptr, &desc, nullptr);
     if (res == ZE_RESULT_SUCCESS) {
         if (desc.id) {
-            switch (desc.type) {
-            case ZE_MEMORY_TYPE_HOST:
-            case ZE_MEMORY_TYPE_DEVICE:
-            case ZE_MEMORY_TYPE_SHARED:
+            if ((desc.type & ZE_MEMORY_TYPE_HOST) || (desc.type & ZE_MEMORY_TYPE_DEVICE) ||
+                (desc.type & ZE_MEMORY_TYPE_SHARED)) {
                 return true;
-                break;
-            case ZE_MEMORY_TYPE_UNKNOWN:
-            case ZE_MEMORY_TYPE_FORCE_UINT32:
-            default:
-                break;
             }
         }
     }

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -611,19 +611,6 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
     return levelZeroTensors.at(ioIndex);
 }
 
-std::vector<ov::SoPtr<ov::ITensor>> ZeroInferRequest::get_tensors(const ov::Output<const ov::Node>& port) const {
-    OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "get_tensors");
-
-    auto foundPort = find_port(port);
-    OPENVINO_ASSERT(foundPort.found(), "Cannot find input tensors for port ", port);
-
-    if (foundPort.is_input() && is_batched_input(foundPort.idx)) {
-        return _userBatchedTensors.at(foundPort.idx);
-    }
-
-    return {};
-}
-
 void ZeroInferRequest::infer() {
     infer_async();
     get_result();

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -487,7 +487,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
         return;
     }
 
-    auto& foundPort = find_port(port);
+    auto foundPort = find_port(port);
     OPENVINO_ASSERT(foundPort.found(), "Cannot find input tensor for port ", port);
     if (!foundPort.is_input()) {
         OPENVINO_THROW("set_input_tensors/set_tensors is not supported for output port.");
@@ -605,7 +605,7 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
 std::vector<ov::SoPtr<ov::ITensor>> ZeroInferRequest::get_tensors(const ov::Output<const ov::Node>& port) const {
     OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "get_tensors");
 
-    auto& foundPort = find_port(port);
+    auto foundPort = find_port(port);
     OPENVINO_ASSERT(foundPort.found(), "Cannot find input tensors for port ", port);
 
     if (foundPort.is_input() && is_batched_input(foundPort.idx)) {

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -515,7 +515,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                 _batchedTensorsData[foundPort.idx].resize(tensors.size());
 
                 if (remoteTensor == nullptr) {
-                    bool tensorL0Context = false;
+                    bool tensorHasSameL0Context = false;
 
                     ze_memory_allocation_properties_t desc = {};
                     desc.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
@@ -530,7 +530,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                                     "ZeroInferRequest::set_tensors - tensor was created in the same L0 context");
 
                                 _levelZeroBatchedTensors[foundPort.idx][i] = tensors[i];
-                                tensorL0Context = true;
+                                tensorHasSameL0Context = true;
                                 break;
                             case ZE_MEMORY_TYPE_UNKNOWN:
                             case ZE_MEMORY_TYPE_FORCE_UINT32:
@@ -540,7 +540,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                         }
                     }
 
-                    if (!tensorL0Context) {
+                    if (!tensorHasSameL0Context) {
                         _logger.debug("ZeroInferRequest::set_tensors - tensor wasn't created in the same L0 context, "
                                       "create a L0 tensor");
 

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -154,30 +154,32 @@ void Pipeline::reset() const {
     _logger.debug("Pipeline - rest() completed");
 };
 
-void Pipeline::updateCommandList(const TensorData& tensorsData,
-                                 uint32_t index,
-                                 bool batchedInput,
-                                 size_t commandListIndex) {
+void Pipeline::updateCommandList(const TensorData& tensorsData, uint32_t index) {
     OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_IP_UMCL, itt::domains::LevelZeroBackend, "Pipeline", "updateCommandList");
     _logger.debug("Pipeline - updateCommandList");
 
     const size_t numberOfCommandLists = _command_lists.size();
 
-    if (batchedInput) {
-        OPENVINO_ASSERT(commandListIndex < numberOfCommandLists,
-                        "Command list index is higgher than the number of Command lists ",
-                        commandListIndex);
-
-        _command_lists.at(commandListIndex)->updateMutableCommandList(index, tensorsData.mem);
-        _command_lists.at(commandListIndex)->close();
-    } else {
-        for (size_t i = 0; i < numberOfCommandLists; i++) {
-            _command_lists.at(i)->updateMutableCommandList(
-                index,
-                static_cast<unsigned char*>(tensorsData.mem) + (i * tensorsData.size) / numberOfCommandLists);
-            _command_lists.at(i)->close();
-        }
+    for (size_t i = 0; i < numberOfCommandLists; i++) {
+        _command_lists.at(i)->updateMutableCommandList(
+            index,
+            static_cast<unsigned char*>(tensorsData.mem) + (i * tensorsData.size) / numberOfCommandLists);
+        _command_lists.at(i)->close();
     }
+};
+
+void Pipeline::updateCommandList(const TensorData& tensorsData, uint32_t index, size_t commandListIndex) {
+    OV_ITT_TASK_CHAIN(ZERO_EXECUTOR_IP_UMCL, itt::domains::LevelZeroBackend, "Pipeline", "updateCommandList");
+    _logger.debug("Pipeline - updateCommandList");
+
+    const size_t numberOfCommandLists = _command_lists.size();
+
+    OPENVINO_ASSERT(commandListIndex < numberOfCommandLists,
+                    "Command list index is higgher than the number of Command lists ",
+                    commandListIndex);
+
+    _command_lists.at(commandListIndex)->updateMutableCommandList(index, tensorsData.mem);
+    _command_lists.at(commandListIndex)->close();
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -59,12 +59,10 @@ Pipeline::Pipeline(const Config& config,
         size_t ioIndex = 0;
         for (const auto& desc : _executor->get_input_descriptors()) {
             if (inputTensorsData.at(ioIndex).size() > 1) {
-                if (numberOfCommandLists > 1) {
-                    _executor->setArgumentValue(desc.idx, inputTensorsData.at(ioIndex).at(i)->mem);
+                _executor->setArgumentValue(desc.idx, inputTensorsData.at(ioIndex).at(i)->mem);
 
-                    ++ioIndex;
-                    continue;
-                }
+                ++ioIndex;
+                continue;
             }
 
             _executor->setArgumentValue(desc.idx,

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -1,0 +1,21 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "behavior/batched_tensors_tests/batched_run.hpp"
+
+#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
+#include "intel_npu/al/config/common.hpp"
+
+using namespace ov::test::behavior;
+
+const std::vector<ov::AnyMap> batchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)},
+                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER)},
+                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::AUTO)}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         BatchedTensorsRunTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(batchedConfigs)),
+                         BatchedTensorsRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -1,0 +1,301 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "base/ov_behavior_test_utils.hpp"
+#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
+#include "functional_test_utils/ov_plugin_cache.hpp"
+#include "npu_private_properties.hpp"
+#include "openvino/core/any.hpp"
+#include "openvino/core/node_vector.hpp"
+#include "openvino/core/type/element_iterator.hpp"
+#include "openvino/op/op.hpp"
+#include "openvino/opsets/opset8.hpp"
+#include "openvino/runtime/compiled_model.hpp"
+#include "openvino/runtime/core.hpp"
+#include "openvino/runtime/intel_npu/level_zero/level_zero.hpp"
+#include "overload/overload_test_utils_npu.hpp"
+
+using CompilationParams = std::tuple<std::string,  // Device name
+                                     ov::AnyMap    // Config
+                                     >;
+
+using ::testing::AllOf;
+using ::testing::HasSubstr;
+
+namespace ov {
+namespace test {
+namespace behavior {
+class BatchedTensorsRunTests : public ov::test::behavior::OVPluginTestBase,
+                               public testing::WithParamInterface<CompilationParams> {
+protected:
+    std::shared_ptr<ov::Core> core = utils::PluginCache::get().core();
+    ov::AnyMap configuration;
+    std::shared_ptr<ov::Model> ov_model;
+    ov::CompiledModel compiled_model;
+    ov::Output<const ov::Node> input;
+    ov::Output<const ov::Node> output;
+    std::string m_cache_dir;
+
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<CompilationParams> obj) {
+        std::string targetDevice;
+        ov::AnyMap configuration;
+        std::tie(targetDevice, configuration) = obj.param;
+        std::replace(targetDevice.begin(), targetDevice.end(), ':', '_');
+        targetDevice = ov::test::utils::getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU);
+
+        std::ostringstream result;
+        result << "targetDevice=" << targetDevice << "_";
+        result << "targetPlatform=" << ov::test::utils::getTestsPlatformFromEnvironmentOr(targetDevice) << "_";
+        if (!configuration.empty()) {
+            for (auto& configItem : configuration) {
+                result << "configItem=" << configItem.first << "_";
+                configItem.second.print(result);
+            }
+        }
+
+        return result.str();
+    }
+
+    void SetUp() override {
+        std::tie(target_device, configuration) = this->GetParam();
+
+        SKIP_IF_CURRENT_TEST_IS_DISABLED()
+        OVPluginTestBase::SetUp();
+        ov_model = getDefaultNGraphFunctionForTheDeviceNPU();  // FIXME: E#80555
+    }
+
+    std::string generateCacheDirName(const std::string& test_name) {
+        using namespace std::chrono;
+        // Generate unique file names based on test name, thread id and timestamp
+        // This allows execution of tests in parallel (stress mode)
+        auto hash = std::to_string(std::hash<std::string>()(test_name));
+        std::stringstream ss;
+        auto ts = duration_cast<nanoseconds>(high_resolution_clock::now().time_since_epoch());
+        ss << hash << "_"
+           << "_" << ts.count();
+        return ss.str();
+    }
+
+    void TearDown() override {
+        if (!m_cache_dir.empty()) {
+            core->set_property({ov::cache_dir()});
+            core.reset();
+            ov::test::utils::PluginCache::get().reset();
+            ov::test::utils::removeFilesWithExt(m_cache_dir, "blob");
+            ov::test::utils::removeDir(m_cache_dir);
+        }
+
+        if (!configuration.empty()) {
+            utils::PluginCache::get().reset();
+        }
+
+        APIBaseTest::TearDown();
+    }
+
+    std::shared_ptr<Model> create_n_inputs(size_t n,
+                                           element::Type type,
+                                           const PartialShape& shape,
+                                           const ov::Layout& layout) {
+        ResultVector res;
+        ParameterVector params;
+
+        for (size_t i = 0; i < n; i++) {
+            auto index_str = std::to_string(i);
+            auto data1 = std::make_shared<ov::op::v0::Parameter>(type, shape);
+            data1->set_friendly_name("input" + index_str);
+            data1->get_output_tensor(0).set_names({"tensor_input" + index_str});
+            data1->set_layout(layout);
+            auto constant = opset8::Constant::create(type, {1}, {1});
+            auto op1 = std::make_shared<ov::op::v1::Add>(data1, constant);
+            op1->set_friendly_name("Add" + index_str);
+            auto res1 = std::make_shared<ov::op::v0::Result>(op1);
+            res1->set_friendly_name("Result" + index_str);
+            res1->get_output_tensor(0).set_names({"tensor_output" + index_str});
+            params.push_back(data1);
+            res.push_back(res1);
+        }
+
+        return std::make_shared<Model>(res, params);
+    }
+};
+
+TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    size_t batch = 4;
+    auto one_shape = Shape{1, 2, 2, 2};
+    auto batch_shape = Shape{batch, 2, 2, 2};
+    auto one_shape_size = ov::shape_size(one_shape);
+    auto model = BatchedTensorsRunTests::create_n_inputs(2, element::f32, batch_shape, "N...");
+    auto execNet = core->compile_model(model, target_device, configuration);
+    auto context = core->get_default_context(target_device);
+    // Create InferRequest
+    ov::InferRequest req;
+    req = execNet.create_infer_request();
+    std::vector<ov::Tensor> tensors;
+    for (auto i = 0; i < batch; ++i) {
+        // non contiguous memory
+        auto tensor = context.create_host_tensor(ov::element::f32, one_shape);
+        tensors.push_back(std::move(tensor));
+    }
+    req.set_tensors("tensor_input0", tensors);
+
+    auto actual_tensor = req.get_tensor("tensor_output0");
+    auto* actual = actual_tensor.data<float>();
+    for (auto testNum = 0; testNum < 5; testNum++) {
+        for (auto i = 0; i < batch; ++i) {
+            auto* f = tensors[i].data<float>();
+            for (auto j = 0; j < one_shape_size; ++j) {
+                f[j] = static_cast<float>(testNum + 20);
+            }
+        }
+        req.infer();  // Adds '1' to each element
+        for (auto j = 0; j < one_shape_size * batch; ++j) {
+            EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+                                               << ", actual=" << actual[j] << " for index " << j;
+        }
+    }
+}
+
+TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInfer) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    size_t batch = 4;
+    auto one_shape = Shape{1, 2, 2, 2};
+    auto batch_shape = Shape{batch, 2, 2, 2};
+    auto one_shape_size = ov::shape_size(one_shape);
+    auto model = BatchedTensorsRunTests::create_n_inputs(2, element::f32, batch_shape, "N...");
+    auto execNet = core->compile_model(model, target_device, configuration);
+    auto context = core->get_default_context(target_device);
+    // Create InferRequest
+    ov::InferRequest req;
+    req = execNet.create_infer_request();
+    std::vector<ov::Tensor> tensors;
+
+    std::vector<float> buffer(one_shape_size * 2 * 2, 0);
+
+    auto tensor0 = ov::Tensor(element::f32, one_shape, &buffer[(0 * 2) * one_shape_size]);
+    auto tensor1 = context.create_host_tensor(ov::element::f32, one_shape);
+    auto tensor2 = ov::Tensor(element::f32, one_shape, &buffer[(1 * 2) * one_shape_size]);
+    auto tensor3 = context.create_host_tensor(ov::element::f32, one_shape);
+
+    tensors.push_back(std::move(tensor0));
+    tensors.push_back(std::move(tensor1));
+    tensors.push_back(std::move(tensor2));
+    tensors.push_back(std::move(tensor3));
+
+    req.set_tensors("tensor_input0", tensors);
+
+    auto actual_tensor = req.get_tensor("tensor_output0");
+    auto* actual = actual_tensor.data<float>();
+    for (auto testNum = 0; testNum < 5; testNum++) {
+        for (auto i = 0; i < batch; ++i) {
+            auto* f = tensors[i].data<float>();
+            for (auto j = 0; j < one_shape_size; ++j) {
+                f[j] = static_cast<float>(testNum + 20);
+            }
+        }
+        req.infer();  // Adds '1' to each element
+        for (auto j = 0; j < one_shape_size * batch; ++j) {
+            EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+                                               << ", actual=" << actual[j] << " for index " << j;
+        }
+    }
+}
+
+TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInferMCL) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+
+    size_t batch = 4;
+    auto one_shape = Shape{1, 2, 2, 2};
+    auto batch_shape = Shape{batch, 2, 2, 2};
+    auto one_shape_size = ov::shape_size(one_shape);
+    auto model = BatchedTensorsRunTests::create_n_inputs(2, element::f32, batch_shape, "N...");
+    auto execNet = core->compile_model(model, target_device, configuration);
+    auto context = core->get_default_context(target_device);
+    // Create InferRequest
+    ov::InferRequest req;
+    req = execNet.create_infer_request();
+
+    std::vector<float> buffer(one_shape_size * batch * 2, 0);
+
+    {
+        std::vector<ov::Tensor> tensors;
+
+        auto tensor0 = ov::Tensor(element::f32, one_shape, &buffer[(0 * 2) * one_shape_size]);
+        auto tensor1 = context.create_host_tensor(ov::element::f32, one_shape);
+        auto tensor2 = ov::Tensor(element::f32, one_shape, &buffer[(1 * 2) * one_shape_size]);
+        auto tensor3 = context.create_host_tensor(ov::element::f32, one_shape);
+
+        tensors.push_back(std::move(tensor0));
+        tensors.push_back(std::move(tensor1));
+        tensors.push_back(std::move(tensor2));
+        tensors.push_back(std::move(tensor3));
+
+        req.set_tensors("tensor_input0", tensors);
+
+        auto actual_tensor = req.get_tensor("tensor_output0");
+        auto* actual = actual_tensor.data<float>();
+        for (auto testNum = 0; testNum < 5; testNum++) {
+            for (auto i = 0; i < batch; ++i) {
+                auto* f = tensors[i].data<float>();
+                for (auto j = 0; j < one_shape_size; ++j) {
+                    f[j] = static_cast<float>(testNum + 20);
+                }
+            }
+            req.infer();  // Adds '1' to each element
+            for (auto j = 0; j < one_shape_size * batch; ++j) {
+                EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
+                                                   << ", actual=" << actual[j] << " for index " << j;
+            }
+        }
+    }
+
+    {
+        std::vector<ov::Tensor> tensors;
+
+        auto tensor0 = ov::Tensor(element::f32, one_shape, &buffer[(2 * 2) * one_shape_size]);
+        auto tensor1 = context.create_host_tensor(ov::element::f32, one_shape);
+        auto tensor2 = ov::Tensor(element::f32, one_shape, &buffer[(3 * 2) * one_shape_size]);
+        auto tensor3 = context.create_host_tensor(ov::element::f32, one_shape);
+
+        tensors.push_back(std::move(tensor0));
+        tensors.push_back(std::move(tensor1));
+        tensors.push_back(std::move(tensor2));
+        tensors.push_back(std::move(tensor3));
+
+        req.set_tensors("tensor_input0", tensors);
+
+        auto actual_tensor = req.get_tensor("tensor_output0");
+        auto* actual = actual_tensor.data<float>();
+        for (auto testNum = 0; testNum < 5; testNum++) {
+            for (auto i = 0; i < batch; ++i) {
+                auto* f = tensors[i].data<float>();
+                for (auto j = 0; j < one_shape_size; ++j) {
+                    f[j] = static_cast<float>(testNum + 200);
+                }
+            }
+            req.infer();  // Adds '1' to each element
+            for (auto j = 0; j < one_shape_size * batch; ++j) {
+                EXPECT_EQ(actual[j], testNum + 201) << "Infer " << testNum << ": Expected=" << testNum + 21
+                                                    << ", actual=" << actual[j] << " for index " << j;
+            }
+        }
+    }
+}
+
+}  // namespace behavior
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -143,7 +143,7 @@ TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
     ov::InferRequest req;
     req = execNet.create_infer_request();
     std::vector<ov::Tensor> tensors;
-    for (auto i = 0; i < batch; ++i) {
+    for (size_t i = 0; i < batch; ++i) {
         // non contiguous memory
         auto tensor = context.create_host_tensor(ov::element::f32, one_shape);
         tensors.push_back(std::move(tensor));
@@ -153,14 +153,14 @@ TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
     auto actual_tensor = req.get_tensor("tensor_output0");
     auto* actual = actual_tensor.data<float>();
     for (auto testNum = 0; testNum < 5; testNum++) {
-        for (auto i = 0; i < batch; ++i) {
+        for (size_t i = 0; i < batch; ++i) {
             auto* f = tensors[i].data<float>();
-            for (auto j = 0; j < one_shape_size; ++j) {
+            for (size_t j = 0; j < one_shape_size; ++j) {
                 f[j] = static_cast<float>(testNum + 20);
             }
         }
         req.infer();  // Adds '1' to each element
-        for (auto j = 0; j < one_shape_size * batch; ++j) {
+        for (size_t j = 0; j < one_shape_size * batch; ++j) {
             EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                << ", actual=" << actual[j] << " for index " << j;
         }
@@ -200,14 +200,14 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInfer) {
     auto actual_tensor = req.get_tensor("tensor_output0");
     auto* actual = actual_tensor.data<float>();
     for (auto testNum = 0; testNum < 5; testNum++) {
-        for (auto i = 0; i < batch; ++i) {
+        for (size_t i = 0; i < batch; ++i) {
             auto* f = tensors[i].data<float>();
-            for (auto j = 0; j < one_shape_size; ++j) {
+            for (size_t j = 0; j < one_shape_size; ++j) {
                 f[j] = static_cast<float>(testNum + 20);
             }
         }
         req.infer();  // Adds '1' to each element
-        for (auto j = 0; j < one_shape_size * batch; ++j) {
+        for (size_t j = 0; j < one_shape_size * batch; ++j) {
             EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                << ", actual=" << actual[j] << " for index " << j;
         }
@@ -249,14 +249,14 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInferMCL) {
         auto actual_tensor = req.get_tensor("tensor_output0");
         auto* actual = actual_tensor.data<float>();
         for (auto testNum = 0; testNum < 5; testNum++) {
-            for (auto i = 0; i < batch; ++i) {
+            for (size_t i = 0; i < batch; ++i) {
                 auto* f = tensors[i].data<float>();
-                for (auto j = 0; j < one_shape_size; ++j) {
+                for (size_t j = 0; j < one_shape_size; ++j) {
                     f[j] = static_cast<float>(testNum + 20);
                 }
             }
             req.infer();  // Adds '1' to each element
-            for (auto j = 0; j < one_shape_size * batch; ++j) {
+            for (size_t j = 0; j < one_shape_size * batch; ++j) {
                 EXPECT_EQ(actual[j], testNum + 21) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                    << ", actual=" << actual[j] << " for index " << j;
             }
@@ -281,14 +281,14 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentTensorsMultipleInferMCL) {
         auto actual_tensor = req.get_tensor("tensor_output0");
         auto* actual = actual_tensor.data<float>();
         for (auto testNum = 0; testNum < 5; testNum++) {
-            for (auto i = 0; i < batch; ++i) {
+            for (size_t i = 0; i < batch; ++i) {
                 auto* f = tensors[i].data<float>();
-                for (auto j = 0; j < one_shape_size; ++j) {
+                for (size_t j = 0; j < one_shape_size; ++j) {
                     f[j] = static_cast<float>(testNum + 200);
                 }
             }
             req.infer();  // Adds '1' to each element
-            for (auto j = 0; j < one_shape_size * batch; ++j) {
+            for (size_t j = 0; j < one_shape_size * batch; ++j) {
                 EXPECT_EQ(actual[j], testNum + 201) << "Infer " << testNum << ": Expected=" << testNum + 21
                                                     << ", actual=" << actual[j] << " for index " << j;
             }

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -705,14 +705,8 @@ std::vector<std::string> disabledTestPatterns() {
         // [Tracking number: E#116494]
         _skipRegistry.addPatterns(
                 "NPU plugin doesn't implement `set_tensors` function", {
-                ".*OVInferRequestBatchedTests.SetInputTensorsBase.*",
-                ".*OVInferRequestBatchedTests.SetInputTensorsAsync.*",
-                ".*OVInferRequestBatchedTests.SetInputTensors_override_with_set.*",
                 ".*OVInferRequestBatchedTests.SetInputTensorsBase_Caching.*",
-                ".*OVInferRequestBatchedTests.SetInputTensors_Multiple_Infer.*",
                 ".*OVInferRequestBatchedTests.SetInputTensors_Can_Infer_Dynamic.*",
-                ".*OVInferRequestBatchedTests.SetInputTensors_Get_Tensor_Not_Allowed.*",
-                ".*OVInferRequestBatchedTests.SetInputTensors_Correct_all.*",
                 ".*OVInferRequestBatchedTests.SetInputTensors_Cache_CheckDeepCopy.*"
         });
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -704,9 +704,7 @@ std::vector<std::string> disabledTestPatterns() {
 
         _skipRegistry.addPatterns(
                 "NPU plugin doesn't support infer dynamic", {
-                ".*OVInferRequestBatchedTests.SetInputTensorsBase_Caching.*",
                 ".*OVInferRequestBatchedTests.SetInputTensors_Can_Infer_Dynamic.*",
-                ".*OVInferRequestBatchedTests.SetInputTensors_Cache_CheckDeepCopy.*"
         });
 
         // [Tracking number: E#118381]

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -702,9 +702,8 @@ std::vector<std::string> disabledTestPatterns() {
                 ".*OVCompiledModelPropertiesDefaultSupportedTests.CanCompileWithDefaultValueFromPlugin.*"
         });
 
-        // [Tracking number: E#116494]
         _skipRegistry.addPatterns(
-                "NPU plugin doesn't implement `set_tensors` function", {
+                "NPU plugin doesn't support infer dynamic", {
                 ".*OVInferRequestBatchedTests.SetInputTensorsBase_Caching.*",
                 ".*OVInferRequestBatchedTests.SetInputTensors_Can_Infer_Dynamic.*",
                 ".*OVInferRequestBatchedTests.SetInputTensors_Cache_CheckDeepCopy.*"


### PR DESCRIPTION
### Details:
 - *Adding support for the set_tensor method*

set_tensors works differently in case the plugin or the compiler handles the batch:
- in case the compiler handles batching we need to create a continuous L0 tensor and copy all the tensors into that big tensor even when tensors are part of the same L0 context
- in case the plugin handles batching and the remote tensor feature is supported copy is not used if the tensors are part of the same L0 context.

### Tickets:
 - *EISW-116494*
