### PR TITLE
[Fix][STFT] OPENVINO_OP macro for STFT with opset15

### DIFF
--- a/src/core/include/openvino/op/stft.hpp
+++ b/src/core/include/openvino/op/stft.hpp
@@ -13,7 +13,7 @@ namespace v15 {
 /// \ingroup ov_ops_cpp_api
 class OPENVINO_API STFT : public Op {
 public:
-    OPENVINO_OP("STFT");
+    OPENVINO_OP("STFT", "opset15");
     STFT() = default;
 
     /// \brief Constructs a STFT operation.


### PR DESCRIPTION
### Details:
 - Fix OPENVINO_OP macro for STFT with opset15 (without that it is registered and serialized with version="extension" by default, and can't be deserialized)
 - It follows all of the other ops OPENVINO_OP macro, the "opset15" has been missed for STFT
 Example: https://github.com/openvinotoolkit/openvino/blob/4d8ff86bd2e853b84a28acd2ece1836d28523f9e/src/core/include/openvino/op/slice_scatter.hpp#L17
 
 

### Tickets:
 - 156667
