### PR TITLE
[TRANSFORMATIONS] Check if FROM types are different from a node's type in ConvertPrecision

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -220,7 +220,7 @@ bool convert_function_precision(const std::shared_ptr<Model>& f,
     // otherwise we insert Convert operation.
     auto ops = f->get_ordered_ops();
     for (auto& node : ops) {
-        if ((skip_precision_sensitive && fp16_compression_is_disabled(node) && has_fp16_compression))
+        if (skip_precision_sensitive && fp16_compression_is_disabled(node) && has_fp16_compression)
             continue;
         is_changed = convert_node_input_precision(node, precisions, type_to_extend) || is_changed;
     }
@@ -1000,7 +1000,7 @@ bool extend_select_type(const std::shared_ptr<ov::Node>& node, const precisions_
         type_relaxed->set_origin_input_type(ov::element::boolean, 0);
         return true;
     } else if (auto casted = ov::as_type_ptr<ov::op::v1::Select>(node)) {
-        if (casted->input(0).get_element_type() != ov::element::boolean) {
+        if (casted->get_input_source_output(0).get_element_type() != ov::element::boolean) {
             auto relaxed_op =
                 std::make_shared<op::TypeRelaxed<ov::op::v1::Select>>(*casted,
                                                                       ov::element::TypeVector{ov::element::boolean},

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -1000,10 +1000,10 @@ bool extend_select_type(const std::shared_ptr<ov::Node>& node, const precisions_
         return true;
     } else if (auto casted = ov::as_type_ptr<ov::op::v1::Select>(node)) {
         if (precisions.count(ov::element::boolean) != 0) {
-            auto relaxed_op = 
-            std::make_shared<op::TypeRelaxed<ov::op::v1::Select>>(*casted,
-                                                                  ov::element::TypeVector{ov::element::boolean},
-                                                                  ov::element::TypeVector{});
+            auto relaxed_op =
+                std::make_shared<op::TypeRelaxed<ov::op::v1::Select>>(*casted,
+                                                                      ov::element::TypeVector{ov::element::boolean},
+                                                                      ov::element::TypeVector{});
             replace_node(node, relaxed_op);
             return true;
         }

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -254,7 +254,6 @@ bool convert_function_precision(const std::shared_ptr<Model>& f,
     // Register internal constants only after fixing input type that could lead to nodes
     // replacement
     register_constants(ops);
-
     for (auto& node : ops) {
         // skip precision sensitive nodes
         if (skip_precision_sensitive && fp16_compression_is_disabled(node) && has_fp16_compression)
@@ -1000,11 +999,11 @@ bool extend_select_type(const std::shared_ptr<ov::Node>& node, const precisions_
         type_relaxed->set_origin_input_type(ov::element::boolean, 0);
         return true;
     } else if (auto casted = ov::as_type_ptr<ov::op::v1::Select>(node)) {
-        if (casted->get_input_source_output(0).get_element_type() != ov::element::boolean) {
-            auto relaxed_op =
-                std::make_shared<op::TypeRelaxed<ov::op::v1::Select>>(*casted,
-                                                                      ov::element::TypeVector{ov::element::boolean},
-                                                                      ov::element::TypeVector{});
+        if (precisions.count(ov::element::boolean) != 0) {
+            auto relaxed_op = 
+            std::make_shared<op::TypeRelaxed<ov::op::v1::Select>>(*casted,
+                                                                  ov::element::TypeVector{ov::element::boolean},
+                                                                  ov::element::TypeVector{});
             replace_node(node, relaxed_op);
             return true;
         }

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -500,6 +500,7 @@ bool ov::pass::ConvertPrecision::run_on_model(const std::shared_ptr<ov::Model>& 
         type_to_fuse[it.first] = it.second;
     }
 
+    type_to_fuse.insert(m_additional_type_to_fuse_map.begin(), m_additional_type_to_fuse_map.end());
 
     static type_to_fuse_map type_to_extend{
         {ov::op::v1::Select::get_type_info_static(), extend_select_type},

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -245,7 +245,7 @@ bool convert_function_precision(const std::shared_ptr<Model>& f,
     auto ops = f->get_ordered_ops();
     for (auto& node : ops) {
         // This is a hotfix that checks if FROM types are not different from the
-        // node's input/output element type. To be investigated more in CVS-155990
+        // node's output element type. To be investigated more in CVS-155990
         if ((skip_precision_sensitive && fp16_compression_is_disabled(node) && has_fp16_compression) ||
             !node_output_type_match(node, precisions))
             continue;

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -195,7 +195,7 @@ bool convert_node_input_precision(const std::shared_ptr<ov::Node>& node,
 
 // Part of hotfix from CVS-155745 & CVS-155990
 static bool node_input_output_type_different(const std::shared_ptr<ov::Node> node, const precisions_map& precisions) {
-    for (const auto &p : precisions) {
+    for (const auto& p : precisions) {
         const auto& type_from = p.first;
 
         auto different_type_input = [&type_from](const ov::Input<Node>& input) -> bool {
@@ -208,8 +208,8 @@ static bool node_input_output_type_different(const std::shared_ptr<ov::Node> nod
 
         if (std::any_of(node->inputs().cbegin(), node->inputs().cend(), different_type_input) ||
             std::any_of(node->outputs().cbegin(), node->outputs().cend(), different_type_output)) {
-                return true;
-            }
+            return true;
+        }
     }
 
     return false;

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -963,6 +963,34 @@ TEST(TransformationTests, ConvertPrecision_Select) {
     ASSERT_TRUE(has_type<element::Type_t::u8>(f));
 }
 
+TEST(TransformationTests, ConvertPrecision_Select_Relaxed) {
+    std::shared_ptr<Model> f(nullptr);
+    {
+        auto input1 = std::make_shared<opset4::Parameter>(element::boolean, Shape{15, 20, 3});
+        auto node = std::make_shared<opset4::LogicalNot>(input1);
+        auto select = std::make_shared<opset4::Select>(node, input1, input1);
+
+        f = std::make_shared<Model>(OutputVector{select}, ParameterVector{input1});
+
+        // Explicitly setting the element type of a node to a different one to
+        // test the appearance of TypeRelaxed within Select
+        node->set_output_type(0, ov::element::u8, node->get_output_partial_shape(0));
+
+        pass::Manager manager;
+        manager.register_pass<pass::InitNodeInfo>();
+        manager.register_pass<pass::ConvertPrecision>(precisions_map{{element::u8, element::boolean}});
+        manager.run_passes(f);
+    }
+    OV_ASSERT_NO_THROW(check_rt_info(f));
+    ASSERT_FALSE(has_type<element::Type_t::u8>(f));
+    ASSERT_TRUE(has_type<element::Type_t::boolean>(f));
+    int counter = 0;
+    for (const auto& node : f->get_ordered_ops())
+        if (std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(node))
+            ++counter;
+    ASSERT_EQ(counter, 1);
+}
+
 TEST(TransformationTests, ConvertPrecision_TypeRelaxedWithSelect) {
     std::shared_ptr<Model> f(nullptr);
     {


### PR DESCRIPTION
[TRANSFORMATIONS] Check if Select is 'relaxed' only if 0th input is not boolean in ConvertPrecision

The ConvertPrecision transformation wraps Select node (its 0th input in particular) into RelaxedType to accept tensors with other element types than boolean. Add a check to perform the appearance of RelaxedType only if the 0th input is not boolean.

Tickets:
	* CVS-155745
	* CVS-155990

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
