### PR TITLE
[GPU] Set fc format to bfyx when its spatial pitches are not one

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -82,7 +82,9 @@ format::type get_preferred_format(fully_connected_node const& node, const kernel
     // "is_batch_after_spatial" should return true)
     if (data_type_traits::is_floating_point(input_layout.data_type) &&
         input_layout.format == format::bfyx &&
-        input_layout.batch() > 1)
+        input_layout.batch() > 1 &&
+        input_pitches[2] == 1 &&
+        input_pitches[3] == 1)
         return format::yxfb;
 
     return format::bfyx;

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -148,4 +148,19 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMul_fc_fb_io_block_f16, GPUMatMulLayerTest,
                 ::testing::Values(ov::test::utils::DEVICE_GPU),
                 ::testing::Values(additional_config)),
         MatMulLayerTest::getTestCaseName);
+
+std::vector<std::vector<ov::Shape>> fc4d_shapeRelatedParams = {
+        { {16, 16, 16, 576}, {576, 1728} },
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMul_fc4d, GPUMatMulLayerTest,
+        ::testing::Combine(
+                ::testing::ValuesIn(ov::test::static_shapes_to_test_representation(fc4d_shapeRelatedParams)),
+                ::testing::Values(std::make_pair(false, false)),
+                ::testing::ValuesIn(inputPrecisions),
+                ::testing::ValuesIn(fc_f16_secondaryInputTypes),
+                ::testing::Values(ov::test::utils::DEVICE_GPU),
+                ::testing::Values(additional_config)),
+        MatMulLayerTest::getTestCaseName);
+
 } // namespace


### PR DESCRIPTION
### Details:
 - *Set fc format to bfyx when its spatial pitches are not one to avoid to select fb_io_block kernel*
 
### Tickets:
 - *155068*
