### PR TITLE
NPUW: Introduce 'last' keyword for dump options

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
@@ -324,7 +324,7 @@ static constexpr ov::Property<bool> full{"NPUW_DUMP_FULL"};
  * Dump the specified subgraph(s) in OpenVINO IR form in the current directory.
  * Possible values: Comma-separated list of subgraph indices or "YES" for all
  * subgraphs, "NO" or just empty value to turn option off. Keyword "last" can
- * be used for dumping last subgraph without specifying it by specific indice.
+ * be used for dumping last subgraph without specifying it by specific index.
  * E.g. "0,1" or "0,1,last" or "YES".
  * Default value: empty.
  */

--- a/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/npuw_private_properties.hpp
@@ -30,8 +30,8 @@ static constexpr ov::Property<std::string> devices{"NPUW_DEVICES"};
  * @brief
  * Type: std::string.
  * Force the specific subgraph to specific device. The device must be present in the NPUW_DEVICES list.
- * Possible values: Comma-separated "Subgraph index:OpenVINO device name" pairs,
- * e.g. "0:CPU,1:NPU".
+ * Possible values: Comma-separated "Subgraph index:OpenVINO device name" pairs, "last" keyword can be
+ * used for last subgraph, e.g. "0:CPU,1:NPU,last:CPU".
  * Default value: empty.
  */
 static constexpr ov::Property<std::string> submodel_device{"NPUW_SUBMODEL_DEVICE"};
@@ -323,7 +323,9 @@ static constexpr ov::Property<bool> full{"NPUW_DUMP_FULL"};
  * Type: std::string.
  * Dump the specified subgraph(s) in OpenVINO IR form in the current directory.
  * Possible values: Comma-separated list of subgraph indices or "YES" for all
- * subgraphs, "NO" or just empty value to turn option off. E.g. "0,1" or "YES".
+ * subgraphs, "NO" or just empty value to turn option off. Keyword "last" can
+ * be used for dumping last subgraph without specifying it by specific indice.
+ * E.g. "0,1" or "0,1,last" or "YES".
  * Default value: empty.
  */
 static constexpr ov::Property<std::string> subgraphs{"NPUW_DUMP_SUBS"};
@@ -333,7 +335,8 @@ static constexpr ov::Property<std::string> subgraphs{"NPUW_DUMP_SUBS"};
  * Type: std::string.
  * Dump subgraph on disk if a compilation failure happens.
  * Possible values: Comma-separated list of subgraph indices or "YES" for all
- * subgraphs, "NO" or just empty value to turn option off. E.g. "0,1" or "YES".
+ * subgraphs, "NO" or just empty value to turn option off. Keyword "last" can
+ * be used for dumping last subgraph. E.g. "0,1" or "0,1,last" or "YES".
  * Default value: empty.
  */
 static constexpr ov::Property<std::string> subgraphs_on_fail{"NPUW_DUMP_SUBS_ON_FAIL"};
@@ -343,7 +346,8 @@ static constexpr ov::Property<std::string> subgraphs_on_fail{"NPUW_DUMP_SUBS_ON_
  * Type: std::string.
  * Dump input & output tensors for subgraph(s).
  * Possible values: Comma-separated list of subgraph indices or "YES" for all
- * subgraphs, "NO" or just empty value to turn option off. E.g. "0,1" or "YES".
+ * subgraphs, "NO" or just empty value to turn option off. Keyword "last" can
+ * be used for last subgraph. E.g. "0,1" or "0,1,last" or "YES".
  * Default value: empty.
  */
 static constexpr ov::Property<std::string> inputs_outputs{"NPUW_DUMP_IO"};

--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -211,8 +211,8 @@ void ov::npuw::IBaseInferRequest::infer() {
 
 void ov::npuw::IBaseInferRequest::dump_input_tensors(std::size_t idx) {
     const std::string dump_ios_opt = m_npuw_model->m_cfg.get<::intel_npu::NPUW_DUMP_IO>();
-    const std::size_t last_idx = m_npuw_model->m_compiled_submodels.size() - 1;
-    if (!ov::npuw::util::is_set(idx, dump_ios_opt, last_idx)) {
+    const std::size_t end_idx = m_npuw_model->m_compiled_submodels.size();
+    if (!ov::npuw::util::is_set(idx, dump_ios_opt, end_idx)) {
         return;
     }
 
@@ -289,8 +289,8 @@ void ov::npuw::IBaseInferRequest::dump_input_tensors(std::size_t idx) {
 
 void ov::npuw::IBaseInferRequest::dump_output_tensors(std::size_t idx) {
     const std::string dump_ios_opt = m_npuw_model->m_cfg.get<::intel_npu::NPUW_DUMP_IO>();
-    const std::size_t last_idx = m_npuw_model->m_compiled_submodels.size() - 1;
-    if (!ov::npuw::util::is_set(idx, dump_ios_opt, last_idx)) {
+    const std::size_t end_idx = m_npuw_model->m_compiled_submodels.size();
+    if (!ov::npuw::util::is_set(idx, dump_ios_opt, end_idx)) {
         return;
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/base_sync_infer_request.cpp
@@ -211,7 +211,8 @@ void ov::npuw::IBaseInferRequest::infer() {
 
 void ov::npuw::IBaseInferRequest::dump_input_tensors(std::size_t idx) {
     const std::string dump_ios_opt = m_npuw_model->m_cfg.get<::intel_npu::NPUW_DUMP_IO>();
-    if (!ov::npuw::util::is_set(idx, dump_ios_opt)) {
+    const std::size_t last_idx = m_npuw_model->m_compiled_submodels.size() - 1;
+    if (!ov::npuw::util::is_set(idx, dump_ios_opt, last_idx)) {
         return;
     }
 
@@ -288,7 +289,8 @@ void ov::npuw::IBaseInferRequest::dump_input_tensors(std::size_t idx) {
 
 void ov::npuw::IBaseInferRequest::dump_output_tensors(std::size_t idx) {
     const std::string dump_ios_opt = m_npuw_model->m_cfg.get<::intel_npu::NPUW_DUMP_IO>();
-    if (!ov::npuw::util::is_set(idx, dump_ios_opt)) {
+    const std::size_t last_idx = m_npuw_model->m_compiled_submodels.size() - 1;
+    if (!ov::npuw::util::is_set(idx, dump_ios_opt, last_idx)) {
         return;
     }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -344,11 +344,10 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
     std::map<std::size_t, std::string> forced_sub_devices{};
     std::string fsd_opt = m_cfg.get<::intel_npu::NPUW_SUBMODEL_DEVICE>();
     // Change "last" keyword to tail subgraph number
-    uint32_t last_sub_id = static_cast<uint32_t>(m_compiled_submodels.size() - 1);
     std::size_t last_pos = fsd_opt.find("last");
     if (last_pos != std::string::npos) {
         fsd_opt.erase(last_pos, 4);
-        fsd_opt.insert(last_pos, std::to_string(last_sub_id));
+        fsd_opt.insert(last_pos, std::to_string(last_sub_idx));
     }
 
     forced_sub_devices = ::intel_npu ::OptionParser<std::map<std::size_t, std::string>>::parse(fsd_opt);

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -256,6 +256,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
     // - dump the subgraphs, if necessary
     std::map<std::string, std::size_t> compiledFunctions;
     m_compiled_submodels.resize(orderedSubgraphs.size());
+    const std::size_t last_sub_idx = orderedSubgraphs.size() - 1;
 
     const std::string dump_sub_opt = m_cfg.get<::intel_npu::NPUW_DUMP_SUBS>();
 
@@ -323,7 +324,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
             fill_empty_tensor_names(m_compiled_submodels[real_id].model);
         }
 
-        if (ov::npuw::util::is_set(id, dump_sub_opt)) {
+        if (ov::npuw::util::is_set(id, dump_sub_opt, last_sub_idx)) {
             LOG_INFO("Dumping Subgraph[" << id << "]");
             LOG_BLOCK();
             if (real_id != id) {
@@ -694,8 +695,9 @@ ov::SoPtr<ov::ICompiledModel> ov::npuw::CompiledModel::compile_submodel(const st
 
 void ov::npuw::CompiledModel::dump_on_fail(std::size_t id, const std::string& device_to_try, const char* extra) {
     const std::string dof_opt = m_cfg.get<::intel_npu::NPUW_DUMP_SUBS_ON_FAIL>();
+    const std::size_t last_idx = m_compiled_submodels.size() - 1;
 
-    if (ov::npuw::util::is_set(id, dof_opt)) {
+    if (ov::npuw::util::is_set(id, dof_opt, last_idx)) {
         ov::npuw::dump_failure(m_compiled_submodels[id].model, device_to_try, extra);
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include "accuracy/comparator.hpp"
 #include "intel_npu/npu_private_properties.hpp"
@@ -341,7 +342,15 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
     }      // for(orderedSubgraphs)
 
     std::map<std::size_t, std::string> forced_sub_devices{};
-    const std::string fsd_opt = m_cfg.get<::intel_npu::NPUW_SUBMODEL_DEVICE>();
+    std::string fsd_opt = m_cfg.get<::intel_npu::NPUW_SUBMODEL_DEVICE>();
+    // Change "last" keyword to tail subgraph number
+    uint32_t last_sub_id = static_cast<uint32_t>(m_compiled_submodels.size() - 1);
+    std::size_t last_pos = fsd_opt.find("last");
+    if (last_pos != std::string::npos) {
+        fsd_opt.erase(last_pos, 4);
+        fsd_opt.insert(last_pos, std::to_string(last_sub_id));
+    }
+
     forced_sub_devices = ::intel_npu ::OptionParser<std::map<std::size_t, std::string>>::parse(fsd_opt);
 
     // Exclude optimized out subgraphs from compilation target beforehand - otherwise we might get head and repeated

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -257,7 +257,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
     // - dump the subgraphs, if necessary
     std::map<std::string, std::size_t> compiledFunctions;
     m_compiled_submodels.resize(orderedSubgraphs.size());
-    const std::size_t last_sub_idx = orderedSubgraphs.size() - 1;
+    const std::size_t end_sub_idx = orderedSubgraphs.size();
 
     const std::string dump_sub_opt = m_cfg.get<::intel_npu::NPUW_DUMP_SUBS>();
 
@@ -325,7 +325,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
             fill_empty_tensor_names(m_compiled_submodels[real_id].model);
         }
 
-        if (ov::npuw::util::is_set(id, dump_sub_opt, last_sub_idx)) {
+        if (ov::npuw::util::is_set(id, dump_sub_opt, end_sub_idx)) {
             LOG_INFO("Dumping Subgraph[" << id << "]");
             LOG_BLOCK();
             if (real_id != id) {
@@ -347,7 +347,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
     std::size_t last_pos = fsd_opt.find("last");
     if (last_pos != std::string::npos) {
         fsd_opt.erase(last_pos, 4);
-        fsd_opt.insert(last_pos, std::to_string(last_sub_idx));
+        fsd_opt.insert(last_pos, std::to_string(end_sub_idx));
     }
 
     forced_sub_devices = ::intel_npu ::OptionParser<std::map<std::size_t, std::string>>::parse(fsd_opt);
@@ -703,9 +703,9 @@ ov::SoPtr<ov::ICompiledModel> ov::npuw::CompiledModel::compile_submodel(const st
 
 void ov::npuw::CompiledModel::dump_on_fail(std::size_t id, const std::string& device_to_try, const char* extra) {
     const std::string dof_opt = m_cfg.get<::intel_npu::NPUW_DUMP_SUBS_ON_FAIL>();
-    const std::size_t last_idx = m_compiled_submodels.size() - 1;
+    const std::size_t end_idx = m_compiled_submodels.size();
 
-    if (ov::npuw::util::is_set(id, dof_opt, last_idx)) {
+    if (ov::npuw::util::is_set(id, dof_opt, end_idx)) {
         ov::npuw::dump_failure(m_compiled_submodels[id].model, device_to_try, extra);
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -17,7 +17,7 @@
 #include "openvino/runtime/make_tensor.hpp"  // get_tensor_impl
 #include "util_xarch.hpp"
 
-bool ov::npuw::util::is_set(const std::size_t sub_idx, const std::string& opt) {
+bool ov::npuw::util::is_set(const std::size_t sub_idx, const std::string& opt, const std::size_t last_idx) {
     if (opt.empty() || opt == "NO") {
         return false;
     }
@@ -25,12 +25,20 @@ bool ov::npuw::util::is_set(const std::size_t sub_idx, const std::string& opt) {
         return true;
     }
 
+    std::string str(opt);
+    std::size_t last_pos = str.find("last");
+    if (last_pos != std::string::npos) {
+        str.erase(last_pos, 4);
+        if (last_idx != SIZE_MAX && sub_idx == last_idx) {
+            return true;
+        }
+    }
+
     std::vector<std::size_t> sub_inds{};
-    sub_inds = ::intel_npu ::OptionParser<std::vector<std::size_t>>::parse(opt);
+    sub_inds = ::intel_npu ::OptionParser<std::vector<std::size_t>>::parse(str);
     if (std::find(sub_inds.begin(), sub_inds.end(), sub_idx) != sub_inds.end()) {
         return true;
     }
-
     return false;
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -17,7 +17,7 @@
 #include "openvino/runtime/make_tensor.hpp"  // get_tensor_impl
 #include "util_xarch.hpp"
 
-bool ov::npuw::util::is_set(const std::size_t sub_idx, const std::string& opt, const std::size_t last_idx) {
+bool ov::npuw::util::is_set(const std::size_t sub_idx, const std::string& opt, const std::size_t end_idx) {
     if (opt.empty() || opt == "NO") {
         return false;
     }
@@ -29,7 +29,7 @@ bool ov::npuw::util::is_set(const std::size_t sub_idx, const std::string& opt, c
     std::size_t last_pos = str.find("last");
     if (last_pos != std::string::npos) {
         str.erase(last_pos, 4);
-        if (last_idx != SIZE_MAX && sub_idx == last_idx) {
+        if (end_idx != SIZE_MAX && sub_idx == end_idx - 1) {
             return true;
         }
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -15,7 +15,9 @@ namespace ov {
 namespace npuw {
 namespace util {
 
-bool is_set(const std::size_t sub_idx, const std::string& opt);
+bool is_set(const std::size_t sub_idx,
+            const std::string& opt,
+            const std::size_t last_idx = SIZE_MAX);
 
 // Every great project has its own string class...
 // NB: Newer C++ standards would allow to use string views or smt

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace npuw {
 namespace util {
 
-bool is_set(const std::size_t sub_idx, const std::string& opt, const std::size_t last_idx = SIZE_MAX);
+bool is_set(const std::size_t sub_idx, const std::string& opt, const std::size_t end_idx = SIZE_MAX);
 
 // Every great project has its own string class...
 // NB: Newer C++ standards would allow to use string views or smt

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -15,9 +15,7 @@ namespace ov {
 namespace npuw {
 namespace util {
 
-bool is_set(const std::size_t sub_idx,
-            const std::string& opt,
-            const std::size_t last_idx = SIZE_MAX);
+bool is_set(const std::size_t sub_idx, const std::string& opt, const std::size_t last_idx = SIZE_MAX);
 
 // Every great project has its own string class...
 // NB: Newer C++ standards would allow to use string views or smt


### PR DESCRIPTION
### Details:
 - The problem is that for different networks the number of NPUW's detected block may be different and it is hard to tell what the last block number will be. Now 'last' option can be used to tell NPUW to dump tail block without setting specific number.

### Tickets:
 - E-139857
