### PR TITLE
[GPU] Enable output transposed gemm for onednn

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -186,8 +186,15 @@ protected:
             if (ret) {
                 tag = convert_data_format(transposed_format);
                 dnnl::memory::dims original_dims = dims;
-                for (size_t i = 0; i < original_dims.size(); ++i) {
-                    dims[i] = original_dims[order[i]];
+                if (is_input) {
+                    for (size_t i = 0; i < original_dims.size(); ++i) {
+                        dims[i] = original_dims[order[i]];
+                    }
+                } else {
+                    // Get non-transposed dims for output dims
+                    for (size_t i = 0; i < original_dims.size(); ++i) {
+                        dims[order[i]] = original_dims[i];
+                    }
                 }
             } else {
                 std::ostringstream ostream;


### PR DESCRIPTION
### Details:
 - *The gemm onednn requires non-transposed output shape and transposed order info. But the current impl uses output-transposed shape itself. It needs to use non-transposed output shape.*

### Tickets:
 - *155222*
