### PR TITLE
[core] Move malloc_tim to compile model implementation

### DIFF
--- a/src/inference/dev_api/openvino/runtime/icompiled_model.hpp
+++ b/src/inference/dev_api/openvino/runtime/icompiled_model.hpp
@@ -136,11 +136,11 @@ public:
 
     /**
      * @brief Release intermediate memory
-     * 
+     *
      */
     virtual void release_memory();
 
-    virtual ~ICompiledModel() = default;
+    virtual ~ICompiledModel();
 
 private:
     std::shared_ptr<const ov::IPlugin> m_plugin;

--- a/src/inference/src/cpp/compiled_model.cpp
+++ b/src/inference/src/cpp/compiled_model.cpp
@@ -8,10 +8,6 @@
 #include "openvino/runtime/icompiled_model.hpp"
 #include "openvino/runtime/properties.hpp"
 
-#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
-#    include <malloc.h>
-#endif
-
 #define OV_COMPILED_MODEL_CALL_STATEMENT(...)                 \
     if (_impl == nullptr)                                     \
         OPENVINO_THROW("CompiledModel was not initialized."); \
@@ -27,12 +23,6 @@ namespace ov {
 
 CompiledModel::~CompiledModel() {
     _impl = {};
-#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
-    // Linux memory manager doesn't return system memory immediately after release.
-    // It depends on memory chunk size and allocation history.
-    // Try return memory from a process to system now to reduce memory usage and not wait to the end of the process.
-    malloc_trim(0);
-#endif
 }
 
 CompiledModel::CompiledModel(const std::shared_ptr<ov::ICompiledModel>& impl, const std::shared_ptr<void>& so)

--- a/src/inference/src/dev/icompiled_model.cpp
+++ b/src/inference/src/dev/icompiled_model.cpp
@@ -10,6 +10,10 @@
 #include "openvino/runtime/properties.hpp"
 #include "transformations/utils/utils.hpp"
 
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
+#    include <malloc.h>
+#endif
+
 ov::ICompiledModel::ICompiledModel(const std::shared_ptr<const ov::Model>& model,
                                    const std::shared_ptr<const ov::IPlugin>& plugin,
                                    const std::shared_ptr<ov::threading::ITaskExecutor>& task_executor,
@@ -150,4 +154,13 @@ void ov::ICompiledModel::set_model_shared_object(ov::Model& model, const std::sh
 
 void ov::ICompiledModel::release_memory() {
     // nothing to do
+}
+
+ov::ICompiledModel::~ICompiledModel() {
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
+    // Linux memory margent doesn't return system memory immediate after release.
+    // It depends on memory chunk size and allocation history.
+    // Try return memory from a process to system now to reduce memory usage and not wait to the end of the process.
+    malloc_trim(0);
+#endif
 }


### PR DESCRIPTION
### Details:
 - The `malloc_trim` in `CompileModel` class cause to often trigger not when real implementation is removed but on each destruction of wrapper. Now the destructor of `ICompileModel` trigger it should be called after all inference related to this model.

### Port of PR:
- #27881 

### Tickets:
- CVS-158427