### PR TITLE
[TMP][Snippets] FullyConnected performance experiments

### DIFF
--- a/src/common/snippets/src/pass/common_optimizations.cpp
+++ b/src/common/snippets/src/pass/common_optimizations.cpp
@@ -47,6 +47,7 @@ CommonOptimizations::CommonOptimizations(const SnippetsTokenization::Config& con
         // Then if Subgraph contains FakeQuantize we enable specific transformation for quantized subgraphs.
         ov::pass::Manager manager(get_pass_config(), "Snippets:CommonOptimizations");
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::TransformConvertToConvertTruncation, true);
+        // Note: in case of FullyConnected, some common optimizations shouldn't be applied. At least, ExplicitTransposeMatMulInputs
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::ExplicitTransposeMatMulInputs, is_domain_sensitive);
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::CommonFakeQuantizeDecomposition, is_quantized);
         REGISTER_SNIPPETS_PASS(manager, ov::snippets::pass::SoftmaxReshapeElimination, is_domain_sensitive);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.cpp
@@ -287,7 +287,8 @@ void BrgemmKernelExecutor::update_config(const ov::snippets::lowered::Expression
     // In case of data repacking LDB is chosen in accordance with repacking buffer size
     if (with_repacking(brgemm_node->get_type()))
         LDB = brgemm_utils::repacking::compute_out_leading_dim(N, brgemm_node->get_input_element_type(1));
-
+    // hack to imitate blocking layout
+    LDB = std::getenv("N_b") ? std::atoi(std::getenv("N_b")) : 64;;
     config.update(DIM_CAST(M), DIM_CAST(N), DIM_CAST(K), LDA, LDB, LDC, beta);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp
@@ -26,6 +26,9 @@ MemoryPtr prepareWeightsMemory(const DnnlMemoryDescPtr srcWeightDesc,
     const auto& eng = context->getEngine();
     const auto& format = dstWeightDesc->serializeFormat();
 
+    std::cout << "[ INFO ] prepareWeightsMemory: repacking from " << srcWeightDesc->serializeFormat() << " to "
+              << dstWeightDesc->serializeFormat() << std::endl;
+
     const auto privateWeightCache = context->getPrivateWeighCache();
     OPENVINO_ASSERT(privateWeightCache, "privateWeightCache is nullptr");
     if (privateWeightCache) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
@@ -70,7 +70,10 @@ std::tuple<size_t, size_t, size_t> BrgemmCPUBlocking::get_blocking_params(const 
         n_blk = get_full_dim_value();
         k_blk = get_full_dim_value();
     }
-    return std::make_tuple(m_blk, n_blk, k_blk);
+    const size_t M = std::getenv("M_b") ? std::atoi(std::getenv("M_b")) : m_blk;
+    const size_t K = std::getenv("K_b") ? std::atoi(std::getenv("K_b")) : k_blk;
+    const size_t N = std::getenv("N_b") ? std::atoi(std::getenv("N_b")) : n_blk;
+    return std::make_tuple(M, N, K);
 }
 
 SpecificIterationHandlers BrgemmCPUBlocking::get_k_loop_handlers(size_t work_amount, size_t block_size) const {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -404,10 +404,13 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::KeepConstAndDecompression);
     CPU_SET_CALLBACK_COMMON(manager,
         [](const_node_ptr &node) -> bool {
-            const auto consumers = node->get_output_target_inputs(0);
-            return std::all_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
-                return !ov::is_type<ov::op::v0::MatMul>(consumer.get_node());
-            });
+            // Note: To tokenize MatMul with f16 const and f32 convert on weights in snippets,
+            // weights should be folded to f32 const before snippets, so KeepConstAndDecompression is disabled in this case
+            return true;
+            // const auto consumers = node->get_output_target_inputs(0);
+            // return std::all_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
+            //     return !ov::is_type<ov::op::v0::MatMul>(consumer.get_node());
+            // });
         },
         ov::pass::KeepConstAndDecompression);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
@@ -149,6 +149,26 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MatMulEltwiseChainCascade, MatMulEltwise
                              ::testing::Values(ov::test::utils::DEVICE_CPU)),
                          MatMul::getTestCaseName);
 
+const size_t M = std::getenv("M") ? std::atoi(std::getenv("M")) : 32;
+const size_t K = std::getenv("K") ? std::atoi(std::getenv("K")) : 64;
+const size_t N = std::getenv("N") ? std::atoi(std::getenv("N")) : 256;
+
+std::vector<std::vector<ov::test::InputShape>> fc_input_shapes{
+    {
+        {PartialShape{}, {{1, 1, M, K}}},
+        {{}, {{K, N}}}
+    },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Snippets_FullyConnected, MatMul,
+                         ::testing::Combine(
+                             ::testing::ValuesIn(fc_input_shapes),
+                             ::testing::ValuesIn(precisions(false)),
+                             ::testing::Values(MatMulType::FullyConnected),
+                             ::testing::Values(1), // MatMul
+                             ::testing::Values(1), // Tokenized MatMul
+                             ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                         MatMul::getTestCaseName);
 const auto& transpose_b_shapes = STATIC_SHAPES(
     {{3, 3, 64, 64}, {3, 3, 64, 64}},
     {{1, 1, 32, 128}, {1, 1, 64, 128}},


### PR DESCRIPTION
### Details:
The PR contains several hacks for FC with repacked weights execution via snippets. Also, added MatMul test case which allows to variate dimensions and block sizes via environment variables.

### Examples:
1. Default shapes:
> N_b=32 K_b=16 ./ov_cpu_func_tests_subset --gtest_filter=*smoke_Snippets_FullyConnected/MatMul.*f32\*
2. Custom shapes:
> M=32 K=64 N=256 M_b=32 K_b=16 N_b=32  ./ov_cpu_func_tests_subset --gtest_filter=*smoke_Snippets_FullyConnected/MatMul.*f32\*
