### PR TITLE
[GPU][TRANSFORMATIONS] Rope for flux

### DIFF
--- a/src/common/transformations/include/ov_ops/rotary_positional_embeddings.hpp
+++ b/src/common/transformations/include/ov_ops/rotary_positional_embeddings.hpp
@@ -23,13 +23,14 @@ public:
     struct Config {
         size_t slice_start = 0;  // slice inner-most dimensions of input
         size_t slice_stop = 0;
-        bool input_trans0213 = false;  // transpose input dim 1&2
-        bool is_interleaved = false;   // interleaved mode, implies trans0213 happens after RoPE
-        size_t rotary_ndims = 0;       // dimensions to be embedded (d in the description)
-        bool is_chatglm = false;       // chatglm is special which overrides other setting
-        bool support_2d_rope = false;  // 2d rope mode, Support 2 dimentional rope which is independant of batch and
-                                       // each head. change input order to [batch, head_cnt, 4608] to support 2d rope
-        bool is_qwen = false;          // Qwen is special which overrides other setting
+        bool input_trans0213 = false;   // transpose input dim 1&2
+        bool output_trans0213 = false;  // implies trans0213 happens after RoPE
+        bool is_interleaved = false;    // coordinates are interleaved
+        size_t rotary_ndims = 0;        // dimensions to be embedded (d in the description)
+        bool is_chatglm = false;        // chatglm is special which overrides other setting
+        bool support_2d_rope = false;   // 2d rope mode, Support 2 dimentional rope which is independant of batch and
+                                        // each head. change input order to [batch, head_cnt, 4608] to support 2d rope
+        bool is_qwen = false;           // Qwen is special which overrides other setting
         size_t head_cnt = 0;
         size_t head_size = 0;
         int gather_position_arg_id =

--- a/src/common/transformations/include/transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp
@@ -12,6 +12,7 @@ namespace pass {
 
 class TRANSFORMATIONS_API RoPEFusion;
 class TRANSFORMATIONS_API RoPEFusionGPTNEOX;
+class TRANSFORMATIONS_API RoPEFusionFlux;
 class TRANSFORMATIONS_API RoPEFusionGPTJ;
 class TRANSFORMATIONS_API RoPEFusionChatGLM;
 class TRANSFORMATIONS_API RoPEFusionQwen;
@@ -27,6 +28,12 @@ class ov::pass::RoPEFusionGPTNEOX : public ov::pass::MatcherPass {
 public:
     OPENVINO_RTTI("RoPEFusionGPTNEOX", "0");
     RoPEFusionGPTNEOX();
+};
+
+class ov::pass::RoPEFusionFlux : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("RoPEFusionFlux", "0");
+    RoPEFusionFlux();
 };
 
 class ov::pass::RoPEFusionGPTJ : public ov::pass::MatcherPass {
@@ -85,6 +92,7 @@ class ov::pass::RoPEFusion : public ov::pass::GraphRewrite {
 public:
     OPENVINO_RTTI("RoPEFusion", "0");
     RoPEFusion(bool support_2d_rope = false) {
+        add_matcher<ov::pass::RoPEFusionFlux>();
         add_matcher<ov::pass::RoPEFusionGPTNEOX>();
         add_matcher<ov::pass::RoPEFusionGPTJ>();
         // optional heads & tails are fused in separate matcher pass,

--- a/src/common/transformations/src/ov_ops/rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/ov_ops/rotary_positional_embeddings.cpp
@@ -76,7 +76,7 @@ void RoPE::validate_and_infer_types() {
     if (m_config.input_trans0213) {
         // transpose 0213 ([B,L,H,S]=>[B,H,L,S]) happens before RoPE
         std::swap(input_pshape[2], input_pshape[1]);
-    } else if (m_config.is_interleaved) {
+    } else if (m_config.output_trans0213) {
         // transpose 0213 ([B,L,H,S]=>[B,H,L,S]) happens after RoPE
         std::swap(input_pshape[2], input_pshape[1]);
     }
@@ -90,6 +90,7 @@ bool RoPE::visit_attributes(ov::AttributeVisitor& visitor) {
     visitor.on_attribute("slice_start", m_config.slice_start);
     visitor.on_attribute("slice_stop", m_config.slice_stop);
     visitor.on_attribute("input_trans0213", m_config.input_trans0213);
+    visitor.on_attribute("output_trans0213", m_config.output_trans0213);
     visitor.on_attribute("is_interleaved", m_config.is_interleaved);
     visitor.on_attribute("rotary_ndims", m_config.rotary_ndims);
     visitor.on_attribute("is_chatglm", m_config.is_chatglm);

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -392,7 +392,7 @@ void RoPE::initSupportedPrimitiveDescriptors() {
             m_executor = std::make_shared<RoPEExecutorChatGLM<float>>(m_config);
             rtPrecision = ov::element::f32;
         }
-    } else if (m_config.is_interleaved) {
+    } else if (m_config.is_interleaved && m_config.output_trans0213) {
         OPENVINO_ASSERT(m_config.input_trans0213 == false);
         OPENVINO_ASSERT(m_config.slice_start == 0);
         OPENVINO_ASSERT(m_config.slice_stop == 0);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -842,6 +842,7 @@ void Transformations::PostLpt() {
 
     CPU_REGISTER_PASS_X64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_REGISTER_PASS_ARM64(postLPTPassManager, ov::pass::RoPEFusion, true);
+    CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionFlux);
     CPU_REGISTER_PASS_X64(postLPTPassManager, CausalMaskPreprocessFusion);
 
 #if defined(OPENVINO_ARCH_X86_64)

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/rope.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/rope.hpp
@@ -43,6 +43,7 @@ struct rope : public primitive_base<rope> {
         seed = hash_combine(seed, config.input_trans0213);
         seed = hash_combine(seed, config.is_chatglm);
         seed = hash_combine(seed, config.support_2d_rope);
+        seed = hash_combine(seed, config.output_trans0213);
         seed = hash_combine(seed, config.is_interleaved);
         seed = hash_combine(seed, config.is_qwen);
         seed = hash_combine(seed, config.rotary_ndims);
@@ -64,6 +65,7 @@ struct rope : public primitive_base<rope> {
                config.input_trans0213 == rhs_casted.config.input_trans0213 &&
                config.is_chatglm == rhs_casted.config.is_chatglm &&
                config.support_2d_rope == rhs_casted.config.support_2d_rope &&
+               config.output_trans0213 == rhs_casted.config.output_trans0213 &&
                config.is_interleaved == rhs_casted.config.is_interleaved &&
                config.is_qwen == rhs_casted.config.is_qwen &&
                config.rotary_ndims == rhs_casted.config.rotary_ndims &&
@@ -80,6 +82,7 @@ struct rope : public primitive_base<rope> {
         ob << config.input_trans0213;
         ob << config.is_chatglm;
         ob << config.support_2d_rope;
+        ob << config.output_trans0213;
         ob << config.is_interleaved;
         ob << config.is_qwen;
         ob << config.rotary_ndims;
@@ -96,6 +99,7 @@ struct rope : public primitive_base<rope> {
         ib >> config.input_trans0213;
         ib >> config.is_chatglm;
         ib >> config.support_2d_rope;
+        ib >> config.output_trans0213;
         ib >> config.is_interleaved;
         ib >> config.is_qwen;
         ib >> config.rotary_ndims;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/rope.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/rope.cpp
@@ -45,7 +45,7 @@ struct rope_impl : typed_primitive_impl_ocl<rope> {
         params.slice_stop = primitive->config.slice_stop;
 
         params.axis = primitive->config.is_qwen || primitive->config.is_chatglm ? 2 : 3;
-        params.num_of_inputs = primitive->config.is_chatglm || primitive->config.is_interleaved ? 2 : 3;
+        params.num_of_inputs = primitive->config.is_chatglm || (primitive->config.output_trans0213 && primitive->config.is_interleaved)  ? 2 : 3;
 
         if (params.gather_rank > 0) {
             params.num_of_inputs++;
@@ -53,6 +53,7 @@ struct rope_impl : typed_primitive_impl_ocl<rope> {
 
         params.is_qwen = primitive->config.is_qwen;
         params.is_chatglm = primitive->config.is_chatglm;
+        params.is_interleaved = primitive->config.is_interleaved;
         params.support_2d_rope = primitive->config.support_2d_rope;
         params.transposed_input = primitive->config.input_trans0213;
 

--- a/src/plugins/intel_gpu/src/graph/rope.cpp
+++ b/src/plugins/intel_gpu/src/graph/rope.cpp
@@ -54,7 +54,7 @@ std::vector<layout> rope_inst::calc_output_layouts(rope_node const& node, kernel
             output_shape[3] = input_slice_size;
         }
 
-        if (desc->config.input_trans0213 || desc->config.is_interleaved) {
+        if (desc->config.input_trans0213 || desc->config.output_trans0213) {
             std::swap(output_shape[2], output_shape[1]);
         }
     }
@@ -77,6 +77,7 @@ std::string rope_inst::to_string(rope_node const& node) {
     rope_info.add("input_trans0213", desc->config.input_trans0213);
     rope_info.add("is_chatglm", desc->config.is_chatglm);
     rope_info.add("support_2d_rope", desc->config.support_2d_rope);
+    rope_info.add("output_trans0213", desc->config.output_trans0213);
     rope_info.add("is_interleaved", desc->config.is_interleaved);
     rope_info.add("is_qwen", desc->config.is_qwen);
     rope_info.add("rotary_ndims", desc->config.rotary_ndims);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.cpp
@@ -51,6 +51,8 @@ JitConstants RoPEKernelBase::GetJitConstants(const rope_params& params, RoPEKern
             jit.AddConstant(MakeJitConstant("SUPPORT_2D_ROPE", true));
         }
         jit.AddConstant(MakeJitConstant("CHATGLM", true));
+    } else if (params.is_interleaved) {
+        jit.AddConstant(MakeJitConstant("RotateInterleaved", true));
     } else {
         jit.AddConstant(MakeJitConstant("RotateHalf", true));
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rope/rope_kernel_base.h
@@ -24,6 +24,7 @@ struct rope_params : public base_params {
 
     bool is_qwen = false;
     bool is_chatglm = false;
+    bool is_interleaved = false;
     bool support_2d_rope = false;
     bool transposed_input = false;
 };

--- a/src/plugins/intel_gpu/src/plugin/ops/rope.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/rope.cpp
@@ -29,6 +29,8 @@ static void CreateRoPEOp(ProgramBuilder& p, const std::shared_ptr<op::internal::
         gather_rank = op->get_input_partial_shape(config.gather_position_arg_id).size();
     }
 
+    OPENVINO_ASSERT(!config.is_interleaved || !config.output_trans0213, "[GPU] Unsupported ROPE parameters");
+
     auto rope = cldnn::rope(layer_type_name_ID(op),
                             inputs,
                             config,

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/rotary_pos_emb.cpp
@@ -7,6 +7,11 @@
 namespace ov {
 namespace test {
 
+INSTANTIATE_TEST_SUITE_P(smoke_RoPETestFlux,
+                         RoPETestFlux,
+                         ::testing::Values(ov::test::utils::DEVICE_GPU),
+                         RoPETestFlux::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(smoke_RoPETestChatGLM,
                          RoPETestChatGLMStridedSlice,
                          ::testing::Values(ov::test::utils::DEVICE_GPU),

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/rotary_pos_emb.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/rotary_pos_emb.hpp
@@ -24,6 +24,13 @@ inline void CheckNumberOfNodesWithType(std::shared_ptr<const ov::Model> function
     ASSERT_EQ(num_ops, expectedCount);
 }
 
+TEST_P(RoPETestFlux, CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
+    run();
+    auto function = compiledModel.get_runtime_model();
+    CheckNumberOfNodesWithType(function, {"RoPE"}, 1);
+};
+
 TEST_P(RoPETestLlama2StridedSlice, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/rotary_pos_emb.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/rotary_pos_emb.hpp
@@ -9,6 +9,20 @@
 namespace ov {
 namespace test {
 
+class RoPETestFlux : public SubgraphBaseTest, public testing::WithParamInterface<std::string> {
+private:
+    std::shared_ptr<ov::Model> build_rope_flux(int batch,
+                                               int seq_length,
+                                               int num_head,
+                                               int ndims);
+protected:
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+    void SetUp() override;
+
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<std::string>& obj);
+};
+
 class RoPETestLlama2StridedSlice : public SubgraphBaseTest, public testing::WithParamInterface<std::string> {
 private:
     std::shared_ptr<ov::Model> buildROPE_Llama2(int batch,


### PR DESCRIPTION
### Details:
 - Enabled ROPE op fusion for flux.1 model on GPU to improve the performance
 - New mode for RoPE is added which enables the case when coordinates and angles are interleaved and sin/cos tables are separate inputs. It's activated when `is_interleaved=true` and `output_trans0213=false`

