### PR TITLE
[GPU] Init tensor.data when allocating inputs for string type

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -187,7 +187,6 @@ void fill_tensor_from_strings(ov::Tensor& tensor, py::array& array) {
     }
     py::buffer_info buf = array.request();
     auto data = tensor.data<std::string>();
-    std::cout << "fill_tensor_from_strings()" << std::endl;
     for (size_t i = 0; i < tensor.get_size(); ++i) {
         char* ptr = reinterpret_cast<char*>(buf.ptr) + (i * buf.itemsize);
         // TODO: check other unicode kinds? 2BYTE and 1BYTE?

--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -187,6 +187,7 @@ void fill_tensor_from_strings(ov::Tensor& tensor, py::array& array) {
     }
     py::buffer_info buf = array.request();
     auto data = tensor.data<std::string>();
+    std::cout << "fill_tensor_from_strings()" << std::endl;
     for (size_t i = 0; i < tensor.get_size(); ++i) {
         char* ptr = reinterpret_cast<char*>(buf.ptr) + (i * buf.itemsize);
         // TODO: check other unicode kinds? 2BYTE and 1BYTE?
@@ -194,10 +195,7 @@ void fill_tensor_from_strings(ov::Tensor& tensor, py::array& array) {
             PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, reinterpret_cast<void*>(ptr), buf.itemsize / 4);
         PyObject* _utf8_obj = PyUnicode_AsUTF8String(_unicode_obj);
         const char* _tmp_str = PyBytes_AsString(_utf8_obj);
-        std::string d(_tmp_str);
-        if (!d.empty()) {
-            data[i] = d;
-        }
+        data[i] = std::string(_tmp_str);
         Py_XDECREF(_unicode_obj);
         Py_XDECREF(_utf8_obj);
     }

--- a/src/bindings/python/src/pyopenvino/core/common.cpp
+++ b/src/bindings/python/src/pyopenvino/core/common.cpp
@@ -194,7 +194,10 @@ void fill_tensor_from_strings(ov::Tensor& tensor, py::array& array) {
             PyUnicode_FromKindAndData(PyUnicode_4BYTE_KIND, reinterpret_cast<void*>(ptr), buf.itemsize / 4);
         PyObject* _utf8_obj = PyUnicode_AsUTF8String(_unicode_obj);
         const char* _tmp_str = PyBytes_AsString(_utf8_obj);
-        data[i] = std::string(_tmp_str);
+        std::string d(_tmp_str);
+        if (!d.empty()) {
+            data[i] = d;
+        }
         Py_XDECREF(_unicode_obj);
         Py_XDECREF(_utf8_obj);
     }

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -595,10 +595,9 @@ void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, si
     if (element_type == ov::element::string) {
         // In case the element type is string and input data is an empty string,
         // it produces the segmentation fault unless the each element of tensor.data is initialized.
-        // So it needs to initialize tensor.data with '\0'.
         std::string* data = m_user_inputs.at(input_idx).ptr->data<std::string>();
         for (size_t i = 0; i < m_user_inputs.at(input_idx).ptr->get_size(); ++i) {
-            data[i] = '\0';
+            data->get_allocator().construct(data + i, std::string());
         }
     }
     ov::ISyncInferRequest::set_tensor(port, m_user_inputs.at(input_idx).ptr);

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -592,6 +592,12 @@ void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, si
     auto element_type = port.get_element_type();
 
     m_user_inputs[input_idx] = { create_host_tensor(shape, element_type), TensorOwner::PLUGIN };
+    if (element_type == ov::element::string) {
+        std::string* data = m_user_inputs.at(input_idx).ptr->data<std::string>();
+        for (size_t i = 0; i < m_user_inputs.at(input_idx).ptr->get_size(); ++i) {
+            data[i] = '\0';
+        }
+    }
     ov::ISyncInferRequest::set_tensor(port, m_user_inputs.at(input_idx).ptr);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -593,6 +593,9 @@ void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, si
 
     m_user_inputs[input_idx] = { create_host_tensor(shape, element_type), TensorOwner::PLUGIN };
     if (element_type == ov::element::string) {
+        // In case the element type is string and input data is an empty string,
+        // it produces the segmentation fault unless the each element of tensor.data is initialized.
+        // So it needs to initialize tensor.data with '\0'.
         std::string* data = m_user_inputs.at(input_idx).ptr->data<std::string>();
         for (size_t i = 0; i < m_user_inputs.at(input_idx).ptr->get_size(); ++i) {
             data[i] = '\0';

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -595,10 +595,8 @@ void SyncInferRequest::allocate_input(const ov::Output<const ov::Node>& port, si
     if (element_type == ov::element::string) {
         // In case the element type is string and input data is an empty string,
         // it produces the segmentation fault unless the each element of tensor.data is initialized.
-        std::string* data = m_user_inputs.at(input_idx).ptr->data<std::string>();
-        for (size_t i = 0; i < m_user_inputs.at(input_idx).ptr->get_size(); ++i) {
-            data->get_allocator().construct(data + i, std::string());
-        }
+        auto data = m_user_inputs.at(input_idx).ptr->data<std::string>();
+        std::uninitialized_fill_n(data, m_user_inputs.at(input_idx).ptr->get_size(), std::string());
     }
     ov::ISyncInferRequest::set_tensor(port, m_user_inputs.at(input_idx).ptr);
 }

--- a/tests/layer_tests/tensorflow_tests/test_tf_LookupTableSize.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_LookupTableSize.py
@@ -69,8 +69,6 @@ class TestLookupTableSizeOps(CommonTFLayerTest):
     def test_lookup_table_size(self, hash_table_type, params, ie_device, precision, ir_version, temp_dir,
                                use_legacy_frontend):
         keys_type = params['keys_type']
-        if ie_device == 'GPU' and keys_type == str:
-            pytest.skip("148921: Segmentation fault on GPU")
         self._test(*self.create_lookup_table_size_net(hash_table_type=hash_table_type, **params),
                    ie_device, precision, ir_version, temp_dir=temp_dir,
                    use_legacy_frontend=use_legacy_frontend)


### PR DESCRIPTION
### Details:
 - In case the element type is string produces the segmentation fault when input data is an empty string, unless the each element of tensor.data is initialized.

### Tickets:
 - 148921
