### PR TITLE
[GHA] Fix sanitizers tests trigger in forks

### DIFF
--- a/.github/workflows/linux_sanitizers.yml
+++ b/.github/workflows/linux_sanitizers.yml
@@ -204,7 +204,7 @@ jobs:
 
   CXX_Unit_Tests:
     name: C++ unit tests
-    if: always()
+    if: ${{ github.repository_owner == 'openvinotoolkit' }}
     needs: Build
     timeout-minutes: 100
     runs-on: 'aks-linux-16-cores-32gb'


### PR DESCRIPTION
Even if parent build skipped in forks it continues to wait for it 'cause of "always()" condition
