### PR TITLE
[OP][CPU] Fix SliceScatter issues with non-constant slice params

### DIFF
--- a/src/core/shape_inference/include/utils.hpp
+++ b/src/core/shape_inference/include/utils.hpp
@@ -46,8 +46,12 @@ struct TensorTransform : element::NotSupported<void> {
  */
 template <class T, class TResult = std::vector<T>, class UnaryOperation>
 TResult get_raw_data_as(const element::Type_t et, const void* const ptr, const size_t size, UnaryOperation&& func) {
-    OPENVINO_ASSERT(!!ptr, "ptr is Null");
     TResult out;
+    if (!ptr && size == 0) {
+        // Tensor is empty
+        return out;
+    }
+    OPENVINO_ASSERT(!!ptr, "ptr is Null");
     auto out_it = std::inserter(out, out.end());
 
     using namespace ov::element;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice_scatter.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice_scatter.cpp
@@ -83,7 +83,13 @@ protected:
                                                                  in_data);
             } else {
                 // Fill the slice input2~input5 with specified data.
-                tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i], inputValues[i - 2]};
+                auto inputValue = inputValues[i - 2];
+                if (!inputValue) {
+                    const auto param = ov::as_type_ptr<const ov::op::v0::Parameter>(funcInput.get_node_shared_ptr());
+                    tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i]};
+                } else {
+                    tensor = ov::Tensor{ov::element::i64, targetInputStaticShapes[i], inputValue};
+                }
             }
             inputs.insert({funcInput.get_node_shared_ptr(), tensor});
         }
@@ -228,7 +234,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Plain_Static_2D,
                          SliceScatterLayerCPUTest,
                          ::testing::Combine(::testing::Values(static_shapes_to_test_representation({{32, 16}})),
                                             ::testing::ValuesIn(paramsPlain2D),
-                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputLayerTypes),
                                             ::testing::ValuesIn(inputPrecisions),
                                             ::testing::Values(emptyCPUSpec)),
                          SliceScatterLayerCPUTest::getTestCaseName);
@@ -319,7 +325,7 @@ INSTANTIATE_TEST_SUITE_P(
     SliceScatterLayerCPUTest,
     ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic4D)),
                        ::testing::ValuesIn(testCasesCommon4D),
-                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputLayerTypes),
                        ::testing::ValuesIn(inputPrecisions),
                        ::testing::ValuesIn(CPUParamsCommon4D)),
     SliceScatterLayerCPUTest::getTestCaseName);
@@ -407,7 +413,7 @@ INSTANTIATE_TEST_SUITE_P(
     SliceScatterLayerCPUTest,
     ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(inputShapesStatic5D)),
                        ::testing::ValuesIn(testCasesCommon5D),
-                       ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                       ::testing::ValuesIn(inputLayerTypes),
                        ::testing::ValuesIn(inputPrecisions),
                        ::testing::ValuesIn(CPUParamsCommon5D)),
     SliceScatterLayerCPUTest::getTestCaseName);
@@ -441,7 +447,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_CompareWithRefs_Common_Full_Slice_5D,
                          SliceScatterLayerCPUTest,
                          ::testing::Combine(::testing::ValuesIn(inputShapesFullSlice5D),
                                             ::testing::ValuesIn(testCasesFullSlice5D),
-                                            ::testing::Values(ov::test::utils::InputLayerType::CONSTANT),
+                                            ::testing::ValuesIn(inputLayerTypes),
                                             ::testing::ValuesIn(inputPrecisions),
                                             ::testing::ValuesIn(CPUParamsCommon5D)),
                          SliceScatterLayerCPUTest::getTestCaseName);

--- a/src/plugins/template/tests/functional/op_reference/slice_scatter.cpp
+++ b/src/plugins/template/tests/functional/op_reference/slice_scatter.cpp
@@ -194,6 +194,13 @@ std::vector<SliceScatterParams> generateSliceScatterParamsUnsigned() {
                            reference_tests::Tensor{{1}, AXIS_ET, std::vector<AXIS_T>{0}},
                            reference_tests::Tensor{{4}, DATA_ET, std::vector<DATA_T>{1, 10, 3, 20}},
                            "1D_2_step_replace"),
+        SliceScatterParams(reference_tests::Tensor{{4}, DATA_ET, std::vector<DATA_T>{1, 2, 3, 4}},
+                           reference_tests::Tensor{{4}, DATA_ET, std::vector<DATA_T>{10, 20, 30, 40}},
+                           reference_tests::Tensor{{0}, IND_ET, std::vector<IND_T>{}},
+                           reference_tests::Tensor{{0}, IND_ET, std::vector<IND_T>{}},
+                           reference_tests::Tensor{{0}, IND_ET, std::vector<IND_T>{}},
+                           reference_tests::Tensor{{4}, DATA_ET, std::vector<DATA_T>{10, 20, 30, 40}},
+                           "1D_full_replace_empty_slice_params"),
         SliceScatterParams(
             reference_tests::Tensor{{4, 4},
                                     DATA_ET,
@@ -348,6 +355,23 @@ std::vector<SliceScatterParams> generateSliceScatterParamsUnsigned() {
                                                                                30, 31, 32, 33, 34, 35, 54, 55, 38, 39,
                                                                                40, 41, 56, 57, 44, 45, 46, 47}},
             "4D_partial_replace_even_axes"),
+        SliceScatterParams(
+            reference_tests::Tensor{{4, 2, 3, 2}, DATA_ET, std::vector<DATA_T>{}},
+            reference_tests::Tensor{{4, 2, 3, 2}, DATA_ET, std::vector<DATA_T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                                                               10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                                                               20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                                                               30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                                                               40, 41, 42, 43, 44, 45, 46, 47}},
+            reference_tests::Tensor{{0}, IND_ET, std::vector<IND_T>{}},
+            reference_tests::Tensor{{0}, IND_ET, std::vector<IND_T>{}},
+            reference_tests::Tensor{{0}, IND_ET, std::vector<IND_T>{}},
+            reference_tests::Tensor{{0}, IND_ET, std::vector<AXIS_T>{}},
+            reference_tests::Tensor{{4, 2, 3, 2}, DATA_ET, std::vector<DATA_T>{0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+                                                                               10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                                                               20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                                                                               30, 31, 32, 33, 34, 35, 36, 37, 38, 39,
+                                                                               40, 41, 42, 43, 44, 45, 46, 47}},
+            "4D_full_replace_empty_slice_params"),
     };
     return test_params;
 }


### PR DESCRIPTION
### Details:
 - *SliceScatter could experience failures caused by not calling prepareParams() depending on input and execution type*
 - *Fix issue in calling get_raw_data in shape_inference on empty tensors*

### Tickets:
 - *CVS-156349*
