### PR TITLE
[GPU] Do not use usm_host when network output tensor size is large

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/sync_infer_request.hpp
@@ -118,6 +118,7 @@ private:
 
     void init_mappings();
     bool is_batched_input(const ov::Output<const ov::Node>& port) const;
+    uint64_t total_output_bytes = 0;
 };
 
 }  // namespace intel_gpu

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/debug_configuration.hpp
@@ -142,6 +142,7 @@ public:
     int disable_runtime_skip_reorder;                           // Disable runtime skip reorder
     int disable_primitive_fusing;                               // Disable primitive fusing
     int disable_fake_alignment;                                 // Disable fake alignment
+    int use_usm_host;                                           // Set explicit usm_host usage for network input and output
     std::vector<std::string> dynamic_quantize_layers_without_onednn;  // Specify Fully-connected layers which enable Dynamic quantization
     int use_kv_cache_compression;                               // Enable KV-cache compression
     int dynamic_quantize_group_size;                            // Enable Dynamic quantization for fully connected primitive by specified group size

--- a/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
+++ b/src/plugins/intel_gpu/src/runtime/debug_configuration.cpp
@@ -183,6 +183,8 @@ static void print_help_messages() {
     message_list.emplace_back("OV_GPU_DisableRuntimeSkipReorder", "Disable runtime skip reorder.");
     message_list.emplace_back("OV_GPU_DisablePrimitiveFusing", "Disable primitive fusing");
     message_list.emplace_back("OV_GPU_DisableFakeAlignment", "Disable fake alignment");
+    message_list.emplace_back("OV_GPU_UseUsmHost", "Set explicit policy for usm host usage for network input/output. "
+                              "0: default, 1: use usm_host, 2: do not use usm_host");
     message_list.emplace_back("OV_GPU_KVCacheCompression", "Enable/Disable KV-cache compression");
     message_list.emplace_back("OV_GPU_DynamicQuantizeLayersWithoutOnednn", "Enable Dynamic quantization for specified Fully connected layers only, "
                                 "separated by space. Support case-insensitive and regular expression. For example .*fully_connected.*");
@@ -254,6 +256,7 @@ debug_configuration::debug_configuration()
         , disable_runtime_skip_reorder(0)
         , disable_primitive_fusing(0)
         , disable_fake_alignment(0)
+        , use_usm_host(0)
         , use_kv_cache_compression(-1)
         , dynamic_quantize_group_size(DYNAMIC_QUANTIZE_GROUP_SIZE_NOT_SET)
         , disable_horizontal_fc_fusion(0) {
@@ -307,6 +310,7 @@ debug_configuration::debug_configuration()
     get_gpu_debug_env_var("DisableRuntimeSkipReorder", disable_runtime_skip_reorder);
     get_gpu_debug_env_var("DisablePrimitiveFusing", disable_primitive_fusing);
     get_gpu_debug_env_var("DisableFakeAlignment", disable_fake_alignment);
+    get_gpu_debug_env_var("UseUsmHost", use_usm_host);
     get_gpu_debug_env_var("KVCacheCompression", use_kv_cache_compression);
     get_gpu_debug_env_var("DynamicQuantizeGroupSize", dynamic_quantize_group_size);
     get_gpu_debug_env_var("DisableHorizontalFCFusion", disable_horizontal_fc_fusion);


### PR DESCRIPTION
### Details:
 - For dGPU including A770, when network output size is large, performance is better with explicit copy then writing data to usm_host.
 - Allow usm_host access for input
 - Next-gen dGPU, write to usm_device and copy it to usm_host
 - For DG2, write to usm_device only for large output

### Tickets:
 - 157439
