### PR TITLE
[docs] Update LSTM sequence specification (version update)

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset1.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset1.rst
@@ -66,7 +66,6 @@ Table of Contents
 * :doc:`LogicalXor <../operation-specs/logical/logical-xor-1>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-1>`
 * :doc:`Maximum <../operation-specs/arithmetic/maximum-1>`
@@ -122,5 +121,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset10.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset10.rst
@@ -107,7 +107,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-8>`
@@ -192,4 +192,3 @@ Table of Contents
 * :doc:`Unique <../operation-specs/movement/unique-10>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset11.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset11.rst
@@ -107,7 +107,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-8>`
@@ -192,4 +192,3 @@ Table of Contents
 * :doc:`Unique <../operation-specs/movement/unique-10>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset12.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset12.rst
@@ -108,7 +108,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-8>`
@@ -193,4 +193,3 @@ Table of Contents
 * :doc:`Unique <../operation-specs/movement/unique-10>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset13.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset13.rst
@@ -113,7 +113,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-8>`
@@ -201,4 +201,3 @@ Table of Contents
 * :doc:`Unique <../operation-specs/movement/unique-10>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset14.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset14.rst
@@ -115,7 +115,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-14>`

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset15.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset15.rst
@@ -120,7 +120,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-14>`

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset2.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset2.rst
@@ -68,7 +68,6 @@ Table of Contents
 * :doc:`LogicalXor <../operation-specs/logical/logical-xor-1>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-1>`
 * :doc:`Maximum <../operation-specs/arithmetic/maximum-1>`
@@ -128,5 +127,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset3.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset3.rst
@@ -76,7 +76,6 @@ Table of Contents
 * :doc:`LogicalXor <../operation-specs/logical/logical-xor-1>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-1>`
 * :doc:`Maximum <../operation-specs/arithmetic/maximum-1>`
@@ -144,4 +143,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset5.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset5.rst
@@ -86,7 +86,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-1>`
 * :doc:`Maximum <../operation-specs/arithmetic/maximum-1>`
@@ -162,5 +162,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset6.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset6.rst
@@ -93,7 +93,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-1>`
 * :doc:`Maximum <../operation-specs/arithmetic/maximum-1>`
@@ -168,4 +168,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset7.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset7.rst
@@ -96,7 +96,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-1>`
 * :doc:`Maximum <../operation-specs/arithmetic/maximum-1>`
@@ -172,4 +172,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset8.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset8.rst
@@ -101,7 +101,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-8>`
@@ -183,5 +183,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset9.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/available-opsets/opset9.rst
@@ -105,7 +105,7 @@ Table of Contents
 * :doc:`Loop <../operation-specs/infrastructure/loop-5>`
 * :doc:`LRN <../operation-specs/normalization/lrn-1>`
 * :doc:`LSTMCell <../operation-specs/sequence/lstm-cell-1>`
-* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-1>`
+* :doc:`LSTMSequence <../operation-specs/sequence/lstm-sequence-5>`
 * :doc:`MatMul <../operation-specs/matrix/matmul-1>`
 * :doc:`MatrixNMS <../operation-specs/sort/matrix-non-max-suppression-8>`
 * :doc:`MaxPool <../operation-specs/pooling/max-pool-8>`
@@ -189,4 +189,3 @@ Table of Contents
 * :doc:`Transpose <../operation-specs/movement/transpose-1>`
 * :doc:`Unsqueeze <../operation-specs/shape/unsqueeze-1>`
 * :doc:`VariadicSplit <../operation-specs/movement/variadic-split-1>`
-

--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sequence/lstm-sequence-5.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/sequence/lstm-sequence-5.rst
@@ -3,10 +3,10 @@ LSTMSequence
 
 
 .. meta::
-  :description: Learn about LSTMSequence-1 - a sequence processing operation, which
+  :description: Learn about LSTMSequence-5 - a sequence processing operation, which
                 can be performed on seven required input tensors.
 
-**Versioned name**: *LSTMSequence-1*
+**Versioned name**: *LSTMSequence-5*
 
 **Category**: *Sequence processing*
 
@@ -145,4 +145,3 @@ A single cell in the sequence is implemented in the same way as in :doc:`LSTM Ce
            </port>
        </output>
    </layer>
-


### PR DESCRIPTION
### Details:
 - Align LSTM sequence version in specification, after LSTM sequence v0 removal from OV opset.

### Blocked by:
- #27330 

### Tickets:
 - CVS-156182
