### PR TITLE
[PT FE] Remove explicit optimum deps from validation

### DIFF
--- a/tests/requirements_pytorch
+++ b/tests/requirements_pytorch
@@ -24,7 +24,6 @@ datasets==3.0.1
 easyocr==1.7.2
 facexlib==0.3.0; python_version < "3.12"
 librosa==0.10.2; python_version < "3.12"
-optimum==1.22.0; python_version < "3.12"
 packaging==24.1
 pandas==2.2.3
 protobuf==5.28.2


### PR DESCRIPTION
**Details:** Optimum-intel will install the required version. Since we primarily validate compatibility OV with `optimum-intel`, let us leave only `optimum-intel`

**Ticket:** 154283
