### PR TITLE
[GHA] Add merge queue stub check for ci/jenkins

### DIFF
--- a/.github/workflows/merge_queue_stub.yml
+++ b/.github/workflows/merge_queue_stub.yml
@@ -1,0 +1,13 @@
+on:
+  merge_group:
+
+jobs:
+  merge_group_stub_check:
+    name: ci/jenkins
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    if: ${{ github.event_name == 'merge_group' }}
+    steps:
+      - run: echo "Just a stub check to keep Jenkins running in pre-commits but not in merge queue"


### PR DESCRIPTION
Allows to keep Jenkins running in pre-commits, but not in merge queue without paralyzing queue when Jenkins is offline
