### PR TITLE
Fixed OVC app name in telemetry.

### DIFF
--- a/tools/ovc/openvino/tools/ovc/__init__.py
+++ b/tools/ovc/openvino/tools/ovc/__init__.py
@@ -12,7 +12,7 @@ except importlib_metadata.PackageNotFoundError:
     optimum_version = None
 
 from openvino.runtime import get_version as get_rt_version  # pylint: disable=no-name-in-module,import-error
-telemetry = init_ovc_telemetry('Model Conversion API')
+telemetry = init_ovc_telemetry('OpenVINO')
 telemetry.send_event("ov", "import", "general_import")
 
 if is_optimum() and optimum_version is not None:

--- a/tools/ovc/openvino/tools/ovc/__init__.py
+++ b/tools/ovc/openvino/tools/ovc/__init__.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino.tools.ovc.convert import convert_model
-from openvino.tools.ovc.telemetry_utils import is_optimum, init_mo_telemetry
+from openvino.tools.ovc.telemetry_utils import is_optimum, init_ovc_telemetry
 
 import importlib.metadata as importlib_metadata
 
@@ -11,10 +11,10 @@ try:
 except importlib_metadata.PackageNotFoundError:
     optimum_version = None
 
+from openvino.runtime import get_version as get_rt_version  # pylint: disable=no-name-in-module,import-error
+telemetry = init_ovc_telemetry('Model Conversion API')
+telemetry.send_event("ov", "import", "general_import")
+
 if is_optimum() and optimum_version is not None:
-    from openvino.runtime import get_version as get_rt_version  # pylint: disable=no-name-in-module,import-error
-    telemetry = init_mo_telemetry("Optimum Intel", optimum_version)
-    telemetry.send_event("ov", "import", "import_from_optimum,ov_version:{}".format(get_rt_version()))
-else:
-    telemetry = init_mo_telemetry()
-    telemetry.send_event("ov", "import", "general_import")
+    telemetry = init_ovc_telemetry("Optimum Intel", optimum_version)
+    telemetry.send_event("optimum", "import", "import_from_optimum,ov_version:{}".format(get_rt_version()))

--- a/tools/ovc/openvino/tools/ovc/__main__.py
+++ b/tools/ovc/openvino/tools/ovc/__main__.py
@@ -4,7 +4,7 @@
 import sys
 
 from openvino.tools.ovc.main import main
-from openvino.tools.ovc.telemetry_utils import init_mo_telemetry
+from openvino.tools.ovc.telemetry_utils import init_ovc_telemetry
 
-init_mo_telemetry()
+init_ovc_telemetry()
 sys.exit(main())

--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -433,7 +433,7 @@ def _convert(cli_parser: argparse.ArgumentParser, args, python_api_used):
     telemetry.send_event('ovc', 'version', simplified_ie_version)
     # Initialize logger with 'ERROR' as default level to be able to form nice messages
     # before arg parser deliver log_level requested by user
-    #init_logger('ERROR', False)
+    init_logger('ERROR', False)
     argv = None
     # Minimize modifications among other places in case if multiple pieces are passed as input_model
     if python_api_used:

--- a/tools/ovc/openvino/tools/ovc/convert_impl.py
+++ b/tools/ovc/openvino/tools/ovc/convert_impl.py
@@ -32,7 +32,7 @@ from openvino.tools.ovc.version import VersionChecker
 from openvino.tools.ovc.utils import check_values_equal
 from openvino.tools.ovc.logger import init_logger
 from openvino.tools.ovc.telemetry_utils import send_params_info, send_conversion_result, \
-    init_mo_telemetry
+    init_ovc_telemetry
 from openvino.tools.ovc.moc_frontend.pytorch_frontend_utils import get_pytorch_decoder, \
     extract_input_info_from_example, get_pytorch_decoder_for_model_on_disk
 from openvino.tools.ovc.moc_frontend.paddle_frontend_utils import paddle_frontend_converter
@@ -428,12 +428,12 @@ def _convert(cli_parser: argparse.ArgumentParser, args, python_api_used):
         tracemalloc.start()
 
     simplified_ie_version = VersionChecker().get_ie_simplified_version()
-    telemetry = init_mo_telemetry()
+    telemetry = init_ovc_telemetry()
     telemetry.start_session('ovc')
     telemetry.send_event('ovc', 'version', simplified_ie_version)
     # Initialize logger with 'ERROR' as default level to be able to form nice messages
     # before arg parser deliver log_level requested by user
-    init_logger('ERROR', False)
+    #init_logger('ERROR', False)
     argv = None
     # Minimize modifications among other places in case if multiple pieces are passed as input_model
     if python_api_used:
@@ -484,11 +484,11 @@ def _convert(cli_parser: argparse.ArgumentParser, args, python_api_used):
 
         argv.feManager = FrontEndManager()
 
-        # send telemetry with params info
-        send_params_info(argv, cli_parser)
-
         non_default_params = get_non_default_params(argv, cli_parser)
         argv.is_python_api_used = python_api_used
+
+        # send telemetry with params info
+        send_params_info(non_default_params)
 
         argv.framework = model_framework
 

--- a/tools/ovc/openvino/tools/ovc/ovc.py
+++ b/tools/ovc/openvino/tools/ovc/ovc.py
@@ -6,8 +6,8 @@
 import sys
 
 if __name__ == "__main__":
-    from openvino.tools.ovc.telemetry_utils import init_mo_telemetry
+    from openvino.tools.ovc.telemetry_utils import init_ovc_telemetry
     from openvino.tools.ovc.main import main
 
-    init_mo_telemetry()
+    init_ovc_telemetry()
     sys.exit(main())

--- a/tools/ovc/openvino/tools/ovc/telemetry_utils.py
+++ b/tools/ovc/openvino/tools/ovc/telemetry_utils.py
@@ -100,7 +100,7 @@ def arg_to_str(arg):
 def send_params_info(params: dict):
     """
     This function sends information about used command line parameters.
-    :param params: command line parameters dictionary.
+    :param params: command-line parameters dictionary.
     """
     t = tm.Telemetry()
     params_with_paths = get_params_with_paths_list()

--- a/tools/ovc/openvino/tools/ovc/telemetry_utils.py
+++ b/tools/ovc/openvino/tools/ovc/telemetry_utils.py
@@ -25,7 +25,7 @@ def is_optimum():
     return False
 
 
-def init_mo_telemetry(app_name='Model Conversion API', app_version=None):
+def init_ovc_telemetry(app_name='OVC', app_version=None):
     app_version = app_version if app_version is not None else get_rt_version()
     return init_telemetry_class(tid=get_tid(),
                                 app_name=app_name,
@@ -97,22 +97,19 @@ def arg_to_str(arg):
     return str(type(arg))
 
 
-def send_params_info(argv: argparse.Namespace, cli_parser: argparse.ArgumentParser):
+def send_params_info(params: dict):
     """
     This function sends information about used command line parameters.
-    :param argv: command line parameters.
-    :param cli_parser: command line parameters parser.
+    :param params: command line parameters dictionary.
     """
     t = tm.Telemetry()
     params_with_paths = get_params_with_paths_list()
-    for arg in vars(argv):
-        arg_value = getattr(argv, arg)
-        if not check_values_equal(arg_value, cli_parser.get_default(arg)):
-            if arg in params_with_paths:
-                # If command line argument value is a directory or a path to file it is not sent
-                # as it may contain confidential information. "1" value is used instead.
-                param_str = arg + ":" + str(1)
-            else:
-                param_str = arg + ":" + arg_to_str(arg_value)
+    for key, value in params.items():
+        if key in params_with_paths:
+            # If command line argument value is a directory or a path to file it is not sent
+            # as it may contain confidential information. "1" value is used instead.
+            param_str = key + ":" + str(1)
+        else:
+            param_str = key + ":" + arg_to_str(value)
 
-            t.send_event('ovc', 'cli_parameters', param_str)
+        t.send_event('ovc', 'cli_parameters', param_str)


### PR DESCRIPTION
### Details:
 - Fixed the issue, that '`Model Conversion API`' telemetry category includes `OVC` and all other tools, now `OVC` has a separate category "`OVC`".
 - Refactored `send_params_info()` method and fixed naming of telemetry init method.

