### PR TITLE
[Benchmark App] Prioritize the config for device given in CLI when multiple are available

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -315,9 +315,13 @@ def main():
                     del device_number_streams[device]
 
         device_config = {}
-        for device in config:
-            if benchmark.device.find(device) == 0:
-                device_config = config[device]
+        # In case of multiple devices found prefer the one given in CLI argument
+        if benchmark.device.find(device_name) == 0 and device_name in config.keys():
+            device_config = config[device_name]
+        else:
+            for device in config:
+                if benchmark.device.find(device) == 0:
+                    device_config = config[device]
         if args.cache_dir:
             benchmark.set_cache_dir(args.cache_dir)
 


### PR DESCRIPTION
### Details:
 - In the case reported in the ticket the config was given for a device `BATCH:GPU.1(128)`, which was also specified in the CLI as `-d BATCH:GPU.1(128)`
 - The previous code first found `BATCH:GPU.1(128)` as an available device and assigned the config correctly, but afterwards it also found `BATCH` device and overwrote the `device_config` variable with incorrect value
 - Prioritizing the device given in the CLI solves the issue

### Tickets:
 - CVS-130165
