### PR TITLE
[PyOV] Use `python -m build` only for old `pip` versions

### DIFF
--- a/src/bindings/python/wheel/CMakeLists.txt
+++ b/src/bindings/python/wheel/CMakeLists.txt
@@ -100,14 +100,31 @@ set(openvino_wheel_path "${openvino_wheels_output_dir}/${openvino_wheel_name}")
 # create target for openvino.wheel
 #
 
-# for --config-setting explanation see https://github.com/pypa/setuptools/issues/2491
-set(wheel_build_command
-    ${Python3_EXECUTABLE} -m build "${CMAKE_CURRENT_SOURCE_DIR}"
+execute_process(COMMAND ${Python3_EXECUTABLE} -m pip --version
+                OUTPUT_VARIABLE pip_version OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+string(REGEX MATCH "pip[ ]+([\\.0-9]*)" pip_version "${pip_version}")
+set(pip_version ${CMAKE_MATCH_1})
+
+if(pip_version VERSION_GREATER_EQUAL 22.0)
+    set(wheel_build_command
+        ${Python3_EXECUTABLE} -m pip wheel
+            --no-deps
+            --wheel-dir ${openvino_wheels_output_dir}
+            --verbose
+            --build-option --build-number=${WHEEL_BUILD}
+            --build-option --plat-name=${PLATFORM_TAG}
+            "${CMAKE_CURRENT_SOURCE_DIR}")
+else()
+    # for --config-setting explanation see https://github.com/pypa/setuptools/issues/2491
+    set(wheel_build_command
+        ${Python3_EXECUTABLE} -m build "${CMAKE_CURRENT_SOURCE_DIR}"
         --outdir ${openvino_wheels_output_dir}
         --config-setting=--build-option=--build-number=${WHEEL_BUILD}
         --config-setting=--build-option=--plat-name=${PLATFORM_TAG}
         --config-setting=--quiet
         --wheel)
+endif()
 
 add_custom_command(OUTPUT ${openvino_wheel_path}
     COMMAND ${setup_py_env} ${wheel_build_command}


### PR DESCRIPTION
### Details:
 - An alternative to https://github.com/openvinotoolkit/openvino/pull/27426
 - The functionality branching based on pip version has recently been removed in https://github.com/openvinotoolkit/openvino/pull/27190
 - This fix has originated from discussion at https://github.com/openvinotoolkit/openvino/pull/27190/files#r1830707810
 - Fix for issues with NPU building on Windows machines
 - A disadvantage is that we need to have `build` as a dependency no matter what, there's no environment marker for `pip` version which would allow us to install it conditionally

### Tickets:
 - EISW-146038
