### PR TITLE
[GPU] Disable OneDNN for unknown arch via dpas flag faking

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/concatenation_onednn.hpp
@@ -19,7 +19,7 @@ struct ConcatenationImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<concatenation>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         static const std::vector<ov::element::Type_t> supported_types = { ov::element::f16, ov::element::u8, ov::element::i8 };

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.hpp
@@ -24,7 +24,7 @@ struct ConvolutionImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<convolution>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         const auto& conv_node = node.as<convolution>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.hpp
@@ -20,7 +20,7 @@ struct DeconvolutionImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<deconvolution>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         const auto& deconv_node = node.as<deconvolution>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
@@ -22,7 +22,7 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<fully_connected>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         const auto& fc_node = node.as<fully_connected>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
@@ -19,7 +19,7 @@ struct GemmImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<gemm>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         const auto& gemm_node = node.as<gemm>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/pooling_onednn.hpp
@@ -20,7 +20,7 @@ struct PoolingImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<pooling>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         const auto& in_layout = node.get_input_layout(0);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
@@ -49,7 +49,7 @@ struct ReduceImplementationManager : public ImplementationManager {
     bool validate_impl(const program_node& node) const override {
         assert(node.is_type<reduce>());
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         const auto& reduce_node = node.as<reduce>();

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.hpp
@@ -57,7 +57,7 @@ struct ReorderImplementationManager : public ImplementationManager {
             return true;
 
         const auto& info = node.get_program().get_engine().get_device_info();
-        if (!info.supports_immad)
+        if (!info.supports_immad || info.arch == gpu_arch::unknown)
             return false;
 
         if (!one_of(input_fmt.value, supported_formats) || !one_of(output_fmt.value, supported_formats))

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -330,6 +330,14 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
     ngen::Product product = {ngen::ProductFamily::Unknown, 0};
     jit_generator<ngen::HW::Unknown>::detectHWInfo(context.get(), device.get(), hw, product);
     info.arch = convert_ngen_arch(hw);
+    // We change the value of this flag to avoid OneDNN usage for the platforms unknown to OneDNN
+    // This is required to guarantee some level of forward compatibility for the new HW generations
+    // as OneDNN code generators are not generic and typically requires some updates for the new architectures
+    // Ideally, we shouldn't do that as OCL impls sometimes also check this flag, but in order to avoid that
+    // we need to ensure that graph transformations are not relying on this flag as indicator that onednn will be used
+    if (product.family == ngen::ProductFamily::Unknown) {
+        info.supports_immad = false;
+    }
 #else  // ENABLE_ONEDNN_FOR_GPU
     info.arch = gpu_arch::unknown;
 #endif  // ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details:
 - This patch enforces dpas availability flag to false when HW architecture is unknown to onednn to fallback to OCL kernels which are supposed to be more generic and more forward compatible.
 - Also, added an architecture check in each onednn-based impl if in the future we'll stop relying on `supports_immad` flag when decide whether to use onednn or not.