### PR TITLE
[TF FE][Keras] Use latest Keras for TF FE validation and adopt tests

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_dot.py
@@ -44,9 +44,7 @@ class TestKerasDot(CommonTF2LayerTest):
         ([[5, 1, 5, 2], [5, 1, 2, 5]], (2, 3)),
         ([[5, 1, 102, 2], [5, 1, 4, 102]], (-2, -1))
     ])
-    @pytest.mark.parametrize('input_type', [np.float32, np.float64,
-                                            np.int8, np.int16, np.int32, np.int64,
-                                            np.uint8, np.uint16, np.uint32, np.uint64])
+    @pytest.mark.parametrize('input_type', [np.float32, np.float64])
     @pytest.mark.parametrize('normalize', [True, False])
     @pytest.mark.nightly
     @pytest.mark.precommit

--- a/tests/requirements_tensorflow
+++ b/tests/requirements_tensorflow
@@ -4,6 +4,8 @@ pytest==7.0.1
 pytest-xdist[psutil]==3.6.1
 pytest-html==4.1.1
 transformers==4.45.1
+# install exact keras version since tensorflow depends and has no upper bound for it
+keras==3.6.0
 tensorflow==2.17.0; platform_system != "Darwin" or platform_machine != "x86_64"
 tensorflow==2.16.2; platform_system == "Darwin" and platform_machine == "x86_64"
 # tensorflow-text is not available for both Windows and ARM platforms


### PR DESCRIPTION
**Details:** New Keras Dot operation does not support integer operands

**Ticket:** TBD
