### PR TITLE
[CPU] Enable memory reuse for nested graphs

### DIFF
--- a/src/plugins/intel_cpu/src/allocation_context.hpp
+++ b/src/plugins/intel_cpu/src/allocation_context.hpp
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace ov {
+namespace intel_cpu {
+
+class Node;
+class Edge;
+
+using GlobalExecutionIndex = std::unordered_map<std::shared_ptr<Node>, std::pair<int, int>>;
+
+struct AllocationContext {
+    std::vector<std::shared_ptr<Edge>> edges;
+    GlobalExecutionIndex execIndex;
+    std::vector<size_t> syncPoints;
+};
+
+}  // namespace intel_cpu
+}  // namespace ov

--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -56,8 +56,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
       m_cfg{std::move(cfg)},
       m_name{model->get_name()},
       m_loaded_from_cache(loaded_from_cache),
-      m_sub_memory_manager(std::move(sub_memory_manager)),
-      m_networkMemoryControl(std::make_shared<NetworkMemoryControl>()) {
+      m_sub_memory_manager(std::move(sub_memory_manager)) {
     m_mutex = std::make_shared<std::mutex>();
     const auto& core = m_plugin->get_core();
     if (!core) {

--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -10,9 +10,11 @@
 #include "async_infer_request.h"
 #include "config.h"
 #include "cpu/x64/cpu_isa_traits.hpp"
+#include "graph.h"
 #include "infer_request.h"
 #include "itt.h"
 #include "low_precision/low_precision.hpp"
+#include "memory_control.hpp"
 #include "memory_state.h"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/intel_cpu/properties.hpp"
@@ -54,7 +56,8 @@ CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
       m_cfg{std::move(cfg)},
       m_name{model->get_name()},
       m_loaded_from_cache(loaded_from_cache),
-      m_sub_memory_manager(std::move(sub_memory_manager)) {
+      m_sub_memory_manager(std::move(sub_memory_manager)),
+      m_networkMemoryControl(std::make_shared<NetworkMemoryControl>()) {
     m_mutex = std::make_shared<std::mutex>();
     const auto& core = m_plugin->get_core();
     if (!core) {
@@ -163,15 +166,16 @@ CompiledModel::GraphGuard::Lock CompiledModel::get_graph() const {
                     std::lock_guard<std::mutex> lock{*m_mutex.get()};
                     auto isQuantizedFlag = (m_cfg.lpTransformsMode == Config::On) &&
                                            ov::pass::low_precision::LowPrecision::isFunctionQuantized(m_model);
-
                     ctx = std::make_shared<GraphContext>(m_cfg,
                                                          m_socketWeights[socketId],
                                                          isQuantizedFlag,
                                                          streamsExecutor,
                                                          m_sub_memory_manager);
                 }
+
                 const std::shared_ptr<const ov::Model> model = m_model;
-                graphLock._graph.CreateGraph(model, ctx);
+                graphLock._graph.Init(model, ctx);
+                graphLock._graph.Activate();
             } catch (...) {
                 exception = std::current_exception();
             }
@@ -355,7 +359,7 @@ void CompiledModel::release_memory() {
                         "Attempt to call release_memory() on a compiled model in a busy state. Please ensure that all "
                         "infer requests are completed before releasing memory.");
         auto ctx = graph.getGraphContext();
-        ctx->getNetworkMemoryControl()->releaseMemory();
+        ctx->releaseMemory();
     }
 }
 

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -68,10 +68,6 @@ public:
         return m_name;
     }
 
-    std::shared_ptr<NetworkMemoryControl> get_network_memory_control() const {
-        return m_networkMemoryControl;
-    }
-
 private:
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
     friend class CompiledModelHolder;
@@ -105,7 +101,6 @@ private:
 
     std::vector<std::shared_ptr<CompiledModel>> m_sub_compiled_models;
     std::shared_ptr<SubMemoryManager> m_sub_memory_manager = nullptr;
-    std::shared_ptr<NetworkMemoryControl> m_networkMemoryControl = nullptr;
     bool m_has_sub_compiled_models = false;
 };
 

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -19,8 +19,6 @@
 namespace ov {
 namespace intel_cpu {
 
-class NetworkMemoryControl;
-
 class CompiledModel : public ov::ICompiledModel {
 public:
     struct GraphGuard : public Graph {

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -13,11 +14,12 @@
 #include "openvino/runtime/iinfer_request.hpp"
 #include "openvino/runtime/iplugin.hpp"
 #include "openvino/runtime/isync_infer_request.hpp"
-#include "openvino/runtime/threading/thread_local.hpp"
 #include "sub_memory_manager.hpp"
 
 namespace ov {
 namespace intel_cpu {
+
+class NetworkMemoryControl;
 
 class CompiledModel : public ov::ICompiledModel {
 public:
@@ -66,6 +68,10 @@ public:
         return m_name;
     }
 
+    std::shared_ptr<NetworkMemoryControl> get_network_memory_control() const {
+        return m_networkMemoryControl;
+    }
+
 private:
     std::shared_ptr<ov::ISyncInferRequest> create_sync_infer_request() const override;
     friend class CompiledModelHolder;
@@ -99,6 +105,7 @@ private:
 
     std::vector<std::shared_ptr<CompiledModel>> m_sub_compiled_models;
     std::shared_ptr<SubMemoryManager> m_sub_memory_manager = nullptr;
+    std::shared_ptr<NetworkMemoryControl> m_networkMemoryControl = nullptr;
     bool m_has_sub_compiled_models = false;
 };
 

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -272,7 +272,7 @@ Edge::ReorderStatus Edge::needReorder() {
 }
 
 void Edge::reuse(MemoryPtr ptr) {
-    OPENVINO_ASSERT(ptr != nullptr, "Attempt to reuse initialized memory in ", *this);
+    OPENVINO_ASSERT(ptr != nullptr, "Attempt to reuse uninitialized memory in ", *this);
     memoryPtr = std::move(ptr);
     changeStatus(Status::Allocated);
 
@@ -461,13 +461,18 @@ const MemoryDesc& Edge::getOutputDesc() const {
     return *memDescPtr;
 }
 
-const MemoryDesc& Edge::getDesc() const {
+const MemoryDesc& Edge::getOriginalDesc() const {
+    OPENVINO_ASSERT(!one_of(status, Status::Validated, Status::Allocated),
+                    "Desc of an Allocated edge ",
+                    *this,
+                    " must be accessed through the memory object");
+
     if (getInputDesc().getPrecision() == element::undefined) {
         return getInputDesc();
     }
 
     if (!getInputDesc().isCompatible(getOutputDesc())) {
-        OPENVINO_THROW("Cannot get descriptor for edge: ", getParent()->getName(), "->", getChild()->getName());
+        OPENVINO_THROW("Cannot get descriptor for edge: ", *this);
     }
 
     return getInputDesc();
@@ -498,7 +503,7 @@ void Edge::validate() {
     getChild();
 
     if (status != Status::Allocated || !memoryPtr) {
-        OPENVINO_THROW("Error memory is not allocated!");
+        OPENVINO_THROW("Error memory is not allocated for edge: ", *this);
     }
     status = Status::Validated;
 }

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -26,7 +26,13 @@ class Edge {
 public:
     Edge(const std::shared_ptr<Node>& parent, const std::shared_ptr<Node>& child, int pr_port = 0, int ch_port = 0);
 
-    enum class Status { Uninitialized, NeedAllocation, NotAllocated, Allocated, Validated };
+    enum class Status {
+        Uninitialized,   // base edge is unknown yet
+        NeedAllocation,  // edge is the base edge
+        NotAllocated,    // edge references another edge
+        Allocated,       // edge memory is allocated
+        Validated        // edge is validated
+    };
 
     enum class ReorderStatus { Regular = 0, Optimized = 1, No = 2 };
 
@@ -84,10 +90,11 @@ public:
     EdgePtr getSharedEdge(std::nothrow_t) const;
 
     bool hasDefinedMaxSize() const {
-        return getDesc().hasDefinedMaxSize();
+        return getOriginalDesc().hasDefinedMaxSize();
     }
 
     std::string hash() const;
+    const MemoryDesc& getOriginalDesc() const;
 
 private:
     std::weak_ptr<Node> parent;
@@ -105,7 +112,6 @@ private:
     PortDescBaseCPtr getInputPortDesc() const;
     PortDescBaseCPtr getOutputPortDesc() const;
 
-    const MemoryDesc& getDesc() const;
     bool enforceReorder();
 
     void collectConsumers(std::vector<std::shared_ptr<Node>>& result) const;

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -915,19 +915,20 @@ int Graph::RegisterToAllocationContext(int offset, AllocationContext& context) {
     ResolveInOutInPlaceEdges(graphEdges);
 
     // nodes are expected to be topologically sorted
-    for (size_t execIndex = 0, j = 0; execIndex < graphNodes.size(); execIndex++) {
+    for (size_t execIndex = 0, syncNodeIdx = 0; execIndex < graphNodes.size(); execIndex++) {
         const auto& node = graphNodes[execIndex];
         const auto inputExecIndex = offset;
+        // register local sync node idx to global allocation context as well
+        if (syncNodeIdx < syncNodesInds.size() && syncNodesInds[syncNodeIdx] == execIndex) {
+            context.syncPoints.push_back(inputExecIndex);
+            syncNodeIdx++;
+        }
+
         // an offset is the number of nodes in the internal graph minus the current node (-1)
         offset = node->registerToAllocationContext(inputExecIndex, context);
         const auto outputExecIndex = offset;
         offset++;
         context.execIndex[node] = {inputExecIndex, outputExecIndex};
-
-        if (j < syncNodesInds.size() && syncNodesInds[j] == execIndex) {
-            context.syncPoints.push_back(inputExecIndex);
-            j++;
-        }
     }
 
     context.edges.insert(context.edges.end(), graphEdges.begin(), graphEdges.end());

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -309,7 +309,7 @@ static std::tuple<std::vector<NodePtr>, std::vector<size_t>> ExtractExecutableNo
         if (!node->isConstant() &&  // constants are executed once in scope of compile_model
             !staticZeroDims &&      // never execute static nodes with zero dim input / output tensors
             (CPU_DEBUG_CAPS_ALWAYS_TRUE(!node->canBeSkipped()) ||  // execute all executable nodes
-             dynamicNonInputOutput)) {                            // plus dynamic ones, except inputs / outputs
+             dynamicNonInputOutput)) {                             // plus dynamic ones, except inputs / outputs
             graphIdToExecutableId[i] = executableGraphNodes.size();
             executableGraphNodes.emplace_back(node);
         }
@@ -742,7 +742,7 @@ void Graph::ResolveComplexInplaceConflicts() {
 
 /**
  * Partition the \clusters of Edges, by moving to the end and allocating at the same time
- * the clusters which cannot be handled as part of generic memory solver algorithm.
+ * the clusters that cannot be handled as part of the generic memory solver algorithm.
  * Such clusters meet one of the following criteria:
  * - base edge of a cluster is already Allocated
  * - base edge of a cluster is a "ov::element::string" type of edge
@@ -798,7 +798,7 @@ static size_t AllocateStringsAndConstants(EdgeClusters& clusters, const GraphCon
                                             [](const EdgePtr& edge) {
                                                 return edge->getOriginalDesc().getPrecision() == element::string;
                                             }),
-                                "All edges in the cluster must be string.");
+                                "All edges in the string cluster must be strings.");
                 auto memBlock = allocateStringMemory(baseEdge);
                 for (auto& edge : cluster) {
                     if (edge->getStatus() == Edge::Status::NotAllocated) {
@@ -874,9 +874,6 @@ std::vector<size_t> Graph::CreateExecutionGraph() {
 
     std::tie(m_executableGraphNodes, m_executableSyncNodesInds) =
         ExtractExecutableNodesAndSyncPoints(syncNodesInds, graphNodes);
-
-    status = hasDynNodes ? (parallel_get_max_threads() > 1 ? Status::ReadyDynamic : Status::ReadyDynamicSeq)
-                         : Status::ReadyStatic;
 
     if (hasDynNodes) {
         status = Status::ReadyDynamic;

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdlib>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
@@ -17,12 +19,16 @@
 #include <utility>
 #include <vector>
 
+#include "allocation_context.hpp"
 #include "common/primitive_desc_iface.hpp"
+#include "cpu_types.h"
 #include "edge.h"
+#include "graph_context.h"
 #include "graph_dumper.h"
 #include "graph_optimizer.h"
 #include "infer_request.h"
 #include "itt.h"
+#include "memory_control.hpp"
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "memory_desc/dnnl_blocked_memory_desc.h"
 #include "node.h"
@@ -32,11 +38,13 @@
 #include "nodes/input.h"
 #include "nodes/memory.hpp"
 #include "nodes/reorder.h"
+#include "nodes/tensoriterator.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/op/tensor_iterator.hpp"
 #include "openvino/runtime/exception.hpp"
 #include "openvino/runtime/threading/cpu_streams_executor.hpp"
 #include "utils/debug_capabilities.h"
@@ -68,10 +76,10 @@ void Graph::CreateGraph(NET& model, const GraphContext::CPtr& context) {
     Activate();
 }
 
-void Graph::CreateGraph(const std::vector<NodePtr>& graphNodes,
-                        const std::vector<EdgePtr>& graphEdges,
-                        const GraphContext::CPtr& context,
-                        std::string name) {
+void Graph::Init(const std::vector<NodePtr>& graphNodes,
+                 const std::vector<EdgePtr>& graphEdges,
+                 const GraphContext::CPtr& context,
+                 std::string name) {
     if (IsReady()) {
         ForgetGraphData();
     }
@@ -97,6 +105,13 @@ void Graph::CreateGraph(const std::vector<NodePtr>& graphNodes,
     }
 
     Configure();
+}
+
+void Graph::CreateGraph(const std::vector<NodePtr>& graphNodes,
+                        const std::vector<EdgePtr>& graphEdges,
+                        const GraphContext::CPtr& context,
+                        std::string name) {
+    Init(graphNodes, graphEdges, context, std::move(name));
 
     Activate();
 }
@@ -294,7 +309,7 @@ static std::tuple<std::vector<NodePtr>, std::vector<size_t>> ExtractExecutableNo
 
         if (!node->isConstant() &&  // constants are executed once in scope of compile_model
             !staticZeroDims &&      // never execute static nodes with zero dim input / output tensors
-            (CPU_DEBUG_CAPS_ALWAYS_TRUE(node->isExecutable()) ||  // execute all executable nodes
+            (CPU_DEBUG_CAPS_ALWAYS_TRUE(!node->canBeSkipped()) ||  // execute all executable nodes
              dynamicNonInputOutput)) {                            // plus dynamic ones, except inputs / outputs
             graphIdToExecutableId[i] = executableGraphNodes.size();
             executableGraphNodes.emplace_back(node);
@@ -364,15 +379,15 @@ static void UseExternalOutputMemory(const std::map<std::size_t, NodePtr>& output
 
 void Graph::Activate(const std::vector<MemoryPtr>& externalInputMemory,
                      const std::vector<MemoryPtr>& externalOutputMemory) {
-    OPENVINO_ASSERT(status == Status::Initialized, "Invalid graph status");
-
-    const bool hasDynNodes = ProcessDynNodes();
-    const auto syncNodesInds = hasDynNodes ? IdentifySyncPoints(graphNodes) : std::vector<size_t>{};
+    // @todo It is possible that execution graph is already created in scope of
+    // the allocation context collection from the outer graph so the state for inner graph is "Ready"
+    // We probably want to avoid such uncertancy
+    // OPENVINO_ASSERT(status == Status::Initialized, "Invalid graph status: ", static_cast<int>(status));
 
     UseExternalInputMemory(inputNodesMap, externalInputMemory);
     UseExternalOutputMemory(outputNodesMap, externalOutputMemory);
 
-    Allocate(syncNodesInds);
+    Allocate();
 
     CreatePrimitivesAndExecConstants();
 
@@ -382,23 +397,6 @@ void Graph::Activate(const std::vector<MemoryPtr>& externalInputMemory,
     }
 #endif
 
-    std::tie(m_executableGraphNodes, m_executableSyncNodesInds) =
-        ExtractExecutableNodesAndSyncPoints(syncNodesInds, graphNodes);
-
-    if (hasDynNodes) {
-        status = Status::ReadyDynamic;
-        // Here we use the following heuristic: if the number of sync nodes is less than 10 times of the number of exec
-        // nodes, it does make sense to use Sequential dynamic shapes processing due to the high overheads on context
-        // switching when the dynamic shapes are being processed in parallel and there are a lot of sync points. Also
-        // this rule works for short graphs (usually subgraphs) when the amount of nodes is to low to process them in
-        // parallel.
-        const auto exec2sync = m_executableGraphNodes.size() / m_executableSyncNodesInds.size();
-        if (exec2sync < 10 || parallel_get_max_threads() < 2) {
-            status = Status::ReadyDynamicSeq;
-        }
-    } else {
-        status = Status::ReadyStatic;
-    }
     CPU_DEBUG_CAP_ENABLE(serialize(*this));
 }
 
@@ -743,98 +741,275 @@ void Graph::ResolveComplexInplaceConflicts() {
     }
 }
 
-static inline bool isConstOutput(const EdgePtr& edge) {
-    return edge->getParent()->isConstant() && !edge->getChild()->isConstant();
+/**
+ * Partition the \clusters of Edges, by moving to the end and allocating at the same time
+ * the clusters which cannot be handled as part of generic memory solver algorithm.
+ * Such clusters meet one of the following criteria:
+ * - base edge of a cluster is already Allocated
+ * - base edge of a cluster is a "ov::element::string" type of edge
+ * - base edge of a cluster is a Constant edge
+ *
+ * @return a remaining number of clusters to process (left partition)
+ */
+static size_t AllocateStringsAndConstants(EdgeClusters& clusters, const GraphContext::CPtr& context) {
+    auto allocateConstantEdge = [&context](const EdgePtr& edge) {
+        if (edge->getParent()->getType() == Type::Input) {
+            auto constNode = std::static_pointer_cast<node::Input>(edge->getParent());
+            edge->reuse(std::const_pointer_cast<IMemory>(constNode->getMemoryPtr()));
+        } else {
+            edge->externalAllocate(context->getWeightsCache());
+        }
+    };
+
+    auto allocateStringMemory = [&context](const EdgePtr& edge) {
+        auto memory = std::make_shared<StringMemory>(context->getEngine(), edge->getOriginalDesc());
+        edge->reuse(memory);
+        return memory->getStringMemoryBlockPtr();
+    };
+
+    auto notAllocatedPartitionEnd = std::partition(
+        clusters.begin(),
+        clusters.end(),
+        [&allocateStringMemory, &allocateConstantEdge, &context](const EdgeCluster& cluster) {
+            if (cluster.empty())
+                return false;
+
+            auto baseEdgeIt = std::find_if(cluster.begin(), cluster.end(), [](const EdgePtr& edge) {
+                return one_of(edge->getStatus(), Edge::Status::Allocated, Edge::Status::NeedAllocation);
+            });
+
+            OPENVINO_ASSERT(baseEdgeIt != cluster.end(), "Unexpected cluster state");
+
+            const auto& baseEdge = *baseEdgeIt;
+            if (baseEdge->getStatus() == Edge::Status::Allocated) {
+                return false;
+            }
+
+            // Allocate a cluster of the constants
+            if (baseEdge->getParent()->isConstant()) {
+                allocateConstantEdge(baseEdge);
+                return false;
+            }
+
+            // Allocate a non-constant string cluster
+            if (baseEdge->getOriginalDesc().getPrecision() == element::string) {
+                OPENVINO_ASSERT(std::all_of(cluster.begin(),
+                                            cluster.end(),
+                                            [](const EdgePtr& edge) {
+                                                return edge->getOriginalDesc().getPrecision() == element::string;
+                                            }),
+                                "All edges in the cluster must be string.");
+                auto memBlock = allocateStringMemory(baseEdge);
+                for (auto& edge : cluster) {
+                    if (edge->getStatus() == Edge::Status::NotAllocated) {
+                        edge->reuse(
+                            std::make_shared<StringMemory>(context->getEngine(), edge->getOriginalDesc(), memBlock));
+                    }
+                }
+                return false;
+            }
+
+            return true;
+        });
+
+    return std::distance(clusters.begin(), notAllocatedPartitionEnd);
 }
 
-void Graph::AllocateWithReuse(const std::vector<size_t>& syncNodesInds) {
-    edgeClusters edge_clusters = MemoryControl::findEdgeClusters(graphEdges);
+static void AllocateBaseEdges(const EdgeClusters& edgeClusters, const MemoryControl::MemorySolution& memorySolution) {
+    // attach all the not yet allocated edges to the memory control
+    for (auto&& item : memorySolution) {
+        int count = 0;
+        for (auto&& edge : edgeClusters[item.first]) {
+            if (edge->getStatus() == Edge::Status::NeedAllocation) {
+                edge->allocate(item.second);
+                // TODO: WA for some test (like strided_slice_test) which use tensors with
+                //       shapes {0}. And it is implicitly converted into {1} tensor.
+                //       Zeroing of input data allow pass tests.
+                if (edge->getParent()->getType() == Type::Input && edge->getMemory().getDesc().hasDefinedMaxSize())
+                    edge->getMemoryPtr()->nullify();
 
-    size_t remaining_edge_clusters_count = edge_clusters.size();
-
-    // Resolve special cases:
-    for (size_t i = 0; i < remaining_edge_clusters_count;) {
-        auto& cluster = edge_clusters[i];
-        bool erase = false;
-        for (auto& edge : cluster) {
-            // Remove already allocated edges from the mem reuse algo
-            if (edge->getStatus() == Edge::Status::Allocated) {
-                erase = true;
-                break;
+                count++;
             }
-
-            // Special allocation for string tensors
-            if (edge->getDesc().getPrecision() == element::string &&
-                edge->getStatus() == Edge::Status::NeedAllocation) {
-                StringMemory::StringMemoryBlockPtr memBlcok;
-                if (edge->getParent()->isConstant()) {
-                    if (edge->getParent()->getType() == Type::Input) {
-                        auto constNode = static_cast<node::Input*>(edge->getParent().get());
-                        edge->reuse(std::const_pointer_cast<IMemory>(constNode->getMemoryPtr()));
-                    } else {
-                        edge->externalAllocate(m_context->getWeightsCache());
-                    }
-                    auto stringMemory = dynamic_cast<StringMemory*>(edge->getMemoryPtr().get());
-                    OPENVINO_ASSERT(stringMemory,
-                                    "[CPU] Edge between nodes '",
-                                    edge->getParent()->getName(),
-                                    "' and '",
-                                    edge->getChild()->getName(),
-                                    "' must have StringMemory.");
-                    memBlcok = stringMemory->getStringMemoryBlockPtr();
-                } else {
-                    auto memory = std::make_shared<StringMemory>(getEngine(), edge->getDesc());
-                    edge->reuse(memory);
-                    memBlcok = memory->getStringMemoryBlockPtr();
-                }
-                for (auto& edge_c : cluster) {
-                    if (edge_c == edge) {
-                        continue;
-                    }
-                    OPENVINO_ASSERT(edge_c->getDesc().getPrecision() == element::string,
-                                    "All edges in the cluster must be string.");
-                    if (edge_c->getStatus() == Edge::Status::NotAllocated) {
-                        auto memory = std::make_shared<StringMemory>(getEngine(), edge_c->getDesc(), memBlcok);
-                        edge_c->reuse(memory);
-                    } else {
-                        OPENVINO_THROW("[CPU] String tensors allocation in the cluster. Edge between nodes '",
-                                       edge_c->getParent()->getName(),
-                                       "' and '",
-                                       edge_c->getChild()->getName(),
-                                       "' has an unexpected status: ",
-                                       static_cast<int>(edge_c->getStatus()));
-                    }
-                }
-                erase = true;
-                continue;
-            }
-
-            // Special allocation for constants
-            if (edge->getStatus() != Edge::Status::NeedAllocation || !edge->getParent()->isConstant()) {
-                continue;
-            }
-            if (edge->getParent()->getType() == Type::Input) {
-                auto constNode = std::static_pointer_cast<node::Input>(edge->getParent());
-                edge->reuse(std::const_pointer_cast<IMemory>(constNode->getMemoryPtr()));
-            } else {
-                edge->externalAllocate(m_context->getWeightsCache());
-            }
-            erase = true;
         }
+        OPENVINO_ASSERT(count == 1, "Expected exactly one allocation. Actual number of allocations: ", count);
+    }
+}
 
-        if (erase) {
-            std::swap(edge_clusters[i], edge_clusters[remaining_edge_clusters_count - 1]);
-            --remaining_edge_clusters_count;
-        } else {
-            ++i;
+static void AllocatedReferencingEdges(const EdgeClusters& clusters) {
+    for (auto& cluster : clusters) {
+        for (auto& edge : cluster) {
+            if (edge->getStatus() != Edge::Status::NotAllocated) {
+                continue;
+            }
+
+            std::vector<EdgePtr> edges_to_process;
+            edges_to_process.push_back(edge);
+            for (auto next_edge = edge->getSharedEdge(std::nothrow); next_edge;
+                 next_edge = next_edge->getSharedEdge(std::nothrow)) {
+                edges_to_process.push_back(next_edge);
+            }
+
+            std::for_each(edges_to_process.rbegin(), edges_to_process.rend(), [](const EdgePtr& edge) {
+                if (edge->getStatus() == Edge::Status::NotAllocated) {
+                    if (edge->inPlace(Edge::LOOK_DOWN)) {
+                        edge->getChild()->resolveInPlaceEdges(Edge::LOOK_DOWN);
+                    } else if (edge->inPlace(Edge::LOOK_UP)) {
+                        edge->getParent()->resolveInPlaceEdges(Edge::LOOK_UP);
+                    } else {
+                        auto sharedEdge = edge->getSharedEdge();
+                        auto sharedEdgeParent = sharedEdge->getParent();
+                        edge->allocate(sharedEdge->getMemoryPtr()->getMemoryBlock());
+                        DEBUG_LOG(*edge, " sharedEdge with ", *sharedEdge);
+                    }
+                }
+            });
+        }
+    }
+}
+
+std::vector<size_t> Graph::CreateExecutionGraph() {
+    const bool hasDynNodes = ProcessDynNodes();
+    auto syncNodesInds = hasDynNodes ? IdentifySyncPoints(graphNodes) : std::vector<size_t>{};
+
+    std::tie(m_executableGraphNodes, m_executableSyncNodesInds) =
+        ExtractExecutableNodesAndSyncPoints(syncNodesInds, graphNodes);
+
+    status = hasDynNodes ? (parallel_get_max_threads() > 1 ? Status::ReadyDynamic : Status::ReadyDynamicSeq)
+                         : Status::ReadyStatic;
+
+    if (hasDynNodes) {
+        status = Status::ReadyDynamic;
+        // Here we use the following heuristic: if the number of sync nodes is less than 10 times of the number of exec
+        // nodes, it does make sense to use Sequential dynamic shapes processing due to the high overheads on context
+        // switching when the dynamic shapes are being processed in parallel and there are a lot of sync points. Also
+        // this rule works for short graphs (usually subgraphs) when the amount of nodes is to low to process them in
+        // parallel.
+        const auto exec2sync = m_executableGraphNodes.size() / m_executableSyncNodesInds.size();
+        if (exec2sync < 10 || parallel_get_max_threads() < 2) {
+            status = Status::ReadyDynamicSeq;
+        }
+    } else {
+        status = Status::ReadyStatic;
+    }
+
+    return syncNodesInds;
+}
+
+static void ResolveInOutInPlaceEdges(const std::vector<EdgePtr>& edges) {
+    for (const auto& edge : edges) {
+        if (edge->getStatus() == Edge::Status::Uninitialized) {
+            if (edge->getParent()->getParentEdges().empty() &&
+                one_of(edge->getParent()->getType(), Type::MemoryInput) && edge->inPlace(Edge::LOOK_UP)) {
+                edge->getParent()->resolveInPlaceEdges(Edge::LOOK_UP);
+            } else if (edge->getChild()->getChildEdges().empty() &&
+                       one_of(edge->getChild()->getType(), Type::MemoryOutput) && edge->inPlace(Edge::LOOK_DOWN)) {
+                edge->getChild()->resolveInPlaceEdges(Edge::LOOK_DOWN);
+            }
+        }
+    }
+}
+
+int Graph::RegisterToAllocationContext(int offset, AllocationContext& context) {
+    auto syncNodesInds = CreateExecutionGraph();
+
+    ResolveInOutInPlaceEdges(graphEdges);
+
+    // nodes are expected to be topologically sorted
+    for (size_t execIndex = 0, j = 0; execIndex < graphNodes.size(); execIndex++) {
+        const auto& node = graphNodes[execIndex];
+        const auto inputExecIndex = offset;
+        // an offset is the number of nodes in the internal graph minus the current node (-1)
+        offset = node->registerToAllocationContext(inputExecIndex, context);
+        const auto outputExecIndex = offset;
+        offset++;
+        context.execIndex[node] = {inputExecIndex, outputExecIndex};
+
+        if (j < syncNodesInds.size() && syncNodesInds[j] == execIndex) {
+            context.syncPoints.push_back(inputExecIndex);
+            j++;
         }
     }
 
-    // Markup the memory regions
-    std::vector<MemoryRegion> memoryRegions;
-    memoryRegions.reserve(remaining_edge_clusters_count);
+    context.edges.insert(context.edges.end(), graphEdges.begin(), graphEdges.end());
 
-    for (size_t i = 0; i < remaining_edge_clusters_count; ++i) {
+    return offset - 1;
+}
+
+static void InitEdgeStatus(const std::vector<EdgePtr>& edges) {
+    for (auto& edge : edges)
+        edge->init();
+}
+
+static void ValidateEdgeStatus(const std::vector<EdgePtr>& edges) {
+    for (auto& edge : edges)
+        edge->validate();
+}
+
+/**
+ * Forms clusters of edges.
+ * An edge cluster is a collection of edges, with the following properties:
+ * - base edge is an edge with a Memory which other edges point to by means of inplace logic
+ * - first edge of a cluster is a base edge with a status either NeedAllocation or Allocated
+ * - rest of the edges in a cluster are NotAllocated ones, since they point to another edge
+ */
+static EdgeClusters FormEdgeClusters(const std::vector<EdgePtr>& graphEdges) {
+    using EdgeClusterIdxMap = std::unordered_map<EdgePtr, size_t>;
+    EdgeClusters edgeClusters;
+    EdgeClusterIdxMap edgeClusterIndices;
+
+    for (auto& edge : graphEdges) {
+        if (edgeClusterIndices.count(edge))
+            continue;  // edge is visited
+
+        size_t clusterIdx = edgeClusters.size();
+        EdgePtr lastSharedEdge = nullptr;
+
+        // find cluster index
+        for (auto shared_edge = edge->getSharedEdge(std::nothrow); shared_edge;
+             shared_edge = shared_edge->getSharedEdge(std::nothrow)) {
+            auto shared_edge_it = edgeClusterIndices.find(shared_edge);
+            if (shared_edge_it != edgeClusterIndices.end()) {
+                clusterIdx = shared_edge_it->second;
+                lastSharedEdge = shared_edge;
+                break;
+            }
+        }
+
+        if (clusterIdx == edgeClusters.size())
+            edgeClusters.emplace_back(EdgeCluster{edge});
+
+        // use recursive approach to ensure that the base edge is placed as a first entry of a cluster
+        std::function<void(EdgePtr)> addToCluster;
+        addToCluster =
+            [&addToCluster, &edgeClusterIndices, &clusterIdx, &edgeClusters, &lastSharedEdge](const EdgePtr& edge) {
+                if (edge == lastSharedEdge)
+                    return;
+
+                addToCluster(edge->getSharedEdge(std::nothrow));
+
+                if (edgeClusterIndices.emplace(edge, clusterIdx).second) {
+                    edgeClusters[clusterIdx].push_back(edge);
+                }
+            };
+
+        addToCluster(edge);
+    }
+
+    return edgeClusters;
+}
+
+static MemoryRegions FormMemoryRegions(const EdgeClusters& clusters,
+                                       size_t remaining,
+                                       const GlobalExecutionIndex& globalExecIndex) {
+    auto isConstOutput = [](const EdgePtr& edge) {
+        return edge->getParent()->isConstant() && !edge->getChild()->isConstant();
+    };
+
+    // Markup the memory regions
+    MemoryRegions memoryRegions;
+    memoryRegions.reserve(remaining);
+
+    for (size_t i = 0; i < remaining; ++i) {
         MemoryRegion reg = {std::numeric_limits<int>::max(),
                             0,
                             0,
@@ -844,11 +1019,26 @@ void Graph::AllocateWithReuse(const std::vector<size_t>& syncNodesInds) {
 
         int64_t boxSize = 0;
         bool isConst = false, isOutput = false, isInput = false;
-        for (auto& edge : edge_clusters[i]) {
-            int e_start = edge->getParent()->getExecIndex();
-            int e_finish = edge->getChild()->getExecIndex();
 
-            auto&& desc = edge->getDesc();
+        for (auto& edge : clusters[i]) {
+            const auto& parent = edge->getParent();
+            const auto& child = edge->getChild();
+
+            auto usesInOutMemoryMultipleTimes = [](const NodePtr& node) {
+                if (auto tensorIterator = std::dynamic_pointer_cast<node::TensorIterator>(node)) {
+                    return tensorIterator->usesInOutMemoryMultipleTimes();
+                }
+
+                return false;
+            };
+            // If node uses its input / output memory multiple times in scope of a single execution (i.e TensorIterator)
+            // prolong the lifetime of a memory region till execution is finished
+            int e_start = usesInOutMemoryMultipleTimes(parent) ? globalExecIndex.at(parent).first
+                                                               : globalExecIndex.at(parent).second;
+            int e_finish = usesInOutMemoryMultipleTimes(child) ? globalExecIndex.at(child).second
+                                                               : globalExecIndex.at(child).first;
+
+            auto&& desc = edge->getOriginalDesc();
 
             if (boxSize != -1 && desc.isDefined()) {
                 int64_t e_size =
@@ -870,8 +1060,8 @@ void Graph::AllocateWithReuse(const std::vector<size_t>& syncNodesInds) {
             reg.alloc_type = allocType;
 
             isConst |= isConstOutput(edge);
-            isOutput |= edge->getChild()->getType() == Type::Output;
-            isInput |= edge->getParent()->getType() == Type::Input;
+            isOutput |= child->getType() == Type::Output;
+            isInput |= parent->getType() == Type::Input;
         }
 
         reg.size = boxSize;
@@ -891,128 +1081,107 @@ void Graph::AllocateWithReuse(const std::vector<size_t>& syncNodesInds) {
         memoryRegions.push_back(reg);
     }
 
-    // special processing of the dynamic output edges
-    auto it = std::remove_if(memoryRegions.begin(), memoryRegions.end(), [&](const MemoryRegion& region) {
-        if (region.size >= 0 || !one_of(region.type, MemoryRegion::RegionType::OUTPUT, MemoryRegion::RegionType::IO)) {
-            return false;
-        }
-        bool result = false;
-        for (auto& edge : edge_clusters[region.id]) {
-            auto child = edge->getChild();
-            if (child->getType() == Type::Output && edge->getStatus() == Edge::Status::NeedAllocation) {
-                auto proxyMemBlock = std::make_shared<ProxyMemoryBlock>();
-                DEBUG_LOG("ProxyMemoryBlock ", proxyMemBlock, " ", this);
-                edge->allocate(proxyMemBlock);
-
-                // Store the output memory blocks.
-                // So that, the infer requests can be able to access them.
-                int count = 0;
-                for (auto& output : outputNodesMap) {
-                    if (output.second == child) {
-                        outputNodesMemBlocksMap[output.first] = proxyMemBlock;
-                        count++;
-                    }
-                }
-                // sometimes there are unused output ports.
-                OPENVINO_ASSERT(count <= 1, "CPU plugin cannot find output node. count ", count);
-                result = true;
-            }
-        }
-        return result;
-    });
-
-    memoryRegions.erase(it, memoryRegions.end());
-
-    // Set up the memory control subsystem.
-    this->m_pMemoryControl = &(getGraphContext()->getNetworkMemoryControl()->createMemoryControlUnit(syncNodesInds));
-    auto memoryBlocks = m_pMemoryControl->insert(memoryRegions);
-
-    // attach all the not yet allocated edges to the memory contol
-    for (auto&& item : memoryBlocks) {
-        int count = 0;
-        for (auto&& edge : edge_clusters[item.first]) {
-            if (edge->getStatus() == Edge::Status::NeedAllocation) {
-                edge->allocate(item.second);
-
-                // TODO: WA for some test (like strided_slice_test) which use tensors with
-                //       shapes {0}. And it is implicitly converted into {1} tensor.
-                //       Zeroing of input data allow pass tests.
-                if (edge->getParent()->type == Type::Input && edge->hasDefinedMaxSize()) {
-                    edge->getMemoryPtr()->nullify();
-                }
-
-                count++;
-            }
-        }
-        OPENVINO_ASSERT(count == 1);
-    }
-
-    m_pMemoryControl->allocateMemory();
-
-    // Resolve all other edges with status NotAllocated and in-place
-    for (auto& cluster : edge_clusters) {
-        for (auto& edge : cluster) {
-            if (edge->getStatus() != Edge::Status::NotAllocated) {
-                continue;
-            }
-            std::vector<EdgePtr> edges_to_process;
-            edges_to_process.push_back(edge);
-            for (auto next_edge = edge->getSharedEdge(std::nothrow); next_edge;
-                 next_edge = next_edge->getSharedEdge(std::nothrow)) {
-                edges_to_process.push_back(next_edge);
-            }
-            std::for_each(edges_to_process.rbegin(), edges_to_process.rend(), [](const EdgePtr& edge) {
-                if (edge->getStatus() == Edge::Status::NotAllocated) {
-                    if (edge->inPlace(Edge::LOOK_DOWN)) {
-                        edge->getChild()->resolveInPlaceEdges(Edge::LOOK_DOWN);
-                    } else if (edge->inPlace(Edge::LOOK_UP)) {
-                        edge->getParent()->resolveInPlaceEdges(Edge::LOOK_UP);
-                    } else {
-                        auto sharedEdge = edge->getSharedEdge();
-                        auto sharedEdgeParent = sharedEdge->getParent();
-                        edge->allocate(sharedEdge->getMemoryPtr()->getMemoryBlock());
-                        DEBUG_LOG(*edge, " sharedEdge with ", *sharedEdge);
-                    }
-                }
-            });
-        }
-    }
+    return memoryRegions;
 }
 
-void Graph::Allocate(const std::vector<size_t>& syncNodesInds) {
-    OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::Allocate");
+static Graph::OutputMemoryBlocks FilterOutDynamicOutputEdges(MemoryRegions& memoryRegions,
+                                                             const EdgeClusters& clusters,
+                                                             const std::map<std::size_t, NodePtr>& outputNodes) {
+    Graph::OutputMemoryBlocks outputMemBlocks;
+    memoryRegions.erase(
+        std::remove_if(memoryRegions.begin(),
+                       memoryRegions.end(),
+                       [&](const MemoryRegion& region) {
+                           if (region.size >= 0 ||
+                               !one_of(region.type, MemoryRegion::RegionType::OUTPUT, MemoryRegion::RegionType::IO)) {
+                               return false;
+                           }
+                           bool result = false;
+                           for (auto& edge : clusters[region.id]) {
+                               auto child = edge->getChild();
+                               if (child->getType() == Type::Output &&
+                                   edge->getStatus() == Edge::Status::NeedAllocation) {
+                                   auto proxyMemBlock = std::make_shared<ProxyMemoryBlock>();
+                                   DEBUG_LOG("ProxyMemoryBlock ", proxyMemBlock);
 
-    // resolve inplace dead end nodes
-    for (const auto& edge : graphEdges) {
-        if (edge->getStatus() == Edge::Status::Uninitialized) {
-            if (edge->getParent()->getParentEdges().empty() &&
-                one_of(edge->getParent()->getType(), Type::Input, Type::MemoryInput) && edge->inPlace(Edge::LOOK_UP)) {
-                edge->getParent()->resolveInPlaceEdges(Edge::LOOK_UP);
-            } else if (edge->getChild()->getChildEdges().empty() &&
-                       one_of(edge->getChild()->getType(), Type::Output, Type::MemoryOutput) &&
-                       edge->inPlace(Edge::LOOK_DOWN)) {
-                edge->getChild()->resolveInPlaceEdges(Edge::LOOK_DOWN);
-            }
-        }
-    }
+                                   edge->allocate(proxyMemBlock);
 
-    // resolve edges. Define which will be a view on others
-    //   NeedAllocation - real blob
-    //   NotAllocated - view on other blob, peer or in-place
-    for (auto& edge : graphEdges) {
-        edge->init();
-    }
+                                   // Store the output memory blocks.
+                                   // So that, the infer requests can be able to access them.
+                                   // @todo Can we just get them from outputNodesMap instead?
+                                   int count = 0;
+                                   for (auto& output : outputNodes) {
+                                       if (output.second == child) {
+                                           outputMemBlocks[output.first] = proxyMemBlock;
+                                           count++;
+                                       }
+                                   }
+                                   // sometimes there are unused output ports.
+                                   OPENVINO_ASSERT(count <= 1, "CPU plugin cannot find output node. count ", count);
+                                   result = true;
+                               }
+                           }
+                           return result;
+                       }),
+        memoryRegions.end());
 
-    // Allocate memory space for all edges marked with NeedAllocation
-    AllocateWithReuse(syncNodesInds);
-
-    // Check all getters. Should work.
-    for (auto& edge : graphEdges) {
-        edge->validate();
-    }
+    return outputMemBlocks;
 }
 
-bool Graph::ProcessDynNodes() {
+/**
+ * Solve memory reuse
+ * Ideally only MemorySolution should be returned
+ * For now we have to additionally return:
+ * 1) EdgeClusters - to propagate the solution through the graph
+ * 2) OutputMemoryBlocks - to allow memory sharing between graph and infer request
+ */
+static std::tuple<MemoryControl::MemorySolution, EdgeClusters, Graph::OutputMemoryBlocks> SolveMemoryReuse(
+    const std::shared_ptr<MemoryControl>& memoryControl,
+    const AllocationContext& allocationContext,
+    const GraphContext::CPtr& graphContext,
+    const std::map<std::size_t, NodePtr>& outputNodesMap) {
+    const auto& edges = allocationContext.edges;
+
+    auto edgeClusters = FormEdgeClusters(edges);
+
+    const size_t remainingEdgeClustersCount = AllocateStringsAndConstants(edgeClusters, graphContext);
+
+    auto memoryRegions = FormMemoryRegions(edgeClusters, remainingEdgeClustersCount, allocationContext.execIndex);
+
+    auto outputNodesMemBlocks = FilterOutDynamicOutputEdges(memoryRegions, edgeClusters, outputNodesMap);
+
+    memoryControl->insert(memoryRegions, allocationContext.syncPoints);
+    auto memoryBlocks = memoryControl->solve();
+
+    return std::make_tuple(memoryBlocks, edgeClusters, outputNodesMemBlocks);
+}
+
+void Graph::Allocate() {
+    auto memoryControl = m_context->getMemoryControl();
+
+    if (memoryControl->allocated()) {
+        return;  // memory is already allocated globally
+    }
+
+    AllocationContext allocationContext;
+    RegisterToAllocationContext(0, allocationContext);
+
+    const auto& edges = allocationContext.edges;
+    InitEdgeStatus(edges);
+
+    auto [solution, edgeClusters, m_outputNodesMemBlocks] =
+        SolveMemoryReuse(memoryControl, allocationContext, m_context, outputNodesMap);
+
+    AllocateBaseEdges(edgeClusters, solution);
+
+    memoryControl->allocateMemory();
+
+    AllocatedReferencingEdges(edgeClusters);
+
+    ValidateEdgeStatus(edges);
+}
+
+bool Graph::ProcessDynNodes() const {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::ProcessDynNodes");
 
     const bool containsDynamicNodes = std::any_of(graphNodes.begin(), graphNodes.end(), [](const NodePtr& node) {
@@ -1484,13 +1653,7 @@ void Graph::Infer(SyncInferRequest* request) {
     DEBUG_LOG("Infer graph: ", GetName(), ". Status: ", static_cast<int>(status));
     const int numaId = GetNumaNodeId(m_context);
 
-    if (!m_pMemoryControl) {
-        OPENVINO_THROW("Memory control unit is not initilized in graph: ", GetName());
-    }
-
-    if (!m_pMemoryControl->allocated()) {
-        m_pMemoryControl->allocateMemory();
-    }
+    m_context->allocateMemory();
 
     switch (status) {
     case Status::ReadyDynamic:
@@ -1780,8 +1943,8 @@ NodePtr Graph::InsertReorder(const EdgePtr& edge,
     // Due to the specificity of GraphOptimizer::MergeTransposeAndReorder() that isOptimized flag uses, we shouldn't do
     // these checks.
     if (!isOptimized) {
-        reorder->getParentEdgeAt(0)->getDesc();
-        reorder->getChildEdgeAt(0)->getDesc();
+        reorder->getParentEdgeAt(0)->getOriginalDesc();
+        reorder->getChildEdgeAt(0)->getOriginalDesc();
     }
 
     return reorder;

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "allocation_context.hpp"
 #include "config.h"
 #include "cpu_memory.h"
 #include "edge.h"
@@ -17,7 +18,6 @@
 #include "memory_state.h"
 #include "node.h"
 #include "nodes/input.h"
-#include "openvino/core/node_vector.hpp"
 #include "openvino/runtime/profiling_info.hpp"
 #include "openvino/runtime/so_ptr.hpp"
 #include "proxy_mem_blk.h"
@@ -32,7 +32,8 @@ class MemoryStateNode;
 
 class Graph {
 public:
-    typedef std::shared_ptr<Graph> Ptr;
+    using Ptr = std::shared_ptr<Graph>;
+    using OutputMemoryBlocks = std::unordered_map<std::size_t, ProxyMemoryBlockPtr>;
 
     enum class Status {
         NotReady = 0,
@@ -64,9 +65,23 @@ public:
         return m_context->getConfig();
     }
 
+    /**
+     * Obsolete way of creating graph
+     * To enable layout propagation and global memory reuse
+     * two-stage creation should be used instead:
+     * - Init()
+     * - Allocate()
+     */
     template <typename NET>
     void CreateGraph(NET& model, const GraphContext::CPtr& context);
 
+    /**
+     * Obsolete way of creating graph
+     * To enable layout propagation and global memory reuse
+     * two-stage creation should be used instead:
+     * - Init()
+     * - Allocate()
+     */
     void CreateGraph(const std::vector<NodePtr>& graphNodes,
                      const std::vector<EdgePtr>& graphEdges,
                      const GraphContext::CPtr& context,
@@ -225,6 +240,13 @@ public:
         return graphHasDynamicInput;
     }
 
+    const std::unordered_map<std::string, node::MemoryStateNode*>& getInternalStateNodes() const;
+
+    void Init(const std::vector<NodePtr>& graphNodes,
+              const std::vector<EdgePtr>& graphEdges,
+              const GraphContext::CPtr& context,
+              std::string name);
+
     /**
      * Init graph using \p model, \p context, \p inputConfigs and \p outputConfigs
      */
@@ -239,8 +261,27 @@ public:
     void Activate(const std::vector<MemoryPtr>& externalInputMemory = {},
                   const std::vector<MemoryPtr>& externalOutputMemory = {});
 
-    const std::unordered_map<std::size_t, ProxyMemoryBlockPtr>& getOutputNodesMemBlocksMap() {
-        return outputNodesMemBlocksMap;
+    /**
+     * Register the graph in the global allocation context by transforming
+     * local execution data into the global one:
+     * 1) Local execution indices are transformed into global ones, represented by input and output execution index
+     *    where output execution index is an index of the last node of the inner graph
+     * 2) Local sync node indices are transformed into global ones using global input execution index
+     * 3) Local edges are added to the global list of edges
+     *
+     * Example graph with subgraphs:
+     * 0 -> 1 -> 2 -> 3 [0 -> 1 -> 2] -> 4 [0 -> 1] -> 5
+     *
+     * Virtually flatten:
+     * 0(0) -> 1(1) -> 2(2) -> 3(5) [3 -> 4 -> 5] -> 6(7) [6 -> 7] -> 8
+     *
+     * This is basically an equivalent to the actually flatten graph:
+     * 0 -> 1 -> 2 -> [3 -> 4 -> 5] -> [6 -> 7] -> 8
+     */
+    int RegisterToAllocationContext(int offset, AllocationContext& context);
+
+    const std::unordered_map<std::size_t, ProxyMemoryBlockPtr>& getOutputNodesMemBlocksMap() const {
+        return m_outputNodesMemBlocks;
     }
 
 protected:
@@ -271,6 +312,7 @@ protected:
                    const std::vector<node::Input::OutputConfig>& outputConfigs = {});
 
     void Configure(bool optimize = true);
+    void Allocate();
 
     void InitNodes();
     void InitDescriptors();
@@ -278,10 +320,10 @@ protected:
     void InitOptimalPrimitiveDescriptors();
     void ResolveEdgeConflicts();
     void ResolveComplexInplaceConflicts();
-    bool ProcessDynNodes();
-    void Allocate(const std::vector<size_t>& syncNodesInds);
-    void AllocateWithReuse(const std::vector<size_t>& syncNodesInds);
+    bool ProcessDynNodes() const;
+    void AllocateWithReuse(const std::vector<size_t>& syncNodesInds, GlobalExecutionIndex globalExecIndex);
     void CreatePrimitivesAndExecConstants() const;
+    std::vector<size_t> CreateExecutionGraph();
 
     /**
      * Execute a given \p node within \p request using \p numaId
@@ -322,7 +364,7 @@ private:
     std::map<std::size_t, NodePtr> inputNodesMap;
     std::map<std::size_t, NodePtr> outputNodesMap;
 
-    std::unordered_map<std::size_t, ProxyMemoryBlockPtr> outputNodesMemBlocksMap;
+    OutputMemoryBlocks m_outputNodesMemBlocks;
 
     // these node pointers (from graphNodes) are to avoid regular checking for
     // constantness of nodes in Infer methods and calls of
@@ -332,8 +374,6 @@ private:
 
     GraphContext::CPtr m_context;
     dnnl::stream m_stream;
-
-    MemoryControl* m_pMemoryControl = nullptr;
 };
 
 using GraphPtr = std::shared_ptr<Graph>;

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -254,10 +254,9 @@ public:
               const std::vector<node::Input::OutputConfig>& outputConfigs = {});
 
     /**
-     * Activate execution graph using \p externalInputMemory and \p externalOutputMemory
+     * Activate execution graph
      */
-    void Activate(const std::vector<MemoryPtr>& externalInputMemory = {},
-                  const std::vector<MemoryPtr>& externalOutputMemory = {});
+    void Activate();
 
     /**
      * Register the graph in the global allocation context by transforming

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -70,7 +70,7 @@ public:
      * To enable layout propagation and global memory reuse
      * two-stage creation should be used instead:
      * - Init()
-     * - Allocate()
+     * - Activate()
      */
     template <typename NET>
     void CreateGraph(NET& model, const GraphContext::CPtr& context);
@@ -80,7 +80,7 @@ public:
      * To enable layout propagation and global memory reuse
      * two-stage creation should be used instead:
      * - Init()
-     * - Allocate()
+     * - Activate()
      */
     void CreateGraph(const std::vector<NodePtr>& graphNodes,
                      const std::vector<EdgePtr>& graphEdges,
@@ -239,8 +239,6 @@ public:
     bool hasDynamicInput() const {
         return graphHasDynamicInput;
     }
-
-    const std::unordered_map<std::string, node::MemoryStateNode*>& getInternalStateNodes() const;
 
     void Init(const std::vector<NodePtr>& graphNodes,
               const std::vector<EdgePtr>& graphEdges,

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -28,8 +28,8 @@ GraphContext::GraphContext(Config config,
       m_auxiliaryNetworkMemoryControl(std::make_shared<NetworkMemoryControl>()),
       m_memoryControl(m_auxiliaryNetworkMemoryControl->createMemoryControlUnit()) {
     if (m_streamExecutor) {
-        auto cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(m_streamExecutor);
-        m_numaNodeId = cpuStreamExecutor ? cpuStreamExecutor->get_numa_node_id() : 0;
+        m_cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(m_streamExecutor);
+        m_numaNodeId = m_cpuStreamExecutor ? m_cpuStreamExecutor->get_numa_node_id() : 0;
         auto nNumaNodes = get_num_numa_nodes();
         if (m_numNumaNodes < nNumaNodes) {
             m_numNumaNodes = nNumaNodes;

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -25,10 +25,11 @@ GraphContext::GraphContext(Config config,
       m_subMemoryManager(std::move(sub_memory_manager)),
       m_numNumaNodes(1),
       m_memoryStatesRegister(std::make_shared<node::MemoryStatesRegister>()),
-      m_networkMemoryControl(std::make_shared<NetworkMemoryControl>()) {
+      m_auxiliaryNetworkMemoryControl(std::make_shared<NetworkMemoryControl>()),
+      m_memoryControl(m_auxiliaryNetworkMemoryControl->createMemoryControlUnit()) {
     if (m_streamExecutor) {
-        m_cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(m_streamExecutor);
-        m_numaNodeId = m_cpuStreamExecutor ? m_cpuStreamExecutor->get_numa_node_id() : 0;
+        auto cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(m_streamExecutor);
+        m_numaNodeId = cpuStreamExecutor ? cpuStreamExecutor->get_numa_node_id() : 0;
         auto nNumaNodes = get_num_numa_nodes();
         if (m_numNumaNodes < nNumaNodes) {
             m_numNumaNodes = nNumaNodes;

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -7,7 +7,6 @@
 #include "async_infer_request.h"
 #include "dnnl_extension_utils.h"
 #include "itt.h"
-#include "memory_control.hpp"
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "nodes/common/cpu_convert.h"
 #include "nodes/memory_state_base.h"

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -7,6 +7,7 @@
 #include "async_infer_request.h"
 #include "dnnl_extension_utils.h"
 #include "itt.h"
+#include "memory_control.hpp"
 #include "memory_desc/cpu_memory_desc_utils.h"
 #include "nodes/common/cpu_convert.h"
 #include "nodes/memory_state_base.h"

--- a/src/plugins/intel_cpu/src/memory_control.cpp
+++ b/src/plugins/intel_cpu/src/memory_control.cpp
@@ -4,11 +4,13 @@
 
 #include "memory_control.hpp"
 
+#include <cstddef>
+#include <memory>
 #include <ov_optional.hpp>
 #include <utility>
 
-#include "node.h"
 #include "openvino/runtime/memory_solver.hpp"
+#include "utils/general_utils.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -86,8 +88,8 @@ private:
 class IMemoryManager {
 public:
     virtual ~IMemoryManager() = default;
-    virtual void insert(const MemoryRegion& reg) = 0;
-    virtual const MemoryControl::MemoryBlockMap& lastSolution() = 0;
+    virtual void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) = 0;
+    virtual const MemoryControl::MemorySolution& lastSolution() = 0;
     virtual void allocate() = 0;
     virtual void release() = 0;
 };
@@ -101,11 +103,12 @@ std::shared_ptr<DnnlMemoryBlock> makeDnnlMemoryBlock(Args&&... args) {
 
 class MemoryManagerIO : public IMemoryManager {
 public:
-    void insert(const MemoryRegion& reg) override {
+    void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) override {
+        (void)syncInds;
         m_blocks.insert({reg.id, makeDnnlMemoryBlock<MemoryBlockWithReuse>()});
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() override {
+    const MemoryControl::MemorySolution& lastSolution() override {
         return m_blocks;
     }
 
@@ -117,16 +120,17 @@ public:
     }
 
 private:
-    MemoryControl::MemoryBlockMap m_blocks;
+    MemoryControl::MemorySolution m_blocks;
 };
 
 class MemoryManagerStatic : public IMemoryManager {
 public:
-    void insert(const MemoryRegion& reg) override {
+    void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) override {
+        (void)syncInds;
         m_boxes.emplace_back(MemorySolver::Box{reg.start, reg.finish, reg.size, reg.id});
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() override {
+    const MemoryControl::MemorySolution& lastSolution() override {
         if (!m_boxes.empty() && m_blocks.empty()) {
             solve();
         }
@@ -165,7 +169,7 @@ private:
     }
 
 private:
-    MemoryControl::MemoryBlockMap m_blocks;
+    MemoryControl::MemorySolution m_blocks;
     std::vector<MemorySolver::Box> m_boxes;
     std::shared_ptr<MemoryBlockWithRelease> m_workspace;
     size_t m_totalSize = 0;
@@ -173,18 +177,17 @@ private:
 
 class MemoryManageNonOverlapingSets : public IMemoryManager {
 public:
-    MemoryManageNonOverlapingSets(std::vector<size_t> syncInds) : m_syncInds(std::move(syncInds)) {}
-    void insert(const MemoryRegion& reg) override {
+    void insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) override {
         MemorySolver::Box box = {reg.start, reg.finish, reg.size, reg.id};
         if (-1 != reg.finish) {
             // We have to extend the lifespan of tensors that are crossing a sync point border in order to save
             // the intermediate computation results from possible loss due to the tensor resize
-            auto itr_upper = std::upper_bound(m_syncInds.begin(), m_syncInds.end(), box.finish, [](int y, int x) {
+            auto itr_upper = std::upper_bound(syncInds.begin(), syncInds.end(), box.finish, [](int y, int x) {
                 return y <= x;
             });
-            auto itr_lower = std::lower_bound(m_syncInds.begin(), m_syncInds.end(), box.start);
+            auto itr_lower = std::lower_bound(syncInds.begin(), syncInds.end(), box.start);
             if (itr_lower != itr_upper) {  // across sections
-                if (itr_upper == m_syncInds.end()) {
+                if (itr_upper == syncInds.end()) {
                     box.finish = -1;
                 } else {
                     box.finish = *itr_upper;
@@ -194,10 +197,10 @@ public:
         m_boxes.emplace_back(box);
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() override {
+    const MemoryControl::MemorySolution& lastSolution() override {
         if (!m_boxes.empty() && m_blocks.empty()) {
             solve();
-            m_blocks = MemoryControl::MemoryBlockMap{m_internalBlocks.begin(), m_internalBlocks.end()};
+            m_blocks = MemoryControl::MemorySolution{m_internalBlocks.begin(), m_internalBlocks.end()};
         }
         return m_blocks;
     }
@@ -243,11 +246,10 @@ private:
     }
 
 private:
-    MemoryControl::MemoryBlockMap m_blocks;
-    std::unordered_map<MemoryControl::MemoryBlockMap::key_type, std::shared_ptr<MemoryBlockWithRelease>>
+    MemoryControl::MemorySolution m_blocks;
+    std::unordered_map<MemoryControl::MemorySolution::key_type, std::shared_ptr<MemoryBlockWithRelease>>
         m_internalBlocks;
     std::vector<MemorySolver::Box> m_boxes;
-    std::vector<size_t> m_syncInds;
 };
 
 }  // namespace
@@ -261,16 +263,16 @@ public:
         : m_cond(std::move(cond)),
           m_memManager(std::move(memManager)) {}
 
-    bool insert(const MemoryRegion& reg) {
+    bool insert(const MemoryRegion& reg, const std::vector<size_t>& syncInds) {
         if (!m_cond(reg)) {
             return false;
         }
 
-        m_memManager->insert(reg);
+        m_memManager->insert(reg, syncInds);
         return true;
     }
 
-    const MemoryControl::MemoryBlockMap& lastSolution() const {
+    const MemoryControl::MemorySolution& lastSolution() const {
         return m_memManager->lastSolution();
     }
 
@@ -297,10 +299,8 @@ MemoryControl::RegionHandlerPtr buildHandler(F&& f, Args&&... args) {
 
 }  // namespace
 
-MemoryControl::MemoryControl(std::vector<size_t> syncInds) {
+MemoryControl::MemoryControl() {
     // init handlers
-
-    // handler for dynamic tensors
     m_handlers.emplace_back(buildHandler<MemoryManagerStatic>([](const MemoryRegion& reg) {
         if (reg.size < 0 || MemoryRegion::RegionType::VARIABLE != reg.type ||
             MemoryRegion::AllocType::POD != reg.alloc_type) {
@@ -310,15 +310,13 @@ MemoryControl::MemoryControl(std::vector<size_t> syncInds) {
     }));
 
     // handler for static tensors
-    m_handlers.emplace_back(buildHandler<MemoryManageNonOverlapingSets>(
-        [](const MemoryRegion& reg) {
-            if (reg.size >= 0 || MemoryRegion::RegionType::VARIABLE != reg.type ||
-                MemoryRegion::AllocType::POD != reg.alloc_type) {
-                return false;
-            }
-            return true;
-        },
-        std::move(syncInds)));
+    m_handlers.emplace_back(buildHandler<MemoryManageNonOverlapingSets>([](const MemoryRegion& reg) {
+        if (reg.size >= 0 || MemoryRegion::RegionType::VARIABLE != reg.type ||
+            MemoryRegion::AllocType::POD != reg.alloc_type) {
+            return false;
+        }
+        return true;
+    }));
 
     // handler for I/O tensors, so far simply individual blocks
     m_handlers.emplace_back(buildHandler<MemoryManagerIO>([](const MemoryRegion& reg) {
@@ -329,22 +327,23 @@ MemoryControl::MemoryControl(std::vector<size_t> syncInds) {
     }));
 }
 
-void MemoryControl::insert(const MemoryRegion& region) {
+void MemoryControl::insert(const MemoryRegion& region, const std::vector<size_t>& syncInds) {
     for (auto&& handler : m_handlers) {
-        if (handler->insert(region)) {
+        if (handler->insert(region, syncInds)) {
             return;
         }
     }
     OPENVINO_THROW("No suitable hanlder was found for the given memory region");
 }
 
-MemoryControl::MemoryBlockMap MemoryControl::insert(const std::vector<MemoryRegion>& regions) {
+void MemoryControl::insert(const std::vector<MemoryRegion>& regions, const std::vector<size_t>& syncInds) {
     for (auto&& region : regions) {
-        insert(region);
+        insert(region, syncInds);
     }
+}
 
-    MemoryControl::MemoryBlockMap blocksMap;
-    blocksMap.reserve(regions.size());
+MemoryControl::MemorySolution MemoryControl::solve() {
+    MemoryControl::MemorySolution blocksMap;
 
     for (auto&& handler : m_handlers) {
         auto&& solution = handler->lastSolution();
@@ -371,54 +370,9 @@ void MemoryControl::releaseMemory() {
     m_allocated = false;
 }
 
-edgeClusters MemoryControl::findEdgeClusters(const std::vector<EdgePtr>& graphEdges) {
-    typedef std::unordered_map<EdgePtr, size_t> edge_cluster_idx_map_t;
-
-    edgeClusters edge_clusters;
-    edge_cluster_idx_map_t edge_cluster_indices;
-
-    for (auto& edge : graphEdges) {
-        auto edge_it = edge_cluster_indices.find(edge);
-        if (edge_it != edge_cluster_indices.end()) {
-            continue;  // edge is visited
-        }
-
-        size_t cluster_idx = edge_clusters.size();
-        EdgePtr last_shared_edge = nullptr;
-
-        // find cluster index
-        for (auto shared_edge = edge->getSharedEdge(std::nothrow); shared_edge;
-             shared_edge = shared_edge->getSharedEdge(std::nothrow)) {
-            auto shared_edge_it = edge_cluster_indices.find(shared_edge);
-            if (shared_edge_it != edge_cluster_indices.end()) {
-                cluster_idx = shared_edge_it->second;
-                last_shared_edge = shared_edge;
-                break;
-            }
-        }
-
-        // add shared edges to cluster
-        edge_cluster_indices.emplace(edge, cluster_idx);
-
-        if (cluster_idx == edge_clusters.size()) {
-            edge_clusters.emplace_back(edgeCluster{edge});
-        } else {
-            edge_clusters[cluster_idx].emplace(edge);
-        }
-
-        for (auto shared_edge = edge->getSharedEdge(std::nothrow); shared_edge != last_shared_edge;
-             shared_edge = shared_edge->getSharedEdge(std::nothrow)) {
-            edge_cluster_indices.emplace(shared_edge, cluster_idx);
-            edge_clusters[cluster_idx].emplace(shared_edge);
-        }
-    }
-
-    return edge_clusters;
-}
-
-MemoryControl& NetworkMemoryControl::createMemoryControlUnit(std::vector<size_t> syncInds) {
-    m_controlUnits.emplace_back(std::unique_ptr<MemoryControl>(new MemoryControl(std::move(syncInds))));
-    return *(m_controlUnits.back());
+MemoryControl::Ptr NetworkMemoryControl::createMemoryControlUnit() {
+    m_controlUnits.emplace_back(std::shared_ptr<MemoryControl>(new MemoryControl()));
+    return m_controlUnits.back();
 }
 
 void NetworkMemoryControl::allocateMemory() {

--- a/src/plugins/intel_cpu/src/memory_control.hpp
+++ b/src/plugins/intel_cpu/src/memory_control.hpp
@@ -9,8 +9,8 @@
 namespace ov {
 namespace intel_cpu {
 
-using edgeCluster = std::unordered_set<EdgePtr>;
-using edgeClusters = std::vector<edgeCluster>;
+using EdgeCluster = std::vector<EdgePtr>;
+using EdgeClusters = std::vector<EdgeCluster>;
 
 struct MemoryRegion {
     int start;     // Execution order index of first use.
@@ -22,17 +22,21 @@ struct MemoryRegion {
     enum class AllocType : uint8_t { POD, STRING, UNKNOWN } alloc_type;
 };
 
+using MemoryRegions = std::vector<MemoryRegion>;
+
 class MemoryControl {
 public:
     class RegionHandler;
 
     using RegionHandlerPtr = std::shared_ptr<RegionHandler>;
-    using MemoryBlockMap = std::unordered_map<decltype(MemoryRegion::id), MemoryBlockPtr>;
+    using MemorySolution = std::unordered_map<decltype(MemoryRegion::id), MemoryBlockPtr>;
+    using Ptr = std::shared_ptr<MemoryControl>;
+    using CPtr = std::shared_ptr<const MemoryControl>;
 
 public:
-    static edgeClusters findEdgeClusters(const std::vector<EdgePtr>& graphEdges);
+    void insert(const MemoryRegions& regions, const std::vector<size_t>& syncInds);
 
-    MemoryBlockMap insert(const std::vector<MemoryRegion>& regions);
+    MemorySolution solve();
 
     bool allocated() const {
         return m_allocated;
@@ -42,13 +46,12 @@ public:
     void releaseMemory();
 
 private:
-    explicit MemoryControl(std::vector<size_t> syncInds);
-    void insert(const MemoryRegion& region);
+    MemoryControl();
+    void insert(const MemoryRegion& region, const std::vector<size_t>& syncInds);
 
     friend class NetworkMemoryControl;
 
 private:
-    std::vector<size_t> m_syncInds;
     std::vector<RegionHandlerPtr> m_handlers;
     bool m_allocated = false;
 };
@@ -56,16 +59,18 @@ private:
 class NetworkMemoryControl {
 public:
     NetworkMemoryControl() = default;
-    MemoryControl& createMemoryControlUnit(std::vector<size_t> syncInds);
+
+    MemoryControl::Ptr createMemoryControlUnit();
 
     void allocateMemory();
     void releaseMemory();
 
-private:
-    using value_type = std::unique_ptr<MemoryControl>;
+    const std::vector<MemoryControl::Ptr>& controlUnits() const {
+        return m_controlUnits;
+    }
 
 private:
-    std::vector<value_type> m_controlUnits;
+    std::vector<MemoryControl::Ptr> m_controlUnits;
 };
 
 }  // namespace intel_cpu

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1815,7 +1815,7 @@ bool Node::isOutputTensorAtPortEmpty(size_t port) const {
         return outputShapes[port].hasZeroDims();
     }
     auto&& mem = getChildEdgeAt(port)->getMemory();
-    if (mem.isDefined()) {
+    if (mem.isDefined() && !mem.getDesc().empty()) {
         return mem.getShape().hasZeroDims();
     }
     return false;

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -327,7 +327,7 @@ public:
 
     bool isInPlace() const;
 
-    virtual bool canBeSkipped() const {
+    virtual bool neverExecute() const {
         return getSelectedPrimitiveDescriptor()->hasZeroInputDims();
     }
     // must be called only after Graph::ResolveEdgeConflicts()

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.h
@@ -17,7 +17,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
 
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         const auto& spd = getSelectedPrimitiveDescriptor();
         return spd->hasZeroInputDims() || spd->hasZeroOutputDims();
     }

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.h
@@ -17,6 +17,11 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
 
+    bool canBeSkipped() const override {
+        const auto& spd = getSelectedPrimitiveDescriptor();
+        return spd->hasZeroInputDims() || spd->hasZeroOutputDims();
+    }
+
     // output shape can potentially be empty
     bool isExecutable() const override {
         return !hasEmptyInputTensors() && !hasEmptyOutputTensors();

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -189,7 +189,7 @@ bool Broadcast::needShapeInfer() const {
     return false;
 }
 
-bool Broadcast::canBeSkipped() const {
+bool Broadcast::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -189,6 +189,10 @@ bool Broadcast::needShapeInfer() const {
     return false;
 }
 
+bool Broadcast::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Broadcast::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/broadcast.h
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.h
@@ -24,6 +24,7 @@ public:
     void executeDynamicImpl(const dnnl::stream& strm) override;
     bool created() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/broadcast.h
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.h
@@ -24,7 +24,7 @@ public:
     void executeDynamicImpl(const dnnl::stream& strm) override;
     bool created() const override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -221,6 +221,10 @@ void Bucketize::prepareParams() {
                                  std::multiplies<size_t>());
 }
 
+bool Bucketize::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Bucketize::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -221,7 +221,7 @@ void Bucketize::prepareParams() {
                                  std::multiplies<size_t>());
 }
 
-bool Bucketize::canBeSkipped() const {
+bool Bucketize::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/bucketize.h
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.h
@@ -24,6 +24,7 @@ public:
 
     void prepareParams() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/bucketize.h
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.h
@@ -24,7 +24,7 @@ public:
 
     void prepareParams() override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/composite.cpp
+++ b/src/plugins/intel_cpu/src/nodes/composite.cpp
@@ -43,16 +43,15 @@ void Composite::selectOptimalPrimitiveDescriptor() {
     std::vector<PortConfig> inConfs;
     std::vector<Input::InputConfig> graphInputConfig;
 
+    constexpr bool isInPlace = true;
+
     for (size_t i = 0; i < getParentEdges().size(); i++) {
         auto desc = getParentOutputMemDesc(getParentEdgeAt(i));
         inConfs.emplace_back(desc);
-        graphInputConfig.emplace_back(node::Input::InputConfig{std::move(desc), true});
+        graphInputConfig.emplace_back(node::Input::InputConfig{std::move(desc), isInPlace});
     }
 
-    std::vector<Input::OutputConfig> graphOutputConfig;
-    for (size_t i = 0; i < outputShapes.size(); i++) {
-        graphOutputConfig.emplace_back(node::Input::OutputConfig{true, true});
-    }
+    std::vector<Input::OutputConfig> graphOutputConfig(outputShapes.size(), node::Input::OutputConfig{true, isInPlace});
 
     // configure the inner graph to get the information about output memory descriptors
     m_graph.Init(m_body, context, graphInputConfig, graphOutputConfig);
@@ -75,23 +74,37 @@ void Composite::selectOptimalPrimitiveDescriptor() {
 
 // @todo add ascii diagramm for memory mapping / reuse
 void Composite::createPrimitive() {
+    m_graph.Activate();
+}
+
+int Composite::registerToAllocationContext(int offset, AllocationContext& context) {
     OPENVINO_ASSERT(getOriginalInputsNumber() == m_graph.inputsNumber(),
                     "Number of node inputs must be equal the number of inner graph's inputs");
 
-    std::vector<MemoryPtr> inputMemory;
     for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
-        inputMemory.emplace_back(getSrcMemoryAtPort(i));
+        auto parentEdge = getParentEdgeAt(i);
+        auto inputEdges = m_graph.getInputNodeByIndex(i)->getChildEdgesAtPort(0);
+        for (const auto& inputEdge : inputEdges) {
+            OPENVINO_ASSERT(inputEdge->getStatus() == Edge::Status::Uninitialized,
+                            "Expected Uninitialized state for edge: ",
+                            *this);
+            inputEdge->sharedMemFrom(parentEdge);
+        }
     }
 
     OPENVINO_ASSERT(getOriginalOutputsNumber() == m_graph.outputsNumber(),
                     "Number of node outputs must be equal the number of inner graph's outputs");
 
-    std::vector<MemoryPtr> outputMemory;
     for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
-        outputMemory.emplace_back(getDstMemoryAtPort(i));
+        auto childEdge = getChildEdgeAt(i);
+        auto outputEdge = m_graph.getOutputNodeByIndex(i)->getParentEdgeAt(0);
+        OPENVINO_ASSERT(outputEdge->getStatus() == Edge::Status::Uninitialized,
+                        "Expected Uninitialized state for edge: ",
+                        *outputEdge);
+        outputEdge->sharedMemFrom(childEdge);
     }
 
-    m_graph.Activate(inputMemory, outputMemory);
+    return m_graph.RegisterToAllocationContext(offset, context);
 }
 
 void Composite::execute(const dnnl::stream&) {

--- a/src/plugins/intel_cpu/src/nodes/composite.h
+++ b/src/plugins/intel_cpu/src/nodes/composite.h
@@ -31,7 +31,7 @@ public:
         return false;
     }
 
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/composite.h
+++ b/src/plugins/intel_cpu/src/nodes/composite.h
@@ -31,6 +31,10 @@ public:
         return false;
     }
 
+    bool canBeSkipped() const override {
+        return false;
+    }
+
     bool isExecutable() const override {
         return true;
     }
@@ -40,6 +44,8 @@ public:
     void createPrimitive() override;
     void execute(const dnnl::stream&) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
+
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
 
     const Graph& graph() const {
         return m_graph;

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -29,7 +29,7 @@ namespace {
 constexpr size_t channelAxis = 1lu;
 }
 
-bool Concat::canBeSkipped() const {
+bool Concat::neverExecute() const {
     return isInPlace() || getSelectedPrimitiveDescriptor()->hasZeroOutputDims();
 }
 

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -29,6 +29,10 @@ namespace {
 constexpr size_t channelAxis = 1lu;
 }
 
+bool Concat::canBeSkipped() const {
+    return isInPlace() || getSelectedPrimitiveDescriptor()->hasZeroOutputDims();
+}
+
 bool Concat::isExecutable() const {
     return !isInPlace() && !hasEmptyOutputTensors();
 }

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -29,7 +29,7 @@ public:
 
     ov::element::Type getRuntimePrecision() const override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -29,6 +29,7 @@ public:
 
     ov::element::Type getRuntimePrecision() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -923,8 +923,9 @@ void Convolution::selectOptimalPrimitiveDescriptor() {
 }
 
 int Convolution::registerToAllocationContext(int offset, AllocationContext& context) {
-    if (subgraph)
+    if (subgraph) {
         return subgraph->RegisterToAllocationContext(offset, context);
+    }
 
     return Node::registerToAllocationContext(offset, context);
 }

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -24,6 +24,8 @@ public:
     void initDescriptor(const NodeConfig& config) override;
     void selectOptimalPrimitiveDescriptor() override;
     void initSupportedPrimitiveDescriptors() override;
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
+    void createPrimitive() override;
     bool created() const override;
     bool canBeInPlace() const override {
         return false;

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
@@ -161,7 +161,7 @@ void EmbeddingBagOffset::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
-bool EmbeddingBagOffset::canBeSkipped() const {
+bool EmbeddingBagOffset::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
@@ -161,6 +161,10 @@ void EmbeddingBagOffset::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
+bool EmbeddingBagOffset::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool EmbeddingBagOffset::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
@@ -20,6 +20,7 @@ public:
     void execute(const dnnl::stream& strm) override;
     bool created() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
@@ -20,7 +20,7 @@ public:
     void execute(const dnnl::stream& strm) override;
     bool created() const override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
@@ -126,6 +126,10 @@ void EmbeddingBagPacked::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
+bool EmbeddingBagPacked::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool EmbeddingBagPacked::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
@@ -126,7 +126,7 @@ void EmbeddingBagPacked::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
-bool EmbeddingBagPacked::canBeSkipped() const {
+bool EmbeddingBagPacked::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
@@ -21,6 +21,7 @@ public:
     bool created() const override;
 
     bool isExecutable() const override;
+    bool canBeSkipped() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
@@ -21,7 +21,7 @@ public:
     bool created() const override;
 
     bool isExecutable() const override;
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -157,7 +157,7 @@ void EmbeddingSegmentsSum::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
-bool EmbeddingSegmentsSum::canBeSkipped() const {
+bool EmbeddingSegmentsSum::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -157,6 +157,10 @@ void EmbeddingSegmentsSum::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
+bool EmbeddingSegmentsSum::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool EmbeddingSegmentsSum::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
@@ -20,6 +20,7 @@ public:
     void execute(const dnnl::stream& strm) override;
     bool created() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
@@ -20,7 +20,7 @@ public:
     void execute(const dnnl::stream& strm) override;
     bool created() const override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -949,8 +949,8 @@ bool Gather::created() const {
     return getType() == Type::Gather;
 }
 
-bool Gather::canBeSkipped() const {
-    return isInPlace() || Node::canBeSkipped();
+bool Gather::neverExecute() const {
+    return isInPlace() || Node::neverExecute();
 }
 
 bool Gather::isExecutable() const {

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -949,6 +949,10 @@ bool Gather::created() const {
     return getType() == Type::Gather;
 }
 
+bool Gather::canBeSkipped() const {
+    return isInPlace() || Node::canBeSkipped();
+}
+
 bool Gather::isExecutable() const {
     return !isInPlace() && Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -25,6 +25,7 @@ public:
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
     bool created() const override;
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void resolveInPlaceEdges(Edge::LOOK look) override;
 

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -25,7 +25,7 @@ public:
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
     bool created() const override;
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     void resolveInPlaceEdges(Edge::LOOK look) override;
 

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -111,8 +111,9 @@ void If::initSupportedPrimitiveDescriptors() {
 }
 
 int If::registerToAllocationContext(int offset, AllocationContext& context) {
-    offset = m_thenGraph.RegisterToAllocationContext(offset, context);
-    return m_elseGraph.RegisterToAllocationContext(offset, context);
+    const int thenOffset = m_thenGraph.RegisterToAllocationContext(offset, context);
+    const int elseOffset = m_elseGraph.RegisterToAllocationContext(thenOffset, context);
+    return m_elseGraph.RegisterToAllocationContext(elseOffset, context);
 }
 
 void If::createPrimitive() {

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -80,8 +80,9 @@ If::If(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
 }
 
 void If::initSupportedPrimitiveDescriptors() {
-    if (!supportedPrimitiveDescriptors.empty())
+    if (!supportedPrimitiveDescriptors.empty()) {
         return;
+    }
 
     auto ifOp = ov::as_type_ptr<ov::op::v8::If>(m_op);
 

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <vector>
 
+#include "openvino/op/if.hpp"
+
 namespace ov {
 namespace intel_cpu {
 namespace node {
@@ -80,7 +82,7 @@ private:
 
     std::vector<PortMap> thenInputPortMap, thenOutputPortMap, elseInputPortMap, elseOutputPortMap;
 
-    const std::shared_ptr<ov::Node> m_op;
+    std::shared_ptr<ov::op::v8::If> m_op;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -21,10 +21,15 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
     void initSupportedPrimitiveDescriptors() override;
-    void getSupportedDescriptors() override;
+    void getSupportedDescriptors() override {}
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
     void createPrimitive() override;
     bool created() const override;
+
     void execute(const dnnl::stream& strm) override;
+    bool canBeSkipped() const override {
+        return false;
+    }
     bool isExecutable() const override {
         return true;
     }
@@ -65,8 +70,8 @@ private:
         ptrdiff_t size;
     };
 
-    Graph subGraphThen;
-    Graph subGraphElse;
+    Graph m_thenGraph;
+    Graph m_elseGraph;
     std::vector<std::deque<MemoryPtr>> inputMemThen, inputMemElse;
     std::deque<MemoryPtr> outputMemThen, outputMemElse;
 
@@ -75,7 +80,7 @@ private:
 
     std::vector<PortMap> thenInputPortMap, thenOutputPortMap, elseInputPortMap, elseOutputPortMap;
 
-    const std::shared_ptr<ov::Node> ovOp;
+    const std::shared_ptr<ov::Node> m_op;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -29,7 +29,7 @@ public:
     bool created() const override;
 
     void execute(const dnnl::stream& strm) override;
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return false;
     }
     bool isExecutable() const override {

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -578,8 +578,9 @@ void Input::initSupportedPdFromMemDesc() {
 }
 
 void Input::resolveInPlaceEdges(Edge::LOOK look) {
-    if (!m_isInPlace)
+    if (!m_isInPlace) {
         return Node::resolveInPlaceEdges(look);
+    }
 
     if (look & Edge::LOOK_UP) {
         auto edges = getChildEdgesAtPort(0);

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -499,7 +499,7 @@ void Input::selectOptimalPrimitiveDescriptor() {
     // ignore previous configuration
     supportedPrimitiveDescriptors.clear();
 
-    int inPlacePort = m_isInPlace ? 0 : -1;
+    const int inPlacePort = m_isInPlace ? 0 : -1;
     // and just use parent memory descriptor for Output node to avoid reorders insertion
     std::vector<PortConfig> inConfs;
     for (size_t i = 0; i < getParentEdges().size(); i++) {

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -499,10 +499,12 @@ void Input::selectOptimalPrimitiveDescriptor() {
     // ignore previous configuration
     supportedPrimitiveDescriptors.clear();
 
+    int inPlacePort = m_isInPlace ? 0 : -1;
     // and just use parent memory descriptor for Output node to avoid reorders insertion
     std::vector<PortConfig> inConfs;
     for (size_t i = 0; i < getParentEdges().size(); i++) {
-        inConfs.push_back({PortConfig(getParentOutputMemDesc(getParentEdgeAt(i)), BlockedMemoryDesc::FULL_MASK, 0)});
+        inConfs.push_back(
+            {PortConfig(getParentOutputMemDesc(getParentEdgeAt(0)), BlockedMemoryDesc::FULL_MASK, inPlacePort)});
     }
     NodeConfig config(inConfs, {});
 
@@ -573,6 +575,37 @@ void Input::initSupportedPdFromMemDesc() {
     }
 
     supportedPrimitiveDescriptors.emplace_back(std::move(config), impl_desc_type::unknown);
+}
+
+void Input::resolveInPlaceEdges(Edge::LOOK look) {
+    if (!m_isInPlace)
+        return Node::resolveInPlaceEdges(look);
+
+    if (look & Edge::LOOK_UP) {
+        auto edges = getChildEdgesAtPort(0);
+        for (const auto& edge : edges) {
+            EdgePtr sharedEdge = edge;
+
+            while (sharedEdge->getSharedEdge(std::nothrow)) {
+                sharedEdge = sharedEdge->getSharedEdge(std::nothrow);
+            }
+
+            edge->reuse(sharedEdge->getMemoryPtr());
+        }
+    }
+
+    if (look & Edge::LOOK_DOWN) {
+        for (size_t i = 0; i < getParentEdges().size(); i++) {
+            auto edge = getParentEdgeAt(i);
+            EdgePtr sharedEdge = edge;
+
+            while (sharedEdge->getSharedEdge(std::nothrow)) {
+                sharedEdge = sharedEdge->getSharedEdge(std::nothrow);
+            }
+
+            edge->reuse(sharedEdge->getMemoryPtr());
+        }
+    }
 }
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/input.h
+++ b/src/plugins/intel_cpu/src/nodes/input.h
@@ -64,7 +64,7 @@ public:
     void execute(const dnnl::stream& strm) override {}
     void executeDynamicImpl(const dnnl::stream& strm) override {}
 
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return true;
     }
     bool isExecutable() const override {

--- a/src/plugins/intel_cpu/src/nodes/input.h
+++ b/src/plugins/intel_cpu/src/nodes/input.h
@@ -56,12 +56,17 @@ public:
     void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
     bool created() const override;
+    void resolveInPlaceEdges(Edge::LOOK look) override;
 
     void withMeanImage();
     MemoryCPtr getMemoryPtr() const;
 
     void execute(const dnnl::stream& strm) override {}
     void executeDynamicImpl(const dnnl::stream& strm) override {}
+
+    bool canBeSkipped() const override {
+        return true;
+    }
     bool isExecutable() const override {
         return false;
     }

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -361,6 +361,10 @@ void Interaction::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
+bool Interaction::canBeSkipped() const {
+    return false;
+}
+
 bool Interaction::isExecutable() const {
     return true;
 }

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -361,7 +361,7 @@ void Interaction::executeDynamicImpl(const dnnl::stream& strm) {
     execute(strm);
 }
 
-bool Interaction::canBeSkipped() const {
+bool Interaction::neverExecute() const {
     return false;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/interaction.h
+++ b/src/plugins/intel_cpu/src/nodes/interaction.h
@@ -50,7 +50,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/interaction.h
+++ b/src/plugins/intel_cpu/src/nodes/interaction.h
@@ -50,6 +50,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/lora.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lora.cpp
@@ -51,17 +51,19 @@ void LoRA::selectOptimalPrimitiveDescriptor() {
     auto mainInputPrc = mainInputDesc->getPrecision();  // we have to align precision across all the inputs
 
     inConfs.emplace_back(mainInputDesc);
-    graphInputConfig.emplace_back(node::Input::InputConfig{mainInputDesc, true});
+
+    constexpr bool isInPlace = true;
+    graphInputConfig.emplace_back(node::Input::InputConfig{mainInputDesc, isInPlace});
 
     for (size_t i = 1; i < getParentEdges().size(); i++) {
         auto desc = getParentOutputMemDesc(getParentEdgeAt(i))->cloneWithNewPrecision(mainInputPrc);
         inConfs.emplace_back(desc);
-        graphInputConfig.emplace_back(node::Input::InputConfig{desc, true});
+        graphInputConfig.emplace_back(node::Input::InputConfig{desc, isInPlace});
     }
 
     std::vector<Input::OutputConfig> graphOutputConfig;
     // enforce the same memory descriptor on the output as on the input to allow inPlace memory
-    graphOutputConfig.emplace_back(node::Input::OutputConfig{inConfs.front().getMemDesc(), true});
+    graphOutputConfig.emplace_back(node::Input::OutputConfig{inConfs.front().getMemDesc(), isInPlace});
 
     // configure the inner graph to get the information about output memory descriptors
     m_graph.Init(m_body, context, graphInputConfig, graphOutputConfig);
@@ -86,24 +88,45 @@ void LoRA::selectOptimalPrimitiveDescriptor() {
     selectPrimitiveDescriptorByIndex(0);
 }
 
-// @todo add ascii diagram for memory mapping / reuse
-void LoRA::createPrimitive() {
+int LoRA::registerToAllocationContext(int offset, AllocationContext& context) {
     CPU_NODE_ASSERT(getOriginalInputsNumber() == m_graph.inputsNumber(),
                     "Number of node inputs must be equal the number of inner graph's inputs");
 
-    std::vector<MemoryPtr> inputMemory;
     for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
-        auto srcEdgeMem = getSrcMemoryAtPort(i);
-        auto mem = std::make_shared<Memory>(getEngine(), srcEdgeMem->getDescPtr(), srcEdgeMem->getMemoryBlock());
-        subgraphMemoryPtrs.push_back(mem);
-        inputMemory.emplace_back(std::move(mem));
+        auto parentEdge = getParentEdgeAt(i);
+        auto inputEdges = m_graph.getInputNodeByIndex(i)->getChildEdgesAtPort(0);
+        for (const auto& inputEdge : inputEdges) {
+            OPENVINO_ASSERT(inputEdge->getStatus() == Edge::Status::Uninitialized,
+                            "Expected Uninitialized Edge instead of: ",
+                            static_cast<int>(inputEdge->getStatus()));
+            inputEdge->sharedMemFrom(parentEdge);
+        }
     }
 
     CPU_NODE_ASSERT(getOriginalOutputsNumber() == m_graph.outputsNumber(),
                     "Number of node outputs must be equal the number of inner graph's outputs");
 
-    std::vector<MemoryPtr> outputMemory{getDstMemoryAtPort(0)};
-    m_graph.Activate(inputMemory, outputMemory);
+    for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
+        auto childEdge = getChildEdgeAt(i);
+        auto outputEdge = m_graph.getOutputNodeByIndex(i)->getParentEdgeAt(0);
+        outputEdge->sharedMemFrom(childEdge);
+    }
+
+    return m_graph.RegisterToAllocationContext(offset, context);
+}
+
+void LoRA::createPrimitive() {
+    CPU_NODE_ASSERT(getOriginalInputsNumber() == m_graph.inputsNumber(),
+                    "Number of node inputs must be equal the number of inner graph's inputs");
+    // Workaround to avoid making LoRa node always executable (isExecutable() = true)
+    // This way we update subgraph's input memory without performing an actual Infer() call
+    for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
+        auto subgraphInputNode = m_graph.getInputNodeByIndex(i);
+        auto subgraphInputMemory = subgraphInputNode->getDstMemoryAtPort(0);
+        subgraphMemoryPtrs.emplace_back(subgraphInputMemory);
+    }
+
+    m_graph.Activate();
 }
 
 void LoRA::execute(const dnnl::stream&) {

--- a/src/plugins/intel_cpu/src/nodes/lora.h
+++ b/src/plugins/intel_cpu/src/nodes/lora.h
@@ -23,6 +23,7 @@ public:
 
     void getSupportedDescriptors() override{};
     void selectOptimalPrimitiveDescriptor() override;
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
     void createPrimitive() override;
     void prepareParams() override;
     void execute(const dnnl::stream&) override;

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -737,7 +737,7 @@ const std::vector<impl_desc_type>& MatMul::getDefaultImplPriority() {
     return priorities;
 }
 
-bool MatMul::canBeSkipped() const {
+bool MatMul::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroOutputDims();
 }
 

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -737,6 +737,10 @@ const std::vector<impl_desc_type>& MatMul::getDefaultImplPriority() {
     return priorities;
 }
 
+bool MatMul::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroOutputDims();
+}
+
 bool MatMul::isExecutable() const {
     return !hasEmptyOutputTensors();
 }

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -43,6 +43,7 @@ public:
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
     bool canBeExecutedInInt8() const override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -43,7 +43,7 @@ public:
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
     bool canBeExecutedInInt8() const override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
 protected:

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -315,8 +315,8 @@ void MatrixNms::prepareParams() {
     }
 }
 
-bool MatrixNms::canBeSkipped() const {
-    return !isDynamicNode() && Node::canBeSkipped();
+bool MatrixNms::neverExecute() const {
+    return !isDynamicNode() && Node::neverExecute();
 }
 
 bool MatrixNms::isExecutable() const {

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -315,6 +315,10 @@ void MatrixNms::prepareParams() {
     }
 }
 
+bool MatrixNms::canBeSkipped() const {
+    return !isDynamicNode() && Node::canBeSkipped();
+}
+
 bool MatrixNms::isExecutable() const {
     return isDynamicNode() || Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.h
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.h
@@ -29,7 +29,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.h
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.h
@@ -29,6 +29,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -703,11 +703,10 @@ void MemoryInput::createPrimitive() {
         CPU_NODE_ASSERT(getParentEdges().size() == subGraph->inputsNumber(),
                         "Number of node inputs must be equal the number of inner graph's inputs");
 
-        for (size_t i = 0; i < getParentEdges().size(); i++) {
-            auto srcEdgeMem = getSrcMemoryAtPort(i);
-            // create a separate input memory objects instead of share them. avoid data corruption.
-            auto mem = std::make_shared<Memory>(getEngine(), srcEdgeMem->getDescPtr(), srcEdgeMem->getMemoryBlock());
-            subgraphMemoryPtrs.push_back(mem);
+        for (size_t i = 0; i < subGraph->inputsNumber(); i++) {
+            auto subgraphInputNode = subGraph->getInputNodeByIndex(i);
+            auto subgraphInputMemory = subgraphInputNode->getDstMemoryAtPort(0);
+            subgraphMemoryPtrs.push_back(subgraphInputMemory);
         }
 
         subGraph->Activate();

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -701,9 +701,9 @@ void MemoryInput::initOptimalPrimitiveDescriptor() {
 void MemoryInput::createPrimitive() {
     if (haveSubgraph()) {
         CPU_NODE_ASSERT(getParentEdges().size() == subGraph->inputsNumber(),
-                        "Number of node inputs must be equal the number of inner graph's inputs");
+                        "The number of node inputs must be equal to the number of inner graph's inputs");
 
-        for (size_t i = 0; i < subGraph->inputsNumber(); i++) {
+        for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
             auto subgraphInputNode = subGraph->getInputNodeByIndex(i);
             auto subgraphInputMemory = subgraphInputNode->getDstMemoryAtPort(0);
             subgraphMemoryPtrs.push_back(subgraphInputMemory);

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -235,7 +235,7 @@ void MemoryOutputBase::assignState(const MemStatePtr& newState) {
     assignExtMemory(state->output_mem(), state->internal_desc());
 }
 
-bool MemoryOutputBase::canBeSkipped() const {
+bool MemoryOutputBase::neverExecute() const {
     return false;
 }
 
@@ -504,7 +504,7 @@ void MemoryInputBase::deregisterSibling(MemoryOutputBase* node) {
     }
 }
 
-bool MemoryInputBase::canBeSkipped() const {
+bool MemoryInputBase::neverExecute() const {
     return false;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -68,7 +68,7 @@ public:
     void executeDynamicImpl(const dnnl::stream& strm) override final;  // NOLINT
 
     bool isExecutable() const override final;  // NOLINT
-    bool canBeSkipped() const override final;  // NOLINT
+    bool neverExecute() const override final;  // NOLINT
 
     void registerInputNode(MemoryInputBase* node);
     void deregisterSibling(MemoryInputBase* node);
@@ -151,7 +151,7 @@ public:
     bool needPrepareParams() const override {
         return false;
     }
-    bool canBeSkipped() const override final;  // NOLINT
+    bool neverExecute() const override final;  // NOLINT
     bool isExecutable() const override final;  // NOLINT
 
     void registerOutputNode(MemoryOutputBase* node);

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -66,7 +66,9 @@ public:
 
     void execute(const dnnl::stream& strm) override final;             // NOLINT
     void executeDynamicImpl(const dnnl::stream& strm) override final;  // NOLINT
-    bool isExecutable() const override final;                          // NOLINT
+
+    bool isExecutable() const override final;  // NOLINT
+    bool canBeSkipped() const override final;  // NOLINT
 
     void registerInputNode(MemoryInputBase* node);
     void deregisterSibling(MemoryInputBase* node);
@@ -149,6 +151,7 @@ public:
     bool needPrepareParams() const override {
         return false;
     }
+    bool canBeSkipped() const override final;  // NOLINT
     bool isExecutable() const override final;  // NOLINT
 
     void registerOutputNode(MemoryOutputBase* node);
@@ -211,6 +214,8 @@ public:
     void initOptimalPrimitiveDescriptor() override;
 
     void resolveInPlaceEdges(Edge::LOOK look) override;
+
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
 
     void createPrimitive() override;
 

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -226,6 +226,10 @@ void MultiClassNms::prepareParams() {
     m_numBoxOffset.resize(m_numBatches);
 }
 
+bool MultiClassNms::canBeSkipped() const {
+    return !isDynamicNode() && Node::canBeSkipped();
+}
+
 bool MultiClassNms::isExecutable() const {
     return isDynamicNode() || Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -226,8 +226,8 @@ void MultiClassNms::prepareParams() {
     m_numBoxOffset.resize(m_numBatches);
 }
 
-bool MultiClassNms::canBeSkipped() const {
-    return !isDynamicNode() && Node::canBeSkipped();
+bool MultiClassNms::neverExecute() const {
+    return !isDynamicNode() && Node::neverExecute();
 }
 
 bool MultiClassNms::isExecutable() const {

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -27,7 +27,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -27,6 +27,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 

--- a/src/plugins/intel_cpu/src/nodes/multinomial.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.cpp
@@ -116,6 +116,11 @@ void Multinomial::prepareParams() {
     m_batches_samples_probs_count = m_output_elements_count * m_probs_count;
 }
 
+bool Multinomial::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(PROBS_PORT) ||
+           getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(NUM_SAMPLES_PORT);
+}
+
 bool Multinomial::isExecutable() const {
     return !isInputTensorAtPortEmpty(PROBS_PORT) && !isInputTensorAtPortEmpty(NUM_SAMPLES_PORT);
 }

--- a/src/plugins/intel_cpu/src/nodes/multinomial.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.cpp
@@ -116,7 +116,7 @@ void Multinomial::prepareParams() {
     m_batches_samples_probs_count = m_output_elements_count * m_probs_count;
 }
 
-bool Multinomial::canBeSkipped() const {
+bool Multinomial::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(PROBS_PORT) ||
            getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(NUM_SAMPLES_PORT);
 }

--- a/src/plugins/intel_cpu/src/nodes/multinomial.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.hpp
@@ -30,7 +30,7 @@ public:
 
     void createPrimitive() override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;

--- a/src/plugins/intel_cpu/src/nodes/multinomial.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.hpp
@@ -30,6 +30,7 @@ public:
 
     void createPrimitive() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -139,6 +139,11 @@ public:
         _desc = createPortDesc(desc, cmpMask);
     }
 
+    bool hasZeroDims() const {
+        const auto desc = getMemDesc();
+        return desc->getShape().hasZeroDims() && !desc->empty();
+    }
+
 private:
     PortDescBasePtr createPortDesc(const MemoryDescPtr& desc, BlockedMemoryDesc::CmpMask cmpMask) {
         if (desc->getType() & Blocked)

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -968,6 +968,10 @@ void NonMaxSuppression::checkOutput(const Shape& shape, const std::string& name,
     }
 }
 
+bool NonMaxSuppression::canBeSkipped() const {
+    return !isDynamicNode() && Node::canBeSkipped();
+}
+
 bool NonMaxSuppression::isExecutable() const {
     return isDynamicNode() || Node::isExecutable();
 }

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -968,8 +968,8 @@ void NonMaxSuppression::checkOutput(const Shape& shape, const std::string& name,
     }
 }
 
-bool NonMaxSuppression::canBeSkipped() const {
-    return !isDynamicNode() && Node::canBeSkipped();
+bool NonMaxSuppression::neverExecute() const {
+    return !isDynamicNode() && Node::neverExecute();
 }
 
 bool NonMaxSuppression::isExecutable() const {

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
@@ -48,7 +48,7 @@ public:
         int suppress_begin_index;
     };
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
     bool needShapeInfer() const override {

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
@@ -48,6 +48,7 @@ public:
         int suppress_begin_index;
     };
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     bool needShapeInfer() const override {

--- a/src/plugins/intel_cpu/src/nodes/non_zero.h
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.h
@@ -34,6 +34,9 @@ public:
     void executeDynamicImpl(const dnnl::stream& strm) override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
+    bool canBeSkipped() const override {
+        return false;
+    }
     bool isExecutable() const override {
         return true;
     }

--- a/src/plugins/intel_cpu/src/nodes/non_zero.h
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.h
@@ -34,7 +34,7 @@ public:
     void executeDynamicImpl(const dnnl::stream& strm) override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return false;
     }
     bool isExecutable() const override {

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -962,7 +962,7 @@ void NormalizeL2::createPrimitive() {
     }
 }
 
-bool NormalizeL2::canBeSkipped() const {
+bool NormalizeL2::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -962,6 +962,10 @@ void NormalizeL2::createPrimitive() {
     }
 }
 
+bool NormalizeL2::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool NormalizeL2::isExecutable() const {
     return !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -98,7 +98,7 @@ public:
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
     enum class NormEpsMode { ADD, MAX };

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -98,6 +98,7 @@ public:
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     enum class NormEpsMode { ADD, MAX };

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -210,7 +210,7 @@ void Pad::createPrimitive() {
     }
 }
 
-bool Pad::canBeSkipped() const {
+bool Pad::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -210,6 +210,10 @@ void Pad::createPrimitive() {
     }
 }
 
+bool Pad::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
+}
+
 bool Pad::isExecutable() const {
     return !isOutputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -23,6 +23,7 @@ public:
 
     void prepareParams() override;
     bool needShapeInfer() const override;
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -23,7 +23,7 @@ public:
 
     void prepareParams() override;
     bool needShapeInfer() const override;
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.h
@@ -22,10 +22,19 @@ public:
     bool created() const override {
         return getType() == Type::PagedAttention;
     }
+
+    // pastkv may have zero dimension
+    bool canBeSkipped() const override {
+        return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(1) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(2);
+    }
+
     // pastkv may have zero dimension
     bool isExecutable() const override {
         return !isInputTensorAtPortEmpty(0) && !isInputTensorAtPortEmpty(1) && !isInputTensorAtPortEmpty(2);
     }
+
     bool needPrepareParams() const override {
         return false;
     }

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.h
@@ -24,7 +24,7 @@ public:
     }
 
     // pastkv may have zero dimension
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
                getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(1) ||
                getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(2);

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -236,6 +236,10 @@ bool RandomUniform::needShapeInfer() const {
     return !m_const_inputs[SHAPE];
 }
 
+bool RandomUniform::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(SHAPE);
+}
+
 bool RandomUniform::isExecutable() const {
     return !isInputTensorAtPortEmpty(SHAPE);
 }

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -236,7 +236,7 @@ bool RandomUniform::needShapeInfer() const {
     return !m_const_inputs[SHAPE];
 }
 
-bool RandomUniform::canBeSkipped() const {
+bool RandomUniform::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(SHAPE);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
@@ -41,6 +41,7 @@ public:
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     void createPrimitive() override;

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
@@ -41,7 +41,7 @@ public:
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
     void createPrimitive() override;

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -2237,6 +2237,10 @@ void Reduce::initSupportedPrimitiveDescriptors() {
     }
 }
 
+bool Reduce::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
+}
+
 bool Reduce::isExecutable() const {
     return !isOutputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -2237,7 +2237,7 @@ void Reduce::initSupportedPrimitiveDescriptors() {
     }
 }
 
-bool Reduce::canBeSkipped() const {
+bool Reduce::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -103,6 +103,7 @@ public:
         return false;
     }
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -103,7 +103,7 @@ public:
         return false;
     }
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -24,7 +24,7 @@ public:
     bool needPrepareParams() const override {
         return false;
     }
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return false;
     }
     bool isExecutable() const override {

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -24,6 +24,9 @@ public:
     bool needPrepareParams() const override {
         return false;
     }
+    bool canBeSkipped() const override {
+        return false;
+    }
     bool isExecutable() const override {
         return true;
     }

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -28,8 +28,8 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
-bool Reorder::canBeSkipped() const {
-    return isOptimized || Node::canBeSkipped();
+bool Reorder::neverExecute() const {
+    return isOptimized || Node::neverExecute();
 }
 
 bool Reorder::isExecutable() const {

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -28,8 +28,12 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
+bool Reorder::canBeSkipped() const {
+    return isOptimized || Node::canBeSkipped();
+}
+
 bool Reorder::isExecutable() const {
-    return Node::isExecutable() && !isOptimized;
+    return !isOptimized && Node::isExecutable();
 }
 
 Reorder::Reorder(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -26,6 +26,7 @@ public:
     bool created() const override;
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     void createPrimitive() override;

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -26,7 +26,7 @@ public:
     bool created() const override;
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
     void createPrimitive() override;

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -142,7 +142,7 @@ void Reshape::execute(const dnnl::stream& strm) {
     }
 }
 
-bool Reshape::isExecutable() const {
+bool Reshape::canBeSkipped() const {
     bool inPlaceEnabled = false;
     if (auto prim_desc = getSelectedPrimitiveDescriptor()) {
         auto& config = prim_desc->getConfig();
@@ -150,7 +150,11 @@ bool Reshape::isExecutable() const {
             inPlaceEnabled = true;
         }
     }
-    return !inPlaceEnabled;
+    return inPlaceEnabled;
+}
+
+bool Reshape::isExecutable() const {
+    return !canBeSkipped();
 }
 
 bool Reshape::created() const {

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -142,7 +142,7 @@ void Reshape::execute(const dnnl::stream& strm) {
     }
 }
 
-bool Reshape::canBeSkipped() const {
+bool Reshape::neverExecute() const {
     bool inPlaceEnabled = false;
     if (auto prim_desc = getSelectedPrimitiveDescriptor()) {
         auto& config = prim_desc->getConfig();
@@ -154,7 +154,7 @@ bool Reshape::canBeSkipped() const {
 }
 
 bool Reshape::isExecutable() const {
-    return !canBeSkipped();
+    return !neverExecute();
 }
 
 bool Reshape::created() const {

--- a/src/plugins/intel_cpu/src/nodes/reshape.h
+++ b/src/plugins/intel_cpu/src/nodes/reshape.h
@@ -18,6 +18,7 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     bool created() const override;
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     bool needShapeInfer() const override;

--- a/src/plugins/intel_cpu/src/nodes/reshape.h
+++ b/src/plugins/intel_cpu/src/nodes/reshape.h
@@ -18,7 +18,7 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     bool created() const override;
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
     bool needShapeInfer() const override;

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.h
@@ -21,6 +21,12 @@ public:
     bool created() const override {
         return getType() == Type::ScaledDotProductAttention;
     }
+
+    bool canBeSkipped() const override {
+        return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(1) ||
+               getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(2);
+    }
     // pastkv may have zero dimension
     bool isExecutable() const override {
         return !isInputTensorAtPortEmpty(0) && !isInputTensorAtPortEmpty(1) && !isInputTensorAtPortEmpty(2);

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.h
@@ -22,7 +22,7 @@ public:
         return getType() == Type::ScaledDotProductAttention;
     }
 
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
                getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(1) ||
                getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(2);

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -70,6 +70,10 @@ bool ScatterUpdate::isSupportedOperation(const std::shared_ptr<const ov::Node>& 
     return true;
 }
 
+bool ScatterUpdate::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(DATA_ID);
+}
+
 bool ScatterUpdate::isExecutable() const {
     return !isInputTensorAtPortEmpty(DATA_ID);
 }

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -70,7 +70,7 @@ bool ScatterUpdate::isSupportedOperation(const std::shared_ptr<const ov::Node>& 
     return true;
 }
 
-bool ScatterUpdate::canBeSkipped() const {
+bool ScatterUpdate::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(DATA_ID);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.h
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.h
@@ -89,7 +89,7 @@ public:
     bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.h
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.h
@@ -89,6 +89,7 @@ public:
     bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -82,10 +82,6 @@ void ShapeOf::initOptimalPrimitiveDescriptor() {
     selected_pd->setConfig(config);
 }
 
-bool ShapeOf::isExecutable() const {
-    return true;
-}
-
 void ShapeOf::execute(const dnnl::stream& strm) {
     auto inPtr = getSrcMemoryAtPort(0);
     auto outPtr = getDstMemoryAtPort(0);

--- a/src/plugins/intel_cpu/src/nodes/shapeof.h
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.h
@@ -28,11 +28,17 @@ public:
     bool needPrepareParams() const override {
         return false;
     };
+
     void executeDynamicImpl(const dnnl::stream& strm) override {
         execute(strm);
     }
 
-    bool isExecutable() const override;
+    bool canBeSkipped() const override {
+        return false;
+    };
+    bool isExecutable() const override {
+        return true;
+    }
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 };

--- a/src/plugins/intel_cpu/src/nodes/shapeof.h
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.h
@@ -33,7 +33,7 @@ public:
         execute(strm);
     }
 
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return false;
     };
     bool isExecutable() const override {

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -293,7 +293,7 @@ void Split::prepareParams() {
     }
 }
 
-bool Split::canBeSkipped() const {
+bool Split::neverExecute() const {
     return isInPlace() || getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -293,6 +293,10 @@ void Split::prepareParams() {
     }
 }
 
+bool Split::canBeSkipped() const {
+    return isInPlace() || getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Split::isExecutable() const {
     return !isInPlace() && !isInputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -23,6 +23,7 @@ public:
 
     void initOptimalPrimitiveDescriptor() override;
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
 
     bool needPrepareParams() const override;

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -23,7 +23,7 @@ public:
 
     void initOptimalPrimitiveDescriptor() override;
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
 
     bool needPrepareParams() const override;

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -325,7 +325,7 @@ void StridedSlice::initSupportedPrimitiveDescriptors() {
     }
 }
 
-bool StridedSlice::canBeSkipped() const {
+bool StridedSlice::neverExecute() const {
     return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
            getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -325,6 +325,11 @@ void StridedSlice::initSupportedPrimitiveDescriptors() {
     }
 }
 
+bool StridedSlice::canBeSkipped() const {
+    return getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0) ||
+           getSelectedPrimitiveDescriptor()->hasZeroOutputDimsAtPort(0);
+}
+
 bool StridedSlice::isExecutable() const {
     return !isInputTensorAtPortEmpty(0) && !isOutputTensorAtPortEmpty(0);
 }

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -27,6 +27,7 @@ public:
         return false;
     }
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needShapeInfer() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -27,7 +27,7 @@ public:
         return false;
     }
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     bool needShapeInfer() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -436,29 +436,39 @@ TensorIterator::TensorIterator(const std::shared_ptr<ov::Node>& op, const GraphC
     }
 }
 
-void TensorIterator::getSupportedDescriptors() {
-    auto tiOp = ov::as_type_ptr<const ov::op::util::SubGraphOp>(ngraphOp);
-    if (!tiOp) {
-        THROW_CPU_NODE_ERR("cannot be cast to ov::op::util::SubGraphOp");
-    }
-    const std::shared_ptr<const ov::Model> body = tiOp->get_function();
-    sub_graph.CreateGraph(body, context);
+void TensorIterator::initSupportedPrimitiveDescriptors() {
+    auto subgraphOp = ov::as_type_ptr<const ov::op::util::SubGraphOp>(ngraphOp);
+    CPU_NODE_ASSERT(subgraphOp, "cannot be cast to ov::op::util::SubGraphOp");
 
-    for (const auto& param : tiOp->get_function()->get_parameters()) {
-        if (auto inNode = sub_graph.getInputNodeByIndex(tiOp->get_function()->get_parameter_index(param))) {
+    sub_graph.Init(subgraphOp->get_function(), context);
+
+    if (!supportedPrimitiveDescriptors.empty())
+        return;
+
+    supportedPrimitiveDescriptors.emplace_back(make_plain_config(ngraphOp), impl_desc_type::unknown);
+}
+
+void TensorIterator::createPrimitive() {
+    sub_graph.Activate();
+
+    auto subgraphOp = ov::as_type_ptr<const ov::op::util::SubGraphOp>(ngraphOp);
+    CPU_NODE_ASSERT(subgraphOp, "cannot be cast to ov::op::util::SubGraphOp");
+
+    for (const auto& param : subgraphOp->get_function()->get_parameters()) {
+        if (auto inNode = sub_graph.getInputNodeByIndex(subgraphOp->get_function()->get_parameter_index(param))) {
             input_mems.push_back(getToMemories(inNode.get(), 0));
         }
     }
 
-    for (const auto& out : tiOp->get_function()->get_results()) {
-        if (auto outNode = sub_graph.getOutputNodeByIndex(tiOp->get_function()->get_result_index(out))) {
+    for (const auto& out : subgraphOp->get_function()->get_results()) {
+        if (auto outNode = sub_graph.getOutputNodeByIndex(subgraphOp->get_function()->get_result_index(out))) {
             auto outMem = outNode->getSrcMemoryAtPort(0);
             output_mem.push_back(outMem);
         }
     }
 
     // Port map: outputs
-    for (const auto& desc : tiOp->get_output_descriptions()) {
+    for (const auto& desc : subgraphOp->get_output_descriptions()) {
         auto body_output_idx = desc->m_body_value_index;
 
         std::string type_name = desc->get_type_info().name;
@@ -490,7 +500,7 @@ void TensorIterator::getSupportedDescriptors() {
     }
 
     // Port map : inputs and back edges
-    for (const auto& desc : tiOp->get_input_descriptions()) {
+    for (const auto& desc : subgraphOp->get_input_descriptions()) {
         auto body_input_index = desc->m_body_parameter_index;
 
         if (auto slice_desc = ov::as_type_ptr<const ov::op::util::SubGraphOp::SliceInputDescription>(desc)) {
@@ -543,17 +553,7 @@ void TensorIterator::getSupportedDescriptors() {
     } else {
         THROW_CPU_NODE_ERR("isn't supported!");
     }
-}
 
-void TensorIterator::initSupportedPrimitiveDescriptors() {
-    if (!supportedPrimitiveDescriptors.empty()) {
-        return;
-    }
-
-    supportedPrimitiveDescriptors.emplace_back(make_plain_config(ngraphOp), impl_desc_type::unknown);
-}
-
-void TensorIterator::createPrimitive() {
     if (loopBodyConditionOutputIdx == -1) {
         continue_cond_check.reset(new staticValueCheck(true));  // always true
     }
@@ -571,6 +571,10 @@ void TensorIterator::createPrimitive() {
         prepareParamsImpl(compileStage);
         updateLastInputDims();
     }
+}
+
+int TensorIterator::registerToAllocationContext(int offset, AllocationContext& context) {
+    return sub_graph.RegisterToAllocationContext(offset, context);
 }
 
 bool TensorIterator::needPrepareParams() const {

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -442,8 +442,9 @@ void TensorIterator::initSupportedPrimitiveDescriptors() {
 
     sub_graph.Init(subgraphOp->get_function(), context);
 
-    if (!supportedPrimitiveDescriptors.empty())
+    if (!supportedPrimitiveDescriptors.empty()) {
         return;
+    }
 
     supportedPrimitiveDescriptors.emplace_back(make_plain_config(ngraphOp), impl_desc_type::unknown);
 }

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -118,7 +118,7 @@ public:
     int registerToAllocationContext(int offset, AllocationContext& context) override;
     bool created() const override;
     void execute(const dnnl::stream& strm) override;
-    bool canBeSkipped() const override {
+    bool neverExecute() const override {
         return false;
     }
     bool isExecutable() const override {

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -113,11 +113,19 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
     void initSupportedPrimitiveDescriptors() override;
-    void getSupportedDescriptors() override;
+    void getSupportedDescriptors() override{};
     void createPrimitive() override;
+    int registerToAllocationContext(int offset, AllocationContext& context) override;
     bool created() const override;
     void execute(const dnnl::stream& strm) override;
+    bool canBeSkipped() const override {
+        return false;
+    }
     bool isExecutable() const override {
+        return true;
+    }
+    // @todo limit to particular in / out ports
+    bool usesInOutMemoryMultipleTimes() {
         return true;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -127,8 +127,12 @@ void Transpose::initSupportedPrimitiveDescriptors() {
     }
 }
 
+bool Transpose::canBeSkipped() const {
+    return isOptimized || getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
+}
+
 bool Transpose::isExecutable() const {
-    return !isInputTensorAtPortEmpty(0) && !isOptimized;
+    return !isOptimized && !isInputTensorAtPortEmpty(0);
 }
 
 bool Transpose::needPrepareParams() const {

--- a/src/plugins/intel_cpu/src/nodes/transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/transpose.cpp
@@ -127,7 +127,7 @@ void Transpose::initSupportedPrimitiveDescriptors() {
     }
 }
 
-bool Transpose::canBeSkipped() const {
+bool Transpose::neverExecute() const {
     return isOptimized || getSelectedPrimitiveDescriptor()->hasZeroInputDimsAtPort(0);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/transpose.h
+++ b/src/plugins/intel_cpu/src/nodes/transpose.h
@@ -34,6 +34,7 @@ public:
         return order;
     }
 
+    bool canBeSkipped() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/transpose.h
+++ b/src/plugins/intel_cpu/src/nodes/transpose.h
@@ -34,7 +34,7 @@ public:
         return order;
     }
 
-    bool canBeSkipped() const override;
+    bool neverExecute() const override;
     bool isExecutable() const override;
     bool needPrepareParams() const override;
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -533,7 +533,7 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
     conf.applyRtInfo(model);
     conf.readProperties(config, modelType);
 
-    auto context = std::make_shared<GraphContext>(conf, fake_w_cache, false, nullptr);
+    auto context = std::make_shared<GraphContext>(conf, fake_w_cache, false);
 
     auto supported = ov::get_supported_nodes(
         model,

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -7,6 +7,7 @@
 #include "cpu_streams_calculation.hpp"
 #include "internal_properties.hpp"
 #include "itt.h"
+#include "openvino/core/parallel.hpp"
 #include "openvino/op/paged_attention.hpp"
 #include "openvino/runtime/intel_cpu/properties.hpp"
 #include "openvino/runtime/internal_properties.hpp"
@@ -532,7 +533,7 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
     conf.applyRtInfo(model);
     conf.readProperties(config, modelType);
 
-    auto context = std::make_shared<GraphContext>(conf, fake_w_cache, false);
+    auto context = std::make_shared<GraphContext>(conf, fake_w_cache, false, nullptr);
 
     auto supported = ov::get_supported_nodes(
         model,

--- a/src/plugins/intel_cpu/tests/functional/cmake/target_per_test.cmake
+++ b/src/plugins/intel_cpu/tests/functional/cmake/target_per_test.cmake
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# create targed with prefix TARGET_PREFIX for each test file in directory TEST_DIR
+#create targed with prefix TARGET_PREFIX for each test file in directory TEST_DIR
 function(create_target_per_test_for_directory TEST_DIR TARGET_PREFIX)
-  # exclude every other test file inside directory
+#exclude every other test file inside directory
   set(EXCLUDED_SOURCE_PATHS_FOR_TEST
     ${TEST_DIR})
 
-  # list of object files required for each test
+#list of object files required for each test
   set(REQUIRED_OBJECT_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/core_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/skip_tests_config.cpp
@@ -96,7 +96,7 @@ endif()
 endfunction()
 
 if(ENABLE_CPU_SPECIFIC_TARGET_PER_TEST)
-  create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/subgraph_tests/src ov_cpu_func_subgraph)
+  create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/subgraph_tests/src/common ov_cpu_func_subgraph)
   create_target_per_test_for_directory(${CMAKE_CURRENT_SOURCE_DIR}/custom/single_layer_tests ov_cpu_func_slt)
 endif()
 

--- a/src/plugins/intel_cpu/tests/unit/graph/inplace_resolve_io.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/inplace_resolve_io.cpp
@@ -92,7 +92,6 @@ private:
     std::vector<NodePtr> nodes;
     std::vector<EdgePtr> edges;
     std::unordered_set<NodePtr> nodesSet;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };
 
 class RNNConcatCPUTest : public InplaceResolveIOCPUTestBase {

--- a/src/plugins/intel_cpu/tests/unit/graph/inplace_resolve_io.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/inplace_resolve_io.cpp
@@ -5,24 +5,26 @@
 
 #include "dummy_node.hpp"
 #include "graph.h"
-
-#include "nodes/input.h"
+#include "memory_control.hpp"
 #include "nodes/concat.h"
+#include "nodes/input.h"
 #include "nodes/rnn.h"
-
 #include "openvino/op/concat.hpp"
-#include "openvino/op/result.hpp"
-#include "openvino/op/parameter.hpp"
 #include "openvino/op/gru_sequence.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
 
 using namespace ov::intel_cpu;
 using namespace ov::op;
 
 // helper to check the inplace direction of a node with a part of its name
-static void CheckInplaceDirection(const std::shared_ptr<Graph> graph, const std::string &partial_name, size_t inport, const Edge::LOOK undesiredDirection) {
+static void CheckInplaceDirection(const std::shared_ptr<Graph> graph,
+                                  const std::string& partial_name,
+                                  size_t inport,
+                                  const Edge::LOOK undesiredDirection) {
     const std::vector<NodePtr>& graph_nodes = graph->GetNodes();
     size_t actualCount = 0;
-    for (auto &node : graph_nodes) {
+    for (auto& node : graph_nodes) {
         if (node->getName().find(partial_name) != std::string::npos) {
             auto parentEdge = node->getParentEdgeAt(inport);
             if (undesiredDirection == 0)
@@ -36,13 +38,14 @@ static void CheckInplaceDirection(const std::shared_ptr<Graph> graph, const std:
     ASSERT_EQ(1, actualCount);
 }
 
-
 class InplaceResolveIOCPUTestBase : public ::testing::Test {
 public:
-    std::shared_ptr<Graph> create_graph(const std::vector<ov::PartialShape>& input_shapes, const size_t num_consumers = 1) {
+    std::shared_ptr<Graph> create_graph(const std::vector<ov::PartialShape>& input_shapes,
+                                        const size_t num_consumers = 1) {
         Config conf;
         conf.rtCacheCapacity = 100;
-        const auto context = std::make_shared<const GraphContext>(conf, nullptr, false);
+        const auto context =
+            std::make_shared<const GraphContext>(conf, nullptr, false);
 
         std::shared_ptr<Graph> graph = std::shared_ptr<Graph>(new Graph());
 
@@ -82,30 +85,33 @@ protected:
 private:
     void Replicate(ov::ParameterVector params, ov::ResultVector results, GraphContext::CPtr context) {
         replicate_impl(params, results, context);
-        for (auto &node : nodesSet) nodes.emplace_back(node);
+        for (auto& node : nodesSet)
+            nodes.emplace_back(node);
     }
 
     std::vector<NodePtr> nodes;
     std::vector<EdgePtr> edges;
     std::unordered_set<NodePtr> nodesSet;
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };
 
 class RNNConcatCPUTest : public InplaceResolveIOCPUTestBase {
-/*This test runs the following subgraph:
-                    param0  param1 param2
-                      H_t      X  seq_lens
-                     /   \     |     /
-                    /     \    |    / 
-                 Softmax0  RNNSequence
-                    \       /(Ho)   \(Y)
-                     \     /         \
-                     Concat       Reshape1
-                       |              |
-                       |              |
-                     Result0       Result1
+    /*This test runs the following subgraph:
+                        param0  param1 param2
+                          H_t      X  seq_lens
+                         /   \     |     /
+                        /     \    |    /
+                     Softmax0  RNNSequence
+                        \       /(Ho)   \(Y)
+                         \     /         \
+                         Concat       Reshape1
+                           |              |
+                           |              |
+                         Result0       Result1
 
-Edge Concat -> Result0 can share memory of inference output; Reshape1 -> Result1 can share memory of inference output;
-*/
+    Edge Concat -> Result0 can share memory of inference output; Reshape1 -> Result1 can share memory of inference
+    output;
+    */
 protected:
     void replicate_impl(ov::ParameterVector params, ov::ResultVector results, GraphContext::CPtr context) override {
         std::vector<std::shared_ptr<node::Input>> inputNodes;
@@ -113,10 +119,16 @@ protected:
             inputNodes.push_back(std::make_shared<node::Input>(params[i], context));
         }
 
-        auto dummy_softmax = std::make_shared<cpu_unit_test::DummyNode>(
-            params[0]->get_output_partial_shape(0), testPrec, "Softmax0" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, 0/*look*/);
+        auto dummy_softmax = std::make_shared<cpu_unit_test::DummyNode>(params[0]->get_output_partial_shape(0),
+                                                                        testPrec,
+                                                                        "Softmax0" /*name*/,
+                                                                        "DummyNode" /*type*/,
+                                                                        context,
+                                                                        LayoutType::ncsp,
+                                                                        0 /*look*/);
 
-        auto concat = std::make_shared<v0::Concat>(ov::OutputVector{params[0], params[0]}, 0);  // default, the connection will be reset by addEdge
+        auto concat = std::make_shared<v0::Concat>(ov::OutputVector{params[0], params[0]},
+                                                   0);  // default, the connection will be reset by addEdge
         auto concatNode = std::make_shared<node::Concat>(concat, context);
 
         constexpr size_t input_size = 8;
@@ -128,19 +140,30 @@ protected:
         auto wNode = std::make_shared<node::Input>(W, context);
         auto rNode = std::make_shared<node::Input>(R, context);
         auto bNode = std::make_shared<node::Input>(B, context);
-        auto rnnseq = std::make_shared<v5::GRUSequence>(
-                params[1],   // X
-                params[0],   // H_t
-                params[2],   // sequence_lengths
-                W, R, B,
-                hidden_size, RecurrentSequenceDirection::FORWARD);
+        auto rnnseq = std::make_shared<v5::GRUSequence>(params[1],  // X
+                                                        params[0],  // H_t
+                                                        params[2],  // sequence_lengths
+                                                        W,
+                                                        R,
+                                                        B,
+                                                        hidden_size,
+                                                        RecurrentSequenceDirection::FORWARD);
         auto rnnseqNode = std::make_shared<node::RNN>(rnnseq, context);
 
-        auto dummy_reshape = std::make_shared<cpu_unit_test::DummyNode>(
-            rnnseq->get_output_partial_shape(0), testPrec, "Reshape1" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, Edge::LOOK::LOOK_BOTH);
+        auto dummy_reshape = std::make_shared<cpu_unit_test::DummyNode>(rnnseq->get_output_partial_shape(0),
+                                                                        testPrec,
+                                                                        "Reshape1" /*name*/,
+                                                                        "DummyNode" /*type*/,
+                                                                        context,
+                                                                        LayoutType::ncsp,
+                                                                        Edge::LOOK::LOOK_BOTH);
 
         auto outputNode0 = std::make_shared<node::Input>(results.front(), context);
-        auto outputNode1 = std::make_shared<node::Input>(dummy_reshape->getOutputShapeAtPort(0), testPrec, "_result1", "Result", context);
+        auto outputNode1 = std::make_shared<node::Input>(dummy_reshape->getOutputShapeAtPort(0),
+                                                         testPrec,
+                                                         "_result1",
+                                                         "Result",
+                                                         context);
 
         addEdge(inputNodes[0], dummy_softmax, 0, 0);
         addEdge(inputNodes[0], rnnseqNode, 0, 0);
@@ -155,8 +178,8 @@ protected:
         addEdge(rNode, rnnseqNode, 0, 4);
         addEdge(bNode, rnnseqNode, 0, 5);
 
-        addEdge(rnnseqNode, dummy_reshape, 0, 0); // Y
-        addEdge(rnnseqNode, concatNode, 1, 1);  // Ho
+        addEdge(rnnseqNode, dummy_reshape, 0, 0);  // Y
+        addEdge(rnnseqNode, concatNode, 1, 1);     // Ho
 
         addEdge(dummy_reshape, outputNode1, 0, 0);
     }
@@ -164,26 +187,32 @@ protected:
 
 TEST_F(RNNConcatCPUTest, smoke_resolve_inplace_io) {
     auto graph = create_graph({ov::PartialShape{-1, 1, 3}, ov::PartialShape{-1, 10, 8}, ov::PartialShape{-1}}, 2);
-    CheckInplaceDirection(graph, std::string("Concat"), 0/*inport*/, Edge::LOOK::LOOK_UP/*undesired edge look direction*/);
-    CheckInplaceDirection(graph, std::string("_result1"), 0/*inport*/, Edge::LOOK::LOOK_UP/*undesired edge look direction*/);
+    CheckInplaceDirection(graph,
+                          std::string("Concat"),
+                          0 /*inport*/,
+                          Edge::LOOK::LOOK_UP /*undesired edge look direction*/);
+    CheckInplaceDirection(graph,
+                          std::string("_result1"),
+                          0 /*inport*/,
+                          Edge::LOOK::LOOK_UP /*undesired edge look direction*/);
 }
 
 class SoftmaxAddReshapeOutputCPUTest : public InplaceResolveIOCPUTestBase {
-/*This test runs the following subgraph:
+    /*This test runs the following subgraph:
 
-                      param
-                        |
-                        |
-                      Softmax
-                     /     \
-                    /       \
-                   Add     Reshape0
-                    |         |
-                    |         |
-                 Result0   Result1
+                          param
+                            |
+                            |
+                          Softmax
+                         /     \
+                        /       \
+                       Add     Reshape0
+                        |         |
+                        |         |
+                     Result0   Result1
 
-expect edge Reshape0->Result1 to be referenced by its upstreams, instead of referencing to its upstreams.
-*/
+    expect edge Reshape0->Result1 to be referenced by its upstreams, instead of referencing to its upstreams.
+    */
 protected:
     void replicate_impl(ov::ParameterVector params, ov::ResultVector results, GraphContext::CPtr context) override {
         std::vector<std::shared_ptr<node::Input>> inputNodes;
@@ -196,14 +225,29 @@ protected:
             outputNodes.push_back(std::make_shared<node::Input>(results[i], context));
         }
 
-        auto dummy_softmax = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "softmax" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, 0/*look*/);
+        auto dummy_softmax = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                        testPrec,
+                                                                        "softmax" /*name*/,
+                                                                        "DummyNode" /*type*/,
+                                                                        context,
+                                                                        LayoutType::ncsp,
+                                                                        0 /*look*/);
 
-        auto dummy_add = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "add" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, 0/*look*/);
+        auto dummy_add = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                    testPrec,
+                                                                    "add" /*name*/,
+                                                                    "DummyNode" /*type*/,
+                                                                    context,
+                                                                    LayoutType::ncsp,
+                                                                    0 /*look*/);
 
-        auto dummy_reshape = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "reshape" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, Edge::LOOK::LOOK_BOTH);
+        auto dummy_reshape = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                        testPrec,
+                                                                        "reshape" /*name*/,
+                                                                        "DummyNode" /*type*/,
+                                                                        context,
+                                                                        LayoutType::ncsp,
+                                                                        Edge::LOOK::LOOK_BOTH);
 
         addEdge(inputNodes.front(), dummy_softmax, 0, 0);
 
@@ -217,30 +261,32 @@ protected:
 
 TEST_F(SoftmaxAddReshapeOutputCPUTest, smoke_resolve_inplace_io) {
     auto graph = create_graph({ov::PartialShape{2, -1}}, 2);
-    CheckInplaceDirection(graph, std::string("_result1"), 0/*inport*/, Edge::LOOK::LOOK_UP/*undesired edge look direction*/);
+    CheckInplaceDirection(graph,
+                          std::string("_result1"),
+                          0 /*inport*/,
+                          Edge::LOOK::LOOK_UP /*undesired edge look direction*/);
 }
 
-
 class SoftmaxAddReshapeTwoOutputsCPUTest : public InplaceResolveIOCPUTestBase {
-/*This test runs the following subgraph:
+    /*This test runs the following subgraph:
 
-                      param
-                        |
-                        |
-                      Softmax
-                     /       \
-                    /         \
-                   Add       Reshape0
-                    |         |      \
-                    |         |       \
-                 Result0   Reshape1  Result2
-                              |         
-                              |
-                            Result1
+                          param
+                            |
+                            |
+                          Softmax
+                         /       \
+                        /         \
+                       Add       Reshape0
+                        |         |      \
+                        |         |       \
+                     Result0   Reshape1  Result2
+                                  |
+                                  |
+                                Result1
 
-Hope Reshape0 could resolve downstream, so either edge Reshape1 -> Result1 or Reshape0 -> Result2
-could get a chance to be referenced by infer request.
-*/
+    Hope Reshape0 could resolve downstream, so either edge Reshape1 -> Result1 or Reshape0 -> Result2
+    could get a chance to be referenced by infer request.
+    */
 protected:
     void replicate_impl(ov::ParameterVector params, ov::ResultVector results, GraphContext::CPtr context) override {
         std::vector<std::shared_ptr<node::Input>> inputNodes;
@@ -253,17 +299,37 @@ protected:
             outputNodes.push_back(std::make_shared<node::Input>(results[i], context));
         }
 
-        auto dummy_softmax = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "softmax" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, 0/*look*/);
+        auto dummy_softmax = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                        testPrec,
+                                                                        "softmax" /*name*/,
+                                                                        "DummyNode" /*type*/,
+                                                                        context,
+                                                                        LayoutType::ncsp,
+                                                                        0 /*look*/);
 
-        auto dummy_add = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "add" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, 0/*look*/);
+        auto dummy_add = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                    testPrec,
+                                                                    "add" /*name*/,
+                                                                    "DummyNode" /*type*/,
+                                                                    context,
+                                                                    LayoutType::ncsp,
+                                                                    0 /*look*/);
 
-        auto dummy_reshape0 = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "reshape0" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, Edge::LOOK::LOOK_BOTH);
+        auto dummy_reshape0 = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                         testPrec,
+                                                                         "reshape0" /*name*/,
+                                                                         "DummyNode" /*type*/,
+                                                                         context,
+                                                                         LayoutType::ncsp,
+                                                                         Edge::LOOK::LOOK_BOTH);
 
-        auto dummy_reshape1 = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "reshape1" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, Edge::LOOK::LOOK_BOTH);
+        auto dummy_reshape1 = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                         testPrec,
+                                                                         "reshape1" /*name*/,
+                                                                         "DummyNode" /*type*/,
+                                                                         context,
+                                                                         LayoutType::ncsp,
+                                                                         Edge::LOOK::LOOK_BOTH);
 
         addEdge(inputNodes.front(), dummy_softmax, 0, 0);
 
@@ -280,22 +346,25 @@ protected:
 
 TEST_F(SoftmaxAddReshapeTwoOutputsCPUTest, smoke_resolve_inplace_io) {
     auto graph = create_graph({ov::PartialShape{2, -1}}, 3);
-    CheckInplaceDirection(graph, std::string("reshape0"), 0/*inport*/, Edge::LOOK::LOOK_UP/*undesired edge look direction*/);
+    CheckInplaceDirection(graph,
+                          std::string("reshape0"),
+                          0 /*inport*/,
+                          Edge::LOOK::LOOK_UP /*undesired edge look direction*/);
 }
 
 class InputReshapeOutputCPUTest : public InplaceResolveIOCPUTestBase {
-/*This test runs the following subgraph:
+    /*This test runs the following subgraph:
 
-                      param
-                        |
-                        |
-                    Reshape0
-                        |
-                        |
-                     Result0
+                          param
+                            |
+                            |
+                        Reshape0
+                            |
+                            |
+                         Result0
 
-Edge Reshape0 -> Result0 cannot be referenced by its upstreams as its upstream is an input.
-*/
+    Edge Reshape0 -> Result0 cannot be referenced by its upstreams as its upstream is an input.
+    */
 protected:
     void replicate_impl(ov::ParameterVector params, ov::ResultVector results, GraphContext::CPtr context) override {
         std::vector<std::shared_ptr<node::Input>> inputNodes;
@@ -308,8 +377,13 @@ protected:
             outputNodes.push_back(std::make_shared<node::Input>(results[i], context));
         }
 
-        auto dummy_reshape = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, testPrec, "reshape0" /*name*/, "DummyNode" /*type*/, context, LayoutType::ncsp, Edge::LOOK::LOOK_BOTH);
+        auto dummy_reshape = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                        testPrec,
+                                                                        "reshape0" /*name*/,
+                                                                        "DummyNode" /*type*/,
+                                                                        context,
+                                                                        LayoutType::ncsp,
+                                                                        Edge::LOOK::LOOK_BOTH);
 
         addEdge(inputNodes.front(), dummy_reshape, 0, 0);
         addEdge(dummy_reshape, outputNodes.front(), 0, 0);
@@ -318,5 +392,8 @@ protected:
 
 TEST_F(InputReshapeOutputCPUTest, smoke_resolve_inplace_io) {
     auto graph = create_graph({ov::PartialShape{2, -1}});
-    CheckInplaceDirection(graph, std::string("reshape0"), 0/*inport*/, Edge::LOOK::LOOK_DOWN/*undesired edge look direction*/);
+    CheckInplaceDirection(graph,
+                          std::string("reshape0"),
+                          0 /*inport*/,
+                          Edge::LOOK::LOOK_DOWN /*undesired edge look direction*/);
 }

--- a/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
@@ -4,12 +4,12 @@
 #include <gtest/gtest.h>
 
 #include "dummy_node.hpp"
-
 #include "graph.h"
-#include "nodes/memory.hpp"
-#include "nodes/softmax.h"
-#include "nodes/shapeof.h"
+#include "memory_control.hpp"
 #include "nodes/convert.h"
+#include "nodes/memory.hpp"
+#include "nodes/shapeof.h"
+#include "nodes/softmax.h"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/softmax.hpp"
@@ -58,8 +58,8 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
         // The ReadValue/Assign operations must be used in pairs in the model.
         // For each such a pair, its own variable object must be created.
         const std::string variable_name("variable0");
-        auto variable = std::make_shared<ov::op::util::Variable>(
-            ov::op::util::VariableInfo{test_shape, test_prec, variable_name});
+        auto variable =
+            std::make_shared<ov::op::util::Variable>(ov::op::util::VariableInfo{test_shape, test_prec, variable_name});
 
         // creat ngraph ops to build CPU nodes
         auto read = std::make_shared<ov::op::v6::ReadValue>(param, variable);
@@ -78,26 +78,34 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
             nodes_set.insert(child);
         };
 
-        //create graph context
+        // create graph context
 
         Config conf;
         conf.rtCacheCapacity = 0;
-        auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+        std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+        auto context =
+            std::make_shared<GraphContext>(conf, nullptr, false);
 
         auto input_node = std::make_shared<node::Input>(param, context);
         auto memory_input = std::make_shared<node::MemoryInput>(read, context);
-        auto first_dummy = std::make_shared<cpu_unit_test::DummyNode>(
-            test_shape, test_prec,
-            "first_dummy",
-            "DummyNode",
-            context,
-            LayoutType::ncsp,
-            first_dummy_inplace_direction,
-            true);
+        auto first_dummy = std::make_shared<cpu_unit_test::DummyNode>(test_shape,
+                                                                      test_prec,
+                                                                      "first_dummy",
+                                                                      "DummyNode",
+                                                                      context,
+                                                                      LayoutType::ncsp,
+                                                                      first_dummy_inplace_direction,
+                                                                      true);
 
         auto memory_output = std::make_shared<node::MemoryOutput>(assign, context);
-        auto second_dummy = std::make_shared<cpu_unit_test::DummyNode>(
-            test_shape, test_prec, "second_dummy", "DummyNode", context, LayoutType::ncsp, Edge::LOOK::LOOK_UP, true);
+        auto second_dummy = std::make_shared<cpu_unit_test::DummyNode>(test_shape,
+                                                                       test_prec,
+                                                                       "second_dummy",
+                                                                       "DummyNode",
+                                                                       context,
+                                                                       LayoutType::ncsp,
+                                                                       Edge::LOOK::LOOK_UP,
+                                                                       true);
         auto softmax_node = std::make_shared<node::SoftMax>(softmax, context);
         auto output_node = std::make_shared<node::Input>(res, context);
 
@@ -117,8 +125,9 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
     auto find_node_str = [](const Graph& graph, const char* name) -> NodePtr {
         auto&& nodes = graph.GetNodes();
-        auto itr =
-            std::find_if(nodes.begin(), nodes.end(), [=](const NodePtr& node){ return name == node->getName(); });
+        auto itr = std::find_if(nodes.begin(), nodes.end(), [=](const NodePtr& node) {
+            return name == node->getName();
+        });
 
         if (itr == nodes.end()) {
             return nullptr;
@@ -129,8 +138,9 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
     auto find_node_type = [](const Graph& graph, Type type) -> NodePtr {
         auto&& nodes = graph.GetNodes();
-        auto itr =
-            std::find_if(nodes.begin(), nodes.end(), [=](const NodePtr& node){ return type == node->getType(); });
+        auto itr = std::find_if(nodes.begin(), nodes.end(), [=](const NodePtr& node) {
+            return type == node->getType();
+        });
 
         if (itr == nodes.end()) {
             return nullptr;
@@ -165,7 +175,7 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
         auto second_dummy_out_mem = second_dummy->getDstDataAtPort(0);
         auto memory_output_inp_mem = memory_output->getSrcDataAtPort(0);
-        //otherwise the memory will be modified by the dummy_look_up
+        // otherwise the memory will be modified by the dummy_look_up
         ASSERT_NE(second_dummy_out_mem, memory_output_inp_mem);
 
         // due to double buffer usage by default
@@ -203,7 +213,7 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
         auto second_dummy_out_mem = second_dummy->getDstDataAtPort(0);
         auto memory_output_inp_mem = memory_output->getSrcDataAtPort(0);
-        //otherwise the memory will be modified by the dummy_look_up
+        // otherwise the memory will be modified by the dummy_look_up
         ASSERT_NE(second_dummy_out_mem, memory_output_inp_mem);
 
         // as the input memory bypassed through a cascade of look_up inplace nodes, it's set directly to the output
@@ -255,8 +265,8 @@ TEST(MemStateGraphTest, smoke_ShapeOf_no_Inplace_Conflicts) {
     // The ReadValue/Assign operations must be used in pairs in the model.
     // For each such a pair, its own variable object must be created.
     const std::string variable_name("variable0");
-    auto variable = std::make_shared<ov::op::util::Variable>(
-        ov::op::util::VariableInfo{test_shape, test_prec, variable_name});
+    auto variable =
+        std::make_shared<ov::op::util::Variable>(ov::op::util::VariableInfo{test_shape, test_prec, variable_name});
 
     // creat ngraph ops to build CPU nodes
     auto read = std::make_shared<ov::op::v6::ReadValue>(param, variable);
@@ -277,22 +287,24 @@ TEST(MemStateGraphTest, smoke_ShapeOf_no_Inplace_Conflicts) {
         nodes_set.insert(child);
     };
 
-    //create graph context
+    // create graph context
 
     Config conf;
     conf.rtCacheCapacity = 0;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context =
+        std::make_shared<GraphContext>(conf, nullptr, false);
 
     auto input_node = std::make_shared<node::Input>(param, context);
     auto memory_input = std::make_shared<node::MemoryInput>(read, context);
-    auto dummy = std::make_shared<cpu_unit_test::DummyNode>(
-        test_shape, test_prec,
-        "first_dummy",
-        "DummyNode",
-        context,
-        LayoutType::ncsp,
-        Edge::LOOK::LOOK_UP,
-        true);
+    auto dummy = std::make_shared<cpu_unit_test::DummyNode>(test_shape,
+                                                            test_prec,
+                                                            "first_dummy",
+                                                            "DummyNode",
+                                                            context,
+                                                            LayoutType::ncsp,
+                                                            Edge::LOOK::LOOK_UP,
+                                                            true);
 
     auto memory_output = std::make_shared<node::MemoryOutput>(assign, context);
     auto shapeof_node = std::make_shared<node::ShapeOf>(shapeof, context);
@@ -318,8 +330,9 @@ TEST(MemStateGraphTest, smoke_ShapeOf_no_Inplace_Conflicts) {
     graph.CreateGraph(graph_nodes, graph_edges, context, "test_graph");
 
     auto&& nodes = graph.GetNodes();
-    auto itr = std::find_if(nodes.begin(), nodes.end(),
-        [](const NodePtr& node){ return Type::Reorder == node->getType(); });
+    auto itr = std::find_if(nodes.begin(), nodes.end(), [](const NodePtr& node) {
+        return Type::Reorder == node->getType();
+    });
 
     ASSERT_EQ(itr, nodes.end());
 }

--- a/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/memory_state.cpp
@@ -82,7 +82,6 @@ TEST(MemStateGraphTest, smoke_Check_Memory_Modification_Guard) {
 
         Config conf;
         conf.rtCacheCapacity = 0;
-        std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
         auto context =
             std::make_shared<GraphContext>(conf, nullptr, false);
 
@@ -291,7 +290,6 @@ TEST(MemStateGraphTest, smoke_ShapeOf_no_Inplace_Conflicts) {
 
     Config conf;
     conf.rtCacheCapacity = 0;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
     auto context =
         std::make_shared<GraphContext>(conf, nullptr, false);
 

--- a/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <gtest/gtest.h>
+#include <memory_desc/cpu_blocked_memory_desc.h>
 
 #include <common_test_utils/test_common.hpp>
-#include <memory_desc/cpu_blocked_memory_desc.h>
 
 #include "common_test_utils/node_builders/constant.hpp"
 #include "dummy_node.hpp"
 #include "graph.h"
+#include "memory_control.hpp"
 #include "nodes/input.h"
 #include "nodes/reorder.h"
 #include "nodes/reshape.h"
@@ -73,10 +74,12 @@ protected:
         const auto& shape = std::get<0>(GetParam());
         const auto& params = std::get<1>(GetParam());
         OPENVINO_ASSERT(shape.size() == 4 || shape.size() == 3,
-                        "MergeTransposeReorderCPUTest doesn't support shape", shape,
+                        "MergeTransposeReorderCPUTest doesn't support shape",
+                        shape,
                         ". Only 4D and 3D shapes are supported");
         Config conf;
-        m_context = std::make_shared<GraphContext>(conf, nullptr, false);
+        m_context =
+            std::make_shared<GraphContext>(conf, nullptr, false);
         const auto replication_result = CreateModelAndReplicate(shape,
                                                                 params.firstNodeLayout,
                                                                 params.firstNodeInplaceDirection,
@@ -87,12 +90,13 @@ protected:
         m_graph->CreateGraph(replication_result.first, replication_result.second, m_context, "fused_graph");
     }
 
-    virtual std::pair<std::vector<NodePtr>, std::vector<EdgePtr>> CreateModelAndReplicate(const ov::Shape& testShape,
-                                                                                          LayoutType firstNodeLayout,
-                                                                                          LOOK firstNodeInplaceDirection,
-                                                                                          LayoutType lastNodeLayout,
-                                                                                          LOOK lastNodeInplaceDirection,
-                                                                                          size_t num_consumers) {
+    virtual std::pair<std::vector<NodePtr>, std::vector<EdgePtr>> CreateModelAndReplicate(
+        const ov::Shape& testShape,
+        LayoutType firstNodeLayout,
+        LOOK firstNodeInplaceDirection,
+        LayoutType lastNodeLayout,
+        LOOK lastNodeInplaceDirection,
+        size_t num_consumers) {
         const auto precision = ov::element::f32;
         // ov::Model with only a transpose node
         ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(precision, testShape)};
@@ -118,8 +122,13 @@ protected:
 
         auto inputNode = std::make_shared<node::Input>(params[0], m_context);
 
-        auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, precision, "reshape", "DummyNode", m_context, firstNodeLayout, firstNodeInplaceDirection);
+        auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                     precision,
+                                                                     "reshape",
+                                                                     "DummyNode",
+                                                                     m_context,
+                                                                     firstNodeLayout,
+                                                                     firstNodeInplaceDirection);
 
         auto orderNode = std::make_shared<node::Input>(constOrder, m_context);
         auto transposeNode = std::make_shared<node::Transpose>(transpose, m_context);
@@ -142,13 +151,14 @@ protected:
             addEdge(transposeNode, dummyConsumer, 0, 0);
             addEdge(dummyConsumer, outputNode, 0, 0);
         }
-        for (auto &node : nodesSet) nodes.emplace_back(node);
+        for (auto& node : nodesSet)
+            nodes.emplace_back(node);
         return {nodes, edges};
     }
 
     void CheckTransposeCount(size_t ref_transpose_count) const {
         size_t transpose_count = 0;
-        for (auto &node : m_graph->GetNodes()) {
+        for (auto& node : m_graph->GetNodes()) {
             if (node->getType() == Type::Transpose) {
                 transpose_count++;
             }
@@ -159,7 +169,7 @@ protected:
     void CheckReorderCount(size_t ref_optimized_reorder_count, size_t ref_not_optimized_reorder_count) const {
         size_t optimized_count = 0;
         size_t not_optimized_count = 0;
-        for (auto &node : m_graph->GetNodes()) {
+        for (auto& node : m_graph->GetNodes()) {
             if (auto reorder_node = std::dynamic_pointer_cast<node::Reorder>(node)) {
                 if (reorder_node->getOptimized())
                     optimized_count++;
@@ -173,32 +183,33 @@ protected:
 
     std::shared_ptr<GraphContext> m_context;
     std::unique_ptr<Graph> m_graph;
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };  // class MergeTransposeReorderCPUTest
 
 /*
- ┌───────┐  
- │ Input │  
- └───┬───┘  
-     │      
- ┌───┴───┐  
- │ Dummy │  
- └───┬───┘  
-     │      
- ┌───┴───┐  
- │Reshape│  
- └───┬───┘  
-     │      
-┌────┴────┐ 
-│Transpose│ 
-└────┬────┘ 
-     │      
- ┌───┴───┐  
- │ Dummy │  
- └───┬───┘  
-     │      
-┌────┴───┐  
-│ Output │  
-└────────┘  
+ ┌───────┐
+ │ Input │
+ └───┬───┘
+     │
+ ┌───┴───┐
+ │ Dummy │
+ └───┬───┘
+     │
+ ┌───┴───┐
+ │Reshape│
+ └───┬───┘
+     │
+┌────┴────┐
+│Transpose│
+└────┬────┘
+     │
+ ┌───┴───┐
+ │ Dummy │
+ └───┬───┘
+     │
+┌────┴───┐
+│ Output │
+└────────┘
  */
 class MergeTransposeReorderWithReshapeCPUTest : public MergeTransposeReorderCPUTest {
     std::pair<std::vector<NodePtr>, std::vector<EdgePtr>> CreateModelAndReplicate(const ov::Shape& testShape,
@@ -209,7 +220,8 @@ class MergeTransposeReorderWithReshapeCPUTest : public MergeTransposeReorderCPUT
                                                                                   size_t num_consumers) override {
         const auto precision = ov::element::f32;
         const auto param = std::make_shared<ov::op::v0::Parameter>(precision, testShape);
-        auto reshape_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int>{0, 0, -1});
+        auto reshape_const =
+            std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int>{0, 0, -1});
         auto reshape = std::make_shared<ov::op::v1::Reshape>(param, reshape_const, true);
         auto order = std::vector<int32_t>{0, 2, 1};
         auto transpose_order = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{order.size()}, order);
@@ -232,8 +244,13 @@ class MergeTransposeReorderWithReshapeCPUTest : public MergeTransposeReorderCPUT
         };
 
         auto inputNode = std::make_shared<node::Input>(param, m_context);
-        auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
-            testShape, precision, "before_reshape", "DummyNode", m_context, LayoutType::nspc, LOOK::LOOK_UP);
+        auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                     precision,
+                                                                     "before_reshape",
+                                                                     "DummyNode",
+                                                                     m_context,
+                                                                     LayoutType::nspc,
+                                                                     LOOK::LOOK_UP);
 
         auto reshapeConstNode = std::make_shared<node::Input>(reshape_const, m_context);
         auto reshapeNode = std::make_shared<node::Reshape>(reshape, m_context);
@@ -261,7 +278,8 @@ class MergeTransposeReorderWithReshapeCPUTest : public MergeTransposeReorderCPUT
             addEdge(transposeNode, dummyConsumer, 0, 0);
             addEdge(dummyConsumer, outputNode, 0, 0);
         }
-        for (auto &node : nodesSet) nodes.emplace_back(node);
+        for (auto& node : nodesSet)
+            nodes.emplace_back(node);
         return {nodes, edges};
     }
 };
@@ -335,35 +353,53 @@ TEST(MergeTransposeReorder, smoke_InplaceConflict) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context =
+        std::make_shared<GraphContext>(conf, nullptr, false);
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
 
     const ov::Shape testShape{1, 8, 8, 8};
-    ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape{1, 8, 8, 8})};
+    ov::ParameterVector params{
+        std::make_shared<ov::op::v0::Parameter>(ov::element::Type_t::f32, ov::Shape{1, 8, 8, 8})};
 
-    auto shape_constant = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{3}, std::vector<int64_t>{1, 8, 64});
+    auto shape_constant =
+        std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{3}, std::vector<int64_t>{1, 8, 64});
     auto reshape_node = std::make_shared<ov::op::v1::Reshape>(params[0], shape_constant, true);
-    auto order_constant = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{3}, std::vector<int64_t>{0, 2, 1});
+    auto order_constant =
+        std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{3}, std::vector<int64_t>{0, 2, 1});
     auto transpose_node = std::make_shared<ov::op::v1::Transpose>(reshape_node, order_constant);
 
     ov::ResultVector results{std::make_shared<ov::op::v0::Result>(transpose_node),
                              std::make_shared<ov::op::v0::Result>(params[0])};
 
     auto nspcCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::nspc);
-    auto inDesc = nspcCreator->createSharedDesc(ov::element::Type_t::f32, ov::intel_cpu::Shape(ov::intel_cpu::VectorDims{1, 8, 8, 8}));
+    auto inDesc = nspcCreator->createSharedDesc(ov::element::Type_t::f32,
+                                                ov::intel_cpu::Shape(ov::intel_cpu::VectorDims{1, 8, 8, 8}));
     auto inputNode = std::make_shared<node::Input>(inDesc->clone(), "Input0", "Parameter", context);
 
     auto shapeConst = std::make_shared<node::Input>(shape_constant, context);
     auto reshapeNode = std::make_shared<node::Reshape>(reshape_node, context);
     auto orderConst = std::make_shared<node::Input>(order_constant, context);
     auto transposeNode = std::make_shared<node::Transpose>(transpose_node, context);
-    auto dummyNode0 = std::make_shared<cpu_unit_test::DummyNode>(
-        ov::Shape{1, 64, 8}, ov::element::Type_t::f32, "Dummy0", "DummyNode", context, LayoutType::ncsp, Edge::LOOK::LOOK_UP, true);
+    auto dummyNode0 = std::make_shared<cpu_unit_test::DummyNode>(ov::Shape{1, 64, 8},
+                                                                 ov::element::Type_t::f32,
+                                                                 "Dummy0",
+                                                                 "DummyNode",
+                                                                 context,
+                                                                 LayoutType::ncsp,
+                                                                 Edge::LOOK::LOOK_UP,
+                                                                 true);
     auto outputNode0 = std::make_shared<node::Input>(results[0], context);
 
-    auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
-        ov::Shape{1, 8, 8, 8}, ov::element::Type_t::f32, "Dummy1", "DummyNode", context, LayoutType::nspc, Edge::LOOK::LOOK_UP, true);
+    auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(ov::Shape{1, 8, 8, 8},
+                                                                 ov::element::Type_t::f32,
+                                                                 "Dummy1",
+                                                                 "DummyNode",
+                                                                 context,
+                                                                 LayoutType::nspc,
+                                                                 Edge::LOOK::LOOK_UP,
+                                                                 true);
     auto outputNode1 = std::make_shared<node::Input>(results[1], context);
 
     std::vector<NodePtr> graphNodes;
@@ -387,7 +423,8 @@ TEST(MergeTransposeReorder, smoke_InplaceConflict) {
     addEdge(transposeNode, dummyNode0, 0, 0);
     addEdge(dummyNode0, outputNode0, 0, 0);
 
-    for (auto &node : nodesSet) graphNodes.emplace_back(node);
+    for (auto& node : nodesSet)
+        graphNodes.emplace_back(node);
 
     graph->CreateGraph(graphNodes, graphEdges, context, "test_graph");
     auto expected_reorder_node0 = dummyNode0->getParentEdgeAt(0)->getParent();

--- a/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/merge_transpose_reorder_test.cpp
@@ -183,7 +183,6 @@ protected:
 
     std::shared_ptr<GraphContext> m_context;
     std::unique_ptr<Graph> m_graph;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };  // class MergeTransposeReorderCPUTest
 
 /*
@@ -353,9 +352,7 @@ TEST(MergeTransposeReorder, smoke_InplaceConflict) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
-    auto context =
-        std::make_shared<GraphContext>(conf, nullptr, false);
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
 

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -44,9 +44,7 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
-    auto context =
-        std::make_shared<GraphContext>(conf, nullptr, false);
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
     const dnnl::engine cpuEngine = context->getEngine();
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
@@ -118,9 +116,7 @@ TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
-    auto context =
-        std::make_shared<GraphContext>(conf, nullptr, false);
+    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
 

--- a/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/graph/resolve_edge_conflicts_test.cpp
@@ -5,16 +5,17 @@
 
 #include "dummy_node.hpp"
 #include "graph.h"
-#include "nodes/input.h"
+#include "memory_control.hpp"
 #include "nodes/concat.h"
+#include "nodes/input.h"
 #include "openvino/op/concat.hpp"
-#include "openvino/opsets/opset.hpp"
-#include "openvino/op/shape_of.hpp"
-#include "openvino/op/parameter.hpp"
-#include "openvino/op/result.hpp"
-#include "openvino/op/reduce_prod.hpp"
-#include "openvino/op/scatter_nd_update.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/reduce_prod.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/scatter_nd_update.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/opsets/opset.hpp"
 
 using namespace ov::intel_cpu;
 
@@ -37,13 +38,15 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
                   |
                 Output
 
-        Dummy1, Dummy2 and Dummy3 can be inplace. In ResolveEdgeConflicts(), detect Dummy3 is 
+        Dummy1, Dummy2 and Dummy3 can be inplace. In ResolveEdgeConflicts(), detect Dummy3 is
         a modifying node. Collect consumers of edge Input->Dummy1 and find consumer execution
         order is after Dummy3. Then insert Reorder in edge Input->Dummy2.
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context =
+        std::make_shared<GraphContext>(conf, nullptr, false);
     const dnnl::engine cpuEngine = context->getEngine();
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
@@ -57,14 +60,24 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
     auto inputNode = std::make_shared<node::Input>(params[0], context);
     auto outputNode = std::make_shared<node::Input>(results[0], context);
     auto concatNode = std::make_shared<node::Concat>(concat, context);
-    auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(
-        testShape, testPrec, "Dummy1", "DummyNode", context);
-    auto dummyNode2 = std::make_shared<cpu_unit_test::DummyNode>(
-        testShape, testPrec, "Dummy2", "DummyNode", context);
-    auto dummyNode3 = std::make_shared<cpu_unit_test::DummyNode>(
-        testShape, testPrec, "Dummy3", "DummyNode", context, LayoutType::ncsp, Edge::LOOK::LOOK_UP, true);
-    auto dummyNode4 = std::make_shared<cpu_unit_test::DummyNode>(
-        testShape, testPrec, "Dummy4", "DummyNode", context, LayoutType::ncsp, 0, true);
+    auto dummyNode1 = std::make_shared<cpu_unit_test::DummyNode>(testShape, testPrec, "Dummy1", "DummyNode", context);
+    auto dummyNode2 = std::make_shared<cpu_unit_test::DummyNode>(testShape, testPrec, "Dummy2", "DummyNode", context);
+    auto dummyNode3 = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                 testPrec,
+                                                                 "Dummy3",
+                                                                 "DummyNode",
+                                                                 context,
+                                                                 LayoutType::ncsp,
+                                                                 Edge::LOOK::LOOK_UP,
+                                                                 true);
+    auto dummyNode4 = std::make_shared<cpu_unit_test::DummyNode>(testShape,
+                                                                 testPrec,
+                                                                 "Dummy4",
+                                                                 "DummyNode",
+                                                                 context,
+                                                                 LayoutType::ncsp,
+                                                                 0,
+                                                                 true);
 
     std::vector<NodePtr> graphNodes;
     std::vector<EdgePtr> graphEdges;
@@ -84,7 +97,8 @@ TEST(ResolveEdgeConflictsCPUTest, smoke_Run_ResolveEdgeConflicts) {
     addEdge(inputNode, dummyNode1, 0, 0);
     addEdge(dummyNode1, concatNode, 0, 0);
     addEdge(concatNode, outputNode, 0, 0);
-    for (auto &node : nodesSet) graphNodes.emplace_back(node);
+    for (auto& node : nodesSet)
+        graphNodes.emplace_back(node);
     graph->CreateGraph(graphNodes, graphEdges, context, "test_graph");
 
     // Check whether reorder is inserted
@@ -104,7 +118,9 @@ TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
     */
     Config conf;
     conf.rtCacheCapacity = 100;
-    auto context = std::make_shared<GraphContext>(conf, nullptr, false);
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
+    auto context =
+        std::make_shared<GraphContext>(conf, nullptr, false);
 
     std::unique_ptr<Graph> graph = std::unique_ptr<Graph>(new Graph());
 
@@ -116,9 +132,12 @@ TEST(ResolveEdgeConflictsCPUTest2, smoke_Run_ResolveEdgeConflicts2) {
 
     auto org_ReduceProd_423 = std::make_shared<ov::op::v1::ReduceProd>(org_ShapeOf_386, params[1]);
 
-    auto org_Constant_387 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1, 1}, std::vector<int64_t>{1});
-    auto org_Constant_1 = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1}, std::vector<int64_t>{1});
-    auto org_ScatterNDUpdate_411 = std::make_shared<ov::op::v3::ScatterNDUpdate>(org_ShapeOf_386, org_Constant_387, org_Constant_1);
+    auto org_Constant_387 =
+        std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1, 1}, std::vector<int64_t>{1});
+    auto org_Constant_1 =
+        std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i32, ov::Shape{1}, std::vector<int64_t>{1});
+    auto org_ScatterNDUpdate_411 =
+        std::make_shared<ov::op::v3::ScatterNDUpdate>(org_ShapeOf_386, org_Constant_387, org_Constant_1);
 
     ov::ResultVector results{std::make_shared<ov::op::v0::Result>(org_ScatterNDUpdate_411),
                              std::make_shared<ov::op::v0::Result>(org_ReduceProd_423)};

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -150,7 +150,6 @@ protected:
     std::shared_ptr<ov::intel_cpu::Edge> parentEdge;
     std::shared_ptr<ov::intel_cpu::Edge> childEdge;
     ov::element::Type prec;
-    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };
 
 }  // namespace ReorderCPUTest

--- a/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/nodes/reorder_node_test.cpp
@@ -14,6 +14,7 @@
 #include <dnnl.hpp>
 
 #include "common_test_utils/common_utils.hpp"
+#include "memory_control.hpp"
 #include "nodes/input.h"
 
 using namespace ov::intel_cpu;
@@ -109,17 +110,14 @@ public:
         auto context = std::make_shared<GraphContext>(conf,
                                                       std::make_shared<WeightsSharing>(),
                                                       false);
+
         const dnnl::engine cpuEngine = context->getEngine();
 
-        inputNode = std::make_shared<ov::intel_cpu::node::Input>(inputDesc.clone(),
-                                                                      "Reorder_Input",
-                                                                      "Parameter",
-                                                                      context);
+        inputNode =
+            std::make_shared<ov::intel_cpu::node::Input>(inputDesc.clone(), "Reorder_Input", "Parameter", context);
         reorderNode = std::make_shared<ov::intel_cpu::node::Reorder>(inputDesc, outputDesc, "Reorder", context);
-        outputNode = std::make_shared<ov::intel_cpu::node::Input>(outputDesc.clone(),
-                                                                       "Reorder_Output",
-                                                                       "Result",
-                                                                       context);
+        outputNode =
+            std::make_shared<ov::intel_cpu::node::Input>(outputDesc.clone(), "Reorder_Output", "Result", context);
 
         parentEdge = std::make_shared<ov::intel_cpu::Edge>(inputNode, reorderNode, 0, 0);
         childEdge = std::make_shared<ov::intel_cpu::Edge>(reorderNode, outputNode, 0, 0);
@@ -152,9 +150,10 @@ protected:
     std::shared_ptr<ov::intel_cpu::Edge> parentEdge;
     std::shared_ptr<ov::intel_cpu::Edge> childEdge;
     ov::element::Type prec;
+    std::shared_ptr<NetworkMemoryControl> networkMemoryControl = std::make_shared<NetworkMemoryControl>();
 };
 
-}// namespace ReorderCPUTest
+}  // namespace ReorderCPUTest
 
 using namespace ReorderCPUTest;
 
@@ -305,8 +304,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_ReorderTestCustomStrideWithFactor,
  * ReorderCPUTest to test the CPU plugin-in dynamism and RT cache
  */
 class ReorderDynamismCPUTest : public ::testing::Test,
-                       public ::testing::WithParamInterface<ReorderCPUTestParamSet>,
-                       public ::ReorderCPUTest::ReorderCPUTestGraph {
+                               public ::testing::WithParamInterface<ReorderCPUTestParamSet>,
+                               public ::ReorderCPUTest::ReorderCPUTestGraph {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReorderCPUTestParamSet>& obj) {
         ReorderCPUTestParamSet p = obj.param;


### PR DESCRIPTION
### Details:
 - All the nested graphs are now must be a part of a global memory reuse logic
 - The core logic of the memory reuse is untouched (a bit refactored)
 - Instead of solving memory reuse for every graph / subgraph, now all the edges and global execution indices are collected from the "virtually flatten" graph first and then memory reuse is solved once for a model.
 - All the nodes with nested graphs are updated, including:
    1. LoRa
    2. Composite
    3. If
    4. TensorIterator
    5. Convolution + Sum fallback subgraph

### Tickets:
 - *ticket-id*