### PR TITLE
[GPU] Update TF AdjustSaturation test to additional shape

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_AdjustSaturation.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_AdjustSaturation.py
@@ -46,7 +46,7 @@ class TestAdjustSaturation(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_adjust_saturation_basic(self, input_shape, input_type, special_case,
                                      ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
-        if ie_device == 'GPU' and input_shape in [[5, 23, 27, 3], [3, 4, 13, 15, 3]]:
+        if ie_device == 'GPU' and input_shape in [[5, 23, 27, 3]]:
             pytest.skip("151264: accuracy error on GPU")
         if platform.machine() in ["aarch64", "arm64", "ARM64"] and input_shape in [[5, 23, 27, 3], [3, 4, 13, 15, 3]]:
             pytest.skip("151263: accuracy error on ARM")


### PR DESCRIPTION
For GPU,  [3, 4, 13, 15, 3] is passing.  Enable it to test. 

Shape [5, 23, 7, 3] won't possible to fix due to accuracy issue where the gather index requires multiple multiple/divide/floor causing some index slightly different than CPU.

 ### Tickets:
[*CVS-151264*]