### PR TITLE
[GPU] switch onednn primitive to use other primitive_impl constructor

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -66,7 +66,7 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
         }
 
     typed_primitive_onednn_impl(const engine& engine, const ExecutionConfig& config = {})
-        : typed_primitive_impl<PType>({}, "undef"),
+        : typed_primitive_impl<PType>("undef"),
         _engine(&engine),
         _pd(),
         _prim() {
@@ -78,7 +78,7 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
         }
 
     typed_primitive_onednn_impl()
-        : typed_primitive_impl<PType>({}, "undef"),
+        : typed_primitive_impl<PType>("undef"),
           _engine(nullptr),
           _pd(), _prim() {
         _attrs = std::make_shared<dnnl::primitive_attr>();


### PR DESCRIPTION
### Details:
 - Changes the constructor used from primitive_impl to use one that already assigns a nullptr rather than passing in an empty array, which currently leads to an empty array comparison to nullptr

### Tickets:
 - 112755
