### PR TITLE
[GPU] Fix fused op macro for dynamic shape eltwise fusing into convoltion, fix deconvolution attribute kernel param when 1d

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -5,6 +5,7 @@
 #include "primitive_base.hpp"
 
 #include "deconvolution_inst.h"
+#include "intel_gpu/plugin/common_utils.hpp"
 #include "deconvolution/deconvolution_kernel_selector.h"
 #include "deconvolution/deconvolution_kernel_base.h"
 
@@ -54,19 +55,16 @@ public:
 
         params.filterSize = { kx, ky, kz };
 
-        uint32_t pad_z = std::max<std::ptrdiff_t>(pad.size() >= 3 ? pad[pad.size() - 3] : 0, 0);
-        uint32_t pad_y = std::max<std::ptrdiff_t>(pad.size() >= 2 ? pad[pad.size() - 2] : 0, 0);
-        uint32_t pad_x = std::max<std::ptrdiff_t>(pad.size() >= 1 ? pad[pad.size() - 1] : 0, 0);
+        uint32_t pad_x, pad_y, pad_z;
+        std::tie(pad_x, pad_y, pad_z) = ov::intel_gpu::get_xyz<ov::CoordinateDiff, uint32_t>(pad, 0);
         params.padding = {pad_x, pad_y, pad_z};
 
-        uint32_t stride_z = stride.size() >= 3 ? static_cast<uint32_t>(stride[stride.size() - 3]) : 1;
-        uint32_t stride_y = stride.size() >= 2 ? static_cast<uint32_t>(stride[stride.size() - 2]) : 1;
-        uint32_t stride_x = stride.size() >= 1 ? static_cast<uint32_t>(stride[stride.size() - 1]) : 1;
+        uint32_t stride_x, stride_y, stride_z;
+        std::tie(stride_x, stride_y, stride_z) = ov::intel_gpu::get_xyz<ov::Strides, uint32_t>(stride, 1);
         params.stride = {stride_x, stride_y, stride_z};
 
-        uint32_t dilation_z = dilation.size() >= 3 ? static_cast<uint32_t>(dilation[dilation.size() - 3]) : 1;
-        uint32_t dilation_y = dilation.size() >= 2 ? static_cast<uint32_t>(dilation[dilation.size() - 2]) : 1;
-        uint32_t dilation_x = dilation.size() >= 1 ? static_cast<uint32_t>(dilation[dilation.size() - 1]) : 1;
+        uint32_t dilation_x, dilation_y, dilation_z;
+        std::tie(dilation_x, dilation_y, dilation_z) = ov::intel_gpu::get_xyz<ov::Strides, uint32_t>(dilation, 1);
         params.dilation = {dilation_x, dilation_y, dilation_z};
 
         return params;

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -2197,7 +2197,7 @@ std::string FusedOpsCodeGenerator::GetJitLoad(const FusedOpsConfiguration& conf,
 
             if (vec_size > 1) {
                 return block_read;
-            } else if (input_tensor.LogicalSize() > 1) {
+            } else if (input_tensor.LogicalSize() > 1 || input_tensor.is_dynamic()) {
                 // Currently we assume that in such scenario we can safely load sub_group_size elements from the pointer
                 return Broadcast(block_read, input_dt, vec_size);
             } else {

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -211,4 +211,40 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D_AutoPadding_OutputPaddi
                                 ::testing::Values(ov::test::utils::DEVICE_GPU)),
                         ConvolutionBackpropDataLayerTest::getTestCaseName);
 
+const std::vector<size_t> numOutChannels1d = {256};
+
+/* ============= 1D ConvolutionBackpropData ============= */
+const std::vector<ov::element::Type> netPrecisions1D = {
+        ov::element::f32
+};
+
+const std::vector<std::vector<ov::Shape>> inputShapes1D = {{{1, 512, 577}}};
+const std::vector<std::vector<size_t >> kernels1D = {{16}};
+const std::vector<std::vector<size_t >> strides1D = {{8}};
+const std::vector<std::vector<ptrdiff_t>> padBegins1D = {{4}};
+const std::vector<std::vector<ptrdiff_t>> padEnds1D = {{4}};
+const std::vector<std::vector<size_t >> dilations1D = {{1}};
+
+
+const std::vector<std::vector<ptrdiff_t>> outputPadding1D = {{0}};
+
+const auto conv1DParams_ExplicitPadding_output_padding = ::testing::Combine(
+        ::testing::ValuesIn(kernels1D),
+        ::testing::ValuesIn(strides1D),
+        ::testing::ValuesIn(padBegins1D),
+        ::testing::ValuesIn(padEnds1D),
+        ::testing::ValuesIn(dilations1D),
+        ::testing::ValuesIn(numOutChannels1d),
+        ::testing::Values(ov::op::PadType::EXPLICIT),
+        ::testing::ValuesIn(outputPadding1D)
+);
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData1D_ExplicitPadding, ConvolutionBackpropDataLayerTest,
+                        ::testing::Combine(
+                                conv1DParams_ExplicitPadding_output_padding,
+                                ::testing::ValuesIn(netPrecisions1D),
+                                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(inputShapes1D)),
+                                ::testing::ValuesIn(emptyOutputShape),
+                                ::testing::Values(ov::test::utils::DEVICE_GPU)),
+                        ConvolutionBackpropDataLayerTest::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
@@ -4,6 +4,7 @@
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "common_test_utils/node_builders/activation.hpp"
 #include "common_test_utils/node_builders/convolution.hpp"
+#include "common_test_utils/node_builders/eltwise.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "shared_test_classes/single_op/convolution.hpp"
 
@@ -317,4 +318,216 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_dynamic3DAsymPad, Convolu
                 ::testing::Values(false)),
                 ConvolutionLayerGPUTestDynamic::getTestCaseName);
 
+typedef std::tuple<
+        convSpecificParams,
+        ov::element::Type,              // Model type
+        std::vector<InputShape>,        // Input shapes
+        std::string,                    // Device name
+        bool                            // activation fusing
+> convLayerFusingTestParamsSet;
+
+
+class ConvolutionLayerGPUTestDynamicEltwiseFusing : public testing::WithParamInterface<convLayerFusingTestParamsSet>,
+                                                    virtual public ov::test::SubgraphBaseTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<convLayerFusingTestParamsSet>& obj) {
+        convSpecificParams convParams;
+        ov::element::Type model_type;
+        std::vector<InputShape> inputShapes;
+        std::string targetDevice;
+        bool activationFusing;
+        std::tie(convParams, model_type, inputShapes, targetDevice, activationFusing) = obj.param;
+
+        ov::op::PadType padType;
+        std::vector<size_t> kernel, stride, dilation;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t convOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+
+        std::ostringstream result;
+        for (const auto& inputShape : inputShapes) {
+                result << "IS=";
+                result  << ov::test::utils::partialShape2str({inputShape.first}) << "_";
+                result << "TS=(";
+                for (const auto& shape : inputShape.second) {
+                result << ov::test::utils::vec2str(shape) << "_";
+                }
+        }
+        result << ")_";
+        result << "K" << ov::test::utils::vec2str(kernel) << "_";
+        result << "S" << ov::test::utils::vec2str(stride) << "_";
+        result << "PB" << ov::test::utils::vec2str(padBegin) << "_";
+        result << "PE" << ov::test::utils::vec2str(padEnd) << "_";
+        result << "D=" << ov::test::utils::vec2str(dilation) << "_";
+        result << "O=" << convOutChannels << "_";
+        result << "AP=" << padType << "_";
+        result << "netPRC=" << model_type << "_";
+        result << "trgDev=" << targetDevice << "_";
+        result << "activationFusing=" << activationFusing;
+
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        convSpecificParams convParams;
+        std::vector<InputShape> inputShapes;
+        auto model_type = ov::element::undefined;
+        bool activationFusing;
+        std::tie(convParams, model_type, inputShapes, targetDevice, activationFusing) = this->GetParam();
+
+        init_input_shapes({inputShapes});
+
+        ov::op::PadType padType;
+        std::vector<size_t> kernel, stride, dilation;
+        std::vector<ptrdiff_t> padBegin, padEnd;
+        size_t convOutChannels;
+        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+
+        ov::ParameterVector inputParams;
+        for (auto&& shape : inputDynamicShapes)
+            inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(model_type, shape));
+
+        auto convolutionNode = ov::test::utils::make_convolution(inputParams.front(), model_type, kernel, stride, padBegin,
+                                                                 padEnd, dilation, padType, convOutChannels);
+        if (activationFusing) {
+                auto activationNode = ov::test::utils::make_activation(convolutionNode, model_type, ov::test::utils::ActivationTypes::Relu);
+                auto eltwiseNode = ov::test::utils::make_eltwise(inputParams.back(), activationNode, ov::test::utils::EltwiseTypes::ADD);
+
+                ov::ResultVector results;
+                for (size_t i = 0; i < eltwiseNode->get_output_size(); i++)
+                        results.push_back(std::make_shared<ov::op::v0::Result>(eltwiseNode->output(i)));
+
+                function = std::make_shared<ov::Model>(results, inputParams, "Convolution");
+        } else {
+                auto eltwiseNode = ov::test::utils::make_eltwise(inputParams.back(), convolutionNode, ov::test::utils::EltwiseTypes::ADD);
+
+                ov::ResultVector results;
+                for (size_t i = 0; i < eltwiseNode->get_output_size(); i++)
+                        results.push_back(std::make_shared<ov::op::v0::Result>(eltwiseNode->output(i)));
+
+                function = std::make_shared<ov::Model>(results, inputParams, "Convolution");
+        }
+    }
+};
+
+TEST_P(ConvolutionLayerGPUTestDynamicEltwiseFusing, Inference) {
+    run();
+}
+const std::vector<std::vector<ov::test::InputShape>> dynInputShapes1D_test = {
+        {
+        {
+                {1, 192, ov::Dimension::dynamic()},
+                {{1, 192, 191}}
+        },
+        {
+                {1, 192, ov::Dimension::dynamic()},
+                {{1, 192, 1}}
+        }
+        },
+        {
+        {
+                {ov::Dimension::dynamic(), 192, ov::Dimension::dynamic()},
+                {{1, 192, 257}}
+        },
+        {
+                {1, 1, ov::Dimension::dynamic()},
+                {{1, 1, 257}}
+        }
+        },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_dynamic1D_test_0, ConvolutionLayerGPUTestDynamicEltwiseFusing,
+        ::testing::Combine(
+                ::testing::Combine(
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0}),
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(192),
+                        ::testing::Values(ov::op::PadType::EXPLICIT)),
+                ::testing::Values(ov::element::f32),
+                ::testing::ValuesIn(dynInputShapes1D_test),
+                ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
+                ::testing::Values(false)),
+                ConvolutionLayerGPUTestDynamicEltwiseFusing::getTestCaseName);
+
+const std::vector<std::vector<ov::test::InputShape>> dynInputShapes1D_test1 = {
+        {
+        {
+                {1, 512, ov::Dimension::dynamic()},
+                {{1, 512, 191}}
+        },
+        {
+                {1, 512, ov::Dimension::dynamic()},
+                {{1, 512, 1}}
+        }
+        },
+        {
+        {
+                {ov::Dimension::dynamic(), 512, ov::Dimension::dynamic()},
+                {{1, 512, 191}}
+        },
+        {
+                {1, 1, ov::Dimension::dynamic()},
+                {{1, 1, 191}}
+        }
+        },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_dynamic1D_test_1, ConvolutionLayerGPUTestDynamicEltwiseFusing,
+        ::testing::Combine(
+                ::testing::Combine(
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0}),
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(512),
+                        ::testing::Values(ov::op::PadType::EXPLICIT)),
+                ::testing::Values(ov::element::f32),
+                ::testing::ValuesIn(dynInputShapes1D_test1),
+                ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
+                ::testing::Values(false)),
+                ConvolutionLayerGPUTestDynamicEltwiseFusing::getTestCaseName);
+
+const std::vector<std::vector<ov::test::InputShape>> dynInputShapes1D_test2 = {
+        {
+        {
+                {1, 2048, ov::Dimension::dynamic()},
+                {{1, 2048, 191}}
+        },
+        {
+                {1, 2048, ov::Dimension::dynamic()},
+                {{1, 2048, 1}}
+        }
+        },
+        {
+        {
+                {1, 2048, ov::Dimension::dynamic()},
+                {{1, 2048, 191}}
+        },
+        {
+                {ov::Dimension::dynamic(), 1, ov::Dimension::dynamic()},
+                {{1, 1, 191}}
+        }
+        },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_dynamic1D_test_2, ConvolutionLayerGPUTestDynamicEltwiseFusing,
+        ::testing::Combine(
+                ::testing::Combine(
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0}),
+                        ::testing::Values(std::vector<size_t>{1}),
+                        ::testing::Values(2048),
+                        ::testing::Values(ov::op::PadType::EXPLICIT)),
+                ::testing::Values(ov::element::f32),
+                ::testing::ValuesIn(dynInputShapes1D_test2),
+                ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
+                ::testing::Values(false)),
+                ConvolutionLayerGPUTestDynamicEltwiseFusing::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution_backprop_data.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution_backprop_data.cpp
@@ -102,8 +102,8 @@ public:
                 tensor = ov::Tensor(funcInput.get_element_type(), targetInputStaticShapes[i], outShapeData[inferRequestNum].data());
             } else {
                 ov::test::utils::InputGenerateData in_data;
-                in_data.start_from = 0;
-                in_data.range = 2560;
+                in_data.start_from = -20;
+                in_data.range = 20;
                 in_data.resolution = 256;
                 tensor = ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], in_data);
             }
@@ -280,4 +280,49 @@ INSTANTIATE_TEST_SUITE_P(smoke_Deconv_2D_Dynamic_OutputShape_FP32, Deconvolution
         ::testing::Values(emptyAdditionalConfig)),
     DeconvolutionLayerGPUTest::getTestCaseName);
 
+
+const std::vector<std::vector<ptrdiff_t>> emptyOutputPadding1d = { {0} };
+
+/* ============= Deconvolution params ============= */
+const std::vector<size_t> numOutChannels1d = { 256 };
+
+/* ============= Deconvolution params (1D) ============= */
+const std::vector<std::vector<size_t>> kernels1d = { {16} };
+const std::vector<std::vector<size_t>> strides1d = { {8} };
+const std::vector<std::vector<ptrdiff_t>> padBegins1d = { {4} };
+const std::vector<std::vector<ptrdiff_t>> padEnds1d = { {4} };
+const std::vector<std::vector<size_t>> dilations1d = { {1} };
+
+/* ============= Deconvolution (1D) ============= */
+const auto convParams_ExplicitPadding_1D = ::testing::Combine(
+    ::testing::ValuesIn(kernels1d),
+    ::testing::ValuesIn(strides1d),
+    ::testing::ValuesIn(padBegins1d),
+    ::testing::ValuesIn(padEnds1d),
+    ::testing::ValuesIn(dilations1d),
+    ::testing::ValuesIn(numOutChannels1d),
+    ::testing::Values(ov::op::PadType::EXPLICIT),
+    ::testing::ValuesIn(emptyOutputPadding1d)
+);
+
+const std::vector<DeconvInputData> dyn_1D_inputs_smoke = {
+    DeconvInputData{
+        InputShape{{1, 512, -1}, {{1, 512, 577}}},
+        ov::test::utils::InputLayerType::CONSTANT,
+        {}
+    },
+};
+
+const std::vector<ov::element::Type> netPrecisions1D = {
+        ov::element::f32
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_Deconv_1D_Dynamic_FP32, DeconvolutionLayerGPUTest,
+    ::testing::Combine(
+        convParams_ExplicitPadding_1D,
+        ::testing::ValuesIn(dyn_1D_inputs_smoke),
+        ::testing::ValuesIn(netPrecisions1D),
+        ::testing::Values(ov::test::utils::DEVICE_GPU),
+        ::testing::Values(emptyAdditionalConfig)),
+    DeconvolutionLayerGPUTest::getTestCaseName);
 } // namespace


### PR DESCRIPTION
 ### Details:
 - fix fused op load macro for convolution with dynamcis shape eltwise fusing
 - fix deconvolution kernel  ide, dilation axis extension for 1d,

### Tickets:
 - 152406

