### PR TITLE
Support for model reshape in protopipe

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/README.md
+++ b/src/plugins/intel_npu/tools/protopipe/README.md
@@ -60,6 +60,7 @@ log_level: INFO
 - `ol` - **Optional**. Output layer layout.
 - `iml` - **Optional**. Input model layout.
 - `oml` - **Optional**. Output model layout.
+- `shape` - **Optional**. Input layer shape.
 
 Examples:
 ```

--- a/src/plugins/intel_npu/tools/protopipe/README.md
+++ b/src/plugins/intel_npu/tools/protopipe/README.md
@@ -60,7 +60,7 @@ log_level: INFO
 - `ol` - **Optional**. Output layer layout.
 - `iml` - **Optional**. Input model layout.
 - `oml` - **Optional**. Output model layout.
-- `reshape` - **Optional**. Set shape for input layer. For example, "input1: [1,3,224,224], input2: [1,4]" or "[1,3,224,224]" in case of one input size.
+- `reshape` - **Optional**. Set shape for input layers. For example, "input1: [1,3,224,224], input2: [1,4]" or "[1,3,224,224]" in case of one input layer.
 
 Examples:
 ```

--- a/src/plugins/intel_npu/tools/protopipe/README.md
+++ b/src/plugins/intel_npu/tools/protopipe/README.md
@@ -60,7 +60,7 @@ log_level: INFO
 - `ol` - **Optional**. Output layer layout.
 - `iml` - **Optional**. Input model layout.
 - `oml` - **Optional**. Output model layout.
-- `shape` - **Optional**. Input layer shape.
+- `reshape` - **Optional**. Set shape for input layer. For example, "input1: [1,3,224,224], input2: [1,4]" or "[1,3,224,224]" in case of one input size.
 
 Examples:
 ```

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -345,6 +345,10 @@ struct convert<OpenVINOParams> {
             params.output_model_layout = node["oml"].as<LayerVariantAttr<std::string>>();
         }
 
+        if (node["shape"]) {
+            params.shape = node["shape"].as<LayerVariantAttr<std::vector<int64_t>>> ();
+        }
+
         if (node["config"]) {
             params.config = node["config"].as<std::map<std::string, std::string>>();
         }
@@ -474,7 +478,6 @@ struct convert<InferOp> {
         if (node["input_data"]) {
             op.input_data = node["input_data"].as<LayerVariantAttr<std::string>>();
         }
-
         if (node["output_data"]) {
             op.output_data = node["output_data"].as<LayerVariantAttr<std::string>>();
         }

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -346,7 +346,7 @@ struct convert<OpenVINOParams> {
         }
 
         if (node["shape"]) {
-            params.shape = node["shape"].as<LayerVariantAttr<std::vector<int64_t>>> ();
+            params.shape = node["shape"].as<LayerVariantAttr<std::vector<uint64_t>>> ();
         }
 
         if (node["config"]) {

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -345,8 +345,8 @@ struct convert<OpenVINOParams> {
             params.output_model_layout = node["oml"].as<LayerVariantAttr<std::string>>();
         }
 
-        if (node["shape"]) {
-            params.shape = node["shape"].as<LayerVariantAttr<std::vector<uint64_t>>> ();
+        if (node["reshape"]) {
+            params.reshape = node["reshape"].as<LayerVariantAttr<std::vector<uint64_t>>> ();
         }
 
         if (node["config"]) {

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -478,6 +478,7 @@ struct convert<InferOp> {
         if (node["input_data"]) {
             op.input_data = node["input_data"].as<LayerVariantAttr<std::string>>();
         }
+
         if (node["output_data"]) {
             op.output_data = node["output_data"].as<LayerVariantAttr<std::string>>();
         }

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -346,7 +346,7 @@ struct convert<OpenVINOParams> {
         }
 
         if (node["reshape"]) {
-            params.reshape = node["reshape"].as<LayerVariantAttr<std::vector<uint64_t>>> ();
+            params.reshape = node["reshape"].as<LayerVariantAttr<std::vector<size_t>>> ();
         }
 
         if (node["config"]) {

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
@@ -91,7 +91,7 @@ struct OpenVINOParams {
     LayerVariantAttr<std::string> output_layout;
     LayerVariantAttr<std::string> input_model_layout;
     LayerVariantAttr<std::string> output_model_layout;
-    LayerVariantAttr<std::vector<int64_t>> shape;
+    LayerVariantAttr<std::vector<uint64_t>> shape;
     std::map<std::string, std::string> config;
     size_t nireq = 1u;
 };

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
@@ -91,7 +91,7 @@ struct OpenVINOParams {
     LayerVariantAttr<std::string> output_layout;
     LayerVariantAttr<std::string> input_model_layout;
     LayerVariantAttr<std::string> output_model_layout;
-    LayerVariantAttr<std::vector<uint64_t>> shape;
+    LayerVariantAttr<std::vector<uint64_t>> reshape;
     std::map<std::string, std::string> config;
     size_t nireq = 1u;
 };

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
@@ -91,7 +91,7 @@ struct OpenVINOParams {
     LayerVariantAttr<std::string> output_layout;
     LayerVariantAttr<std::string> input_model_layout;
     LayerVariantAttr<std::string> output_model_layout;
-    LayerVariantAttr<std::vector<uint64_t>> reshape;
+    LayerVariantAttr<std::vector<size_t>> reshape;
     std::map<std::string, std::string> config;
     size_t nireq = 1u;
 };

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
@@ -91,6 +91,7 @@ struct OpenVINOParams {
     LayerVariantAttr<std::string> output_layout;
     LayerVariantAttr<std::string> input_model_layout;
     LayerVariantAttr<std::string> output_model_layout;
+    LayerVariantAttr<std::vector<int64_t>> shape;
     std::map<std::string, std::string> config;
     size_t nireq = 1u;
 };

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -131,11 +131,15 @@ static void cfgOutputPostproc(ov::preprocess::PrePostProcessor& ppp, const std::
 static void cfgPartialShapes(const std::shared_ptr<ov::Model>& model, 
                              const AttrMap<std::vector<uint64_t>> shape_map) {
 
+    // std::map<std::string, ov::PartialShape> partial_shapes;
+    // for (const auto& shape : shape_map) {
+    //     std::vector<ov::Dimension> vecDimension;
+    //     for (const auto& dimension : shape.second) { vecDimension.emplace_back(dimension); }
+    //     partial_shapes[shape.first] = std::move(vecDimension);
+    // }
     std::map<std::string, ov::PartialShape> partial_shapes;
-    for (const auto& shape : shape_map) {
-        std::vector<ov::Dimension> vecDimension;
-        for (const auto& dimension : shape.second) { vecDimension.emplace_back(dimension); }
-        partial_shapes[shape.first] = std::move(vecDimension);
+    for (const auto& [layer_name, shape] : shape_map) {
+        partial_shapes.emplace(layer_name, shape);
     }
     model->reshape(partial_shapes);
 }

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -160,7 +160,7 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         const auto iml_map = unpackLayerAttr(params.input_model_layout, input_names, "input model layout");
         cfgInputPreproc(ppp, model, ip_map, il_map, iml_map);
 
-        const auto shape_map = unpackLayerAttr(params.shape, input_names, "shape");
+        const auto shape_map = unpackLayerAttr(params.reshape, input_names, "shape");
         cfgPartialShapes(model, shape_map);
 
         const auto& output_names = extractLayerNames(model->outputs());

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -160,7 +160,7 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         const auto iml_map = unpackLayerAttr(params.input_model_layout, input_names, "input model layout");
         cfgInputPreproc(ppp, model, ip_map, il_map, iml_map);
 
-        const auto shape_map = unpackLayerAttr(params.shape, input_names, "dynamic shape");
+        const auto shape_map = unpackLayerAttr(params.shape, input_names, "shape");
         cfgPartialShapes(model, shape_map);
 
         const auto& output_names = extractLayerNames(model->outputs());
@@ -172,22 +172,6 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         model = ppp.build();
     }
 
-    std::map<std::string, ov::PartialShape> partial_shapes;
-    if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
-        auto &shapeMap = std::get<AttrMap<std::vector<uint64_t>>>(params.shape);
-        std::vector<ov::Dimension> dims;
-        for (auto& shape : shapeMap) {
-            for (auto& dim : shape.second) { dims.emplace_back(dim); }
-            partial_shapes[shape.first] = dims;
-        }
-        model->reshape(partial_shapes);
-    } else {
-        std::vector<uint64_t> vecDims = std::get<std::vector<uint64_t>>(params.shape);
-        ov::PartialShape dims;
-        for (auto& dim : vecDims) { dims.emplace_back(dim); }
-        model->reshape(dims);
-    }
-    
     auto input_layers = ovToLayersInfo(model->inputs());
     auto output_layers = ovToLayersInfo(model->outputs());
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -128,8 +128,8 @@ static void cfgOutputPostproc(ov::preprocess::PrePostProcessor& ppp, const std::
     }
 }
 
-static void cfgModelPartialShapes(const std::shared_ptr<ov::Model>& model, 
-                                  const AttrMap<std::vector<uint64_t>> shape_map) {
+static void cfgPartialShapes(const std::shared_ptr<ov::Model>& model, 
+                             const AttrMap<std::vector<uint64_t>> shape_map) {
 
     std::map<std::string, ov::PartialShape> partial_shapes;
     for (const auto& shape : shape_map) {
@@ -161,7 +161,7 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         cfgInputPreproc(ppp, model, ip_map, il_map, iml_map);
 
         const auto shape_map = unpackLayerAttr(params.shape, input_names, "dynamic shape");
-        cfgModelPartialShapes(model, shape_map);
+        cfgPartialShapes(model, shape_map);
 
         const auto& output_names = extractLayerNames(model->outputs());
         const auto op_map = unpackLayerAttr(params.output_precision, output_names, "output precision");
@@ -181,7 +181,7 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
             partial_shapes[shape.first] = dims;
         }
         model->reshape(partial_shapes);
-    } else if (std::holds_alternative<std::vector<uint64_t>>(params.shape)) {
+    } else {
         std::vector<uint64_t> vecDims = std::get<std::vector<uint64_t>>(params.shape);
         ov::PartialShape dims;
         for (auto& dim : vecDims) { dims.emplace_back(dim); }

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -129,7 +129,7 @@ static void cfgOutputPostproc(ov::preprocess::PrePostProcessor& ppp, const std::
 }
 
 static void cfgReshape(const std::shared_ptr<ov::Model>& model, 
-                       const AttrMap<std::vector<uint64_t>> shape_map) {
+                       const AttrMap<std::vector<size_t>> shape_map) {
     std::map<std::string, ov::PartialShape> partial_shapes;
     for (const auto& [layer_name, shape] : shape_map) {
         partial_shapes.emplace(layer_name, shape);

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -128,15 +128,8 @@ static void cfgOutputPostproc(ov::preprocess::PrePostProcessor& ppp, const std::
     }
 }
 
-static void cfgPartialShapes(const std::shared_ptr<ov::Model>& model, 
-                             const AttrMap<std::vector<uint64_t>> shape_map) {
-
-    // std::map<std::string, ov::PartialShape> partial_shapes;
-    // for (const auto& shape : shape_map) {
-    //     std::vector<ov::Dimension> vecDimension;
-    //     for (const auto& dimension : shape.second) { vecDimension.emplace_back(dimension); }
-    //     partial_shapes[shape.first] = std::move(vecDimension);
-    // }
+static void cfgReshape(const std::shared_ptr<ov::Model>& model, 
+                       const AttrMap<std::vector<uint64_t>> shape_map) {
     std::map<std::string, ov::PartialShape> partial_shapes;
     for (const auto& [layer_name, shape] : shape_map) {
         partial_shapes.emplace(layer_name, shape);
@@ -165,7 +158,7 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         cfgInputPreproc(ppp, model, ip_map, il_map, iml_map);
 
         const auto shape_map = unpackLayerAttr(params.reshape, input_names, "shape");
-        cfgPartialShapes(model, shape_map);
+        cfgReshape(model, shape_map);
 
         const auto& output_names = extractLayerNames(model->outputs());
         const auto op_map = unpackLayerAttr(params.output_precision, output_names, "output precision");

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -157,6 +157,20 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         model = ppp.build();
     }
 
+    std::map<std::string, ov::PartialShape> partial_shapes;
+    if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
+        auto &shapeMap = std::get<AttrMap<std::vector<uint64_t>>>(params.shape);
+        std::vector<ov::Dimension> dims;
+        for (auto& shape : shapeMap) {
+            for (auto& dim : shape.second) {
+                dims.push_back(dim);
+            }
+        partial_shapes[shape.first] = dims;
+        }
+    } else { //SeNe ToDo
+
+    }
+    model->reshape(partial_shapes);
     auto input_layers = ovToLayersInfo(model->inputs());
     auto output_layers = ovToLayersInfo(model->outputs());
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -129,9 +129,9 @@ static void cfgOutputPostproc(ov::preprocess::PrePostProcessor& ppp, const std::
 }
 
 static void cfgReshape(const std::shared_ptr<ov::Model>& model, 
-                       const AttrMap<std::vector<size_t>> shape_map) {
+                       const AttrMap<std::vector<size_t>> reshape_map) {
     std::map<std::string, ov::PartialShape> partial_shapes;
-    for (const auto& [layer_name, shape] : shape_map) {
+    for (const auto& [layer_name, shape] : reshape_map) {
         partial_shapes.emplace(layer_name, shape);
     }
     model->reshape(partial_shapes);
@@ -157,8 +157,8 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         const auto iml_map = unpackLayerAttr(params.input_model_layout, input_names, "input model layout");
         cfgInputPreproc(ppp, model, ip_map, il_map, iml_map);
 
-        const auto shape_map = unpackLayerAttr(params.reshape, input_names, "shape");
-        cfgReshape(model, shape_map);
+        const auto reshape_map = unpackLayerAttr(params.reshape, input_names, "reshape");
+        cfgReshape(model, reshape_map);
 
         const auto& output_names = extractLayerNames(model->outputs());
         const auto op_map = unpackLayerAttr(params.output_precision, output_names, "output precision");

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -162,15 +162,17 @@ InOutLayers OpenVINOLayersReader::Impl::readFromModel(const std::string& model_p
         auto &shapeMap = std::get<AttrMap<std::vector<uint64_t>>>(params.shape);
         std::vector<ov::Dimension> dims;
         for (auto& shape : shapeMap) {
-            for (auto& dim : shape.second) {
-                dims.push_back(dim);
-            }
-        partial_shapes[shape.first] = dims;
+            for (auto& dim : shape.second) { dims.emplace_back(dim); }
+            partial_shapes[shape.first] = dims;
         }
-    } else { //SeNe ToDo
-
+        model->reshape(partial_shapes);
+    } else if (std::holds_alternative<std::vector<uint64_t>>(params.shape)) {
+        std::vector<uint64_t> vecDims = std::get<std::vector<uint64_t>>(params.shape);
+        ov::PartialShape dims;
+        for (auto& dim : vecDims) { dims.emplace_back(dim); }
+        model->reshape(dims);
     }
-    model->reshape(partial_shapes);
+    
     auto input_layers = ovToLayersInfo(model->inputs());
     auto output_layers = ovToLayersInfo(model->outputs());
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -25,9 +25,11 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
     if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
         auto &shapeMap = std::get<AttrMap<std::vector<uint64_t>>>(params.shape);
         network->cfgReshape(shapeMap);
-    } else { //SeNe ToDo
-
+    } else if (std::holds_alternative<std::vector<uint64_t>>(params.shape)) {
+        auto &shape = std::get<std::vector<uint64_t>>(params.shape);
+        network->cfgReshape(shape);
     }
+
     network->cfgPluginConfig(params.config);
     network->cfgNumRequests(params.nireq);
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -22,7 +22,12 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
         const auto& blob_path = std::get<OpenVINOParams::BlobPath>(params.path);
         network = std::make_unique<P>(tag, blob_path.blob, params.device);
     }
+    if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
+        auto &shapeMap = std::get<AttrMap<std::vector<uint64_t>>>(params.shape);
+        network->cfgReshape(shapeMap);
+    } else { //SeNe ToDo
 
+    }
     network->cfgPluginConfig(params.config);
     network->cfgNumRequests(params.nireq);
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -22,10 +22,10 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
         const auto& blob_path = std::get<OpenVINOParams::BlobPath>(params.path);
         network = std::make_unique<P>(tag, blob_path.blob, params.device);
     }
-    if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
-        network->cfgReshape(std::get<AttrMap<std::vector<uint64_t>>>(params.shape));
+    if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.reshape)) {
+        network->cfgReshape(std::get<AttrMap<std::vector<uint64_t>>>(params.reshape));
     } else {
-        network->cfgReshape(std::get<std::vector<uint64_t>>(params.shape));
+        network->cfgReshape(std::get<std::vector<uint64_t>>(params.reshape));
     }
 
     network->cfgPluginConfig(params.config);

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -22,10 +22,10 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
         const auto& blob_path = std::get<OpenVINOParams::BlobPath>(params.path);
         network = std::make_unique<P>(tag, blob_path.blob, params.device);
     }
-    if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.reshape)) {
-        network->cfgReshape(std::get<AttrMap<std::vector<uint64_t>>>(params.reshape));
+    if (std::holds_alternative<AttrMap<std::vector<size_t>>>(params.reshape)) {
+        network->cfgReshape(std::get<AttrMap<std::vector<size_t>>>(params.reshape));
     } else {
-        network->cfgReshape(std::get<std::vector<uint64_t>>(params.reshape));
+        network->cfgReshape(std::get<std::vector<size_t>>(params.reshape));
     }
 
     network->cfgPluginConfig(params.config);

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -24,7 +24,7 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
     }
     if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
         network->cfgReshape(std::get<AttrMap<std::vector<uint64_t>>>(params.shape));
-    } else if (std::holds_alternative<std::vector<uint64_t>>(params.shape)) {
+    } else {
         network->cfgReshape(std::get<std::vector<uint64_t>>(params.shape));
     }
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -23,11 +23,9 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
         network = std::make_unique<P>(tag, blob_path.blob, params.device);
     }
     if (std::holds_alternative<AttrMap<std::vector<uint64_t>>>(params.shape)) {
-        auto &shapeMap = std::get<AttrMap<std::vector<uint64_t>>>(params.shape);
-        network->cfgReshape(shapeMap);
+        network->cfgReshape(std::get<AttrMap<std::vector<uint64_t>>>(params.shape));
     } else if (std::holds_alternative<std::vector<uint64_t>>(params.shape)) {
-        auto &shape = std::get<std::vector<uint64_t>>(params.shape);
-        network->cfgReshape(shape);
+        network->cfgReshape(std::get<std::vector<uint64_t>>(params.shape));
     }
 
     network->cfgPluginConfig(params.config);


### PR DESCRIPTION
### Details:
Support for model reshape in protopipe
Added new OpenVINO parameter in config.yaml `-reshape` able to reshape input layers.
For ONNX models dynamic dimensions are set to `1`. This is consistent with the behavior of onnxruntime_perf_test.
