### PR TITLE
[ONNX] Removed redundant memory copying for small data types when MMAP is using

### DIFF
--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -266,6 +266,57 @@ std::vector<std::string> Tensor::get_data() const {
     ONNX_INVALID_DATA_TYPE(m_tensor_proto->data_type(), "STRING");
 }
 
+std::shared_ptr<ov::op::v0::Constant> Tensor::get_ov_constant() const
+{
+    if (m_tensor_proto->has_segment()) {
+        FRONT_END_THROW("Loading segments isn't supported");
+    }
+    switch (m_tensor_proto->data_type()) {
+    case TensorProto_DataType::TensorProto_DataType_BOOL:
+        return make_ov_constant<char>(ov::element::boolean);
+    case TensorProto_DataType::TensorProto_DataType_FLOAT:
+        return make_ov_constant<float>(ov::element::f32);
+    case TensorProto_DataType::TensorProto_DataType_FLOAT16:
+        return make_ov_constant<ov::float16>(ov::element::f16);
+    case TensorProto_DataType::TensorProto_DataType_DOUBLE:
+        return make_ov_constant<double>(ov::element::f64);
+    case TensorProto_DataType::TensorProto_DataType_INT4:
+        return make_ov_constant<int8_t>(ov::element::i4);
+    case TensorProto_DataType::TensorProto_DataType_INT8:
+        return make_ov_constant<int8_t>(ov::element::i8);
+    case TensorProto_DataType::TensorProto_DataType_INT16:
+        return make_ov_constant<int16_t>(ov::element::i16);
+    case TensorProto_DataType::TensorProto_DataType_INT32:
+        return make_ov_constant<int32_t>(ov::element::i32);
+    case TensorProto_DataType::TensorProto_DataType_INT64:
+        return make_ov_constant<int64_t>(ov::element::i64);
+    case TensorProto_DataType::TensorProto_DataType_UINT4:
+        return make_ov_constant<uint8_t>(ov::element::u4);
+    case TensorProto_DataType::TensorProto_DataType_UINT8:
+        return make_ov_constant<uint8_t>(ov::element::u8);
+    case TensorProto_DataType::TensorProto_DataType_UINT16:
+        return make_ov_constant<uint16_t>(ov::element::u16);
+    case TensorProto_DataType::TensorProto_DataType_UINT32:
+        return make_ov_constant<uint32_t>(ov::element::u32);
+    case TensorProto_DataType::TensorProto_DataType_UINT64:
+        return make_ov_constant<uint64_t>(ov::element::u64);
+    case TensorProto_DataType::TensorProto_DataType_BFLOAT16:
+        return make_ov_constant<ov::bfloat16>(ov::element::bf16);
+    case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
+        return make_ov_constant<ov::float8_e4m3>(ov::element::f8e4m3);
+    case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
+        return make_ov_constant<ov::float8_e5m2>(ov::element::f8e5m2);
+    case TensorProto_DataType::TensorProto_DataType_STRING:
+        return make_ov_constant<std::string>(ov::element::string);
+    default:
+        ONNX_UNSUPPORTED_DATA_TYPE(
+            m_tensor_proto->data_type(),
+            "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, INT8, INT16, INT32, INT64, "
+            "UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
+    }
+}
+
+
 }  // namespace onnx
 }  // namespace frontend
 }  // namespace ov

--- a/src/frontends/onnx/frontend/src/core/tensor.hpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.hpp
@@ -208,14 +208,7 @@ private:
 
     const void* get_data_ptr() const {
         if (has_external_data()) {
-            const auto ext_data = detail::TensorExternalData(*m_tensor_proto);
-            std::shared_ptr<ov::AlignedBuffer> buffer = nullptr;
-            if (m_mmap_cache) {
-                buffer = ext_data.load_external_mmap_data(m_model_dir, m_mmap_cache);
-            } else {
-                buffer = ext_data.load_external_data(m_model_dir);
-            }
-            return buffer->get_ptr();
+            FRONT_END_THROW("Unexpected usage of method for externally stored data");
         }
         if (m_tensor_proto->has_raw_data()) {
             return m_tensor_proto->raw_data().data();

--- a/src/frontends/onnx/frontend/src/core/tensor.hpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.hpp
@@ -186,54 +186,7 @@ public:
         return static_cast<TensorProto_DataType>(m_tensor_proto->data_type());
     }
 
-    std::shared_ptr<ov::op::v0::Constant> get_ov_constant() const {
-        if (m_tensor_proto->has_segment()) {
-            FRONT_END_THROW("Loading segments isn't supported");
-        }
-        switch (m_tensor_proto->data_type()) {
-        case TensorProto_DataType::TensorProto_DataType_BOOL:
-            return make_ov_constant<char>(ov::element::boolean);
-        case TensorProto_DataType::TensorProto_DataType_FLOAT:
-            return make_ov_constant<float>(ov::element::f32);
-        case TensorProto_DataType::TensorProto_DataType_FLOAT16:
-            return make_ov_constant<ov::float16>(ov::element::f16);
-        case TensorProto_DataType::TensorProto_DataType_DOUBLE:
-            return make_ov_constant<double>(ov::element::f64);
-        case TensorProto_DataType::TensorProto_DataType_INT4:
-            return make_ov_constant<int8_t>(ov::element::i4);
-        case TensorProto_DataType::TensorProto_DataType_INT8:
-            return make_ov_constant<int8_t>(ov::element::i8);
-        case TensorProto_DataType::TensorProto_DataType_INT16:
-            return make_ov_constant<int16_t>(ov::element::i16);
-        case TensorProto_DataType::TensorProto_DataType_INT32:
-            return make_ov_constant<int32_t>(ov::element::i32);
-        case TensorProto_DataType::TensorProto_DataType_INT64:
-            return make_ov_constant<int64_t>(ov::element::i64);
-        case TensorProto_DataType::TensorProto_DataType_UINT4:
-            return make_ov_constant<uint8_t>(ov::element::u4);
-        case TensorProto_DataType::TensorProto_DataType_UINT8:
-            return make_ov_constant<uint8_t>(ov::element::u8);
-        case TensorProto_DataType::TensorProto_DataType_UINT16:
-            return make_ov_constant<uint16_t>(ov::element::u16);
-        case TensorProto_DataType::TensorProto_DataType_UINT32:
-            return make_ov_constant<uint32_t>(ov::element::u32);
-        case TensorProto_DataType::TensorProto_DataType_UINT64:
-            return make_ov_constant<uint64_t>(ov::element::u64);
-        case TensorProto_DataType::TensorProto_DataType_BFLOAT16:
-            return make_ov_constant<ov::bfloat16>(ov::element::bf16);
-        case TensorProto_DataType::TensorProto_DataType_FLOAT8E4M3FN:
-            return make_ov_constant<ov::float8_e4m3>(ov::element::f8e4m3);
-        case TensorProto_DataType::TensorProto_DataType_FLOAT8E5M2:
-            return make_ov_constant<ov::float8_e5m2>(ov::element::f8e5m2);
-        case TensorProto_DataType::TensorProto_DataType_STRING:
-            return make_ov_constant<std::string>(ov::element::string);
-        default:
-            ONNX_UNSUPPORTED_DATA_TYPE(
-                m_tensor_proto->data_type(),
-                "BOOL, BFLOAT16, FLOAT8E4M3FN, FLOAT8E5M2, FLOAT, FLOAT16, DOUBLE, INT4, INT8, INT16, INT32, INT64, "
-                "UINT4, UINT8, UINT16, UINT32, UINT64, STRING");
-        }
-    }
+    std::shared_ptr<ov::op::v0::Constant> get_ov_constant() const;
 
 private:
     template <typename T, typename std::enable_if<!std::is_same<T, std::string>::value, bool>::type = true>

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -46,6 +46,14 @@ public:
     /// \return     State of TensorExternalData as string representation
     std::string to_string() const;
 
+    /// \brief      Object contains a data length after construction. Method allows read-only access to this
+    ///             information.
+    ///
+    /// \return     Returns a stored data size in bytes
+    uint64_t size() const {
+        return m_data_length;
+    }
+
 private:
     std::string m_data_location{};
     uint64_t m_offset = 0;


### PR DESCRIPTION
### Details:
 - Removed a redundant memory copying for data types less than 4 bytes when MMAP is using
 - Implementation verified by a previously added tests named onnx_external_data_*

### Tickets:
 - 159161
