### PR TITLE
[core] On Linux try return not used memory to system on compile model destructor

### DIFF
--- a/src/inference/src/cpp/compiled_model.cpp
+++ b/src/inference/src/cpp/compiled_model.cpp
@@ -8,6 +8,10 @@
 #include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/properties.hpp"
 
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
+#    include <malloc.h>
+#endif
+
 #define OV_COMPILED_MODEL_CALL_STATEMENT(...)                 \
     if (_impl == nullptr)                                     \
         OPENVINO_THROW("CompiledModel was not initialized."); \
@@ -23,6 +27,12 @@ namespace ov {
 
 CompiledModel::~CompiledModel() {
     _impl = {};
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
+    // Linux memory margent doesn't return system memory immediate after release.
+    // It depends on memory chunk size and allocation history.
+    // Try return memory from a process to system now to reduce memory usage and not wait to the end of the process.
+    malloc_trim(0);
+#endif
 }
 
 CompiledModel::CompiledModel(const std::shared_ptr<ov::ICompiledModel>& impl, const std::shared_ptr<void>& so)


### PR DESCRIPTION
### Details:
 - Optimize Linux process using OV memory consumption by returning not used memory to the system when compiled model is destroyed.
 - It should optimize memory usage by C++ and Python applications, as Linux avoid reclaim memory until process end especially for small chunks of allocations.

### Tickets:
 - CVS-149497
