### PR TITLE
Implement runtime scatter update skippable

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/kernel_impl_params.hpp
@@ -38,6 +38,7 @@ struct kernel_impl_params final {
     std::shared_ptr<const primitive> desc;
     size_t unique_id;
     bool _can_be_optimized = false;
+    bool _runtime_skippable = false;
     std::vector<layout> input_layouts;
     std::vector<layout> output_layouts;
     std::vector<tensor> input_offsets;
@@ -143,6 +144,10 @@ struct kernel_impl_params final {
 
     bool can_be_optimized() const {
         return _can_be_optimized;
+    }
+
+    bool runtime_skippable() const {
+        return _runtime_skippable;
     }
 
     template <class PType>

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -22,6 +22,9 @@
 #include "permute_inst.h"
 #include "strided_slice_inst.h"
 #include "broadcast_inst.h"
+#include "scatter_update_inst.h"
+#include "scatter_elements_update_inst.h"
+#include "scatter_nd_update_inst.h"
 
 #include <vector>
 #include <list>
@@ -88,11 +91,14 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
         // concat buffer fusing for dynamic shape is adaptively applied at runtime. So we need to build dynamic impl at build time.
         if (impl_param.can_be_optimized() &&
-            !((impl_param.is_type<concatenation>() ||
+            !((impl_param.is_type<concatenation>() || // Runtime skippable?
                impl_param.is_type<gather>() ||
                impl_param.is_type<permute>() ||
                impl_param.is_type<strided_slice>() ||
                impl_param.is_type<broadcast>() ||
+               impl_param.is_type<scatter_elements_update>() ||
+               impl_param.is_type<scatter_nd_update>() ||
+               impl_param.is_type<scatter_update>() ||
                impl_param.is_type<crop>()) && impl_param.is_dynamic())) {
             return make_unique<ImplType>(kernel_selector::kernel_data{});
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -91,14 +91,12 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
         // concat buffer fusing for dynamic shape is adaptively applied at runtime. So we need to build dynamic impl at build time.
         if (impl_param.can_be_optimized() &&
-            !((impl_param.is_type<concatenation>() || // Runtime skippable?
+            !((impl_param.runtime_skippable() ||
+               impl_param.is_type<concatenation>() ||
                impl_param.is_type<gather>() ||
                impl_param.is_type<permute>() ||
                impl_param.is_type<strided_slice>() ||
                impl_param.is_type<broadcast>() ||
-               impl_param.is_type<scatter_elements_update>() ||
-               impl_param.is_type<scatter_nd_update>() ||
-               impl_param.is_type<scatter_update>() ||
                impl_param.is_type<crop>()) && impl_param.is_dynamic())) {
             return make_unique<ImplType>(kernel_selector::kernel_data{});
         }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -91,13 +91,8 @@ struct typed_primitive_impl_ocl : public typed_primitive_impl<PType> {
     static std::unique_ptr<primitive_impl> create(const typed_program_node<PType>& arg, const kernel_impl_params& impl_param) {
         // concat buffer fusing for dynamic shape is adaptively applied at runtime. So we need to build dynamic impl at build time.
         if (impl_param.can_be_optimized() &&
-            !((impl_param.runtime_skippable() ||
-               impl_param.is_type<concatenation>() ||
-               impl_param.is_type<gather>() ||
-               impl_param.is_type<permute>() ||
-               impl_param.is_type<strided_slice>() ||
-               impl_param.is_type<broadcast>() ||
-               impl_param.is_type<crop>()) && impl_param.is_dynamic())) {
+            !((impl_param.runtime_skippable() || impl_param.is_type<crop>()) &&
+            impl_param.is_dynamic())) {
             return make_unique<ImplType>(kernel_selector::kernel_data{});
         }
         auto kernel_params = ImplType::get_kernel_params(ImplType::static_canonicalize_shapes(impl_param));

--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -261,6 +261,7 @@ public:
     void do_runtime_in_place_concat();
     void do_runtime_in_place_kv_cache();
     void do_runtime_in_place_crop();
+    void do_runtime_skip_scatter_update();
     void configure_shape_of_dependencies();
 
     memory::ptr fused_memory(size_t dep_id) const {

--- a/src/plugins/intel_gpu/src/graph/include/program_node.h
+++ b/src/plugins/intel_gpu/src/graph/include/program_node.h
@@ -131,6 +131,7 @@ public:
                                                                                  get_unique_id(), in_layouts, out_layouts, get_fused_primitives()));
         params->memory_deps = get_const_memory_deps();
         params->_can_be_optimized = this->optimized;
+        params->_runtime_skippable = this->runtime_skippable;
         params->in_port_to_shape_info_offset = get_input_port_to_shape_info_offset_map();
         params->out_port_to_shape_info_offset = get_output_port_to_shape_info_offset_map();
         auto deps = get_dependencies();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -746,6 +746,11 @@ event::ptr primitive_inst::realloc_if_needed() {
             if (curr_inst->can_be_optimized()
                     && (curr_output_memory_ptr
                         && get_network().get_engine().is_the_same_buffer(*curr_output_memory_ptr, *input_mem_ptr))) {
+                if (curr_inst->mem_allocated()) {
+                    get_network().get_memory_pool().release_memory(curr_inst->_outputs[0].get(),
+                            curr_inst->get_node().get_unique_id(), curr_inst->id(), get_network_id());
+                    _mem_allocated = false;
+                }
                 curr_inst->_outputs[0] = nullptr;
                 curr_inst->_max_output_layout_count[0] = 0;
                 for (auto& user_inst : curr_inst->get_user_insts()) {
@@ -770,6 +775,11 @@ event::ptr primitive_inst::realloc_if_needed() {
             return ev;
         } else if (_outputs[0] && dep_memory_ptr(0) &&
                    _network.get_engine().is_the_same_buffer(dep_memory(0), output_memory(0))) {
+            if (mem_allocated()) {
+                get_network().get_memory_pool().release_memory(_outputs[0].get(),
+                        get_node().get_unique_id(), id(), get_network_id());
+                _mem_allocated = false;
+            }
             _outputs[0] = nullptr;
             _max_output_layout_count[0] = 0;
             // Check users recursively and if the users is can_be_optimized && runtime_skippable

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -744,7 +744,6 @@ event::ptr primitive_inst::realloc_if_needed() {
         reset_user_output_memory = [&](cldnn::primitive_inst* curr_inst, cldnn::memory::ptr input_mem_ptr) {
             auto curr_output_memory_ptr = curr_inst->output_memory_ptr(0);
             if (curr_inst->can_be_optimized()
-                    && curr_inst->get_node().is_runtime_skippable()
                     && (curr_output_memory_ptr
                         && get_network().get_engine().is_the_same_buffer(*curr_output_memory_ptr, *input_mem_ptr))) {
                 curr_inst->_outputs[0] = nullptr;

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1587,9 +1587,6 @@ void primitive_inst::do_runtime_in_place_concat() {
     GPU_DEBUG_TRACE_DETAIL << "[In place concat] " << concat_inst->id() << ": can_be_optimized " << std::endl;
 }
 
-// scatter_elements_update (data, idx, uid)
-// scatter_update (dict, idx, idupd)
-// scatter_nd_udpate (data, idx, idupd)
 void primitive_inst::do_runtime_skip_scatter_update() {
     OV_ITT_SCOPED_TASK(ov::intel_gpu::itt::domains::intel_gpu_plugin, openvino::itt::handle("do_runtime_skip_scatter_update: " + id()));
     // Check pattern

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1635,8 +1635,11 @@ void primitive_inst::do_runtime_skip_scatter_update() {
     auto update_layout = _impl_params->get_input_layout(2);
 
     if (idx_layout.count() > 0 && update_layout.count() > 0) {
+        // set shape_change to realloc memory for same input shapes
+        if (can_be_optimized()) {
+            set_shape_change();
+        }
         set_can_be_optimized(false);
-        set_shape_change();
         GPU_DEBUG_TRACE_DETAIL << "--- Cannot optimize because idx_layout (" << idx_layout.to_short_string()
                         << ") and update_layout(" << update_layout.to_short_string() << ") are not zero" << std::endl;
         return;
@@ -1647,6 +1650,10 @@ void primitive_inst::do_runtime_skip_scatter_update() {
     GPU_DEBUG_TRACE_DETAIL << "            - Idx layout    : " << _impl_params->get_input_layout(1).to_short_string() << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "            - Update layout : " << _impl_params->get_input_layout(2).to_short_string() << std::endl;
     GPU_DEBUG_TRACE_DETAIL << "            - Output layout : " << _impl_params->get_output_layout().to_short_string() << std::endl;
+    // set shape_change to realloc memory for same input shapes
+    if (!can_be_optimized()) {
+        set_shape_change();
+    }
     set_can_be_optimized(true);
 }
 

--- a/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_elements_update.cpp
@@ -53,16 +53,18 @@ std::string scatter_elements_update_inst::to_string(scatter_elements_update_node
     return primitive_description.str();
 }
 
-scatter_elements_update_inst::typed_primitive_inst(network& network, scatter_elements_update_node const& node) : parent(network, node) {}
-void scatter_elements_update_inst::on_execute() {
-    auto input1_shape = _impl_params->input_layouts[1].get_partial_shape();
-    auto input2_shape = _impl_params->input_layouts[2].get_partial_shape();
+scatter_elements_update_inst::typed_primitive_inst(network& network, scatter_elements_update_node const& node) : parent(network, node) {
+    update_output_memory();
+}
 
-    if ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0))
-        update_output_memory();
+void scatter_elements_update_inst::on_execute() {
+    update_output_memory();
 }
 
 void scatter_elements_update_inst::update_output_memory() {
+    if (!can_be_optimized() || _impl_params->is_dynamic())
+        return;
+
     if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;

--- a/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_nd_update.cpp
@@ -64,18 +64,18 @@ std::string scatter_nd_update_inst::to_string(scatter_nd_update_node const& node
     return primitive_description.str();
 }
 
-scatter_nd_update_inst::typed_primitive_inst(network& network, scatter_nd_update_node const& node) : parent(network, node) {}
+scatter_nd_update_inst::typed_primitive_inst(network& network, scatter_nd_update_node const& node) : parent(network, node) {
+    update_output_memory();
+}
 
 void scatter_nd_update_inst::on_execute() {
-    auto input1_shape = _impl_params->input_layouts[1].get_partial_shape();
-    auto input2_shape = _impl_params->input_layouts[2].get_partial_shape();
-    auto same_layouts = _impl_params->input_layouts[0] == _impl_params->output_layouts[0];
-
-    if (same_layouts && ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0)))
-        update_output_memory();
+    update_output_memory();
 }
 
 void scatter_nd_update_inst::update_output_memory() {
+    if (!can_be_optimized() || _impl_params->is_dynamic())
+        return;
+
     if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;

--- a/src/plugins/intel_gpu/src/graph/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/scatter_update.cpp
@@ -44,17 +44,18 @@ std::string scatter_update_inst::to_string(scatter_update_node const& node) {
     return primitive_description.str();
 }
 
-scatter_update_inst::typed_primitive_inst(network& network, scatter_update_node const& node) : parent(network, node) {}
+scatter_update_inst::typed_primitive_inst(network& network, scatter_update_node const& node) : parent(network, node) {
+    update_output_memory();
+}
 
 void scatter_update_inst::on_execute() {
-    auto input1_shape = _impl_params->input_layouts[1].get_partial_shape();
-    auto input2_shape = _impl_params->input_layouts[2].get_partial_shape();
-
-    if ((ov::shape_size(input1_shape.to_shape()) == 0) || (ov::shape_size(input2_shape.to_shape()) == 0))
-        update_output_memory();
+    update_output_memory();
 }
 
 void scatter_update_inst::update_output_memory() {
+    if (!can_be_optimized() || _impl_params->is_dynamic())
+        return;
+
     if (_outputs.size() > 0 && static_cast<bool>(_outputs[0])
         && _network.get_engine().is_the_same_buffer(output_memory(), input_memory()))
         return;

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/skip_scatter_update_at_runtime.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/skip_scatter_update_at_runtime.cpp
@@ -1,0 +1,184 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "test_utils.h"
+
+#include <intel_gpu/primitives/input_layout.hpp>
+#include <intel_gpu/primitives/scatter_elements_update.hpp>
+#include <intel_gpu/primitives/scatter_nd_update.hpp>
+#include <intel_gpu/primitives/scatter_update.hpp>
+#include <intel_gpu/primitives/reorder.hpp>
+#include <intel_gpu/primitives/data.hpp>
+
+#include "permute_inst.h"
+#include "program_wrapper.h"
+
+#include <cmath>
+#include <algorithm>
+
+using namespace cldnn;
+using namespace ::tests;
+
+namespace skip_scatter_update_tests {
+
+enum scatter_update_type {
+	ScatterUpdate           = 0,
+	ScatterNDUpdate         = 1,
+	ScatterElementsUpdate   = 2
+};
+
+struct skip_scatter_update_params {
+    scatter_update_type scatter_type;
+    bool scatter_update_01_skipped;
+    bool scatter_update_02_skipped;
+};
+
+class skip_scatter_update_at_runtime_test : public testing::TestWithParam<skip_scatter_update_params> {};
+
+TEST_P(skip_scatter_update_at_runtime_test, runtime_skip) {
+    auto p = GetParam();
+    auto& engine = get_test_engine();
+
+    auto input_layout_static    = layout{ov::PartialShape{1,16}, data_types::f16, format::bfyx};
+    auto rank                   = input_layout_static.get_partial_shape().size();
+    auto input_layout_dynamic   = layout {ov::PartialShape::dynamic(rank), data_types::f16, format::get_default_format(rank)};
+
+    auto idx1_nonzero_layout    = layout{ov::PartialShape{1,16}, data_types::f16, format::bfyx};
+    auto idx1_zero_layout       = layout{ov::PartialShape{0,16}, data_types::f16, format::bfyx};
+    auto update1_nonzero_layout = layout{ov::PartialShape{1,16}, data_types::f16, format::bfyx};
+    auto update1_zero_layout    = layout{ov::PartialShape{0,16}, data_types::f16, format::bfyx};
+
+    auto idx2_nonzero_layout    = layout{ov::PartialShape{1,16}, data_types::f16, format::bfyx};
+    auto idx2_zero_layout       = layout{ov::PartialShape{0,16}, data_types::f16, format::bfyx};
+    auto update2_nonzero_layout = layout{ov::PartialShape{1,16}, data_types::f16, format::bfyx};
+    auto update2_zero_layout    = layout{ov::PartialShape{0,16}, data_types::f16, format::bfyx};
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    cldnn::network::ptr network = nullptr;
+
+    if (p.scatter_type == scatter_update_type::ScatterElementsUpdate) {
+        topology topology(input_layout("input", input_layout_dynamic),
+                            input_layout("idx1", input_layout_dynamic),
+                            input_layout("idx2", input_layout_dynamic),
+                            input_layout("update1", input_layout_dynamic),
+                            input_layout("update2", input_layout_dynamic),
+                            scatter_elements_update("scatter1", input_info("input"),    input_info("idx1"), input_info("update1"), 0),
+                            scatter_elements_update("scatter2", input_info("scatter1"), input_info("idx2"), input_info("update2"), 0),
+                            reorder("reorder", input_info("scatter2"), format::get_default_format(rank), data_types::f32));
+
+        network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+    } else if (p.scatter_type == scatter_update_type::ScatterUpdate) {
+        topology topology(input_layout("input", input_layout_dynamic),
+                            input_layout("idx1", input_layout_dynamic),
+                            input_layout("idx2", input_layout_dynamic),
+                            input_layout("update1", input_layout_dynamic),
+                            input_layout("update2", input_layout_dynamic),
+                            scatter_update("scatter1", input_info("input"),    input_info("idx1"), input_info("update1"), 0),
+                            scatter_update("scatter2", input_info("scatter1"), input_info("idx2"), input_info("update2"), 0),
+                            reorder("reorder", input_info("scatter2"), format::get_default_format(rank), data_types::f32));
+
+        network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+    } else if (p.scatter_type == scatter_update_type::ScatterNDUpdate) {
+        input_layout_static     = layout{ov::PartialShape{12}, data_types::f16, format::bfyx};
+        rank                    = input_layout_static.get_partial_shape().size();
+        input_layout_dynamic    = layout {ov::PartialShape::dynamic(rank), data_types::f16, format::get_default_format(rank)};
+
+        idx1_nonzero_layout     = layout{ov::PartialShape{12,1}, data_types::f16, format::bfyx};
+        idx1_zero_layout        = layout{ov::PartialShape{0,1}, data_types::f16, format::bfyx};
+        update1_nonzero_layout  = layout{ov::PartialShape{12}, data_types::f16, format::bfyx};
+        update1_zero_layout     = layout{ov::PartialShape{0}, data_types::f16, format::bfyx};
+        rank                    = idx1_nonzero_layout.get_partial_shape().size();
+        auto idx_layout_dynamic = layout {ov::PartialShape::dynamic(rank), data_types::f16, format::get_default_format(rank)};
+
+        idx2_nonzero_layout     = layout{ov::PartialShape{12,1}, data_types::f16, format::bfyx};
+        idx2_zero_layout        = layout{ov::PartialShape{0,1}, data_types::f16, format::bfyx};
+        update2_nonzero_layout  = layout{ov::PartialShape{12}, data_types::f16, format::bfyx};
+        update2_zero_layout     = layout{ov::PartialShape{0}, data_types::f16, format::bfyx};
+
+
+
+        topology topology(input_layout("input", input_layout_dynamic),
+                            input_layout("idx1", idx_layout_dynamic),
+                            input_layout("idx2", idx_layout_dynamic),
+                            input_layout("update1", input_layout_dynamic),
+                            input_layout("update2", input_layout_dynamic),
+                            scatter_nd_update("scatter1", input_info("input"),    input_info("idx1"), input_info("update1"), 2),
+                            scatter_nd_update("scatter2", input_info("scatter1"), input_info("idx2"), input_info("update2"), 2),
+                            reorder("reorder", input_info("scatter2"), format::get_default_format(rank), data_types::f32));
+
+        network = get_network(engine, topology, config, get_test_stream_ptr(), false);
+    }
+
+    auto input_mem              = engine.allocate_memory(input_layout_static);
+
+    auto idx1_layout_static     = p.scatter_update_01_skipped? idx1_zero_layout : idx1_nonzero_layout;
+    auto update1_layout_static  = p.scatter_update_01_skipped? update1_zero_layout : update1_nonzero_layout;
+
+    auto idx1_mem               = engine.allocate_memory(idx1_nonzero_layout);
+    auto update1_mem            = engine.allocate_memory(update1_nonzero_layout);
+
+    if (p.scatter_update_01_skipped) {
+        idx1_mem    = engine.reinterpret_buffer(*idx1_mem, idx1_zero_layout);
+        update1_mem = engine.reinterpret_buffer(*update1_mem, update1_zero_layout);
+    }
+
+    auto idx2_layout_static     = p.scatter_update_02_skipped? idx2_zero_layout : idx2_nonzero_layout;
+    auto update2_layout_static  = p.scatter_update_02_skipped? update2_zero_layout : update2_nonzero_layout;
+
+    auto idx2_mem               = engine.allocate_memory(idx2_nonzero_layout);
+    auto update2_mem            = engine.allocate_memory(update2_nonzero_layout);
+    if (p.scatter_update_02_skipped) {
+        idx2_mem    = engine.reinterpret_buffer(*idx2_mem, idx2_zero_layout);
+        update2_mem = engine.reinterpret_buffer(*update2_mem, update2_zero_layout);
+    }
+    network->set_input_data("input", input_mem);
+    network->set_input_data("idx1", idx1_mem);
+    network->set_input_data("idx2", idx2_mem);
+    network->set_input_data("update1", update1_mem);
+    network->set_input_data("update2", update2_mem);
+    auto outputs = network->execute();
+    outputs.begin()->second.get_memory();
+
+    auto input_inst = network->get_primitive("input");
+    auto scatter1_inst = network->get_primitive("scatter1");
+    auto scatter2_inst = network->get_primitive("scatter2");
+
+    ASSERT_EQ(scatter1_inst->can_be_optimized(), p.scatter_update_01_skipped);
+    ASSERT_EQ(scatter2_inst->can_be_optimized(), p.scatter_update_02_skipped);
+
+    if (scatter1_inst->can_be_optimized()) {
+        ASSERT_TRUE(engine.is_the_same_buffer(scatter1_inst->dep_memory(0),     scatter1_inst->output_memory(0)));
+    } else {
+        ASSERT_FALSE(engine.is_the_same_buffer(scatter1_inst->dep_memory(0),    scatter1_inst->output_memory(0)));
+    }
+
+    if (scatter2_inst->can_be_optimized()) {
+        ASSERT_TRUE(engine.is_the_same_buffer(scatter2_inst->dep_memory(0),     scatter2_inst->output_memory(0)));
+    } else {
+        ASSERT_FALSE(engine.is_the_same_buffer(scatter2_inst->dep_memory(0),    scatter2_inst->output_memory(0)));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke, skip_scatter_update_at_runtime_test,
+    testing::ValuesIn(std::vector<skip_scatter_update_params> {
+        { scatter_update_type::ScatterUpdate,           true,       true },
+        { scatter_update_type::ScatterUpdate,           true,       false},
+        { scatter_update_type::ScatterUpdate,           false,      true },
+        { scatter_update_type::ScatterUpdate,           false,      false},
+
+        { scatter_update_type::ScatterNDUpdate,         true,       true },
+        { scatter_update_type::ScatterNDUpdate,         true,       false},
+        { scatter_update_type::ScatterNDUpdate,         false,      true },
+        { scatter_update_type::ScatterNDUpdate,         false,      false},
+
+        { scatter_update_type::ScatterElementsUpdate,   true,       true },
+        { scatter_update_type::ScatterElementsUpdate,   true,       false},
+        { scatter_update_type::ScatterElementsUpdate,   false,      true },
+        { scatter_update_type::ScatterElementsUpdate,   false,      false},
+
+    }));
+}  // skip permute tests


### PR DESCRIPTION
### Details:
 - *Fix the memory corruption error found runtime skipped nodes for scatter element update*
 - *Implement do_runtime_scatter_update_skippable*
 - *Add scatter_update to mark_runtime_skippable_nodes*
 - *Update memory clearing codes to support the following cases:*
   - ***Issued case1***
     - *iter0: node1(executed) -> node2(skipped) -> node3(skipped)*
     - *iter1: node1(skipped)  -> node2(skipped) -> node3(executed)*
   - ***Issued case2***
     - *iter0: node1(skipped)  -> node2(skipped) -> node3(skipped)*
     - *iter1: node1(executed) -> node2(skipped) -> node3(executed)*

### Tickets:
 - *154591*
