### PR TITLE
fix assertion failed on lockable_mem when using devicemem 

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -776,7 +776,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_input(const std::string
     auto device_tensor_et = convert_to_supported_device_type(element_type);
     bool convert_needed = is_convert_required(element_type, device_tensor_et);
 
-    if (is_remote_tensor_impl && !need_lockable_mem) {
+    if (is_remote_tensor_impl) {
         if (convert_needed) {
             m_plugin_inputs[input_idx] = { create_device_tensor(pshape,
                                                                 cldnn::element_type_to_data_type(element_type),


### PR DESCRIPTION
### Details:
 - *The issue caused by the memory select of the input. In the changed behavior called locked memory ( by Shlypnikov, Sergey in #26123) will put the input into host memory if any the implementation of  its users is CPU.*
 - *when the input is set to "use_device_mem" by benchmark_app, the locked memory will ignore the memory, which will trigger the assertion failure.*
 - *fixed just ignore "need_lockable_mem" option in case of remote tensors, because the data could be cloned implicitly at attempt to access device buffer from the host side to have this copy*

### Tickets:
 - *CSV-152365*
