### PR TITLE
[GPU] Fix bug in GatherND reference GPU kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gather_nd_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gather_nd_ref.cl
@@ -135,55 +135,46 @@ KERNEL(gather_nd_ref)(
     const uint data_idx = GET_UPDATES_INDEX(INPUT0, IN_ORDER);
 
     // Calculate output index
-    #if BATCH_DIMS <= 1
-        const uint out_x = idx_x;
-        const uint out_y = idx_y;
-        const uint out_z = idx_z;
-        const uint out_w = idx_w;
-        const uint out_f = idx_f;
-        const uint out_b = idx_b;
-    #else
-        #if BATCH_MERGED_OUTPUT
-            uint pitch_acc = 1;
-            uint output_batch_size = 0;
-            for (int i = BATCH_DIMS - 1; i >= 0; i--) {
-                output_batch_size += (idx_arr[i] * pitch_acc);
-                pitch_acc *= idx_dim[i];
-            }
+    #if BATCH_MERGED_OUTPUT && BATCH_DIMS > 1
+        uint pitch_acc = 1;
+        uint output_batch_size = 0;
+        for (int i = BATCH_DIMS - 1; i >= 0; i--) {
+            output_batch_size += (idx_arr[i] * pitch_acc);
+            pitch_acc *= idx_dim[i];
+        }
 
-            #if OUTPUT_DIMS == 4
-                const uint out_x = idx_arr[BATCH_DIMS+2];
-                const uint out_y = idx_arr[BATCH_DIMS+1];
-            #elif OUTPUT_DIMS == 5
-                const uint out_x = idx_arr[BATCH_DIMS+3];
-                const uint out_y = idx_arr[BATCH_DIMS+2];
-                const uint out_z = idx_arr[BATCH_DIMS+1];
-            #else
-                const uint out_x = idx_arr[BATCH_DIMS+4];
-                const uint out_y = idx_arr[BATCH_DIMS+3];
-                const uint out_z = idx_arr[BATCH_DIMS+2];
-                const uint out_w = idx_arr[BATCH_DIMS+1];
-            #endif
-            const uint out_f = idx_arr[BATCH_DIMS+0];
-            const uint out_b = output_batch_size;
+        #if OUTPUT_DIMS == 4
+            const uint out_x = idx_arr[BATCH_DIMS+2];
+            const uint out_y = idx_arr[BATCH_DIMS+1];
+        #elif OUTPUT_DIMS == 5
+            const uint out_x = idx_arr[BATCH_DIMS+3];
+            const uint out_y = idx_arr[BATCH_DIMS+2];
+            const uint out_z = idx_arr[BATCH_DIMS+1];
         #else
-            #if OUTPUT_DIMS == 4
-                const uint out_x = idx_arr[3];
-                const uint out_y = idx_arr[2];
-            #elif OUTPUT_DIMS == 5
-                const uint out_x = idx_arr[4];
-                const uint out_y = idx_arr[3];
-                const uint out_z = idx_arr[2];
-            #else
-                const uint out_x = idx_arr[5];
-                const uint out_y = idx_arr[4];
-                const uint out_z = idx_arr[3];
-                const uint out_w = idx_arr[2];
-            #endif
-            const uint out_f = idx_arr[1];
-            const uint out_b = idx_arr[0];
-
+            const uint out_x = idx_arr[BATCH_DIMS+4];
+            const uint out_y = idx_arr[BATCH_DIMS+3];
+            const uint out_z = idx_arr[BATCH_DIMS+2];
+            const uint out_w = idx_arr[BATCH_DIMS+1];
         #endif
+        const uint out_f = idx_arr[BATCH_DIMS+0];
+        const uint out_b = output_batch_size;
+    #else
+        #if OUTPUT_DIMS == 4
+            const uint out_x = idx_arr[3];
+            const uint out_y = idx_arr[2];
+        #elif OUTPUT_DIMS == 5
+            const uint out_x = idx_arr[4];
+            const uint out_y = idx_arr[3];
+            const uint out_z = idx_arr[2];
+        #else
+            const uint out_x = idx_arr[5];
+            const uint out_y = idx_arr[4];
+            const uint out_z = idx_arr[3];
+            const uint out_w = idx_arr[2];
+        #endif
+        const uint out_f = idx_arr[1];
+        const uint out_b = idx_arr[0];
+
     #endif
 
     const uint output_idx = GET_OUTPUT_INDEX(OUT_ORDER);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gather_nd_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gather_nd_gpu_test.cpp
@@ -752,6 +752,51 @@ TEST(gather_nd_gpu_fp16, d22_i32_ir2_batch0) {
     DoTestV8(engine, input0, input1, expected_results, indices_rank, batch_dims, format::bfyx, { 3, 1, 1, 1 });
 }
 
+TEST(gather_nd_gpu_fp16, d1333_i11164_ir5_batch0) {
+    auto& engine = get_test_engine();
+
+    const int indices_rank = 5;
+    const int batch_dims = 0;
+    auto input0 = engine.allocate_memory({ data_types::f16, format::bfyx, { 1, 3, 3, 3 } }); // data
+    auto input1 = engine.allocate_memory({ data_types::f16, format::bfzyx, { 1, 1, 4, 6, 1 } }); // indices
+    // expected output dim: {1,1,1,6}
+
+    set_values(input0, {
+        ov::float16(0), ov::float16(1), ov::float16(2),
+        ov::float16(3), ov::float16(4), ov::float16(5),
+        ov::float16(6), ov::float16(7), ov::float16(8),
+
+        ov::float16(10), ov::float16(11), ov::float16(12),
+        ov::float16(13), ov::float16(14), ov::float16(15),
+        ov::float16(16), ov::float16(17), ov::float16(18),
+
+        ov::float16(20), ov::float16(21), ov::float16(22),
+        ov::float16(23), ov::float16(24), ov::float16(25),
+        ov::float16(26), ov::float16(27), ov::float16(28),
+    });
+
+    set_values(input1, {
+        ov::float16(0), ov::float16(0), ov::float16(0), ov::float16(0),
+        ov::float16(0), ov::float16(0), ov::float16(0), ov::float16(1),
+        ov::float16(0), ov::float16(0), ov::float16(0), ov::float16(2),
+        ov::float16(0), ov::float16(0), ov::float16(1), ov::float16(0),
+        ov::float16(0), ov::float16(0), ov::float16(1), ov::float16(1),
+        ov::float16(0), ov::float16(0), ov::float16(1), ov::float16(2),
+    });
+
+    std::vector<float> expected_results = {
+        ov::float16(0),
+        ov::float16(1),
+        ov::float16(2),
+        ov::float16(3),
+        ov::float16(4),
+        ov::float16(5),
+    };
+
+    DoTestV5(engine,input0, input1, expected_results, indices_rank, batch_dims, format::bfyx, { 1, 1, 6, 1 });
+    DoTestV8(engine, input0, input1, expected_results, indices_rank, batch_dims, format::bfyx, { 1, 1, 6, 1 });
+}
+
 TEST(gather_nd_gpu_fp16, export_import) {
     auto& engine = get_test_engine();
 


### PR DESCRIPTION
There is a bug in the GPU plugin's GatherND kernel where the output indices are incorrect for 5D index inputs when the 4th dimension of the index input is not of size 1 and `batch_dims == 0`.

### Details:
 - When `batch_dims <= 1` the current implementation of GatherND in the GPU plugin does not shift the output indices as expected. For example, `out_x` is set to `idx_x` (the x index for the second input). However, this is not correct since the last dimension of the second input to GatherND is the indices to use and does not contribute to the shape of the output tensor (beyond deciding how many of the original input dimensions to keep). The current logic happens to work in most cases, but is not generally correct.
 - This PR adds a test case that demonstrates the bug (it fails on main), and the changes in this PR cause the test case to pass.
 - The fix in this PR is to just use the same logic as the case where `batch_dims > 1` and not `BATCH_MERGED_OUTPUT`.

### Tickets:
