### PR TITLE
[RTTI] Add OPENVINO_MATCHER_PASS_RTTI definition

### DIFF
--- a/src/common/low_precision_transformations/include/low_precision/base_matcher_pass.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/base_matcher_pass.hpp
@@ -19,6 +19,7 @@ class LP_TRANSFORMATIONS_API BaseMatcherPass;
 
 class LP_TRANSFORMATIONS_API ov::pass::low_precision::BaseMatcherPass : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::BaseMatcherPass");
     BaseMatcherPass(const AttributeParameters& params = AttributeParameters());
     AttributeParameters params;
 };

--- a/src/common/low_precision_transformations/include/low_precision/convert_subtract_constant.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/convert_subtract_constant.hpp
@@ -31,6 +31,6 @@ class LP_TRANSFORMATIONS_API ConvertSubtractConstant;
  */
 class ov::pass::low_precision::ConvertSubtractConstant : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ConvertSubtractConstant", "0");
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::ConvertSubtractConstant");
     ConvertSubtractConstant(const std::vector<ov::element::Type>& constantPrecisions = {});
 };

--- a/src/common/low_precision_transformations/include/low_precision/create_precisions_dependent_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/create_precisions_dependent_attribute.hpp
@@ -40,6 +40,7 @@ class CreatePrecisionsDependentAttribute;
 template <typename AttributeType, typename OperationType>
 class ov::pass::low_precision::CreatePrecisionsDependentAttribute : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::CreatePrecisionsDependentAttribute");
     CreatePrecisionsDependentAttribute() {
         auto operation = pattern::wrap_type<OperationType>();
 

--- a/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -244,6 +244,7 @@ inline std::ostream &operator << (std::ostream &os, const DataPrecision& value) 
  */
 class LP_TRANSFORMATIONS_API LayerTransformation : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::LayerTransformation");
     class Params {
     public:
         Params(

--- a/src/common/low_precision_transformations/include/low_precision/markup_bias.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/markup_bias.hpp
@@ -23,7 +23,7 @@ namespace low_precision {
  */
 class LP_TRANSFORMATIONS_API MarkupBias : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("MarkupBias", "0");
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::MarkupBias");
     MarkupBias();
 };
 

--- a/src/common/low_precision_transformations/include/low_precision/propagate_through_precision_preserved.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/propagate_through_precision_preserved.hpp
@@ -38,7 +38,9 @@ class PropagateThroughPrecisionPreserved;
 template <typename AttributeType>
 class ov::pass::low_precision::PropagateThroughPrecisionPreserved : public ov::pass::MatcherPass {
 public:
-    PropagateThroughPrecisionPreserved(const std::vector<ov::element::Type>& defaultPrecisions = precision_set::get_int8_support()) {
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::PropagateThroughPrecisionPreserved");
+    PropagateThroughPrecisionPreserved(
+        const std::vector<ov::element::Type>& defaultPrecisions = precision_set::get_int8_support()) {
         ov::graph_rewrite_callback callback = [&](pattern::Matcher& m) {
             auto node = m.get_match_root();
             if (transformation_callback(node)) {

--- a/src/common/low_precision_transformations/include/low_precision/propagate_to_input.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/propagate_to_input.hpp
@@ -37,7 +37,8 @@ class PropagateToInput;
 template <typename AttributeType>
 class ov::pass::low_precision::PropagateToInput : public ov::pass::MatcherPass {
 public:
-    PropagateToInput(const std::vector<ov::element::Type>& defaultPrecisions = { ov::element::u8, ov::element::i8 }) {
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::PropagateToInput");
+    PropagateToInput(const std::vector<ov::element::Type>& defaultPrecisions = {ov::element::u8, ov::element::i8}) {
         ov::graph_rewrite_callback callback = [&](pattern::Matcher& m) {
             auto node = m.get_match_root();
             if (transformation_callback(node)) {

--- a/src/common/low_precision_transformations/include/low_precision/pull_reshape_through_dequantization.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/pull_reshape_through_dequantization.hpp
@@ -30,6 +30,6 @@ class LP_TRANSFORMATIONS_API PullReshapeThroughDequantization;
  */
 class ov::pass::low_precision::PullReshapeThroughDequantization : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("PullReshapeThroughDequantization", "0");
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::PullReshapeThroughDequantization");
     PullReshapeThroughDequantization(const std::vector<ov::element::Type>& inputPrecisions = {});
 };

--- a/src/common/low_precision_transformations/include/low_precision/pull_transpose_through_dequantization.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/pull_transpose_through_dequantization.hpp
@@ -30,6 +30,6 @@ class LP_TRANSFORMATIONS_API PullTransposeThroughDequantization;
  */
 class ov::pass::low_precision::PullTransposeThroughDequantization : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("PullTransposeThroughDequantization", "0");
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::PullTransposeThroughDequantization");
     PullTransposeThroughDequantization(const std::vector<ov::element::Type>& inputPrecisions = {});
 };

--- a/src/common/low_precision_transformations/include/low_precision/update_shared_precision_preserved.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/update_shared_precision_preserved.hpp
@@ -36,7 +36,9 @@ class UpdateSharedPrecisionPreserved;
 template <typename AttributeType, typename ExpectedAttributeType = AttributeType>
 class ov::pass::low_precision::UpdateSharedPrecisionPreserved : public ov::pass::MatcherPass {
 public:
-    UpdateSharedPrecisionPreserved(const std::vector<ov::element::Type>& defaultPrecisions = precision_set::get_int8_support()) {
+    OPENVINO_MATCHER_PASS_RTTI("low_precision::UpdateSharedPrecisionPreserved");
+    UpdateSharedPrecisionPreserved(
+        const std::vector<ov::element::Type>& defaultPrecisions = precision_set::get_int8_support()) {
         ov::graph_rewrite_callback callback = [&](ov::pass::pattern::Matcher& m) {
             auto node = m.get_match_root();
 

--- a/src/common/offline_transformations/include/compress_quantize_weights.hpp
+++ b/src/common/offline_transformations/include/compress_quantize_weights.hpp
@@ -63,7 +63,7 @@ class CompressWeightsWithFakeConvert;
 */
 class ov::pass::CompressWeightsWithFakeQuantize : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("CompressWeightsWithFakeQuantize", "0");
+    OPENVINO_MATCHER_PASS_RTTI("CompressWeightsWithFakeQuantize");
 
     CompressWeightsWithFakeQuantize();
 };
@@ -95,7 +95,7 @@ public:
 */
 class ov::pass::CompressWeightsWithFakeConvert : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("CompressWeightsWithFakeConvert", "0");
+    OPENVINO_MATCHER_PASS_RTTI("CompressWeightsWithFakeConvert");
 
     CompressWeightsWithFakeConvert();
 };

--- a/src/common/offline_transformations/include/pruning.hpp
+++ b/src/common/offline_transformations/include/pruning.hpp
@@ -41,7 +41,7 @@ public:
  */
 class ov::pass::InitConstMask : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("InitConstMask", "0");
+    OPENVINO_MATCHER_PASS_RTTI("InitConstMask");
     explicit InitConstMask(
         const ov::AxisSet& dims,
         const std::function<bool(const double& value)>& condition = [](const double& value) {

--- a/src/common/offline_transformations/src/pruning/init_masks.cpp
+++ b/src/common/offline_transformations/src/pruning/init_masks.cpp
@@ -22,6 +22,7 @@ class InitMatMulMask;
 
 class ov::pass::init_masks::InitConvMask : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("init_masks::InitConvMask");
     InitConvMask() {
         auto input = pattern::any_input();
         auto weights = pattern::any_input();
@@ -59,6 +60,7 @@ public:
 
 class ov::pass::init_masks::InitMatMulMask : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("init_masks::InitMatMulMask");
     InitMatMulMask() {
         auto a = pattern::any_input();
         auto b = pattern::any_input();

--- a/src/common/offline_transformations/src/pruning/propagate_masks.cpp
+++ b/src/common/offline_transformations/src/pruning/propagate_masks.cpp
@@ -65,6 +65,7 @@ static ov::Shape broadcast_shape_to_rank(ov::Shape shape_to_broadcast, int64_t d
 
 class ov::pass::mask_propagation::MatMul : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::MatMul");
     MatMul() {
         auto a = pattern::any_input(pattern::has_static_shape());
         auto b = pattern::any_input(pattern::has_static_shape());
@@ -201,6 +202,7 @@ public:
 
 class ov::pass::mask_propagation::Convolution : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Convolution");
     Convolution() {
         auto input = pattern::any_input();
         auto weights = pattern::any_input(pattern::has_static_shape());
@@ -280,6 +282,7 @@ public:
 
 class ov::pass::mask_propagation::GroupConvolution : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::GroupConvolution");
     GroupConvolution() {
         auto input = pattern::any_input(pattern::has_static_dim(1));
         auto weights = pattern::any_input(pattern::has_static_shape());
@@ -366,6 +369,7 @@ public:
 
 class ov::pass::mask_propagation::GroupConvolutionReshape : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::GroupConvolutionReshape");
     GroupConvolutionReshape() {
         auto input = pattern::any_input(pattern::has_static_shape());
         auto shape = pattern::any_input();
@@ -456,6 +460,7 @@ public:
 
 class ov::pass::mask_propagation::Elementwise : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Elementwise");
     Elementwise() {
         auto input = pattern::any_input();
         auto weights = pattern::any_input();
@@ -646,6 +651,7 @@ private:
 
 class ov::pass::mask_propagation::FakeQuantize : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::FakeQuantize");
     FakeQuantize() {
         auto input = pattern::any_input(pattern::has_static_shape());
         auto input_low = pattern::any_input(pattern::has_static_shape());
@@ -758,6 +764,7 @@ public:
 
 class ov::pass::mask_propagation::Concat : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Concat");
     Concat() {
         auto concat = pattern::wrap_type<opset10::Concat>(pattern::has_static_shape());
 
@@ -864,6 +871,7 @@ public:
 
 class ov::pass::mask_propagation::PassThrough : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::PassThrough");
     PassThrough() {
         auto unary_op = pattern::wrap_type<op::util::UnaryElementwiseArithmetic,
                                            opset10::Clamp,
@@ -906,6 +914,7 @@ public:
 
 class ov::pass::mask_propagation::Reduce : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Reduce");
     Reduce() {
         auto inputs = pattern::any_input();
         auto weights = pattern::wrap_type<opset10::Constant>();
@@ -1117,6 +1126,7 @@ static std::vector<DimsAttr> collect_dims_attrs(const std::vector<dims_vec> dims
 
 class ov::pass::mask_propagation::Reshape : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Reshape");
     Reshape() {
         auto inputs = pattern::any_input(pattern::has_static_shape());
         auto weights = pattern::any_input();
@@ -1373,6 +1383,7 @@ public:
 
 class ov::pass::mask_propagation::Transpose : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Transpose");
     Transpose() {
         auto input = pattern::any_input();
         auto weights = pattern::any_input();
@@ -1480,6 +1491,7 @@ static ov::Mask::Ptr create_connect_split_output_mask(ov::Mask::Ptr input_mask,
 
 class ov::pass::mask_propagation::VariadicSplit : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::VariadicSplit");
     VariadicSplit() {
         auto input_pattern = pattern::any_input(pattern::has_static_rank());
         auto axis_pattern = pattern::wrap_type<ov::opset10::Constant>();
@@ -1547,6 +1559,7 @@ public:
 
 class ov::pass::mask_propagation::Split : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::Split");
     Split() {
         auto input_pattern = pattern::any_input(pattern::has_static_rank());
         auto axis_pattern = pattern::wrap_type<ov::opset10::Constant>();
@@ -1597,6 +1610,7 @@ public:
 
 class ov::pass::mask_propagation::StopPropagation : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::StopPropagation");
     StopPropagation() {
         auto any_node = pattern::any_input();
 
@@ -1654,6 +1668,7 @@ public:
 
 class ov::pass::mask_propagation::SkipPropagation : public MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("mask_propagation::SkipPropagation");
     SkipPropagation() {
         // Skip mask propagation for ShapeOf operation to prevent this opearation to be
         // processed as stop op.

--- a/src/common/snippets/include/snippets/pass/broadcast_to_movebroadcast.hpp
+++ b/src/common/snippets/include/snippets/pass/broadcast_to_movebroadcast.hpp
@@ -19,6 +19,7 @@ namespace pass {
  */
 class BroadcastToMoveBroadcast: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::BroadcastToMoveBroadcast");
     BroadcastToMoveBroadcast();
 };
 

--- a/src/common/snippets/include/snippets/pass/collapse_subgraph.hpp
+++ b/src/common/snippets/include/snippets/pass/collapse_subgraph.hpp
@@ -35,7 +35,7 @@ namespace pass {
  */
 class TokenizeSnippets: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TokenizeSnippets", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeSnippets");
     explicit TokenizeSnippets(const SnippetsTokenization::Config& config);
 
     static bool AppropriateForSubgraph(const std::shared_ptr<const Node>&);

--- a/src/common/snippets/include/snippets/pass/common_optimizations.hpp
+++ b/src/common/snippets/include/snippets/pass/common_optimizations.hpp
@@ -19,7 +19,7 @@ class CommonOptimizations : public ov::pass::MatcherPass {
     friend class SplitDimensionM;
 
 public:
-    OPENVINO_RTTI("CommonOptimizations", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::CommonOptimizations");
     CommonOptimizations(const SnippetsTokenization::Config& config);
 };
 

--- a/src/common/snippets/include/snippets/pass/convert_constants.hpp
+++ b/src/common/snippets/include/snippets/pass/convert_constants.hpp
@@ -19,6 +19,7 @@ namespace pass {
  */
 class ConvertConstantsToScalars: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::ConvertConstantsToScalars");
     ConvertConstantsToScalars();
 };
 

--- a/src/common/snippets/include/snippets/pass/convert_power_to_powerstatic.hpp
+++ b/src/common/snippets/include/snippets/pass/convert_power_to_powerstatic.hpp
@@ -17,6 +17,7 @@ namespace pass {
  */
 class ConvertPowerToPowerStatic: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::ConvertPowerToPowerStatic");
     ConvertPowerToPowerStatic();
 };
 

--- a/src/common/snippets/include/snippets/pass/explicit_transpose_matmul_inputs.hpp
+++ b/src/common/snippets/include/snippets/pass/explicit_transpose_matmul_inputs.hpp
@@ -23,7 +23,7 @@ namespace pass {
  */
 class ExplicitTransposeMatMulInputs: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ExplicitTransposeMatMulInputs", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::ExplicitTransposeMatMulInputs");
     ExplicitTransposeMatMulInputs();
 
     // Return `True` if all inputs (except 0-th input) have scalar shape. Otherwise returns `False`

--- a/src/common/snippets/include/snippets/pass/extract_reshapes_from_mha.hpp
+++ b/src/common/snippets/include/snippets/pass/extract_reshapes_from_mha.hpp
@@ -31,7 +31,7 @@ namespace pass {
  */
 class ExtractReshapesFromMHA: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ExtractReshapesFromMHA", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::ExtractReshapesFromMHA");
     ExtractReshapesFromMHA();
 };
 

--- a/src/common/snippets/include/snippets/pass/fc_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/fc_tokenization.hpp
@@ -18,7 +18,7 @@ namespace pass {
  */
 class TokenizeFCSnippets: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TokenizeFCSnippets", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeFCSnippets");
     TokenizeFCSnippets(const SnippetsTokenization::Config& config);
 };
 

--- a/src/common/snippets/include/snippets/pass/fq_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/fq_decomposition.hpp
@@ -49,6 +49,7 @@ namespace pass {
 
 class FakeQuantizeDecomposition : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::FakeQuantizeDecomposition");
     FakeQuantizeDecomposition();
 
     static bool getScalesAndShifts(const std::shared_ptr<const ov::op::v0::FakeQuantize>& fq_node,

--- a/src/common/snippets/include/snippets/pass/fuse_transpose_brgemm.hpp
+++ b/src/common/snippets/include/snippets/pass/fuse_transpose_brgemm.hpp
@@ -23,7 +23,7 @@ namespace pass {
  */
 class FuseTransposeBrgemm: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("FuseTransposeBrgemm", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::FuseTransposeBrgemm");
     FuseTransposeBrgemm();
 
     static bool is_supported_transpose(const Output<Node>& transpose_out);

--- a/src/common/snippets/include/snippets/pass/gn_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/gn_decomposition.hpp
@@ -17,7 +17,7 @@ namespace pass {
  */
 class GNDecomposition: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("GNDecomposition", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::GNDecomposition");
     GNDecomposition();
 };
 

--- a/src/common/snippets/include/snippets/pass/gn_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/gn_tokenization.hpp
@@ -18,7 +18,7 @@ namespace pass {
  */
 class TokenizeGNSnippets : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TokenizeGNSnippets", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeGNSnippets");
     TokenizeGNSnippets();
 };
 

--- a/src/common/snippets/include/snippets/pass/insert_movebroadcast.hpp
+++ b/src/common/snippets/include/snippets/pass/insert_movebroadcast.hpp
@@ -18,6 +18,7 @@ namespace pass {
  */
 class InsertMoveBroadcast: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::InsertMoveBroadcast");
     InsertMoveBroadcast();
 
     static Output<ov::Node> BroadcastNodeLastDim(const ov::Output<ov::Node>& value,

--- a/src/common/snippets/include/snippets/pass/matmul_to_brgemm.hpp
+++ b/src/common/snippets/include/snippets/pass/matmul_to_brgemm.hpp
@@ -19,7 +19,7 @@ namespace pass {
  */
 class MatMulToBrgemm: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("MatMulToBrgemm", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::MatMulToBrgemm");
     MatMulToBrgemm();
 };
 

--- a/src/common/snippets/include/snippets/pass/mha_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/mha_tokenization.hpp
@@ -40,7 +40,7 @@ namespace pass {
  */
 class TokenizeMHASnippets: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TokenizeMHASnippets", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeMHASnippets");
     TokenizeMHASnippets(const SnippetsTokenization::Config& config);
 
     static std::vector<int32_t> get_fusion_transpose_order(size_t rank);

--- a/src/common/snippets/include/snippets/pass/reduce_to_snippets_reduce.hpp
+++ b/src/common/snippets/include/snippets/pass/reduce_to_snippets_reduce.hpp
@@ -18,6 +18,7 @@ namespace pass {
  */
 class ReduceToSnippetsReduce: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::ReduceToSnippetsReduce");
     ReduceToSnippetsReduce();
 };
 

--- a/src/common/snippets/include/snippets/pass/softmax_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/softmax_decomposition.hpp
@@ -17,7 +17,7 @@ namespace pass {
  */
 class SoftmaxDecomposition: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("SoftmaxDecomposition", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::SoftmaxDecomposition");
     SoftmaxDecomposition();
 };
 

--- a/src/common/snippets/include/snippets/pass/softmax_reshape_elimination.hpp
+++ b/src/common/snippets/include/snippets/pass/softmax_reshape_elimination.hpp
@@ -17,6 +17,7 @@ namespace pass {
  */
 class SoftmaxReshapeElimination: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::SoftmaxReshapeElimination");
     SoftmaxReshapeElimination();
 };
 

--- a/src/common/snippets/include/snippets/pass/transform_convert.hpp
+++ b/src/common/snippets/include/snippets/pass/transform_convert.hpp
@@ -19,6 +19,7 @@ namespace pass {
  */
 class TransformConvertToConvertTruncation: public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TransformConvertToConvertTruncation");
     TransformConvertToConvertTruncation();
 };
 

--- a/src/common/snippets/include/snippets/pass/transpose_decomposition.hpp
+++ b/src/common/snippets/include/snippets/pass/transpose_decomposition.hpp
@@ -17,7 +17,7 @@ namespace pass {
  */
 class TransposeDecomposition: public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TransposeDecomposition", "0");
+    OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TransposeDecomposition");
     TransposeDecomposition();
 
     static bool is_supported_transpose(const Output<Node>& transpose_out);

--- a/src/core/include/openvino/core/rtti.hpp
+++ b/src/core/include/openvino/core/rtti.hpp
@@ -7,8 +7,9 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/visibility.hpp"
 
-#define _OPENVINO_RTTI_EXPAND(X)                                  X
-#define _OPENVINO_RTTI_DEFINITION_SELECTOR(_1, _2, _3, NAME, ...) NAME
+#define _OPENVINO_RTTI_EXPAND(X)                                    X
+#define _OPENVINO_RTTI_DEFINITION_SELECTOR_2(_1, _2, NAME, ...)     NAME
+#define _OPENVINO_RTTI_DEFINITION_SELECTOR_3(_1, _2, _3, NAME, ...) NAME
 
 #define _OPENVINO_RTTI_WITH_TYPE(TYPE_NAME) _OPENVINO_RTTI_WITH_TYPE_VERSION(TYPE_NAME, "util")
 
@@ -87,11 +88,11 @@
 /// OPENVINO_RTTI(name, version_id)
 /// OPENVINO_RTTI(name, version_id, parent)
 /// OPENVINO_RTTI(name, version_id, parent, old_version)
-#define OPENVINO_RTTI(...)                                                                            \
-    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR(__VA_ARGS__,                             \
-                                                             _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT, \
-                                                             _OPENVINO_RTTI_WITH_TYPE_VERSION,        \
-                                                             _OPENVINO_RTTI_WITH_TYPE)(__VA_ARGS__))
+#define OPENVINO_RTTI(...)                                                                              \
+    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR_3(__VA_ARGS__,                             \
+                                                               _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT, \
+                                                               _OPENVINO_RTTI_WITH_TYPE_VERSION,        \
+                                                               _OPENVINO_RTTI_WITH_TYPE)(__VA_ARGS__))
 
 /// Note: Please don't use this macros for new operations
 #define BWDCMP_RTTI_DECLARATION

--- a/src/core/include/openvino/op/op.hpp
+++ b/src/core/include/openvino/op/op.hpp
@@ -14,18 +14,18 @@
 #define _OPENVINO_RTTI_OP_WITH_TYPE_VERSION(TYPE_NAME, VERSION_NAME) \
     _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT(TYPE_NAME, VERSION_NAME, ::ov::op::Op)
 
-#define OPENVINO_OP(...)                                                                                \
-    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR(__VA_ARGS__,                               \
-                                                             _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT,   \
-                                                             _OPENVINO_RTTI_OP_WITH_TYPE_VERSION,       \
-                                                             _OPENVINO_RTTI_OP_WITH_TYPE)(__VA_ARGS__)) \
-    /* Add accessibility for Op to the method: evaluate from the Base class                             \
-     Usually C++ allows to use virtual methods of Base class from Derived class but if they have        \
-     the same name and not all of them are overrided in Derived class, the only overrided methods       \
-     will be available from Derived class. We need to explicitly cast Derived to Base class to          \
-     have an access to remaining methods or use this using. */                                          \
-    using ov::op::Op::evaluate;                                                                         \
-    using ov::op::Op::evaluate_lower;                                                                   \
+#define OPENVINO_OP(...)                                                                                  \
+    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR_3(__VA_ARGS__,                               \
+                                                               _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT,   \
+                                                               _OPENVINO_RTTI_OP_WITH_TYPE_VERSION,       \
+                                                               _OPENVINO_RTTI_OP_WITH_TYPE)(__VA_ARGS__)) \
+    /* Add accessibility for Op to the method: evaluate from the Base class                               \
+     Usually C++ allows to use virtual methods of Base class from Derived class but if they have          \
+     the same name and not all of them are overrided in Derived class, the only overrided methods         \
+     will be available from Derived class. We need to explicitly cast Derived to Base class to            \
+     have an access to remaining methods or use this using. */                                            \
+    using ov::op::Op::evaluate;                                                                           \
+    using ov::op::Op::evaluate_lower;                                                                     \
     using ov::op::Op::evaluate_upper;
 
 namespace ov {

--- a/src/core/include/openvino/pass/matcher_pass.hpp
+++ b/src/core/include/openvino/pass/matcher_pass.hpp
@@ -17,11 +17,10 @@
 #define _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE_VERSION(TYPE_NAME, VERSION_NAME) \
     _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT(TYPE_NAME, VERSION_NAME, ::ov::pass::MatcherPass)
 
-#define OPENVINO_MATCHER_PASS_RTTI(...)                                                                     \
-    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR(__VA_ARGS__,                                   \
-                                                             _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT,       \
-                                                             _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE_VERSION, \
-                                                             _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE)(__VA_ARGS__))
+#define OPENVINO_MATCHER_PASS_RTTI(...)                                                                       \
+    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR_2(__VA_ARGS__,                                   \
+                                                               _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE_VERSION, \
+                                                               _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE)(__VA_ARGS__))
 
 namespace ov {
 using matcher_pass_callback = std::function<bool(pass::pattern::Matcher& m)>;

--- a/src/core/include/openvino/pass/matcher_pass.hpp
+++ b/src/core/include/openvino/pass/matcher_pass.hpp
@@ -6,9 +6,22 @@
 
 #include <functional>
 #include <memory>
-#include <set>
+#include <string>
+#include <vector>
 
+#include "openvino/core/rtti.hpp"
 #include "openvino/pass/node_registry.hpp"
+
+#define _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE(TYPE_NAME) _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE_VERSION(TYPE_NAME, "0")
+
+#define _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE_VERSION(TYPE_NAME, VERSION_NAME) \
+    _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT(TYPE_NAME, VERSION_NAME, ::ov::pass::MatcherPass)
+
+#define OPENVINO_MATCHER_PASS_RTTI(...)                                                                     \
+    _OPENVINO_RTTI_EXPAND(_OPENVINO_RTTI_DEFINITION_SELECTOR(__VA_ARGS__,                                   \
+                                                             _OPENVINO_RTTI_WITH_TYPE_VERSION_PARENT,       \
+                                                             _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE_VERSION, \
+                                                             _OPENVINO_MATCHER_PASS_RTTI_WITH_TYPE)(__VA_ARGS__))
 
 namespace ov {
 using matcher_pass_callback = std::function<bool(pass::pattern::Matcher& m)>;

--- a/src/core/tests/graph_rewrite.cpp
+++ b/src/core/tests/graph_rewrite.cpp
@@ -23,7 +23,7 @@ using namespace ov::pass;
 
 class TestPass : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TestPass");
+    OPENVINO_MATCHER_PASS_RTTI("TestPass");
     TestPass() : MatcherPass() {
         auto divide = std::make_shared<ov::pass::pattern::op::Label>(element::f32,
                                                                      Shape{},
@@ -44,7 +44,7 @@ public:
 
 class GatherNodesPass : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("GatherNodesPass");
+    OPENVINO_MATCHER_PASS_RTTI("GatherNodesPass");
     GatherNodesPass(NodeVector& order) : MatcherPass() {
         ov::matcher_pass_callback callback = [&order](pattern::Matcher& m) {
             order.push_back(m.get_match_root());
@@ -187,6 +187,7 @@ TEST(GraphRewriteTest, MatcherPassCallbackDerived) {
 
 class TypeBasedTestPass : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("TypeBasedTestPass");
     TypeBasedTestPass() : MatcherPass() {
         auto divide = std::make_shared<ov::op::v1::Divide>(std::make_shared<ov::pass::pattern::op::Label>(),
                                                            std::make_shared<ov::pass::pattern::op::Label>());
@@ -207,6 +208,7 @@ public:
 
 class TypeBasedTestPassDerived : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("TypeBasedTestPassDerived");
     TypeBasedTestPassDerived() : MatcherPass() {
         auto divide = std::make_shared<PrivateDivide>(std::make_shared<ov::pass::pattern::op::Label>(),
                                                       std::make_shared<ov::pass::pattern::op::Label>());
@@ -388,7 +390,7 @@ TEST(PassConfigTest, Test1) {
 
 class CheckConsumers : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("CheckConsumers");
+    OPENVINO_MATCHER_PASS_RTTI("CheckConsumers");
     CheckConsumers() {
         ov::matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
             auto node = m.get_match_root();

--- a/src/core/tests/matcher_pass.cpp
+++ b/src/core/tests/matcher_pass.cpp
@@ -21,6 +21,7 @@ using namespace std;
 
 class TestMatcherPass : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("TestMatcherPass");
     TestMatcherPass() {
         auto m_relu1 = ov::pass::pattern::wrap_type<ov::op::v0::Relu>(pattern::consumers_count(1));
         auto m_relu2 = ov::pass::pattern::wrap_type<ov::op::v0::Relu>({m_relu1});

--- a/src/core/tests/pass_config.cpp
+++ b/src/core/tests/pass_config.cpp
@@ -19,7 +19,7 @@ using namespace ov::pass;
 
 class RenameReLU : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("RanameReLU");
+    OPENVINO_MATCHER_PASS_RTTI("RenameReLU");
     RenameReLU() : MatcherPass() {
         auto relu = ov::pass::pattern::wrap_type<ov::op::v0::Relu>();
         ov::matcher_pass_callback callback = [](pattern::Matcher& m) {
@@ -35,7 +35,7 @@ public:
 
 class RenameSigmoid : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("RenameSigmoid");
+    OPENVINO_MATCHER_PASS_RTTI("RenameSigmoid");
     RenameSigmoid() : MatcherPass() {
         auto sigmoid = pattern::wrap_type<ov::op::v0::Sigmoid>();
         ov::matcher_pass_callback callback = [](pattern::Matcher& m) {
@@ -259,7 +259,7 @@ TEST(PassConfig, EnableDisablePasses9) {
 
 class TestNestedMatcher : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("TestNestedMatcher");
+    OPENVINO_MATCHER_PASS_RTTI("TestNestedMatcher");
     TestNestedMatcher() : MatcherPass() {
         auto any_op = pattern::any_input();
         ov::matcher_pass_callback callback = [this](pattern::Matcher& m) {

--- a/src/frontends/common/src/extension/decoder_transformation.cpp
+++ b/src/frontends/common/src/extension/decoder_transformation.cpp
@@ -25,6 +25,7 @@ private:
 /// \brief Helper class to register user matcher pass initialization as a MatcherPass
 class CustomMatcherPass : public ov::pass::MatcherPass {
 public:
+    OPENVINO_MATCHER_PASS_RTTI("frontend::CustomMatcherPass");
     explicit CustomMatcherPass(const std::function<void(ov::pass::MatcherPass*)>& matcher_pass_initializer) {
         matcher_pass_initializer(this);
     }

--- a/src/frontends/paddle/src/internal/pass/transform_fakequantize.hpp
+++ b/src/frontends/paddle/src/internal/pass/transform_fakequantize.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class TransformFakeQuantize : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::paddle::pass::TransformFakeQuantize");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::paddle::pass::TransformFakeQuantize");
     TransformFakeQuantize();
 
 private:

--- a/src/frontends/paddle/src/internal/pass/transform_if.hpp
+++ b/src/frontends/paddle/src/internal/pass/transform_if.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class TransformIf : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::paddle::pass::TransformIf");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::paddle::pass::TransformIf");
     TransformIf(std::vector<std::shared_ptr<Model>> functions);
 
 private:

--- a/src/frontends/paddle/src/internal/pass/transform_tensorarray.hpp
+++ b/src/frontends/paddle/src/internal/pass/transform_tensorarray.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class TransformTensorArray : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::paddle::pass::TransformTensorArray");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::paddle::pass::TransformTensorArray");
     TransformTensorArray(std::vector<std::shared_ptr<Model>> functions);
 
 private:

--- a/src/frontends/paddle/src/internal/pass/transform_while.hpp
+++ b/src/frontends/paddle/src/internal/pass/transform_while.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class TransformWhile : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::paddle::pass::TransformWhile");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::paddle::pass::TransformWhile");
     TransformWhile(std::vector<std::shared_ptr<Model>> functions);
 
 private:

--- a/src/frontends/pytorch/src/transforms/append_list_unpack_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/append_list_unpack_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class AppendListUnpackReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AppendListUnpackReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AppendListUnpackReplacer");
     AppendListUnpackReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/aten_cat_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/aten_cat_replacer.hpp
@@ -15,7 +15,7 @@ namespace pass {
 // This transformation replaces pattern prim::ListConstruct->aten::append{none or many}->aten::cat
 class AtenCatToConcat : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenCatToConcat");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AtenCatToConcat");
     AtenCatToConcat();
 };
 

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class AtenGetItemReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenGetItemReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AtenGetItemReplacer");
     AtenGetItemReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/aten_index_put_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/aten_index_put_replacer.hpp
@@ -15,7 +15,7 @@ namespace pass {
 
 class PYTORCH_API AtenIndexPutReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenIndexPutReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AtenIndexPutReplacer");
     AtenIndexPutReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/aten_index_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/aten_index_replacer.hpp
@@ -16,7 +16,7 @@ namespace pass {
 // This transformation replaces pattern prim::ListConstruct->aten::index
 class PYTORCH_API AtenIndexToSelect : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenIndexToSelect");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AtenIndexToSelect");
     AtenIndexToSelect();
 };
 

--- a/src/frontends/pytorch/src/transforms/aten_stack_list_construct_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/aten_stack_list_construct_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class AtenStackListConstructReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenStackListConstructReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AtenStackListConstructReplacer");
     AtenStackListConstructReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/einsum_list_construct.hpp
+++ b/src/frontends/pytorch/src/transforms/einsum_list_construct.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class AtenEinsumListConstructReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenEinsumListConstructReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::AtenEinsumListConstructReplacer");
     AtenEinsumListConstructReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/index_loop_getitem_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/index_loop_getitem_replacer.hpp
@@ -18,7 +18,7 @@ namespace pass {
  */
 class IndexLoopGetitemReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::IndexLoopGetitemReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::IndexLoopGetitemReplacer");
     IndexLoopGetitemReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/irfftn_complex_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/irfftn_complex_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class IRFFTNComplexReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::IRFFTNComplexReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::IRFFTNComplexReplacer");
     IRFFTNComplexReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/listconstruct_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/listconstruct_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class ListConstructReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::ListConstructReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::ListConstructReplacer");
     ListConstructReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/min_max_prim_list_construct_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/min_max_prim_list_construct_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class MinMaxPrimListConstructReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::MinMaxPrimListConstructReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::MinMaxPrimListConstructReplacer");
     MinMaxPrimListConstructReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/prim_list_construct_pad.hpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_construct_pad.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class PrimListConstructPadReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::PrimListConstructPadReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::PrimListConstructPadReplacer");
     PrimListConstructPadReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class PrimListUnpackReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::PrimListUnpackReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::PrimListUnpackReplacer");
     PrimListUnpackReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/quantized_node_remover.hpp
+++ b/src/frontends/pytorch/src/transforms/quantized_node_remover.hpp
@@ -20,7 +20,7 @@ namespace pass {
  */
 class QuantizedNodeRemover : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::QuantizedNodeRemover");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::QuantizedNodeRemover");
     QuantizedNodeRemover();
 };
 

--- a/src/frontends/pytorch/src/transforms/remove_packing_ops.hpp
+++ b/src/frontends/pytorch/src/transforms/remove_packing_ops.hpp
@@ -17,7 +17,7 @@ namespace pass {
  */
 class MovePackThroughLstm : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::MovePackThroughLstm");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::MovePackThroughLstm");
     MovePackThroughLstm();
 };
 
@@ -26,7 +26,7 @@ public:
  */
 class RemovePackingOps : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::RemovePackingOps");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::RemovePackingOps");
     RemovePackingOps();
 };
 

--- a/src/frontends/pytorch/src/transforms/reverseprop_resolver.hpp
+++ b/src/frontends/pytorch/src/transforms/reverseprop_resolver.hpp
@@ -17,7 +17,7 @@ namespace pass {
  */
 class ReversepropResolver : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::ReversepropResolver");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::ReversepropResolver");
     ReversepropResolver();
 };
 

--- a/src/frontends/pytorch/src/transforms/rfftn_complex_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/rfftn_complex_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class RFFTNComplexReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::RFFTNComplexReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::RFFTNComplexReplacer");
     RFFTNComplexReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/string_equality_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/string_equality_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class StringEqualityReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::StringEqualityReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::StringEqualityReplacer");
     StringEqualityReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/torchfx_gptq_pattern_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/torchfx_gptq_pattern_replacer.hpp
@@ -15,7 +15,7 @@ namespace pass {
 // This transformation replaces the GPTQ pattern with a Constant node
 class GPTQDecompressionReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::GPTQDecompressionReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::GPTQDecompressionReplacer");
     GPTQDecompressionReplacer();
 };
 
@@ -24,7 +24,7 @@ public:
 // additional optimizations
 class GPTQMultPatternReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::GPTQMultPatternReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::GPTQMultPatternReplacer");
     GPTQMultPatternReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/tuple_unpack_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/tuple_unpack_replacer.hpp
@@ -14,7 +14,7 @@ namespace pass {
 
 class PrimTupleUnpackReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::PrimTupleUnpackReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::PrimTupleUnpackReplacer");
     PrimTupleUnpackReplacer();
 };
 

--- a/src/frontends/pytorch/src/transforms/u4_block_repack.hpp
+++ b/src/frontends/pytorch/src/transforms/u4_block_repack.hpp
@@ -14,13 +14,13 @@ namespace pass {
 
 class U4BlockRepack : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::U4BlockRepack");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::U4BlockRepack");
     U4BlockRepack(bool is_symmetrical = false);
 };
 
 class U4ConvertReshape : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::pytorch::pass::U4ConvertReshape");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::pytorch::pass::U4ConvertReshape");
     U4ConvertReshape();
 };
 

--- a/src/frontends/tensorflow/src/transformations/uninitialized_variable_resolve.hpp
+++ b/src/frontends/tensorflow/src/transformations/uninitialized_variable_resolve.hpp
@@ -19,7 +19,7 @@ namespace pass {
 // it borrows value of Variable that was used for some state (or node) in a graph
 class UninitializedVariableResolver : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::UninitializedVariableResolver");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::UninitializedVariableResolver");
     UninitializedVariableResolver();
 };
 

--- a/src/frontends/tensorflow_common/include/helper_transforms/embedding_segments_feature_fusing.hpp
+++ b/src/frontends/tensorflow_common/include/helper_transforms/embedding_segments_feature_fusing.hpp
@@ -20,7 +20,7 @@ namespace pass {
 // Such sub-graph is met in the Wide and Deep model in case of the SINGLE categorical feature.
 class EmbeddingSegmentSingleFeatureFusion : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::EmbeddingSegmentSingleFeatureFusion");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::EmbeddingSegmentSingleFeatureFusion");
     EmbeddingSegmentSingleFeatureFusion();
 };
 

--- a/src/frontends/tensorflow_common/include/helper_transforms/tensor_array_v3_replacer.hpp
+++ b/src/frontends/tensorflow_common/include/helper_transforms/tensor_array_v3_replacer.hpp
@@ -19,7 +19,7 @@ namespace pass {
 // that simulates initial state of tensor array container
 class TensorArrayV3Replacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::TensorArrayV3Replacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::TensorArrayV3Replacer");
     TensorArrayV3Replacer();
 };
 

--- a/src/frontends/tensorflow_common/include/helper_transforms/tensor_list_ops_resolver.hpp
+++ b/src/frontends/tensorflow_common/include/helper_transforms/tensor_list_ops_resolver.hpp
@@ -15,14 +15,14 @@ namespace pass {
 // Replace internal operation TensorListReserve with a sub-graph producing initial container
 class TensorListReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::TensorListReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::TensorListReplacer");
     TensorListReplacer();
 };
 
 // Replace internal operation TensorListSetItem with a sub-graph that inserts a new tensor into container
 class TensorListSetItemReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::TensorListSetItemReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::TensorListSetItemReplacer");
     TensorListSetItemReplacer();
 };
 
@@ -30,14 +30,14 @@ public:
 // that inserts a new tensor into the tail of the container
 class TensorListPushBackReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::TensorListPushBackReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::TensorListPushBackReplacer");
     TensorListPushBackReplacer();
 };
 
 // Replace internal operation TensorListGetItem with a sub-graph that gets a tensor from container by index
 class TensorListGetItemReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::TensorListGetItemReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::TensorListGetItemReplacer");
     TensorListGetItemReplacer();
 };
 
@@ -45,7 +45,7 @@ public:
 // Replace TensorListSetItem and TensorListGetItem with ConcatOutput and SlicedInput
 class TensorListInLoopOptimization : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow::pass::TensorListInLoopOptimization");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow::pass::TensorListInLoopOptimization");
     TensorListInLoopOptimization();
 };
 

--- a/src/frontends/tensorflow_lite/src/tflite_transformations/rfft2d_complex_abs.h
+++ b/src/frontends/tensorflow_lite/src/tflite_transformations/rfft2d_complex_abs.h
@@ -24,7 +24,7 @@ namespace pass {
 //               \-(imag)-> Unsqueeze -> Reshape -> Square /
 class Rfft2dSimplifier : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow_lite::pass::Rfft2dSimplifier");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow_lite::pass::Rfft2dSimplifier");
     Rfft2dSimplifier();
 };
 

--- a/src/frontends/tensorflow_lite/src/tflite_transformations/tflite_quantize_resolver.hpp
+++ b/src/frontends/tensorflow_lite/src/tflite_transformations/tflite_quantize_resolver.hpp
@@ -18,14 +18,14 @@ namespace pass {
 // Fuses Convert into TFLQuantize operation
 class TFLQuantizeConvert : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow_lite::pass::TFLQuantizeConvert");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow_lite::pass::TFLQuantizeConvert");
     TFLQuantizeConvert();
 };
 
 // Replaces TFLQuantize operation with FQ or sub-mul pattern if necessary
 class TFLQuantizeReplacer : public ov::pass::MatcherPass {
 public:
-    OPENVINO_RTTI("ov::frontend::tensorflow_lite::pass::TFLQuantizeReplacer");
+    OPENVINO_MATCHER_PASS_RTTI("ov::frontend::tensorflow_lite::pass::TFLQuantizeReplacer");
     TFLQuantizeReplacer();
 };
 


### PR DESCRIPTION
### Details:
 - Adds RTTI definition for passes derived from `ov::pass::MatcherPass`
 - Applies the macro to:
   - common/snippets
   - Offline Transformations
   - LP Transformations
   - Frontends
   - Core

### Tickets:
 - CVS-159217

Co-authored-by: Cathy Bao <cathy.bao@intel.com>
Co-authored-by: Venkat Raghavulu <venkat.raghavulu@intel.com>
Co-authored-by: Ivan Tikhonov <ivan.tikhonov@intel.com>
