### PR TITLE
[CPU]Fix heap buffer overflow in DenormalNullifyCheck

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/denormal_check.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/denormal_check.cpp
@@ -36,8 +36,8 @@ void SetUp() override {
     targetStaticShapes.push_back({inpShape});
     targetDevice = ov::test::utils::DEVICE_CPU;
 
-    const auto elemsCount = shape_size(inpShape);
     const auto rtPrc = ov::element::f32;
+    const auto elemsCount = shape_size(inpShape) * rtPrc.size();
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(rtPrc, ov::Shape(inpShape))};
     pConstStorage.reset(new ov::AlignedBuffer(elemsCount, alignment));
 


### PR DESCRIPTION
### Details:
 - *try to fix the SEH abort in windows test*


### Tickets:
 - *CVS-150527*
