### PR TITLE
[CPU][OMP] Handle exception outside parallel region

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1286,23 +1286,40 @@ public:
         if (origin_nested_levels < 2) {
             set_max_nested_levels(2);
         }
+        // In OpenMP, an exception that is thrown in a parallel region must be caught and handled in the same region by the same thread.
+        // Therefore, need to pass the error message and throw a new exception outside the parallel region.
+        const char* what = nullptr;
 
         #pragma omp parallel
         #pragma omp sections
         {
             #pragma omp section
             {
-                updateDynParams(startCounter, stopIndx);
+                try{
+                    updateDynParams(startCounter, stopIndx);
+                } catch (std::exception& e) {
+                    what = e.what();
+                } catch (...) {
+                    what = "[ CPU ] Could not update dynamic parameters.";
+                }
             }
             #pragma omp section
             {
-                updateShapes(startCounter, stopIndx);
+                try {
+                    updateShapes(startCounter, stopIndx);
+                } catch (std::exception& e) {
+                    what = e.what();
+                } catch (...) {
+                    what = "[ CPU ] Could not update shapes.";
+                }
             }
         }
 
         if (origin_nested_levels != 2) {
             set_max_nested_levels(origin_nested_levels);
         }
+
+        OPENVINO_ASSERT(what == nullptr, what);
     }
 };
 #endif


### PR DESCRIPTION
### Details:
 - *Handle exception inside OMP threads to avoid immediate program interruption.*

### Tickets:
 - *152606*
