### PR TITLE
[CPU][DEBUG_CAPS] Do not include all the nodes to executable ones

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -277,13 +277,8 @@ static std::tuple<std::vector<NodePtr>, std::vector<size_t>> ExtractExecutableNo
     std::vector<NodePtr> executableGraphNodes;
     for (size_t i = 0; i < graphNodes.size(); i++) {
         const auto& graphNode = graphNodes[i];
-        if ((!graphNode->isConstant() && CPU_DEBUG_CAPS_ALWAYS_TRUE(graphNode->isExecutable())) || // non-constant executable or
+        if ((!graphNode->isConstant() && graphNode->isExecutable()) || // non-constant executable or
             (graphNode->isDynamicNode() && !one_of(graphNode->getType(), Type::Input, Type::Output))) { // dynamic, except inputs / outputs
-            /* @todo
-             * Revise implementation.
-             * With current way it is possible that with debug_caps enabled
-             * we execute a node, which is not ready to be executed
-             */
             graphIdToExecutableId[i] = executableGraphNodes.size();
             executableGraphNodes.emplace_back(graphNode);
         }

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -162,7 +162,6 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
         } while (0)
 
 #define CPU_DEBUG_CAP_ENABLE(...) __VA_ARGS__
-#define CPU_DEBUG_CAPS_ALWAYS_TRUE(x) true
 
 #define DEBUG_LOG(...) DEBUG_LOG_EXT(nullptr, std::cout, "[ DEBUG ] ", __VA_ARGS__)
 #define ERROR_LOG(...) DEBUG_LOG_EXT(nullptr, std::cerr, "[ ERROR ] ", __VA_ARGS__)
@@ -267,7 +266,6 @@ bool getEnvBool(const char* name);
 #else // !CPU_DEBUG_CAPS
 
 #define CPU_DEBUG_CAP_ENABLE(...)
-#define CPU_DEBUG_CAPS_ALWAYS_TRUE(x) x
 
 #define DEBUG_LOG(...)
 #define ERROR_LOG(...)


### PR DESCRIPTION
There is a case, when a node is a static one and it has 0 dim in one of its input shapes.
In this case we must not execute this node, but performing
additional isExecutable() check in runtime for all the static nodes
would be to expensive