### PR TITLE
[GPU] Added empty LoRA adapters support

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -48,8 +48,8 @@ struct memory {
     virtual ~memory() = default;
     virtual void* lock(const stream& stream, mem_lock_type type = mem_lock_type::read_write) = 0;
     virtual void unlock(const stream& stream) = 0;
-    virtual event::ptr fill(stream& stream, unsigned char pattern) = 0;
-    virtual event::ptr fill(stream& stream) = 0;
+    virtual event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) = 0;
+    virtual event::ptr fill(stream& stream, bool blocking = true) = 0;
     // only supports gpu_usm
     virtual void* buffer_ptr() const { return nullptr; }
 
@@ -147,8 +147,8 @@ struct simple_attached_memory : memory {
 
     void* lock(const stream& /* stream */, mem_lock_type /* type */) override { return _pointer; }
     void unlock(const stream& /* stream */) override {}
-    event::ptr fill(stream& /* stream */, unsigned char) override { return nullptr; }
-    event::ptr fill(stream& /* stream */) override { return nullptr; }
+    event::ptr fill(stream& /* stream */, unsigned char, bool) override { return nullptr; }
+    event::ptr fill(stream& /* stream */, bool) override { return nullptr; }
     shared_mem_params get_internal_params() const override { return { shared_mem_type::shared_mem_empty, nullptr, nullptr, nullptr,
 #ifdef _WIN32
         nullptr,

--- a/src/plugins/intel_gpu/src/graph/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/crop.cpp
@@ -50,7 +50,7 @@ std::vector<layout> crop_inst::calc_output_layouts(const crop_node& /*node*/, co
     std::vector<ShapeType> input_shapes = {
         impl_param.input_layouts[0].get<ShapeType>(),
     };
-    for (size_t i = 1; i < impl_param.input_layouts.size(); ++i) {
+    for (size_t i = 1; i < desc->input.size(); ++i) {
         input_shapes.push_back(impl_param.input_layouts[i].get<ShapeType>());
     }
     int64_t axis = desc->axis;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -461,7 +461,7 @@ bool crop_in_place_optimization::match(const program_node& node,
         return false;
     // if the node is marked as network output, prevent optimizations which would affect a form of its output,
     // unless debug flag is set
-    if (node.is_output() || crop_params.fused_desc.size() > 0 || node.is_in_shape_of_subgraph())
+    if (node.is_output() || crop_params.has_fused_primitives() || node.is_in_shape_of_subgraph())
         return false;
 
     const auto& crop_layout = crop_params.get_output_layout();
@@ -546,6 +546,9 @@ bool crop_in_place_optimization::optimize(crop_node& node) {
     auto crop_layout = node.get_output_layout();
     auto input_layout = node.get_input_layout(0);
     auto crop_params = node.get_kernel_impl_params();
+
+    if (crop_params->has_fused_primitives())
+        return false;
 
     //  Regular crop
     //  crop input buffer

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/read_value.cpp
@@ -59,7 +59,7 @@ struct read_value_impl : public typed_primitive_impl<read_value> {
             if (instance.get_impl_params()->input_layouts.size() > 0) {
                 variable.get_memory()->copy_from(stream, instance.dep_memory(0), true);
             } else {
-                variable.get_memory()->fill(stream, 0);
+                variable.get_memory()->fill(stream);
             }
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -157,6 +157,7 @@ protected:
         if (instance.get_input_layout(0).count() == 0 ||
             instance.get_input_layout(1).count() == 0) {
             stream& stream = instance.get_network().get_stream();
+            stream.enqueue_barrier();
             return instance.output_memory_ptr()->fill(stream);
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -158,7 +158,7 @@ protected:
             instance.get_input_layout(1).count() == 0) {
             stream& stream = instance.get_network().get_stream();
             stream.enqueue_barrier();
-            return instance.output_memory_ptr()->fill(stream);
+            return instance.output_memory_ptr()->fill(stream, false);
         }
 
         if (need_indirect_load(instance))

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -154,6 +154,12 @@ protected:
     }
 
     event::ptr execute_impl(const std::vector<event::ptr>& events, gemm_inst& instance) override {
+        if (instance.get_input_layout(0).count() == 0 ||
+            instance.get_input_layout(1).count() == 0) {
+            stream& stream = instance.get_network().get_stream();
+            return instance.output_memory_ptr()->fill(stream);
+        }
+
         if (need_indirect_load(instance))
             return execute_stage(events, instance, indirect_gemm);
         else

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -37,7 +37,7 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
     event::ptr execute_impl(const std::vector<event::ptr>& events, count_nonzero_inst& instance) override {
         if (instance.get_impl_params()->input_layouts[0].count() == 0) {
             // set count of non-zero elements to 0 in case if input tensor is empty to have correct memory alloc for gather_nonzero
-            return instance.output_memory(0).fill(instance.get_network().get_stream(), 0);
+            return instance.output_memory(0).fill(instance.get_network().get_stream());
         } else {
             return parent::execute_impl(events, instance);
         }

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1527,7 +1527,7 @@ event::ptr primitive_inst::execute(const std::vector<event::ptr>& events) {
         }
 
         if (can_skip_execution) {
-            auto ev = get_network().get_stream().create_user_event(true);
+            auto ev = get_network().get_stream().aggregate_events(events);
             update_shape_done_by_other = false; // reset
             return ev;
         }

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -655,7 +655,7 @@ event::ptr primitive_inst::realloc_if_needed() {
         }
     }
 
-    // Clear out memory if if was previously reused, but now primitive can't be optimized
+    // Clear out memory if was previously reused, but now primitive can't be optimized
     if (!_node->is_type<concatenation>() && (_node->is_runtime_skippable() || _node->is_type<crop>())) {
         if (can_be_optimized()) {
             _max_output_layout_count = _deps[0].first->_max_output_layout_count;
@@ -663,7 +663,7 @@ event::ptr primitive_inst::realloc_if_needed() {
             return ev;
         } else if (_outputs[0] && dep_memory_ptr(0) &&
                    _network.get_engine().is_the_same_buffer(dep_memory(0), output_memory(0))) {
-            // Clear out memory if if was previously reused, but now primitive can't be optimized
+            // Clear out memory if was previously reused, but now primitive can't be optimized
             _outputs[0] = nullptr;
             _max_output_layout_count[0] = 0;
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
@@ -29,11 +29,7 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
                   START_BUFFER
                   STEP_BUFFER
                   AXES_BUFFER
-                  __global OUTPUT_TYPE* restrict output
-#if HAS_FUSED_OPS_DECLS
-                , FUSED_OPS_DECLS
-#endif
-)
+                  __global OUTPUT_TYPE* restrict output)
 {
     LOAD_BUFFER(START, start_buff);
     LOAD_BUFFER(STEP, step_buff);
@@ -88,12 +84,7 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
         slice_begin_dim4 + output_dim4 * slice_step[4]);
 #endif
 
-#if HAS_FUSED_OPS
-    FUSED_OPS;
-    output[output_index] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT);
-#else
     output[output_index] = ACTIVATION(input[input_index], ACTIVATION_PARAMS);
-#endif
 }
 
 #undef LOAD_BUFFER;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/slice_ref.cl
@@ -24,12 +24,16 @@
     out_name[4] = in_prefix##_VAL4;
 #endif
 
-KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG 
+KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
                   const __global INPUT0_TYPE* restrict input,
                   START_BUFFER
                   STEP_BUFFER
                   AXES_BUFFER
-                  __global OUTPUT_TYPE* restrict output)
+                  __global OUTPUT_TYPE* restrict output
+#if HAS_FUSED_OPS_DECLS
+                , FUSED_OPS_DECLS
+#endif
+)
 {
     LOAD_BUFFER(START, start_buff);
     LOAD_BUFFER(STEP, step_buff);
@@ -84,7 +88,12 @@ KERNEL(slice_ref)(OPTIONAL_SHAPE_INFO_ARG
         slice_begin_dim4 + output_dim4 * slice_step[4]);
 #endif
 
+#if HAS_FUSED_OPS
+    FUSED_OPS;
+    output[output_index] = TO_OUTPUT_TYPE(FUSED_OPS_RESULT);
+#else
     output[output_index] = ACTIVATION(input[input_index], ACTIVATION_PARAMS);
+#endif
 }
 
 #undef LOAD_BUFFER;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
@@ -142,16 +142,6 @@ JitConstants SliceKernelRef::GetJitConstants(const slice_params& params) const {
     addJitConstantsForParam(jit, "START", params.compile_time_start, params.start_data_type, default_decorator);
     addJitConstantsForParam(jit, "STEP", params.compile_time_step, params.step_data_type, default_decorator);
 
-    if (!params.fused_ops.empty()) {
-        std::vector<std::string> idx_order = {"b", "f", "y", "x"};
-        if (params.inputs[0].GetDims().size() == 5) {
-            idx_order = {"b", "f", "z", "y", "x"};
-        }
-
-        FusedOpsConfiguration conf = { "", idx_order, "input[input_index]", params.inputs[0].GetDType() };
-        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
-    }
-
     return jit;
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
@@ -142,6 +142,16 @@ JitConstants SliceKernelRef::GetJitConstants(const slice_params& params) const {
     addJitConstantsForParam(jit, "START", params.compile_time_start, params.start_data_type, default_decorator);
     addJitConstantsForParam(jit, "STEP", params.compile_time_step, params.step_data_type, default_decorator);
 
+    if (!params.fused_ops.empty()) {
+        std::vector<std::string> idx_order = {"b", "f", "y", "x"};
+        if (params.inputs[0].GetDims().size() == 5) {
+            idx_order = {"b", "f", "z", "y", "x"};
+        }
+
+        FusedOpsConfiguration conf = { "", idx_order, "input[input_index]", params.inputs[0].GetDType() };
+        jit.Merge(MakeFusedOpsJitConstants(params, {conf}));
+    }
+
     return jit;
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
@@ -45,6 +45,12 @@ void CreateVariableAccessPrimitive(ProgramBuilder &p, const std::shared_ptr<ov::
     p.add_primitive(*op, prim);
 }
 
+bool IsReadValueOp(std::shared_ptr<ov::Node> op) {
+    return ov::is_type<ov::op::v3::ReadValue>(op) ||
+           ov::is_type<ov::op::v6::ReadValue>(op) ||
+           ov::is_type<ov::intel_gpu::op::ReadValue>(op);
+}
+
 void CreateReadValueOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v3::ReadValue>& op) {
     validate_inputs_count(op, {0, 1});
     CreateVariableAccessPrimitive<cldnn::read_value>(p, op, op->get_variable_id());
@@ -57,6 +63,9 @@ void CreateReadValueOp(ProgramBuilder& p, const std::shared_ptr<ov::intel_gpu::o
 
 void CreateAssignOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v3::Assign>& op) {
     validate_inputs_count(op, {1});
+    if (IsReadValueOp(op->get_input_node_shared_ptr(0))) {
+        return;
+    }
     CreateVariableAccessPrimitive<cldnn::assign>(p, op, op->get_variable_id());
 }
 
@@ -67,6 +76,9 @@ void CreateReadValueOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v6::Read
 
 void CreateAssignOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v6::Assign>& op) {
     validate_inputs_count(op, {1});
+    if (IsReadValueOp(op->get_input_node_shared_ptr(0))) {
+        return;
+    }
     CreateVariableAccessPrimitive<cldnn::assign>(p, op, op->get_variable_id());
 }
 

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -70,6 +70,11 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
     m_layout.set_partial_shape(src_shape);
     update_device_buffer();
 
+    if (actual_size == 0) {
+        set();
+        return;
+    }
+
     // check whether the src tensor is padded
     std::vector<size_t> src_stride_no_pad(src_rank, 1);
     std::vector<int32_t> upper_pad(src_rank, 0);

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -91,15 +91,15 @@ void gpu_buffer::unlock(const stream& stream) {
     }
 }
 
-event::ptr gpu_buffer::fill(stream& stream) {
+event::ptr gpu_buffer::fill(stream& stream, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
     }
-    return fill(stream, 0);
+    return fill(stream, 0, blocking);
 }
 
-event::ptr gpu_buffer::fill(stream& stream, unsigned char pattern) {
+event::ptr gpu_buffer::fill(stream& stream, unsigned char pattern, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
@@ -109,6 +109,9 @@ event::ptr gpu_buffer::fill(stream& stream, unsigned char pattern) {
     cl::Event& ev_ocl = downcast<ocl_event>(ev.get())->get();
     try {
         cl_stream.get_cl_queue().enqueueFillBuffer<unsigned char>(_buffer, pattern, 0, size(), nullptr, &ev_ocl);
+        if (blocking) {
+            ev_ocl.wait();
+        }
     } catch (cl::Error const& err) {
         OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
     }
@@ -272,15 +275,15 @@ gpu_image2d::gpu_image2d(ocl_engine* engine,
     _slice_pitch = _buffer.getImageInfo<CL_IMAGE_SLICE_PITCH>();
 }
 
-event::ptr gpu_image2d::fill(stream& stream) {
+event::ptr gpu_image2d::fill(stream& stream, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
     }
-    return fill(stream, 0);
+    return fill(stream, 0, blocking);
 }
 
-event::ptr gpu_image2d::fill(stream& stream, unsigned char pattern) {
+event::ptr gpu_image2d::fill(stream& stream, unsigned char pattern, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
@@ -291,6 +294,9 @@ event::ptr gpu_image2d::fill(stream& stream, unsigned char pattern) {
     cl_uint4 pattern_uint4 = {{pattern, pattern, pattern, pattern}};
     try {
         cl_stream.get_cl_queue().enqueueFillImage(_buffer, pattern_uint4, {0, 0, 0}, {_width, _height, 1}, 0, &ev_ocl);
+        if (blocking) {
+            ev_ocl.wait();
+        }
     } catch (cl::Error const& err) {
         OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
     }
@@ -509,7 +515,7 @@ void gpu_usm::unlock(const stream& /* stream */) {
     }
 }
 
-event::ptr gpu_usm::fill(stream& stream, unsigned char pattern) {
+event::ptr gpu_usm::fill(stream& stream, unsigned char pattern, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip gpu_usm::fill for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
@@ -520,6 +526,9 @@ event::ptr gpu_usm::fill(stream& stream, unsigned char pattern) {
     try {
         cl_stream.get_usm_helper().enqueue_fill_mem(
                 cl_stream.get_cl_queue(), _buffer.get(), static_cast<const void*>(&pattern), sizeof(unsigned char), _bytes_count, nullptr, &ev_ocl);
+        if (blocking) {
+            ev_ocl.wait();
+        }
     } catch (cl::Error const& err) {
         OPENVINO_THROW(OCL_ERR_MSG_FMT(err));
     }
@@ -527,7 +536,7 @@ event::ptr gpu_usm::fill(stream& stream, unsigned char pattern) {
     return ev;
 }
 
-event::ptr gpu_usm::fill(stream& stream) {
+event::ptr gpu_usm::fill(stream& stream, bool blocking) {
     // event::ptr ev{ new base_event(_context), false };
     // cl::Event ev_ocl = downcast<ocl_event>(ev.get())->get();
     // cl::usm::enqueue_set_mem(cl_stream.get_cl_queue(), _buffer.get(), 0, _bytes_count, nullptr, &ev_ocl);
@@ -538,7 +547,7 @@ event::ptr gpu_usm::fill(stream& stream) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return stream.create_user_event(true);
     }
-    return fill(stream, 0);
+    return fill(stream, 0, blocking);
 }
 
 event::ptr gpu_usm::copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
@@ -32,8 +32,8 @@ struct gpu_buffer : public lockable_gpu_mem, public memory {
 
     void* lock(const stream& stream, mem_lock_type type = mem_lock_type::read_write) override;
     void unlock(const stream& stream) override;
-    event::ptr fill(stream& stream, unsigned char pattern) override;
-    event::ptr fill(stream& stream) override;
+    event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) override;
+    event::ptr fill(stream& stream, bool blocking = true) override;
     shared_mem_params get_internal_params() const override;
     const cl::Buffer& get_buffer() const {
         assert(0 == _lock_count);
@@ -58,8 +58,8 @@ struct gpu_image2d : public lockable_gpu_mem, public memory {
 
     void* lock(const stream& stream, mem_lock_type type = mem_lock_type::read_write) override;
     void unlock(const stream& stream) override;
-    event::ptr fill(stream& stream, unsigned char pattern) override;
-    event::ptr fill(stream& stream) override;
+    event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) override;
+    event::ptr fill(stream& stream, bool blocking = true) override;
     shared_mem_params get_internal_params() const override;
     const cl::Image2D& get_buffer() const {
         assert(0 == _lock_count);
@@ -112,8 +112,8 @@ struct gpu_usm : public lockable_gpu_mem, public memory {
     cl::UsmMemory& get_buffer() { return _buffer; }
     void* buffer_ptr() const override { return _buffer.get(); }
 
-    event::ptr fill(stream& stream, unsigned char pattern) override;
-    event::ptr fill(stream& stream) override;
+    event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) override;
+    event::ptr fill(stream& stream, bool blocking = true) override;
     shared_mem_params get_internal_params() const override;
 
     event::ptr copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/non_zero_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/non_zero_gpu_test.cpp
@@ -556,7 +556,7 @@ TEST(non_zero_gpu, empty_input) {
 
     // Put some value into out buffer to ensure that it's non empty
     // That is needed to ensure that implementation correctly handles the cases when input tensor is empty and set count non zero to 0
-    count_nonzero_inst->output_memory(0).fill(engine.get_service_stream(), 1);
+    count_nonzero_inst->output_memory(0).fill(engine.get_service_stream(), 1, true);
     engine.get_service_stream().finish();
 
     auto count_nonzero_impl = count_nonzero_inst->get_impl();


### PR DESCRIPTION
### Details:
 - *Added functional support of empty LoRA adapters*
 - *Added fusing support for `crop` operation*
 - *Removed unnecessary `Assign` after `ReadValue`*
 - *Use enqueue_fill_mem instead enqueue_memcpy in gpu_usm::fill()*
 
### Tickets:
 - *[152852](https://jira.devtools.intel.com/browse/CVS-152852)*
