### PR TITLE
[NPU] Adjust wording to avoid confusion when running benchmarks

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_profiling.cpp
@@ -103,7 +103,7 @@ void ProfilingQuery::getProfilingProperties(ze_device_profiling_data_properties_
 
 void ProfilingQuery::verifyProfilingProperties() const {
     if (!_handle) {
-        OPENVINO_THROW("Can't get profiling statistics because profiling is disabled.");
+        OPENVINO_THROW("No available profiling data.");
     }
     const auto stringifyVersion = [](auto version) -> std::string {
         return std::to_string(ZE_MAJOR_VERSION(version)) + "." + std::to_string(ZE_MINOR_VERSION(version));


### PR DESCRIPTION
### Details:
While investigating the problem raised by the EISW-117106 ticket, turned out that, in fact, a problem lies within the Benchmark App. For that problem, we've filed a separate ticket CVS-156823 and here we adjust the wording, aiming to reduce end-user confusion.

### Tickets:
 - E-117106
