### PR TITLE
typo fix

### DIFF
--- a/docs/articles_en/documentation/openvino-extensibility.rst
+++ b/docs/articles_en/documentation/openvino-extensibility.rst
@@ -45,7 +45,7 @@ The first part is required for inference. The second part is required for succes
 Definition of Operation Semantics
 #################################
 
-If the custom operation can be mathematically represented as a combination of exiting OpenVINO operations and such decomposition gives desired performance, then low-level operation implementation is not required. Refer to the latest OpenVINO operation set, when deciding feasibility of such decomposition. You can use any valid combination of exiting operations. The next section of this document describes the way to map a custom operation.
+If the custom operation can be mathematically represented as a combination of existing OpenVINO operations and such decomposition gives desired performance, then low-level operation implementation is not required. Refer to the latest OpenVINO operation set, when deciding feasibility of such decomposition. You can use any valid combination of existing operations. The next section of this document describes the way to map a custom operation.
 
 If such decomposition is not possible or appears too bulky with a large number of constituent operations that do not perform well, then a new class for the custom operation should be implemented, as described in the :doc:`Custom Operation Guide <openvino-extensibility/custom-openvino-operations>`.
 


### PR DESCRIPTION
**Overview:**
This pull request fixes a typo where word `exiting` is wrongly used in the given context.
https://docs.openvino.ai/2024/documentation/openvino-extensibility.html

![image](https://github.com/user-attachments/assets/5fc33ae8-731e-4b49-b5aa-30f1a395281a)


**Dependencies:**
- No dependencies on other pull requests.

**CC:**
- @rkazants 
