### PR TITLE
[GPU] Add per layer scaling for FC to fix accuracy issue regarding fp16 overflow

### DIFF
--- a/src/bindings/python/src/openvino/runtime/properties/hint/__init__.py
+++ b/src/bindings/python/src/openvino/runtime/properties/hint/__init__.py
@@ -23,3 +23,4 @@ from openvino._pyopenvino.properties.hint import model
 from openvino._pyopenvino.properties.hint import allow_auto_batching
 from openvino._pyopenvino.properties.hint import dynamic_quantization_group_size
 from openvino._pyopenvino.properties.hint import kv_cache_precision
+from openvino._pyopenvino.properties.hint import activations_scale_factor

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -101,6 +101,7 @@ void regmodule_properties(py::module m) {
     wrap_property_RW(m_hint, ov::hint::allow_auto_batching, "allow_auto_batching");
     wrap_property_RW(m_hint, ov::hint::dynamic_quantization_group_size, "dynamic_quantization_group_size");
     wrap_property_RW(m_hint, ov::hint::kv_cache_precision, "kv_cache_precision");
+    wrap_property_RW(m_hint, ov::hint::activations_scale_factor, "activations_scale_factor");
 
     // Submodule intel_cpu
     py::module m_intel_cpu =

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -336,6 +336,11 @@ def test_properties_ro(ov_property_ro, expected_value):
         ),
         (hints.kv_cache_precision, "KV_CACHE_PRECISION", ((Type.f32, Type.f32),)),
         (
+            hints.activations_scale_factor,
+            "ACTIVATIONS_SCALE_FACTOR",
+            ((0.0, 0.0),),
+        ),
+        (
             intel_cpu.denormals_optimization,
             "CPU_DENORMALS_OPTIMIZATION",
             ((True, True),),

--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -132,6 +132,12 @@ static constexpr Property<bool> enable_sdpa_optimization{"GPU_ENABLE_SDPA_OPTIMI
  * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
  */
 static constexpr Property<bool> enable_kernels_reuse{"GPU_ENABLE_KERNELS_REUSE"};
+
+/**
+ * @brief Turning on this property enables activation scaling.
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+static constexpr Property<bool> enable_activations_scaling{"GPU_ENABLE_ACTIVATIONS_SCALING"};
 }  // namespace hint
 
 /**

--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -132,12 +132,6 @@ static constexpr Property<bool> enable_sdpa_optimization{"GPU_ENABLE_SDPA_OPTIMI
  * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
  */
 static constexpr Property<bool> enable_kernels_reuse{"GPU_ENABLE_KERNELS_REUSE"};
-
-/**
- * @brief Turning on this property enables activation scaling.
- * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
- */
-static constexpr Property<bool> enable_activations_scaling{"GPU_ENABLE_ACTIVATIONS_SCALING"};
 }  // namespace hint
 
 /**

--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -580,6 +580,12 @@ static constexpr Property<uint64_t, PropertyMutability::RW> dynamic_quantization
  */
 static constexpr Property<element::Type, PropertyMutability::RW> kv_cache_precision{"KV_CACHE_PRECISION"};
 
+/**
+ * @brief This property scales down activations to prevent overflows when inference precision is f16.
+ * @ingroup ov_runtime_cpp_prop_api
+ */
+static constexpr Property<float, PropertyMutability::RW> activations_scale_factor{"ACTIVATIONS_SCALE_FACTOR"};
+
 }  // namespace hint
 
 /**

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -257,6 +257,7 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
             ov::PropertyName{ov::hint::num_requests.name(), PropertyMutability::RO},
             ov::PropertyName{ov::hint::inference_precision.name(), PropertyMutability::RO},
             ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RO},
+            ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RO},
             ov::PropertyName{ov::device::id.name(), PropertyMutability::RO},
             ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO},
         };

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -573,7 +573,6 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::intel_gpu::hint::queue_priority.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::queue_throttle.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::enable_sdpa_optimization.name(), PropertyMutability::RW},
-        ov::PropertyName{ov::intel_gpu::hint::enable_activations_scaling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RW},

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -573,6 +573,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::intel_gpu::hint::queue_priority.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::queue_throttle.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::hint::enable_sdpa_optimization.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::intel_gpu::hint::enable_activations_scaling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::enable_loop_unrolling.name(), PropertyMutability::RW},
         ov::PropertyName{ov::intel_gpu::disable_winograd_convolution.name(), PropertyMutability::RW},
         ov::PropertyName{ov::cache_dir.name(), PropertyMutability::RW},

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -540,6 +540,7 @@ std::vector<ov::PropertyName> Plugin::get_caching_properties() const {
         ov::PropertyName{ov::hint::execution_mode.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::performance_mode.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RW},
     };
 
     return caching_properties;
@@ -585,7 +586,8 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::hint::inference_precision.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::enable_cpu_pinning.name(), PropertyMutability::RW},
         ov::PropertyName{ov::device::id.name(), PropertyMutability::RW},
-        ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RW}
+        ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RW}
     };
 
     return supported_properties;

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.cpp
@@ -1,0 +1,71 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "fc_per_layer_scaling.hpp"
+
+#include "intel_gpu/op/fully_connected_compressed.hpp"
+#include "intel_gpu/op/placeholder.hpp"
+
+#include "openvino/op/multiply.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/pass/pattern/op/or.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+FullyConnectedPerLayerScaling::FullyConnectedPerLayerScaling() {
+    using namespace ov::pass::pattern;
+
+    auto data_m = any_input();
+    auto weights_m = any_input();
+    auto bias_m = any_input();
+    auto fc_compressed_wo_zp_m = wrap_type<op::FullyConnectedCompressed>({data_m, weights_m, bias_m, any_input()}, consumers_count(1));
+    auto fc_compressed_w_zp_m = wrap_type<op::FullyConnectedCompressed>({data_m, weights_m, bias_m, any_input(), any_input()}, consumers_count(1));
+    auto fc_compressed_m = std::make_shared<ov::pass::pattern::op::Or>(OutputVector{fc_compressed_wo_zp_m, fc_compressed_w_zp_m});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) {
+        auto fc = std::dynamic_pointer_cast<op::FullyConnectedCompressed>(m.get_match_root());
+        if (!fc || transformation_callback(fc))
+            return false;
+
+        const auto& pattern_map = m.get_pattern_value_map();
+        const auto& data = pattern_map.at(data_m).get_node_shared_ptr();
+        const auto& bias = pattern_map.at(bias_m).get_node_shared_ptr();
+
+        const float scale_factor = 2.f;
+
+        ov::Shape scale_const_shape = {1};
+        std::vector<float> scale_down_value = {(1.f / scale_factor)};
+        std::vector<float> scale_up_value = {scale_factor};
+        std::shared_ptr<ov::Node> scale_down_const_f16 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, scale_const_shape, scale_down_value);
+        std::shared_ptr<ov::Node> scale_down_const_f32 = std::make_shared<ov::op::v0::Constant>(ov::element::f32, scale_const_shape, scale_down_value);
+        std::shared_ptr<ov::Node> scale_up_const_f16 = std::make_shared<ov::op::v0::Constant>(ov::element::f16, scale_const_shape, scale_up_value);
+        std::shared_ptr<ov::Node> scale_up_const_f32 = std::make_shared<ov::op::v0::Constant>(ov::element::f32, scale_const_shape, scale_up_value);
+
+        std::shared_ptr<ov::Node> scale_down_const = (data->get_element_type() == ov::element::f16) ? scale_down_const_f16 : scale_down_const_f32;
+        auto scale_down = std::make_shared<ov::op::v1::Multiply>(data, scale_down_const);
+        fc->input(0).replace_source_output(scale_down->output(0));
+
+        if (!std::dynamic_pointer_cast<op::Placeholder>(bias)) {
+            std::shared_ptr<ov::Node> bias_scale_down_const = (bias->get_element_type() == ov::element::f16) ? scale_down_const_f16 : scale_down_const_f32;
+            auto bias_scale_down = std::make_shared<ov::op::v1::Multiply>(bias, bias_scale_down_const);
+            fc->input(2).replace_source_output(bias_scale_down->output(0));
+        }
+
+        std::shared_ptr<ov::Node> scale_up_const = (fc->get_element_type() == ov::element::f16) ? scale_up_const_f16 : scale_up_const_f32;
+        auto scale_up = std::make_shared<ov::op::v1::Multiply>(fc, scale_up_const);
+        ov::replace_node(fc, scale_up);
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(fc_compressed_m, "FullyConnectedPerLayerScaling");
+    this->register_matcher(m, callback);
+}
+
+}  // namespace intel_gpu
+}  // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.hpp
@@ -1,0 +1,19 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov {
+namespace intel_gpu {
+
+class FullyConnectedPerLayerScaling: public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("FullyConnectedPerLayerScaling", "0");
+    FullyConnectedPerLayerScaling();
+};
+
+}   // namespace intel_gpu
+}   // namespace ov

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_per_layer_scaling.hpp
@@ -12,7 +12,7 @@ namespace intel_gpu {
 class FullyConnectedPerLayerScaling: public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("FullyConnectedPerLayerScaling", "0");
-    FullyConnectedPerLayerScaling();
+    FullyConnectedPerLayerScaling(float scale_factor);
 };
 
 }   // namespace intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -880,8 +880,13 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
-        if (config.get_property(ov::intel_gpu::hint::enable_activations_scaling))
-            manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
+        bool enable_activations_scaling = false;
+        auto activations_scale_factor = config.get_property(ov::hint::activations_scale_factor);
+        if (!(activations_scale_factor == 0.f || activations_scale_factor == 1.f)) {
+            enable_activations_scaling = true;
+        }
+        if (enable_activations_scaling)
+            manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(activations_scale_factor);
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -71,6 +71,7 @@
 #include "plugin/transformations/move_fc_reshape_to_weights.hpp"
 #include "plugin/transformations/bcast_and_pad_zp_buffers.hpp"
 #include "plugin/transformations/print_model_statistics.hpp"
+#include "plugin/transformations/fc_per_layer_scaling.hpp"
 #include "plugin/transformations/swiglu_fusion.hpp"
 #include "plugin/transformations/transpose_fusion.hpp"
 #include "plugin/transformations/indirect_kv_cache.hpp"
@@ -879,6 +880,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
+        manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>();
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -880,7 +880,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
-        manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>();
+        if (config.get_property(ov::intel_gpu::hint::enable_activations_scaling))
+            manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -880,13 +880,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
-        bool enable_activations_scaling = false;
-        auto activations_scale_factor = config.get_property(ov::hint::activations_scale_factor);
-        if (!(activations_scale_factor == 0.f || activations_scale_factor == 1.f)) {
-            enable_activations_scaling = true;
-        }
-        if (enable_activations_scaling)
-            manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(activations_scale_factor);
+        manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -61,6 +61,8 @@ void ExecutionConfig::set_default() {
         std::make_tuple(ov::hint::kv_cache_precision, ov::element::undefined),
         std::make_tuple(ov::intel_gpu::hint::enable_kernels_reuse, false),
         std::make_tuple(ov::weights_path, ""),
+        std::make_tuple(ov::intel_gpu::hint::enable_activations_scaling, false),
+        std::make_tuple(ov::hint::activations_scale_factor, 0.f),
 
         // Legacy API properties
         std::make_tuple(ov::intel_gpu::nv12_two_inputs, false),

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -61,7 +61,6 @@ void ExecutionConfig::set_default() {
         std::make_tuple(ov::hint::kv_cache_precision, ov::element::undefined),
         std::make_tuple(ov::intel_gpu::hint::enable_kernels_reuse, false),
         std::make_tuple(ov::weights_path, ""),
-        std::make_tuple(ov::intel_gpu::hint::enable_activations_scaling, false),
         std::make_tuple(ov::hint::activations_scale_factor, 0.f),
 
         // Legacy API properties

--- a/src/plugins/intel_gpu/tests/unit/transformations/fc_per_layer_scaling_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fc_per_layer_scaling_test.cpp
@@ -1,0 +1,117 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+#include "common_test_utils/graph_comparator.hpp"
+#include "common_test_utils/ov_test_utils.hpp"
+
+#include <string>
+#include <memory>
+
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/pass/manager.hpp"
+
+#include <transformations/utils/utils.hpp>
+#include "plugin/transformations/fc_per_layer_scaling.hpp"
+#include "intel_gpu/op/placeholder.hpp"
+#include "intel_gpu/op/fully_connected_compressed.hpp"
+
+using namespace testing;
+using namespace ov::intel_gpu;
+
+namespace ov {
+namespace test {
+namespace intel_gpu {
+
+TEST_F(TransformationTestsF, FullyConnectedPerLayerScalingTest1) {
+    float scale_factor = 2.f;
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, no_bias, scale_const, zp_const);
+        auto convert = std::make_shared<ov::op::v0::Convert>(fc_compressed, ov::element::f32);
+        auto result = std::make_shared<ov::op::v0::Result>(convert);
+
+        model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+        manager.register_pass<FullyConnectedPerLayerScaling>(scale_factor);
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto scale_down_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1 }, { 1.f / scale_factor });
+        auto scale_down = std::make_shared<ov::op::v1::Multiply>(input, scale_down_const);
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(scale_down, weights_const, no_bias, scale_const, zp_const);
+        auto scale_up_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1 }, { scale_factor });
+        auto scale_up = std::make_shared<ov::op::v1::Multiply>(fc_compressed, scale_up_const);
+        auto convert = std::make_shared<ov::op::v0::Convert>(scale_up, ov::element::f32);
+        auto result = std::make_shared<ov::op::v0::Result>(convert);
+
+        model_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, FullyConnectedPerLayerScalingTest2) {
+    float scale_factor = 2.f;
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto bias = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{ 1, 32 });
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, bias, scale_const, zp_const);
+        auto convert = std::make_shared<ov::op::v0::Convert>(fc_compressed, ov::element::f32);
+        auto result = std::make_shared<ov::op::v0::Result>(convert);
+
+        model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+        manager.register_pass<FullyConnectedPerLayerScaling>(scale_factor);
+    }
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto bias = std::make_shared<ov::op::v0::Constant>(ov::element::f16, ov::Shape{ 1, 32 });
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto scale_down_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1 }, { 1.f / scale_factor });
+        auto scale_down = std::make_shared<ov::op::v1::Multiply>(input, scale_down_const);
+        auto bias_scale_down_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1 }, { 1.f / scale_factor });
+        auto bias_scale_down = std::make_shared<ov::op::v1::Multiply>(bias, scale_down_const);
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(scale_down, weights_const, bias_scale_down, scale_const, zp_const);
+        auto scale_up_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1 }, { scale_factor });
+        auto scale_up = std::make_shared<ov::op::v1::Multiply>(fc_compressed, scale_up_const);
+        auto convert = std::make_shared<ov::op::v0::Convert>(scale_up, ov::element::f32);
+        auto result = std::make_shared<ov::op::v0::Result>(convert);
+
+        model_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+        comparator.enable(FunctionsComparator::ATTRIBUTES);
+    }
+}
+
+TEST_F(TransformationTestsF, FullyConnectedPerLayerScalingTest3) {
+    {
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{ -1, 16 });
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 32, 16 }, { 1 });
+        auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
+        auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, no_bias, scale_const, zp_const);
+        auto convert = std::make_shared<ov::op::v0::Convert>(fc_compressed, ov::element::f32);
+        auto result = std::make_shared<ov::op::v0::Result>(convert);
+
+        model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
+        manager.register_pass<FullyConnectedPerLayerScaling>(1.f);
+    }
+}
+
+}  // namespace intel_gpu
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Fix LLM accuracy issue due to fp16 overflow when using decompression_post_opt in fully_connected_gpu_bf_tiled_opt kernel
 - In the fc kernel, to optimize grouped scale, we calculate acc first as mad of activation (fp16) * weight (int4) first , and then apply scale value. This can cause accuracy issue when only multiply of activation and weight overflows. 
 - In this case we can resolve the issue by applying scale down to the activation. 
 - Implement per layer scaling for FCs

### Tickets:
 - 154583
