### PR TITLE
[GPU] cache behavior fix for LLM models

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/program_builder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program_builder.cpp
@@ -308,7 +308,7 @@ void ProgramBuilder::add_primitive(const ov::Node& op, std::shared_ptr<cldnn::pr
     if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
         auto rt_info = op.get_rt_info();
         auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
-        if (weightless_cache_attr != rt_info.end()) {
+        if (weightless_cache_attr != rt_info.end() && !this->m_config.get_property(ov::weights_path).empty()) {
             data_prim->bin_offset = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().bin_offset;
             data_prim->original_size = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().original_size;
         }


### PR DESCRIPTION
### Details:
 - For LLM, model cache was not working as cache files were always removed 
 - It was happening because is_cache_without_weights was turned on while saving data,
    while is_cache_without_weights was turned off while loading data
 - So, is_cache_without_weights is turned off while saving data.

