### PR TITLE
[PyOV] update numpy <2.3.0

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -1,5 +1,5 @@
 # used in multiple components
-numpy>=1.16.6,<2.2.0  # Python bindings, frontends
+numpy>=1.16.6,<2.3.0  # Python bindings, frontends
 
 # pytest
 pytest>=5.0,<8.4

--- a/src/bindings/python/requirements.txt
+++ b/src/bindings/python/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.16.6,<2.2.0
+numpy>=1.16.6,<2.3.0
 openvino-telemetry>=2023.2.1
 packaging


### PR DESCRIPTION
Support [NumPy 2.2.0](https://github.com/numpy/numpy/releases/tag/v2.2.0) release (actually, not a major release)