### PR TITLE
Reset output memory when status of current prim is changed from optim…

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -399,6 +399,7 @@ protected:
     bool _can_share_buffer = true;
     bool _is_constant = false;
     bool _needs_completion_event = false;
+    bool _is_prev_optimized = false;
 
     std::vector<size_t> _max_output_layout_count;
     std::vector<size_t> max_intermediates_memory_sizes;


### PR DESCRIPTION
### Details:
 - *Reset output memory when status of current prim is changed from optimized out to executed or is skipped*

### Tickets:
 - *154591*
