### PR TITLE
[intel-npu] Adding new metric property NPU_MAX_MEM_ALLOC_SIZE

### DIFF
--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -47,6 +47,16 @@ static constexpr ov::Property<uint64_t, ov::PropertyMutability::RO> device_total
 
 /**
  * @brief [Only for NPU plugin]
+ * Type: uint64_t
+ * Read-only property to get maximum size the device can allocate for a model
+ *
+ * Note: Queries driver both for discrete/integrated NPU devices
+ * @ingroup ov_runtime_npu_prop_cpp_api
+ */
+static constexpr ov::Property<uint64_t, ov::PropertyMutability::RO> device_max_mem_alloc_size{"NPU_MAX_MEM_ALLOC_SIZE"};
+
+/**
+ * @brief [Only for NPU plugin]
  * Type: uint32_t
  * Read-only property to get NPU driver version (for both discrete/integrated NPU devices)
  * @ingroup ov_runtime_npu_prop_cpp_api

--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -170,6 +170,7 @@ The following properties are supported:
 | `ov::device::pci_info`/</br>`DEVICE_PCI_INFO` | RO | Returns the PCI bus information of device. See PCIInfo struct definition for details | `N/A`| `N/A` |
 | `ov::intel_npu::device_alloc_mem_size`/</br>`NPU_DEVICE_ALLOC_MEM_SIZE` | RO | Size of already allocated NPU DDR memory | `N/A` | `N/A` |
 | `ov::intel_npu::device_total_mem_size`/</br>`NPU_DEVICE_TOTAL_MEM_SIZE` | RO | Size of available NPU DDR memory | `N/A` | `N/A` |
+| `ov::intel_npu::device_max_mem_alloc_size`/</br>`NPU_MAX_MEM_ALLOC_SIZE` | RO | Maximum size allowed for allocation in NPU DDR memory | `N/A` | `N/A` |
 | `ov::intel_npu::driver_version`/</br>`NPU_DRIVER_VERSION` | RO | NPU driver version. | `N/A` | `N/A` |
 | `ov::intel_npu::compilation_mode_params`/</br>`NPU_COMPILATION_MODE_PARAMS` | RW | Set various parameters supported by the NPU compiler. (See bellow) | `<std::string>`| `N/A` |
 | `ov::intel_npu::turbo`/</br>`NPU_TURBO` | RW | Set Turbo mode on/off | `YES`/ `NO`| `NO` |

--- a/src/plugins/intel_npu/src/al/include/npu.hpp
+++ b/src/plugins/intel_npu/src/al/include/npu.hpp
@@ -76,6 +76,7 @@ public:
     virtual uint32_t getMaxNumSlices() const;
     virtual uint64_t getAllocMemSize() const;
     virtual uint64_t getTotalMemSize() const;
+    virtual uint64_t getMaxMemAllocSize() const;
     virtual ov::device::PCIInfo getPciInfo() const;
     virtual ov::device::Type getDeviceType() const;
     virtual std::map<ov::element::Type, float> getGops() const;

--- a/src/plugins/intel_npu/src/al/src/npu.cpp
+++ b/src/plugins/intel_npu/src/al/src/npu.cpp
@@ -59,6 +59,10 @@ uint64_t IDevice::getTotalMemSize() const {
     OPENVINO_THROW("Get TotalMemSize is not supported");
 }
 
+uint64_t IDevice::getMaxMemAllocSize() const {
+    OPENVINO_THROW("Get MaxMemAllocSize is not supported");
+}
+
 ov::device::PCIInfo IDevice::getPciInfo() const {
     OPENVINO_THROW("Get PCIInfo is not supported");
 }

--- a/src/plugins/intel_npu/src/backend/include/zero_device.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_device.hpp
@@ -30,6 +30,7 @@ public:
     uint32_t getMaxNumSlices() const override;
     uint64_t getAllocMemSize() const override;
     uint64_t getTotalMemSize() const override;
+    uint64_t getMaxMemAllocSize() const override;
     ov::device::PCIInfo getPciInfo() const override;
     std::map<ov::element::Type, float> getGops() const override;
     ov::device::Type getDeviceType() const override;

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -152,6 +152,10 @@ uint64_t ZeroDevice::getTotalMemSize() const {
     return query.total;
 }
 
+uint64_t ZeroDevice::getMaxMemAllocSize() const {
+    return device_properties.maxMemAllocSize;
+}
+
 ov::device::PCIInfo ZeroDevice::getPciInfo() const {
     return ov::device::PCIInfo{pci_properties.address.domain,
                                pci_properties.address.bus,

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -33,6 +33,7 @@ public:
     std::string GetBackendName() const;
     uint64_t GetDeviceAllocMemSize(const std::string& specifiedDeviceName) const;
     uint64_t GetDeviceTotalMemSize(const std::string& specifiedDeviceName) const;
+    uint64_t GetMaxMemAllocSize(const std::string& specifiedDeviceName) const;
     uint32_t GetDriverVersion() const;
     uint32_t GetGraphExtVersion() const;
     uint32_t GetSteppingNumber(const std::string& specifiedDeviceName) const;

--- a/src/plugins/intel_npu/src/plugin/src/metrics.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/metrics.cpp
@@ -159,6 +159,15 @@ uint64_t Metrics::GetDeviceTotalMemSize(const std::string& specifiedDeviceName) 
     OPENVINO_THROW("No device with name '", specifiedDeviceName, "' is available");
 }
 
+uint64_t Metrics::GetMaxMemAllocSize(const std::string& specifiedDeviceName) const {
+    const auto devName = getDeviceName(specifiedDeviceName);
+    auto device = _backends->getDevice(devName);
+    if (device) {
+        return device->getMaxMemAllocSize();
+    }
+    OPENVINO_THROW("No device with name '", specifiedDeviceName, "' is available");
+}
+
 std::string Metrics::getDeviceName(const std::string& specifiedDeviceName) const {
     std::vector<std::string> devNames;
     if (_backends == nullptr || (devNames = _backends->getAvailableDevicesNames()).empty()) {

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -438,6 +438,12 @@ Plugin::Plugin()
           [&](const Config& config) {
               return _metrics->GetDeviceTotalMemSize(get_specified_device_name(config));
           }}},
+        {ov::intel_npu::device_max_mem_alloc_size.name(),
+         {true,
+          ov::PropertyMutability::RO,
+          [&](const Config& config) {
+              return _metrics->GetMaxMemAllocSize(get_specified_device_name(config));
+          }}},
         {ov::intel_npu::driver_version.name(),
          {true,
           ov::PropertyMutability::RO,


### PR DESCRIPTION
### Details:
 - Adding new property NPU_MAX_MEM_ALLOC_SIZE (intel_npu::device_max_mem_alloc_size) for querying maximum memory allocation size permitted by driver

### Tickets:
 - *EISW-143246*
