### PR TITLE
[GHA] Use action_path in default smart ci config path

### DIFF
--- a/.github/actions/smart-ci/action.yml
+++ b/.github/actions/smart-ci/action.yml
@@ -30,7 +30,6 @@ inputs:
   components_config_schema:
     description: "Path to the schema file for components configuration"
     required: false
-    default: ".github/actions/smart-ci/components_schema.yml"
   labeler_config:
     description: "Path to labeler configuration file"
     required: false
@@ -101,7 +100,7 @@ runs:
           -f "${{ inputs.ref_name }}" \
           -p "${{ inputs.component_pattern }}" \
           -c "${{ inputs.components_config }}" \
-          -m "${{ inputs.components_config_schema }}" \
+          -m "${{ inputs.components_config_schema || env.DEFAULT_CONFIG_SCHEMA }}" \
           -l "${{ inputs.labeler_config }}" \
           --enable_for_org "${{ inputs.enable_for_org }}" \
           --skip-when-only-listed-labels-set "${{ inputs.skip_when_only_listed_labels_set }}" \
@@ -109,3 +108,4 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.repo_token }}
+        DEFAULT_CONFIG_SCHEMA: "${{ github.action_path }}/components_schema.yml"


### PR DESCRIPTION
For easier usage in 3rd-party repos