### PR TITLE
[IR FE] Read RuntimeAttribute version mangled with name

### DIFF
--- a/src/common/transformations/include/transformations/rt_info/attributes.hpp
+++ b/src/common/transformations/include/transformations/rt_info/attributes.hpp
@@ -30,7 +30,7 @@ class TRANSFORMATIONS_API Attributes {
 public:
     Attributes();
 
-    Any create_by_type_info(const ov::DiscreteTypeInfo& type_info_name);
+    Any create_by_type_name(const std::string& type_info_name);
 
 private:
     template <class T>
@@ -40,7 +40,7 @@ private:
         });
     }
 
-    std::unordered_map<ov::DiscreteTypeInfo, std::function<Any()>> m_factory_registry;
+    std::unordered_map<std::string, std::function<Any()>> m_factory_registry;
 };
 }  // namespace pass
 }  // namespace ov

--- a/src/common/transformations/src/transformations/rt_info/attributes.cpp
+++ b/src/common/transformations/src/transformations/rt_info/attributes.cpp
@@ -19,7 +19,7 @@ ov::pass::Attributes::Attributes() {
     register_factory<PreprocessingAttribute>();
 }
 
-ov::Any ov::pass::Attributes::create_by_type_info(const ov::DiscreteTypeInfo& type_info) {
+ov::Any ov::pass::Attributes::create_by_type_name(const std::string& type_info) {
     auto it_type = m_factory_registry.find(type_info);
     if (it_type != m_factory_registry.end()) {
         return it_type->second();

--- a/src/frontends/ir/tests/rt_info_deserialization.cpp
+++ b/src/frontends/ir/tests/rt_info_deserialization.cpp
@@ -404,7 +404,7 @@ TEST_F(RTInfoDeserialization, node_v11) {
             <rt_info>
                 <attribute name="old_api_map_element_type" version="0" value="f16"/>
                 <attribute name="old_api_map_order" version="0" value="0,2,3,1"/>
-                <attribute name="fused_names" version="0" value="in1"/>
+                <attribute name="fused_names_0" value="in1"/>
             </rt_info>
             <output>
                 <port id="0" precision="FP32" names="input_tensor">


### PR DESCRIPTION
### Details:
 - IR FrontEnd can read RuntimeAttribute version both ways joined with name and separated:
current `<attribute name="fused_names" version="0" value="in1"/>`
new (currently not supported) `<attribute name="fused_names_0" value="in1"/>`
 - It assures forward compatibility with OpenVINO versions which serialize name and version joined.
 - RuntimeAttribute serialization remains unchanged to keep backward compatibility (only separated are stored) while deprecated.

### Tickets:
 - CVS-105807
