### PR TITLE
[PyOV] Create constant from Tensor with shared_memory

### DIFF
--- a/src/bindings/python/src/openvino/opset13/ops.py
+++ b/src/bindings/python/src/openvino/opset13/ops.py
@@ -343,7 +343,7 @@ def constant(
 @nameable_op
 def constant(  # noqa: F811
     tensor: Tensor,
-    shared_memory: bool = False,
+    shared_memory: bool = True,
     name: Optional[str] = None,
 ) -> Constant:
     return Constant(tensor, shared_memory=shared_memory)

--- a/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/ops/constant.cpp
@@ -72,7 +72,7 @@ void regclass_graph_op_Constant(py::module m) {
                      return Common::object_from_data<ov::op::v0::Constant>(tensor, shared_memory);
                  }),
                  py::arg("tensor"),
-                 py::arg("shared_memory") = false);
+                 py::arg("shared_memory") = true);
     constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<char>&>());
     constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<ov::float16>&>());
     constant.def(py::init<const ov::element::Type&, const ov::Shape&, const std::vector<float>&>());

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -774,3 +774,16 @@ def test_const_from_tensor(shared_flag):
 
     assert ov_const.strides == [72, 36, 12, 4]
     assert ov_const.get_tensor_view().get_strides() == Strides([72, 36, 12, 4])
+
+
+def test_const_from_tensor_with_shared_memory_by_default():
+    shape = [1, 2, 3, 3]
+    arr = np.ones(shape).astype(np.float32)
+    ov_tensor = Tensor(arr, shape, Type.f32)
+    ov_const = ops.constant(tensor=ov_tensor)
+
+    assert isinstance(ov_const, Constant)
+    assert np.all(list(ov_const.shape) == shape)
+    arr += 1
+    assert np.array_equal(ov_const.data, arr)
+    assert np.shares_memory(arr, ov_const.data)


### PR DESCRIPTION
### Details:
 - change `shared_memory` from False to True by default for the case when Const is created from Tensor (to be aligned here with C++ behavior)

### Tickets:
 - *ticket-id*
