### PR TITLE
[GPU] Use ifm size of fc for dynamic quantize

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -21,6 +21,7 @@ static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params
 
     // In Some model, input_f could be dynamic in input0. It refers to IFM value of weight.
     if (params.inputs[0].is_dynamic() && input_f == 0) {
+        OPENVINO_ASSERT(params.fc_ifm_size != 0, "[GPU] Invalid fc_ifm_size value");
         input_f = params.fc_ifm_size;
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -19,6 +19,11 @@ static std::pair<size_t, size_t> get_input_bf_size(const dynamic_quantize_params
         input_batch = params.inputs[0].Batch().v * params.inputs[0].Feature().v;
     }
 
+    // In Some model, input_f could be dynamic in input0. It refers to IFM value of weight.
+    if (params.inputs[0].is_dynamic() && input_f == 0) {
+        input_f = params.fc_ifm_size;
+    }
+
     return {input_batch, input_f};
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.h
@@ -12,6 +12,7 @@ namespace kernel_selector {
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 struct dynamic_quantize_params : public base_params {
     dynamic_quantize_params() : base_params(KernelType::DYNAMIC_QUANTIZE) {}
+    size_t fc_ifm_size = 0;
 };
 
 class DynamicQuantizeKernelRef : public KernelBaseOpenCL {


### PR DESCRIPTION
### Details:
 - *DynamicQuantize requires the FC ifm size to generate the kernel.*
 - *But it cannot be obtained with fully dynamic input shape, so it has been queried from fc.*

### Tickets:
 - *152019*
