### PR TITLE
[core] Extend Core API to accept std::filesystem::path when build with cpp17

### DIFF
--- a/src/core/shape_inference/include/ov_optional.hpp
+++ b/src/core/shape_inference/include/ov_optional.hpp
@@ -7,6 +7,9 @@
 #include <cstddef>
 
 namespace ov {
+#ifdef OPENVINO_CPP_17_VER
+using optional = std::optional;
+#else
 
 /**
  * @brief Store optional object of type T (basic version of std::optional).
@@ -132,4 +135,5 @@ private:
     bool m_has_value = false;
     Storage<T> m_opt{};
 };
+#endif
 }  // namespace ov

--- a/src/core/tests/pattern.cpp
+++ b/src/core/tests/pattern.cpp
@@ -558,8 +558,8 @@ TEST(pattern, multiple_optionals_in_row) {
 
     // Pattern:
     auto in = wrap_type<v0::Parameter>();
-    auto pattern_convert = optional<v0::Convert>(in);
-    auto pattern_relu = optional<v0::Relu>(pattern_convert);
+    auto pattern_convert = pattern::optional<v0::Convert>(in);
+    auto pattern_relu = pattern::optional<v0::Relu>(pattern_convert);
     auto pattern_sigmoid = wrap_type<v0::Sigmoid>({pattern_relu});
 
     // Test:

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -25,6 +25,10 @@
 #include "openvino/runtime/remote_context.hpp"
 #include "openvino/runtime/tensor.hpp"
 
+#ifdef OPENVINO_CPP_VER_17
+#    include <filesystem>
+#endif
+
 namespace ov {
 
 /**
@@ -95,8 +99,17 @@ public:
      *  * TF (*.pb)
      *  * TFLite (*.tflite)
      * @return A model.
+     * @{
      */
     std::shared_ptr<ov::Model> read_model(const std::string& model_path, const std::string& bin_path = {}) const;
+
+#ifdef OPENVINO_CPP_VER_17
+    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    std::shared_ptr<ov::Model> read_model(const Path& model_path, const Path& bin_path = {}) const {
+        return read_model(model_path.string(), bin_path.string());
+    }
+#endif
+    /// @}
 
     /**
      * @brief Reads models from IR / ONNX / PDPD / TF / TFLite formats.
@@ -197,6 +210,13 @@ public:
      */
     CompiledModel compile_model(const std::string& model_path, const AnyMap& properties = {});
 
+#ifdef OPENVINO_CPP_VER_17
+    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    auto compile_model(const Path& model_path, const AnyMap& properties = {}) const {
+        return compile_model(model_path.string(), properties);
+    }
+#endif
+
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     CompiledModel compile_model(const std::wstring& model_path, const AnyMap& properties = {});
 #endif
@@ -222,6 +242,13 @@ public:
                                                                            Properties&&... properties) {
         return compile_model(model_path, AnyMap{std::forward<Properties>(properties)...});
     }
+
+#ifdef OPENVINO_CPP_VER_17
+    template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    auto compile_model(const Path& model_path, Properties&&... properties) {
+        return compile_model(model_path.string(), std::forward<Properties>(properties)...);
+    }
+#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     template <typename... Properties>
@@ -249,6 +276,13 @@ public:
     CompiledModel compile_model(const std::string& model_path,
                                 const std::string& device_name,
                                 const AnyMap& properties = {});
+
+#ifdef OPENVINO_CPP_VER_17
+    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    auto compile_model(const Path& model_path, const std::string& device_name, const AnyMap& properties = {}) {
+        return compile_model(model_path.string(), device_name, properties);
+    }
+#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     CompiledModel compile_model(const std::wstring& model_path,
@@ -278,6 +312,13 @@ public:
                                                                            Properties&&... properties) {
         return compile_model(model_path, device_name, AnyMap{std::forward<Properties>(properties)...});
     }
+
+#ifdef OPENVINO_CPP_VER_17
+    template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    auto compile_model(const Path& model_path, const std::string& device_name, Properties&&... properties) {
+        return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
+    }
+#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     template <typename... Properties>
@@ -359,8 +400,16 @@ public:
     /**
      * @brief Registers an extension to a Core object.
      * @param library_path Path to the library with ov::Extension.
+     * @{
      */
     void add_extension(const std::string& library_path);
+
+#ifdef OPENVINO_CPP_VER_17
+    void add_extension(const std::filesystem::path& model_path) const {
+        add_extension(model_path.string());
+    }
+#endif
+    /// @}
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     /**

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -405,7 +405,8 @@ public:
     void add_extension(const std::string& library_path);
 
 #ifdef OPENVINO_CPP_VER_17
-    void add_extension(const std::filesystem::path& model_path) const {
+    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    void add_extension(const Path& model_path) {
         add_extension(model_path.string());
     }
 #endif

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -8,8 +8,25 @@
 
 #include "common_test_utils/common_utils.hpp"
 #include "common_test_utils/file_utils.hpp"
+#include "functional_test_utils/test_model/test_model.hpp"
 #include "openvino/runtime/core.hpp"
 #include "openvino/util/file_util.hpp"
+
+class CoreBaseTest : public testing::Test {
+protected:
+    void generate_test_model_files(const std::string& name) {
+        auto prefix = ov::test::utils::generateTestFilePrefix();
+        model_file_name = prefix + name + ".xml";
+        weight_file_name = prefix + name + ".bin";
+        ov::test::utils::generate_test_model(model_file_name, weight_file_name);
+    }
+
+    void TearDown() override {
+        ov::test::utils::removeIRFiles(model_file_name, weight_file_name);
+    }
+
+    std::string model_file_name, weight_file_name;
+};
 
 #ifndef OPENVINO_STATIC_LIBRARY
 
@@ -33,7 +50,7 @@ static void remove_plugin_xml(const std::string& file_name) {
     ov::test::utils::removeFile(file_name);
 }
 
-TEST(CoreBaseTest, LoadPluginXML) {
+TEST_F(CoreBaseTest, LoadPluginXML) {
     std::string xml_file_name = "test_plugin.xml";
     std::string xml_file_path =
         ov::test::utils::getOpenvinoLibDirectory() + ov::util::FileTraits<char>::file_separator + xml_file_name;
@@ -42,7 +59,7 @@ TEST(CoreBaseTest, LoadPluginXML) {
     remove_plugin_xml(xml_file_path);
 }
 
-TEST(CoreBaseTest, LoadPluginDifferentXMLExtension) {
+TEST_F(CoreBaseTest, LoadPluginDifferentXMLExtension) {
     std::string xml_file_name = "test_plugin.test";
     std::string xml_file_path =
         ov::test::utils::getOpenvinoLibDirectory() + ov::util::FileTraits<char>::file_separator + xml_file_name;
@@ -51,7 +68,7 @@ TEST(CoreBaseTest, LoadPluginDifferentXMLExtension) {
     remove_plugin_xml(xml_file_path);
 }
 
-TEST(CoreBaseTest, LoadAbsoluteOVPathPluginXML) {
+TEST_F(CoreBaseTest, LoadAbsoluteOVPathPluginXML) {
     std::string xml_file_name = "test_plugin.xml";
     std::string xml_file_path =
         ov::test::utils::getOpenvinoLibDirectory() + ov::util::FileTraits<char>::file_separator + xml_file_name;
@@ -60,7 +77,7 @@ TEST(CoreBaseTest, LoadAbsoluteOVPathPluginXML) {
     remove_plugin_xml(xml_file_path);
 }
 
-TEST(CoreBaseTest, LoadAbsoluteCWPathPluginXML) {
+TEST_F(CoreBaseTest, LoadAbsoluteCWPathPluginXML) {
     std::string xml_file_name = "test_plugin.xml";
     std::string xml_file_path =
         ov::test::utils::getCurrentWorkingDir() + ov::util::FileTraits<char>::file_separator + xml_file_name;
@@ -69,7 +86,7 @@ TEST(CoreBaseTest, LoadAbsoluteCWPathPluginXML) {
     remove_plugin_xml(xml_file_path);
 }
 
-TEST(CoreBaseTest, LoadRelativeCWPathPluginXML) {
+TEST_F(CoreBaseTest, LoadRelativeCWPathPluginXML) {
     std::string xml_file_name = "test_plugin.xml";
     std::string xml_file_path =
         ov::test::utils::getCurrentWorkingDir() + ov::util::FileTraits<char>::file_separator + xml_file_name;
@@ -78,7 +95,7 @@ TEST(CoreBaseTest, LoadRelativeCWPathPluginXML) {
     remove_plugin_xml(xml_file_path);
 }
 
-TEST(CoreBaseTest, LoadOVFolderOverCWPathPluginXML) {
+TEST_F(CoreBaseTest, LoadOVFolderOverCWPathPluginXML) {
     std::string xml_file_name = "test_plugin.xml";
     std::string cwd_file_path =
         ov::test::utils::getCurrentWorkingDir() + ov::util::FileTraits<char>::file_separator + xml_file_name;
@@ -95,4 +112,44 @@ TEST(CoreBaseTest, LoadOVFolderOverCWPathPluginXML) {
     remove_plugin_xml(ov_file_path);
 }
 
+#endif
+
+#if defined(OPENVINO_CPP_VER_17) && defined(ENABLE_OV_IR_FRONTEND)
+namespace ov::test {
+TEST_F(CoreBaseTest, read_model_with_std_fs_path) {
+    generate_test_model_files("test-model");
+
+    const auto model_path = std::filesystem::path(model_file_name);
+    const auto weight_path = std::filesystem::path(weight_file_name);
+
+    ov::Core core;
+    {
+        const auto model = core.read_model(model_path);
+        EXPECT_NE(model, nullptr);
+    }
+    {
+        const auto model = core.read_model(model_path, weight_path);
+        EXPECT_NE(model, nullptr);
+    }
+}
+
+TEST_F(CoreBaseTest, compile_model_with_std_fs_path) {
+    generate_test_model_files("model2");
+
+    const auto model_path = std::filesystem::path(model_file_name);
+    const auto weight_path = std::filesystem::path(weight_file_name);
+
+    ov::Core core;
+    {
+        const auto model = core.compile_model(model_path);
+        EXPECT_TRUE(model);
+    }
+    {
+        const auto devices = core.get_available_devices();
+
+        const auto model = core.compile_model(model_path, devices.at(0), ov::AnyMap{});
+        EXPECT_TRUE(model);
+    }
+}
+}  // namespace ov::test
 #endif

--- a/src/inference/tests/functional/ov_extension_test.cpp
+++ b/src/inference/tests/functional/ov_extension_test.cpp
@@ -82,6 +82,12 @@ public:
 };
 
 #if defined(ENABLE_OV_IR_FRONTEND)
+#    ifdef OPENVINO_CPP_VER_17
+TEST_F(OVExtensionTests, ReshapeIRWithNewExtensionsPathLib) {
+    core.add_extension(std::filesystem::path(getOVExtensionPath()));
+    test();
+}
+#    endif
 
 TEST_F(OVExtensionTests, ReshapeIRWithNewExtensionsLib) {
     core.add_extension(getOVExtensionPath());


### PR DESCRIPTION
### Details:
 - The `ov::Core` accepts `std::filesytem::path` in functions where string as path is used.

### Tickets:
 - CVS-157908
