### PR TITLE
[CORE] Squeeze v15 reverse infer

### DIFF
--- a/src/core/include/openvino/op/squeeze.hpp
+++ b/src/core/include/openvino/op/squeeze.hpp
@@ -50,7 +50,7 @@ public:
     ///
     /// \param data Input tensor with data
     /// \param allow_axis_skip Shape inference result dynamic rank if selected axis has 1 in range of its dynamic
-    Squeeze(const Output<Node>& data, const bool allow_axis_skip = false);
+    Squeeze(const Output<Node>& data);
     /// \brief Constructs a squeeze v15 operation.
     ///
     /// \param data Input tensor with data

--- a/src/core/src/op/squeeze.cpp
+++ b/src/core/src/op/squeeze.cpp
@@ -62,9 +62,8 @@ bool Squeeze::evaluate(TensorVector& outputs, const TensorVector& inputs) const 
 namespace v15 {
 Squeeze::Squeeze() : util::SqueezeBase() {}
 
-Squeeze::Squeeze(const Output<Node>& data, const bool allow_axis_skip)
-    : util::SqueezeBase(data),
-      m_allow_axis_skip{allow_axis_skip} {
+Squeeze::Squeeze(const Output<Node>& data)
+    : util::SqueezeBase(data){
     constructor_validate_and_infer_types();
 }
 
@@ -80,7 +79,7 @@ std::shared_ptr<Node> Squeeze::clone_with_new_inputs(const OutputVector& new_arg
 
     switch (new_args.size()) {
     case 1:
-        return std::make_shared<Squeeze>(new_args[0], m_allow_axis_skip);
+        return std::make_shared<Squeeze>(new_args[0]);
     case 2:
         return std::make_shared<Squeeze>(new_args[0], new_args[1], m_allow_axis_skip);
     default:

--- a/src/core/tests/type_prop/squeeze.cpp
+++ b/src/core/tests/type_prop/squeeze.cpp
@@ -641,12 +641,16 @@ TEST(SqueezeDynamicAxis, squeeze_dynamic_non_const_axes) {
 
 TEST(SqueezeDynamicAxis, squeeze_dynamic_empty_axes) {
     auto p_shape = PartialShape{1, 2, -1, 4};
-    auto exp_shape = PartialShape::dynamic();
-
+    auto axes_node = make_shared<ov::op::v0::Constant>(element::u64, Shape{});
+    auto exp_shape = PartialShape{2, -1, 4};
     auto param = make_shared<ov::op::v0::Parameter>(element::f32, p_shape);
-    const auto squeeze1 = std::make_shared<op::v15::Squeeze>(param, true);
-    const auto squeeze2 = std::make_shared<op::v15::Squeeze>(param, false);
-    const auto squeeze3 = std::make_shared<op::v15::Squeeze>(param);
+
+    const auto squeeze0 = std::make_shared<op::v0::Squeeze>(param, axes_node);
+    const auto squeeze1 = std::make_shared<op::v15::Squeeze>(param, axes_node, true);
+    const auto squeeze2 = std::make_shared<op::v15::Squeeze>(param, axes_node, false);
+
+    EXPECT_EQ(squeeze0->get_element_type(), element::f32);
+    EXPECT_EQ(squeeze0->get_output_partial_shape(0), exp_shape);
 
     EXPECT_EQ(squeeze1->get_element_type(), element::f32);
     EXPECT_EQ(squeeze1->get_output_partial_shape(0), exp_shape);
@@ -656,9 +660,22 @@ TEST(SqueezeDynamicAxis, squeeze_dynamic_empty_axes) {
     EXPECT_EQ(squeeze2->get_output_partial_shape(0), exp_shape);
     EXPECT_EQ(squeeze2->get_allow_axis_skip(), false);
 
-    EXPECT_EQ(squeeze3->get_element_type(), element::f32);
-    EXPECT_EQ(squeeze3->get_output_partial_shape(0), exp_shape);
-    EXPECT_EQ(squeeze3->get_allow_axis_skip(), false);
+}
+TEST(SqueezeDynamicAxis, squeeze_dynamic_no_axes) {
+    auto p_shape = PartialShape{1, 2, -1, 4};
+    auto axes_node = make_shared<ov::op::v0::Constant>(element::u64, Shape{});
+    auto exp_shape = PartialShape::dynamic();
+    auto param = make_shared<ov::op::v0::Parameter>(element::f32, p_shape);
+
+    const auto squeeze0 = std::make_shared<op::v0::Squeeze>(param);
+    const auto squeeze1 = std::make_shared<op::v15::Squeeze>(param);
+
+    EXPECT_EQ(squeeze0->get_element_type(), element::f32);
+    EXPECT_EQ(squeeze0->get_output_partial_shape(0), exp_shape);
+
+    EXPECT_EQ(squeeze1->get_element_type(), element::f32);
+    EXPECT_EQ(squeeze1->get_output_partial_shape(0), exp_shape);
+    EXPECT_EQ(squeeze1->get_allow_axis_skip(), false);
 }
 
 }  // namespace

--- a/src/core/tests/type_prop/squeeze.cpp
+++ b/src/core/tests/type_prop/squeeze.cpp
@@ -639,4 +639,26 @@ TEST(SqueezeDynamicAxis, squeeze_dynamic_non_const_axes) {
     EXPECT_EQ(squeeze->get_allow_axis_skip(), allow_axis_skip);
 }
 
+TEST(SqueezeDynamicAxis, squeeze_dynamic_empty_axes) {
+    auto p_shape = PartialShape{1, 2, -1, 4};
+    auto exp_shape = PartialShape::dynamic();
+
+    auto param = make_shared<ov::op::v0::Parameter>(element::f32, p_shape);
+    const auto squeeze1 = std::make_shared<op::v15::Squeeze>(param, true);
+    const auto squeeze2 = std::make_shared<op::v15::Squeeze>(param, false);
+    const auto squeeze3 = std::make_shared<op::v15::Squeeze>(param);
+
+    EXPECT_EQ(squeeze1->get_element_type(), element::f32);
+    EXPECT_EQ(squeeze1->get_output_partial_shape(0), exp_shape);
+    EXPECT_EQ(squeeze1->get_allow_axis_skip(), true);
+
+    EXPECT_EQ(squeeze2->get_element_type(), element::f32);
+    EXPECT_EQ(squeeze2->get_output_partial_shape(0), exp_shape);
+    EXPECT_EQ(squeeze2->get_allow_axis_skip(), false);
+
+    EXPECT_EQ(squeeze3->get_element_type(), element::f32);
+    EXPECT_EQ(squeeze3->get_output_partial_shape(0), exp_shape);
+    EXPECT_EQ(squeeze3->get_allow_axis_skip(), false);
+}
+
 }  // namespace

--- a/src/plugins/template/tests/functional/op_reference/squeeze.cpp
+++ b/src/plugins/template/tests/functional/op_reference/squeeze.cpp
@@ -223,7 +223,7 @@ private:
                 std::make_shared<op::v0::Constant>(params.m_axes_type, params.m_axes_shape, params.m_axes_value.data());
             squeeze = std::make_shared<op::v15::Squeeze>(in, axes_node, true);
         } else {
-            squeeze = std::make_shared<op::v15::Squeeze>(in, true);
+            squeeze = std::make_shared<op::v15::Squeeze>(in);
         }
 
         return std::make_shared<ov::Model>(squeeze, ParameterVector{in});


### PR DESCRIPTION
### Details:
 - Add reverse shape inference transformation for squeeze v15
 - Remove unnecessary Squeeze v15 constructor
 - Refactor squeeze shape inference

### Tickets:
 - [*CVS-154038*](https://jira.devtools.intel.com/browse/CVS-154038)
