### PR TITLE
[Kaldi] Work around conversion for stateful Kaldi models with Python>3.8

### DIFF
--- a/tools/mo/requirements_kaldi.txt
+++ b/tools/mo/requirements_kaldi.txt
@@ -1,5 +1,6 @@
 -c ../constraints.txt
-numpy>=1.16.6,<1.27
+# wa: conversion for stateful models is failed on higher numpy versions
+numpy>=1.16.6,<1.25
 networkx
 defusedxml
 requests

--- a/tools/mo/requirements_kaldi.txt
+++ b/tools/mo/requirements_kaldi.txt
@@ -1,6 +1,7 @@
 -c ../constraints.txt
 # wa: conversion for stateful models is failed on higher numpy versions
-numpy>=1.16.6,<1.25
+numpy>=1.16.6,<1.25; python_version<"3.12"
+numpy>=1.16.6,<1.27; python_version>="3.12"
 networkx
 defusedxml
 requests


### PR DESCRIPTION
**Details:** Work around conversion for stateful Kaldi models with Python>3.8. Now it fails for unknown reason on higher numpy versions. Since this is quite legacy stuff and will removed in 2025.0. we decided not to invest our time for proper resolution. So we proceed with easy-fix.

**Ticket:** 153367
