### PR TITLE
Update genai-guide-npu.rst

### DIFF
--- a/docs/articles_en/learn-openvino/llm_inference_guide/genai-guide-npu.rst
+++ b/docs/articles_en/learn-openvino/llm_inference_guide/genai-guide-npu.rst
@@ -43,7 +43,7 @@ You select one of the methods by setting the ``--group-size`` parameter to eithe
       .. code-block:: console
          :name: group-quant
 
-         optimum-cli export openvino -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 --weight-format int4 --sym --ratio 1.0 --group_size 128 TinyLlama-1.1B-Chat-v1.0
+         optimum-cli export openvino -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 --weight-format int4 --sym --ratio 1.0 --group-size 128 TinyLlama-1.1B-Chat-v1.0
 
    .. tab-item:: Channel-wise quantization
 


### PR DESCRIPTION
Rename group_size used with optimum-cli during model export.

### Details:
 - The parameter group_size needs to be changed to group-size. Using group_size gives error 'unrecognized argument'
 - Ref: https://github.com/huggingface/optimum-intel/blob/6a3b1ba5924b0b017b0b0f5de5b10adb77095b84/docs/source/openvino/export.mdx#L37