### PR TITLE
Skip test_tf_Bucketize for boundaries_size is 0 on GPU

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_Bucketize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Bucketize.py
@@ -61,6 +61,8 @@ class TestBucketize(CommonTFLayerTest):
     def test_bucketize(self, input_shape, input_type, boundaries_size,
                        ie_device, precision, ir_version, temp_dir,
                        use_legacy_frontend):
+        if ie_device == 'GPU' and boundaries_size == 0:
+            pytest.skip("152562: sporadic accuracy issue for boundaries_size == 0 on GPU")
         if platform.machine() in ["aarch64", "arm64", "ARM64"] and boundaries_size == 0:
             pytest.skip("149853: segmentation fault or signal 11 for boundaries_size == 0 on CPU")
         self._test(*self.create_bucketize_net(input_shape, input_type, boundaries_size),


### PR DESCRIPTION
### Details:
 - There is sporadic accuracy issue occurred in the certain machine when boundaries_size is 0 on GPU
 - It needs to skip until the issue will be solved

### Tickets:
 - 152562
 - 154261
