### PR TITLE
Enable weightless caching with compile_model() API without providing weights_path property

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1449,13 +1449,11 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
                 update_config[ov::loaded_from_cache.name()] = true;
 
                 if (util::contains(plugin.get_property(ov::supported_properties), ov::weights_path)) {
-                    std::string weights_path;
-                    auto pos = cacheContent.modelPath.rfind('.');
-                    if (cacheContent.modelPath.substr(pos) == ".xml") {
-                        weights_path = cacheContent.modelPath.substr(0, pos);
+                    std::string weights_path = cacheContent.modelPath;
+                    auto pos = weights_path.rfind('.');
+                    if (pos != weights_path.npos && weights_path.substr(pos) == ".xml") {
+                        weights_path = weights_path.substr(0, pos);
                         weights_path += ".bin";
-                    } else {
-                        weights_path = cacheContent.modelPath;
                     }
                     if (ov::util::file_exists(weights_path)) {
                         update_config[ov::weights_path.name()] = weights_path;

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1457,10 +1457,9 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
                     } else {
                         weights_path = cacheContent.modelPath;
                     }
-                    if (!ov::util::file_exists(weights_path)) {
-                        OPENVINO_THROW("Weights file does not exist");
+                    if (ov::util::file_exists(weights_path)) {
+                        update_config[ov::weights_path.name()] = weights_path;
                     }
-                    update_config[ov::weights_path.name()] = weights_path;
                 }
                 compiled_model = context ? plugin.import_model(networkStream, context, update_config)
                                          : plugin.import_model(networkStream, update_config);

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1448,13 +1448,15 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
                 ov::AnyMap update_config = config;
                 update_config[ov::loaded_from_cache.name()] = true;
 
-                if (update_config[ov::cache_mode.name()] == ov::CacheMode::OPTIMIZE_SIZE) {
+                if (util::contains(plugin.get_property(ov::supported_properties), ov::weights_path)) {
                     std::string weights_path;
                     auto pos = cacheContent.modelPath.rfind('.');
-                    if (pos != cacheContent.modelPath.npos) {
+                    if (cacheContent.modelPath.substr(pos) == ".xml") {
                         weights_path = cacheContent.modelPath.substr(0, pos);
+                        weights_path += ".bin";
+                    } else {
+                        weights_path = cacheContent.modelPath;
                     }
-                    weights_path += ".bin";
                     if (!ov::util::file_exists(weights_path)) {
                         OPENVINO_THROW("Weights file does not exist");
                     }

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1447,6 +1447,19 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
 
                 ov::AnyMap update_config = config;
                 update_config[ov::loaded_from_cache.name()] = true;
+
+                if (update_config[ov::cache_mode.name()] == ov::CacheMode::OPTIMIZE_SIZE) {
+                    std::string weights_path;
+                    auto pos = cacheContent.modelPath.rfind('.');
+                    if (pos != cacheContent.modelPath.npos) {
+                        weights_path = cacheContent.modelPath.substr(0, pos);
+                    }
+                    weights_path += ".bin";
+                    if (!ov::util::file_exists(weights_path)) {
+                        OPENVINO_THROW("Weights file does not exist");
+                    }
+                    update_config[ov::weights_path.name()] = weights_path;
+                }
                 compiled_model = context ? plugin.import_model(networkStream, context, update_config)
                                          : plugin.import_model(networkStream, update_config);
             });

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -596,7 +596,8 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::hint::enable_cpu_pinning.name(), PropertyMutability::RW},
         ov::PropertyName{ov::device::id.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RW},
-        ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RW}
+        ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::weights_path.name(), PropertyMutability::RW},
     };
 
     return supported_properties;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -597,7 +597,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::device::id.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RW},
-        ov::PropertyName{ov::weights_path.name(), PropertyMutability::RW},
+        ov::PropertyName{ov::weights_path.name(), PropertyMutability::RO},
     };
 
     return supported_properties;


### PR DESCRIPTION
Requested in https://jira.devtools.intel.com/browse/CVS-126606?focusedId=25564110&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-25564110