### PR TITLE
Build yaml-cpp statically

### DIFF
--- a/src/plugins/intel_npu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_npu/thirdparty/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 #
 
 if(ENABLE_INTEL_NPU_PROTOPIPE)
+    set(YAML_BUILD_SHARED_LIBS OFF)
     add_subdirectory(yaml-cpp EXCLUDE_FROM_ALL)
     # NB: Suppress warnings in yaml-cpp
     if(SUGGEST_OVERRIDE_SUPPORTED)


### PR DESCRIPTION
### Details:
 - no need to build dynamic yaml-cpp library. Overlooked while moving it from npu project https://github.com/openvinotoolkit/npu_plugin/blob/develop/thirdparty/CMakeLists.txt#L27
 - before 
 ```
 Creating library C:/Users/mdoronin/work/openvino/bin/intel64/Release/yaml-cpp.lib and object C:/Users/mdoronin/work/openvino/bin/intel64/Release/yaml-cpp.exp
  yaml-cpp.vcxproj -> C:\Users\mdoronin\work\openvino\bin\intel64\Release\yaml-cpp.dll
 ```
- after 
```
yaml-cpp.vcxproj -> C:\Users\mdoronin\work\openvino\bin\intel64\Release\yaml-cpp.lib
```

### Tickets:
 - *ticket-id*
