### PR TITLE
[PyOV] Improve import_model memory consumption

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/core.cpp
+++ b/src/bindings/python/src/pyopenvino/core/core.cpp
@@ -499,57 +499,13 @@ void regclass_Core(py::module m) {
     cls.def(
         "import_model",
         [](ov::Core& self,
-           const std::string& model_stream,
-           const std::string& device_name,
-           const std::map<std::string, py::object>& properties) {
-            auto _properties = Common::utils::properties_to_any_map(properties);
-            py::gil_scoped_release release;
-            std::stringstream _stream;
-            _stream << model_stream;
-            return self.import_model(_stream, device_name, _properties);
-        },
-        py::arg("model_stream"),
-        py::arg("device_name"),
-        py::arg("properties"),
-        R"(
-            Imports a compiled model from a previously exported one.
-
-            GIL is released while running this function.
-
-            :param model_stream: Input stream, containing a model previously exported, using export_model method.
-            :type model_stream: bytes
-            :param device_name: Name of device to which compiled model is imported.
-                                Note: if device_name is not used to compile the original model, an exception is thrown.
-            :type device_name: str
-            :param properties: Optional map of pairs: (property name, property value) relevant only for this load operation.
-            :type properties: dict, optional
-            :return: A compiled model.
-            :rtype: openvino.runtime.CompiledModel
-
-            :Example:
-            .. code-block:: python
-
-                user_stream = compiled.export_model()
-
-                with open('./my_model', 'wb') as f:
-                    f.write(user_stream)
-
-                # ...
-
-                new_compiled = core.import_model(user_stream, "CPU")
-        )");
-
-    // keep as second one to solve overload resolution problem
-    cls.def(
-        "import_model",
-        [](ov::Core& self,
            const py::object& model_stream,
            const std::string& device_name,
            const std::map<std::string, py::object>& properties) {
             const auto _properties = Common::utils::properties_to_any_map(properties);
-            if (!(py::isinstance(model_stream, pybind11::module::import("io").attr("BytesIO")))) {
+            if (!(py::isinstance(model_stream, pybind11::module::import("io").attr("BytesIO"))) && !py::isinstance<py::bytes>(model_stream)) {
                 throw py::type_error("CompiledModel.import_model(model_stream) incompatible function argument: "
-                                     "`model_stream` must be an io.BytesIO object but " +
+                                     "`model_stream` must be an io.BytesIO object or bytes but " +
                                      (std::string)(py::repr(model_stream)) + "` provided");
             }
             std::random_device rd;
@@ -557,9 +513,14 @@ void regclass_Core(py::module m) {
             std::uniform_int_distribution<> distr(1000, 9999);
             std::string filename = "model_stream_" + std::to_string(distr(gen)) + ".txt";
             std::fstream _stream(filename, std::ios::out | std::ios::binary);
-            model_stream.attr("seek")(0);  // Always rewind stream!
             if (_stream.is_open()) {
-                const py::bytes data = model_stream.attr("read")();
+                py::bytes data;
+                if (py::isinstance(model_stream, pybind11::module::import("io").attr("BytesIO"))) {
+                    model_stream.attr("seek")(0);  // Always rewind stream!
+                    data = model_stream.attr("read")();
+                } else {
+                    data = model_stream;
+                }
                 // convert the Python bytes object to C++ string
                 char* buffer;
                 Py_ssize_t length;
@@ -601,7 +562,7 @@ void regclass_Core(py::module m) {
 
 
             :param model_stream: Input stream, containing a model previously exported, using export_model method.
-            :type model_stream: io.BytesIO
+            :type model_stream: Union[io.BytesIO, bytes]
             :param device_name: Name of device to which compiled model is imported.
                                 Note: if device_name is not used to compile the original model, an exception is thrown.
             :type device_name: str

--- a/src/bindings/python/src/pyopenvino/frontend/frontend.cpp
+++ b/src/bindings/python/src/pyopenvino/frontend/frontend.cpp
@@ -20,13 +20,6 @@ namespace py = pybind11;
 
 using namespace ov::frontend;
 
-class MemoryBuffer : public std::streambuf {
-public:
-    MemoryBuffer(char* data, std::size_t size) {
-        setg(data, data, data + size);
-    }
-};
-
 void regclass_frontend_FrontEnd(py::module m) {
     py::class_<FrontEnd, std::shared_ptr<FrontEnd>> fem(m, "FrontEnd", py::dynamic_attr(), py::module_local());
     fem.doc() = "openvino.frontend.FrontEnd wraps ov::frontend::FrontEnd";
@@ -57,7 +50,7 @@ void regclass_frontend_FrontEnd(py::module m) {
             } else if (py::isinstance(py_obj, pybind11::module::import("io").attr("BytesIO"))) {
                 // support of BytesIO
                 py::buffer_info info = py::buffer(py_obj.attr("getbuffer")()).request();
-                MemoryBuffer mb(reinterpret_cast<char*>(info.ptr), info.size);
+                Common::utils::MemoryBuffer mb(reinterpret_cast<char*>(info.ptr), info.size);
                 std::istream _istream(&mb);
                 return self.load(&_istream, enable_mmap);
             } else {


### PR DESCRIPTION
### Details:
 - Writing to stringstream caused additional copy
 - Usage of fstream also caused extra memory usage. Also we needed to proper handle saving/removal of the tmp_file.
 - So I've squeezed two `import_model` methods to one and I've implemented/reused custom buffer that wraps interactions with python memory without extra copies

### Tickets:
 - EISW-137436
