### PR TITLE
Use find_library to find clang on linux

### DIFF
--- a/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
+++ b/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
@@ -80,7 +80,7 @@ if(ENABLE_NCC_STYLE)
         set(CMAKE_FIND_LIBRARY_PREFIXES ${_old_CMAKE_FIND_LIBRARY_PREFIXES})
         set(CMAKE_FIND_LIBRARY_SUFFIXES ${_old_CMAKE_FIND_LIBRARY_SUFFIXES})
     else()
-        find_library(libclang_location
+        find_host_library(libclang_location
             NAMES clang libclang libclang-${clang_version} libclang-${clang_version}.so libclang-${clang_version}.so.1
             PATHS /usr/lib /usr/local/lib /usr/lib/llvm-${clang_version}/lib /usr/lib/x86_64-linux-gnu
             NO_DEFAULT_PATH

--- a/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
+++ b/cmake/developer_package/ncc_naming_style/ncc_naming_style.cmake
@@ -80,11 +80,11 @@ if(ENABLE_NCC_STYLE)
         set(CMAKE_FIND_LIBRARY_PREFIXES ${_old_CMAKE_FIND_LIBRARY_PREFIXES})
         set(CMAKE_FIND_LIBRARY_SUFFIXES ${_old_CMAKE_FIND_LIBRARY_SUFFIXES})
     else()
-        find_host_package(Clang QUIET)
-    endif()
-
-    if(Clang_FOUND AND TARGET libclang)
-        get_target_property(libclang_location libclang LOCATION)
+        find_library(libclang_location
+            NAMES clang libclang libclang-${clang_version} libclang-${clang_version}.so libclang-${clang_version}.so.1
+            PATHS /usr/lib /usr/local/lib /usr/lib/llvm-${clang_version}/lib /usr/lib/x86_64-linux-gnu
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH)
     endif()
 
     if(NOT libclang_location)


### PR DESCRIPTION
### Details:

**Problem:** When a project includes both OpenVINO (via the OpenVINO developer package) and LLVM as an in-tree dependency, it can lead to conflicts between different versions of LLVM.

**Solution:**

* One way to resolve this is by including clang directly using `find_library`, rather than relying on `find_package`.
* This approach avoids the implicit call to `find_package(LLVM)` that occurs when using `find_package(CLANG)`, thus preventing version conflicts.

### Tickets:
 - E-78260
