### PR TITLE
[CPU] Matmul node support quantized outputs for f16 bias to avoid unnecessary reorder following

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -70,6 +70,7 @@ static const TypeMapping dnnlFCTypeMapping {
     // quantization configuration
     // int8 inner_product does not support f16 output and bias
     {{_u8 | _i8, _i8, _u8 | _i8 | _i32 | _bf16 | _f32 | _undefined, _u8 | _i8 | _i32 | _bf16 | _f32}, pt(bypass(), bypass(), bypass(),  bypass())},
+    {{_u8 | _i8, _i8, _f16, _i8 | _u8}, pt(bypass(), bypass(), just<f32>(), bypass())},
     {{_u8 | _i8, _i8, _any, _any}, pt(bypass(), bypass(), just<f32>(), just<f32>())},
     // compresses int weights (@todo more strict requrements for output precision?)
     {{_bf16, _u8 | _i8 | _nf4 | _u4 | _i4 | _f4e2m1, _any, _any},       pt(bypass(), bypass(), use<0>(), use<0>()),

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_implementations.cpp
@@ -70,7 +70,7 @@ static const TypeMapping dnnlFCTypeMapping {
     // quantization configuration
     // int8 inner_product does not support f16 output and bias
     {{_u8 | _i8, _i8, _u8 | _i8 | _i32 | _bf16 | _f32 | _undefined, _u8 | _i8 | _i32 | _bf16 | _f32}, pt(bypass(), bypass(), bypass(),  bypass())},
-    {{_u8 | _i8, _i8, _f16, _i8 | _u8}, pt(bypass(), bypass(), just<f32>(), bypass())},
+    {{_u8 | _i8, _i8, _f16, _u8 | _i8 | _i32 | _bf16 | _f32}, pt(bypass(), bypass(), just<f32>(), bypass())},
     {{_u8 | _i8, _i8, _any, _any}, pt(bypass(), bypass(), just<f32>(), just<f32>())},
     // compresses int weights (@todo more strict requrements for output precision?)
     {{_bf16, _u8 | _i8 | _nf4 | _u4 | _i4 | _f4e2m1, _any, _any},       pt(bypass(), bypass(), use<0>(), use<0>()),

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
@@ -16,13 +16,11 @@ namespace ov {
 namespace test {
 
 using ElementType = ov::element::Type_t;
-using MatmulBrgemmInt8TestParams = std::tuple<ov::Shape,          // input shape
-                                              bool,               // true: FullyConnected false: Matmul
-                                              bool,               // ture: FullyConnected primitive implement type check
-                                              ElementType,        // input u8/s8
-                                              ElementType,        // output f32/u8/s8
-                                              CPUSpecificParams,  // brgemm/jit primitive implement type
-                                              ov::AnyMap          // Additional config
+using MatmulBrgemmInt8TestParams = std::tuple<ov::Shape,         // input shape
+                                              bool,              // true: FullyConnected false: Matmul
+                                              ElementType,       // input u8/s8
+                                              ElementType,       // output f32/u8/s8
+                                              CPUSpecificParams  // brgemm/jit primitive implement type
                                               >;
 
 // subgraph:
@@ -36,36 +34,23 @@ public:
     static std::string getTestCaseName(testing::TestParamInfo<MatmulBrgemmInt8TestParams> obj) {
         ov::Shape supportedInputShapes;
         bool isFC;
-        bool isFCPrimCheck;
-        ov::AnyMap additionalConfig;
         ElementType inType;
         ElementType outType;
         CPUSpecificParams cpuParams;
-        std::tie(supportedInputShapes, isFC, isFCPrimCheck, inType, outType, cpuParams, additionalConfig) = obj.param;
+        std::tie(supportedInputShapes, isFC, inType, outType, cpuParams) = obj.param;
 
         std::ostringstream result;
         result << "IS=" << supportedInputShapes.to_string() << "_";
         result << (isFC ? "FullyConnected" : "MatMul") << "_";
-        result << "FCPrimCheck=" << isFCPrimCheck << "_";
         result << "InputType=" << inType << "_";
         result << "OutputType=" << outType << "_";
         result << CPUTestsBase::getTestCaseName(cpuParams);
-
-        if (!additionalConfig.empty()) {
-            result << "_PluginConf";
-            for (auto& item : additionalConfig) {
-                if (item.second == ov::element::bf16 || item.second == ov::element::f16)
-                    result << "_" << item.first << "=" << item.second.as<std::string>();
-            }
-        }
 
         return result.str();
     }
 
 protected:
     bool isFC;
-    bool isFCPrimCheck;
-    ov::AnyMap additionalConfig;
     std::string nameMatmul = "TestedMatmul";
     ElementType inType;
     ElementType outType;
@@ -73,7 +58,7 @@ protected:
         targetDevice = ov::test::utils::DEVICE_CPU;
         ov::Shape inShapes;
         CPUSpecificParams cpuParams;
-        std::tie(inShapes, isFC, isFCPrimCheck, inType, outType, cpuParams, additionalConfig) = this->GetParam();
+        std::tie(inShapes, isFC, inType, outType, cpuParams) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         const auto ngPrec = ov::element::f32;
         ov::ParameterVector inputParams {std::make_shared<ov::op::v0::Parameter>(ngPrec, ov::Shape(inShapes))};
@@ -82,7 +67,6 @@ protected:
         std::shared_ptr<ov::Node> matMul;
         std::shared_ptr<ov::Node> nodeBeforeConv;
         selectedType = makeSelectedTypeStr(selectedType, ElementType::i8);
-        configuration.insert(additionalConfig.begin(), additionalConfig.end());
         if (inType == ElementType::u8)
             fq1 = ov::test::utils::make_fake_quantize(inputParams[0], ngPrec, 256, {}, {0.0f}, {2.55f}, {0.0f}, {2.55f});
         else
@@ -90,25 +74,13 @@ protected:
 
         if (isFC) {
             ov::Shape weightShape = inShapes;
-            std::shared_ptr<ov::Node> biasWeightsNode;
-            if (!isFCPrimCheck)
-                std::swap(weightShape[0], weightShape[1]);
-            else
-                std::swap(weightShape[1], weightShape[2]);
+            std::swap(weightShape[0], weightShape[1]);
             auto weightsNode = ov::test::utils::make_constant(ngPrec, weightShape);
-            auto fq2 =
-                ov::test::utils::make_fake_quantize(weightsNode, ngPrec, 256, {}, {-1.28f}, {1.27f}, {-1.28f}, {1.27f});
+            auto fq2 = ov::test::utils::make_fake_quantize(weightsNode, ngPrec, 256, {}, {-1.28f}, {1.27f}, {-1.28f}, {1.27f});
             auto fc = std::make_shared<ov::op::v0::MatMul>(fq1, fq2, false, false);
             fc->get_rt_info() = getCPUInfo();
             fc->set_friendly_name(nameMatmul);
-            if (!isFCPrimCheck) {
-                biasWeightsNode = ov::test::utils::make_constant(ngPrec, ov::Shape{});
-            } else {
-                auto fcShape = fc->get_output_shape(0);
-                ov::Shape biasShape(fcShape.size(), 1);
-                biasShape.back() = fcShape.back();
-                biasWeightsNode = ov::test::utils::make_constant(ngPrec, biasShape);
-            }
+            auto biasWeightsNode = ov::test::utils::make_constant(ngPrec, ov::Shape{});
             matMul = std::make_shared<ov::op::v1::Add>(fc, biasWeightsNode);
         } else {
             auto fq2 = ov::test::utils::make_fake_quantize(inputParams[0], ngPrec, 256, {}, {-1.28f}, {1.27f}, {-1.28f}, {1.27f});
@@ -153,16 +125,9 @@ protected:
 };
 
 TEST_P(MatmulBrgemmInt8Test, CompareWithRefs) {
-    // matmulBrgemmInt8 only cover avx2_vnni
-    if (ov::with_cpu_x86_avx512_core_amx_fp16()) {
-        if (!isFCPrimCheck) {
-            GTEST_SKIP();
-        }
-    } else {
-        if (ov::with_cpu_x86_avx512_core() || !ov::with_cpu_x86_avx2_vnni() || isFCPrimCheck) {
-            GTEST_SKIP();
-        }
-    }
+    // only cover avx2_vnni
+    if (ov::with_cpu_x86_avx512_core() || !ov::with_cpu_x86_avx2_vnni())
+        GTEST_SKIP();
 
     run();
     if (!!compiledModel) {
@@ -187,33 +152,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_matmulBrgemmInt8,
                          MatmulBrgemmInt8Test,
                          ::testing::Combine(::testing::ValuesIn(supportedInputShapes),
                                             ::testing::ValuesIn({true, false}),
-                                            ::testing::Values(false),
                                             ::testing::ValuesIn({ElementType::u8, ElementType::i8}),
                                             ::testing::ValuesIn({ElementType::f32, ElementType::u8, ElementType::i8}),
-                                            ::testing::ValuesIn(matmulSpecificFilterParams),
-                                            ::testing::Values(ov::AnyMap{})),
-                         MatmulBrgemmInt8Test::getTestCaseName);
-
-std::vector<ov::AnyMap> additionalConfig = {{ov::hint::inference_precision(ov::element::f32)},
-                                            {ov::hint::inference_precision(ov::element::bf16)},
-                                            {ov::hint::inference_precision(ov::element::f16)}};
-
-const std::vector<CPUSpecificParams>fullyconnectedSpecificFilterParams = {
-    {{}, {}, {"brgemm_avx512_amx"}, "brgemm_avx512_amx"},
-    {{}, {}, {"jit_gemm"}, "jit_gemm"}
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_fullyconnected_prim_impl_type_check,
-                         MatmulBrgemmInt8Test,
-                         ::testing::Combine(::testing::Values(ov::Shape{1, 32, 36}),
-                                            ::testing::Values(true),
-                                            ::testing::Values(true),
-                                            ::testing::Values(ElementType::u8),
-                                            ::testing::Values(ElementType::u8),
-                                            ::testing::ValuesIn(fullyconnectedSpecificFilterParams),
-                                            ::testing::ValuesIn(additionalConfig)),
+                                            ::testing::ValuesIn(matmulSpecificFilterParams)),
                          MatmulBrgemmInt8Test::getTestCaseName);
 
 }  // namespace
+
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
@@ -16,11 +16,13 @@ namespace ov {
 namespace test {
 
 using ElementType = ov::element::Type_t;
-using MatmulBrgemmInt8TestParams = std::tuple<ov::Shape,         // input shape
-                                              bool,              // true: FullyConnected false: Matmul
-                                              ElementType,       // input u8/s8
-                                              ElementType,       // output f32/u8/s8
-                                              CPUSpecificParams  // brgemm/jit primitive implement type
+using MatmulBrgemmInt8TestParams = std::tuple<ov::Shape,          // input shape
+                                              bool,               // true: FullyConnected false: Matmul
+                                              bool,               // ture: FullyConnected primitive implement type check
+                                              ElementType,        // input u8/s8
+                                              ElementType,        // output f32/u8/s8
+                                              CPUSpecificParams,  // brgemm/jit primitive implement type
+                                              ov::AnyMap          // Additional config
                                               >;
 
 // subgraph:
@@ -34,23 +36,36 @@ public:
     static std::string getTestCaseName(testing::TestParamInfo<MatmulBrgemmInt8TestParams> obj) {
         ov::Shape supportedInputShapes;
         bool isFC;
+        bool isFCPrimCheck;
+        ov::AnyMap additionalConfig;
         ElementType inType;
         ElementType outType;
         CPUSpecificParams cpuParams;
-        std::tie(supportedInputShapes, isFC, inType, outType, cpuParams) = obj.param;
+        std::tie(supportedInputShapes, isFC, isFCPrimCheck, inType, outType, cpuParams, additionalConfig) = obj.param;
 
         std::ostringstream result;
         result << "IS=" << supportedInputShapes.to_string() << "_";
         result << (isFC ? "FullyConnected" : "MatMul") << "_";
+        result << "FCPrimCheck=" << isFCPrimCheck << "_";
         result << "InputType=" << inType << "_";
         result << "OutputType=" << outType << "_";
         result << CPUTestsBase::getTestCaseName(cpuParams);
+
+        if (!additionalConfig.empty()) {
+            result << "_PluginConf";
+            for (auto& item : additionalConfig) {
+                if (item.second == ov::element::bf16 || item.second == ov::element::f16)
+                    result << "_" << item.first << "=" << item.second.as<std::string>();
+            }
+        }
 
         return result.str();
     }
 
 protected:
     bool isFC;
+    bool isFCPrimCheck;
+    ov::AnyMap additionalConfig;
     std::string nameMatmul = "TestedMatmul";
     ElementType inType;
     ElementType outType;
@@ -58,7 +73,7 @@ protected:
         targetDevice = ov::test::utils::DEVICE_CPU;
         ov::Shape inShapes;
         CPUSpecificParams cpuParams;
-        std::tie(inShapes, isFC, inType, outType, cpuParams) = this->GetParam();
+        std::tie(inShapes, isFC, isFCPrimCheck, inType, outType, cpuParams, additionalConfig) = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         const auto ngPrec = ov::element::f32;
         ov::ParameterVector inputParams {std::make_shared<ov::op::v0::Parameter>(ngPrec, ov::Shape(inShapes))};
@@ -67,6 +82,7 @@ protected:
         std::shared_ptr<ov::Node> matMul;
         std::shared_ptr<ov::Node> nodeBeforeConv;
         selectedType = makeSelectedTypeStr(selectedType, ElementType::i8);
+        configuration.insert(additionalConfig.begin(), additionalConfig.end());
         if (inType == ElementType::u8)
             fq1 = ov::test::utils::make_fake_quantize(inputParams[0], ngPrec, 256, {}, {0.0f}, {2.55f}, {0.0f}, {2.55f});
         else
@@ -74,13 +90,18 @@ protected:
 
         if (isFC) {
             ov::Shape weightShape = inShapes;
-            std::swap(weightShape[0], weightShape[1]);
+            std::shared_ptr<ov::Node> biasWeightsNode;
+            if (!isFCPrimCheck)
+                std::swap(weightShape[0], weightShape[1]);
             auto weightsNode = ov::test::utils::make_constant(ngPrec, weightShape);
             auto fq2 = ov::test::utils::make_fake_quantize(weightsNode, ngPrec, 256, {}, {-1.28f}, {1.27f}, {-1.28f}, {1.27f});
             auto fc = std::make_shared<ov::op::v0::MatMul>(fq1, fq2, false, false);
             fc->get_rt_info() = getCPUInfo();
             fc->set_friendly_name(nameMatmul);
-            auto biasWeightsNode = ov::test::utils::make_constant(ngPrec, ov::Shape{});
+            if (!isFCPrimCheck)
+                biasWeightsNode = ov::test::utils::make_constant(ngPrec, ov::Shape{});
+            else
+                biasWeightsNode = ov::test::utils::make_constant(ngPrec, ov::Shape{1, 1, inShapes.back()});
             matMul = std::make_shared<ov::op::v1::Add>(fc, biasWeightsNode);
         } else {
             auto fq2 = ov::test::utils::make_fake_quantize(inputParams[0], ngPrec, 256, {}, {-1.28f}, {1.27f}, {-1.28f}, {1.27f});
@@ -125,8 +146,11 @@ protected:
 };
 
 TEST_P(MatmulBrgemmInt8Test, CompareWithRefs) {
-    // only cover avx2_vnni
-    if (ov::with_cpu_x86_avx512_core() || !ov::with_cpu_x86_avx2_vnni())
+    // matmulBrgemmInt8 only cover avx2_vnni
+    if (ov::with_cpu_x86_avx512_core_amx_fp16() && !isFCPrimCheck) {
+        GTEST_SKIP();
+    }
+    if ((ov::with_cpu_x86_avx512_core() || !ov::with_cpu_x86_avx2_vnni()) && !ov::with_cpu_x86_avx512_core_amx_fp16())
         GTEST_SKIP();
 
     run();
@@ -152,12 +176,33 @@ INSTANTIATE_TEST_SUITE_P(smoke_matmulBrgemmInt8,
                          MatmulBrgemmInt8Test,
                          ::testing::Combine(::testing::ValuesIn(supportedInputShapes),
                                             ::testing::ValuesIn({true, false}),
+                                            ::testing::Values(false),
                                             ::testing::ValuesIn({ElementType::u8, ElementType::i8}),
                                             ::testing::ValuesIn({ElementType::f32, ElementType::u8, ElementType::i8}),
-                                            ::testing::ValuesIn(matmulSpecificFilterParams)),
+                                            ::testing::ValuesIn(matmulSpecificFilterParams),
+                                            ::testing::Values(ov::AnyMap{})),
+                         MatmulBrgemmInt8Test::getTestCaseName);
+
+std::vector<ov::AnyMap> additionalConfig = {{ov::hint::inference_precision(ov::element::f32)},
+                                            {ov::hint::inference_precision(ov::element::bf16)},
+                                            {ov::hint::inference_precision(ov::element::f16)}};
+
+const std::vector<CPUSpecificParams>fullyconnectedSpecificFilterParams = {
+    {{}, {}, {"brgemm_avx512_amx"}, "brgemm_avx512_amx"},
+    {{}, {}, {"jit_gemm"}, "jit_gemm"}
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_fullyconnected_prim_impl_type_check,
+                         MatmulBrgemmInt8Test,
+                         ::testing::Combine(::testing::Values(ov::Shape{1, 32, 32}),
+                                            ::testing::Values(true),
+                                            ::testing::Values(true),
+                                            ::testing::Values(ElementType::u8),
+                                            ::testing::Values(ElementType::u8),
+                                            ::testing::ValuesIn(fullyconnectedSpecificFilterParams),
+                                            ::testing::ValuesIn(additionalConfig)),
                          MatmulBrgemmInt8Test::getTestCaseName);
 
 }  // namespace
-
 }  // namespace test
 }  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
@@ -154,11 +154,15 @@ protected:
 
 TEST_P(MatmulBrgemmInt8Test, CompareWithRefs) {
     // matmulBrgemmInt8 only cover avx2_vnni
-    if (ov::with_cpu_x86_avx512_core_amx_fp16() && !isFCPrimCheck) {
-        GTEST_SKIP();
+    if (ov::with_cpu_x86_avx512_core_amx_fp16()) {
+        if (!isFCPrimCheck) {
+            GTEST_SKIP();
+        }
+    } else {
+        if (ov::with_cpu_x86_avx512_core() || !ov::with_cpu_x86_avx2_vnni() || isFCPrimCheck) {
+            GTEST_SKIP();
+        }
     }
-    if ((ov::with_cpu_x86_avx512_core() || !ov::with_cpu_x86_avx2_vnni()) && !ov::with_cpu_x86_avx512_core_amx_fp16())
-        GTEST_SKIP();
 
     run();
     if (!!compiledModel) {


### PR DESCRIPTION


### Details:
 - *Matmul node support quantized outputs for f16 bias to avoid unnecessary reorder following*


### Tickets:
 - *CVS-156727*
