### PR TITLE
[GPU] Fix different element types of MatMul dequantization scales issue

### DIFF
--- a/src/common/low_precision_transformations/src/mat_mul.cpp
+++ b/src/common/low_precision_transformations/src/mat_mul.cpp
@@ -160,7 +160,7 @@ bool MatMulTransformation::transform(TransformationContext &context, ov::pass::p
     }
 
     const auto newMulConst = NetworkHelper::toScalarIfPossible(fold<ov::opset1::Multiply>(
-            mulConst1,
+            foldConvert(mulConst1, element::f32),
             foldConvert(mulConst2, element::f32)));
 
     const auto newMultiply = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Multiply>>(


### PR DESCRIPTION
### Details:
 - MatMul dequantization
Convert both dequantization scale variables (mulConst1 & mulConst2) to f32 instead of just one (mulConst2), to avoid different data type complaint issue (f16 & f32).

### Tickets:
 - 151988
