### PR TITLE
[GPU] Updated GPU cache size retrieval and refined closest_pow_of_2

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -56,6 +56,7 @@ struct device_info {
     uint64_t max_local_mem_size;                ///< Maximum size of local memory arena in bytes.
     uint64_t max_global_mem_size;               ///< Maximum size of global device memory in bytes.
     uint64_t max_alloc_mem_size;                ///< Maximum size of memory object allocation in bytes.
+    uint64_t max_global_cache_size;             ///< Maximum size of cache memory bytes.
 
     uint64_t max_image2d_width;                 ///< Maximum image 2d width supported by the device.
     uint64_t max_image2d_height;                ///< Maximum image 2d height supported by the device.

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/arg_max_min.cpp
@@ -131,7 +131,7 @@ public:
 
 namespace detail {
 attach_arg_max_min_impl::attach_arg_max_min_impl() {
-    auto types = {data_types::f16, data_types::f32, data_types::i8, data_types::i32};
+    auto types = {data_types::f16, data_types::f32, data_types::i8, data_types::i32, data_types::u8};
 
     auto formats = {
         format::bfyx,

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -52,6 +52,7 @@ ParamsKey ArgMaxMinKernelAxis::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::F16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::INT32);
     k.EnableAllOutputDataType();
     k.EnableInputLayout(DataLayout::bfyx);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_gpu_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_gpu_ref.cpp
@@ -10,6 +10,7 @@ ParamsKey ArgMaxMinKernelGPURef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::F16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::UINT8);
     k.EnableAllOutputDataType();
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableInputLayout(DataLayout::yxfb);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_opt.cpp
@@ -10,6 +10,7 @@ ParamsKey ArgMaxMinKernelOpt::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::F16);
     k.EnableInputDataType(Datatype::F32);
     k.EnableInputDataType(Datatype::INT8);
+    k.EnableInputDataType(Datatype::UINT8);
     k.EnableOutputDataType(Datatype::F32);
     k.EnableInputLayout(DataLayout::bfyx);
     k.EnableOutputLayout(DataLayout::bfyx);

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -780,12 +780,24 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
     auto device_id = get_property(ov::device::id.name(), options).as<std::string>();
     auto context = get_default_contexts().at(device_id);
     const auto& device_info = context->get_engine().get_device_info();
-    auto next_pow_of_2 = [] (float x) {
-        return pow(2, ceil(std::log(x)/std::log(2)));
-    };
+
     auto closest_pow_of_2 = [] (float x) {
-        return pow(2, floor(std::log(x)/std::log(2)));
+        int lower_power = static_cast<int>(floor(std::log(x) / std::log(2)));
+        double lower_value = pow(2, lower_power);        // Current power of 2
+        double upper_value = pow(2, lower_power + 1);   // Next power of 2
+
+        // Determine the threshold (70% of the range between lower and upper values)
+        // If x is within the upper 30% of the range, return the upper power of 2.
+        double threshold = 0.7 * (upper_value - lower_value);
+
+        // Compare x with the threshold and return the appropriate power of 2
+        if (x - lower_value > threshold) {
+            return upper_value;  // Return the next power of 2
+        } else {
+            return lower_value;  // Return the current power of 2
+        }
     };
+
     auto model_param = options.find(ov::hint::model.name());
     if (model_param == options.end()) {
         GPU_DEBUG_INFO << "[OPTIMAL_BATCH_SIZE] ov::hint::model is not set: return 1" << std::endl;
@@ -799,31 +811,10 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
     }
     GPU_DEBUG_INFO << "DEVICE_INFO:"
                    << "gfx_version.major, " << device_info.gfx_ver.major
-                   << "gfx_version.minor " << std::to_string(device_info.gfx_ver.minor) << std::endl;
-    static std::map<cldnn::gfx_version, size_t> gen_kbytes_per_bank = {
-            {{12, 0, 0}, 480},  // TGL
-            {{12, 1, 0}, 2048}, // DG1
-            {{12, 5, 0}, 320},
-            {{12, 7, 0}, 512},
-    };
-    size_t L3_cache_size = device_info.gfx_ver.major && (device_info.gfx_ver.major <= 9)
-            ? 768 * 1024 // Gen9
-            : 2 * 768 * 1024;  //reasonable default when no arch has been detected (e.g. due to old driver ver)
-    cldnn::gfx_version gen = {device_info.gfx_ver.major, device_info.gfx_ver.minor, 0 /*ignore the revision*/};
-    auto val = gen_kbytes_per_bank.find(gen);
-    if (gen_kbytes_per_bank.end() != val) {
-        auto kbytes_per_bank = val->second;
-        auto num_banks_per_slice = device_info.num_sub_slices_per_slice > 4
-                                    ? next_pow_of_2(device_info.num_sub_slices_per_slice)
-                                    : 2 * device_info.num_sub_slices_per_slice;
-        L3_cache_size = kbytes_per_bank * 1024 * num_banks_per_slice * device_info.num_slices;
-        GPU_DEBUG_INFO << "DEVICE_INFO:"
-                        << "num_slices " << device_info.num_slices
-                        << ", num_sub_slices_per_slice " << device_info.num_sub_slices_per_slice
-                        << ", num_banks_per_slice " << num_banks_per_slice
-                        << ", gen_kbytes_per_bank : " << kbytes_per_bank
-                        << ", L3_cache_size is (MB): " << float(L3_cache_size) / 1024 / 1024 << std::endl;
-    }
+                   << "gfx_version.minor " << std::to_string(device_info.gfx_ver.minor)
+                   << "Cache size " << std::to_string(device_info.max_global_cache_size) << std::endl;
+
+    size_t L3_cache_size = device_info.max_global_cache_size;
     auto config = m_configs_map.at(device_id);
     auto cloned_model = clone_and_transform_model(model, config, context);
     ov::MemBandwidthPressure memPressure = ov::mem_bandwidth_pressure_tolerance(cloned_model, L3_cache_size);

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -224,6 +224,7 @@ device_info init_device_info(const cl::Device& device, const cl::Context& contex
     info.max_local_mem_size = static_cast<uint64_t>(device.getInfo<CL_DEVICE_LOCAL_MEM_SIZE>());
     info.max_global_mem_size = static_cast<uint64_t>(device.getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>());
     info.max_alloc_mem_size = static_cast<uint64_t>(device.getInfo<CL_DEVICE_MAX_MEM_ALLOC_SIZE>());
+    info.max_global_cache_size = static_cast<uint64_t>(device.getInfo<CL_DEVICE_GLOBAL_MEM_CACHE_SIZE>());
 
     info.supports_image = static_cast<uint8_t>(device.getInfo<CL_DEVICE_IMAGE_SUPPORT>());
     info.max_image2d_width = static_cast<uint64_t>(device.getInfo<CL_DEVICE_IMAGE2D_MAX_WIDTH>());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -16,7 +16,6 @@
 using namespace cldnn;
 using namespace ::tests;
 
-
 template <format::type layoutFormat, typename DataType>
 struct arg_max_input_types {
     static const auto format = layoutFormat;
@@ -56,9 +55,20 @@ using format_types = testing::Types<arg_max_input_types<format::bfyx, float>,
                                     arg_max_input_types<format::bfyx, ov::float16>,
                                     arg_max_input_types<format::bs_fs_yx_bsv32_fsv16, ov::float16>,
                                     arg_max_input_types<format::bfyx, int8_t>,
-                                    arg_max_input_types<format::bs_fs_yx_bsv32_fsv16, int8_t>>;
+                                    arg_max_input_types<format::bs_fs_yx_bsv32_fsv16, int8_t>,
+                                    arg_max_input_types<format::bs_fs_yx_bsv32_fsv32, int8_t>,
+                                    arg_max_input_types<format::bfyx, u_int8_t>,
+                                    arg_max_input_types<format::bs_fs_yx_bsv32_fsv16, u_int8_t>,
+                                    arg_max_input_types<format::bs_fs_yx_bsv32_fsv32, u_int8_t>>;
 
 TYPED_TEST_SUITE(argmax_gpu_test, format_types);
+
+// Helper trait to check for u_int8_t input_type
+template<typename T>
+struct is_u_int8_input : std::false_type {};
+
+template<format::type Fmt>
+struct is_u_int8_input<arg_max_input_types<Fmt, u_int8_t>> : std::true_type {};
 
 TYPED_TEST(argmax_gpu_test, base) {
     //  Input  : 2x4x2x2
@@ -82,7 +92,25 @@ TYPED_TEST(argmax_gpu_test, base) {
                                     /*b1f1*/ 4.f,  0.5f,  8.f,   8.2f,
                                     /*b1f2*/ 0.2f, 0.2f,  -10.f, 5.2f,
                                     /*b1f3*/ 4.f,  0.5f,  8.f,   8.2f};
-    set_values(input, this->getTypedVector(input_vec));
+
+    // Positive values for u8 input type test
+    std::vector<float> input_vec_u8 = {// y0x0 y0x1 y1x0 y1x1
+                                    /*b0f0*/ 0.1f, 0.1f, 0.9f,  1.5f,
+                                    /*b0f1*/ 0.2f, 0.2f,  0.1f, 5.2f,
+                                    /*b0f2*/ 0.2f, 0.2f,  0.1f, 5.2f,
+                                    /*b0f3*/ 0.2f, 0.2f,  0.1f, 4.2f,
+
+                                    /*b1f0*/ 3.f,  0.5f,  7.f,   10.f,
+                                    /*b1f1*/ 4.f,  0.5f,  8.f,   8.2f,
+                                    /*b1f2*/ 0.2f, 0.2f,  0.1f, 5.2f,
+                                    /*b1f3*/ 4.f,  0.5f,  8.f,   8.2f};
+
+    // If format is of type u8 then use non negative values as input.
+    if (is_u_int8_input<TypeParam>::value) {
+        set_values(input, this->getTypedVector(input_vec_u8));
+    } else {
+        set_values(input, this->getTypedVector(input_vec));
+    }
 
     network network(engine, topology, get_test_default_config(engine));
 

--- a/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_ArgMinMax.py
@@ -69,8 +69,6 @@ class TestArgMinMax(CommonTFLayerTest):
                             ie_device, precision, ir_version, temp_dir, use_legacy_frontend):
         if platform.machine() in ['aarch64', 'arm64', 'ARM64']:
             pytest.skip('153077: Segmentation fault on ARM')
-        if ie_device == 'GPU' and input_type == np.uint8:
-            pytest.skip('153078: No layout format available for topk')
         if ie_device == 'GPU' and input_type == np.float32 and input_shape == [10, 15, 20]:
             pytest.skip('153079: Accuracy error on GPU')
         self._test(*self.create_argmin_max_net(input_shape=input_shape, dimension=dimension,

--- a/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_TopKV2.py
@@ -55,8 +55,6 @@ class TestTopKV2(CommonTFLayerTest):
     def test_topk_v2(self, input_shape, input_type, k, k_type, sorted, index_type,
                      ie_device, precision, ir_version,
                      temp_dir, use_legacy_frontend):
-        if ie_device == 'GPU' and input_type == np.uint8:
-            pytest.skip('156587: Check correct_layout_selected failed for input uint8 on GPU')
         if platform.machine() in ['arm', 'armv7l', 'aarch64', 'arm64', 'ARM64'] and \
                 input_type in [np.int32, np.uint8, np.int16, np.int8, np.int64,
                                np.uint16, np.uint32, np.uint64]:


### PR DESCRIPTION
    Details:
    This update introduces a new member variable, max_global_cache_size,
    to store the GPU's global cache size, obtained via the OpenCL property
    CL_DEVICE_GLOBAL_MEM_CACHE_SIZE. The existing hard coded cache
    calculations are removed.  Additionally, the closest_pow_of_2 function
    has been enhanced to return the nearest power of 2, favoring the upper
    value if the input is within 30% of the range for the upper bound.
    These changes improve memory management and ensure better utilization
    of GPU resources towards bottle neck situations.
    
    Tickets:
         CVS-159076
