### PR TITLE
[TESTS] Remove restart condition as it happens in nested exception

### DIFF
--- a/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
+++ b/tests/layer_tests/py_frontend_tests/test_torchvision_preprocessor.py
@@ -36,12 +36,9 @@ def _infer_pipelines(test_input, preprocess_pipeline, input_channels=3):
         try:
             return _infer_pipelines_impl(test_input, preprocess_pipeline, input_channels)
         except RuntimeError as e:
-            if "builtin cannot be used as a value" in str(e):
-                # This is a potentially sporadic issue
-                print(f"An error occurred: {e}. Retrying...")
-                retries += 1
-            else:
-                raise
+            # This is a potentially sporadic issue
+            print(f"An error occurred: {e}. Retrying...")
+            retries += 1
     else:
         print("Max retries reached. Function execution failed.")
 

--- a/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
+++ b/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
@@ -77,12 +77,9 @@ class PytorchLayerTest:
             try:
                 return self._test_impl(model, ref_net, kind, ie_device, precision, ir_version, infer_timeout, dynamic_shapes, **kwargs)
             except RuntimeError as e:
-                if "builtin cannot be used as a value" in str(e):
-                    # This is a potentially sporadic issue
-                    print(f"An error occurred: {e}. Retrying...")
-                    retries += 1
-                else:
-                    raise
+                # This is a potentially sporadic issue
+                print(f"An error occurred: {e}. Retrying...")
+                retries += 1
         else:
             print("Max retries reached. Function execution failed.")
 


### PR DESCRIPTION
### Details:
 - *Will restart any `RuntimeError` as the searching text in the exception class is not reliable enough*

### Tickets:
 - *CVS-151277*
