### PR TITLE
[CPU] Throw when release_memory is called during inference

### DIFF
--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -183,7 +183,6 @@ CompiledModel::GraphGuard::Lock CompiledModel::get_graph() const {
 }
 
 std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request() const {
-    m_numRequests++;
     return std::make_shared<SyncInferRequest>(std::static_pointer_cast<const CompiledModel>(shared_from_this()));
 }
 

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -21,6 +21,15 @@ namespace intel_cpu {
 
 class CompiledModel : public ov::ICompiledModel {
 public:
+    struct GraphGuard : public Graph {
+        std::mutex _mutex;
+        struct Lock : public std::unique_lock<std::mutex> {
+            explicit Lock(GraphGuard& graph) : std::unique_lock<std::mutex>(graph._mutex), _graph(graph) {}
+            GraphGuard& _graph;
+        };
+    };
+
+public:
     typedef std::shared_ptr<CompiledModel> Ptr;
 
     CompiledModel(const std::shared_ptr<ov::Model>& model,
@@ -51,9 +60,13 @@ public:
 
     void release_memory() override;
 
+    std::string name() const {
+        return m_name;
+    }
+
 private:
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
-    friend class SyncInferRequest;
+    friend class CompiledModelHandler;
 
     const std::shared_ptr<ov::Model> m_model;
     const std::shared_ptr<const ov::IPlugin> m_plugin;
@@ -66,13 +79,6 @@ private:
     Config m_cfg;
     mutable std::atomic_int m_numRequests = {0};
     std::string m_name;
-    struct GraphGuard : public Graph {
-        std::mutex _mutex;
-        struct Lock : public std::unique_lock<std::mutex> {
-            explicit Lock(GraphGuard& graph) : std::unique_lock<std::mutex>(graph._mutex), _graph(graph) {}
-            GraphGuard& _graph;
-        };
-    };
 
     const bool m_loaded_from_cache;
     // WARNING: Do not use m_graphs directly.
@@ -92,6 +98,59 @@ private:
     std::vector<std::shared_ptr<CompiledModel>> m_sub_compiled_models;
     std::shared_ptr<SubMemoryManager> m_sub_memory_manager = nullptr;
     bool m_has_sub_compiled_models = false;
+};
+
+// This class provides safe access to the internal CompiledModel structures and helps to decouple SyncInferRequest and
+// the CompiledModel internal structures
+class CompiledModelHandler {
+public:
+    CompiledModelHandler(std::shared_ptr<const CompiledModel> compiled_model)
+        : m_compiled_model(std::move(compiled_model)) {
+        OPENVINO_ASSERT(!m_compiled_model->m_graphs.empty(),
+                        "No graph was found in the compiled model: ",
+                        m_compiled_model->name());
+        m_graph = &(m_compiled_model->get_graph()._graph);
+        OPENVINO_ASSERT(m_graph, "Graph ptr null check failed");
+        m_id = (m_compiled_model->m_numRequests)++;
+    }
+
+    ~CompiledModelHandler() {
+        --(m_compiled_model->m_numRequests);
+    }
+
+    CompiledModelHandler(const CompiledModelHandler&) = delete;
+    CompiledModelHandler& operator=(const CompiledModelHandler&) = delete;
+
+    CompiledModelHandler(CompiledModelHandler&&) = default;
+    CompiledModelHandler& operator=(CompiledModelHandler&&) = default;
+
+    const Graph& graph() const {
+        return *m_graph;
+    }
+
+    CompiledModel::GraphGuard::Lock lock() {
+        auto lock = m_compiled_model->get_graph();
+        m_graph = &(lock._graph);
+        OPENVINO_ASSERT(m_graph, "Graph ptr null check failed");
+        return lock;
+    }
+
+    std::string name() const {
+        return m_compiled_model->name();
+    }
+
+    std::shared_ptr<const ov::ICompiledModel> compiled_model() const {
+        return m_compiled_model;
+    }
+
+    int id() const {
+        return m_id;
+    }
+
+private:
+    std::shared_ptr<const CompiledModel> m_compiled_model;
+    const Graph* m_graph;
+    int m_id;
 };
 
 }   // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -115,7 +115,9 @@ public:
     }
 
     ~CompiledModelHandler() {
-        --(m_compiled_model->m_numRequests);
+        if (m_compiled_model) {
+            --(m_compiled_model->m_numRequests);
+        }
     }
 
     CompiledModelHandler(const CompiledModelHandler&) = delete;

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -89,22 +89,22 @@ public:
         return _name;
     }
 
-    std::map<std::size_t, NodePtr>& GetInputNodesMap() {
+    const std::map<std::size_t, NodePtr>& GetInputNodesMap() const {
         return inputNodesMap;
     }
 
-    std::map<std::size_t, NodePtr>& GetOutputNodesMap() {
+    const std::map<std::size_t, NodePtr>& GetOutputNodesMap() const {
         return outputNodesMap;
     }
 
-    NodePtr getInputNodeByIndex(const std::size_t &index) {
+    NodeConstPtr getInputNodeByIndex(const std::size_t &index) const {
         auto input = inputNodesMap.find(index);
         if (input == inputNodesMap.end())
             OPENVINO_THROW("CPU execution graph doesn't contain input node with index: ", index);
         return input->second;
     }
 
-    NodePtr getOutputNodeByIndex(const std::size_t &index) {
+    NodeConstPtr getOutputNodeByIndex(const std::size_t &index) const {
         auto output = outputNodesMap.find(index);
         if (output == outputNodesMap.end())
             OPENVINO_THROW("CPU execution graph doesn't contain output node with index: ", index);

--- a/src/plugins/intel_cpu/tests/functional/custom/behavior/ov_executable_network/concurent_release_memory.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/behavior/ov_executable_network/concurent_release_memory.cpp
@@ -1,0 +1,177 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gmock/gmock-spec-builders.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+#include <common_test_utils/test_common.hpp>
+#include <common_test_utils/test_constants.hpp>
+#include <condition_variable>
+#include <openvino/core/model.hpp>
+#include <openvino/op/op.hpp>
+#include <openvino/openvino.hpp>
+#include <thread>
+
+namespace ov {
+namespace intel_cpu {
+namespace cpu_unit_test {
+// Openvino extension operation that sleeps for X us in its evaluate method
+
+class Sleep : public ov::op::Op {
+public:
+    OPENVINO_OP("Sleep");
+    Sleep() = default;
+    Sleep(const ov::OutputVector& args,
+          size_t sleep,
+          std::shared_ptr<std::mutex> mutex,
+          std::shared_ptr<std::condition_variable> cv,
+          std::shared_ptr<std::atomic<bool>> ready_flag)
+        : Op(args),
+          m_sleep(sleep),
+          m_mutex(mutex),
+          m_cv(cv),
+          m_ready_flag(ready_flag) {
+        constructor_validate_and_infer_types();
+    }
+
+    void validate_and_infer_types() override {
+        set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
+    }
+
+    std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override {
+        OPENVINO_ASSERT(new_args.size() == 1, "Incorrect number of new arguments");
+        auto new_op = std::make_shared<Sleep>(new_args, m_sleep, m_mutex, m_cv, m_ready_flag);
+        return new_op;
+    }
+
+    bool visit_attributes(ov::AttributeVisitor& visitor) override {
+        return true;
+    }
+
+    void revalidate_and_infer_types() override {
+        validate_and_infer_types();
+    }
+
+    bool evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) const override {
+        {
+            // this is required to start all the evaluate calls at the same time
+            std::unique_lock<std::mutex> lock(*m_mutex);
+            m_cv->wait(lock, [&] {
+                return m_ready_flag->load();
+            });
+        }
+        std::this_thread::sleep_for(std::chrono::microseconds(m_sleep));
+        return true;
+    }
+
+    bool evaluate(ov::TensorVector& output_values,
+                  const ov::TensorVector& input_values,
+                  const ov::EvaluationContext& evaluationContext) const override {
+        return evaluate(output_values, input_values);
+    }
+
+    bool has_evaluate() const override {
+        return true;
+    }
+
+private:
+    size_t m_sleep;  // sleep time in us
+    std::shared_ptr<std::mutex> m_mutex;
+    std::shared_ptr<std::condition_variable> m_cv;
+    std::shared_ptr<std::atomic<bool>> m_ready_flag;
+};
+}  // namespace cpu_unit_test
+}  // namespace intel_cpu
+}  // namespace ov
+
+class ReleaseMemoryMultiThreadTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        using namespace ov::intel_cpu::cpu_unit_test;
+
+        param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1});
+
+        constexpr size_t sleep_time = 5;  // us
+        mutex = std::make_shared<std::mutex>();
+        cv = std::make_shared<std::condition_variable>();
+        ready_flag = std::make_shared<std::atomic<bool>>(false);
+
+        auto sleep = std::make_shared<Sleep>(ov::OutputVector{param}, sleep_time, mutex, cv, ready_flag);
+        ov::ResultVector results{std::make_shared<ov::op::v0::Result>(sleep)};
+        ov::ParameterVector params{param};
+
+        auto model = std::make_shared<ov::Model>(results, params, "testModel");
+
+        compiled_model = core.compile_model(model, ov::test::utils::DEVICE_CPU, {{"NUM_STREAMS", num_streams}});
+    }
+
+protected:
+    const size_t num_streams = 4;
+    ov::Core core;
+    ov::CompiledModel compiled_model;
+    std::shared_ptr<ov::op::v0::Parameter> param;
+
+    std::shared_ptr<std::mutex> mutex;
+    std::shared_ptr<std::condition_variable> cv;
+    std::shared_ptr<std::atomic<bool>> ready_flag;
+};
+
+TEST_F(ReleaseMemoryMultiThreadTest, smoke_throwInferenceIsRunning) {
+    // Create and infer a few infer requests concurrently
+    std::vector<ov::InferRequest> inferRequests;
+    for (size_t i = 0; i < num_streams; i++) {
+        auto inferRequest = compiled_model.create_infer_request();
+        inferRequest.set_tensor(param, ov::Tensor(ov::element::f32, ov::Shape{1}));
+        inferRequests.push_back(std::move(inferRequest));
+    }
+    // infer the infer requests
+    for (auto& inferRequest : inferRequests) {
+        inferRequest.start_async();
+    }
+
+    // While the infer requests are waiting on the cv, call release_memory.
+    // We expect that the method will throw an exception when it is called while infer requests are running.
+    EXPECT_THROW(compiled_model.release_memory(), ov::Exception);
+
+    {
+        // lets unlock cv
+        std::lock_guard<std::mutex> lock(*mutex);
+        ready_flag->store(true);
+    }
+    cv->notify_all();
+
+    for (auto& inferRequest : inferRequests) {
+        inferRequest.wait();
+    }
+}
+
+TEST_F(ReleaseMemoryMultiThreadTest, smoke_noThrowInferenceIsNotRunning) {
+    // Create and infer a few infer requests concurrently
+    std::vector<ov::InferRequest> inferRequests;
+    for (size_t i = 0; i < num_streams; i++) {
+        auto inferRequest = compiled_model.create_infer_request();
+        inferRequest.set_tensor(param, ov::Tensor(ov::element::f32, ov::Shape{1}));
+        inferRequests.push_back(std::move(inferRequest));
+    }
+    // infer the infer requests
+    for (auto& inferRequest : inferRequests) {
+        inferRequest.start_async();
+    }
+
+    {
+        // lets unlock cv
+        std::lock_guard<std::mutex> lock(*mutex);
+        ready_flag->store(true);
+    }
+    cv->notify_all();
+
+    for (auto& inferRequest : inferRequests) {
+        inferRequest.wait();
+    }
+
+    // Don't throw when the infer requests are finished
+    EXPECT_NO_THROW(compiled_model.release_memory());
+}


### PR DESCRIPTION
### Details:
This PR changes the behavior of the `CompiledModel::release_memory()` implementation in the CPU plugin for the situation when the method is being called concurrently with other graph state modifying methods (e.g. graph initialization, inference, properties request). This is necessary to ensure thread safety and provide a clear defined behavior when the method is called concurrently.
Also, the PR contains some refactoring of the Infer request implementation, aimed at decoupling the InferRequest implementation from the compiled model internals and providing a safer interface that ensuring thread safe access to the CPU graph structures.