### PR TITLE
[GPU] fix SDPA produce NaN after transpose_fusion pass.

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.cpp
@@ -89,7 +89,7 @@ JitConstants SDPAKernelBase::GetJitConstants(const sdpa_params& params) const {
     };
 
     auto use_index_calc_func = [&](const std::vector<int64_t> order, bool is_query = false) {
-        if (!params.input0_order.empty() && !is_default_order(params.input0_order))
+        if (!order.empty() && !is_default_order(order))
             return true;
 
         if (params.conf.broadcast_axis != -1)


### PR DESCRIPTION
### Details:
 - The issue only happens is fp16 model and even fp32 model if a hint for fp32 is not set.
 - The NaN starts to produce after the comit 27780a6 which reverts the fake alignment. *CVS-155861*
 - 


### Tickets:
 - *CVS-156289*
