### PR TITLE
[GPU] Enable weightless cache with precision conversion

### DIFF
--- a/src/core/dev_api/openvino/core/rt_info/weightless_caching_attributes.hpp
+++ b/src/core/dev_api/openvino/core/rt_info/weightless_caching_attributes.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "openvino/core/core_visibility.hpp"
+#include "openvino/core/node.hpp"
 #include "openvino/core/runtime_attribute.hpp"
 
 namespace ov {
@@ -25,14 +26,19 @@ public:
 
     WeightlessCacheAttribute() = delete;
 
-    WeightlessCacheAttribute(size_t original_size, size_t bin_offset)
+    WeightlessCacheAttribute(size_t original_size, size_t bin_offset, ov::element::Type original_dtype)
         : original_size(original_size),
-          bin_offset(bin_offset) {}
+          bin_offset(bin_offset),
+          original_dtype(original_dtype),
+          curr_dtype(original_dtype) {}
 
     bool is_copyable() const override;
+    bool is_copyable(const std::shared_ptr<Node>& from, const std::shared_ptr<Node>& to) const override;
 
     size_t original_size;
     size_t bin_offset;
+    ov::element::Type original_dtype;
+    ov::element::Type curr_dtype;
 };
 
 }  // namespace ov

--- a/src/core/include/openvino/core/runtime_attribute.hpp
+++ b/src/core/include/openvino/core/runtime_attribute.hpp
@@ -31,6 +31,7 @@ public:
     virtual ~RuntimeAttribute() = default;
     virtual bool is_copyable() const;
     virtual bool is_copyable(const std::shared_ptr<Node>& to) const;
+    virtual bool is_copyable(const std::shared_ptr<Node>& from, const std::shared_ptr<Node>& to) const;
     virtual Any init(const std::shared_ptr<Node>& node) const;
     virtual Any merge(const ov::NodeVector& nodes) const;
     virtual Any merge(const ov::OutputVector& outputs) const;

--- a/src/core/src/op/util/weightless_caching_attributes.cpp
+++ b/src/core/src/op/util/weightless_caching_attributes.cpp
@@ -3,7 +3,17 @@
 //
 
 #include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+#include "openvino/op/util/op_types.hpp"
 
 bool ov::WeightlessCacheAttribute::is_copyable() const {
     return false;
+}
+
+bool ov::WeightlessCacheAttribute::is_copyable(const std::shared_ptr<ov::Node>& from,
+                                               const std::shared_ptr<ov::Node>& to) const {
+    if (!ov::op::util::is_constant(from) || !ov::op::util::is_constant(to)) {
+        return false;
+    }
+
+    return from->get_element_type() != to->get_element_type();
 }

--- a/src/core/src/rt_info.cpp
+++ b/src/core/src/rt_info.cpp
@@ -32,7 +32,7 @@ std::unordered_map<std::string, std::vector<ov::Any>> get_copyable_attrs(const o
         for (const auto& item : node->get_rt_info()) {
             bool copy = item.first != "opset";
             if (item.second.is<ov::RuntimeAttribute>()) {
-                copy = copy && item.second.as<ov::RuntimeAttribute>().is_copyable(to);
+                copy = copy && item.second.as<ov::RuntimeAttribute>().is_copyable(node, to);
             }
             if (copy) {
                 attrs[item.first].push_back(item.second);

--- a/src/core/src/runtime_attribute.cpp
+++ b/src/core/src/runtime_attribute.cpp
@@ -36,6 +36,10 @@ bool RuntimeAttribute::is_copyable(const std::shared_ptr<Node>& to) const {
     return is_copyable();
 }
 
+bool RuntimeAttribute::is_copyable(const std::shared_ptr<Node>& from, const std::shared_ptr<Node>& to) const {
+    return is_copyable(to);
+}
+
 std::ostream& operator<<(std::ostream& os, const RuntimeAttribute& attrubute) {
     return os << attrubute.to_string();
 }

--- a/src/frontends/ir/src/ir_deserializer.cpp
+++ b/src/frontends/ir/src/ir_deserializer.cpp
@@ -947,10 +947,12 @@ std::shared_ptr<ov::Node> ov::XmlDeserializer::create_node(const std::vector<ov:
         }
         const auto size = dn.attribute("size");
         const auto offset = dn.attribute("offset");
-        if (size && offset) {
+        const auto element_type = dn.attribute("element_type");
+        if (size && offset && element_type) {
             rtInfo[ov::WeightlessCacheAttribute::get_type_info_static()] =
                 ov::WeightlessCacheAttribute(static_cast<size_t>(pugixml::get_uint64_attr(dn, "size")),
-                                             static_cast<size_t>(pugixml::get_uint64_attr(dn, "offset")));
+                                             static_cast<size_t>(pugixml::get_uint64_attr(dn, "offset")),
+                                             ov::element::Type(pugixml::get_str_attr(dn, "element_type")));
         }
     }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -4,14 +4,161 @@
 
 #pragma once
 #include <climits>
+#include <algorithm>
 
 #include "intel_gpu/runtime/engine.hpp"
 #include "intel_gpu/runtime/memory.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/util/op_types.hpp"
+#include "openvino/pass/manager.hpp"
 #include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/util/mmap_object.hpp"
 #include "primitive.hpp"
+#include "transformations/convert_precision.hpp"
 
 namespace cldnn {
+
+struct weights_mem {
+    std::shared_ptr<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>> shared_buf = nullptr;
+    std::shared_ptr<ov::op::v0::Constant> transformed_constant = nullptr;
+
+    const uint8_t* get_loaded_data() {
+        if (transformed_constant) {
+            return reinterpret_cast<const uint8_t*>(transformed_constant->get_data_ptr());
+        }
+        OPENVINO_ASSERT(shared_buf);
+        return shared_buf->get_ptr<uint8_t>();
+    }
+};
+
+struct weightless_cache_manager {
+    void set_constant_info(size_t bin_offset,
+                           size_t original_size,
+                           ov::element::Type original_dtype,
+                           ov::element::Type curr_dtype) {
+        this->bin_offset = bin_offset;
+        this->original_size = original_size;
+        this->original_dtype = original_dtype;
+        this->curr_dtype = curr_dtype;
+        do_weightless_caching = true;
+
+        if (original_dtype != curr_dtype) {
+            do_precision_conversion = true;
+        }
+    }
+
+    void invalidate() {
+        do_weightless_caching = false;
+    }
+
+    void set_new_dtype(ov::element::Type curr_dtype) {
+        this->curr_dtype = curr_dtype;
+        do_precision_conversion = original_dtype != curr_dtype;
+    }
+
+    bool save(BinaryOutputBuffer& ob, size_t data_size) const {
+        if (!do_weightless_caching) {
+            ob << false;
+            return false;
+        }
+
+        ob << true;
+        ob << bin_offset;
+        ob << do_precision_conversion;
+        if (do_precision_conversion) {
+            ob << original_size;
+            ob << make_data(&original_dtype, sizeof(ov::element::Type));
+            ob << make_data(&curr_dtype, sizeof(ov::element::Type));
+        }
+        return true;
+    }
+
+    std::shared_ptr<weights_mem> load(BinaryInputBuffer& ib,
+                                      std::shared_ptr<ov::MappedMemory> mapped_weights,
+                                      size_t data_size) {
+        ib >> do_weightless_caching;
+        if (!do_weightless_caching) {
+            return nullptr;
+        }
+
+        OPENVINO_ASSERT(mapped_weights != nullptr, "mmap object is null");
+
+        ib >> bin_offset;
+        ib >> do_precision_conversion;
+        if (do_precision_conversion) {
+            ib >> original_size;
+            ib >> make_data(&original_dtype, sizeof(ov::element::Type));
+            ib >> make_data(&curr_dtype, sizeof(ov::element::Type));
+        } else {
+            original_size = data_size;
+        }
+
+        auto mem_obj = std::make_shared<weights_mem>();
+        mem_obj->shared_buf = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
+            mapped_weights->data() + bin_offset,
+            original_size,
+            mapped_weights);
+
+        if (should_run_transformations()) {
+            run_transformations(mem_obj);
+        }
+        return mem_obj;
+    }
+
+private:
+    bool do_weightless_caching = false;
+    bool do_precision_conversion = false;
+
+    size_t bin_offset = SIZE_MAX;
+    size_t original_size = SIZE_MAX;
+    ov::element::Type original_dtype = ov::element::Type_t::undefined;
+    ov::element::Type curr_dtype = ov::element::Type_t::undefined;
+
+    bool should_run_transformations() {
+        return do_precision_conversion;
+    }
+
+    void run_transformations(std::shared_ptr<weights_mem> mem_obj) {
+        size_t num_elems = original_size / original_dtype.size();
+        ov::Shape shape({num_elems});
+        auto orig_constant =
+            std::make_shared<ov::op::v0::Constant>(original_dtype, shape, mem_obj->shared_buf);
+
+        ov::ParameterVector inputParams;
+        ov::ResultVector results;
+        results.push_back(std::make_shared<ov::op::v0::Result>(orig_constant->output(0)));
+        auto model = std::make_shared<ov::Model>(results, inputParams, "aux");
+
+        ov::pass::Manager manager("Plugin:GPU:weightless_cache_transformations");
+
+        if (do_precision_conversion) {
+            precisions_map fp_convert_precision_map = {
+                {original_dtype, curr_dtype}};
+            type_to_fuse_map empty_fuse_map = {};
+            const bool keep_precision_sensitive_in_fp32 = false;
+            const bool convert_input_output_precision = false;
+            const bool store_original_precision_as_rt_attribute = true;
+            manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
+                                                              empty_fuse_map,
+                                                              keep_precision_sensitive_in_fp32,
+                                                              convert_input_output_precision,
+                                                              store_original_precision_as_rt_attribute);
+        }
+
+        manager.run_passes(model);
+        const auto ops = model->get_ops();
+        OPENVINO_ASSERT(std::count_if(ops.begin(), ops.end(), [](const std::shared_ptr<ov::Node>& node) {
+                return ov::op::util::is_constant(node);
+            }) == 1);
+        for (auto& op : model->get_ops()) {
+            if (mem_obj->transformed_constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(op)) {
+                break;
+            }
+        }
+        OPENVINO_ASSERT(mem_obj->transformed_constant);
+        OPENVINO_ASSERT(mem_obj->transformed_constant->get_element_type() == curr_dtype);
+    }
+};
 
 /// @brief Provides input data to topology.
 /// @details This primitive allows to pass data which is known at topology creation.
@@ -20,21 +167,32 @@ namespace cldnn {
 struct data : public primitive_base<data> {
     CLDNN_DECLARE_PRIMITIVE(data)
 
-    data() : primitive_base("", {}) {}
+    data() : primitive_base("", {}) {
+        cache_info = std::make_shared<weightless_cache_manager>();
+    }
 
     /// @brief Constructs data primitive.
     /// @param id This primitive id.
     /// @param mem @ref memory object which contains data.
     /// @note If memory is attached by memory::attach(), the attached buffer should be valid till network build.
-    data(const primitive_id& id, memory::ptr mem)
-        : primitive_base(id, {}), mem(std::move(mem)) {}
+    data(const primitive_id& id, memory::ptr mem) : primitive_base(id, {}), mem(std::move(mem)) {
+        cache_info = std::make_shared<weightless_cache_manager>();
+    }
+
+    data(const primitive_id& id, memory::ptr mem, std::shared_ptr<weightless_cache_manager> cache_info)
+        : primitive_base(id, {}),
+          mem(std::move(mem)),
+          cache_info(cache_info) {
+        if (!cache_info) {
+            this->cache_info = std::make_shared<weightless_cache_manager>();
+        }
+    }
 
     /// @brief @ref memory object which contains data.
     /// @note If memory is attached by memory::attach(), the attached buffer should be valid till network build.
     memory::ptr mem;
 
-    size_t original_size = SIZE_MAX;
-    size_t bin_offset = SIZE_MAX;
+    std::shared_ptr<weightless_cache_manager> cache_info;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
@@ -53,13 +211,8 @@ struct data : public primitive_base<data> {
         size_t data_size = mem->size();
         ob << make_data(&data_size, sizeof(size_t));
 
-        bool is_cache_without_weights = bin_offset != SIZE_MAX && data_size == original_size;
-
-        if (is_cache_without_weights) {
-            ob << true;
-            ob << bin_offset;
-        } else {
-            ob << false;
+        bool do_weightless_caching = cache_info->save(ob, data_size);
+        if (!do_weightless_caching) {
             if (_allocation_type == allocation_type::usm_host || _allocation_type == allocation_type::usm_shared) {
                 ob << make_data(mem->buffer_ptr(), data_size);
             } else {
@@ -88,26 +241,16 @@ struct data : public primitive_base<data> {
 
         mem = ib.get_engine().allocate_memory(output_layout, _allocation_type, false);
 
-        bool is_cache_without_weights;
-        ib >> is_cache_without_weights;
-        if (is_cache_without_weights && mapped_weights == nullptr) {
-            OPENVINO_THROW("mmap object is null");
-        }
-
-        std::shared_ptr<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>> shared_buf;
-        if (is_cache_without_weights) {
-            ib >> bin_offset;
-            original_size = data_size;
-
-            shared_buf = std::make_shared<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>(
-                mapped_weights->data() + bin_offset,
-                data_size,
-                mapped_weights);
+        auto mem_obj = cache_info->load(ib, mapped_weights, data_size);
+        bool is_weightless_caching_enabled = mem_obj != nullptr;
+        const uint8_t* loaded_data;
+        if (is_weightless_caching_enabled) {
+            loaded_data = mem_obj->get_loaded_data();
         }
 
         if (_allocation_type == allocation_type::usm_host || _allocation_type == allocation_type::usm_shared) {
-            if (is_cache_without_weights) {
-                std::memcpy(reinterpret_cast<uint8_t*>(mem->buffer_ptr()), shared_buf->get_ptr<uint8_t>(), data_size);
+            if (is_weightless_caching_enabled) {
+                std::memcpy(reinterpret_cast<uint8_t*>(mem->buffer_ptr()), loaded_data, data_size);
             } else {
                 ib >> make_data(mem->buffer_ptr(), data_size);
             }
@@ -116,8 +259,8 @@ struct data : public primitive_base<data> {
             auto& strm = ib.get_engine().get_service_stream();
             if (data_size < DATA_BLOCK_SIZE || output_layout.format.is_image_2d()) {
                 std::vector<uint8_t> _buf(data_size);
-                if (is_cache_without_weights) {
-                    std::memcpy(reinterpret_cast<uint8_t*>(_buf.data()), shared_buf->get_ptr<uint8_t>(), data_size);
+                if (is_weightless_caching_enabled) {
+                    std::memcpy(reinterpret_cast<uint8_t*>(_buf.data()), loaded_data, data_size);
                 } else {
                     ib >> make_data(_buf.data(), data_size);
                 }
@@ -135,10 +278,8 @@ struct data : public primitive_base<data> {
                     size_t copy_size =
                         (data_size > (dst_offset + DATA_BLOCK_SIZE)) ? DATA_BLOCK_SIZE : (data_size - dst_offset);
                     if (buf_flag) {
-                        if (is_cache_without_weights) {
-                            std::memcpy(reinterpret_cast<uint8_t*>(_buf1.data()),
-                                        shared_buf->get_ptr<uint8_t>() + dst_offset,
-                                        copy_size);
+                        if (is_weightless_caching_enabled) {
+                            std::memcpy(reinterpret_cast<uint8_t*>(_buf1.data()), loaded_data + dst_offset, copy_size);
                         } else {
                             ib >> make_data(_buf1.data(), copy_size);
                         }
@@ -148,10 +289,8 @@ struct data : public primitive_base<data> {
                         }
                         ev1 = mem->copy_from(strm, _buf1.data(), src_offset, dst_offset, copy_size, is_blocking);
                     } else {
-                        if (is_cache_without_weights) {
-                            std::memcpy(reinterpret_cast<uint8_t*>(_buf2.data()),
-                                        shared_buf->get_ptr<uint8_t>() + dst_offset,
-                                        copy_size);
+                        if (is_weightless_caching_enabled) {
+                            std::memcpy(reinterpret_cast<uint8_t*>(_buf2.data()), loaded_data + dst_offset, copy_size);
                         } else {
                             ib >> make_data(_buf2.data(), copy_size);
                         }

--- a/src/plugins/intel_gpu/src/graph/include/pass_manager.h
+++ b/src/plugins/intel_gpu/src/graph/include/pass_manager.h
@@ -205,9 +205,10 @@ public:
 
 private:
     void run(program& p) override;
-    std::list<std::pair<primitive_id, memory::ptr>> calculate(engine& engine,
-                                                              const ExecutionConfig& config,
-                                                              std::shared_ptr<ov::threading::IStreamsExecutor> task_executor);
+    std::list<std::tuple<primitive_id, memory::ptr, std::shared_ptr<weightless_cache_manager>, std::shared_ptr<layout>>>
+    calculate(engine& engine,
+              const ExecutionConfig& config,
+              std::shared_ptr<ov::threading::IStreamsExecutor> task_executor);
     bool has_non_const_user(program_node& node) const;
     void handle_constant(program& prog, program_node& node);
     void add_constant(program& prog, program_node& node);

--- a/src/plugins/intel_gpu/src/plugin/program_builder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/program_builder.cpp
@@ -8,9 +8,11 @@
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/op/lstm_cell.hpp"
 #include "openvino/op/loop.hpp"
+#include "transformations/rt_info/original_precision_attribute.hpp"
 
 #include "intel_gpu/plugin/common_utils.hpp"
 #include "intel_gpu/plugin/program_builder.hpp"
+#include "intel_gpu/primitives/data.hpp"
 #include "intel_gpu/runtime/itt.hpp"
 #include "intel_gpu/runtime/debug_configuration.hpp"
 #include "intel_gpu/primitives/mutable_data.hpp"
@@ -308,11 +310,14 @@ void ProgramBuilder::add_primitive(const ov::Node& op, std::shared_ptr<cldnn::pr
     if (this->m_config.get_property(ov::cache_mode) == ov::CacheMode::OPTIMIZE_SIZE) {
         if (auto data_prim = dynamic_cast<cldnn::data*>(prim.get())) {
             auto rt_info = op.get_rt_info();
+
             auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
             if (weightless_cache_attr != rt_info.end()) {
-                data_prim->bin_offset = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().bin_offset;
-                data_prim->original_size =
-                    weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>().original_size;
+                auto& attr = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>();
+                data_prim->cache_info->set_constant_info(attr.bin_offset,
+                                                         attr.original_size,
+                                                         attr.original_dtype,
+                                                         op.get_element_type());
             }
         }
     }

--- a/src/plugins/intel_gpu/tests/functional/behavior/model_cache.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/model_cache.cpp
@@ -3,53 +3,46 @@
 //
 
 #include <cstdio>
+#include <experimental/filesystem>
 
 #include "base/ov_behavior_test_utils.hpp"
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/file_utils.hpp"
 #include "common_test_utils/ov_tensor_utils.hpp"
-#include "common_test_utils/subgraph_builders/2_input_subtract.hpp"
-#include "common_test_utils/subgraph_builders/concat_with_params.hpp"
-#include "common_test_utils/subgraph_builders/conv_bias.hpp"
-#include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
-#include "common_test_utils/subgraph_builders/conv_pool_relu_no_reshapes.hpp"
-#include "common_test_utils/subgraph_builders/conv_pool_relu_non_zero.hpp"
-#include "common_test_utils/subgraph_builders/convert_transpose.hpp"
-#include "common_test_utils/subgraph_builders/detection_output.hpp"
-#include "common_test_utils/subgraph_builders/kso_func.hpp"
-#include "common_test_utils/subgraph_builders/matmul_bias.hpp"
-#include "common_test_utils/subgraph_builders/multi_single_conv.hpp"
-#include "common_test_utils/subgraph_builders/multiple_input_outpput_double_concat.hpp"
-#include "common_test_utils/subgraph_builders/nested_branch_conv_concat.hpp"
-#include "common_test_utils/subgraph_builders/nested_split_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/read_concat_split_assign.hpp"
 #include "common_test_utils/subgraph_builders/single_concat_with_constant.hpp"
-#include "common_test_utils/subgraph_builders/single_conv.hpp"
-#include "common_test_utils/subgraph_builders/single_split.hpp"
-#include "common_test_utils/subgraph_builders/split_concat.hpp"
-#include "common_test_utils/subgraph_builders/split_conv_concat.hpp"
-#include "common_test_utils/subgraph_builders/split_multi_conv_concat.hpp"
 #include "common_test_utils/subgraph_builders/ti_with_lstm_cell.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/pass/serialize.hpp"
 
 namespace {
-class CheckWeightlessCacheAccuracy : public ::testing::Test,
-                                     public ::testing::WithParamInterface<bool> {
+typedef std::tuple<bool, ov::element::Type, ov::element::Type> testParams;
+
+class CheckWeightlessCacheAccuracy : public ::testing::Test, public ::testing::WithParamInterface<testParams> {
 public:
-    static std::string get_test_case_name(::testing::TestParamInfo<bool> obj) {
-        bool use_compile_model_api = obj.param;
+    static std::string get_test_case_name(::testing::TestParamInfo<testParams> obj) {
+        bool use_compile_model_api_;
+        ov::element::Type inference_mode_;
+        ov::element::Type model_dtype_;
+        std::tie(use_compile_model_api_, inference_mode_, model_dtype_) = obj.param;
 
         std::ostringstream result;
-        result << "use_compile_model_api=" << use_compile_model_api;
+        const char separator = '_';
+        result << "use_compile_model_api=" << use_compile_model_api_ << separator;
+        result << "inference_mode=" << inference_mode_ << separator;
+        result << "model_dtype=" << model_dtype_;
         return result.str();
     }
+
 protected:
     std::shared_ptr<ov::Model> model;
     std::string xml_path;
     std::string bin_path;
     std::string cache_path;
-    bool use_compile_model_api; // for loading from cache
+    std::string cache_dir;
+    bool use_compile_model_api;  // for loading from cache
+    ov::element::Type inference_mode;
+    ov::element::Type model_dtype;
 
     void SetUp() override;
     void TearDown() override;
@@ -61,36 +54,43 @@ void CheckWeightlessCacheAccuracy::SetUp() {
     xml_path = filePrefix + ".xml";
     bin_path = filePrefix + ".bin";
     cache_path = filePrefix + ".blob";
-    use_compile_model_api = GetParam();
+    cache_dir = filePrefix + "_cache_dir";
+
+    std::tie(use_compile_model_api, inference_mode, model_dtype) = GetParam();
 }
 
 void CheckWeightlessCacheAccuracy::TearDown() {
     std::remove(xml_path.c_str());
     std::remove(bin_path.c_str());
     std::remove(cache_path.c_str());
+    std::experimental::filesystem::remove_all(cache_dir);
 }
 
 void CheckWeightlessCacheAccuracy::run() {
-    ov::AnyMap config = { ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE) };
-    ov::AnyMap config_with_weights_path = { ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE), ov::weights_path(bin_path) };
+    ov::AnyMap config = {ov::cache_dir(cache_dir),
+                         ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
+                         ov::hint::inference_precision(inference_mode)};
+    ov::AnyMap config_with_weights_path = {ov::cache_mode(ov::CacheMode::OPTIMIZE_SIZE),
+                                           ov::weights_path(bin_path),
+                                           ov::hint::inference_precision(inference_mode)};
     auto core = ov::test::utils::PluginCache::get().core();
     ov::pass::Serialize(xml_path, bin_path).run_on_model(model);
 
     ov::CompiledModel compiled_model;
-    OV_ASSERT_NO_THROW(compiled_model = core->compile_model(xml_path, ov::test::utils::DEVICE_GPU, config));
+    compiled_model = core->compile_model(xml_path, ov::test::utils::DEVICE_GPU, config);
 
-    auto ofstr = std::ofstream(cache_path, std::ofstream::binary);
-    OV_ASSERT_NO_THROW(compiled_model.export_model(ofstr));
-    ofstr.close();
+    if (!use_compile_model_api) {
+        auto ofstr = std::ofstream(cache_path, std::ofstream::binary);
+        compiled_model.export_model(ofstr);
+        ofstr.close();
+    }
 
     auto ifstr = std::ifstream(cache_path, std::ifstream::binary);
     ov::CompiledModel imported_model;
     if (use_compile_model_api) {
-        OV_ASSERT_NO_THROW(imported_model =
-                               core->compile_model(xml_path, ov::test::utils::DEVICE_GPU, config));
+        imported_model = core->compile_model(xml_path, ov::test::utils::DEVICE_GPU, config);
     } else {
-        OV_ASSERT_NO_THROW(imported_model =
-                               core->import_model(ifstr, ov::test::utils::DEVICE_GPU, config_with_weights_path));
+        imported_model = core->import_model(ifstr, ov::test::utils::DEVICE_GPU, config_with_weights_path);
     }
     ifstr.close();
 
@@ -99,39 +99,57 @@ void CheckWeightlessCacheAccuracy::run() {
 
     for (size_t param_idx = 0; param_idx < model->get_parameters().size(); ++param_idx) {
         auto input = model->get_parameters().at(param_idx);
-        auto tensor = ov::test::utils::create_and_fill_tensor(input->get_element_type(), input->get_shape());
+        auto tensor = ov::test::utils::create_and_fill_tensor_real_distribution(input->get_element_type(),
+                                                                                input->get_shape(),
+                                                                                -100,
+                                                                                100,
+                                                                                param_idx);
         orig_req.set_tensor(input, tensor);
         new_req.set_tensor(input, tensor);
     }
 
-    OV_ASSERT_NO_THROW(orig_req.infer());
-    OV_ASSERT_NO_THROW(new_req.infer());
+    orig_req.infer();
+    new_req.infer();
 
     auto result_vector = model->get_results();
     for (auto& res : result_vector) {
         auto orig_out = orig_req.get_tensor(res);
         auto new_out = new_req.get_tensor(res);
-        ov::test::utils::compare(orig_out, new_out);
+        ov::test::utils::compare(orig_out, new_out, inference_mode);
     }
 }
 
 TEST_P(CheckWeightlessCacheAccuracy, ReadConcatSplitAssign) {
-    model = ov::test::utils::make_read_concat_split_assign({1, 1, 2, 4}, ov::element::f16);
-    run();
+    OV_ASSERT_NO_THROW(model = ov::test::utils::make_read_concat_split_assign({1, 1, 2, 4}, model_dtype));
+    OV_ASSERT_NO_THROW(run());
 }
 
 TEST_P(CheckWeightlessCacheAccuracy, SingleConcatWithConstant) {
-    model = ov::test::utils::make_single_concat_with_constant({1, 1, 2, 4}, ov::element::f16);
-    run();
+    OV_ASSERT_NO_THROW(model = ov::test::utils::make_single_concat_with_constant({1, 1, 2, 4}, model_dtype));
+    OV_ASSERT_NO_THROW(run());
 }
 
 TEST_P(CheckWeightlessCacheAccuracy, TiWithLstmCell) {
-    model = ov::test::utils::make_ti_with_lstm_cell(ov::element::f16);
-    run();
+    OV_ASSERT_NO_THROW(model = ov::test::utils::make_ti_with_lstm_cell(model_dtype));
+    OV_ASSERT_NO_THROW(run());
 }
 
-INSTANTIATE_TEST_SUITE_P(smoke_CheckWeightlessCacheAccuracy, CheckWeightlessCacheAccuracy,
-                         ::testing::Bool(),
+const std::vector<ov::element::Type> inference_modes = {
+    ov::element::f32,
+    ov::element::f16,
+};
+
+const std::vector<ov::element::Type> model_dtypes = {
+    ov::element::f32,
+    ov::element::f16,
+    ov::element::bf16,
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_CheckWeightlessCacheAccuracy,
+                         CheckWeightlessCacheAccuracy,
+                         ::testing::Combine(::testing::Bool(),
+                                            ::testing::ValuesIn(inference_modes),
+                                            ::testing::ValuesIn(model_dtypes)),
                          CheckWeightlessCacheAccuracy::get_test_case_name);
 
 }  // namespace

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/eltwise_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/eltwise_si_test.cpp
@@ -23,11 +23,11 @@ using namespace ov;
 namespace shape_infer_tests {
 
 struct eltwise_test_params {
-    layout input1_layout;
-    layout input2_layout;
+    cldnn::layout input1_layout;
+    cldnn::layout input2_layout;
     eltwise_mode mode;
     AutoBroadcastSpec auto_broadcast_spec;
-    layout expected_layout;
+    cldnn::layout expected_layout;
     std::vector<tensor> stride;
 };
 


### PR DESCRIPTION
### Details:
This change makes constants which undergo precision conversion during transformation pipeline or graph optimization eligible for weightless caching. Information about precision conversion which happened before export to cache is recorded in the cache file. During the import from cache, functionally equivalent conversions are performed.

Besides the unit tests in model_cache.cpp I tested accuracy and performance of llama-2-7b-chat with FP16 inference mode. Performance impact (weightless caching is OPTIMIZE_SIZE):

   | OPTIMIZE_SPEED | OPTIMIZE_SIZE
-- | -- | --
FP16 model import no cache | 25.4 s | 13.6 s
FP16 model import cache exists | 6.2 s | 6.4 s
FP32 model import no cache | 57.6 | 45.8 s
FP32 model import cache exists | 8.5 s | 15.2 s

Model import time is the measurement of from_pretrained() call when running the llama model with openvino.genai/tools/llm_bench tool.

Question to reviewers: I'm unsure if the condition in ov::WeightlessCacheAttribute::is_copyable() is not too lenient. Specifically, I'm thinking of a scenario where a single complex transformation changes constant's data type AND something else at the same time. This would render the constant eligible for weightless caching even though the reconstruction of transformations during the cache load is not aware of anything besides the data type change (which would break the feature). Does such complex transformation exist?

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-157081
