### PR TITLE
[GPU] Add support for i16, u16, and u32 element types in remote tensors

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -64,11 +64,8 @@ inline cldnn::layout make_layout(const ov::element::Type type, const ov::Shape& 
 inline ov::element::Type convert_to_supported_device_type(ov::element::Type et) {
     switch (et) {
         case ov::element::f64:
-        case ov::element::i16:
-        case ov::element::u16:
             return ov::element::f32;
         case ov::element::u64:
-        case ov::element::u32:
             return ov::element::i32;
         default: return et;
     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -342,6 +342,10 @@ void add_required_reorders::run(program& p) {
 
                 std::vector<program_node*> users(node->get_users().begin(), node->get_users().end());
                 for (auto user : users) {
+                    // Skip eltwise nodes as they can handle i16, u16 and u32 data types
+                    if (user->is_type<eltwise>())
+                        continue;
+
                     auto it = std::find_if(user->get_dependencies().begin(), user->get_dependencies().end(),
                         [&](const std::pair<program_node*, int32_t>& dep) {
                             return node == dep.first;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -326,4 +326,38 @@ void add_required_reorders::run(program& p) {
                         " (format: ", original_layout.format.to_string(),
                         ", data_type: ", ov::element::Type(original_layout.data_type), ") ");
     }
+
+    for (auto node : p.get_processing_order()) {
+        if (node->is_type<input_layout>()) {
+            if (node->get_output_layout().data_type == data_types::i16 ||
+                node->get_output_layout().data_type == data_types::u16 ||
+                node->get_output_layout().data_type == data_types::u32) {
+                auto supported_data_type = cldnn::element_type_to_data_type(node->get_output_layout().data_type);
+                layout reorder_layout = node->get_output_layout();
+                reorder_layout.data_type = supported_data_type;
+
+                auto new_reorder = std::make_shared<reorder>(node->id() + "_convert_type", node->id(), reorder_layout);
+                auto& new_reorder_node = p.get_or_create(new_reorder);
+                new_reorder_node.set_output_layout(reorder_layout, false);
+
+                std::vector<program_node*> users(node->get_users().begin(), node->get_users().end());
+                for (auto user : users) {
+                    auto it = std::find_if(user->get_dependencies().begin(), user->get_dependencies().end(),
+                        [&](const std::pair<program_node*, int32_t>& dep) {
+                            return node == dep.first;
+                        });
+
+                    OPENVINO_ASSERT(it != user->get_dependencies().end(),
+                        "[GPU] Inconcistency in topology description: user of a node is not present among its dependecies.");
+
+                    auto idx = it - user->get_dependencies().begin();
+                    OPENVINO_ASSERT(idx >= 0 && (size_t)idx < user->get_dependencies().size(),
+                        "[GPU] Internal Error: container index out of range exception.");
+
+                    p.add_intermediate(new_reorder_node, *user, idx);
+                    new_reorder_node.recalc_output_layouts(false);
+                }
+            }
+        }
+    }
 }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
@@ -10,7 +10,10 @@ ParamsKey ReorderKernelRef::GetSupportedKey() const {
     ParamsKey k;
     k.EnableInputDataType(Datatype::BF16);
     k.EnableInputDataType(Datatype::UINT8);
+    k.EnableInputDataType(Datatype::UINT16);
+    k.EnableInputDataType(Datatype::UINT32);
     k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::INT16);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableInputDataType(Datatype::INT64);
     k.EnableInputDataType(Datatype::F16);
@@ -18,9 +21,12 @@ ParamsKey ReorderKernelRef::GetSupportedKey() const {
     k.EnableOutputDataType(Datatype::F16);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableOutputDataType(Datatype::INT8);
+    k.EnableOutputDataType(Datatype::INT16);
     k.EnableOutputDataType(Datatype::INT32);
     k.EnableOutputDataType(Datatype::INT64);
     k.EnableOutputDataType(Datatype::UINT8);
+    k.EnableOutputDataType(Datatype::UINT16);
+    k.EnableOutputDataType(Datatype::UINT32);
     k.EnableOutputDataType(Datatype::BF16);
     k.EnableSurfaceInputSupport();
     k.EnableDifferentTypes();

--- a/src/plugins/intel_gpu/src/plugin/common_utils.cpp
+++ b/src/plugins/intel_gpu/src/plugin/common_utils.cpp
@@ -236,6 +236,7 @@ void convert_and_copy(const ov::ITensor* src, ov::ITensor* dst, const cldnn::str
         tmp_tensor = ov::Tensor(dst_et, src->get_shape());
         ::convert_and_copy(src_ptr, src_et, tmp_tensor.data(), dst_et, size, cldnn::layout({}, ov::element::undefined, cldnn::format::bfyx, cldnn::padding()));
         remote->copy_from(get_tensor_impl(tmp_tensor)._ptr);
+        return;
     } else {
         dst_ptr = dst->data();
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/parameter.cpp
@@ -29,7 +29,8 @@ static void CreateParameterOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v
     }
 
     cldnn::format input_format = cldnn::format::get_default_format(input_pshape.size());
-    auto element_type = cldnn::element_type_to_data_type(convert_to_supported_device_type(op->get_output_element_type(0)));
+    auto element_type = convert_to_supported_device_type(op->get_output_element_type(0));
+    element_type = element_type == ov::element::boolean ? ov::element::u8 : element_type;
 
     // look at the expected color format of this input
     auto input_name = layer_type_name_ID(op);

--- a/src/plugins/intel_gpu/src/plugin/ops/result.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/result.cpp
@@ -30,7 +30,8 @@ static void CreateResultOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
     auto out_format = cldnn::format::get_default_format(out_rank);
 
     auto out_primitive_name = layer_type_name_ID(op);
-    auto out_data_type = cldnn::element_type_to_data_type(convert_to_supported_device_type(op->get_input_element_type(0)));
+    auto out_data_type = convert_to_supported_device_type(op->get_input_element_type(0));
+    out_data_type = out_data_type == ov::element::boolean ? ov::element::u8 : out_data_type;
 
     auto reorder_primitive = cldnn::reorder(out_primitive_name,
                                             inputs[0],

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -2873,3 +2873,91 @@ TEST(RemoteTensor, smoke_CanSetRoiRemoteTensor) {
 
     compare_tensors(output_tensor_copy_0, output_tensor_copy_1);
 }
+
+
+using RemoteTensorDataTypesOptionsParams = std::tuple<ov::element::Type_t>;
+class OVRemoteTensorDataType_Test : public OVRemoteTensor_Test,
+        public testing::WithParamInterface<RemoteTensorDataTypesOptionsParams> {
+protected:
+    std::shared_ptr<ov::Model> fn_ptr;
+    std::string deviceName;
+    ov::AnyMap config;
+    ov::element::Type_t element_type;
+
+public:
+    void SetUp() override {
+        deviceName = ov::test::utils::DEVICE_GPU;
+        std::tie(element_type) = this->GetParam();
+        config = {ov::hint::inference_precision(ov::element::f16),
+                ov::hint::model_priority(ov::hint::Priority::HIGH),
+                ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE),
+                ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)};
+
+        fn_ptr = ov::test::utils::make_conv_pool_relu();
+    }
+    static std::string getTestCaseName(const testing::TestParamInfo<RemoteTensorDataTypesOptionsParams>& obj) {
+        ov::element::Type_t elem_type;
+        std::tie(elem_type) = obj.param;
+
+        std::ostringstream result;
+        result << "OVRemoteTensorTest_" << elem_type;
+        return result.str();
+    }
+};
+
+TEST_P(OVRemoteTensorDataType_Test, smoke_RemoteTensorDataType) {
+#if defined(ANDROID)
+    GTEST_SKIP();
+#endif
+    // set tensor element type
+    auto ppp = ov::preprocess::PrePostProcessor(fn_ptr);
+    ppp.input(0).tensor().set_element_type(element_type);
+    ppp.output(0).tensor().set_element_type(element_type);
+    auto ov_model = ppp.build();
+
+    auto core = ov::Core();
+    ov::CompiledModel compiled_model = core.compile_model(ov_model, deviceName, config);
+
+    // regular inference
+    auto inf_req = compiled_model.create_infer_request();
+    auto input_element_type = inf_req.get_input_tensor(0).get_element_type();
+    auto input_shape = inf_req.get_input_tensor(0).get_shape();
+    auto output_element_type = inf_req.get_output_tensor(0).get_element_type();
+    auto output_shape = inf_req.get_output_tensor(0).get_shape();
+
+    ASSERT_EQ(input_element_type, element_type);
+    ASSERT_EQ(output_element_type, element_type);
+
+    auto remote_context = compiled_model.get_context().as<ov::intel_gpu::ocl::ClContext>();
+    auto input_tensor = ov::test::utils::create_and_fill_tensor(input_element_type, input_shape);
+    auto output_tensor = ov::test::utils::create_and_fill_tensor(output_element_type, output_shape);
+    auto input_cl_tensor = remote_context.create_tensor(input_element_type, input_shape);
+    auto output_cl_tensor =  remote_context.create_tensor(output_element_type, output_shape);
+
+    input_cl_tensor.copy_from(input_tensor);
+
+    inf_req.set_input_tensor(0, input_tensor);
+    inf_req.set_output_tensor(0, output_tensor);
+    inf_req.infer();
+
+    inf_req.set_input_tensor(0, input_cl_tensor);
+    inf_req.set_output_tensor(0, output_cl_tensor);
+    inf_req.infer();
+
+    auto tmp_tensor = ov::Tensor(output_element_type, output_shape);
+    output_cl_tensor.copy_to(tmp_tensor);
+
+    if (element_type == ov::element::i16) {
+        compare_data<ov::element_type_traits<ov::element::i16>::value_type>(output_tensor, tmp_tensor);
+    } else if (element_type == ov::element::u16) {
+        compare_data<ov::element_type_traits<ov::element::u16>::value_type>(output_tensor, tmp_tensor);
+    } else if (element_type == ov::element::u32) {
+        compare_data<ov::element_type_traits<ov::element::u32>::value_type>(output_tensor, tmp_tensor);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_RemoteTensorDataType, OVRemoteTensorDataType_Test,
+                         ::testing::Combine(::testing::Values(ov::element::Type_t::i16,
+                                                              ov::element::Type_t::u16,
+                                                              ov::element::Type_t::u32)),
+                         OVRemoteTensorDataType_Test::getTestCaseName);


### PR DESCRIPTION
### Details:
 - *Removed host memory data converting for user input/output tensors with data types i16, u16, or u32.*
 - *User tensors can now be directly used as plugin tensors without additional data conversion overhead.*

### Tickets:
 - *156709*
