### PR TITLE
[ov_integration] Remove incompatible test

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
@@ -233,7 +233,7 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVClassCompiledModel
                                             ::testing::ValuesIn(compiledModelIncorrectConfigs)),
                          ov::test::utils::appendPlatformTypeTestName<OVClassCompiledModelPropertiesIncorrectTests>);
 
-INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests, OVCompiledModelIncorrectDevice,
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests, OVCompiledModelIncorrectDevice,
                          ::testing::Values(ov::test::utils::DEVICE_NPU),
                          ov::test::utils::appendPlatformTypeTestName<OVCompiledModelIncorrectDevice>);
 


### PR DESCRIPTION
### Details:
 - Test OVCompiledModelIncorrectDevice fails when setting DEVICE_ID in PV2 driver. Disabling while investigation ongoing.

### Tickets:
 - EISW-141263
