### PR TITLE
Include <chrono> for high_resolution_clock

### DIFF
--- a/src/core/include/openvino/pass/manager.hpp
+++ b/src/core/include/openvino/pass/manager.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <list>
 #include <memory>
 #include <typeinfo>


### PR DESCRIPTION
I am a member of Microsoft vcpkg, due to there are new changes merged by https://github.com/microsoft/STL/pull/5105, which revealed a conformance issue in `openvino`. It must add include `<chrono>` to fix this error.

Compiler error with this STL change:
```
D:\b\openvino\src\2024.4.0-0a411cf5b1.clean\src\core\src\pass\manager.cpp(128): error C2039: 'high_resolution_clock': is not a member of 'std::chrono'

```