### PR TITLE
[tests/requirements_tensorflow] Fix jax version for python 3.9 & NumPy conflict on Py 3.12 on MacOS

### DIFF
--- a/tests/requirements_tensorflow
+++ b/tests/requirements_tensorflow
@@ -1,8 +1,9 @@
 # test ovc with NumPy 2.x on Ubuntu 24 with default Python 3.12
 # test against NumPy 1.x with older Python versions
 # tensorflow-intel 2.18.0 depends on numpy<2.1.0 and >=1.26.0
-numpy==1.26.4; python_version < "3.12"
-numpy==2.0.2; python_version >= "3.12"
+# tensorflow 2.16.2 depends on numpy<2.0.0 and >=1.26.0; python_version >= "3.12"
+numpy==1.26.4; python_version < "3.12" or platform_system == "Darwin" and platform_machine == "x86_64"
+numpy==2.0.2; python_version >= "3.12" and (platform_system != "Darwin" or platform_machine != "x86_64")
 pytest==7.0.1
 pytest-xdist[psutil]==3.6.1
 pytest-html==4.1.1
@@ -16,8 +17,8 @@ wrapt==1.15.0; python_version >= "3.12"
 # tensorflow-text is not available for both Windows and ARM platforms
 tensorflow-text==2.18.0; python_version < "3.12" and platform_system == "Linux" and platform_machine == "x86_64"
 tensorflow-hub==0.16.1
-jax==0.4.35; platform_system != "Darwin" or platform_machine != "x86_64" and python_version > "3.9"
+jax==0.4.35; (platform_system != "Darwin" or platform_machine != "x86_64") and python_version > "3.9"
 # tensorflow 2.16.2 depends on ml-dtypes~=0.3.1 and jax 0.4.35 depends on ml-dtypes>=0.4.0
-jax==0.4.33; platform_system == "Darwin" and platform_machine == "x86_64" and python_version > "3.9"
+jax==0.4.33; (platform_system == "Darwin" and platform_machine == "x86_64") and python_version > "3.9"
 jax==0.4.30; python_version <= "3.9"
 defusedxml==0.7.1

--- a/tests/requirements_tensorflow
+++ b/tests/requirements_tensorflow
@@ -16,7 +16,8 @@ wrapt==1.15.0; python_version >= "3.12"
 # tensorflow-text is not available for both Windows and ARM platforms
 tensorflow-text==2.18.0; python_version < "3.12" and platform_system == "Linux" and platform_machine == "x86_64"
 tensorflow-hub==0.16.1
-jax==0.4.35; platform_system != "Darwin" or platform_machine != "x86_64"
+jax==0.4.35; platform_system != "Darwin" or platform_machine != "x86_64" and python_version > "3.9"
 # tensorflow 2.16.2 depends on ml-dtypes~=0.3.1 and jax 0.4.35 depends on ml-dtypes>=0.4.0
-jax==0.4.33; platform_system == "Darwin" and platform_machine == "x86_64"
+jax==0.4.33; platform_system == "Darwin" and platform_machine == "x86_64" and python_version > "3.9"
+jax==0.4.30; python_version <= "3.9"
 defusedxml==0.7.1


### PR DESCRIPTION
### Details:
Fix one of the blockers for dropping openvino-dev in internal CI
