### PR TITLE
[GPU] Use onednn gemm instead of inner product

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -1017,51 +1017,6 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
                     broadcast_node.recalc_output_layouts(false);
                 }
             }
-        } else if (node->is_type<fully_connected>() && node->get_preferred_impl_type() == impl_types::onednn) {
-            for (const auto& fused_prim : node->get_fused_primitives()) {
-                if (fused_prim.is_type<eltwise>() &&
-                    one_of(fused_prim.typed_desc<eltwise>()->mode, {eltwise_mode::sum, eltwise_mode::sub, eltwise_mode::prod})) {
-                    auto fc_layout = node->get_output_layout();
-                    auto& data = node->get_dependency(fused_prim.outer_dep_start_idx);
-                    auto data_layout = data.get_output_layout();
-
-                    if (fc_layout.is_dynamic() || data_layout.is_dynamic())
-                        continue;
-
-                    // fc_b     | fc_f      | data_b    | data_f    | broadcast condition
-                    // ---------+-----------+-----------+-----------+--------------------
-                    // 1        | 1         | 1         | 1         | no broadcast
-                    // 1        | 1         | 1         | N         | N/A
-                    // 1        | 1         | N         | 1         | N/A
-                    // 1        | 1         | N         | N         | N/A
-                    // 1        | N         | 1         | 1         | implicit broadcast
-                    // 1        | N         | 1         | N         | no broadcast
-                    // 1        | N         | N         | 1         | N/A
-                    // 1        | N         | N         | N         | N/A
-                    // N        | 1         | 1         | 1         | implicit broadcast
-                    // N        | 1         | 1         | N         | N/A
-                    // N        | 1         | N         | 1         | no broadcast
-                    // N        | 1         | N         | N         | N/A
-                    // N        | N         | 1         | 1         | implicit broadcast
-                    // N        | N         | 1         | N         | explicit broadcast
-                    // N        | N         | N         | 1         | explicit broadcast
-                    // N        | N         | N         | N         | no broadcast
-                    if ((fc_layout.batch() == 1 || fc_layout.feature() == 1) ||
-                        (data_layout.batch() == 1 && data_layout.feature() == 1) ||
-                        (fc_layout.count() == data_layout.count())) {
-                        continue;
-                    }
-
-                    static size_t idx = 0;
-                    const auto prim_id = "broadcast:" + data.id() + "_broadcasted" + std::to_string(idx++);
-                    auto broadcast_prim = std::make_shared<cldnn::broadcast>(prim_id, cldnn::input_info(data.id()), fc_layout.get_shape(),
-                                                                            ov::AxisSet{}, ov::op::BroadcastType::NUMPY);
-
-                    auto& broadcast_node = p.get_or_create(broadcast_prim);
-                    p.add_intermediate(broadcast_node, *node, fused_prim.outer_dep_start_idx, true);
-                    broadcast_node.recalc_output_layouts(false);
-                }
-            }
         }
     }
 #endif

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -980,7 +980,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
     // correctly and we need to do it manually
 #ifdef ENABLE_ONEDNN_FOR_GPU
     for (auto& node : p.get_processing_order()) {
-        if (node->is_type<gemm>() && node->get_preferred_impl_type() == impl_types::onednn) {
+        if ((node->is_type<gemm>() || node->is_type<fully_connected>()) && node->get_preferred_impl_type() == impl_types::onednn) {
             for (const auto& fused_prim : node->get_fused_primitives()) {
                 if (fused_prim.is_type<eltwise>() &&
                     one_of(fused_prim.typed_desc<eltwise>()->mode, {eltwise_mode::sum, eltwise_mode::sub, eltwise_mode::prod})) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -980,7 +980,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
     // correctly and we need to do it manually
 #ifdef ENABLE_ONEDNN_FOR_GPU
     for (auto& node : p.get_processing_order()) {
-        if ((node->is_type<gemm>() || node->is_type<fully_connected>()) && node->get_preferred_impl_type() == impl_types::onednn) {
+        if (node->is_type<gemm>() && node->get_preferred_impl_type() == impl_types::onednn) {
             for (const auto& fused_prim : node->get_fused_primitives()) {
                 if (fused_prim.is_type<eltwise>() &&
                     one_of(fused_prim.typed_desc<eltwise>()->mode, {eltwise_mode::sum, eltwise_mode::sub, eltwise_mode::prod})) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -1017,6 +1017,61 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
                     broadcast_node.recalc_output_layouts(false);
                 }
             }
+        } else if (node->is_type<fully_connected>() && node->get_preferred_impl_type() == impl_types::onednn) {
+            for (const auto& fused_prim : node->get_fused_primitives()) {
+                if (fused_prim.is_type<eltwise>() &&
+                    one_of(fused_prim.typed_desc<eltwise>()->mode, {eltwise_mode::sum, eltwise_mode::sub, eltwise_mode::prod})) {
+                    auto fc_layout = node->get_output_layout();
+                    auto& data = node->get_dependency(fused_prim.outer_dep_start_idx);
+                    auto data_layout = data.get_output_layout();
+
+                    if (fc_layout.is_dynamic() || data_layout.is_dynamic())
+                        continue;
+
+                    auto same_spatial = [](layout a, layout b) {
+                        if (a.get_spatial_rank() != b.get_spatial_rank())
+                            return false;
+                        for (size_t i = 0; i < a.get_spatial_rank(); i++) {
+                            if (a.spatial(i) != b.spatial(i))
+                                return false;
+                        }
+                        return true;
+                    };
+                    // fc_b     | fc_f      | data_b    | data_f    | broadcast condition
+                    // ---------+-----------+-----------+-----------+--------------------
+                    // 1        | 1         | 1         | 1         | no broadcast
+                    // 1        | 1         | 1         | N         | N/A
+                    // 1        | 1         | N         | 1         | N/A
+                    // 1        | 1         | N         | N         | N/A
+                    // 1        | N         | 1         | 1         | implicit broadcast
+                    // 1        | N         | 1         | N         | no broadcast
+                    // 1        | N         | N         | 1         | N/A
+                    // 1        | N         | N         | N         | N/A
+                    // N        | 1         | 1         | 1         | implicit broadcast
+                    // N        | 1         | 1         | N         | N/A
+                    // N        | 1         | N         | 1         | no broadcast
+                    // N        | 1         | N         | N         | N/A
+                    // N        | N         | 1         | 1         | implicit broadcast
+                    // N        | N         | 1         | N         | explicit broadcast when spatial different
+                    // N        | N         | N         | 1         | explicit broadcast when spatial different
+                    // N        | N         | N         | N         | no broadcast
+                    if ((fc_layout.batch() == 1 || fc_layout.feature() == 1) ||
+                        (data_layout.batch() == 1 && data_layout.feature() == 1) ||
+                        ((data_layout.batch() == 1 || data_layout.feature() == 1) && same_spatial(fc_layout, data_layout)) ||
+                        (fc_layout.count() == data_layout.count())) {
+                        continue;
+                    }
+
+                    static size_t idx = 0;
+                    const auto prim_id = "broadcast:" + data.id() + "_broadcasted" + std::to_string(idx++);
+                    auto broadcast_prim = std::make_shared<cldnn::broadcast>(prim_id, cldnn::input_info(data.id()), fc_layout.get_shape(),
+                                                                            ov::AxisSet{}, ov::op::BroadcastType::NUMPY);
+
+                    auto& broadcast_node = p.get_or_create(broadcast_prim);
+                    p.add_intermediate(broadcast_node, *node, fused_prim.outer_dep_start_idx, true);
+                    broadcast_node.recalc_output_layouts(false);
+                }
+            }
         }
     }
 #endif

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -98,44 +98,6 @@ protected:
         return args;
     }
 
-    static std::shared_ptr<WeightsReorderParams> get_weights_reorder(const kernel_impl_params& impl_params, const dnnl::primitive_desc& pd) {
-        auto input_layout = impl_params.get_input_layout(0);
-        auto source_weights_layout = impl_params.get_input_layout(1);
-        auto cldnn_prim = impl_params.typed_desc<fully_connected>();
-
-        auto input_pshape = input_layout.get_partial_shape();
-        auto weights_pshape = source_weights_layout.get_partial_shape();
-
-        int64_t feature = input_pshape[std::min(cldnn_prim->input_size, static_cast<size_t>(4)) - 1].get_length();
-        if (cldnn_prim->input_size == 3) {
-            feature = std::max({input_layout.spatial(0), input_layout.spatial(1), input_layout.spatial(2)});
-        }
-        auto target_weights_layout = source_weights_layout;
-        if (weights_pshape.size() != 2) {
-            target_weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));
-        }
-
-        auto target_weights_desc = pd.weights_desc(0);
-
-        auto shape_consistent = onednn::keep_weights_reorder_shape_consistent(source_weights_layout, target_weights_desc);
-        OPENVINO_ASSERT(shape_consistent, "[GPU] Input shape and output shape of weight reorder should be same.");
-
-        auto source_weights_desc = onednn::layout_to_memory_desc(source_weights_layout);
-
-        const bool weights_format = true;
-        const bool grouped = false;
-
-        auto traits = convert_memory_desc_to_traits(target_weights_desc, weights_format, grouped);
-
-        target_weights_layout.format = format(traits);
-
-        return std::make_shared<WeightsReorderParamsOneDNN>(source_weights_layout,
-                                                            target_weights_layout,
-                                                            source_weights_desc,
-                                                            target_weights_desc,
-                                                            false);
-    }
-
     static void transform_layouts(layout& input_layout, layout& weights_layout, layout& output_layout, size_t prim_input_size) {
         auto input_pshape = input_layout.get_partial_shape();
         auto weights_pshape = weights_layout.get_partial_shape();
@@ -161,43 +123,6 @@ protected:
         if (input_size == 3) {
             combine_bf_with_first_spatial_dim(input_layout);
             combine_bf_with_first_spatial_dim(output_layout);
-        }
-    }
-
-    static std::shared_ptr<dnnl::inner_product_forward::primitive_desc>
-        get_inner_product_primitive_descriptor(const kernel_impl_params& impl_params,
-                                               cldnn::engine& engine,
-                                               size_t prim_input_size,
-                                               bool has_bias,
-                                               const dnnl::primitive_attr& attr = dnnl::primitive_attr()) {
-        auto input_layout = impl_params.get_input_layout(0);
-        auto weights_layout = impl_params.get_input_layout(1);
-        auto output_layout = impl_params.get_output_layout();
-
-        transform_layouts(input_layout, weights_layout, output_layout, prim_input_size);
-
-        auto input_md = onednn::layout_to_memory_desc(input_layout, dnnl::memory::format_tag::undef, false);
-        auto weights_md = onednn::layout_to_memory_desc(weights_layout, dnnl::memory::format_tag::any);
-        auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::ab, false);
-
-        if (has_bias) {
-            auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, true);
-            return std::make_shared<dnnl::inner_product_forward::primitive_desc>(
-                engine.get_onednn_engine(),
-                dnnl::prop_kind::forward_inference,
-                input_md,
-                weights_md,
-                bias_md,
-                output_md,
-                attr);
-        } else {
-            return std::make_shared<dnnl::inner_product_forward::primitive_desc>(
-                engine.get_onednn_engine(),
-                dnnl::prop_kind::forward_inference,
-                input_md,
-                weights_md,
-                output_md,
-                attr);
         }
     }
 
@@ -335,13 +260,8 @@ public:
                 _attrs->set_zero_points(DNNL_ARG_SRC, GROUPED, dnnl::memory::dims{1, src_group_size}, dnnl::memory::data_type::u8);
         }
 
-        if (is_compressed) {
-            auto prim_desc = get_matmul_primitive_descriptor(*impl_params, ib.get_engine(), input_size, has_bias, *_attrs);
-            _pd = *prim_desc;
-        } else {
-            auto prim_desc = get_inner_product_primitive_descriptor(*impl_params, ib.get_engine(), input_size, has_bias, *_attrs);
-            _pd = *prim_desc;
-        }
+        auto prim_desc = get_matmul_primitive_descriptor(*impl_params, ib.get_engine(), input_size, has_bias, *_attrs);
+        _pd = *prim_desc;
 
         std::vector<uint8_t> prim_cache;
         ib >> prim_cache;
@@ -426,10 +346,10 @@ public:
             prim_onednn->_dzp_data_type = dzp_data_type;
             return prim_onednn;
         } else {
-            auto prim_desc = get_inner_product_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
-                                                                    prim->input_size, !prim->bias.empty(), *attr);
+            auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
+                                                             prim->input_size, !prim->bias.empty(), *attr);
 
-            return cldnn::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc, get_weights_reorder(impl_params, *prim_desc));
+            return cldnn::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
         }
     }
 };

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -144,7 +144,11 @@ protected:
         auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::ab, false);
 
         if (has_bias) {
-            auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::ab, false);
+            dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::ab;
+            auto bias_l = impl_params.get_input_layout(2);
+            if (bias_l.get_shape().size() == 1)
+                target_fmt = dnnl::memory::format_tag::ba;
+            auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), target_fmt, false);
             return std::make_shared<dnnl::matmul::primitive_desc>(
                 engine.get_onednn_engine(),
                 input_md,

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2665,7 +2665,7 @@ bool primitive_inst::is_valid_fusion() const {
         // * Gemm fused op shape: (1,f,y,x) -> OneDNN shape: (1*f,y,x)
         // If batch dimension of gemm output is not equal to 1, then OneDNN will not be able to broadcast fused op data
         // correctly and we need to do it manually
-        if (_node->is_type<gemm>() && _node->get_preferred_impl_type() == impl_types::onednn) {
+        if ((_node->is_type<gemm>() || _node->is_type<fully_connected>()) && _node->get_preferred_impl_type() == impl_types::onednn) {
             const auto& gemm_layout = _impl_params->get_output_layout();
             const auto& data_layout = outer_dep.first->_impl_params->get_output_layout();
             auto gemm_dims = onednn::convert_gemm_tensor(gemm_layout.get_tensor(),

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2678,18 +2678,6 @@ bool primitive_inst::is_valid_fusion() const {
 
             if (gemm_dims[0] != data_dims[0])
                 return false;
-        } else if (_node->is_type<fully_connected>() && _node->get_preferred_impl_type() == impl_types::onednn) {
-            const auto& fc_layout = _impl_params->get_output_layout();
-            const auto& data_layout = outer_dep.first->_impl_params->get_output_layout();
-
-            const auto fc_dims = fc_layout.get_dims();
-            const auto data_dims = data_layout.get_dims();
-
-            if (!(fc_dims[0] == 1 || fc_dims[1] == 1) &&
-                !(data_dims[0] == 1 && data_dims[1] == 1) &&
-                !(fc_layout.count() == data_layout.count())) {
-                return false;
-            }
         }
 #endif
 

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1584,7 +1584,6 @@ void program_node::create_onednn_primitive_attributes(
                             new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
                             new_layout.set_partial_shape(new_input_pshape);
                             in = new_layout;
-                            // GPU_DEBUG_COUT << "updated: " << in.to_short_string() << std::endl;
                         }
                     } else {
                         ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1564,7 +1564,7 @@ void program_node::create_onednn_primitive_attributes(
                     size_t rank = cldnn::format::dimension(in.format);
                     auto in_pshape = in.get_partial_shape();
                     auto out_pshape = get_output_layout().get_partial_shape();
-                    size_t ones_to_add = 0;
+                    int ones_to_add = 0;
 
                     if (is_type<fully_connected>()) {
                         auto prim = this->as<fully_connected>().get_primitive();

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1564,14 +1564,15 @@ void program_node::create_onednn_primitive_attributes(
                     size_t rank = cldnn::format::dimension(in.format);
                     auto in_pshape = in.get_partial_shape();
                     auto out_pshape = get_output_layout().get_partial_shape();
-                    int ones_to_add = 0;
+                    size_t ones_to_add = 0;
 
                     if (is_type<fully_connected>()) {
                         auto prim = this->as<fully_connected>().get_primitive();
                         if (prim->input_size == in_pshape.size()) {
                             ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
                         } else {
-                            ones_to_add = in_pshape.size() - prim->input_size;
+                            if (in_pshape.size() > prim->input_size)
+                                ones_to_add = in_pshape.size() - prim->input_size;
                         }
                         if (ones_to_add > 0) {
                             layout new_layout = in;

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1564,15 +1564,39 @@ void program_node::create_onednn_primitive_attributes(
                     size_t rank = cldnn::format::dimension(in.format);
                     auto in_pshape = in.get_partial_shape();
                     auto out_pshape = get_output_layout().get_partial_shape();
-                    size_t ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
-                    if (ones_to_add > 0) {
-                        layout new_layout = in;
-                        ov::PartialShape new_input_pshape;
-                        std::vector<ov::Dimension> dims(in_pshape.begin(), in_pshape.begin() + in_pshape.size());
-                        new_input_pshape = ov::PartialShape(dims);
-                        new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
-                        new_layout.set_partial_shape(new_input_pshape);
-                        in = new_layout;
+                    size_t ones_to_add = 0;
+
+                    if (is_type<fully_connected>()) {
+                        auto prim = this->as<fully_connected>().get_primitive();
+                        if (prim->input_size == in_pshape.size()) {
+                            ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
+                        } else {
+                            ones_to_add = in_pshape.size() - prim->input_size;
+                        }
+                        if (ones_to_add > 0) {
+                            layout new_layout = in;
+                            ov::PartialShape new_input_pshape;
+                            auto last = in_pshape.begin() + in_pshape.size();
+                            if (prim->input_size != in_pshape.size())
+                                last -= ones_to_add;
+                            std::vector<ov::Dimension> dims(in_pshape.begin(), last);
+                            new_input_pshape = ov::PartialShape(dims);
+                            new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
+                            new_layout.set_partial_shape(new_input_pshape);
+                            in = new_layout;
+                            // GPU_DEBUG_COUT << "updated: " << in.to_short_string() << std::endl;
+                        }
+                    } else {
+                        ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
+                        if (ones_to_add > 0) {
+                            layout new_layout = in;
+                            ov::PartialShape new_input_pshape;
+                            std::vector<ov::Dimension> dims(in_pshape.begin(), in_pshape.begin() + in_pshape.size());
+                            new_input_pshape = ov::PartialShape(dims);
+                            new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
+                            new_layout.set_partial_shape(new_input_pshape);
+                            in = new_layout;
+                        }
                     }
                     size_t in_batched_size = in.count() / (in.spatial(0) * in.spatial(1));
                     dnnl::memory::dims dims = onednn::convert_gemm_tensor(in.get_tensor(), rank, in_batched_size == 1);

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1571,14 +1571,15 @@ void program_node::create_onednn_primitive_attributes(
                         if (prim->input_size == in_pshape.size()) {
                             ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
                         } else {
-                            if (in_pshape.size() > prim->input_size)
-                                ones_to_add = in_pshape.size() - prim->input_size;
+                            if (prim->input_size == 3)
+                                cldnn::onednn::combine_bf_with_first_spatial_dim(in);
+                            ones_to_add = std::max(in_pshape.size(), prim->input_size) - std::min(in_pshape.size(), prim->input_size);
                         }
                         if (ones_to_add > 0) {
                             layout new_layout = in;
                             ov::PartialShape new_input_pshape;
                             auto last = in_pshape.begin() + in_pshape.size();
-                            if (prim->input_size != in_pshape.size())
+                            if (in_pshape.size() > prim->input_size)
                                 last -= ones_to_add;
                             std::vector<ov::Dimension> dims(in_pshape.begin(), last);
                             new_input_pshape = ov::PartialShape(dims);

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1560,16 +1560,7 @@ void program_node::create_onednn_primitive_attributes(
             auto in = get_input_layout(dep_idx);
             auto in_origin = in;
             auto set_binary_op = [&](dnnl::algorithm alg, onednn_post_op_type op_type) {
-                if (is_type<fully_connected>()) {
-                    auto prim = this->as<fully_connected>().get_primitive();
-                    if (prim->input_size == 3) {
-                        cldnn::onednn::combine_bf_with_first_spatial_dim(in);
-                    }
-                    auto mem_desc = onednn::layout_to_memory_desc(in, dnnl::memory::format_tag::ab);
-                    post_ops.append_binary(alg, mem_desc);
-                    update_onednn_post_op_list(op_type, dep_idx, dnnl::memory::format_tag::ab, false,
-                            mem_desc.get_dims(), mem_desc.get_data_type());
-                } else if (is_type<gemm>()) {
+                if (is_type<fully_connected>() || is_type<gemm>()) {
                     size_t rank = cldnn::format::dimension(in.format);
                     auto in_pshape = in.get_partial_shape();
                     auto out_pshape = get_output_layout().get_partial_shape();

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -162,13 +162,13 @@ public:
 #define CASE_FC_FP32_1 { 1, 3 }, { 1, 4 }, { 4, 3 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP32_2 { 2, 3 }, { 2, 4 }, { 4, 3 }, data_types::f32, format::yxfb, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP32_3 { 2, 32 }, { 2, 16 }, { 16, 32 }, data_types::f32, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3, 1 }, data_types::f32, format::bfyx, data_types::f32, format::os_iyx_osv16, data_types::f32, format::bfyx
-#define CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1, 1 }, data_types::f32, format::bfyx, data_types::f32, format::os_iyx_osv16, data_types::f32, format::bfyx
-#define CASE_FC_FP32_3D_3 { 2, 32, 32 }, { 2, 32, 16 }, { 16, 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::os_iyx_osv16, data_types::f32, format::bfyx
+#define CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP32_3D_3 { 2, 32, 32 }, { 2, 32, 16 }, { 16, 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 
-#define DYN_CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3 }, data_types::f32, format::bfyx, data_types::f32, format::os_iyx_osv16, data_types::f32, format::bfyx
-#define DYN_CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::os_iyx_osv16, data_types::f32, format::bfyx
-#define DYN_CASE_FC_FP32_3D_3 { 2, 32, 32 }, { 2, 32, 16 }, { 16, 32 }, data_types::f32, format::bfyx, data_types::f32, format::os_iyx_osv16, data_types::f32, format::bfyx
+#define DYN_CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define DYN_CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define DYN_CASE_FC_FP32_3D_3 { 2, 32, 32 }, { 2, 32, 16 }, { 16, 32 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 
 #define CASE_FC_U8S8_1 { 1, 3 }, { 1, 4 }, { 4, 3 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_U8S8_2 { 2, 3 }, { 2, 4 }, { 4, 3 }, data_types::u8, format::b_fs_yx_fsv4, data_types::i8, format::oiyx, data_types::f32, format::bfyx


### PR DESCRIPTION
SD3 dynamic has FC unfusion pattern, and needs sub graphs. It caused bad performance.


### Tickets:
 - *152851, 157100*
