### PR TITLE
[CPU] Port for prioritizing the user setting for kvcache type/group size

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -461,10 +461,11 @@ void Config::updateProperties() {
 }
 
 void Config::applyRtInfo(const std::shared_ptr<const ov::Model>& model) {
-    if (model->has_rt_info({"runtime_options", ov::hint::kv_cache_precision.name()})) {
+    // if user sets explicitly, it will be higher priority than rt_info
+    if (!kvCachePrecisionSetExplicitly && model->has_rt_info({"runtime_options", ov::hint::kv_cache_precision.name()})) {
         this->kvCachePrecision = model->get_rt_info<ov::element::Type>({"runtime_options", ov::hint::kv_cache_precision.name()});
     }
-    if (model->has_rt_info({"runtime_options", ov::hint::dynamic_quantization_group_size.name()})) {
+    if (!fcDynamicQuantizationGroupSizeSetExplicitly && model->has_rt_info({"runtime_options", ov::hint::dynamic_quantization_group_size.name()})) {
         this->fcDynamicQuantizationGroupSize =
             model->get_rt_info<uint64_t>({"runtime_options", ov::hint::dynamic_quantization_group_size.name()});
     }

--- a/src/plugins/intel_cpu/tests/functional/custom/behavior/ov_executable_network/properties.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/behavior/ov_executable_network/properties.cpp
@@ -358,4 +358,23 @@ TEST_F(OVClassConfigTestCPU, smoke_CpuExecNetworkCheckCPURuntimOptionsWithCompil
     ASSERT_EQ(size.as<uint64_t>(), 16);
 }
 
+TEST_F(OVClassConfigTestCPU, smoke_CpuExecNetworkCheckCPURuntimOptionsWithCoreProperties) {
+    ov::Core core;
+    ov::Any type;
+    ov::Any size;
+
+    core.set_property(deviceName, ov::hint::kv_cache_precision(ov::element::f32));
+    core.set_property(deviceName, ov::hint::dynamic_quantization_group_size(16));
+
+    ov::CompiledModel compiledModel;
+    model->set_rt_info("f16", "runtime_options", ov::hint::kv_cache_precision.name());
+    model->set_rt_info("0", "runtime_options", ov::hint::dynamic_quantization_group_size.name());
+
+    OV_ASSERT_NO_THROW(compiledModel = core.compile_model(model, deviceName));
+    OV_ASSERT_NO_THROW(type = compiledModel.get_property(ov::hint::kv_cache_precision));
+    OV_ASSERT_NO_THROW(size = compiledModel.get_property(ov::hint::dynamic_quantization_group_size));
+    ASSERT_EQ(type.as<ov::element::Type>(), ov::element::f32);
+    ASSERT_EQ(size.as<uint64_t>(), 16);
+}
+
 } // namespace


### PR DESCRIPTION
### Details:
 - *Prioritize the user setting for kvcache type/group size over rt_info, port from  #27583 in releases/2024/5*

### Tickets:
 - *ticket-id*
