### PR TITLE
[RV64] Disabled multi-stream mode when SHL is used

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -421,6 +421,13 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
         streamsChanged = true;
     }
 
+#if defined(OV_CPU_WITH_SHL)
+    // TODO: multi-stream execution is unsafe when SHL is used:
+    //       The library uses global static variables as flags and counters.
+    streams = 1;
+    streamsChanged = true;
+#endif
+
     this->modelType = modelType;
 
     CPU_DEBUG_CAP_ENABLE(applyDebugCapsProperties());


### PR DESCRIPTION
### Details:
 - *SHL library uses static global variables as flags and counters. It means that multi-stream execution can be unsafe when SHL is used - there can be data racing. The PR manually sets `streams = 1` to avoid possible functional issues in tput scenario with using SHL*

### Tickets:
 - *N/A*
