### PR TITLE
Details:

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/slice/slice_kernel_ref.cpp
@@ -90,6 +90,7 @@ ParamsKey SliceKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);
+    k.EnableOutputDataType(Datatype::UINT8);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::bfzyx);
     k.EnableOutputLayout(DataLayout::bfyx);

--- a/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_Unique.py
@@ -42,8 +42,6 @@ class TestUnique(CommonTFLayerTest):
                           use_legacy_frontend):
         if use_legacy_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
-        if ie_device == 'GPU':
-            pytest.skip("GPU error: Could not find a suitable kernel for slice")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)
@@ -59,8 +57,6 @@ class TestUnique(CommonTFLayerTest):
                                 use_legacy_frontend):
         if use_legacy_frontend:
             pytest.skip("Unique operation is not supported via legacy frontend.")
-        if ie_device == 'GPU':
-            pytest.skip("GPU error: Could not find a suitable kernel for slice")
         self._test(*self.create_unique_net(**params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)


### PR DESCRIPTION

### Details:
GPU tensorflow_tests/test_tf_Unique.py test was failing, Added in slice_ref_kernel following output datatype which was missing. k. EnableOutputDataType(Datatype::UINT8);
And updated  tensorflow_tests/test_tf_Unique.py, removed skip for GPU.

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-105900?focusedId=25293445#comment-25293445
