### PR TITLE
update streams calculation for cpu reservation

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -169,13 +169,19 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         }
     };
 
+    current_socket_id = input_current_socket_id == -1 ? get_current_socket_id() : input_current_socket_id;
+
     if (proc_type_table.size() == 1) {
         proc_socket_table.push_back(proc_type_table[0]);
     } else {
         std::unordered_set<int> socket_id_list(proc_type_table.size());
         for (size_t i = 1; i < proc_type_table.size(); i++) {
             if (!socket_id_list.count(proc_type_table[i][PROC_SOCKET_ID])) {
-                proc_socket_table.push_back(proc_type_table[i]);
+                if (proc_type_table[i][PROC_SOCKET_ID] == current_socket_id) {
+                    proc_socket_table.insert(proc_socket_table.begin(), proc_type_table[i]);
+                } else {
+                    proc_socket_table.push_back(proc_type_table[i]);
+                }
                 socket_id_list.insert(proc_type_table[i][PROC_SOCKET_ID]);
             } else {
                 for (auto& row : proc_socket_table) {
@@ -197,10 +203,12 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         ((input_streams_changed == true) && (input_streams == 1))) {
         n_streams = 1;
         stream_info[NUMBER_OF_STREAMS] = n_streams;
-        for (size_t n = 0; n < proc_socket_table.size(); n++) {
-            if (proc_socket_table[n][ALL_PROC] > 0) {
-                current_socket_id = proc_socket_table[n][PROC_SOCKET_ID];
-                break;
+        if (proc_socket_table[0][ALL_PROC] == 0) {
+            for (size_t n = 0; n < proc_socket_table.size(); n++) {
+                if (proc_socket_table[n][ALL_PROC] > 0) {
+                    current_socket_id = proc_socket_table[n][PROC_SOCKET_ID];
+                    break;
+                }
             }
         }
         if (input_threads > 0) {

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -169,19 +169,13 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         }
     };
 
-    current_socket_id = input_current_socket_id == -1 ? get_current_socket_id() : input_current_socket_id;
-
     if (proc_type_table.size() == 1) {
         proc_socket_table.push_back(proc_type_table[0]);
     } else {
         std::unordered_set<int> socket_id_list(proc_type_table.size());
         for (size_t i = 1; i < proc_type_table.size(); i++) {
             if (!socket_id_list.count(proc_type_table[i][PROC_SOCKET_ID])) {
-                if (proc_type_table[i][PROC_SOCKET_ID] == current_socket_id) {
-                    proc_socket_table.insert(proc_socket_table.begin(), proc_type_table[i]);
-                } else {
-                    proc_socket_table.push_back(proc_type_table[i]);
-                }
+                proc_socket_table.push_back(proc_type_table[i]);
                 socket_id_list.insert(proc_type_table[i][PROC_SOCKET_ID]);
             } else {
                 for (auto& row : proc_socket_table) {
@@ -203,12 +197,10 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         ((input_streams_changed == true) && (input_streams == 1))) {
         n_streams = 1;
         stream_info[NUMBER_OF_STREAMS] = n_streams;
-        if (proc_socket_table[0][ALL_PROC] == 0) {
-            for (size_t n = 0; n < proc_socket_table.size(); n++) {
-                if (proc_socket_table[n][ALL_PROC] > 0) {
-                    current_socket_id = proc_socket_table[n][PROC_SOCKET_ID];
-                    break;
-                }
+        for (size_t n = 0; n < proc_socket_table.size(); n++) {
+            if (proc_socket_table[n][ALL_PROC] > 0) {
+                current_socket_id = proc_socket_table[n][PROC_SOCKET_ID];
+                break;
             }
         }
         if (input_threads > 0) {

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -175,11 +175,7 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         std::unordered_set<int> socket_id_list(proc_type_table.size());
         for (size_t i = 1; i < proc_type_table.size(); i++) {
             if (!socket_id_list.count(proc_type_table[i][PROC_SOCKET_ID])) {
-                if (proc_type_table[i][PROC_SOCKET_ID] == input_current_socket_id) {
-                    proc_socket_table.insert(proc_socket_table.begin(), proc_type_table[i]);
-                } else {
-                    proc_socket_table.push_back(proc_type_table[i]);
-                }
+                proc_socket_table.push_back(proc_type_table[i]);
                 socket_id_list.insert(proc_type_table[i][PROC_SOCKET_ID]);
             } else {
                 for (auto& row : proc_socket_table) {
@@ -201,7 +197,12 @@ std::vector<std::vector<int>> get_streams_info_table(const int input_streams,
         ((input_streams_changed == true) && (input_streams == 1))) {
         n_streams = 1;
         stream_info[NUMBER_OF_STREAMS] = n_streams;
-        current_socket_id = input_current_socket_id == -1 ? get_current_socket_id() : input_current_socket_id;
+        for (size_t n = 0; n < proc_socket_table.size(); n++) {
+            if (proc_socket_table[n][ALL_PROC] > 0) {
+                current_socket_id = proc_socket_table[n][PROC_SOCKET_ID];
+                break;
+            }
+        }
         if (input_threads > 0) {
             if (hint_model_distribution_policy.size() == 0) {
                 for (auto& row : proc_socket_table) {

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
@@ -2575,10 +2575,10 @@ StreamsCalculationTestCase _2sockets_mock_latency_35 = {
     "LATENCY",
     {},
     {{200, 100, 0, 100, -1, -1},
+     {20, 10, 0, 10, 3, 3},
      {80, 40, 0, 40, 0, 0},
      {60, 30, 0, 30, 1, 1},
-     {40, 20, 0, 20, 2, 2},
-     {20, 10, 0, 10, 3, 3}},
+     {40, 20, 0, 20, 2, 2}},
     {{1, ALL_PROC, 20, 3, 3}, {0, MAIN_CORE_PROC, 10, 3, 3}, {0, HYPER_THREADING_PROC, 10, 3, 3}},
 };
 StreamsCalculationTestCase _2sockets_mock_latency_36 = {
@@ -2591,10 +2591,10 @@ StreamsCalculationTestCase _2sockets_mock_latency_36 = {
     "LATENCY",
     {},
     {{200, 100, 0, 100, -1, -1},
+     {20, 10, 0, 10, 3, 3},
      {80, 40, 0, 40, 0, 0},
      {60, 30, 0, 30, 1, 1},
-     {40, 20, 0, 20, 2, 2},
-     {20, 10, 0, 10, 3, 3}},
+     {40, 20, 0, 20, 2, 2}},
     {{1, ALL_PROC, 20, 3, 3}, {0, MAIN_CORE_PROC, 10, 3, 3}, {0, HYPER_THREADING_PROC, 10, 3, 3}},
 };
 StreamsCalculationTestCase _2sockets_mock_latency_37 = {
@@ -2606,7 +2606,7 @@ StreamsCalculationTestCase _2sockets_mock_latency_37 = {
     1,
     "LATENCY",
     {ov::hint::ModelDistributionPolicy::TENSOR_PARALLEL},
-    {{48, 48, 0, 0, -1, -1}, {24, 24, 0, 0, 0, 0}, {24, 24, 0, 0, 1, 1}},
+    {{48, 48, 0, 0, -1, -1}, {24, 24, 0, 0, 1, 1}, {24, 24, 0, 0, 0, 0}},
     {{1, MAIN_CORE_PROC, 48, -1, -1}, {-1, MAIN_CORE_PROC, 24, 1, 1}, {-1, MAIN_CORE_PROC, 24, 0, 0}},
 };
 StreamsCalculationTestCase _2sockets_mock_latency_38 = {


### PR DESCRIPTION
### Details:
 - *update streams calculation for CPU reservation. While the first model occupies all CPUs on socket where the application is running, the second model occupies CPUs on the other sockets.*


### Tickets:
 - *[CVS-155268](https://jira.devtools.intel.com/browse/CVS-155268)*
