### PR TITLE
[CPU] Disable parallel UpdateShapes/PrepairParams processing if there are many sync nodes

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -385,12 +385,6 @@ void Graph::Activate(const std::vector<MemoryPtr>& externalInputMemory,
     } else {
         status = Status::ReadyStatic;
     }
-
-    // std::cout << "Graph '" << GetName() << "' has status : "
-    //           << (status == Status::ReadyStatic ? "ReadyStatic"
-    //                                             : (status == Status::ReadyDynamic ? "ReadyDynamic" : "ReadyDynamicSeq"))
-    //           << std::endl;
-
     CPU_DEBUG_CAP_ENABLE(serialize(*this));
 }
 


### PR DESCRIPTION
### Details:
If there are too many sync nodes in a model, it's not beneficial to run UpdateShapes and PrepairParams stages in parallel as the parallel tasks spawning/synchronization overheads outweigh the performance gain of the parallel execution. As a quantitative characteristic that defines the boundary between parallel and sequential node processing strategy, we use the ratio between the total number of nodes and the number of synchronous nodes.

### Tickets:
- CVS-153035
- CVS-155112
