### PR TITLE
[Transformation Tests] Enable paged attention tests for tiny-random-GPTNeoForCausalLM

### DIFF
--- a/tests/model_hub_tests/transformation_tests/models/hf-tiny-random-models-precommit
+++ b/tests/model_hub_tests/transformation_tests/models/hf-tiny-random-models-precommit
@@ -1,7 +1,7 @@
 hf-internal-testing/tiny-random-LlamaForCausalLM,https://huggingface.co/trl-internal-testing/tiny-random-LlamaForCausalLM
 hf-internal-testing/tiny-random-CohereForCausalLM,https://huggingface.co/hf-internal-testing/tiny-random-CohereForCausalLM
 hf-internal-testing/tiny-random-GPTJForCausalLM,https://huggingface.co/trl-internal-testing/tiny-random-GPTJForCausalLM
-hf-internal-testing/tiny-random-GPTNeoForCausalLM,https://huggingface.co/hf-internal-testing/tiny-random-GPTNeoForCausalLM,xfail,No ScaledDotProductAttention operation observed in the graph CVS-153620
+hf-internal-testing/tiny-random-GPTNeoForCausalLM,https://huggingface.co/hf-internal-testing/tiny-random-GPTNeoForCausalLM
 hf-internal-testing/tiny-random-GPTNeoXForCausalLM,https://huggingface.co/hf-internal-testing/tiny-random-GPTNeoXForCausalLM
 hf-internal-testing/tiny-random-MistralForCausalLM,https://huggingface.co/hf-internal-testing/tiny-random-MistralForCausalLM
 hf-internal-testing/tiny-random-CodeGenForCausalLM,https://huggingface.co/hf-internal-testing/tiny-random-CodeGenForCausalLM


### PR DESCRIPTION
This reverts commit 1ab0448b196ef8f0ef6a685ee6eb068eaa64813f which disabled the tests in the pre-commit
The fix has been merged to optimum-intel https://github.com/huggingface/optimum-intel/pull/917, so we can restore the test

### Tickets:
 - *CVS-153620*
