### PR TITLE
[core] Remove deprecated members of Concat operator

### DIFF
--- a/src/core/include/openvino/op/concat.hpp
+++ b/src/core/include/openvino/op/concat.hpp
@@ -37,17 +37,6 @@ public:
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     /// \return The concatenation axis.
-    OPENVINO_DEPRECATED("The function get_concatenation_axis() is deprecated. Will be removed in 2025.0 release. Use "
-                        "get_axis() instead.")
-    int64_t get_concatenation_axis() const {
-        return m_concat_axis;
-    }
-    OPENVINO_DEPRECATED("The function set_concatenation_axis() is deprecated. Will be removed in 2025.0 release. Use "
-                        "set_axis() instead.")
-    void set_concatenation_axis(int64_t concatenation_axis) {
-        m_concat_axis = concatenation_axis;
-    }
-    /// \return The concatenation axis.
     int64_t get_axis() const {
         return m_axis;
     }


### PR DESCRIPTION
### Details:
 - Remove deprecated members of Concat operator:
   * get_concatenation_axis
   * set_concatenation_axis

### Tickets:
 - CVS-156181
