### PR TITLE
[Snippets] Fixed LoopManager::update_loop_ports

### DIFF
--- a/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_loops.hpp
@@ -25,7 +25,7 @@ public:
     bool run(LinearIR& linear_ir) override;
 
 private:
-    static void update_compile_parameters(const UnifiedLoopInfoPtr& loop_info, size_t loop_id);
+    static void update_compile_parameters(const UnifiedLoopInfoPtr& loop_info);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/lowered/pass/validate_unified_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/validate_unified_loops.hpp
@@ -6,6 +6,9 @@
 
 #include "pass.hpp"
 
+#include "snippets/lowered/loop_manager.hpp"
+
+
 namespace ov {
 namespace snippets {
 namespace lowered {
@@ -27,6 +30,10 @@ public:
     OPENVINO_RTTI("ValidateUnifiedLoops", "Pass")
     ValidateUnifiedLoops() = default;
     bool run(LinearIR& linear_ir) override;
+
+private:
+    static void validate_loop_infos(const LoopManagerPtr& loop_manager);
+    static void validate_loop_port_presence(const LinearIR& linear_ir);
 };
 
 } // namespace pass

--- a/src/common/snippets/include/snippets/utils/loop_utils.hpp
+++ b/src/common/snippets/include/snippets/utils/loop_utils.hpp
@@ -21,6 +21,12 @@ void update_data_pointer_shifts(const ov::snippets::lowered::UnifiedLoopInfoPtr&
  * @brief Updates work amount and updates data pointer shifts of the provided "loop_info"
  */
 void update_runtime_parameters(const ov::snippets::lowered::UnifiedLoopInfoPtr& loop_info);
+/**
+ * @brief Check if the passed expression port should be port of the Loop with ID `loop_id`:
+ *        the target expression port should be connected to an expression from another Loop (missed in the loop with ID `loop_id`),
+ */
+bool should_be_loop_port(const ov::snippets::lowered::ExpressionPort& port, size_t loop_id);
+
 } // namespace utils
 } // namespace snippets
 } // namespace ov

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -16,46 +16,10 @@ namespace lowered {
 namespace pass {
 
 namespace {
-inline void init_is_incremented(LoopPort& port, size_t loop_id) {
+inline void init_is_incremented(LoopPort& port) {
     const auto& expr = port.expr_port->get_expr();
-    const auto& expr_loops = expr->get_loop_ids();
     if (!std::dynamic_pointer_cast<modifier::MemoryAccess>(expr->get_node())) {
         port.is_incremented = false;
-    } else if (expr_loops.back() != loop_id) {
-        // Note: LoopPort connected to Buffer between two loops should not be incremented in the outermost loop
-        // Consider the example below:
-        //     Store; Loop ids [0,1,2,3]
-        //     Buffer; Loop ids [0,1]
-        //     Load; Loop ids [0,1,4,5]
-        // Store is output port of Loop-1, but it should be incremented only in Loop-2 and Loop-3. Similar with Load.
-        auto is_ignored = [=](const ExpressionPtr& target_expr) {
-            if (ov::is_type<BufferExpression>(target_expr)) {
-                const auto& target_loops = target_expr->get_loop_ids();
-                const auto i_max = std::min(expr_loops.size(), target_loops.size());
-                for (size_t i = 0; i < i_max && expr_loops[i] == target_loops[i]; i++) {
-                    if (target_loops[i] == loop_id)
-                        return true;
-                }
-            }
-            return false;
-        };
-        if (port.expr_port->get_type() == ExpressionPort::Type::Output) {
-            const auto& out_connector = expr->get_output_port_connector(port.expr_port->get_index());
-            for (const auto& consumer : out_connector->get_consumers()) {
-                if (is_ignored(consumer.get_expr())) {
-                    port.is_incremented = false;
-                    return;
-                }
-            }
-        } else if (port.expr_port->get_type() == ExpressionPort::Type::Input) {
-            const auto& in_connector = expr->get_input_port_connector(port.expr_port->get_index());
-            if (is_ignored(in_connector->get_source().get_expr())) {
-                port.is_incremented = false;
-                return;
-            }
-        } else {
-            OPENVINO_THROW("Unexpected LoopPort type");
-        }
     }
 }
 
@@ -71,11 +35,11 @@ inline int64_t get_data_size(const LoopPort& loop_port) {
 }
 }  // namespace
 
-void InitLoops::update_compile_parameters(const UnifiedLoopInfoPtr& loop_info, size_t loop_id) {
+void InitLoops::update_compile_parameters(const UnifiedLoopInfoPtr& loop_info) {
     OPENVINO_ASSERT(loop_info != nullptr, "UnifiedLoopInfo is nullptr, nothing to update");
     loop_info->iterate_through_infos(
-        [loop_id](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
-            init_is_incremented(loop_port, loop_id);
+        [](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
+            init_is_incremented(loop_port);
             ptr_shifts_params.data_size = get_data_size(loop_port);
         });
 }
@@ -85,12 +49,10 @@ bool InitLoops::run(LinearIR& linear_ir) {
     if (linear_ir.empty())
         return false;
 
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& loops = loop_manager->get_map();
+    const auto& loops = linear_ir.get_loop_manager()->get_map();
     for (const auto& loop : loops) {
-        const auto& loop_id = loop.first;
         const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop.second);
-        update_compile_parameters(loop_info, loop_id);
+        update_compile_parameters(loop_info);
         ov::snippets::utils::update_runtime_parameters(loop_info);
     }
 

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -7,6 +7,7 @@
 #include "snippets/itt.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include "snippets/lowered/loop_manager.hpp"
+#include "snippets/utils/loop_utils.hpp"
 #include "snippets/utils/utils.hpp"
 
 namespace ov {
@@ -14,14 +15,7 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 
-bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateUnifiedLoops")
-    if (linear_ir.empty())
-        return false;
-
-    const auto& loop_manager = linear_ir.get_loop_manager();
-    const auto& loops = loop_manager->get_map();
-
+void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manager) {
     // Already validated vectors of Loop IDs
     std::set<std::vector<size_t>> validated_nested_loops;
     auto is_already_verified = [&validated_nested_loops](const std::vector<size_t>& ids) {
@@ -66,10 +60,9 @@ bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
         validated_nested_loops.insert(loop_ids);
     };
 
-    for (const auto& pair : loops) {
+    for (const auto& pair : loop_manager->get_map()) {
         const auto& loop_info = ov::as_type_ptr<UnifiedLoopInfo>(pair.second);
-        OPENVINO_ASSERT(loop_info,
-                        "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
+        OPENVINO_ASSERT(loop_info, "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
         loop_info->iterate_through_ports(validate_loop_port);
 
         // Validate that iteration dimnsion is broadcastable
@@ -88,6 +81,45 @@ bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
         OPENVINO_ASSERT(unique_dimensions.size() <= 1,
                         "Loop ports have incompatible dimensions, by which the loop iterates");
     }
+}
+
+void ValidateUnifiedLoops::validate_loop_port_presence(const LinearIR& linear_ir) {
+    auto validate_loop_port = [](const ExpressionPort& expr_port, const LoopInfoPtr& loop_info, size_t loop_id) {
+#define VALIDATE_LOOP_PORT(check, txt) \
+    OPENVINO_ASSERT(check, "Expression port with idx ", expr_port.get_index(), " with node ", expr_port.get_expr()->get_node()->get_friendly_name(), txt);
+        if (utils::should_be_loop_port(expr_port, loop_id)) {
+            VALIDATE_LOOP_PORT(loop_info->is_loop_port(expr_port), " is not Loop port but should be!");
+        } else {
+            VALIDATE_LOOP_PORT(!loop_info->is_loop_port(expr_port), " is Loop port but should not be!");
+        }
+#undef VALIDATE_LOOP_PORT
+    };
+
+    const auto& loop_manager = linear_ir.get_loop_manager();
+    for (const auto& expr : linear_ir) {
+        const auto& op = expr->get_node();
+        if (ov::is_type<ov::snippets::op::LoopBase>(op))
+            continue;
+
+        for (const auto& loop_id : expr->get_loop_ids()) {
+            const auto& loop_info = loop_manager->get_loop_info(loop_id);
+
+            for (size_t i = 0; i < expr->get_input_count(); ++i)
+                validate_loop_port(expr->get_input_port(i), loop_info, loop_id);
+
+            for (size_t i = 0; i < expr->get_output_count(); ++i)
+                validate_loop_port(expr->get_output_port(i), loop_info, loop_id);
+        }
+    }
+}
+
+bool ValidateUnifiedLoops::run(LinearIR& linear_ir) {
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::ValidateUnifiedLoops")
+    if (linear_ir.empty())
+        return false;
+
+    validate_loop_infos(linear_ir.get_loop_manager());
+    validate_loop_port_presence(linear_ir);
 
     return true;
 }

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -85,14 +85,15 @@ void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manage
 
 void ValidateUnifiedLoops::validate_loop_port_presence(const LinearIR& linear_ir) {
     auto validate_loop_port = [](const ExpressionPort& expr_port, const LoopInfoPtr& loop_info, size_t loop_id) {
-#define VALIDATE_LOOP_PORT(check, txt) \
-    OPENVINO_ASSERT(check, "Expression port with idx ", expr_port.get_index(), " with node ", expr_port.get_expr()->get_node()->get_friendly_name(), txt);
         if (utils::should_be_loop_port(expr_port, loop_id)) {
-            VALIDATE_LOOP_PORT(loop_info->is_loop_port(expr_port), " is not Loop port but should be!");
+            OPENVINO_ASSERT(loop_info->is_loop_port(expr_port),
+                            "Expression port with idx ", expr_port.get_index(), " with node ",
+                            expr_port.get_expr()->get_node()->get_friendly_name(), " is not Loop port but should be!");
         } else {
-            VALIDATE_LOOP_PORT(!loop_info->is_loop_port(expr_port), " is Loop port but should not be!");
+            OPENVINO_ASSERT(!loop_info->is_loop_port(expr_port),
+                            "Expression port with idx ", expr_port.get_index(), " with node ",
+                            expr_port.get_expr()->get_node()->get_friendly_name(), " is Loop port but should not be!");
         }
-#undef VALIDATE_LOOP_PORT
     };
 
     const auto& loop_manager = linear_ir.get_loop_manager();

--- a/src/common/snippets/src/utils/loop_utils.cpp
+++ b/src/common/snippets/src/utils/loop_utils.cpp
@@ -82,6 +82,15 @@ void update_runtime_parameters(const UnifiedLoopInfoPtr& loop_info) {
     update_data_pointer_shifts(loop_info);
 }
 
+bool should_be_loop_port(const ov::snippets::lowered::ExpressionPort& port, size_t loop_id) {
+    const auto& connected_ports = port.get_connected_ports();
+    return std::any_of(connected_ports.cbegin(), connected_ports.cend(),
+                       [&](const ExpressionPort& connected_port) {
+                           const auto& loops = connected_port.get_expr()->get_loop_ids();
+                           return std::find(loops.cbegin(), loops.cend(), loop_id) == loops.cend();
+                       });
+}
+
 } // namespace utils
 } // namespace snippets
 } // namespace ov


### PR DESCRIPTION
### Details:
 - *To remind, `LoopPort` is expression port  connected to another expression port which is not in the same Loop. It's like entry (of exit) point of the Loop. It means that some expression port cannot be port of the Loop if all consumers (or sources) are from the same Loop. However, the method `LoopManager::update_loop_ports` sometimes creates these situation. This PR fixes this method. The screenshot below describes this situation: red loop is inner loop and blue loops is outer loop. However, some of output ports of this Loop is inside (green question sign) - invalid situation which is fixed by these changes.*
<img width="233" alt="image" src="https://github.com/user-attachments/assets/88bc6faf-edeb-49c0-b262-55922a884725">

 - *Added the corresponding checks to validate pass*
 - *Remove parts in `init_is_incremented` which handle invalid case by `is_incremented=false`.*

### Tickets:
 - *CVS-156299*
