### PR TITLE
[GHA] Fix wheels storage handling

### DIFF
--- a/.github/workflows/job_build_linux.yml
+++ b/.github/workflows/job_build_linux.yml
@@ -321,7 +321,7 @@ jobs:
           popd
 
       - name: Store artifacts to a shared drive
-        id: store_artifacts_common
+        id: store_artifacts
         if: ${{ always() }}
         uses: ./openvino/.github/actions/store_artifacts
         with:
@@ -331,15 +331,8 @@ jobs:
             ${{ env.BUILD_DIR }}/openvino_tests.tar.gz
             ${{ env.BUILD_DIR }}/deb
             ${{ env.MANIFEST_PATH }}
+            ${{ env.STORE_WHEELS == 'true' && format('{0}/wheels', env.BUILD_DIR) || '' }}
           storage_dir: ${{ env.PRODUCT_TYPE }}
           storage_root: ${{ env.ARTIFACTS_SHARE }}
-          
-      - name: Store artifacts to a shared drive (wheels)
-        id: store_artifacts_wheels
-        if: ${{ inputs.os != 'debian_10' && inputs.arch != 'arm' }}
-        uses: ./openvino/.github/actions/store_artifacts
-        with:
-          artifacts: |
-            ${{ env.BUILD_DIR }}/wheels
-          storage_dir: ${{ env.PRODUCT_TYPE }}
-          storage_root: ${{ env.ARTIFACTS_SHARE }}
+        env:
+          STORE_WHEELS: ${{ inputs.os != 'debian_10' && inputs.arch != 'arm' }}


### PR DESCRIPTION
Calling store_artifacts twice in a row is excessive and causes improper artifacts storage due to dir rotation