### PR TITLE
[GPU] clean oneDNN cache by release memory method

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/compiled_model.hpp
@@ -61,6 +61,8 @@ public:
     const std::vector<std::shared_ptr<Graph>>& get_graphs() const;
     std::shared_ptr<Graph> get_graph(size_t n) const;
 
+    void release_memory() override;
+
 private:
     RemoteContextImpl::Ptr m_context;
     ExecutionConfig m_config;

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -288,5 +288,13 @@ std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request(
     return std::make_shared<SyncInferRequest>(std::static_pointer_cast<const CompiledModel>(shared_from_this()));
 }
 
+
+void CompiledModel::release_memory() {
+#ifdef ENABLE_ONEDNN_FOR_GPU
+    auto capacity = dnnl::get_primitive_cache_capacity();
+    dnnl::set_primitive_cache_capacity(0);
+    dnnl::set_primitive_cache_capacity(capacity);
+#endif
+}
 }  // namespace intel_gpu
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Partial fix for https://jira.devtools.intel.com/browse/CVS-156022
 - explicit call for release memory is required

### Tickets:
 - *ticket-id*
