### PR TITLE
[benchmark] Do not check nireq if sync and time is specified

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -61,9 +61,11 @@ bool parse_and_check_command_line(int argc, char* argv[]) {
     if (FLAGS_api != "async" && FLAGS_api != "sync") {
         throw std::logic_error("Incorrect API. Please set -api option to `sync` or `async` value.");
     }
-    if (FLAGS_api == "sync" && FLAGS_nireq > FLAGS_niter) {
-        throw std::logic_error(
-            "Number of iterations should be greater than number of infer requests when using sync API.");
+    if (FLAGS_api == "sync") {
+        if ((FLAGS_t == 0) && (FLAGS_nireq > FLAGS_niter)) {
+            throw std::logic_error(
+                "Number of iterations should be greater than number of infer requests when using sync API.");
+        }
     }
     if (!FLAGS_hint.empty() && FLAGS_hint != "throughput" && FLAGS_hint != "tput" && FLAGS_hint != "latency" &&
         FLAGS_hint != "cumulative_throughput" && FLAGS_hint != "ctput" && FLAGS_hint != "none") {

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -49,8 +49,9 @@ def parse_and_check_command_line():
         raise Exception("Cannot set precision for a compiled model. " \
                         "Please re-compile your model with required precision.")
 
-    if args.api_type == "sync" and args.number_infer_requests > args.number_iterations:
-        raise Exception("Number of infer requests should be less than or equal to number of iterations in sync mode.")
+    if args.api_type == "sync":
+        if args.time == 0 and (args.number_infer_requests > args.number_iterations):
+            raise Exception("Number of infer requests should be less than or equal to number of iterations in sync mode.")
 
     return args, is_network_compiled
 


### PR DESCRIPTION
### Details:
- This disables nireq check in case execution time is specified when using the sync API

### Tickets:
 - CVS-159638
