### PR TITLE
[intel-npu] Adding CID version query api; Extend optimization_capabilities based on CID version

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_backend.hpp
@@ -24,6 +24,7 @@ public:
     const std::vector<std::string> getDeviceNames() const override;
     uint32_t getDriverVersion() const override;
     uint32_t getGraphExtVersion() const override;
+    uint32_t getCompilerVersion() const override;
 
     bool isBatchingSupported() const override;
     bool isCommandQueueExtSupported() const override;

--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -29,6 +29,10 @@ uint32_t ZeroEngineBackend::getGraphExtVersion() const {
     return _initStruct->getGraphDdiTable().version();
 }
 
+uint32_t ZeroEngineBackend::getCompilerVersion() const {
+    return _initStruct->getCompilerVersion();
+}
+
 bool ZeroEngineBackend::isBatchingSupported() const {
     return _initStruct->isExtensionSupported("ZE_extension_graph_1_6", ZE_MAKE_VERSION(1, 6));
 }

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/npu.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/npu.hpp
@@ -33,6 +33,8 @@ public:
     virtual uint32_t getDriverVersion() const;
     /** @brief Provide driver extension version */
     virtual uint32_t getGraphExtVersion() const;
+    /** @brief Provide compiler-in-driver version */
+    virtual uint32_t getCompilerVersion() const;
     /** @brief Get name of backend */
     virtual const std::string getName() const = 0;
     /** @brief Backend has support for concurrency batching */

--- a/src/plugins/intel_npu/src/common/src/npu.cpp
+++ b/src/plugins/intel_npu/src/common/src/npu.cpp
@@ -33,6 +33,10 @@ uint32_t IEngineBackend::getGraphExtVersion() const {
     OPENVINO_THROW("Get NPU driver extension version is not supported with this backend");
 }
 
+uint32_t IEngineBackend::getCompilerVersion() const {
+    OPENVINO_THROW("Get NPU driver-compiler version is not supported with this backend");
+}
+
 void* IEngineBackend::getContext() const {
     OPENVINO_THROW("Get NPU context is not supported with this backend");
 }

--- a/src/plugins/intel_npu/src/plugin/include/backends.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/backends.hpp
@@ -32,6 +32,7 @@ public:
     std::string getBackendName() const;
     uint32_t getDriverVersion() const;
     uint32_t getGraphExtVersion() const;
+    uint32_t getCompilerVersion() const;
     bool isBatchingSupported() const;
     bool isCommandQueueExtSupported() const;
     bool isLUIDExtSupported() const;

--- a/src/plugins/intel_npu/src/plugin/include/metrics.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metrics.hpp
@@ -36,6 +36,7 @@ public:
     uint64_t GetDeviceTotalMemSize(const std::string& specifiedDeviceName) const;
     uint32_t GetDriverVersion() const;
     uint32_t GetGraphExtVersion() const;
+    uint32_t GetCompilerVersion() const;
     uint32_t GetSteppingNumber(const std::string& specifiedDeviceName) const;
     uint32_t GetMaxTiles(const std::string& specifiedDeviceName) const;
     ov::device::PCIInfo GetPciInfo(const std::string& specifiedDeviceName) const;
@@ -51,7 +52,7 @@ private:
     const std::shared_ptr<const NPUBackends> _backends;
     std::vector<std::string> _supportedMetrics;
     std::vector<std::string> _supportedConfigKeys;
-    const std::vector<std::string> _optimizationCapabilities = {
+    std::vector<std::string> _optimizationCapabilities = {
         ov::device::capability::FP16,
         ov::device::capability::INT8,
         ov::device::capability::EXPORT_IMPORT,

--- a/src/plugins/intel_npu/src/plugin/src/backends.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/backends.cpp
@@ -155,6 +155,14 @@ uint32_t NPUBackends::getGraphExtVersion() const {
     OPENVINO_THROW("No available backend");
 }
 
+uint32_t NPUBackends::getCompilerVersion() const {
+    if (_backend != nullptr) {
+        return _backend->getCompilerVersion();
+    }
+
+    OPENVINO_THROW("No available backend");
+}
+
 bool NPUBackends::isBatchingSupported() const {
     if (_backend != nullptr) {
         return _backend->isBatchingSupported();

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -55,6 +55,9 @@ public:
     inline ze_api_version_t getZeDrvApiVersion() const {
         return ze_drv_api_version;
     }
+    inline uint32_t getCompilerVersion() const {
+        return compiler_version;
+    }
     // Helper function to check if extension with <ext_name> exists and its newer than <version>
     inline bool isExtensionSupported(std::string ext_name, uint32_t version) const {
         auto iter = driver_extension_properties.find(ext_name);
@@ -83,6 +86,8 @@ private:
     uint32_t mutable_command_list_version = 0;
 
     ze_api_version_t ze_drv_api_version = {};
+
+    uint32_t compiler_version = 0;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -248,6 +248,13 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     log.debug("ZeroInitStructsHolder initialize complete");
+
+    // Obtain compiler-in-driver (vcl) version
+    ze_device_graph_properties_t graph_props;
+    graph_props.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
+    auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &graph_props);
+    THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
+    compiler_version = ZE_MAKE_VERSION(graph_props.compilerVersion.major, graph_props.compilerVersion.minor);
 }
 
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {


### PR DESCRIPTION
### Details:
 - Starting to construct ov::device::capabilities.name() (OPTIMIZATION_CAPABILITIES) property with features conditioned by compiler support (compiler version)
 - adding api to metrics to fetch CID version
 - adding "COMPILER_DYNAMIC_QUANTIZATION" optimization capability starting with compiler version 6.3

### Tickets:
 - *EISW-148716*
