### PR TITLE
[PyOV] Remove `py` package

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -9,7 +9,6 @@ pytest-timeout==2.3.1
 
 # Python bindings
 build<1.3
-py>=1.9.0
 pygments>=2.8.1
 setuptools>=65.6.1,<75.3.0
 sympy>=1.10

--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -30,7 +30,6 @@ pytest-forked; sys_platform != 'win32'
 pytest-xdist
 pytest-html
 pytest
-py
 radon
 retrying
 tox

--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -14,6 +14,5 @@ coverage>=4.4.2,<=7.0.5
 astroid>=2.9.0
 pylint>=2.7.0
 pyenchant>=3.0.0
-py>=1.9.0
 urllib3>=1.26.4
 openvino-telemetry>=2023.2.1

--- a/tools/mo/requirements_dev.txt
+++ b/tools/mo/requirements_dev.txt
@@ -6,5 +6,4 @@ pyenchant
 defusedxml
 requests
 pytest
-py
 fastjsonschema


### PR DESCRIPTION
### Details:
 - `py` package has a high CVE on it
 - it's also in maintenance mode
 - there are seemingly no usages of that package in the codebase, so it can be dropped
 - let's wait for CI results to confirm

### Tickets:
 - CVS-156002
