### PR TITLE
[GPU] Don't select add_fusing_type::sum when dependency is input_layout in  loop body network

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -117,7 +117,8 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
             && p_layout.data_padding == d_layout.data_padding
             && dep_node.get_users().size() == 1
             && !dep_node.is_constant()
-            && !p_node.is_type<pooling>()) {
+            && !p_node.is_type<pooling>()
+            && !(dep_node.get_program().is_body_program() && dep_node.is_type<input_layout>())) {
             return add_fusing_type::sum;
         } else if (p_layout.get_tensor() == d_layout.get_tensor()) {
             return add_fusing_type::binary_per_tensor;


### PR DESCRIPTION
### Details:
 - Don't select add_fusing_type::sum when dependency is input_layout in  loop body network. sum op could contaminate memory buffer. 

### Tickets:
 - 154020
