### PR TITLE
[GPU] Enable can_use_fsv16 and can_use_bs_fs_yx_bsv16_fsv16 for group_normalization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1501,6 +1501,7 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
             prim.type() != cldnn::strided_slice::type_id() &&
             prim.type() != cldnn::region_yolo::type_id() &&
             prim.type() != cldnn::normalize::type_id() &&
+            prim.type() != cldnn::group_normalization::type_id() &&
             prim.type() != cldnn::mvn::type_id() &&
             prim.type() != cldnn::gather::type_id() &&
             prim.type() != cldnn::scatter_nd_update::type_id() &&
@@ -1581,6 +1582,7 @@ void program::set_layout_optimizer_attributes(layout_optimizer& lo) {
             prim.type() != cldnn::deconvolution::type_id() &&
             prim.type() != cldnn::multiclass_nms::type_id() &&
             prim.type() != cldnn::normalize::type_id() &&
+            prim.type() != cldnn::group_normalization::type_id() &&
             prim.type() != cldnn::deconvolution::type_id() &&
             prim.type() != cldnn::unique_count::type_id() &&
             prim.type() != cldnn::unique_gather::type_id() &&


### PR DESCRIPTION
### Details:
 - *Enable can_use_fsv16 and can_use_bs_fs_yx_bsv16_fsv16 for group_normalization in pytorch version timm_mobilevitv2_150 OV model to get better performance*


### Tickets:
 - *[CVS-154913](https://jira.devtools.intel.com/browse/CVS-154913)*
