### PR TITLE
[GPU] Fix per-token dynamic quantization 

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -160,8 +160,13 @@ bool DynamicQuantizeKernelOpt::Validate(const Params& params) const {
     if (dq_params.group_sizes.back() != UINT64_MAX)
         return false;
 
-    if (!dq_params.scales_output_order.empty())
-        return false;
+    // Allow only default scales order
+    const auto& scales_output_order = dq_params.scales_output_order;
+    if (!scales_output_order.empty()) {
+        for (size_t i = 0; i < scales_output_order.size(); i++)
+            if (scales_output_order[i] != i)
+                return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
### Details:
 - Allow the DynamicQuantizeKernelOpt kernel to be selected with the default scales order
 - Relax DynamicQuantizeKernelRef kernel validation function
