### PR TITLE
Workaround for sample failure with OV built by VS2022

### DIFF
--- a/samples/python/benchmark/bert_benchmark/bert_benchmark.py
+++ b/samples/python/benchmark/bert_benchmark/bert_benchmark.py
@@ -9,8 +9,8 @@ import sys
 import tempfile
 from time import perf_counter
 
-import datasets
 import openvino as ov
+import datasets
 from openvino.runtime import get_version
 from transformers import AutoTokenizer
 from transformers.onnx import export


### PR DESCRIPTION
### Details:
 When OV is built with VS2022 and imported after datasets module, ov.Core() call fails with access violation error.

### Tickets:
 - CVS-158167