### PR TITLE
[core] Extend model serialize API to support std::filesystem::path

### DIFF
--- a/src/core/include/openvino/core/graph_util.hpp
+++ b/src/core/include/openvino/core/graph_util.hpp
@@ -21,6 +21,10 @@
 #include "openvino/op/parameter.hpp"
 #include "openvino/pass/serialize.hpp"
 
+#ifdef OPENVINO_CPP_VER_17
+#    include <filesystem>
+#endif
+
 namespace ov {
 
 OPENVINO_API
@@ -288,27 +292,46 @@ bool replace_node_update_name(const std::shared_ptr<Node>& target, const std::sh
 /// \param bin_path Path where .bin file will be saved (optional).
 ///                 The same name as for xml_path will be used by default.
 /// \param version Version of the generated IR (optional).
+/// \{
 OPENVINO_API
 void serialize(const std::shared_ptr<const ov::Model>& m,
                const std::string& xml_path,
                const std::string& bin_path = "",
                ov::pass::Serialize::Version version = ov::pass::Serialize::Version::UNSPECIFIED);
 
+#ifdef OPENVINO_CPP_VER_17
+template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+void serialize(const std::shared_ptr<const ov::Model>& m,
+               const Path& xml_path,
+               const Path& bin_path = {""},
+               ov::pass::Serialize::Version version = ov::pass::Serialize::Version::UNSPECIFIED) {
+    serialize(m, xml_path.string(), bin_path.string(), version);
+}
+#endif
+/// \}
+
+// TODO CPP17
 /// \brief Save given model into IR. Floating point weights are compressed to FP16 by default.
 /// This method saves a model to IR applying all necessary transformations that usually applied
-/// in model conversion flow provided by mo tool. Paricularly, floatting point weights are compressed to FP16.
+/// in model conversion flow provided by mo tool. Particularly, floating point weights are compressed to FP16.
 /// \param model Model which will be converted to IR representation.
 /// \param output_model Path to the output model file, must have extension .xml
-/// \param compress_to_fp16 Whether to compress floatting point weights to FP16 (true by default)
+/// \param compress_to_fp16 Whether to compress floating point weights to FP16 (true by default)
 OPENVINO_API
 void save_model(const std::shared_ptr<const ov::Model>& model,
                 const std::string& output_model,
                 bool compress_to_fp16 = true);
-
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT)
 OPENVINO_API
 void save_model(const std::shared_ptr<const ov::Model>& model,
                 const std::wstring& output_model,
                 bool compress_to_fp16 = true);
+#endif
+
+#ifdef OPENVINO_CPP_VER_17
+template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+void save_model(const std::shared_ptr<const ov::Model>& model, const Path& output_model, bool compress_to_fp16 = true) {
+    save_model(model, output_model.string(), compress_to_fp16);
+}
 #endif
 }  // namespace ov

--- a/src/core/include/openvino/core/graph_util.hpp
+++ b/src/core/include/openvino/core/graph_util.hpp
@@ -310,7 +310,6 @@ void serialize(const std::shared_ptr<const ov::Model>& m,
 #endif
 /// \}
 
-// TODO CPP17
 /// \brief Save given model into IR. Floating point weights are compressed to FP16 by default.
 /// This method saves a model to IR applying all necessary transformations that usually applied
 /// in model conversion flow provided by mo tool. Particularly, floating point weights are compressed to FP16.

--- a/src/core/include/openvino/pass/serialize.hpp
+++ b/src/core/include/openvino/pass/serialize.hpp
@@ -11,6 +11,10 @@
 #include "openvino/opsets/opset.hpp"
 #include "openvino/pass/pass.hpp"
 
+#ifdef OPENVINO_CPP_VER_17
+#    include <filesystem>
+#endif
+
 namespace ov {
 namespace pass {
 
@@ -34,6 +38,13 @@ public:
     Serialize(std::ostream& xmlFile, std::ostream& binFile, Version version = Version::UNSPECIFIED);
 
     Serialize(const std::string& xmlPath, const std::string& binPath, Version version = Version::UNSPECIFIED);
+
+#ifdef OPENVINO_CPP_VER_17
+    Serialize(const std::filesystem::path& xmlPath,
+              const std::filesystem::path& binPath,
+              Version version = Version::UNSPECIFIED)
+        : Serialize(xmlPath.string(), binPath.string(), version) {}
+#endif
 
 private:
     std::ostream* m_xmlFile;

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -296,6 +296,47 @@ TEST_P(SerializationDeterministicityInputOutputTest, FromIrModel) {
     EXPECT_TRUE(files_equal(xml_2, xml_1));
 }
 
+#ifdef OPENVINO_CPP_VER_17
+TEST_P(SerializationDeterministicityInputOutputTest, FromOvModelBybPath) {
+    auto irVersion = GetParam();
+
+    std::shared_ptr<ov::Model> modelRef;
+    {
+        auto parameter0 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 22, 22});
+        parameter0->set_friendly_name("input0");
+        auto result0 = std::make_shared<ov::opset1::Result>(parameter0);
+        result0->set_friendly_name("output0");
+        auto parameter1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{1, 3, 22, 22});
+        parameter1->set_friendly_name("input1");
+        auto result1 = std::make_shared<ov::opset1::Result>(parameter1);
+        result1->set_friendly_name("output1");
+        modelRef =
+            std::make_shared<ov::Model>(ov::NodeVector{result0, result1}, ov::ParameterVector{parameter0, parameter1});
+    }
+
+    auto& expected1 = modelRef;
+    const auto out_xml_path = std::filesystem::path(m_out_xml_path_1);
+    const auto out_bin_path = std::filesystem::path(m_out_bin_path_1);
+    ov::pass::Serialize(out_xml_path, out_bin_path, irVersion).run_on_model(modelRef);
+    auto expected2 = ov::test::readModel(m_out_xml_path_1, m_out_bin_path_1);
+
+    ov::pass::Serialize(m_out_xml_path_2, m_out_bin_path_2, irVersion).run_on_model(expected2);
+
+    EXPECT_EQ(input0Name, expected1->input(0).get_node()->get_friendly_name());
+    EXPECT_EQ(input1Name, expected1->input(1).get_node()->get_friendly_name());
+    EXPECT_EQ(output0Name, expected1->output(0).get_node()->get_friendly_name());
+    EXPECT_EQ(output1Name, expected1->output(1).get_node()->get_friendly_name());
+    EXPECT_EQ(input0Name, expected2->input(0).get_node()->get_friendly_name());
+    EXPECT_EQ(input1Name, expected2->input(1).get_node()->get_friendly_name());
+    EXPECT_EQ(output0Name, expected2->output(0).get_node()->get_friendly_name());
+    EXPECT_EQ(output1Name, expected2->output(1).get_node()->get_friendly_name());
+
+    std::ifstream xml_1(m_out_xml_path_1, std::ios::in | std::ios::binary);
+    std::ifstream xml_2(m_out_xml_path_2, std::ios::in | std::ios::binary);
+    EXPECT_TRUE(files_equal(xml_1, xml_2));
+}
+#endif
+
 INSTANTIATE_TEST_SUITE_P(DeterministicityInputOutput,
                          SerializationDeterministicityInputOutputTest,
                          ::testing::Values(ov::pass::Serialize::Version::IR_V10, ov::pass::Serialize::Version::IR_V11));

--- a/src/core/tests/pass/serialization/serialize.cpp
+++ b/src/core/tests/pass/serialization/serialize.cpp
@@ -74,6 +74,23 @@ TEST_P(SerializationTest, SaveModel) {
     });
 }
 
+#ifdef OPENVINO_CPP_VER_17
+TEST_P(SerializationTest, CompareFunctionsByPath) {
+    const auto out_xml_path = std::filesystem::path(m_out_xml_path);
+    const auto out_bin_path = std::filesystem::path(m_out_bin_path);
+    CompareSerialized([&out_xml_path, &out_bin_path](const auto& m) {
+        ov::pass::Serialize(out_xml_path, out_bin_path).run_on_model(m);
+    });
+}
+
+TEST_P(SerializationTest, SaveModelByPath) {
+    const auto out_xml_path = std::filesystem::path(m_out_xml_path);
+    CompareSerialized([&out_xml_path](const auto& m) {
+        ov::save_model(m, out_xml_path, false);
+    });
+}
+#endif
+
 INSTANTIATE_TEST_SUITE_P(
     IRSerialization,
     SerializationTest,


### PR DESCRIPTION
### Details:
 - Extend `Serialize` and `save_model` API to support cpp17 path class

### Tickets:
 - CVS-158889