### PR TITLE
[NPU]Change NPUBackend log

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -70,7 +70,7 @@ namespace intel_npu {
 // TODO Config will be useless here, since only default values will be used
 NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, [[maybe_unused]] const Config& config)
     : _logger("NPUBackends", Logger::global().level()) {
-    std::vector<ov::SoPtr<IEngineBackend>> registeredBackends;
+    std::map<std::string, ov::SoPtr<IEngineBackend>> registeredBackends;
     [[maybe_unused]] const auto registerBackend = [&](ov::SoPtr<IEngineBackend> backend, const std::string& name) {
         const auto backendDevices = backend->getDeviceNames();
         if (!backendDevices.empty()) {
@@ -79,13 +79,13 @@ NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, 
                 deviceNames << device << " ";
             }
             _logger.debug("Register '%s' with devices '%s'", name.c_str(), deviceNames.str().c_str());
-            registeredBackends.emplace_back(backend);
+            registeredBackends.emplace(name, backend);
         }
     };
 
     for (const auto& name : backendRegistry) {
         std::string backendName = backendToString(name);
-        _logger.debug("Try '%s' backend", backendName.c_str());
+        _logger.debug("Try to init '%s' backend", backendName.c_str());
 
         try {
 #if !defined(OPENVINO_STATIC_LIBRARY) && defined(ENABLE_IMD_BACKEND)
@@ -116,18 +116,26 @@ NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, 
     }
 
     if (registeredBackends.empty()) {
-        registeredBackends.emplace_back(nullptr);
+        registeredBackends.emplace("", nullptr);
     }
 
     // TODO: implementation of getDevice methods needs to be updated to go over all
     // registered backends to search a device.
     // A single backend is chosen for now to keep existing behavior
-    _backend = *registeredBackends.begin();
+    _backend = registeredBackends.begin()->second;
 
-    if (_backend != nullptr) {
-        _logger.info("Use '%s' backend for inference", _backend->getName().c_str());
+    if (registeredBackends.size() > 1) {
+        _logger.info("Both ZeroBackend and IMDBackend inited successfully. Use '%s' backend for inference",
+                      _backend->getName().c_str());
     } else {
-        _logger.error("Cannot find backend for inference. Make sure the device is available.");
+        auto name = registeredBackends.begin()->first;
+        if (name == "npu_imd_backend") {
+            _logger.info("Only IMDBackend inited successfuly.");
+        } else if (name == "npu_level_zero_backend") {
+            _logger.info("Only ZeroBackend inited successfuly.");
+        } else {
+            _logger.warning("No backend inited successfully. Only offline compilation can be done!");
+        }
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -127,7 +127,7 @@ NPUBackends::NPUBackends(const std::vector<AvailableBackends>& backendRegistry, 
     if (_backend != nullptr) {
         _logger.info("Use '%s' backend for inference", _backend->getName().c_str());
     } else {
-        _logger.warning("None of the backends were initialized successfully. " \ 
+        _logger.warning("None of the backends were initialized successfully."
                         "Only offline compilation can be done!");
     }
 }

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -24,6 +24,9 @@
 namespace {
 
 constexpr std::string_view NO_EXECUTOR_FOR_INFERENCE =
+    "Can't create infer request due to create executor failed! Only exports can be made.";
+
+constexpr std::string_view NO_EXECUTOR_FOR_INFERENCE_NODEVICE =
     "Can't create infer request!\n"
     "Please make sure that the device is available. Only exports can be made.";
 
@@ -118,8 +121,12 @@ std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() co
     if (_executorPtr == nullptr && _device != nullptr) {
         _executorPtr = _device->createExecutor(_networkPtr, _config);
     }
+
     if (_executorPtr == nullptr) {
-        OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE);
+        if (_device != nullptr)
+            OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE);
+        else
+            OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE_NODEVICE);
     }
 
     const std::shared_ptr<SyncInferRequest>& syncInferRequest =

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -125,8 +125,10 @@ std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() co
     if (_executorPtr == nullptr) {
         if (_device != nullptr)
             OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE);
-        else
+        else {
+            _logger.error("Can not find device!");
             OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE_NODEVICE);
+        }
     }
 
     const std::shared_ptr<SyncInferRequest>& syncInferRequest =

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -123,9 +123,9 @@ std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() co
     }
 
     if (_executorPtr == nullptr) {
-        if (_device != nullptr)
+        if (_device != nullptr) {
             OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE);
-        else {
+        } else {
             _logger.error("Can not find device!");
             OPENVINO_THROW(NO_EXECUTOR_FOR_INFERENCE_NODEVICE);
         }


### PR DESCRIPTION
### Details:
 [log.error of  NPUbackend](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_npu/src/plugin/src/backends.cpp#L130) will confuse the user, thought NPU backend does not impact the compilation and just impact the inference stage.
 Now [in the inference stage in compiledmodel part](https://github.com/openvinotoolkit/openvino/pull/27073/files#diff-74bc81bb7b258118f04e81468e3ec3b05e65e714546d32246bae45eb892f6abcR125-R130), will get a log.error output when no npu device is checked.


### Tickets:
 - 153439
