### PR TITLE
[DOCS] Fixing references in Node.js API docs

### DIFF
--- a/docs/sphinx_setup/api/nodejs_api/nodejs_api.rst
+++ b/docs/sphinx_setup/api/nodejs_api/nodejs_api.rst
@@ -43,10 +43,10 @@ API Development
 
 OpenVINO 2024.4 has introduced the following methods:
 
--	Model.clone()
--	Model.getoutputelementtype()
--	CompiledModel getProperty()
--	CompiledModel.setProperty()
+- :ref:`Model.clone() <clone>`
+- :ref:`Model.getOutputElementType() <getOutputElementType>`
+- :ref:`CompiledModel.getProperty() <getProperty>`
+- :ref:`CompiledModel.setProperty() <setProperty>`
 
 
 Additional Resources

--- a/docs/sphinx_setup/api/nodejs_api/openvino-node/interfaces/CompiledModel.rst
+++ b/docs/sphinx_setup/api/nodejs_api/openvino-node/interfaces/CompiledModel.rst
@@ -243,6 +243,7 @@ Methods
 
 
 .. rubric:: setProperty
+   :name: setProperty
 
 *
 

--- a/docs/sphinx_setup/api/nodejs_api/openvino-node/interfaces/Model.rst
+++ b/docs/sphinx_setup/api/nodejs_api/openvino-node/interfaces/Model.rst
@@ -4,6 +4,7 @@ Interface Model
 .. code-block:: ts
 
    interface Model {
+       clone(): Model;
        inputs: Output[];
        outputs: Output[];
        getFriendlyName(): string;
@@ -59,6 +60,7 @@ Methods
 #####################
 
 .. rubric:: clone
+   :name: clone
 
 *
 
@@ -143,6 +145,7 @@ Methods
      `addon.ts:198 <https://github.com/openvinotoolkit/openvino/blob/master/src/bindings/js/node/lib/addon.ts#L198>`__
 
 .. rubric:: getOutputElementType
+   :name: getOutputElementType
 
 *
 


### PR DESCRIPTION
Fixing references to new methods introduced in the 2024.4 release.
