### PR TITLE
Revert "[GPU] WA to avoid too long consecutive runtime skippable nodes (#27635)"

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_runtime_skippable_nodes.cpp
@@ -19,12 +19,9 @@
 #include "scatter_nd_update_inst.h"
 #include "program_helpers.h"
 
-#include <unordered_map>
-
 using namespace cldnn;
 
 void mark_runtime_skippable_nodes::run(program& p) {
-    std::unordered_map<program_node*, uint8_t> runtime_skippable_depth;
     auto itr = p.get_processing_order().begin();
 
     while (itr != p.get_processing_order().end()) {
@@ -52,24 +49,6 @@ void mark_runtime_skippable_nodes::run(program& p) {
             node->can_be_optimized(true);
             GPU_DEBUG_TRACE_DETAIL << "[mark_runtime_skippable_nodes] : " << node->id() << " has only shape_of as users. Set can_be_optimized always"
                                    << std::endl;
-            continue;
-        }
-
-        // Check whether consecutive runtime skippable nodes is lower than max count.
-        // Too long consecutive runtime skippable nodes causes huge time consumption in add_memory_dependency() of basic_memory_dependencies pass.
-        // max count 7 is experimentally selected in specific model.
-        const uint8_t max_runtime_skippable_depth = 7;
-        uint8_t dep_runtime_skippable_depth = 0;
-        for (const auto& dep : node->get_dependencies()) {
-            if (dep.first->is_runtime_skippable() &&
-               (runtime_skippable_depth.find(dep.first) != runtime_skippable_depth.end())) {
-                dep_runtime_skippable_depth = std::max(runtime_skippable_depth[dep.first], dep_runtime_skippable_depth);
-            }
-        }
-        if (!node->is_runtime_skippable() && (dep_runtime_skippable_depth >= max_runtime_skippable_depth)) {
-            GPU_DEBUG_TRACE_DETAIL << "[mark_runtime_skippable_nodes] : " << node->id()
-                                   << " doesn't have runtime skippable due to max_runtime_skippable_depth("
-                                   << static_cast<int>(max_runtime_skippable_depth) << ")." << std::endl;
             continue;
         }
 
@@ -276,9 +255,5 @@ void mark_runtime_skippable_nodes::run(program& p) {
                 GPU_DEBUG_TRACE_DETAIL << "[mark_runtime_skippable_nodes] : " << node.id() << " can_be_optimized" << std::endl;
             }
         });
-
-        if (node->is_runtime_skippable()) {
-            runtime_skippable_depth[node] = dep_runtime_skippable_depth + 1;
-        }
     }
 }


### PR DESCRIPTION
This reverts commit 9a5d3a5051e52a1c81837b0f901af5e215f9fcb3.

### Details:
 - The WA causes accuracy issue in mixtral model

### Tickets:
 - 157374
