### PR TITLE
[CPU][OMP] Safe usage of threads num with buffers

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -84,7 +84,8 @@ void CTCLoss::execute(dnnl::stream strm) {
     std::vector<int> decodedTargetLenB(batchNum, 0);
     std::vector<std::vector<int>> targetDB(batchNum);
     std::vector<std::vector<std::vector<float>>> logProbabilitiesB(batchNum);
-    std::vector<std::string> errorMsgB(parallel_get_max_threads());
+    const auto threads_num = parallel_get_max_threads();
+    std::vector<std::string> errorMsgB(threads_num);
 
     auto threadBody_1 = [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);
@@ -153,7 +154,7 @@ void CTCLoss::execute(dnnl::stream strm) {
         } // for batch
     }; // threadBody_1
 
-    parallel_nt(0, threadBody_1);
+    parallel_nt(threads_num, threadBody_1);
     if (returnCode != 0) {
         std::string resErr("");
         for (auto& err : errorMsgB) {

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -110,6 +110,7 @@ private:
     bool have_scalar_scale = false;
     size_t zp_group_size = 1u;
     size_t scale_group_size = 1u;
+    size_t m_threads_num = 0lu;
 
     std::shared_ptr<jitGatherKernelBase> jitKernel;
 };

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -149,11 +149,11 @@ void GridSample::createPrimitive() {
     }
     jitKernel->create_ker();
 
-    nthr = parallel_get_max_threads();
-    execParamsPerThread.resize(nthr);
+    m_threads_num = parallel_get_max_threads();
+    execParamsPerThread.resize(m_threads_num);
     if (!x64::mayiuse(x64::avx512_core)) {
         const auto dataElPerVec = jitKernel->getDataElPerVec();
-        parallel_nt(nthr, [&](const int ithr, const int nthr) {
+        parallel_nt(m_threads_num, [&](const int ithr, const int nthr) {
             auto& p = execParamsPerThread[ithr];
 
             p.srcHeightF.resize(dataElPerVec);
@@ -197,9 +197,9 @@ void GridSample::prepareParams() {
     const auto& srcDataShape = dataMemPtr->getStaticDims();
     const auto& dstShape     = dstMemPtr->getStaticDims();
     const uint64_t totalWork = dstShape[2] * dstShape[3];
-    const uint64_t wpt = ((totalWork / dataElPerVec) / nthr + 1) * dataElPerVec;
+    const uint64_t wpt = ((totalWork / dataElPerVec) / m_threads_num + 1) * dataElPerVec;
 
-    parallel_nt(nthr, [&](const int ithr, const int nthr) {
+    parallel_nt(m_threads_num, [&](const int ithr, const int nthr) {
         const uint64_t dstStart = std::min(wpt * ithr, totalWork);
         const uint64_t dstEnd = std::min(wpt * (ithr + 1), totalWork);
 
@@ -303,7 +303,7 @@ void GridSample::execute(dnnl::stream strm) {
         (*jitKernel)(&arg);
     };
 
-    parallel_nt(nthr, threadBody);
+    parallel_nt(m_threads_num, threadBody);
 }
 
 void GridSample::executeDynamicImpl(dnnl::stream strm) {

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.hpp
@@ -62,7 +62,7 @@ private:
     ov::element::Type dataPrecision;
     ov::element::Type gridPrecision = ov::element::f32;
 
-    int nthr = 1;
+    size_t m_threads_num = 0lu;
     std::vector<threadExecParams> execParamsPerThread;
 
     static constexpr size_t IN_DATA = 0;

--- a/src/plugins/intel_cpu/src/nodes/mha.h
+++ b/src/plugins/intel_cpu/src/nodes/mha.h
@@ -238,6 +238,8 @@ private:
     std::unique_ptr<jit_uni_mul_add_softmax_kernel> mulAddSoftmaxKernel;
     std::unique_ptr<jit_uni_convert_reorder_kernel> convertReorderKernel;
     std::unique_ptr<jit_uni_convert_transpose_kernel> convertTransposeKernel;
+
+    size_t m_threads_num = 0lu;
 };
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -2180,11 +2180,6 @@ void MVN::MVNJitExecutor::mvn_pln(const uint8_t* src_data, uint8_t* dst_data, co
     size_t C2 = C1 * D;
     size_t C3 = C2 * C;
 
-#if (OV_THREAD == OV_THREAD_OMP)
-    const auto origin_nested_levels = get_max_nested_levels();
-    set_max_nested_levels(origin_nested_levels + 1);
-#endif  // OV_THREAD == OV_THREAD_OMP
-
     if (mvnAttrs.execAcrossChannels_) {
         parallel_for(N, [&](int b) {
             size_t cb = b * C3;
@@ -2303,10 +2298,6 @@ void MVN::MVNJitExecutor::mvn_pln(const uint8_t* src_data, uint8_t* dst_data, co
             }
         });
     }
-
-#if (OV_THREAD == OV_THREAD_OMP)
-    set_max_nested_levels(origin_nested_levels);
-#endif  // OV_THREAD == OV_THREAD_OMP
 }
 
 void MVN::MVNRefExecutor::mvn_ref(const uint8_t* src_data, uint8_t* dst_data, const VectorDims& shape5d) {
@@ -2321,11 +2312,6 @@ void MVN::MVNRefExecutor::mvn_ref(const uint8_t* src_data, uint8_t* dst_data, co
     size_t C1 = H * W;
     size_t C2 = C1 * D;
     size_t C3 = C2 * C;
-
-#if (OV_THREAD == OV_THREAD_OMP)
-    const auto origin_nested_levels = get_max_nested_levels();
-    set_max_nested_levels(origin_nested_levels + 1);
-#endif  // OV_THREAD == OV_THREAD_OMP
 
     parallel_for(N, [&](int b) {
         size_t cb = b * C3;
@@ -2413,10 +2399,6 @@ void MVN::MVNRefExecutor::mvn_ref(const uint8_t* src_data, uint8_t* dst_data, co
             });
         }
     });
-
-#if (OV_THREAD == OV_THREAD_OMP)
-    set_max_nested_levels(origin_nested_levels);
-#endif  // OV_THREAD == OV_THREAD_OMP
 }
 
 void MVN::MVNJitExecutor::mvn_nspc(const uint8_t* src_data, uint8_t* dst_data, const void *post_ops_data_, const VectorDims& shape5d) {
@@ -2434,11 +2416,6 @@ void MVN::MVNJitExecutor::mvn_nspc(const uint8_t* src_data, uint8_t* dst_data, c
     const size_t D = shape5d[2];
     const size_t H = shape5d[3];
     const size_t W = shape5d[4];
-
-#if (OV_THREAD == OV_THREAD_OMP)
-    const auto origin_nested_levels = get_max_nested_levels();
-    set_max_nested_levels(origin_nested_levels + 1);
-#endif  // OV_THREAD == OV_THREAD_OMP
 
     const size_t threads_num = parallel_get_max_threads();
     size_t aux_buffer_size = mvnAttrs.execAcrossChannels_ ? 1 : rnd_up(C, blk_size) + blk_size;
@@ -2540,10 +2517,6 @@ void MVN::MVNJitExecutor::mvn_nspc(const uint8_t* src_data, uint8_t* dst_data, c
     parallel_nt_static(threads_num, [&](const int ithr, const int nthr) {
         for_1d(ithr, nthr, N, b_loop);
     });
-
-#if (OV_THREAD == OV_THREAD_OMP)
-    set_max_nested_levels(origin_nested_levels);
-#endif  // OV_THREAD == OV_THREAD_OMP
 }
 
 void MVN::MVNJitExecutor::mvn_blk(const uint8_t* src_data, uint8_t* dst_data, const void *post_ops_data_, const VectorDims& shape5d) {

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -1076,7 +1076,7 @@ void ROIAlign::executeSpecified() {
             int bufSize = rnd_up(C, 16);
             size_t threadsNum = parallel_get_max_threads();
             workingBuf.resize(bufSize * threadsNum, 0.f);
-            parallel_for3d(realRois, pooledH, pooledW, [&](int n, int yBinInd, int xBinInd) {
+            auto rhw_loop = [&](int n, int yBinInd, int xBinInd) {
                 int numSamplesROI = numSamples[n];
                 // each sample have 4 values for srcAddressList and weight
                 size_t binOffset = numSamplesROI * BLIParamsNum * pooledW * yBinInd + numSamplesROI * BLIParamsNum * xBinInd;
@@ -1095,6 +1095,10 @@ void ROIAlign::executeSpecified() {
                 arg.dst = static_cast<void*>(&dst[dstOffset]);
                 arg.src_stride = lastBlockDim * W * H; // only valid for blk, nspc generate inside
                 (*roi_align_kernel)(&arg);
+            };
+
+            parallel_nt_static(threadsNum, [&](const int ithr, const int nthr) {
+                for_3d(ithr, nthr, realRois, pooledH, pooledW, rhw_loop);
             });
         } else {
             // one lane for one sample generation, then pooling all samples.

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -348,6 +348,7 @@ StridedSlice::StridedSliceCommonExecutor::StridedSliceCommonExecutor(const Strid
     dimsNormalization();
     dimsGluing();
     indicesCalculation();
+    m_threads_num = parallel_get_max_threads();
 }
 
 void StridedSlice::StridedSliceCommonExecutor::orderParametersByLayouts(const BlockedMemoryDescCPtr& blockedMemoryDesc) {
@@ -642,8 +643,7 @@ void StridedSlice::StridedSliceCommonExecutor::dimsGluing() {
         for (size_t idx = secondDim.first + 1; idx < secondDim.second; idx++)
             params.attrs.begin[1] /= dstBlockedDimsBefore[idx];
 
-        const size_t maxThreads = parallel_get_max_threads();
-        if (params.dstBlockedDims[0] < maxThreads) {
+        if (params.dstBlockedDims[0] < m_threads_num) {
             params.dstBlockedDims[1] /= realDstDim;
             params.srcBlockedDims[1] /= realSrcDim;
             params.dstBlockedDims.insert(params.dstBlockedDims.begin() + 1, realDstDim);
@@ -682,8 +682,7 @@ void StridedSlice::StridedSliceCommonExecutor::indicesCalculation() {
     dstIndices.resize(workAmount, 0);
 
     // should choose more optimal thread count
-    const size_t nthr = parallel_get_max_threads();
-    nThreads = nthr > workAmount ? workAmount : nthr;
+    nThreads = m_threads_num > workAmount ? workAmount : m_threads_num;
 
     if (params.isOptimized) {
         indicesCalculationForOptimized();

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -122,6 +122,7 @@ private:
         size_t workAmount = 0lu;
         size_t lastDstDim = 0lu;
         size_t srcShift = 0lu;
+        size_t m_threads_num = 0lu;
     };
     using executorPtr = std::shared_ptr<StridedSliceExecutor>;
     executorPtr execPtr = nullptr;


### PR DESCRIPTION
### Details:
 - *Function `parallel_get_max_threads()` may returns ether core number or threads number. That can affect buffers access which size depends on threads number.*
 - *...*

### Tickets:
 - *152606*
