### PR TITLE
[TFL FE] Export public API symbols for TFLite Delegate

### DIFF
--- a/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/decoder.hpp
+++ b/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/decoder.hpp
@@ -14,7 +14,7 @@ namespace ov {
 namespace frontend {
 namespace tensorflow_lite {
 
-struct TensorMetaInfo {
+struct TENSORFLOW_LITE_API TensorMetaInfo {
     std::shared_ptr<QuantizationInfo> m_quantization_info;
     std::shared_ptr<SparsityInfo> m_sparsity_info;
     ov::PartialShape m_partial_shape;
@@ -23,11 +23,11 @@ struct TensorMetaInfo {
     std::string m_tensor_name;
 };
 
-class DecoderBase : public ov::frontend::DecoderBase {};
+class TENSORFLOW_LITE_API DecoderBase : public ov::frontend::DecoderBase {};
 
 // DecoderBaseOperation corresponds to operation node to retrieve its attributes and information about input and output
 // tensors
-class DecoderBaseOperation : public ov::frontend::tensorflow_lite::DecoderBase {
+class TENSORFLOW_LITE_API DecoderBaseOperation : public ov::frontend::tensorflow_lite::DecoderBase {
 public:
     /// \brief Get input tensor name by index
     /// Operation nodes are connected between each other by tensors.
@@ -71,7 +71,7 @@ public:
 
 // DecoderBaseTensor corresponds to tensor node to retrieve information about type, shapem quantization and sparsity
 // information
-class DecoderBaseTensor : public ov::frontend::tensorflow_lite::DecoderBase {
+class TENSORFLOW_LITE_API DecoderBaseTensor : public ov::frontend::tensorflow_lite::DecoderBase {
 public:
     /// \brief Get tensor info
     virtual TensorMetaInfo get_tensor_info() const = 0;

--- a/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/graph_iterator.hpp
+++ b/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/graph_iterator.hpp
@@ -24,7 +24,7 @@ namespace tensorflow_lite {
 /// DecoderBaseOperation (for op 1), ..., DecoderBaseOperation (for op k),
 /// where n - number of inputs in the model, m - number of outputs in the model k - number of operation nodes.
 /// NOTE: constants are ignored and no decoder object is returned for constant.
-class GraphIterator : ::ov::RuntimeAttribute {
+class TENSORFLOW_LITE_API GraphIterator : ::ov::RuntimeAttribute {
 public:
     using Ptr = std::shared_ptr<GraphIterator>;
 

--- a/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/quantization_info.hpp
+++ b/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/quantization_info.hpp
@@ -15,7 +15,7 @@ namespace ov {
 namespace frontend {
 namespace tensorflow_lite {
 
-class QuantizationInfo : public ov::RuntimeAttribute {
+class TENSORFLOW_LITE_API QuantizationInfo : public ov::RuntimeAttribute {
 public:
     OPENVINO_RTTI("QuantizationInfo");
     QuantizationInfo() = default;

--- a/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/sparsity_info.hpp
+++ b/src/frontends/tensorflow_lite/include/openvino/frontend/tensorflow_lite/sparsity_info.hpp
@@ -16,7 +16,7 @@ namespace ov {
 namespace frontend {
 namespace tensorflow_lite {
 
-class SparsityInfo : public ov::RuntimeAttribute {
+class TENSORFLOW_LITE_API SparsityInfo : public ov::RuntimeAttribute {
 public:
     struct SparsityDataDesc {
         uint8_t segments_type;


### PR DESCRIPTION
**Details:** We need to properly export public API in tensorflow_lite_frontend shared library so that TFLite delagate can import them. All abstract classes that TFLite Delegate implements on its own should be exported. `QuantizationInfo` also should be exported to avoid duplications/re-definitions in binaries.

**Ticket:** TBD

