### PR TITLE
[NPUW] Fix bank weak_ptr

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<Bank> BankManager::getBank(const std::string& bank_name,
     std::lock_guard<std::mutex> guard(m_mutex);
 
     auto iter = m_bank_map.find(bank_name);
-    if (iter == m_bank_map.end()) {
+    if (iter == m_bank_map.end() || iter->second.expired()) {
         auto bank = std::make_shared<Bank>(core, alloc_device);
         m_bank_map[bank_name] = bank;
         return bank;


### PR DESCRIPTION
After CompiledModel object is deleted, shared_ptr<Bank> is reset - thus expiring weak_ptr in bank manager class. If we try to create a CompiledModel object again with the same bank name - it was trying to utilize already empty bank ptr. This PR fixes such case
Release branch PR https://github.com/openvinotoolkit/openvino/pull/27486
