### PR TITLE
[DOCS] Add missing frontend, bindings and plugins in architecture.md

### DIFF
--- a/src/docs/architecture.md
+++ b/src/docs/architecture.md
@@ -32,19 +32,26 @@ flowchart TB
         subgraph bindings [Bindings]
             c_api[C]
             python_api[Python]
+            js_api[Javascript]
         end
     end
     
     subgraph plugins [OV Plugins]
         auto(["AUTO"])
+        auto_batch(["AUTO_BATCH"])
         cpu(["Intel_CPU"])
         gpu(["Intel_GPU"])
+        npu(["Intel_NPU"])
+        hetero(["Hetero"])
+        template(["Template"])
     end
+    
     subgraph frontends [OV Frontends]
         direction TB
         ir_fe["IR Frontend"]
         onnx_fe["ONNX Frontend"]
         paddle_fe["Paddle Frontend"]
+        tensorflow_fe["Tensorflow Frontend"]
     end
     openvino(openvino library)
     


### PR DESCRIPTION
### Details:
 - The architecture.md does not have the latest list of supported frontends, bindings and plugins. 
 - This PR updates the architecture, so its in line with current features of OpenVino.

### Tickets:
 - There isn't really a ticket for it. It seemed like a small enough change to make a PR directly.

Let me know if something needs to changed.
