### PR TITLE
[intel-npu] Bugfix for total allocable memory property

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -171,19 +171,10 @@ uint64_t ZeroDevice::getTotalMemSize() const {
 
     // For drivers with graph_extension < 1.9 we report fixed 2GB max allocation size (old drivers don't support more)
     // For drivers with graph_extension > 1.9 we report the value they return
-    // Extra case for windows only: for graph_extension 1.8 need to convert driver value to bytes
-    if (_initStructs->isExtensionSupported(std::string("ZE_extension_graph_1_9"), ZE_MAKE_VERSION(1, 9))) {
+    if (_initStructs->isExtensionSupported(std::string(ZE_GRAPH_EXT_NAME), ZE_MAKE_VERSION(1, 9))) {
         // we are safe here, can return the value directly from driver
         return query.total;
-    }
-#if defined(_WIN32) || defined(__CYGWIN__)
-    else if (_initStructs->isExtensionSupported(std::string("ZE_extension_graph_1_8"), ZE_MAKE_VERSION(1, 8))) {
-        // special case for windows-only. It supports correct value from 1.8 but in incorrect unit
-        // need to convert driver value from KB to B
-        return query.total * 1024;  // KB to B -base2
-    }
-#endif  // _WIN32 || __CYGWIN__
-    else {
+    } else {
         // for all older drivers we return fixed 2GB (in bytes)
         return LEGACY_MAX_MEM_ALLOC_SIZE_BYTES;
     }

--- a/src/plugins/intel_npu/src/backend/src/zero_device.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_device.cpp
@@ -174,12 +174,9 @@ uint64_t ZeroDevice::getTotalMemSize() const {
     if (_initStructs->isExtensionSupported(std::string(ZE_GRAPH_EXT_NAME), ZE_MAKE_VERSION(1, 9))) {
         // we are safe here, can return the value directly from driver
         return query.total;
-    } else {
-        // for all older drivers we return fixed 2GB (in bytes)
-        return LEGACY_MAX_MEM_ALLOC_SIZE_BYTES;
     }
 
-    // Default: return 2GB
+    // Default for older drivers: return 2GB
     return LEGACY_MAX_MEM_ALLOC_SIZE_BYTES;
 }
 


### PR DESCRIPTION
### Details:
 - Bugfix in zero_device to return correct maximum allocable memory size in NPU_DEVICE_TOTAL_MEM_SIZE property.
 - For old drivers we return hardcoded 2GB value (compiler limitation)
 - For graph_ext 1.8 windows drivers we just convert KB to B
 - For graph_ext >1.9 drivers we return values from driver as is

### Tickets:
 - *EISW-143246*
