### PR TITLE
[tests/requirements_pytorch] Temporarily fix optimum-intel version on last stable commit (#27985)

### DIFF
--- a/.github/components.yml
+++ b/.github/components.yml
@@ -149,6 +149,7 @@ PyTorch_FE:
   build:
     - CPU
     - Python_API
+    - TOKENIZERS # PyTorch_FE tests depend on tokenizers build
 
 JAX_FE:
   revalidate:

--- a/tests/requirements_pytorch
+++ b/tests/requirements_pytorch
@@ -44,7 +44,7 @@ super-image==0.1.7
 huggingface-hub==0.25.2
 
 # use latest released version once it's available
-git+https://github.com/huggingface/optimum-intel.git@main; python_version < "3.12"
+git+https://github.com/huggingface/optimum-intel.git@5c735487d4bd3dd8d7dccb242d8d5988e7dd4069; python_version < "3.12"
 # set 'export HF_HUB_ENABLE_HF_TRANSFER=1' to benefits from hf_transfer
 hf_transfer==0.1.8
 


### PR DESCRIPTION
There are failures with newer commits, e.g.
https://github.com/openvinotoolkit/openvino/actions/runs/12240792041/job/34146426674
