### PR TITLE
Update ov-tokenizers.rst

### DIFF
--- a/docs/articles_en/learn-openvino/llm_inference_guide/ov-tokenizers.rst
+++ b/docs/articles_en/learn-openvino/llm_inference_guide/ov-tokenizers.rst
@@ -317,9 +317,7 @@ You can find more information and code snippets in the `OpenVINO Tokenizers Note
       # prepare input for new inference
       model_input["input_ids"] = output_token
       model_input["attention_mask"] = np.hstack((model_input["attention_mask"].data, [[1]]))
-      model_input["position_ids"] = np.hstack(
-         (model_input["position_ids"].data, [[model_input["position_ids"].data.shape[-1]]])
-      )
+      model_input["position_ids"] = np.array([[model_input["position_ids"][0, -1] + 1]])
 
 4. Detokenize Output
 +++++++++++++++++++++++++++++


### PR DESCRIPTION
I believe the input `position_ids` in LLMs for 2nd+ inference should only include the position id for the new token.

The code in the notebook also has this problem: [openvinotoolkit/openvino_notebooks/notebooks/openvino-tokenizers/openvino-tokenizers.ipynb](https://github.com/openvinotoolkit/openvino_notebooks/blob/latest/notebooks/openvino-tokenizers/openvino-tokenizers.ipynb)
