### PR TITLE
[CPU] Roll back deconv 3rd rank layout order for non AMX

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -418,24 +418,38 @@ std::pair<VectorDims, VectorDims> Deconvolution::makeDummyInOutShape() {
     return {inShape.getStaticDims(), outShape.getStaticDims()};
 }
 
-std::vector<memory::format_tag> Deconvolution::getAvailableFormatsForDims(const Shape &dims) const {
-    if (dims.getRank() == 0)
+std::vector<memory::format_tag> Deconvolution::getAvailableFormatsForDims(const Shape& dims) const {
+    if (dims.getRank() == 0) {
         return {memory::format_tag::x};
-    else if (dims.getRank() == 1)
+    } else if (dims.getRank() == 1) {
         return {memory::format_tag::x};
-    else if (dims.getRank() == 2)
+    } else if (dims.getRank() == 2) {
         return {memory::format_tag::nc};
-    else if (dims.getRank() == 3)
-        return {memory::format_tag::ncw,
-                memory::format_tag::nCw8c,
-                memory::format_tag::nCw16c,
-                memory::format_tag::nwc};
-    else if (dims.getRank() == 4)
-        return {memory::format_tag::nchw, memory::format_tag::nChw8c,
-                memory::format_tag::nChw16c, memory::format_tag::nhwc };
-    else if (dims.getRank() == 5)
-        return {memory::format_tag::ncdhw, memory::format_tag::nCdhw8c,
-                memory::format_tag::nCdhw16c, dnnl::memory::format_tag::ndhwc };
+    } else if (dims.getRank() == 3) {
+        // Ticket 156640
+        if (impl::cpu::x64::mayiuse(impl::cpu::x64::avx512_core_amx_fp16)) {
+            return {memory::format_tag::ncw,
+                    memory::format_tag::nCw8c,
+                    memory::format_tag::nCw16c,
+                    memory::format_tag::nwc};
+        } else {
+            return {memory::format_tag::tnc,
+                    memory::format_tag::ntc,
+                    memory::format_tag::ncw,
+                    memory::format_tag::nCw8c,
+                    memory::format_tag::nCw16c};
+        }
+    } else if (dims.getRank() == 4) {
+        return {memory::format_tag::nchw,
+                memory::format_tag::nChw8c,
+                memory::format_tag::nChw16c,
+                memory::format_tag::nhwc};
+    } else if (dims.getRank() == 5) {
+        return {memory::format_tag::ncdhw,
+                memory::format_tag::nCdhw8c,
+                memory::format_tag::nCdhw16c,
+                dnnl::memory::format_tag::ndhwc};
+    }
     return {memory::format_tag::any};
 }
 


### PR DESCRIPTION
### Details:
 - *temporal WA limiting Deconv acb Layout to avx512_core_amx_fp16 platform before oneDNN fix the performance regression issue of related primitive creation*


### Tickets:
 - *CVS-156640*
