### PR TITLE
[GPU][TESTS] Fix weightless caching tests

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/behavior/model_cache.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/model_cache.cpp
@@ -97,113 +97,18 @@ void CheckWeightlessCacheAccuracy::run() {
     }
 }
 
-TEST_F(CheckWeightlessCacheAccuracy, 2InputSubtract) {
-    model = ov::test::utils::make_2_input_subtract();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, ConcatWithParams) {
-    model = ov::test::utils::make_concat_with_params();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, ConvBias) {
-    model = ov::test::utils::make_conv_bias();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, ConvPoolRelu) {
-    model = ov::test::utils::make_conv_pool_relu();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, ConvPoolReluNoReshapes) {
-    model = ov::test::utils::make_conv_pool_relu_no_reshapes();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, ConvPoolReluNonZero) {
-    model = ov::test::utils::make_conv_pool_relu_non_zero();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, ConvertTranspose) {
-    model = ov::test::utils::make_convert_transpose();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, DetectionOutput) {
-    model = ov::test::utils::make_detection_output();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, KsoFunction) {
-    model = ov::test::utils::make_kso_function();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, MatmulBias) {
-    model = ov::test::utils::make_matmul_bias();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, MultiSingleConv) {
-    model = ov::test::utils::make_multi_single_conv();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, MultipleInputOutputDoubleConcat) {
-    model = ov::test::utils::make_multiple_input_output_double_concat();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, NestedBranchConvConcat) {
-    model = ov::test::utils::make_nested_branch_conv_concat();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, NestedSplitConvConcat) {
-    model = ov::test::utils::make_nested_split_conv_concat();
-    run();
-}
-
 TEST_F(CheckWeightlessCacheAccuracy, ReadConcatSplitAssign) {
-    model = ov::test::utils::make_read_concat_split_assign();
+    model = ov::test::utils::make_read_concat_split_assign({1, 1, 2, 4}, ov::element::f16);
     run();
 }
 
 TEST_F(CheckWeightlessCacheAccuracy, SingleConcatWithConstant) {
-    model = ov::test::utils::make_single_concat_with_constant();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, SingleConv) {
-    model = ov::test::utils::make_single_conv();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, SingleSplit) {
-    model = ov::test::utils::make_single_split();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, SplitConcat) {
-    model = ov::test::utils::make_split_concat();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, SplitConvConcat) {
-    model = ov::test::utils::make_split_conv_concat();
-    run();
-}
-
-TEST_F(CheckWeightlessCacheAccuracy, SplitMultiConvConcat) {
-    model = ov::test::utils::make_split_multi_conv_concat();
+    model = ov::test::utils::make_single_concat_with_constant({1, 1, 2, 4}, ov::element::f16);
     run();
 }
 
 TEST_F(CheckWeightlessCacheAccuracy, TiWithLstmCell) {
-    model = ov::test::utils::make_ti_with_lstm_cell();
+    model = ov::test::utils::make_ti_with_lstm_cell(ov::element::f16);
     run();
 }
 


### PR DESCRIPTION
Currently the tests have weightless caching enabled, but the models tested contain no constants eligible for weightless caching. This fixes the situation.

To elaborate - all the models have f32 dtype constants by default. In these particular models all of the constants which would otherwise be eligible for weightless caching undergo some precision transformation which invalidates this eligibilty. The PR changes the dtype of the constants to prevent that and deletes the models which contain no constants eligible for weightless caching even after the dtype change.