### PR TITLE
[GPU] Fix mvn segmentation fault for multiple threads start_async

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -28,7 +28,7 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::activation_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<activation_impl>(*this);
+        return make_deep_copy<activation_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/adaptive_pooling.cpp
@@ -19,7 +19,7 @@ struct adaptive_pooling_impl : public typed_primitive_impl_ocl<adaptive_pooling>
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::adaptive_pooling_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<adaptive_pooling_impl>(*this);
+        return make_deep_copy<adaptive_pooling_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -42,7 +42,7 @@ struct arg_max_min_impl : typed_primitive_impl_ocl<arg_max_min> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::arg_max_min_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<arg_max_min_impl>(*this);
+        return make_deep_copy<arg_max_min_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/batch_to_space.cpp
@@ -18,7 +18,7 @@ struct batch_to_space_impl : typed_primitive_impl_ocl<batch_to_space> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::batch_to_space_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<batch_to_space_impl>(*this);
+        return make_deep_copy<batch_to_space_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/border.cpp
@@ -21,7 +21,7 @@ struct border_impl : typed_primitive_impl_ocl<border> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::border_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<border_impl>(*this);
+        return make_deep_copy<border_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/broadcast.cpp
@@ -20,7 +20,7 @@ struct broadcast_impl : typed_primitive_impl_ocl<broadcast> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::broadcast_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<broadcast_impl>(*this);
+        return make_deep_copy<broadcast_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/bucketize.cpp
@@ -20,7 +20,7 @@ struct bucketize_impl : typed_primitive_impl_ocl<bucketize> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::bucketize_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<bucketize_impl>(*this);
+        return make_deep_copy<bucketize_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/concatenation.cpp
@@ -50,7 +50,7 @@ struct concatenation_impl : typed_primitive_impl_ocl<concatenation> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::concatenation_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<concatenation_impl>(*this);
+        return make_deep_copy<concatenation_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convert_color.cpp
@@ -19,7 +19,7 @@ struct convert_color_impl : typed_primitive_impl_ocl<convert_color> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::convert_color_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<convert_color_impl>(*this);
+        return make_deep_copy<convert_color_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -24,7 +24,7 @@ struct convolution_impl : typed_primitive_impl_ocl<convolution> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::convolution_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<convolution_impl>(*this);
+        return make_deep_copy<convolution_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/crop.cpp
@@ -20,7 +20,7 @@ struct crop_impl : typed_primitive_impl_ocl<crop> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::crop_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<crop_impl>(*this);
+        return make_deep_copy<crop_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_greedy_decoder.cpp
@@ -32,7 +32,7 @@ protected:
 
 public:
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<ctc_greedy_decoder_impl>(*this);
+        return make_deep_copy<ctc_greedy_decoder_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/ctc_loss.cpp
@@ -20,7 +20,7 @@ struct ctc_loss_impl : typed_primitive_impl_ocl<ctc_loss> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::ctc_loss_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<ctc_loss_impl>(*this);
+        return make_deep_copy<ctc_loss_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/cum_sum.cpp
@@ -53,7 +53,7 @@ struct cum_sum_impl : typed_primitive_impl_ocl<cum_sum> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::cum_sum_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<cum_sum_impl>(*this);
+        return make_deep_copy<cum_sum_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/deconvolution.cpp
@@ -21,7 +21,7 @@ struct deconvolution_impl : typed_primitive_impl_ocl<deconvolution> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::deconvolution_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<deconvolution_impl>(*this);
+        return make_deep_copy<deconvolution_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/depth_to_space.cpp
@@ -19,7 +19,7 @@ struct depth_to_space_impl : typed_primitive_impl_ocl<depth_to_space> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::depth_to_space_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<depth_to_space_impl>(*this);
+        return make_deep_copy<depth_to_space_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/detection_output.cpp
@@ -21,7 +21,7 @@ struct detection_output_impl : typed_primitive_impl_ocl<detection_output> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::detection_output_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<detection_output_impl>(*this);
+        return make_deep_copy<detection_output_impl, kernel_params_t>(*this);
     }
 
 public:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dft.cpp
@@ -19,7 +19,7 @@ struct dft_impl : typed_primitive_impl_ocl<dft> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::dft_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<dft_impl>(*this);
+        return make_deep_copy<dft_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/dynamic_quantize.cpp
@@ -21,7 +21,7 @@ struct dynamic_quantize_impl : typed_primitive_impl_ocl<dynamic_quantize> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::dynamic_quantize_impl);
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<dynamic_quantize_impl>(*this);
+        return make_deep_copy<dynamic_quantize_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -20,9 +20,7 @@ struct eltwise_impl : typed_primitive_impl_ocl<eltwise> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::eltwise_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        auto prim_impl = make_unique<eltwise_impl>(*this);
-        clone_kernel_data_params<kernel_params_t>(*prim_impl);
-        return prim_impl;
+        return make_deep_copy<eltwise_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -21,8 +21,7 @@ struct eltwise_impl : typed_primitive_impl_ocl<eltwise> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         auto prim_impl = make_unique<eltwise_impl>(*this);
-        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
-        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        clone_kernel_data_params<kernel_params_t>(*prim_impl);
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -20,7 +20,10 @@ struct eltwise_impl : typed_primitive_impl_ocl<eltwise> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::eltwise_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<eltwise_impl>(*this);
+        auto prim_impl = make_unique<eltwise_impl>(*this);
+        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
+        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        return prim_impl;
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/embedding_bag.cpp
@@ -19,7 +19,7 @@ struct embedding_bag_impl : typed_primitive_impl_ocl<embedding_bag> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::embedding_bag_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<embedding_bag_impl>(*this);
+        return make_deep_copy<embedding_bag_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_detection_output.cpp
@@ -20,7 +20,7 @@ struct experimental_detectron_detection_output_impl
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_detection_output_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<experimental_detectron_detection_output_impl>(*this);
+        return make_deep_copy<experimental_detectron_detection_output_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_generate_proposals_single_image.cpp
@@ -20,7 +20,7 @@ struct experimental_detectron_generate_proposals_single_image_impl
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_generate_proposals_single_image_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<experimental_detectron_generate_proposals_single_image_impl>(*this);
+        return make_deep_copy<experimental_detectron_generate_proposals_single_image_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_prior_grid_generator.cpp
@@ -21,7 +21,7 @@ struct experimental_detectron_prior_grid_generator_impl
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_prior_grid_generator_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<experimental_detectron_prior_grid_generator_impl>(*this);
+        return make_deep_copy<experimental_detectron_prior_grid_generator_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_roi_feature_extractor.cpp
@@ -19,7 +19,7 @@ struct experimental_detectron_roi_feature_extractor_impl : public typed_primitiv
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_roi_feature_extractor_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<experimental_detectron_roi_feature_extractor_impl>(*this);
+        return make_deep_copy<experimental_detectron_roi_feature_extractor_impl, kernel_params_t>(*this);
     }
 
     event::ptr execute_impl(const std::vector<event::ptr>& events,

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/experimental_detectron_topk_rois.cpp
@@ -20,7 +20,7 @@ struct experimental_detectron_topk_rois_impl : typed_primitive_impl_ocl<experime
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::experimental_detectron_topk_rois_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<experimental_detectron_topk_rois_impl>(*this);
+        return make_deep_copy<experimental_detectron_topk_rois_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/extract_image_patches.cpp
@@ -30,7 +30,7 @@ struct extract_image_patches_impl : typed_primitive_impl_ocl<extract_image_patch
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::extract_image_patches_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<extract_image_patches_impl>(*this);
+        return make_deep_copy<extract_image_patches_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eye.cpp
@@ -20,7 +20,7 @@ struct eye_impl : typed_primitive_impl_ocl<eye> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::eye_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<eye_impl>(*this);
+        return make_deep_copy<eye_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -46,8 +46,7 @@ struct fully_connected_impl : typed_primitive_impl_ocl<fully_connected> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         auto prim_impl = make_unique<fully_connected_impl>(*this);
-        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
-        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        clone_kernel_data_params<kernel_params_t>(*prim_impl);
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -45,9 +45,7 @@ struct fully_connected_impl : typed_primitive_impl_ocl<fully_connected> {
     }
 
     std::unique_ptr<primitive_impl> clone() const override {
-        auto prim_impl = make_unique<fully_connected_impl>(*this);
-        clone_kernel_data_params<kernel_params_t>(*prim_impl);
-        return prim_impl;
+        return make_deep_copy<fully_connected_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -45,7 +45,10 @@ struct fully_connected_impl : typed_primitive_impl_ocl<fully_connected> {
     }
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<fully_connected_impl>(*this);
+        auto prim_impl = make_unique<fully_connected_impl>(*this);
+        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
+        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        return prim_impl;
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -65,8 +65,7 @@ struct gather_impl : typed_primitive_impl_ocl<gather> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         auto prim_impl = make_unique<gather_impl>(*this);
-        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
-        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        clone_kernel_data_params<kernel_params_t>(*prim_impl);
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -64,9 +64,7 @@ struct gather_impl : typed_primitive_impl_ocl<gather> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        auto prim_impl = make_unique<gather_impl>(*this);
-        clone_kernel_data_params<kernel_params_t>(*prim_impl);
-        return prim_impl;
+        return make_deep_copy<gather_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -64,7 +64,10 @@ struct gather_impl : typed_primitive_impl_ocl<gather> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<gather_impl>(*this);
+        auto prim_impl = make_unique<gather_impl>(*this);
+        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
+        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        return prim_impl;
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_elements.cpp
@@ -51,7 +51,7 @@ struct gather_elements_impl : typed_primitive_impl_ocl<gather_elements> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_elements_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<gather_elements_impl>(*this);
+        return make_deep_copy<gather_elements_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_nd.cpp
@@ -21,7 +21,7 @@ struct gather_nd_impl : typed_primitive_impl_ocl<gather_nd> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_nd_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<gather_nd_impl>(*this);
+        return make_deep_copy<gather_nd_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather_tree.cpp
@@ -20,7 +20,7 @@ struct gather_tree_impl : typed_primitive_impl_ocl<gather_tree> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_tree_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<gather_tree_impl>(*this);
+        return make_deep_copy<gather_tree_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -32,9 +32,7 @@ struct gemm_impl : multi_stage_primitive<gemm> {
     const uint32_t indirect_gemm = 1;
 
     std::unique_ptr<primitive_impl> clone() const override {
-        auto prim_impl = make_unique<gemm_impl>(*this);
-        clone_kernel_data_params<kernel_params_t>(*prim_impl);
-        return prim_impl;
+        return make_deep_copy<gemm_impl, kernel_params_t>(*this);
     }
 
     gemm_impl() = default;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -32,7 +32,12 @@ struct gemm_impl : multi_stage_primitive<gemm> {
     const uint32_t indirect_gemm = 1;
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<gemm_impl>(*this);
+        auto prim_impl = make_unique<gemm_impl>(*this);
+        for (auto& _kernel_data : prim_impl->_kernels_data) {
+            kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(_kernel_data.params.get());
+            _kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        }
+        return prim_impl;
     }
 
     gemm_impl() = default;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -33,10 +33,7 @@ struct gemm_impl : multi_stage_primitive<gemm> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         auto prim_impl = make_unique<gemm_impl>(*this);
-        for (auto& _kernel_data : prim_impl->_kernels_data) {
-            kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(_kernel_data.params.get());
-            _kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
-        }
+        clone_kernel_data_params<kernel_params_t>(*prim_impl);
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/generate_proposals.cpp
@@ -20,7 +20,7 @@ struct generate_proposals_impl
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::generate_proposals_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<generate_proposals_impl>(*this);
+        return make_deep_copy<generate_proposals_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grid_sample.cpp
@@ -49,7 +49,7 @@ struct grid_sample_impl : public typed_primitive_impl_ocl<grid_sample> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::grid_sample_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<grid_sample_impl>(*this);
+        return make_deep_copy<grid_sample_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/grn.cpp
@@ -20,7 +20,7 @@ struct grn_impl : typed_primitive_impl_ocl<grn> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::grn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<grn_impl>(*this);
+        return make_deep_copy<grn_impl, kernel_params_t>(*this);
     }
 
 public:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/group_normalization.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/group_normalization.cpp
@@ -18,7 +18,7 @@ struct group_normalization_impl : typed_primitive_impl_ocl<group_normalization> 
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::group_normalization_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<group_normalization_impl>(*this);
+        return make_deep_copy<group_normalization_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -301,7 +301,7 @@ inline void update_shapes(kernel_selector::Params& p, const kernel_impl_params& 
         fd.output_tensor = convert_data_tensor(fused_prim.output_layout);
         fd.tensors.clear();
         for (size_t i = fd.dep_idx_start; i < fd.dep_idx_start + fd.dep_size; i++) {
-            fd.tensors.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
+            fd.AddTensor(convert_data_tensor(impl_param.get_input_layout(i)));
         }
     }
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kernel_selector_helper.h
@@ -301,7 +301,7 @@ inline void update_shapes(kernel_selector::Params& p, const kernel_impl_params& 
         fd.output_tensor = convert_data_tensor(fused_prim.output_layout);
         fd.tensors.clear();
         for (size_t i = fd.dep_idx_start; i < fd.dep_idx_start + fd.dep_size; i++) {
-            fd.AddTensor(convert_data_tensor(impl_param.get_input_layout(i)));
+            fd.tensors.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
         }
     }
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/kv_cache.cpp
@@ -68,7 +68,7 @@ struct kv_cache_impl : multi_stage_primitive<kv_cache> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::kv_cache_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<kv_cache_impl>(*this);
+        return make_deep_copy<kv_cache_impl, kernel_params_t>(*this);
     }
 
     const size_t concat_stage = 0;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lrn.cpp
@@ -20,7 +20,7 @@ struct lrn_impl : typed_primitive_impl_ocl<lrn> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lrn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<lrn_impl>(*this);
+        return make_deep_copy<lrn_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/lstm_elt.cpp
@@ -20,7 +20,7 @@ struct lstm_elt_impl : typed_primitive_impl_ocl<lstm_elt> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::lstm_elt_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<lstm_elt_impl>(*this);
+        return make_deep_copy<lstm_elt_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/matrix_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/matrix_nms.cpp
@@ -44,7 +44,7 @@ struct matrix_nms_impl : typed_primitive_impl_ocl<matrix_nms> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::matrix_nms_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<matrix_nms_impl>(*this);
+        return make_deep_copy<matrix_nms_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
@@ -141,6 +141,14 @@ protected:
         return {kernels_cache.get_cached_kernel_ids(_kernels)};
     }
 
+    template<typename kernel_params_t>
+    static void clone_kernel_data_params(multi_stage_primitive& prim_impl) {
+        for (auto& _kernel_data : prim_impl._kernels_data) {
+            kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(_kernel_data.params.get());
+            _kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        }
+    }
+
     std::vector<kernel::ptr> get_kernels() const override {
         return _kernels;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
@@ -146,7 +146,9 @@ protected:
         auto prim_impl = make_unique<ImplType>(impl_ocl);
         for (auto& _kernel_data : (*prim_impl)._kernels_data) {
             KernelParamsType* params_ptr = dynamic_cast<KernelParamsType*>(_kernel_data.params.get());
-            _kernel_data.params = make_unique<KernelParamsType>(*params_ptr);
+            if (params_ptr != nullptr) {
+                _kernel_data.params = make_unique<KernelParamsType>(*params_ptr);
+            }
         }
         return prim_impl;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multi_stage_primitive.hpp
@@ -141,12 +141,14 @@ protected:
         return {kernels_cache.get_cached_kernel_ids(_kernels)};
     }
 
-    template<typename kernel_params_t>
-    static void clone_kernel_data_params(multi_stage_primitive& prim_impl) {
-        for (auto& _kernel_data : prim_impl._kernels_data) {
-            kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(_kernel_data.params.get());
-            _kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+    template<typename ImplType, typename KernelParamsType>
+    static std::unique_ptr<primitive_impl> make_deep_copy(const ImplType& impl_ocl) {
+        auto prim_impl = make_unique<ImplType>(impl_ocl);
+        for (auto& _kernel_data : (*prim_impl)._kernels_data) {
+            KernelParamsType* params_ptr = dynamic_cast<KernelParamsType*>(_kernel_data.params.get());
+            _kernel_data.params = make_unique<KernelParamsType>(*params_ptr);
         }
+        return prim_impl;
     }
 
     std::vector<kernel::ptr> get_kernels() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multiclass_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multiclass_nms.cpp
@@ -40,7 +40,7 @@ struct multiclass_nms_impl : public typed_primitive_impl_ocl<multiclass_nms> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::multiclass_nms_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<multiclass_nms_impl>(*this);
+        return make_deep_copy<multiclass_nms_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/multinomial.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/multinomial.cpp
@@ -18,7 +18,7 @@ struct multinomial_impl : typed_primitive_impl_ocl<multinomial> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::multinomial_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<multinomial_impl>(*this);
+        return make_deep_copy<multinomial_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -20,7 +20,10 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::mvn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<mvn_impl>(*this);
+        auto prim_impl = make_unique<mvn_impl>(*this);
+        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
+        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        return prim_impl;
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -20,9 +20,7 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::mvn_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        auto prim_impl = make_unique<mvn_impl>(*this);
-        clone_kernel_data_params<kernel_params_t>(*prim_impl);
-        return prim_impl;
+        return make_deep_copy<mvn_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/mvn.cpp
@@ -21,8 +21,7 @@ struct mvn_impl : typed_primitive_impl_ocl<mvn> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         auto prim_impl = make_unique<mvn_impl>(*this);
-        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
-        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        clone_kernel_data_params<kernel_params_t>(*prim_impl);
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_max_suppression.cpp
@@ -21,7 +21,7 @@ struct non_max_suppression_impl : typed_primitive_impl_ocl<non_max_suppression> 
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::non_max_suppression_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<non_max_suppression_impl>(*this);
+        return make_deep_copy<non_max_suppression_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -22,7 +22,7 @@ struct count_nonzero_impl : typed_primitive_impl_ocl<count_nonzero> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::count_nonzero_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<count_nonzero_impl>(*this);
+        return make_deep_copy<count_nonzero_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/non_zero.cpp
@@ -67,7 +67,7 @@ struct gather_nonzero_impl : typed_primitive_impl_ocl<gather_nonzero> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::gather_nonzero_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<gather_nonzero_impl>(*this);
+        return make_deep_copy<gather_nonzero_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/normalize.cpp
@@ -20,7 +20,7 @@ struct normalize_impl : typed_primitive_impl_ocl<normalize> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::normalize_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<normalize_impl>(*this);
+        return make_deep_copy<normalize_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/one_hot.cpp
@@ -20,7 +20,7 @@ struct one_hot_impl : typed_primitive_impl_ocl<one_hot> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::one_hot_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<one_hot_impl>(*this);
+        return make_deep_copy<one_hot_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -47,9 +47,7 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::permute_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        auto prim_impl = make_unique<permute_impl>(*this);
-        clone_kernel_data_params<kernel_params_t>(*prim_impl);
-        return prim_impl;
+        return make_deep_copy<permute_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -47,7 +47,10 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::permute_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<permute_impl>(*this);
+        auto prim_impl = make_unique<permute_impl>(*this);
+        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
+        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        return prim_impl;
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/permute.cpp
@@ -48,8 +48,7 @@ struct permute_impl : typed_primitive_impl_ocl<permute> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         auto prim_impl = make_unique<permute_impl>(*this);
-        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl->_kernel_data.params.get());
-        prim_impl->_kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+        clone_kernel_data_params<kernel_params_t>(*prim_impl);
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/pooling.cpp
@@ -51,7 +51,7 @@ struct pooling_impl : typed_primitive_impl_ocl<pooling> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::pooling_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<pooling_impl>(*this);
+        return make_deep_copy<pooling_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -170,10 +170,12 @@ protected:
         return {kernels_cache.get_cached_kernel_ids(_kernels)};
     }
 
-    template<typename kernel_params_t>
-    static void clone_kernel_data_params(typed_primitive_impl_ocl& prim_impl) {
-        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl._kernel_data.params.get());
-        prim_impl._kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+    template<typename ImplType, typename KernelParamsType>
+    static std::unique_ptr<primitive_impl> make_deep_copy(const ImplType& impl_ocl) {
+        auto prim_impl = make_unique<ImplType>(impl_ocl);
+        KernelParamsType* params_ptr = dynamic_cast<KernelParamsType*>((*prim_impl)._kernel_data.params.get());
+        (*prim_impl)._kernel_data.params = make_unique<KernelParamsType>(*params_ptr);
+        return prim_impl;
     }
 
     std::vector<kernel::ptr> get_kernels() const override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -174,7 +174,9 @@ protected:
     static std::unique_ptr<primitive_impl> make_deep_copy(const ImplType& impl_ocl) {
         auto prim_impl = make_unique<ImplType>(impl_ocl);
         KernelParamsType* params_ptr = dynamic_cast<KernelParamsType*>((*prim_impl)._kernel_data.params.get());
-        (*prim_impl)._kernel_data.params = make_unique<KernelParamsType>(*params_ptr);
+        if (params_ptr != nullptr) {
+            (*prim_impl)._kernel_data.params = make_unique<KernelParamsType>(*params_ptr);
+        }
         return prim_impl;
     }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/primitive_base.hpp
@@ -170,6 +170,12 @@ protected:
         return {kernels_cache.get_cached_kernel_ids(_kernels)};
     }
 
+    template<typename kernel_params_t>
+    static void clone_kernel_data_params(typed_primitive_impl_ocl& prim_impl) {
+        kernel_params_t* params_ptr = dynamic_cast<kernel_params_t*>(prim_impl._kernel_data.params.get());
+        prim_impl._kernel_data.params = make_unique<kernel_params_t>(*params_ptr);
+    }
+
     std::vector<kernel::ptr> get_kernels() const override {
         return _kernels;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/prior_box.cpp
@@ -20,7 +20,7 @@ struct prior_box_impl : typed_primitive_impl_ocl<prior_box> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::prior_box_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<prior_box_impl>(*this);
+        return make_deep_copy<prior_box_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/quantize.cpp
@@ -20,7 +20,7 @@ struct quantize_impl : typed_primitive_impl_ocl<quantize> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::quantize_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<quantize_impl>(*this);
+        return make_deep_copy<quantize_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/random_uniform.cpp
@@ -20,7 +20,7 @@ struct random_uniform_impl : typed_primitive_impl_ocl<random_uniform> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::random_uniform_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<random_uniform_impl>(*this);
+        return make_deep_copy<random_uniform_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/range.cpp
@@ -20,7 +20,7 @@ struct range_impl : typed_primitive_impl_ocl<range> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::range_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<range_impl>(*this);
+        return make_deep_copy<range_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reduce.cpp
@@ -69,7 +69,7 @@ struct reduce_impl : typed_primitive_impl_ocl<reduce> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reduce_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<reduce_impl>(*this);
+        return make_deep_copy<reduce_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/region_yolo.cpp
@@ -20,7 +20,7 @@ struct region_yolo_impl : typed_primitive_impl_ocl<region_yolo> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::region_yolo_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<region_yolo_impl>(*this);
+        return make_deep_copy<region_yolo_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -22,7 +22,7 @@ struct reorder_impl : typed_primitive_impl_ocl<reorder> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reorder_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<reorder_impl>(*this);
+        return make_deep_copy<reorder_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorg_yolo.cpp
@@ -20,7 +20,7 @@ struct reorg_yolo_impl : typed_primitive_impl_ocl<reorg_yolo> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reorg_yolo_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<reorg_yolo_impl>(*this);
+        return make_deep_copy<reorg_yolo_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -137,7 +137,7 @@ struct resample_impl : typed_primitive_impl_ocl<resample> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::resample_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<resample_impl>(*this);
+        return make_deep_copy<resample_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reshape.cpp
@@ -20,7 +20,7 @@ struct reshape_impl : public typed_primitive_impl_ocl<reshape> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reshape_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<reshape_impl>(*this);
+        return make_deep_copy<reshape_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse.cpp
@@ -20,7 +20,7 @@ struct reverse_impl : typed_primitive_impl_ocl<reverse> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reverse_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<reverse_impl>(*this);
+        return make_deep_copy<reverse_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reverse_sequence.cpp
@@ -19,7 +19,7 @@ struct reverse_sequence_impl : typed_primitive_impl_ocl<reverse_sequence> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::reverse_sequence_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<reverse_sequence_impl>(*this);
+        return make_deep_copy<reverse_sequence_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rms.cpp
@@ -20,7 +20,7 @@ struct rms_impl : typed_primitive_impl_ocl<rms> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::rms_impl);
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<rms_impl>(*this);
+        return make_deep_copy<rms_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_align.cpp
@@ -44,7 +44,7 @@ struct roi_align_impl : typed_primitive_impl_ocl<roi_align> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::roi_align_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<roi_align_impl>(*this);
+        return make_deep_copy<roi_align_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roi_pooling.cpp
@@ -40,7 +40,7 @@ struct roi_pooling_impl : typed_primitive_impl_ocl<roi_pooling> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::roi_pooling_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<roi_pooling_impl>(*this);
+        return make_deep_copy<roi_pooling_impl, kernel_params_t>(*this);
     }
 
 protected:

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -20,7 +20,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::roll_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<roll_impl>(*this);
+        return make_deep_copy<roll_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rope.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rope.cpp
@@ -20,7 +20,7 @@ struct rope_impl : typed_primitive_impl_ocl<rope> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::rope_impl);
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<rope_impl>(*this);
+        return make_deep_copy<rope_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -29,7 +29,7 @@ struct scaled_dot_product_attention_impl : multi_stage_primitive<scaled_dot_prod
     const uint32_t indirect_sdpa = 1;
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<scaled_dot_product_attention_impl>(*this);
+        return make_deep_copy<scaled_dot_product_attention_impl, kernel_params_t>(*this);
     }
 
     scaled_dot_product_attention_impl() = default;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_elements_update.cpp
@@ -68,7 +68,7 @@ struct scatter_elements_update_impl : typed_primitive_impl_ocl<scatter_elements_
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scatter_elements_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<scatter_elements_update_impl>(*this);
+        return make_deep_copy<scatter_elements_update_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_nd_update.cpp
@@ -20,7 +20,7 @@ struct scatter_nd_update_impl : typed_primitive_impl_ocl<scatter_nd_update> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scatter_nd_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<scatter_nd_update_impl>(*this);
+        return make_deep_copy<scatter_nd_update_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scatter_update.cpp
@@ -46,7 +46,7 @@ struct scatter_update_impl : typed_primitive_impl_ocl<scatter_update> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::scatter_update_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<scatter_update_impl>(*this);
+        return make_deep_copy<scatter_update_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/select.cpp
@@ -20,7 +20,7 @@ struct select_impl : typed_primitive_impl_ocl<select> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::select_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<select_impl>(*this);
+        return make_deep_copy<select_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/shuffle_channels.cpp
@@ -20,7 +20,7 @@ struct shuffle_channels_impl : typed_primitive_impl_ocl<shuffle_channels> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::shuffle_channels_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<shuffle_channels_impl>(*this);
+        return make_deep_copy<shuffle_channels_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/slice.cpp
@@ -59,7 +59,7 @@ struct slice_impl : typed_primitive_impl_ocl<slice> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::slice_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<slice_impl>(*this);
+        return make_deep_copy<slice_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/softmax.cpp
@@ -43,7 +43,7 @@ struct softmax_impl : typed_primitive_impl_ocl<softmax> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::softmax_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<softmax_impl>(*this);
+        return make_deep_copy<softmax_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_batch.cpp
@@ -19,7 +19,7 @@ struct space_to_batch_impl : typed_primitive_impl_ocl<space_to_batch> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::space_to_batch_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<space_to_batch_impl>(*this);
+        return make_deep_copy<space_to_batch_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param, bool is_shape_agnostic = false) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/space_to_depth.cpp
@@ -19,7 +19,7 @@ struct space_to_depth_impl : typed_primitive_impl_ocl<space_to_depth> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::space_to_depth_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<space_to_depth_impl>(*this);
+        return make_deep_copy<space_to_depth_impl, kernel_params_t>(*this);
     }
 
     static kernel_params_t get_kernel_params(const kernel_impl_params& impl_param) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/strided_slice.cpp
@@ -75,7 +75,7 @@ struct strided_slice_impl : typed_primitive_impl_ocl<strided_slice> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::strided_slice_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<strided_slice_impl>(*this);
+        return make_deep_copy<strided_slice_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/swiglu.cpp
@@ -20,7 +20,7 @@ struct swiglu_impl : typed_primitive_impl_ocl<swiglu> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::swiglu_impl);
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<swiglu_impl>(*this);
+        return make_deep_copy<swiglu_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/tile.cpp
@@ -20,7 +20,7 @@ struct tile_impl : typed_primitive_impl_ocl<tile> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::tile_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<tile_impl>(*this);
+        return make_deep_copy<tile_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
@@ -19,7 +19,6 @@ struct unique_count_impl : typed_primitive_impl_ocl<unique_count> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::unique_count_impl)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<unique_count_impl>(*this);
         return make_deep_copy<unique_count_impl, kernel_params_t>(*this);
     }
 
@@ -102,7 +101,7 @@ struct unique_gather_impl : typed_primitive_impl_ocl<unique_gather> {
     DECLARE_OBJECT_TYPE_SERIALIZATION(cldnn::ocl::unique_gather)
 
     std::unique_ptr<primitive_impl> clone() const override {
-        return make_unique<unique_gather_impl>(*this);
+        return make_deep_copy<unique_gather_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/unique.cpp
@@ -20,6 +20,7 @@ struct unique_count_impl : typed_primitive_impl_ocl<unique_count> {
 
     std::unique_ptr<primitive_impl> clone() const override {
         return make_unique<unique_count_impl>(*this);
+        return make_deep_copy<unique_count_impl, kernel_params_t>(*this);
     }
 
     void load(BinaryInputBuffer& ib) override {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -14,7 +14,6 @@
 #include <vector>
 #include <utility>
 #include <bitset>
-#include <mutex>
 
 namespace kernel_selector {
 using DataTensor = Tensor::DataTensor;
@@ -628,7 +627,6 @@ struct dep_info {
 //     - fused_operation_desc contains a bunch of methods to generate variable/pointer names, type conversions, data loads
 struct fused_operation_desc {
     std::shared_ptr<fuse_params> op_params;
-    std::shared_ptr<std::mutex> mutex_ptr = std::make_shared<std::mutex>();
     int32_t dep_idx_start;
     size_t dep_size;
     MultiDataTensor tensors;
@@ -648,10 +646,6 @@ struct fused_operation_desc {
     }
     bool has_outer_dep() {
         return dep_idx_start != -1;
-    }
-    void AddTensor(const DataTensor& data_tensor) {
-        std::lock_guard<std::mutex> lock(*mutex_ptr);
-        tensors.push_back(data_tensor);
     }
 };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <utility>
 #include <bitset>
+#include <mutex>
 
 namespace kernel_selector {
 using DataTensor = Tensor::DataTensor;
@@ -627,6 +628,7 @@ struct dep_info {
 //     - fused_operation_desc contains a bunch of methods to generate variable/pointer names, type conversions, data loads
 struct fused_operation_desc {
     std::shared_ptr<fuse_params> op_params;
+    std::shared_ptr<std::mutex> mutex_ptr = std::make_shared<std::mutex>();
     int32_t dep_idx_start;
     size_t dep_size;
     MultiDataTensor tensors;
@@ -646,6 +648,10 @@ struct fused_operation_desc {
     }
     bool has_outer_dep() {
         return dep_idx_start != -1;
+    }
+    void AddTensor(const DataTensor& data_tensor) {
+        std::lock_guard<std::mutex> lock(*mutex_ptr);
+        tensors.push_back(data_tensor);
     }
 };
 


### PR DESCRIPTION
### Details:
 - *Deep copy impl params*: deep copy primitive impl KernelData params for different networks when running start_async() with multi-threads (THROUGHPUT mode)

### Tickets:
 - *[CVS-155564](https://jira.devtools.intel.com/browse/CVS-155564)*

Migrated from PR https://github.com/openvinotoolkit/openvino/pull/27263.