### PR TITLE
[OV JS] Update openvino-node package version to 2024.6.0

### DIFF
--- a/src/bindings/js/node/package-lock.json
+++ b/src/bindings/js/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-node",
-  "version": "2024.5.0-0",
+  "version": "2024.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-node",
-      "version": "2024.5.0-0",
+      "version": "2024.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvino-node",
-  "version": "2024.5.0-0",
+  "version": "2024.6.0",
   "description": "OpenVINO™ utils for using from Node.js environment",
   "repository": {
     "url": "git+https://github.com/openvinotoolkit/openvino.git",

--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -44,7 +44,6 @@
     "tar-fs": "^3.0.4"
   },
   "binary": {
-    "version": "2024.5.0",
     "module_path": "./bin/",
     "remote_path": "./repositories/openvino/nodejs_bindings/{version}/{platform}/",
     "package_name": "openvino_nodejs_bindings_{platform}_{version}_{arch}.tar.gz",

--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -50,6 +50,17 @@
     "host": "https://storage.openvinotoolkit.org"
   },
   "keywords": [
-    "OpenVINO"
+    "OpenVINO",
+    "openvino",
+    "openvino-node",
+    "openvino npm",
+    "openvino binding",
+    "openvino node.js",
+    "openvino library",
+    "intel openvino",
+    "openvino toolkit",
+    "openvino API",
+    "openvino SDK",
+    "openvino integration"
   ]
 }


### PR DESCRIPTION
### Details:
- update openvino-node package version to 2024.6.0
- port of keywords extension from https://github.com/openvinotoolkit/openvino/pull/28047
