### PR TITLE
[OV JS] Extend npm package keywords

### DIFF
--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -51,6 +51,17 @@
     "host": "https://storage.openvinotoolkit.org"
   },
   "keywords": [
-    "OpenVINO"
+    "OpenVINO",
+    "openvino",
+    "openvino-node",
+    "openvino npm",
+    "openvino binding",
+    "openvino node.js",
+    "openvino library",
+    "intel openvino",
+    "openvino toolkit",
+    "openvino API",
+    "openvino SDK",
+    "openvino integration"
   ]
 }


### PR DESCRIPTION
### Details:
 - To better indexing openvino-node npm package we have to add more related keywords into package.json
