### PR TITLE
[CPU] enable brdgmm_dw_conv kernels with non f32 bias

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -980,6 +980,10 @@ void Convolution::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
         memory::data_type bdt = outDnnlDesc.get_data_type();
 #else
         memory::data_type bdt = memory::data_type::f32;
+        // brdgmm_dw_conv supports only bia_type the same as src_type or dst_type
+        auto out_dt = outDnnlDesc.get_data_type();
+        if (!canBeExecutedInInt8() && isDepthWise() && out_dt != memory::data_type::f32)
+            bdt = out_dt;
 #endif
         biasDnnlDesc =
             dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(expectedBiasDims), bdt, memory::format_tag::any);

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -987,11 +987,12 @@ void Convolution::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
         kernel type | brgdconv | jit_uni_dw_convolution_fwd_t
         support impl type | native bf16 ISA without AMX | avx512_core_bf16 or avx512_core
         bias dt | oneof(src,dest) | oneof(src, dest, f32)
-
         FP16:
         kernel type | brgdconv | brgemm_convolution_fwd_t
         impl type | native FP16 ISA without AMX | native FP16 ISA
         bias type | oneof(src,dest) | oneof(src, dest, f32)
+        @todo: this bias type changes may have minor accuracy impact on some models, so when upstream ONEDNN extend this
+        kind of matrix support (ticket MFDNN-12936) we can continue use bdt = memory::data_type::f32 here;
         */
         auto out_dt = outDnnlDesc.get_data_type();
         if (!canBeExecutedInInt8() && isDepthWise()) {


### PR DESCRIPTION
### Details:
 - *brdgmm_dw_conv kernels support only bia_type the same as src_type or dst_type*


### Tickets:
 - *CVS-157009*
