### PR TITLE
[OVC] Fail with unsupported message when output argument is used for pytorch

### DIFF
--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
@@ -132,7 +132,7 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
         to_override_all_outputs = False
         if argv.output:
             _outputs = fe_output_user_data_repack(input_model, argv.output, moc_front_end.get_name())
-            assert len(_outputs) == 0, "output argument is not supported for PyTroch"
+            assert len(_outputs) == 0, "`output` argument is not supported for PyTorch"
         if to_override_all_inputs and to_override_all_outputs:
             input_model.extract_subgraph(iplaces, oplaces)
         elif to_override_all_inputs:

--- a/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
+++ b/tools/ovc/openvino/tools/ovc/moc_frontend/pipeline.py
@@ -126,16 +126,13 @@ def moc_pipeline(argv: argparse.Namespace, moc_front_end: FrontEnd):
                     res.append(p)
             return res
         iplaces = merge_inputs(model_inputs, iplaces)
-        # Currently this only work to reorder inputs/outputs
+        oplaces = []
+        # Currently this only work to reorder inputs
         to_override_all_inputs = check_places_are_same(model_inputs, [{"node": p} for p in iplaces])
         to_override_all_outputs = False
         if argv.output:
-            oplaces = []
             _outputs = fe_output_user_data_repack(input_model, argv.output, moc_front_end.get_name())
-            for out_desc in _outputs:
-                oplaces.append(out_desc["name"])
-            model_outputs = input_model.get_outputs()
-            to_override_all_outputs = check_places_are_same(model_outputs, [{"node": p} for p in oplaces])
+            assert len(_outputs) == 0, "output argument is not supported for PyTroch"
         if to_override_all_inputs and to_override_all_outputs:
             input_model.extract_subgraph(iplaces, oplaces)
         elif to_override_all_inputs:


### PR DESCRIPTION
### Details:
 - *`output` argument cannot be used for pytorch as it is unclear what behavior is expected in this case.*

### Tickets:
 - *#26457 *
