### PR TITLE
[GPU] Fix weight reorder src format to avoid inconsistency ndims of src/dst in weight reorder

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -596,6 +596,14 @@ bool keep_weights_reorder_shape_consistent(cldnn::layout& layout, const dnnl::me
     // Check whether they have same values and orders.
     if (filtered_target_dims == filtered_desc_dims) {
         layout.set_partial_shape(desc_dims);
+        if (layout.get_rank() != desc_dims.size()) {
+            if (cldnn::format::is_default_format(layout.format)) {
+                layout.format = cldnn::format::get_default_format(desc_dims.size());
+            } else {
+                // TO-DO: Consider that weight format is not default format
+                return false;
+            }
+        }
         return true;
     } else {
         return false;


### PR DESCRIPTION
### Details:
 - Fix weight reorder src format to avoid inconsistancy ndims of src/dst in weight reorder

### Tickets:
 - 154614
