### PR TITLE
[Coverity] Uninitialized members

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -17,7 +17,8 @@
 namespace ov {
 namespace intel_gpu {
 
-DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size) {
+DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size)
+    : ov::pass::MatcherPass() {  // Explicitly call the base class constructor{
     GPU_DEBUG_GET_INSTANCE(debug_config);
     using namespace ov::pass::pattern;
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -18,7 +18,7 @@ namespace ov {
 namespace intel_gpu {
 
 DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size)
-    : ov::pass::MatcherPass() {  // Explicitly call the base class constructor{
+    : ov::pass::MatcherPass() {  // Explicitly call the base class constructor
     GPU_DEBUG_GET_INSTANCE(debug_config);
     using namespace ov::pass::pattern;
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -47,7 +47,7 @@ IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() {
 
     auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), rope_cos_input, rope_sin_input});
 
-    ov::matcher_pass_callback callback = [=, this](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         auto matmul_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_map.at(gemm_or_matmul).get_node_shared_ptr());

--- a/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/increase_position_ids_precision.cpp
@@ -47,7 +47,7 @@ IncreasePositionIdsPrecision::IncreasePositionIdsPrecision() {
 
     auto rope = wrap_type<ov::op::internal::RoPE>({any_input(), rope_cos_input, rope_sin_input});
 
-    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [=, this](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
         auto matmul_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_map.at(gemm_or_matmul).get_node_shared_ptr());


### PR DESCRIPTION
### Details:
 - Regarding CID: 1559222 and 1559203. This could be false positive since the class IncreasePositionIdsPrecision does not have any member variables that need initialization.  I updated line 50 to ensure 'this' pointer is properly captured.

- Regarding CID: 1559220 and 1559209. This could also be a false positive. To address this issue I'm proposing to explicitly call the base class constructor in the initializer list of the constructor.

Need to re-run the Coverity scan to confirm fix.

### Tickets:
 - CVS-149659
