### PR TITLE
Fix build with protobuf >= 27

### DIFF
--- a/src/frontends/onnx/frontend/src/frontend.cpp
+++ b/src/frontends/onnx/frontend/src/frontend.cpp
@@ -3,6 +3,9 @@
 //
 
 #include <google/protobuf/port_def.inc>
+#ifndef PROTOBUF_VERSION
+#    include <google/protobuf/runtime_version.h>
+#endif
 #if PROTOBUF_VERSION >= 4022000  // protobuf 4.22
 #    define OV_PROTOBUF_ABSL_IS_USED
 #endif

--- a/src/frontends/paddle/src/frontend.cpp
+++ b/src/frontends/paddle/src/frontend.cpp
@@ -5,6 +5,9 @@
 #include "openvino/frontend/paddle/frontend.hpp"
 
 #include <google/protobuf/port_def.inc>
+#ifndef PROTOBUF_VERSION
+#    include <google/protobuf/runtime_version.h>
+#endif
 #if PROTOBUF_VERSION >= 4022000  // protobuf 4.22
 #    define OV_PROTOBUF_ABSL_IS_USED
 #endif


### PR DESCRIPTION
### Details:
 - Due to https://github.com/protocolbuffers/protobuf/commit/009078df7a6c741d4e72a7471d1df41a58cc4070, `PROTOBUF_VERSION` is not defined in `google/protobuf/port_def.inc`
