### PR TITLE
NPUW: Deref

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -434,6 +434,7 @@ ov::npuw::CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
 
     // Finalize memory in closures and weight banks
     finalize_weights_bank();
+    detach_memory();
 
     // Print stats report when possible
     {
@@ -497,6 +498,25 @@ void ov::npuw::CompiledModel::finalize_weights_bank() {
     }
 
     LOG_INFO("Done.");
+}
+
+void ov::npuw::CompiledModel::detach_memory() {
+    LOG_INFO("Detaching model & weight memory...");
+    LOG_BLOCK();
+    for (size_t idx = 0; idx < m_compiled_submodels.size(); ++idx) {
+        auto& comp_model_desc = m_compiled_submodels[idx];
+        auto& proto_comp_model_desc = m_compiled_submodels[comp_model_desc.replaced_by.value_or(idx)];
+        if (!proto_comp_model_desc.model || !proto_comp_model_desc.compiled_model) {
+            continue; // optimized-out OR already cleared - skip
+        }
+        if (proto_comp_model_desc.device_it + 1 == m_dev_list.end()) {
+            LOG_INFO("No fallback expected - clear the OV model for Subgraph[" << idx << "]");
+            proto_comp_model_desc.model.reset();
+            // proto_comp_model_desc.compiled_model = {}; // Shouldn't be here, CPU only
+        }
+    }
+    m_weights_bank->detach();
+    LOG_INFO("Done");
 }
 
 std::string ov::npuw::CompiledModel::global_mem_device() const {

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -507,7 +507,7 @@ void ov::npuw::CompiledModel::detach_memory() {
         auto& comp_model_desc = m_compiled_submodels[idx];
         auto& proto_comp_model_desc = m_compiled_submodels[comp_model_desc.replaced_by.value_or(idx)];
         if (!proto_comp_model_desc.model || !proto_comp_model_desc.compiled_model) {
-            continue; // optimized-out OR already cleared - skip
+            continue;  // optimized-out OR already cleared - skip
         }
         if (proto_comp_model_desc.device_it + 1 == m_dev_list.end()) {
             LOG_INFO("No fallback expected - clear the OV model for Subgraph[" << idx << "]");

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -512,7 +512,6 @@ void ov::npuw::CompiledModel::detach_memory() {
         if (proto_comp_model_desc.device_it + 1 == m_dev_list.end()) {
             LOG_INFO("No fallback expected - clear the OV model for Subgraph[" << idx << "]");
             proto_comp_model_desc.model.reset();
-            // proto_comp_model_desc.compiled_model = {}; // Shouldn't be here, CPU only
         }
     }
     LOG_INFO("Done");

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -515,7 +515,6 @@ void ov::npuw::CompiledModel::detach_memory() {
             // proto_comp_model_desc.compiled_model = {}; // Shouldn't be here, CPU only
         }
     }
-    m_weights_bank->detach();
     LOG_INFO("Done");
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.hpp
@@ -78,6 +78,7 @@ private:
     void implement_properties();
 
     void finalize_weights_bank();
+    void detach_memory();
     std::string global_mem_device() const;
     std::string funcall_mem_device(const std::size_t idx) const;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -22,10 +22,9 @@ struct Const {
     std::shared_ptr<ov::op::v0::Constant> m_node;
     ov::element::Type m_cached_type;
     ov::Shape m_cached_shape;
-    const void *m_cached_ptr = nullptr;
+    const void* m_cached_ptr = nullptr;
 
-    explicit Const(std::shared_ptr<ov::op::v0::Constant> n)
-        : m_node(n) {
+    explicit Const(std::shared_ptr<ov::op::v0::Constant> n) : m_node(n) {
         m_cached_type = m_node->get_element_type();
         m_cached_shape = m_node->get_shape();
         m_cached_ptr = m_node->get_data_ptr();
@@ -39,8 +38,7 @@ struct Const {
         return seed;
     }
     bool operator==(const Const& other) const {
-        return (m_cached_type == other.m_cached_type &&
-                m_cached_shape == other.m_cached_shape &&
+        return (m_cached_type == other.m_cached_type && m_cached_shape == other.m_cached_shape &&
                 m_cached_ptr == other.m_cached_ptr);
     }
     ov::Tensor eval() const {
@@ -73,7 +71,7 @@ struct Concat {
         return ov::npuw::util::concat(to_concat, axis);
     }
     void detach() {
-        for (auto &&lt : tensors) {
+        for (auto&& lt : tensors) {
             lt.detach();
         }
     }
@@ -196,9 +194,11 @@ template <class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
 
 LazyTensorImpl::LazyTensorImpl(Transform&& t)
-    : m_transform(std::move(t))
-    , m_hash(std::visit(overloaded{[](const auto& op) { return op.hash(); }}, m_transform)) {
-}
+    : m_transform(std::move(t)),
+      m_hash(std::visit(overloaded{[](const auto& op) {
+                            return op.hash();
+                        }},
+                        m_transform)) {}
 
 bool LazyTensorImpl::operator==(const LazyTensorImpl& other) const {
     return m_hash == other.m_hash && m_transform == other.m_transform;
@@ -214,7 +214,10 @@ ov::Tensor LazyTensorImpl::eval() const {
     some kind of indicator that the only difference is concat and we should look for an existing ov::Tensor.
     Perhaps it should be done after model compilation and not handled here.
     */
-    return std::visit(overloaded{[](const auto& op) { return op.eval(); }}, m_transform);
+    return std::visit(overloaded{[](const auto& op) {
+                          return op.eval();
+                      }},
+                      m_transform);
 }
 
 std::size_t LazyTensorImpl::get_hash() const {
@@ -222,7 +225,10 @@ std::size_t LazyTensorImpl::get_hash() const {
 }
 
 void LazyTensorImpl::detach() {
-    std::visit(overloaded{[](auto& op) { op.detach(); }}, m_transform);
+    std::visit(overloaded{[](auto& op) {
+                   op.detach();
+               }},
+               m_transform);
 }
 
 LazyTensor::LazyTensor(const std::shared_ptr<ov::op::v0::Constant>& const_ptr)

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -164,7 +164,6 @@ using Transform = std::variant<op::Const, op::Concat, op::Unpack, op::Permute, o
 
 struct LazyTensorImpl {
 public:
-    LazyTensorImpl() = default;
     explicit LazyTensorImpl(Transform&& t);
     bool operator==(const LazyTensorImpl& other) const;
 

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.cpp
@@ -19,23 +19,36 @@ namespace npuw {
 namespace weights {
 namespace op {
 struct Const {
-    std::shared_ptr<ov::op::v0::Constant> node;
+    std::shared_ptr<ov::op::v0::Constant> m_node;
+    ov::element::Type m_cached_type;
+    ov::Shape m_cached_shape;
+    const void *m_cached_ptr = nullptr;
 
+    explicit Const(std::shared_ptr<ov::op::v0::Constant> n)
+        : m_node(n) {
+        m_cached_type = m_node->get_element_type();
+        m_cached_shape = m_node->get_shape();
+        m_cached_ptr = m_node->get_data_ptr();
+    }
     std::size_t hash() const {
-        std::size_t seed = std::hash<const void*>()(node->get_data_ptr()) + 0x9e3779b9;
-        seed ^= node->get_element_type().hash() + 0x9e3779b9;
-        for (const auto& dim : node->get_shape()) {
+        std::size_t seed = std::hash<const void*>()(m_cached_ptr) + 0x9e3779b9;
+        seed ^= m_cached_type.hash() + 0x9e3779b9;
+        for (const auto& dim : m_cached_shape) {
             seed ^= std::hash<std::size_t>()(dim) + 0x9e3779b9;
         }
         return seed;
     }
     bool operator==(const Const& other) const {
-        return (node->get_shape() == other.node->get_shape() &&
-                node->get_element_type() == other.node->get_element_type() &&
-                node->get_data_ptr() == other.node->get_data_ptr());
+        return (m_cached_type == other.m_cached_type &&
+                m_cached_shape == other.m_cached_shape &&
+                m_cached_ptr == other.m_cached_ptr);
     }
     ov::Tensor eval() const {
-        return ov::npuw::util::tensor_from_const(node);
+        NPUW_ASSERT(m_node && "Const::eval() can only happen before detach");
+        return ov::npuw::util::tensor_from_const(m_node);
+    }
+    void detach() {
+        m_node.reset();
     }
 };
 struct Concat {
@@ -58,6 +71,11 @@ struct Concat {
             to_concat.push_back(lt.eval());
         }
         return ov::npuw::util::concat(to_concat, axis);
+    }
+    void detach() {
+        for (auto &&lt : tensors) {
+            lt.detach();
+        }
     }
 };
 
@@ -95,6 +113,11 @@ struct Unpack {
         }
         return dst;
     }
+    void detach() {
+        w.detach();
+        z.detach();
+        s.detach();
+    }
 };
 struct Permute {
     LazyTensor tensor;
@@ -113,6 +136,9 @@ struct Permute {
     ov::Tensor eval() const {
         return ov::npuw::util::permute(tensor.eval(), axes);
     }
+    void detach() {
+        tensor.detach();
+    }
 };
 struct Convert {
     LazyTensor tensor;
@@ -130,6 +156,9 @@ struct Convert {
         NPUW_ASSERT(ov::element::f16 == type);
         return ov::npuw::util::to_f16(tensor.eval());
     }
+    void detach() {
+        tensor.detach();
+    }
 };
 }  // namespace op
 
@@ -139,11 +168,12 @@ struct LazyTensorImpl {
 public:
     LazyTensorImpl() = default;
     explicit LazyTensorImpl(Transform&& t);
+    bool operator==(const LazyTensorImpl& other) const;
 
     ov::Tensor eval() const;
-
-    bool operator==(const LazyTensorImpl& other) const;
     std::size_t get_hash() const;
+
+    void detach();
 
     Transform m_transform;
     const std::size_t m_hash = 0;
@@ -164,10 +194,6 @@ struct overloaded : Ts... {
 };
 template <class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
-
-std::size_t LazyTensorImpl::get_hash() const {
-    return m_hash;
-}
 
 LazyTensorImpl::LazyTensorImpl(Transform&& t)
     : m_transform(std::move(t))
@@ -191,8 +217,16 @@ ov::Tensor LazyTensorImpl::eval() const {
     return std::visit(overloaded{[](const auto& op) { return op.eval(); }}, m_transform);
 }
 
+std::size_t LazyTensorImpl::get_hash() const {
+    return m_hash;
+}
+
+void LazyTensorImpl::detach() {
+    std::visit(overloaded{[](auto& op) { op.detach(); }}, m_transform);
+}
+
 LazyTensor::LazyTensor(const std::shared_ptr<ov::op::v0::Constant>& const_ptr)
-    : m_impl(std::make_shared<LazyTensorImpl>(op::Const{const_ptr})) {}
+    : m_impl(std::make_shared<LazyTensorImpl>(op::Const(const_ptr))) {}
 LazyTensor::LazyTensor(const std::vector<LazyTensor>& to_concat, const std::size_t axis)
     : m_impl(std::make_shared<LazyTensorImpl>(op::Concat{to_concat, axis})) {}
 LazyTensor::LazyTensor(const LazyTensor& cw,
@@ -240,6 +274,12 @@ std::size_t LazyTensor::get_hash() const {
         return 0;
     }
     return m_impl->get_hash();
+}
+
+void LazyTensor::detach() {
+    if (m_impl) {
+        m_impl->detach();
+    }
 }
 
 std::size_t LazyTensor::Hash::operator()(const LazyTensor& lt) const {

--- a/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/lazy_tensor.hpp
@@ -39,8 +39,8 @@ public:
     bool operator!=(const LazyTensor& other) const;
 
     ov::Tensor eval() const;
-
     std::size_t get_hash() const;
+    void detach();
 
 private:
     std::shared_ptr<LazyTensorImpl> m_impl = nullptr;

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -41,8 +41,7 @@ Group::Group(size_t gid,
     : m_nh(std::move(nh)),
       m_id(gid),
       m_graph(g),
-      m_snapshot(snapshot) {
-}
+      m_snapshot(snapshot) {}
 
 // Include Parameters, Outputs, Converts, etc to content's layers for proper linking at the plugin level
 void Group::includeExtraLayers(detail::OVNodeSet& input_layers,

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.cpp
@@ -23,7 +23,7 @@ using ov::npuw::online::detail::isOp;
 Group::Group(const std::shared_ptr<ov::Node>& node,
              size_t gid,
              own::ade::NodeHandle nh,
-             const std::shared_ptr<own::ade::Graph>& g,
+             const std::weak_ptr<own::ade::Graph>& g,
              const std::weak_ptr<Snapshot>& snapshot)
     : m_nh(std::move(nh)),
       m_id(gid),
@@ -36,12 +36,13 @@ Group::Group(const std::shared_ptr<ov::Node>& node,
 
 Group::Group(size_t gid,
              own::ade::NodeHandle nh,
-             const std::shared_ptr<own::ade::Graph>& g,
+             const std::weak_ptr<own::ade::Graph>& g,
              const std::weak_ptr<Snapshot>& snapshot)
     : m_nh(std::move(nh)),
       m_id(gid),
       m_graph(g),
-      m_snapshot(snapshot) {}
+      m_snapshot(snapshot) {
+}
 
 // Include Parameters, Outputs, Converts, etc to content's layers for proper linking at the plugin level
 void Group::includeExtraLayers(detail::OVNodeSet& input_layers,
@@ -214,14 +215,16 @@ void Group::relinkGraph(const Group::GPtr& gptr_other) {
     auto consumers = gptr_other->dstNodes();
 
     // Remove gptr_other node from the graph. Note: also removes all it's edges
-    m_graph->remove(gptr_other->getHandle());
+    auto&& graph = m_graph.lock();
+    NPUW_ASSERT(graph);
+    graph->remove(gptr_other->getHandle());
     for (const auto& nh : producers) {
         if (m_nh == nh) {
             continue;
         }
         // relink the graph
-        if (!m_graph->linked(nh, m_nh)) {
-            m_graph->link(nh, m_nh);
+        if (!graph->linked(nh, m_nh)) {
+            graph->link(nh, m_nh);
         }
     }
     for (const auto& nh : consumers) {
@@ -229,8 +232,8 @@ void Group::relinkGraph(const Group::GPtr& gptr_other) {
             continue;
         }
         // relink the graph
-        if (!m_graph->linked(m_nh, nh)) {
-            m_graph->link(m_nh, nh);
+        if (!graph->linked(m_nh, nh)) {
+            graph->link(m_nh, nh);
         }
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/group.hpp
@@ -33,11 +33,11 @@ public:
     Group(const std::shared_ptr<ov::Node>& node,
           size_t gid,
           own::ade::NodeHandle nh,
-          const std::shared_ptr<own::ade::Graph>& g,
+          const std::weak_ptr<own::ade::Graph>& g,
           const std::weak_ptr<Snapshot>& snapshot);
     Group(size_t gid,
           own::ade::NodeHandle nh,
-          const std::shared_ptr<own::ade::Graph>& g,
+          const std::weak_ptr<own::ade::Graph>& g,
           const std::weak_ptr<Snapshot>& snapshot);
 
     // After we formed a final structure of partitioning,
@@ -100,7 +100,7 @@ private:
 
     own::ade::NodeHandle m_nh;
     size_t m_id;  // used for utility prints only
-    std::shared_ptr<own::ade::Graph> m_graph;
+    std::weak_ptr<own::ade::Graph> m_graph;
     std::weak_ptr<Snapshot> m_snapshot;
     bool m_frozen = false;
     bool m_nofold = false;

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -142,8 +142,8 @@ Impl<M> _(std::shared_ptr<M> pM) {
 }  // namespace at
 
 // Written here to be a drop-in replacement for ov::parallel_for for the debug purposes
-template<typename F>
-void non_parallel_for(std::size_t count, F &&f) {
+template <typename F>
+void non_parallel_for(std::size_t count, F&& f) {
     for (std::size_t idx = 0u; idx < count; idx++) {
         f(idx);
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/util.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.hpp
@@ -141,6 +141,14 @@ Impl<M> _(std::shared_ptr<M> pM) {
 
 }  // namespace at
 
+// Written here to be a drop-in replacement for ov::parallel_for for the debug purposes
+template<typename F>
+void non_parallel_for(std::size_t count, F &&f) {
+    for (std::size_t idx = 0u; idx < count; idx++) {
+        f(idx);
+    }
+}
+
 }  // namespace util
 }  // namespace npuw
 }  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
@@ -94,7 +94,9 @@ void Bank::evaluate_and_allocate() {
     }
 }
 
-ov::Tensor Bank::eval_and_alloc(const LazyTensor& tensor, Bank::DeviceBank &dbank, const std::string& device_for_alloc) {
+ov::Tensor Bank::eval_and_alloc(const LazyTensor& tensor,
+                                Bank::DeviceBank& dbank,
+                                const std::string& device_for_alloc) {
     // Evaluate concurrently (see evaluate_and_allocate), lock the device
     // mutex only to update the device bank (& allocate on-device memory, if needed)
     const auto& transformed_tensor = tensor.eval();
@@ -116,7 +118,7 @@ ov::Tensor Bank::eval_and_alloc(const LazyTensor& tensor, Bank::DeviceBank &dban
         remote_ctx->create_host_tensor(transformed_tensor.get_element_type(), transformed_tensor.get_shape());
     allocated_tensor = ov::make_tensor(remote_tensor);
     dbank.storage[tensor] = allocated_tensor;
-    guard.unlock(); // Unlock the guard, map update is done - copy can continue in parallel
+    guard.unlock();  // Unlock the guard, map update is done - copy can continue in parallel
 
     transformed_tensor.copy_to(allocated_tensor);
     return allocated_tensor;

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
@@ -47,6 +47,9 @@ ov::Tensor Bank::get(const LazyTensor& tensor, const std::string& device) {
 
     if (iter_device != device_bank.storage.end() && iter_device->second) {
         // Already allocated
+        // tensor (the key) may be coming from a 2nd (3rd, ...) model
+        // detach it here just in case
+        const_cast<LazyTensor&>(tensor).detach();
         return iter_device->second;
     }
     dev_guard.unlock();

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
@@ -8,6 +8,8 @@
 #include "openvino/core/parallel.hpp"
 #include "util.hpp"
 
+#include <iostream>
+
 using ov::npuw::weights::Bank;
 using ov::npuw::weights::LazyTensor;
 
@@ -40,16 +42,19 @@ ov::Tensor Bank::get(const LazyTensor& tensor, const std::string& device) {
 
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    auto& device_bank = m_device_bank[device_for_alloc];
-    auto iter_device = device_bank.find(tensor);
+    auto& device_bank = m_device_banks[device_for_alloc];
 
-    if (iter_device != device_bank.end() && iter_device->second) {
+    std::unique_lock<std::mutex> dev_guard(device_bank.mutex);
+    auto iter_device = device_bank.storage.find(tensor);
+
+    if (iter_device != device_bank.storage.end() && iter_device->second) {
         // Already allocated
         return iter_device->second;
     }
+    dev_guard.unlock();
 
     // Allocation and evaluation needed
-    return unsafe_eval_and_alloc(tensor, device_for_alloc);
+    return eval_and_alloc(tensor, device_bank, device_for_alloc);
 }
 
 void Bank::registerLT(const LazyTensor& tensor, const std::string& device) {
@@ -57,64 +62,77 @@ void Bank::registerLT(const LazyTensor& tensor, const std::string& device) {
 
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    auto& device_bank = m_device_bank[device_for_alloc];
-    if (device_bank.find(tensor) == device_bank.end()) {
-        device_bank[tensor] = ov::Tensor();
+    auto& device_bank = m_device_banks[device_for_alloc];
+    if (device_bank.storage.find(tensor) == device_bank.storage.end()) {
+        device_bank.storage[tensor] = ov::Tensor();
+    }
+}
+
+template<typename F>
+void non_parallel_for(std::size_t count, F &&f) {
+    for (std::size_t idx = 0u; idx < count; idx++) {
+        f(idx);
     }
 }
 
 void Bank::evaluate_and_allocate() {
     std::lock_guard<std::mutex> guard(m_mutex);
 
-    for (auto&& bank : m_device_bank) {
+    for (auto&& bank : m_device_banks) {
         const auto& device_for_alloc = bank.first;
         auto& device_bank = bank.second;
+
         std::vector<LazyTensor> vec;
-        for (const auto& el : device_bank) {
+        vec.reserve(device_bank.storage.size());
+        for (const auto& el : device_bank.storage) {
             vec.push_back(el.first);
         }
         ov::parallel_for(vec.size(), [&](std::size_t idx) {
             const auto& lt = vec[idx];
-            auto iter_device = device_bank.find(lt);
-            if (iter_device != device_bank.end() && iter_device->second) {
+            std::unique_lock dev_guard(device_bank.mutex);
+            auto iter_device = device_bank.storage.find(lt);
+            if (iter_device != device_bank.storage.end() && iter_device->second) {
                 // Already allocated
                 return;
             }
+            dev_guard.unlock();
 
             // Allocation and evaluation needed
-            unsafe_eval_and_alloc(lt, device_for_alloc);
+            eval_and_alloc(lt, device_bank, device_for_alloc);
         });
     }
 }
 
-ov::Tensor Bank::unsafe_eval_and_alloc(const LazyTensor& tensor, const std::string& device_for_alloc) {
-    // Note: private method used inside other methods with already locked mutex
+ov::Tensor Bank::eval_and_alloc(const LazyTensor& tensor, Bank::DeviceBank &dbank, const std::string& device_for_alloc) {
+    // Evaluate concurrently (see evaluate_and_allocate), lock the device
+    // mutex only to update the device bank (& allocate on-device memory, if needed)
     const auto& transformed_tensor = tensor.eval();
+
+    std::unique_lock<std::mutex> guard(dbank.mutex);
     if (device_for_alloc == "CPU") {
-        m_device_bank[device_for_alloc][tensor] = transformed_tensor;
+        dbank.storage[tensor] = transformed_tensor;
         return transformed_tensor;
     }
 
     ov::SoPtr<ov::ITensor> remote_tensor;
     ov::Tensor allocated_tensor;
-    {
-        // FIXME: L0 allocation may crash when run in parallel
-        std::lock_guard<std::mutex> guard(m_alloc_mutex);
-        m_remote_ctx = m_core->get_default_context(device_for_alloc)._ptr;
-        remote_tensor =
-            m_remote_ctx->create_host_tensor(transformed_tensor.get_element_type(), transformed_tensor.get_shape());
-        allocated_tensor = ov::make_tensor(remote_tensor);
-    }
+
+    auto remote_ctx = m_core->get_default_context(device_for_alloc)._ptr;
+    remote_tensor =
+        remote_ctx->create_host_tensor(transformed_tensor.get_element_type(), transformed_tensor.get_shape());
+    allocated_tensor = ov::make_tensor(remote_tensor);
+    dbank.storage[tensor] = allocated_tensor;
+    guard.unlock();
+
     transformed_tensor.copy_to(allocated_tensor);
-    m_device_bank[device_for_alloc][tensor] = allocated_tensor;
     return allocated_tensor;
 }
 
 bool Bank::is_remote(const LazyTensor& tensor) const {
     // FIXME: make generic
-    auto npu_bank = m_device_bank.find("NPU");
-    if (npu_bank != m_device_bank.end() && npu_bank->second.find(tensor) != npu_bank->second.end()) {
-        // Found in NPU bank
+    auto npu_bank = m_device_banks.find("NPU");
+    if (npu_bank != m_device_banks.end() && npu_bank->second.storage.find(tensor) != npu_bank->second.storage.end()) {
+        // Found in NPU bank so considered remote (utterly wrong for the generic case)
         return true;
     }
     return false;

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
@@ -8,8 +8,6 @@
 #include "openvino/core/parallel.hpp"
 #include "util.hpp"
 
-#include <iostream>
-
 using ov::npuw::weights::Bank;
 using ov::npuw::weights::LazyTensor;
 
@@ -65,13 +63,6 @@ void Bank::registerLT(const LazyTensor& tensor, const std::string& device) {
     auto& device_bank = m_device_banks[device_for_alloc];
     if (device_bank.storage.find(tensor) == device_bank.storage.end()) {
         device_bank.storage[tensor] = ov::Tensor();
-    }
-}
-
-template<typename F>
-void non_parallel_for(std::size_t count, F &&f) {
-    for (std::size_t idx = 0u; idx < count; idx++) {
-        f(idx);
     }
 }
 

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
@@ -34,6 +34,9 @@ public:
     void evaluate_and_allocate();
     bool is_remote(const LazyTensor& tensor) const;
 
+    // Drop references to the original buffers, if any
+    void detach();
+
 private:
     // Bank for specified device and their allocated memory
     struct DeviceBank {

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
@@ -34,9 +34,6 @@ public:
     void evaluate_and_allocate();
     bool is_remote(const LazyTensor& tensor) const;
 
-    // Drop references to the original buffers, if any
-    void detach();
-
 private:
     // Bank for specified device and their allocated memory
     struct DeviceBank {

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
@@ -35,13 +35,17 @@ public:
     bool is_remote(const LazyTensor& tensor) const;
 
 private:
-    ov::Tensor unsafe_eval_and_alloc(const LazyTensor& tensor, const std::string& device);
     // Bank for specified device and their allocated memory
-    std::unordered_map<std::string, std::unordered_map<LazyTensor, ov::Tensor, LazyTensor::Hash>> m_device_bank;
+    struct DeviceBank {
+        std::unordered_map<LazyTensor, ov::Tensor, LazyTensor::Hash> storage;
+        std::mutex mutex;
+    };
+    std::unordered_map<std::string, DeviceBank> m_device_banks;
+
+    ov::Tensor eval_and_alloc(const LazyTensor& tensor, DeviceBank &dbank, const std::string& device);
+
     std::mutex m_mutex;
-    std::mutex m_alloc_mutex;
     std::shared_ptr<const ov::ICore> m_core = nullptr;
-    std::shared_ptr<ov::IRemoteContext> m_remote_ctx = nullptr;
     std::string m_alloc_device;
 };
 

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.hpp
@@ -42,7 +42,7 @@ private:
     };
     std::unordered_map<std::string, DeviceBank> m_device_banks;
 
-    ov::Tensor eval_and_alloc(const LazyTensor& tensor, DeviceBank &dbank, const std::string& device);
+    ov::Tensor eval_and_alloc(const LazyTensor& tensor, DeviceBank& dbank, const std::string& device);
 
     std::mutex m_mutex;
     std::shared_ptr<const ov::ICore> m_core = nullptr;


### PR DESCRIPTION
### Details:
 - ~~NPU plugin: Drop reference to `ov::Model` in the NPU plugin's `CompiledModel`~~ - 🚨🚨🚨- moved to a separate PR https://github.com/openvinotoolkit/openvino/pull/27777 
 - NPUW ext: Introduced a `detach_memory` step in the NPUW's `CompiledModel` to clear the original IR references if there's no fallback planned
 - NPUW ext: Fixed cyclic references in the online partitioning (preventing the original `ov::Model` from release)
 - NPUW ext: Fixed crashes in the updated `LazyTensor` implementation;
 - NPUW ext: Reworked `LazyTensor` a bit to have less code in & more predictable hashing behavior;
 - NPUW ext: Introduced `LazyTensor::detach()` & use it in the bank when LT is evaluated;
 - NPUW ext: Reworked the way how internal per-device memory banks are accessed - fixed a potential race.

### Tickets:
 - *E-142478*

### Related:
- https://github.com/openvinotoolkit/openvino.genai/pull/1259
- https://github.com/openvinotoolkit/openvino/pull/27777
