### PR TITLE
NPUW: Fix - don't register an extra parameter to a group

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -65,8 +65,9 @@ ov::Tensor permute(const ov::Tensor& t, const std::vector<std::size_t>& axes);
 ov::Tensor concat(const std::vector<ov::Tensor>& tt, std::size_t axis);
 
 namespace at {
-template <class M>
+template <class M_>
 struct Impl {
+    using M = typename std::decay<M_>::type;
     using V = typename M::mapped_type;
 
     M* m = nullptr;
@@ -94,6 +95,11 @@ struct Impl {
 template <typename M>
 Impl<M> _(M* pM) {
     return Impl<M>(pM);
+}
+
+template <typename M>
+Impl<M> _(M&& m) {
+    return Impl<M>(&m);
 }
 
 template <typename M>


### PR DESCRIPTION
### Details:
 - There's a case where there's a Param->Convert path that stays in model HEAD, and then it acts as an input to all other partitions. In this case, this convert is seen as "extra" input which needs to be registetered - mistakenly.

### Tickets:
 - E-138529
