### PR TITLE
[GPU] fix fused_select_reorder

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/select_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/select_gpu_ref.cl
@@ -45,7 +45,11 @@ KERNEL(select)(
     uint output_offset = OUTPUT_GET_INDEX(b, f, y, x);
 #endif
 
-    const OUTPUT_TYPE res = TO_OUTPUT_TYPE(select(INPUT_2, INPUT_1, MASK));
+    #if INPUT1_IS_FP && !OUTPUT_IS_FP
+     const OUTPUT_TYPE res = TO_OUTPUT_TYPE(convert_long(select(INPUT_2, INPUT_1, MASK)));
+    #else
+     const OUTPUT_TYPE res = TO_OUTPUT_TYPE(select(INPUT_2, INPUT_1, MASK));
+    #endif
 
     output[output_offset] = res;
 }

--- a/src/plugins/intel_gpu/tests/unit/fusions/select_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/select_fusion_test.cpp
@@ -92,7 +92,7 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, select_reorder_fusion, ::testing::ValuesIn
     select_test_params{ CASE_SELECT_FP16_TO_I8_0, 5, 6},
     select_test_params{ CASE_SELECT_FP16_TO_U8_0, 5, 6},
     select_test_params{ CASE_SELECT_FP16_TO_I8_1, 6, 6}, // reorder should not be fused
-    select_test_params{ CASE_SELECT_FP16_TO_U8_1, 6, 6}, // reorder should not be fused
+    select_test_params{ CASE_SELECT_FP16_TO_U8_1, 6, 6},
 }));
 
 class select_reorder_fusion_dynamic : public SelectFusingTest {};

--- a/src/plugins/intel_gpu/tests/unit/fusions/select_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/select_fusion_test.cpp
@@ -63,9 +63,12 @@ public:
 }  // namespace
 
 #define CASE_SELECT_FP32_TO_I8_0  {2, 16, 4, 4}, {2, 16, 4, 4},  data_types::f32, data_types::i8,  format::bfyx, format::bfyx
+#define CASE_SELECT_FP32_TO_U8_0  {2, 16, 4, 4}, {2, 16, 4, 4},  data_types::f32, data_types::u8,  format::bfyx, format::bfyx
 #define CASE_SELECT_FP32_TO_F16_0 {2, 16, 17, 4}, {2, 16, 1, 4}, data_types::f32, data_types::f16, format::bfyx, format::bfyx
 #define CASE_SELECT_FP16_TO_I8_0  {2, 16, 4, 4}, {2, 16, 4, 4},  data_types::f16, data_types::i8,  format::bfyx, format::bfyx
+#define CASE_SELECT_FP16_TO_U8_0  {2, 16, 4, 4}, {2, 16, 4, 4},  data_types::f16, data_types::u8,  format::bfyx, format::bfyx
 #define CASE_SELECT_FP16_TO_I8_1  {2, 16, 4, 4}, {2, 16, 4, 4},  data_types::f16, data_types::i8,  format::bfyx, format::bfzyx
+#define CASE_SELECT_FP16_TO_U8_1  {2, 16, 4, 4}, {2, 16, 4, 4},  data_types::f16, data_types::u8,  format::bfyx, format::bfzyx
 
 class select_reorder_fusion : public SelectFusingTest {};
 TEST_P(select_reorder_fusion, basic) {
@@ -85,8 +88,11 @@ TEST_P(select_reorder_fusion, basic) {
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, select_reorder_fusion, ::testing::ValuesIn(std::vector<select_test_params>{
     select_test_params{ CASE_SELECT_FP32_TO_F16_0, 5, 6},
     select_test_params{ CASE_SELECT_FP32_TO_I8_0, 5, 6},
+    select_test_params{ CASE_SELECT_FP32_TO_U8_0, 5, 6},
     select_test_params{ CASE_SELECT_FP16_TO_I8_0, 5, 6},
+    select_test_params{ CASE_SELECT_FP16_TO_U8_0, 5, 6},
     select_test_params{ CASE_SELECT_FP16_TO_I8_1, 6, 6}, // reorder should not be fused
+    select_test_params{ CASE_SELECT_FP16_TO_U8_1, 6, 6}, // reorder should not be fused
 }));
 
 class select_reorder_fusion_dynamic : public SelectFusingTest {};


### PR DESCRIPTION
### Details:
When the input is f16 and the output is u8, the non-fused select-reorder will execute convert_uchar(convert_long(res)). However, the fused select-reorder will execute convert_uchar(res), resulting in different outputs in some cases.

For example:
convert_uchar(-1.0) = 0, but convert_uchar(convert_long(-1.0)) = 255

### Tickets:
CVS-152175
