### PR TITLE
[TF FE] Skip one test case for keras Embedding on CPU due to timeout issue

### DIFF
--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -64,6 +64,8 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_emb_without_zero_mask_float32(self, params, ie_device, precision, ir_version,
                                                  temp_dir, use_legacy_frontend):
+        if ie_device == 'CPU':
+            pytest.skip('155622: OpenVINO runtime timeout on CPU')
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -42,6 +42,8 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                use_legacy_frontend):
+        if params['input_shapes'] == [[5, 16]] and params['output_dim'] == 324 and ie_device == 'CPU':
+            pytest.skip('155622: OpenVINO runtime timeout on CPU')
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,
                    use_legacy_frontend=use_legacy_frontend, **params)

--- a/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
+++ b/tests/layer_tests/tensorflow2_keras_tests/test_tf2_keras_embedding.py
@@ -42,7 +42,7 @@ class TestKerasEmbedding(CommonTF2LayerTest):
     @pytest.mark.precommit
     def test_keras_emb_float32(self, params, ie_device, precision, ir_version, temp_dir,
                                use_legacy_frontend):
-        if params['input_shapes'] == [[5, 16]] and params['output_dim'] == 324 and ie_device == 'CPU':
+        if ie_device == 'CPU':
             pytest.skip('155622: OpenVINO runtime timeout on CPU')
         self._test(*self.create_keras_emb_net(**params, ir_version=ir_version),
                    ie_device, precision, temp_dir=temp_dir, ir_version=ir_version,

--- a/tests/layer_tests/tensorflow_tests/test_tf_BiasAdd.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_BiasAdd.py
@@ -126,6 +126,8 @@ class TestBiasAdd(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_bias_add_2_consts_4D(self, params, ie_device, precision, ir_version, temp_dir,
                                   use_legacy_frontend):
+        if ie_device == 'CPU':
+            pytest.skip('155622: OpenVINO runtime timeout on CPU')
         self._test(*self.create_bias_add_2_consts_net(**params, ir_version=ir_version,
                                                       use_legacy_frontend=use_legacy_frontend),
                    ie_device, precision, ir_version, temp_dir=temp_dir,


### PR DESCRIPTION
**Details:** Skip one test case for keras Embedding on CPU due to timeout issue

**Ticket:** 155622
