### PR TITLE
[GPU] Disable KV cache compression and FC scaling for GPU with systolic

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
@@ -140,7 +140,7 @@ public:
 
     // Note that RT info property value has lower priority than values set by user via core.set_property or passed to compile_model call
     // So this method should be called after setting all user properties, but before apply_user_properties() call.
-    void apply_rt_info(const ov::RTMap& rt_info);
+    void apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info);
 
     std::string to_string() const;
 

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -190,7 +190,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
     ExecutionConfig config = m_configs_map.at(device_id);
     config.set_user_property(orig_config);
     if (model->has_rt_info("runtime_options"))
-        config.apply_rt_info(model->get_rt_info<ov::AnyMap>("runtime_options"));
+        config.apply_rt_info(context->get_engine().get_device_info(), model->get_rt_info<ov::AnyMap>("runtime_options"));
     config.apply_user_properties(context->get_engine().get_device_info());
 
     set_cache_info(model, config);
@@ -281,7 +281,7 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
     ExecutionConfig config = m_configs_map.at(device_id);
     config.set_user_property(orig_config);
     if (model->has_rt_info("runtime_options"))
-        config.apply_rt_info(model->get_rt_info<ov::AnyMap>("runtime_options"));
+        config.apply_rt_info(ctx->get_engine().get_device_info(), model->get_rt_info<ov::AnyMap>("runtime_options"));
     config.apply_user_properties(ctx->get_engine().get_device_info());
 
     ProgramBuilder prog(ctx->get_engine(), config);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -941,7 +941,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
-        manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
+
+        if (!device_info.supports_immad) {
+            manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
+        }
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();
@@ -951,8 +954,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::pass::GLUFusion>();
         manager.register_pass<ov::intel_gpu::IndirectKVCache>();
 
-        auto kv_cache_compression_dt = config.get_property(ov::hint::kv_cache_precision);
-        manager.register_pass<ov::intel_gpu::KVCacheCompression>(kv_cache_compression_dt);
+        if (!device_info.supports_immad) {
+            auto kv_cache_compression_dt = config.get_property(ov::hint::kv_cache_precision);
+            manager.register_pass<ov::intel_gpu::KVCacheCompression>(kv_cache_compression_dt);
+        }
 
         manager.register_pass<ov::intel_gpu::ConvertConvolutionToInternal>();
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -941,10 +941,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::KVCacheFusion>();
         manager.register_pass<ov::intel_gpu::FullyConnectedConvertFusion>();
         manager.register_pass<ov::intel_gpu::TransposeFusion>(device_info.supports_immad);
-
-        if (!device_info.supports_immad) {
-            manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
-        }
+        manager.register_pass<ov::intel_gpu::FullyConnectedPerLayerScaling>(config.get_property(ov::hint::activations_scale_factor));
 
         if (!device_info.supports_immad) {
             manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeMatmulFusion>();
@@ -954,10 +951,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::pass::GLUFusion>();
         manager.register_pass<ov::intel_gpu::IndirectKVCache>();
 
-        if (!device_info.supports_immad) {
-            auto kv_cache_compression_dt = config.get_property(ov::hint::kv_cache_precision);
-            manager.register_pass<ov::intel_gpu::KVCacheCompression>(kv_cache_compression_dt);
-        }
+        auto kv_cache_compression_dt = config.get_property(ov::hint::kv_cache_precision);
+        manager.register_pass<ov::intel_gpu::KVCacheCompression>(kv_cache_compression_dt);
 
         manager.register_pass<ov::intel_gpu::ConvertConvolutionToInternal>();
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -265,9 +265,9 @@ void ExecutionConfig::apply_user_properties(const cldnn::device_info& info) {
 void ExecutionConfig::apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info) {
     if (!info.supports_immad) {
         apply_rt_info_property(ov::hint::kv_cache_precision, rt_info);
-        apply_rt_info_property(ov::hint::dynamic_quantization_group_size, rt_info);
         apply_rt_info_property(ov::hint::activations_scale_factor, rt_info);
     }
+    apply_rt_info_property(ov::hint::dynamic_quantization_group_size, rt_info);
 }
 
 std::string ExecutionConfig::to_string() const {

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -262,10 +262,12 @@ void ExecutionConfig::apply_user_properties(const cldnn::device_info& info) {
     user_properties.clear();
 }
 
-void ExecutionConfig::apply_rt_info(const ov::RTMap& rt_info) {
-    apply_rt_info_property(ov::hint::kv_cache_precision, rt_info);
-    apply_rt_info_property(ov::hint::dynamic_quantization_group_size, rt_info);
-    apply_rt_info_property(ov::hint::activations_scale_factor, rt_info);
+void ExecutionConfig::apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info) {
+    if (!info.supports_immad) {
+        apply_rt_info_property(ov::hint::kv_cache_precision, rt_info);
+        apply_rt_info_property(ov::hint::dynamic_quantization_group_size, rt_info);
+        apply_rt_info_property(ov::hint::activations_scale_factor, rt_info);
+    }
 }
 
 std::string ExecutionConfig::to_string() const {


### PR DESCRIPTION
### Details:
- GPU with systolic does not need FC scaling
- GPU with systolic does not support kv cache compresssion yet
