### PR TITLE
[CPU] Refactor memory control and allocation

### DIFF
--- a/src/inference/dev_api/openvino/runtime/memory_solver.hpp
+++ b/src/inference/dev_api/openvino/runtime/memory_solver.hpp
@@ -52,6 +52,7 @@ public:
     struct Box {
         /** Execution order index of first use. The data will be produced here. */
         int start;
+        // intel_cpu::GlobalExecutionIndex start;
 
         /**
          * The execution order index of last use. After that data will be released.
@@ -59,6 +60,7 @@ public:
          * end of execution.
          */
         int finish;
+        // intel_cpu::GlobalExecutionIndex finish;
 
         /** Size of data. In abstract unit of measure (byte, simd, cache line, ...) */
         int64_t size;

--- a/src/plugins/intel_cpu/src/allocation_context.hpp
+++ b/src/plugins/intel_cpu/src/allocation_context.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace ov {
+namespace intel_cpu {
+
+class Node;
+class Edge;
+
+using GlobalExecutionIndex = std::unordered_map<std::shared_ptr<Node>, std::pair<int, int>>;
+
+struct AllocationContext {
+    std::vector<std::shared_ptr<Edge>> edges;
+    GlobalExecutionIndex execIndex;
+    std::vector<size_t> syncPoints;
+};
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -18,6 +19,8 @@
 
 namespace ov {
 namespace intel_cpu {
+
+class NetworkMemoryControl;
 
 class CompiledModel : public ov::ICompiledModel {
 public:
@@ -50,6 +53,10 @@ public:
     };
 
     void release_memory() override;
+
+    std::shared_ptr<NetworkMemoryControl> get_network_memory_control() const {
+        return m_networkMemoryControl;
+    }
 
 private:
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
@@ -91,6 +98,7 @@ private:
 
     std::vector<std::shared_ptr<CompiledModel>> m_sub_compiled_models;
     std::shared_ptr<SubMemoryManager> m_sub_memory_manager = nullptr;
+    std::shared_ptr<NetworkMemoryControl> m_networkMemoryControl = nullptr;
     bool m_has_sub_compiled_models = false;
 };
 

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -28,11 +28,11 @@ public:
          int pr_port = 0, int ch_port = 0);
 
     enum class Status {
-        Uninitialized,
-        NeedAllocation,
-        NotAllocated,
-        Allocated,
-        Validated
+        Uninitialized,  // base edge is unknown yet
+        NeedAllocation, // edge is the base edge
+        NotAllocated,   // edge is a referencing edge
+        Allocated,      // edge memory is allocated
+        Validated       // edge is validated
     };
 
     enum class ReorderStatus {
@@ -82,6 +82,7 @@ public:
     }
 
     std::string name() const;
+    const MemoryDesc& getDesc() const;
 
 private:
     std::weak_ptr<Node> parent;
@@ -99,7 +100,6 @@ private:
     PortDescBaseCPtr getInputPortDesc() const;
     PortDescBaseCPtr getOutputPortDesc() const;
 
-    const MemoryDesc& getDesc() const;
     bool enforceReorder();
 
     void collectConsumers(std::vector<std::shared_ptr<Node>>& result) const;

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include "dnnl_types.h"
 #include "graph_context.h"
 #include "nodes/memory.hpp"
 #include "memory_control.hpp"
@@ -12,15 +11,20 @@ namespace intel_cpu {
 GraphContext::GraphContext(const Config& config,
                            WeightsSharing::Ptr w_cache,
                            bool isGraphQuantized,
+                           MemoryControl* memoryControl,
+                           std::shared_ptr<NetworkMemoryControl> networkMemoryControl,
                            ov::threading::IStreamsExecutor::Ptr streamExecutor,
-                           std::shared_ptr<SubMemoryManager> sub_memory_manager)
+                           std::shared_ptr<SubMemoryManager> sub_memory_manager,
+                           bool globalMemoryReuse)
     : config(config),
       weightsCache(std::move(w_cache)),
       isGraphQuantizedFlag(isGraphQuantized),
       streamExecutor(streamExecutor),
       subMemoryManager(sub_memory_manager),
       memoryStatesRegister(std::make_shared<node::MemoryStatesRegister>()),
-      networkMemoryControl(std::make_shared<NetworkMemoryControl>()) {
+      memoryControl(memoryControl),
+      networkMemoryControl(networkMemoryControl),
+      m_globalMemoryReuse(globalMemoryReuse) {
     rtParamsCache = std::make_shared<MultiCache>(config.rtCacheCapacity);
     // primitive/executors can be shared across sub-stream
     // but scratch pad cannot be shared.

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -243,7 +243,6 @@ void serializeToXML(const Graph &graph, const std::string& path) {
 
 void serializeToCout(const Graph &graph) {
     for (const auto& node : graph.GetNodes()) {
-        std::cout << "name: " << node->getName() << " [ ";
         auto nodeDesc = node->getSelectedPrimitiveDescriptor();
         if (nodeDesc) {
             auto& inConfs = nodeDesc->getConfig().inConfs;

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -19,6 +19,7 @@
 #include "utils/general_utils.h"
 #include "utils/ngraph_utils.hpp"
 #include "openvino/runtime/threading/cpu_message.hpp"
+#include "memory_control.hpp"
 
 using OvString = ov::element_type_traits<ov::element::string>::value_type;
 
@@ -134,6 +135,15 @@ void SyncInferRequest::infer() {
     }
 
     push_input_data();
+
+    MemoryControl* network_memory_control = m_graph->getGraphContext()->getMemoryControl();
+    if (!network_memory_control) {
+        OPENVINO_THROW("Memory control unit is not initilized for graph: ", m_graph->GetName());
+    }
+
+    if (!network_memory_control->allocated()) {
+        network_memory_control->allocateMemory();
+    }
 
     m_graph->Infer(this);
 

--- a/src/plugins/intel_cpu/src/memory_control.cpp
+++ b/src/plugins/intel_cpu/src/memory_control.cpp
@@ -4,10 +4,15 @@
 
 #include "memory_control.hpp"
 
+#include <cstddef>
+#include <new>
 #include <ov_optional.hpp>
 
+#include "edge.h"
 #include "node.h"
 #include "openvino/runtime/memory_solver.hpp"
+#include "proxy_mem_blk.h"
+#include "utils/general_utils.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -84,8 +89,8 @@ private:
 class IMemoryManager {
 public:
     virtual ~IMemoryManager() = default;
-    virtual void insert(const MemoryRegion& reg) = 0;
-    virtual const MemoryControl::MemoryBlockMap& lastSolution() = 0;
+    virtual void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) = 0;
+    virtual const MemoryControl::MemorySolution& lastSolution() = 0;
     virtual void allocate() = 0;
     virtual void release() = 0;
 };
@@ -99,11 +104,12 @@ std::shared_ptr<DnnlMemoryBlock> makeDnnlMemoryBlock(Args&&... args) {
 
 class MemoryManagerIO : public IMemoryManager {
 public:
-    void insert(const MemoryRegion& reg) override {
+    void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) override {
+        (void) syncInds;
         m_blocks.insert({reg.id, makeDnnlMemoryBlock<MemoryBlockWithReuse>()});
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() override {
+    const MemoryControl::MemorySolution& lastSolution() override {
         return m_blocks;
     }
 
@@ -115,16 +121,17 @@ public:
     }
 
 private:
-    MemoryControl::MemoryBlockMap m_blocks;
+    MemoryControl::MemorySolution m_blocks;
 };
 
 class MemoryManagerStatic : public IMemoryManager {
 public:
-    void insert(const MemoryRegion& reg) override {
+    void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) override {
+        (void) syncInds;
         m_boxes.emplace_back(MemorySolver::Box{reg.start, reg.finish, reg.size, reg.id});
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() override {
+    const MemoryControl::MemorySolution& lastSolution() override {
         if (!m_boxes.empty() && m_blocks.empty()) {
             solve();
         }
@@ -159,7 +166,7 @@ private:
     }
 
 private:
-    MemoryControl::MemoryBlockMap m_blocks;
+    MemoryControl::MemorySolution m_blocks;
     std::vector<MemorySolver::Box> m_boxes;
     std::shared_ptr<MemoryBlockWithRelease> m_workspace;
     size_t m_totalSize = 0;
@@ -167,19 +174,18 @@ private:
 
 class MemoryManageNonOverlapingSets : public IMemoryManager {
 public:
-    MemoryManageNonOverlapingSets(std::vector<size_t> syncInds) : m_syncInds(std::move(syncInds)) {}
-    void insert(const MemoryRegion& reg) override {
+    void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) override {
         MemorySolver::Box box = {reg.start, reg.finish, reg.size, reg.id};
         if (-1 != reg.finish) {
             //We have to extend the lifespan of tensors that are crossing a sync point border in order to save
             //the intermediate computation results from possible loss due to the tensor resize
             auto itr_upper =
-                std::upper_bound(m_syncInds.begin(), m_syncInds.end(), box.finish, [](int y, int x) {
+                std::upper_bound(syncInds.begin(), syncInds.end(), box.finish, [](int y, int x) {
                     return y <= x;
                 });
-            auto itr_lower = std::lower_bound(m_syncInds.begin(), m_syncInds.end(), box.start);
+            auto itr_lower = std::lower_bound(syncInds.begin(), syncInds.end(), box.start);
             if (itr_lower != itr_upper) { // across sections
-                if (itr_upper == m_syncInds.end()) {
+                if (itr_upper == syncInds.end()) {
                     box.finish = -1;
                 } else {
                     box.finish = *itr_upper;
@@ -189,10 +195,10 @@ public:
         m_boxes.emplace_back(std::move(box));
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() override {
+    const MemoryControl::MemorySolution& lastSolution() override {
         if (!m_boxes.empty() && m_blocks.empty()) {
             solve();
-            m_blocks = MemoryControl::MemoryBlockMap{m_internalBlocks.begin(), m_internalBlocks.end()};
+            m_blocks = MemoryControl::MemorySolution{m_internalBlocks.begin(), m_internalBlocks.end()};
         }
         return m_blocks;
     }
@@ -238,11 +244,10 @@ private:
     }
 
 private:
-    MemoryControl::MemoryBlockMap m_blocks;
-    std::unordered_map<MemoryControl::MemoryBlockMap::key_type, std::shared_ptr<MemoryBlockWithRelease>>
+    MemoryControl::MemorySolution m_blocks;
+    std::unordered_map<MemoryControl::MemorySolution::key_type, std::shared_ptr<MemoryBlockWithRelease>>
         m_internalBlocks;
     std::vector<MemorySolver::Box> m_boxes;
-    std::vector<size_t> m_syncInds;
 };
 
 }  // namespace
@@ -256,16 +261,16 @@ public:
         : m_cond(std::move(cond)),
           m_memManager(std::move(memManager)) {}
 
-    bool insert(const MemoryRegion& reg) {
+    bool insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) {
         if (!m_cond(reg)) {
             return false;
         }
 
-        m_memManager->insert(reg);
+        m_memManager->insert(reg, syncInds);
         return true;
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() const {
+    const MemoryControl::MemorySolution& lastSolution() const {
         return m_memManager->lastSolution();
     }
 
@@ -292,9 +297,8 @@ MemoryControl::RegionHandlerPtr buildHandler(F&& f, Args&&... args) {
 
 }  // namespace
 
-MemoryControl::MemoryControl(std::vector<size_t> syncInds) {
+MemoryControl::MemoryControl() {
     // init handlers
-
     // handler for dynamic tensors
     m_handlers.emplace_back(buildHandler<MemoryManagerStatic>([](const MemoryRegion& reg) {
         if (reg.size < 0 || MemoryRegion::RegionType::VARIABLE != reg.type ||
@@ -311,7 +315,7 @@ MemoryControl::MemoryControl(std::vector<size_t> syncInds) {
             return false;
         }
         return true;
-    }, std::move(syncInds)));
+    }));
 
     //handler for I/O tensors, so far simply individual blocks
     m_handlers.emplace_back(buildHandler<MemoryManagerIO>([](const MemoryRegion& reg) {
@@ -322,22 +326,24 @@ MemoryControl::MemoryControl(std::vector<size_t> syncInds) {
     }));
 }
 
-void MemoryControl::insert(const MemoryRegion& region) {
+void MemoryControl::insert(const MemoryRegion& region, const std::vector<size_t>& syncInds) {
     for (auto&& handler : m_handlers) {
-        if (handler->insert(region)) {
+        if (handler->insert(region, syncInds)) {
             return;
         }
     }
     OPENVINO_THROW("No suitable hanlder was found for the given memory region");
 }
 
-MemoryControl::MemoryBlockMap MemoryControl::insert(const std::vector<MemoryRegion>& regions) {
+void MemoryControl::insert(const std::vector<MemoryRegion>& regions,
+                           const std::vector<size_t>& syncInds) {
     for (auto&& region : regions) {
-        insert(region);
+        insert(region, syncInds);
     }
+}
 
-    MemoryControl::MemoryBlockMap blocksMap;
-    blocksMap.reserve(regions.size());
+MemoryControl::MemorySolution MemoryControl::solve() {
+    MemoryControl::MemorySolution blocksMap;
 
     for (auto&& handler : m_handlers) {
         auto&& solution = handler->lastSolution();
@@ -364,52 +370,9 @@ void MemoryControl::releaseMemory() {
     m_allocated = false;
 }
 
-edgeClusters MemoryControl::findEdgeClusters(const std::vector<EdgePtr>& graphEdges) {
-    typedef std::unordered_map<EdgePtr, size_t> edge_cluster_idx_map_t;
-
-    edgeClusters edge_clusters;
-    edge_cluster_idx_map_t edge_cluster_indices;
-
-    for (auto& edge : graphEdges) {
-        auto edge_it = edge_cluster_indices.find(edge);
-        if (edge_it != edge_cluster_indices.end())
-            continue;  // edge is visited
-
-        size_t cluster_idx = edge_clusters.size();
-        EdgePtr last_shared_edge = nullptr;
-
-        // find cluster index
-        for (auto shared_edge = edge->getSharedEdge(std::nothrow); shared_edge;
-             shared_edge = shared_edge->getSharedEdge(std::nothrow)) {
-            auto shared_edge_it = edge_cluster_indices.find(shared_edge);
-            if (shared_edge_it != edge_cluster_indices.end()) {
-                cluster_idx = shared_edge_it->second;
-                last_shared_edge = shared_edge;
-                break;
-            }
-        }
-
-        // add shared edges to cluster
-        edge_cluster_indices.emplace(edge, cluster_idx);
-
-        if (cluster_idx == edge_clusters.size())
-            edge_clusters.emplace_back(edgeCluster{edge});
-        else
-            edge_clusters[cluster_idx].emplace(edge);
-
-        for (auto shared_edge = edge->getSharedEdge(std::nothrow); shared_edge != last_shared_edge;
-             shared_edge = shared_edge->getSharedEdge(std::nothrow)) {
-            edge_cluster_indices.emplace(shared_edge, cluster_idx);
-            edge_clusters[cluster_idx].emplace(shared_edge);
-        }
-    }
-
-    return edge_clusters;
-}
-
-MemoryControl& NetworkMemoryControl::createMemoryControlUnit(std::vector<size_t> syncInds) {
-    m_controlUnits.emplace_back(std::unique_ptr<MemoryControl>(new MemoryControl(syncInds)));
-    return *(m_controlUnits.back());
+MemoryControl* NetworkMemoryControl::createMemoryControlUnit() {
+    m_controlUnits.emplace_back(std::unique_ptr<MemoryControl>(new MemoryControl()));
+    return m_controlUnits.back().get();
 }
 
 void NetworkMemoryControl::allocateMemory() {

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1152,6 +1152,10 @@ bool Node::isConstant() {
     return getConstantType() == ConstantType::Const;
 }
 
+bool Node::isConstantInput() {
+    return isConstant() && getType() == Type::Input;
+}
+
 void Node::updateConstantType() {
     if (constant == ConstantType::StrictNoConst)
         return;

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.h
@@ -17,6 +17,11 @@ public:
     void getSupportedDescriptors() override {};
     void initSupportedPrimitiveDescriptors() override;
 
+    bool canBeSkipped() const override {
+        const auto& spd = getSelectedPrimitiveDescriptor();
+        return spd->hasZeroInputDims() || spd->hasZeroOutputDims();
+    }
+
     // output shape can potentially be empty
     bool isExecutable() const override {
         return !hasEmptyInputTensors() && !hasEmptyOutputTensors();

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -180,6 +180,10 @@ bool Broadcast::needShapeInfer() const {
     return false;
 }
 
+bool Broadcast::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Broadcast::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/broadcast.h
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.h
@@ -24,6 +24,7 @@ public:
     void executeDynamicImpl(dnnl::stream strm) override;
     bool created() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -216,6 +216,10 @@ void Bucketize::prepareParams() {
         std::accumulate(input_tensor_dims.begin(), input_tensor_dims.end(), size_t(1), std::multiplies<size_t>());
 }
 
+bool Bucketize::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Bucketize::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/bucketize.h
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.h
@@ -24,6 +24,7 @@ public:
 
     void prepareParams() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/composite.h
+++ b/src/plugins/intel_cpu/src/nodes/composite.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
+#include <numeric>
 
 #include "graph.h"
 #include "node.h"
@@ -31,6 +33,10 @@ public:
         return false;
     }
 
+    bool canBeSkipped() const override {
+        return false;
+    }
+
     bool isExecutable() const override {
         return true;
     }
@@ -40,6 +46,8 @@ public:
     void createPrimitive() override;
     void execute(dnnl::stream) override;
     void executeDynamicImpl(dnnl::stream strm) override;
+
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
 
     const Graph& graph() const {
         return m_graph;

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -29,6 +29,10 @@ namespace {
     constexpr size_t channelAxis = 1lu;
 }
 
+bool Concat::canBeSkipped() const {
+    return isInPlace() || getSelectedPrimitiveDescriptor()->hasZeroOutputDims();
+}
+
 bool Concat::isExecutable() const {
     return !isInPlace() && !hasEmptyOutputTensors();
 }

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -27,6 +27,7 @@ public:
 
     ov::element::Type getRuntimePrecision() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
@@ -140,6 +140,10 @@ void EmbeddingBagOffset::executeDynamicImpl(dnnl::stream strm) {
     execute(strm);
 }
 
+bool EmbeddingBagOffset::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool EmbeddingBagOffset::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
@@ -20,6 +20,7 @@ public:
     void execute(dnnl::stream strm) override;
     bool created() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
@@ -107,6 +107,10 @@ void EmbeddingBagPacked::executeDynamicImpl(dnnl::stream strm) {
     execute(strm);
 }
 
+bool EmbeddingBagPacked::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool EmbeddingBagPacked::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
@@ -21,6 +21,7 @@ public:
     bool created() const override;
 
     bool isExecutable() const override;
+    bool canBeSkipped() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -138,6 +138,10 @@ void EmbeddingSegmentsSum::executeDynamicImpl(dnnl::stream strm) {
     execute(strm);
 }
 
+bool EmbeddingSegmentsSum::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool EmbeddingSegmentsSum::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
@@ -20,6 +20,7 @@ public:
     void execute(dnnl::stream strm) override;
     bool created() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -923,6 +923,10 @@ bool Gather::created() const {
     return getType() == Type::Gather;
 }
 
+bool Gather::canBeSkipped() const {
+    return isInPlace() || Node::canBeSkipped();
+}
+
 bool Gather::isExecutable() const {
     return !isInPlace() && Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -24,6 +24,7 @@ public:
     void createPrimitive() override;
     void execute(dnnl::stream strm) override;
     bool created() const override;
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void resolveInPlaceEdges(Edge::LOOK look) override;
 

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -25,6 +25,7 @@ public:
     void createPrimitive() override;
     bool created() const override;
     void execute(dnnl::stream strm) override;
+    bool canBeSkipped() const override { return false; }
     bool isExecutable() const override { return true; }
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -479,7 +479,8 @@ void Input::selectOptimalPrimitiveDescriptor() {
     supportedPrimitiveDescriptors.clear();
 
     // and just use parent memory descriptor for Output node to avoid reorders insertion
-    NodeConfig config({PortConfig(getParentOutputMemDesc(getParentEdgeAt(0)), BlockedMemoryDesc::FULL_MASK, 0)}, {});
+    int inPlacePort = m_isInPlace ? 0 : -1;
+    NodeConfig config({PortConfig(getParentOutputMemDesc(getParentEdgeAt(0)), BlockedMemoryDesc::FULL_MASK, inPlacePort)}, {});
 
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::unknown);
     selectPrimitiveDescriptorByIndex(0);
@@ -541,6 +542,37 @@ void Input::initSupportedPdFromMemDesc() {
     }
 
     supportedPrimitiveDescriptors.emplace_back(std::move(config), impl_desc_type::unknown);
+}
+
+void Input::resolveInPlaceEdges(Edge::LOOK look) {
+    if (!m_isInPlace)
+        return Node::resolveInPlaceEdges(look);
+
+    if (look & Edge::LOOK_UP) {
+        auto edges = getChildEdgesAtPort(0);
+        for (const auto& edge : edges) {
+            EdgePtr sharedEdge = edge;
+
+            while (sharedEdge->getSharedEdge(std::nothrow)) {
+                sharedEdge = sharedEdge->getSharedEdge(std::nothrow);
+            }
+
+            edge->reuse(sharedEdge->getMemoryPtr());
+        }
+    }
+
+    if (look & Edge::LOOK_DOWN) {
+        for (size_t i = 0; i < getParentEdges().size(); i++) {
+            auto edge = getParentEdgeAt(i);
+            EdgePtr sharedEdge = edge;
+
+            while (sharedEdge->getSharedEdge(std::nothrow)) {
+                sharedEdge = sharedEdge->getSharedEdge(std::nothrow);
+            }
+
+            edge->reuse(sharedEdge->getMemoryPtr());
+        }
+    }
 }
 
 }   // namespace node

--- a/src/plugins/intel_cpu/src/nodes/input.h
+++ b/src/plugins/intel_cpu/src/nodes/input.h
@@ -56,15 +56,16 @@ public:
     void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
     bool created() const override;
+    void resolveInPlaceEdges(Edge::LOOK look) override;
 
     void withMeanImage();
     MemoryCPtr getMemoryPtr() const;
 
     void execute(dnnl::stream strm) override {}
     void executeDynamicImpl(dnnl::stream strm) override {}
-    bool isExecutable() const override {
-        return false;
-    }
+
+    bool canBeSkipped() const override { return true; }
+    bool isExecutable() const override { return false; }
 
     bool needShapeInfer() const override { return false; }
     bool needPrepareParams() const override { return false; }

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -356,6 +356,10 @@ void Interaction::executeDynamicImpl(dnnl::stream strm) {
     execute(strm);
 }
 
+bool Interaction::canBeSkipped() const {
+    return false;
+}
+
 bool Interaction::isExecutable() const {
     return true;
 }

--- a/src/plugins/intel_cpu/src/nodes/interaction.h
+++ b/src/plugins/intel_cpu/src/nodes/interaction.h
@@ -50,6 +50,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(dnnl::stream strm) override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/lora.h
+++ b/src/plugins/intel_cpu/src/nodes/lora.h
@@ -23,6 +23,7 @@ public:
 
     void getSupportedDescriptors() override{};
     void selectOptimalPrimitiveDescriptor() override;
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
     void createPrimitive() override;
     void prepareParams() override;
     void execute(dnnl::stream) override;

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -708,6 +708,10 @@ const std::vector<impl_desc_type>& MatMul::getDefaultImplPriority() {
     return priorities;
 }
 
+bool MatMul::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroOutputDims();
+}
+
 bool MatMul::isExecutable() const {
     return !hasEmptyOutputTensors();
 }

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -43,6 +43,7 @@ public:
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
     bool canBeExecutedInInt8() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -287,6 +287,10 @@ void MatrixNms::prepareParams() {
     }
 }
 
+bool MatrixNms::canBeSkipped() const {
+    return !isDynamicNode() && Node::canBeSkipped();
+}
+
 bool MatrixNms::isExecutable() const {
     return isDynamicNode() || Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.h
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.h
@@ -29,6 +29,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(dnnl::stream strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -220,6 +220,10 @@ void MemoryOutputBase::assignState(MemStatePtr newState) {
     assignExtMemory(state->output_mem(), state->internal_desc());
 }
 
+bool MemoryOutputBase::canBeSkipped() const {
+    return false;
+}
+
 bool MemoryOutputBase::isExecutable() const {
     return true;
 }
@@ -469,6 +473,10 @@ void MemoryInputBase::registerOutputNode(MemoryOutputBase* node) {
 
 void MemoryInputBase::deregisterSibling(MemoryOutputBase* node) {
     if (node == outputNode) { outputNode = nullptr; }
+}
+
+bool MemoryInputBase::canBeSkipped() const {
+    return false;
 }
 
 bool MemoryInputBase::isExecutable() const {

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -64,6 +64,8 @@ public:
 
     void execute(dnnl::stream strm) override final; // NOLINT
     void executeDynamicImpl(dnnl::stream strm) override final; // NOLINT
+
+    bool canBeSkipped() const override final; // NOLINT
     bool isExecutable() const override final; // NOLINT
 
     void registerInputNode(MemoryInputBase* node);
@@ -142,6 +144,7 @@ public:
     void executeDynamicImpl(dnnl::stream strm) override final; // NOLINT
     bool needShapeInfer() const override { return false; }
     bool needPrepareParams() const override { return false; }
+    bool canBeSkipped() const override final; // NOLINT
     bool isExecutable() const override final; // NOLINT
 
     void registerOutputNode(MemoryOutputBase* node);

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -211,6 +211,10 @@ void MultiClassNms::prepareParams() {
     m_numBoxOffset.resize(m_numBatches);
 }
 
+bool MultiClassNms::canBeSkipped() const {
+    return !isDynamicNode() && Node::canBeSkipped();
+}
+
 bool MultiClassNms::isExecutable() const {
     return isDynamicNode() || Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -27,6 +27,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(dnnl::stream strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/multinomial.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.cpp
@@ -117,6 +117,11 @@ void Multinomial::prepareParams() {
     m_batches_samples_probs_count = m_output_elements_count * m_probs_count;
 }
 
+bool Multinomial::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(PROBS_PORT) ||
+        getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(NUM_SAMPLES_PORT);
+}
+
 bool Multinomial::isExecutable() const {
     return !isInputTensorAtPortEmpty(PROBS_PORT) && !isInputTensorAtPortEmpty(NUM_SAMPLES_PORT);
 }

--- a/src/plugins/intel_cpu/src/nodes/multinomial.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.hpp
@@ -30,6 +30,7 @@ public:
 
     void createPrimitive() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void execute(dnnl::stream strm) override;
     void executeDynamicImpl(dnnl::stream strm) override;

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -138,6 +138,10 @@ public:
         _desc = createPortDesc(desc, cmpMask);
     }
 
+    bool hasZeroDims() const {
+        return getMemDesc()->getShape().hasZeroDims();
+    }
+
 private:
     PortDescBasePtr createPortDesc(MemoryDescPtr desc, BlockedMemoryDesc::CmpMask cmpMask) {
         if (desc->getType() & Blocked)

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -900,6 +900,10 @@ void NonMaxSuppression::checkOutput(const Shape& shape, const std::string& name,
         THROW_CPU_NODE_ERR("has unsupported '", name, "' output 2nd dimension size: ", dim2str(shape.getDims()[1]));
 }
 
+bool NonMaxSuppression::canBeSkipped() const {
+    return !isDynamicNode() && Node::canBeSkipped();
+}
+
 bool NonMaxSuppression::isExecutable() const {
     return isDynamicNode() || Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
@@ -50,6 +50,7 @@ public:
         int suppress_begin_index;
     };
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     bool needShapeInfer() const override { return false; }

--- a/src/plugins/intel_cpu/src/nodes/non_zero.h
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.h
@@ -29,6 +29,7 @@ public:
     void executeDynamicImpl(dnnl::stream strm) override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override { return false; }
     bool isExecutable() const override { return true; }
 
 private:

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -912,6 +912,10 @@ void NormalizeL2::createPrimitive() {
     }
 }
 
+bool NormalizeL2::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool NormalizeL2::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -94,6 +94,7 @@ public:
     void prepareParams() override;
     void executeDynamicImpl(dnnl::stream strm) override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     enum class NormEpsMode {

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -201,6 +201,10 @@ void Pad::createPrimitive() {
     }
 }
 
+bool Pad::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
+}
+
 bool Pad::isExecutable() const {
     return !isOutputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -23,6 +23,7 @@ public:
 
     void prepareParams() override;
     bool needShapeInfer() const override;
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.h
@@ -22,10 +22,19 @@ public:
     bool created() const override {
         return getType() == Type::PagedAttention;
     }
+
+    // pastkv may have zero dimension
+    bool canBeSkipped() const override {
+        return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(1) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(2);
+    }
+
     // pastkv may have zero dimension
     bool isExecutable() const override {
         return !isInputTensorAtPortEmpty(0) && !isInputTensorAtPortEmpty(1) && !isInputTensorAtPortEmpty(2);
     }
+
     bool needPrepareParams() const override {
         return false;
     }

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -520,6 +520,10 @@ bool RandomUniform::needShapeInfer() const {
     return !m_const_inputs[SHAPE];
 }
 
+bool RandomUniform::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(SHAPE);
+}
+
 bool RandomUniform::isExecutable() const {
     return !isInputTensorAtPortEmpty(SHAPE);
 }

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
@@ -39,6 +39,7 @@ public:
 
     void executeDynamicImpl(dnnl::stream strm) override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     void createPrimitive() override;

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -2088,6 +2088,10 @@ void Reduce::initSupportedPrimitiveDescriptors() {
     }
 }
 
+bool Reduce::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(REDUCE_DATA);
+}
+
 bool Reduce::isExecutable() const {
     return !isInputTensorAtPortEmpty(REDUCE_DATA);
 }

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -102,6 +102,7 @@ public:
         return false;
     }
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -22,6 +22,7 @@ public:
 
     bool needShapeInfer() const override;
     bool needPrepareParams() const override { return false; }
+    bool canBeSkipped() const override { return false; }
     bool isExecutable() const override { return true; }
     void executeDynamicImpl(dnnl::stream strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -32,8 +32,12 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
+bool Reorder::canBeSkipped() const {
+    return isOptimized || Node::canBeSkipped();
+}
+
 bool Reorder::isExecutable() const {
-    return Node::isExecutable() && !isOptimized;
+    return !isOptimized && Node::isExecutable();
 }
 
 Reorder::Reorder(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context) :

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -23,6 +23,7 @@ public:
     bool created() const override;
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     void createPrimitive() override;

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -138,7 +138,7 @@ void Reshape::execute(dnnl::stream strm) {
     }
 }
 
-bool Reshape::isExecutable() const {
+bool Reshape::canBeSkipped() const {
     bool inPlaceEnabled = false;
     if (auto prim_desc = getSelectedPrimitiveDescriptor()) {
         auto& config = prim_desc->getConfig();
@@ -147,7 +147,11 @@ bool Reshape::isExecutable() const {
             inPlaceEnabled = true;
         }
     }
-    return !inPlaceEnabled;
+    return inPlaceEnabled;
+}
+
+bool Reshape::isExecutable() const {
+    return !canBeSkipped();
 }
 
 bool Reshape::created() const {

--- a/src/plugins/intel_cpu/src/nodes/reshape.h
+++ b/src/plugins/intel_cpu/src/nodes/reshape.h
@@ -18,6 +18,7 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     bool created() const override;
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     bool needShapeInfer() const override;

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.h
@@ -21,6 +21,12 @@ public:
     bool created() const override {
         return getType() == Type::ScaledDotProductAttention;
     }
+
+    bool canBeSkipped() const override {
+        return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(1) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(2);
+    }
     // pastkv may have zero dimension
     bool isExecutable() const override {
         return !isInputTensorAtPortEmpty(0) && !isInputTensorAtPortEmpty(1) && !isInputTensorAtPortEmpty(2);

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -53,6 +53,10 @@ bool ScatterUpdate::isSupportedOperation(const std::shared_ptr<const ov::Node>& 
     return true;
 }
 
+bool ScatterUpdate::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(DATA_ID);
+}
+
 bool ScatterUpdate::isExecutable() const {
     return !isInputTensorAtPortEmpty(DATA_ID);
 }

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.h
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.h
@@ -92,6 +92,7 @@ public:
     bool needPrepareParams() const override;
     void executeDynamicImpl(dnnl::stream strm) override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -79,10 +79,6 @@ void ShapeOf::initOptimalPrimitiveDescriptor() {
     selected_pd->setConfig(config);
 }
 
-bool ShapeOf::isExecutable() const {
-    return true;
-}
-
 void ShapeOf::execute(dnnl::stream strm) {
     auto inPtr = getSrcMemoryAtPort(0);
     auto outPtr = getDstMemoryAtPort(0);

--- a/src/plugins/intel_cpu/src/nodes/shapeof.h
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.h
@@ -23,10 +23,11 @@ public:
     void initOptimalPrimitiveDescriptor() override;
     void execute(dnnl::stream strm) override;
     bool created() const override;
-    bool needPrepareParams() const override {return false;};
+    bool needPrepareParams() const override { return false; }
     void executeDynamicImpl(dnnl::stream strm) override { execute(strm); }
 
-    bool isExecutable() const override;
+    bool canBeSkipped() const override { return false; };
+    bool isExecutable() const override { return true; }
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -276,6 +276,10 @@ void Split::prepareParams() {
     }
 }
 
+bool Split::canBeSkipped() const {
+    return isInPlace() || getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Split::isExecutable() const {
     return !isInPlace() && !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -23,6 +23,7 @@ public:
 
     void initOptimalPrimitiveDescriptor() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     bool needPrepareParams() const override;

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -287,6 +287,11 @@ void StridedSlice::initSupportedPrimitiveDescriptors() {
     }
 }
 
+bool StridedSlice::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
+        getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
+}
+
 bool StridedSlice::isExecutable() const {
     return !isInputTensorAtPortEmpty(0) && !isOutputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -26,6 +26,7 @@ public:
         return false;
     }
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needShapeInfer() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -111,6 +111,7 @@ public:
     void createPrimitive() override;
     bool created() const override;
     void execute(dnnl::stream strm) override;
+    bool canBeSkipped() const override { return false; }
     bool isExecutable() const override { return true; }
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -125,8 +125,12 @@ void Transpose::initSupportedPrimitiveDescriptors() {
     }
 }
 
+bool Transpose::canBeSkipped() const {
+    return isOptimized || getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Transpose::isExecutable() const {
-    return !isInputTensorAtPortEmpty(0) && !isOptimized;
+    return !isOptimized && !isInputTensorAtPortEmpty(0);
 }
 
 bool Transpose::needPrepareParams() const {

--- a/src/plugins/intel_cpu/src/nodes/transpose.h
+++ b/src/plugins/intel_cpu/src/nodes/transpose.h
@@ -34,6 +34,7 @@ public:
         return order;
     }
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -521,7 +521,7 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
     Config::ModelType modelType = getModelType(model);
     conf.readProperties(config, modelType);
 
-    auto context = std::make_shared<GraphContext>(conf, fake_w_cache, false);
+    auto context = std::make_shared<GraphContext>(conf, fake_w_cache, false, nullptr, nullptr);
 
     auto supported = ov::get_supported_nodes(
         model,

--- a/src/plugins/intel_cpu/tests/functional/cmake/target_per_test.cmake
+++ b/src/plugins/intel_cpu/tests/functional/cmake/target_per_test.cmake
@@ -96,7 +96,8 @@ endif()
 endfunction()
 
 if(ENABLE_CPU_SPECIFIC_TARGET_PER_TEST)
-  create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/subgraph_tests/src ov_cpu_func_subgraph)
+    # create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/subgraph_tests/src ov_cpu_func_subgraph)
+  create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/subgraph_tests/src/common ov_cpu_func_subgraph)
   create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests ov_cpu_func_slt)
 endif()
 

--- a/src/plugins/intel_cpu/tests/unit/graph/inplace_resolve_io.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/inplace_resolve_io.cpp
@@ -6,6 +6,7 @@
 #include "dummy_node.hpp"
 #include "graph.h"
 
+#include "memory_control.hpp"
 #include "nodes/input.h"
 #include "nodes/concat.h"
 #include "nodes/rnn.h"
@@ -42,7 +43,11 @@ public:
     std::shared_ptr<Graph> create_graph(const std::vector<ov::PartialShape>& input_shapes, const size_t num_consumers = 1) {
         Config conf;
         conf.rtCacheCapacity = 100;
-        const auto context = std::make_shared<const GraphContext>(conf, nullptr, false);
+        const auto context = std::make_shared<const GraphContext>(conf,
+                                                                  nullptr,
+                                                                  false,
+                                                                  networkMemoryControl->createMemoryControlUnit(),
+                                                                  networkMemoryControl);
 
         std::shared_ptr<Graph> graph = std::shared_ptr<Graph>(new Graph());
 
@@ -88,6 +93,7 @@ private:
     std::vector<NodePtr> nodes;
     std::vector<EdgePtr> edges;
     std::unordered_set<NodePtr> nodesSet;
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };
 
 class RNNConcatCPUTest : public InplaceResolveIOCPUTestBase {

--- a/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
@@ -6,6 +6,7 @@
 #include "dummy_node.hpp"
 
 #include "graph.h"
+#include "memory_control.hpp"
 #include "nodes/memory.hpp"
 #include "nodes/softmax.h"
 #include "nodes/shapeof.h"
@@ -82,7 +83,8 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
         Config conf;
         conf.rtCacheCapacity = 0;
-        auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+        std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+        auto context = std::make_shared<GraphContext>(conf, nullptr, false, networkMemoryControl->createMemoryControlUnit(), networkMemoryControl);
 
         auto input_node = std::make_shared<node::Input>(param, context);
         auto memory_input = std::make_shared<node::MemoryInput>(read, context);
@@ -281,7 +283,12 @@ TEST(MemStateGraphTest, smoke_ShapeOf_no_Inplace_Conflicts) {
 
     Config conf;
     conf.rtCacheCapacity = 0;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context = std::make_shared<GraphContext>(conf,
+                                                  nullptr,
+                                                  false,
+                                                  networkMemoryControl->createMemoryControlUnit(),
+                                                  networkMemoryControl);
 
     auto input_node = std::make_shared<node::Input>(param, context);
     auto memory_input = std::make_shared<node::MemoryInput>(read, context);

--- a/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
@@ -9,6 +9,7 @@
 #include "common_test_utils/node_builders/constant.hpp"
 #include "dummy_node.hpp"
 #include "graph.h"
+#include "memory_control.hpp"
 #include "nodes/input.h"
 #include "nodes/reorder.h"
 #include "nodes/reshape.h"
@@ -76,7 +77,7 @@ protected:
                         "MergeTransposeReorderCPUTest doesn't support shape", shape,
                         ". Only 4D and 3D shapes are supported");
         Config conf;
-        m_context = std::make_shared<GraphContext>(conf, nullptr, false);
+        m_context = std::make_shared<GraphContext>(conf, nullptr, false, networkMemoryControl->createMemoryControlUnit(), networkMemoryControl);
         const auto replication_result = CreateModelAndReplicate(shape,
                                                                 params.firstNodeLayout,
                                                                 params.firstNodeInplaceDirection,
@@ -173,6 +174,7 @@ protected:
 
     std::shared_ptr<GraphContext> m_context;
     std::unique_ptr<Graph> m_graph;
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };  // class MergeTransposeReorderCPUTest
 
 /*
@@ -335,7 +337,8 @@ TEST(MergeTransposeReorder, smoke_InplaceConflict) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false, networkMemoryControl->createMemoryControlUnit(), networkMemoryControl);
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
 

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -5,6 +5,7 @@
 
 #include "dummy_node.hpp"
 #include "graph.h"
+#include "memory_control.hpp"
 #include "nodes/input.h"
 #include "nodes/concat.h"
 #include "openvino/op/concat.hpp"
@@ -43,7 +44,12 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context = std::make_shared<GraphContext>(conf,
+                                                  nullptr,
+                                                  false,
+                                                  networkMemoryControl->createMemoryControlUnit(),
+                                                  networkMemoryControl);
     const dnnl::engine cpuEngine = context->getEngine();
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
@@ -104,7 +110,8 @@ TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false, networkMemoryControl->createMemoryControlUnit(), networkMemoryControl);
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
 

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -14,6 +14,7 @@
 #include <dnnl.hpp>
 
 #include "common_test_utils/common_utils.hpp"
+#include "memory_control.hpp"
 #include "nodes/input.h"
 
 using namespace ov::intel_cpu;
@@ -108,7 +109,9 @@ public:
         conf.rtCacheCapacity = 100;
         auto context = std::make_shared<GraphContext>(conf,
                                                       std::make_shared<WeightsSharing>(),
-                                                      false);
+                                                      false,
+                                                      networkMemoryControl->createMemoryControlUnit(),
+                                                      networkMemoryControl);
         const dnnl::engine cpuEngine = context->getEngine();
 
         inputNode = std::make_shared<ov::intel_cpu::node::Input>(inputDesc.clone(),
@@ -152,6 +155,7 @@ protected:
     std::shared_ptr<ov::intel_cpu::Edge> parentEdge;
     std::shared_ptr<ov::intel_cpu::Edge> childEdge;
     ov::element::Type prec;
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };
 
 }// namespace ReorderCPUTest


### PR DESCRIPTION
### Details:
 - All the nested graphs are now can be a part of a global memory reuse logic
 - Code changes are required to enable global memory reuse for a node with a nested graph
 - LoRa and Composite nodes have been updated to support global memory reuse
 - Temporary property has been added to the GraphContext to propagate global memory reuse
   though the nesting levels. If a node does not support global memory reuse (i.e. If operation) then global memory reuse is disabled for all the nested graphs of than node).
   This allows to have both types of the nodes with a subgraph - the updated and not updated ones - at the same time in a single graph.

### Tickets:
 - *ticket-id*