### PR TITLE
[GPU] support fsv16 for output of group norm bfyx opt kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/group_normalization/group_normalization_kernel_bfyx_opt.cpp
@@ -20,6 +20,7 @@ ParamsKey GroupNormalizationKernelBfyx::GetSupportedKey() const {
     k.EnableInputLayout(DataLayout::bfzyx);
     k.EnableOutputLayout(DataLayout::bfyx);
     k.EnableOutputLayout(DataLayout::bfzyx);
+    k.EnableOutputLayout(DataLayout::b_fs_yx_fsv16);
     k.EnableBatching();
     k.EnableTensorOffset();
     k.EnableTensorPitches();

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -168,7 +168,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(group_normalization, input_bfyx_output_fsv16) {
     auto& engine = get_test_engine();
 
-    auto in_layout = layout{ ov::PartialShape{12, 320, 35, 28}, data_types::f32, format::bfyx };
+    auto in_layout = layout{ ov::PartialShape{1, 3, 3, 2}, data_types::f32, format::bfyx };
     auto scale_layout = layout{ ov::PartialShape{1, 1, 1, 1}, data_types::f32, format::bfyx };
     auto bias_layout = layout{ ov::PartialShape{1, 1, 1, 1}, data_types::f32, format::bfyx };
 
@@ -176,14 +176,12 @@ TEST(group_normalization, input_bfyx_output_fsv16) {
     auto scale_mem = engine.allocate_memory(scale_layout);
     auto bias_mem = engine.allocate_memory(bias_layout);
 
-    tests::random_generator rg{"group_normalization"};
-    std::vector<float> input = rg.generate_random_1d<float>(ov::shape_size(in_layout.get_shape()), -1, 1);
-    std::vector<float> scale = rg.generate_random_1d<float>(ov::shape_size(scale_layout.get_shape()), -1, 1);
-    std::vector<float> bias = rg.generate_random_1d<float>(ov::shape_size(bias_layout.get_shape()), -1, 1);
-
-    set_values(input_mem, input);
-    set_values(scale_mem, scale);
-    set_values(bias_mem, bias);
+    set_values(input_mem,
+               { 0.125, 0.125, 0.875, -0.125, 0.125, 0.750,
+                0.875, -0.375, -0.375, -1.000, -0.625, -1.000,
+                -0.125, -0.750, -0.250, 0.625, -0.500, -0.875 });
+    set_values(scale_mem, { 0.125 });
+    set_values(bias_mem, { 0.75 });
 
     topology topology(
         input_layout("input", in_layout),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -168,31 +168,28 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(group_normalization, input_bfyx_output_fsv16) {
     auto& engine = get_test_engine();
 
-    auto in_layout = layout{ ov::PartialShape::dynamic(5), data_types::f16, format::bfzyx };
-    auto scale_layout = layout{ ov::PartialShape{1}, data_types::f16, format::bfyx };
-    auto bias_layout = layout{ ov::PartialShape{1}, data_types::f16, format::bfyx };
+    auto in_layout = layout{ ov::PartialShape{12, 320, 35, 28}, data_types::f32, format::bfyx };
+    auto scale_layout = layout{ ov::PartialShape{1, 1, 1, 1}, data_types::f32, format::bfyx };
+    auto bias_layout = layout{ ov::PartialShape{1, 1, 1, 1}, data_types::f32, format::bfyx };
 
-    auto input_mem = engine.allocate_memory({ ov::PartialShape{2, 6, 320, 35, 28}, data_types::f16, format::bfzyx });
+    auto input_mem = engine.allocate_memory(in_layout);
     auto scale_mem = engine.allocate_memory(scale_layout);
     auto bias_mem = engine.allocate_memory(bias_layout);
 
     tests::random_generator rg{"group_normalization"};
-    std::vector<float> input = rg.generate_random_1d<float>(ov::shape_size(input_mem->get_layout().get_shape()), -1, 1);
+    std::vector<float> input = rg.generate_random_1d<float>(ov::shape_size(in_layout.get_shape()), -1, 1);
     std::vector<float> scale = rg.generate_random_1d<float>(ov::shape_size(scale_layout.get_shape()), -1, 1);
     std::vector<float> bias = rg.generate_random_1d<float>(ov::shape_size(bias_layout.get_shape()), -1, 1);
 
+    set_values(input_mem, input);
     set_values(scale_mem, scale);
     set_values(bias_mem, bias);
 
     topology topology(
         input_layout("input", in_layout),
-        data("scale", scale_mem),
-        data("bias", bias_mem),
-        reshape("reshape", input_info("input"), true, {12, 320, 35, 28}, ov::PartialShape::dynamic(4)),
-        reorder("reorder1", input_info("reshape"), format::b_fs_yx_fsv16, data_types::f16),
-        group_normalization("group_normalization", input_info("reorder1"), input_info("scale"), input_info("bias"), static_cast<std::int64_t>(1), 0.0025),
-        reorder("reorder2", input_info("group_normalization"), format::b_fs_yx_fsv16, data_types::f16),
-        permute("output", input_info("reorder2"), {0, 2, 3, 1})
+        input_layout("scale", scale_layout),
+        input_layout("bias", bias_layout),
+        group_normalization("group_normalization", input_info("input"), input_info("scale"), input_info("bias"), static_cast<std::int64_t>(1), 0.0025)
     );
 
     ExecutionConfig config = get_test_default_config(engine);
@@ -201,19 +198,28 @@ TEST(group_normalization, input_bfyx_output_fsv16) {
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
 
-    reorder_factory rf;
-    auto program = program::build_program(engine, topology, config, false, true);
-    program_wrapper::apply_opt_pass<reorder_inputs>(*program, rf);
-    auto& reorder_node = program->get_node("reorder1");
-    std::vector<layout> layouts = {layout { ov::PartialShape::dynamic(4), data_types::f16, format::bfyx }};
-    reorder_node.set_output_layouts(layouts, false);
+    auto network = std::make_shared<cldnn::network>(engine, topology, config);
+    network->set_input_data("input", input_mem);
+    network->set_input_data("scale", scale_mem);
+    network->set_input_data("bias", bias_mem);
 
-    network network(program, false, false);
-    network.set_input_data("input", input_mem);
-    auto output = network.execute();
+    auto outputs_gold = network->execute();
+    auto output_gold = outputs_gold.at("group_normalization").get_memory();
+    cldnn::mem_lock<float> output_mem_gold(output_gold, get_test_stream());
 
-    ASSERT_EQ(output.size(), size_t(1));
-    ASSERT_EQ(output.begin()->first, "output");
+    auto& gn_node = network->get_program()->get_node("group_normalization");
+    std::vector<layout> layouts = {layout { in_layout.get_shape(), data_types::f32, format::b_fs_yx_fsv16 }};
+    gn_node.set_output_layouts(layouts, false);
 
+    auto outputs_target = network->execute();
+    auto output_target = outputs_target.at("group_normalization").get_memory();
+    cldnn::mem_lock<float> output_mem_target(output_target, get_test_stream());
+
+    ASSERT_EQ(output_mem_gold.size(), output_mem_target.size());
+    ASSERT_EQ(outputs_gold.begin()->first, outputs_target.begin()->first);
+
+    for (std::size_t i = 0; i < output_mem_target.size(); i++) {
+        ASSERT_NEAR(output_mem_target[i], output_mem_gold[i], 0.0001);
+    }
 }
 #endif // ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details:
 - In group normalization, there can be a case requiring input bfyx and output fsv16 in bfyx opt kernel.

### Tickets:
 - 156608
