### PR TITLE
[TRANSFORMATIONS] Allow NOP-elimination for shapes with dynamic 0th dimension

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -134,14 +134,16 @@ static bool eliminate_nop(const shared_ptr<Node>& node) {
 
 // Check if first dim is dynamic, other dims are static
 static bool only_first_dim_dynamic(const PartialShape& pshape) {
-    if (pshape.rank().is_static() && pshape[0].is_dynamic()) {
-        for (size_t i = 1; i < pshape.size(); ++i) {
-            if (pshape[i].is_dynamic()) {
-                return false;
+    if (pshape.rank().is_static() && pshape.size() > 0) { 
+        if (pshape[0].is_dynamic()) {
+            for (size_t i = 1; i < pshape.size(); ++i) {
+                if (pshape[i].is_dynamic()) {
+                    return false;
+                }
             }
-        }
 
-        return true;
+            return true;
+        }
     }
 
     return false;

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -135,24 +135,33 @@ static bool eliminate_nop(const shared_ptr<Node>& node) {
 static bool eliminate_reshape_v1(const shared_ptr<Node>& node) {
     auto input = node->input_value(0);
 
+    std::cout << "THIS: " << node->get_friendly_name() << " "  << node->get_name() << std::endl;
+    std::cout << "INPUT: " << input.get_node_shared_ptr()->get_friendly_name() << " "  << input.get_node_shared_ptr()->get_name() << std::endl;
+
     if (input.get_partial_shape().rank().is_static() && input.get_partial_shape().rank().same_scheme(1)) {
-        if (input.get_partial_shape().same_scheme(node->get_output_partial_shape(0)))
+        if (input.get_partial_shape().same_scheme(node->get_output_partial_shape(0))) {
+            std::cout << "EXIT HERE" << std::endl;
             return replace_output_update_name(node->output(0), input);
+        }
     }
 
     // check if reshape is not identity op
     if (input.get_partial_shape().is_dynamic() || node->get_output_partial_shape(0).is_dynamic()) {
         OPENVINO_DEBUG(node, " has dynamic shapes.");
+        std::cout << "EXIT HERE 1" << std::endl;
         return false;
     }
     // remove identity op
     if (input.get_shape() == node->get_output_shape(0)) {
+        std::cout << "EXIT HERE 2" << std::endl;
         return replace_output_update_name(node->output(0), input);
     }
     // eliminate redundant reshape, squeeze, or unsqueeze
     auto input_node = input.get_node_shared_ptr();
     if (ov::as_type_ptr<ov::op::v0::Squeeze>(input_node) || ov::as_type_ptr<ov::op::v0::Unsqueeze>(input_node) ||
         ov::as_type_ptr<ov::op::v1::Reshape>(input_node)) {
+        std::cout << "---: " << node->get_friendly_name() << " "  << node->get_name() << std::endl;
+        std::cout << "---: " << input.get_node_shared_ptr()->get_friendly_name() << " "  << input.get_node_shared_ptr()->get_name() << std::endl;
         if (input_node->get_output_target_inputs(0).size() != 1)
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -134,7 +134,7 @@ static bool eliminate_nop(const shared_ptr<Node>& node) {
 
 // Check if first dim is dynamic, other dims are static
 static bool only_first_dim_dynamic(const PartialShape& pshape) {
-    if (pshape.rank().is_static() && pshape.size() > 0) { 
+    if (pshape.rank().is_static() && pshape.size() > 0) {
         if (pshape[0].is_dynamic()) {
             for (size_t i = 1; i < pshape.size(); ++i) {
                 if (pshape[i].is_dynamic()) {
@@ -158,12 +158,13 @@ static bool eliminate_reshape_v1(const shared_ptr<Node>& node) {
     }
     // check if reshape is not identity op
     if (input.get_partial_shape().is_dynamic() || node->get_output_partial_shape(0).is_dynamic()) {
-        if (!only_first_dim_dynamic(input.get_partial_shape()) || !only_first_dim_dynamic(node->get_output_partial_shape(0))) {
-            OPENVINO_DEBUG(node, " has dynamic shapes.");
+        if (!only_first_dim_dynamic(input.get_partial_shape()) ||
+            !only_first_dim_dynamic(node->get_output_partial_shape(0))) {
+            OPENVINO_DEBUG(node, " has dynamic shapes with not only 0th dimension dynamic.");
             return false;
         }
     }
-    
+
     // remove identity op
     if (input.get_partial_shape() == node->get_output_partial_shape(0)) {
         return replace_output_update_name(node->output(0), input);
@@ -178,7 +179,8 @@ static bool eliminate_reshape_v1(const shared_ptr<Node>& node) {
         auto shape = node->get_output_partial_shape(0);
 
         // remove interchangeable nodes
-        if (input_node->get_input_partial_shape(0).is_static() && input_node->get_input_shape(0) == node->get_output_shape(0)) {
+        if (input_node->get_input_partial_shape(0).is_static() &&
+            input_node->get_input_partial_shape(0) == node->get_output_partial_shape(0)) {
             return replace_output_update_name(node->output(0), input_node->input_value(0));
         } else {
             vector<int64_t> vi;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -257,7 +257,7 @@ TEST_F(TransformationTestsF, reshape_reshape_elimination_v1_dynamic) {
         auto add = std::make_shared<op::v1::Add>(bottom_reshape, add_param);
         model_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input, add_param});
     }
-    
+
     manager.register_pass<ov::pass::NopElimination>();
     manager.run_passes(model);
 

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -233,6 +233,38 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination_dynamic_without_squeeze_axis
     EXPECT_NO_THROW(pass_manager.run_passes(f));
 }
 
+TEST_F(TransformationTestsF, reshape_reshape_elimination_v1_dynamic) {
+    {
+        auto input = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 32, 1, 128}));
+
+        auto top_reshape_const = op::v0::Constant::create(element::i32, Shape{4}, {-1, 32, 1, 128});
+        auto top_reshape = std::make_shared<op::v1::Reshape>(input, top_reshape_const, false);
+
+        auto bottom_reshape_const = op::v0::Constant::create(element::i32, Shape{2}, {-1, 4096});
+        auto bottom_reshape = std::make_shared<op::v1::Reshape>(top_reshape, bottom_reshape_const, false);
+
+        auto add_param = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 4096}));
+        auto add = std::make_shared<op::v1::Add>(bottom_reshape, add_param);
+        model = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input, add_param});
+    }
+    {
+        auto input = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 32, 1, 128}));
+
+        auto bottom_reshape_const = op::v0::Constant::create(element::i32, Shape{2}, {-1, 4096});
+        auto bottom_reshape = std::make_shared<op::v1::Reshape>(input, bottom_reshape_const, false);
+
+        auto add_param = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 4096}));
+        auto add = std::make_shared<op::v1::Add>(bottom_reshape, add_param);
+        model_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input, add_param});
+    }
+    
+    manager.register_pass<ov::pass::NopElimination>();
+    manager.run_passes(model);
+
+    auto res = comparator.compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
 TEST(nop_elimination, reshape_elimination_v1_dynamic_negative) {
     auto arg = std::make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic());
     auto pattern = make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -844,6 +844,8 @@ void Transformations::PostLpt() {
     CPU_REGISTER_PASS_ARM64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionFlux);
     CPU_REGISTER_PASS_X64(postLPTPassManager, CausalMaskPreprocessFusion);
+    CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::NopElimination);
+    CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::Serialize, "after_nop.xml", "after_nop.bin");
 
 #if defined(OPENVINO_ARCH_X86_64)
     // MLP & QKV fusion optimizations is focused on throughput, only enabled on AMX-bf16 & LLM serving use cases.

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -844,8 +844,6 @@ void Transformations::PostLpt() {
     CPU_REGISTER_PASS_ARM64(postLPTPassManager, ov::pass::RoPEFusion, true);
     CPU_DISABLE_PASS_COMMON(postLPTPassManager, ov::pass::RoPEFusionFlux);
     CPU_REGISTER_PASS_X64(postLPTPassManager, CausalMaskPreprocessFusion);
-    CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::NopElimination);
-    CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::Serialize, "after_nop.xml", "after_nop.bin");
 
 #if defined(OPENVINO_ARCH_X86_64)
     // MLP & QKV fusion optimizations is focused on throughput, only enabled on AMX-bf16 & LLM serving use cases.


### PR DESCRIPTION
NOP-elimination doesn't allow the removal of unnecessary data-movement
operations stacked on top of each other if their shapes are dynamic, even
though certain cases of dynamic shapes can be covered by
NOP-elimination.

Allow NOP-elimination for dynamic shapes if they have only the 0th
dimension dynamic and other static, making this case compatible for
such a fusion.

- Tickets:
  * CVS-158394

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>

