### PR TITLE
[Benchmark App] Reject -nireq > -niter when using sync API

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -60,6 +60,10 @@ bool parse_and_check_command_line(int argc, char* argv[]) {
     if (FLAGS_api != "async" && FLAGS_api != "sync") {
         throw std::logic_error("Incorrect API. Please set -api option to `sync` or `async` value.");
     }
+    if (FLAGS_api == "sync" && FLAGS_nireq > FLAGS_niter) {
+        throw std::logic_error(
+            "Number of iterations should be greater than number of infer requests when using sync API.");
+    }
     if (!FLAGS_hint.empty() && FLAGS_hint != "throughput" && FLAGS_hint != "tput" && FLAGS_hint != "latency" &&
         FLAGS_hint != "cumulative_throughput" && FLAGS_hint != "ctput" && FLAGS_hint != "none") {
         throw std::logic_error("Incorrect performance hint. Please set -hint option to"

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -49,6 +49,9 @@ def parse_and_check_command_line():
         raise Exception("Cannot set precision for a compiled model. " \
                         "Please re-compile your model with required precision.")
 
+    if args.api_type == "sync" and args.number_infer_requests > args.number_iterations:
+        raise Exception("Number of infer requests should be less than or equal to number of iterations in sync mode.")
+
     return args, is_network_compiled
 
 def main():


### PR DESCRIPTION
### Details:
While investigating the problem raised by the E-117106 ticket, turned out that, in fact, a problem lies within the Benchmark App. When choosing the sync API, it is not possible to run more inference requests than specified iterations. Later on, if `-pc` flag was given, the app still tries to display the profiling data for the never launched inferences.  This PR detects this situation and rejects the application execution after writing an explanatory message to the console output. Changes are applied for both C++ and Python versions of the benchmark app.

### Tickets:
 - CVS-156823
