### PR TITLE
Move convert precision logic of ConstantFolding to Node class

### DIFF
--- a/src/core/dev_api/openvino/core/constant_fold_utils.hpp
+++ b/src/core/dev_api/openvino/core/constant_fold_utils.hpp
@@ -17,7 +17,7 @@ OPENVINO_API
 bool is_type_unsupported(const element::Type& type);
 
 OPENVINO_API
-void save_original_input_precisions(const std::shared_ptr<Node>& node);
+void save_original_input_precisions(ov::Node* const node);
 
 OPENVINO_API
 bool has_original_input_precision(const Input<Node>& input);
@@ -40,6 +40,11 @@ OPENVINO_API bool node_requires_precision_conversion(const Node* const node);
 OPENVINO_API std::shared_ptr<Node> convert_to_supported_precision(Node* const node);
 
 OPENVINO_API std::shared_ptr<Node> convert_to_supported_precision(Node* const node, const OutputVector& inputs);
+
+OPENVINO_API std::shared_ptr<ov::Node> to_supported_precision(Node* const node);
+OPENVINO_API bool to_original_precision(Node* const node);
+
+OPENVINO_API void mark_node_requires_precision_conversion(const std::shared_ptr<ov::Node>& node);
 
 OPENVINO_API bool evaluate_node_with_unsupported_precision(const Node* node,
                                                            TensorVector& outputs,

--- a/src/core/src/op/convert_like.cpp
+++ b/src/core/src/op/convert_like.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "itt.hpp"
+#include "openvino/core/constant_fold_utils.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 
@@ -31,14 +32,15 @@ std::shared_ptr<Node> ConvertLike::clone_with_new_inputs(const OutputVector& new
 
 bool ConvertLike::constant_fold(OutputVector& output_values, const OutputVector& input_values) {
     OV_OP_SCOPE(v1_ConvertLike_constant_fold);
-    if (is_const_fold_disabled()) {
-        return false;
+    if (!is_const_fold_disabled()) {
+        if (auto data_const = std::dynamic_pointer_cast<op::v0::Constant>(input_values[0].get_node_shared_ptr())) {
+            auto convert = std::make_shared<ov::op::v0::Convert>(input_values[0], input_values[1].get_element_type());
+            return convert->constant_fold(output_values, OutputVector{data_const});
+        }
     }
 
-    if (auto data_const = std::dynamic_pointer_cast<op::v0::Constant>(input_values[0].get_node_shared_ptr())) {
-        auto convert = std::make_shared<ov::op::v0::Convert>(input_values[0], input_values[1].get_element_type());
-        return convert->constant_fold(output_values, OutputVector{data_const});
-    }
+    // if CF was unsuccessful remove original precision attribute from inputs
+    ov::util::to_original_precision(this);
     return false;
 }
 


### PR DESCRIPTION
### Details:
ConstantFolding transformation takes several seconds even if the graph is not modified.
The root cause is util::convert_to_supported_precision call even if constant folding is skipped.
The suggested fix is to move convert precision logic to constant_fold method of Node class

### Tickets:
[CVS-152428](https://jira.devtools.intel.com/browse/CVS-152428)
