### PR TITLE
[OV JS] Update openvino-node package version to 2024.6.0

### DIFF
--- a/samples/js/node/package-lock.json
+++ b/samples/js/node/package-lock.json
@@ -15,7 +15,7 @@
         "args": "^5.0.3",
         "eslint": "^8.39.0",
         "https-proxy-agent": "^7.0.2",
-        "openvino-node": "^2024.5.0-0"
+        "openvino-node": "^2024.6.0"
       },
       "engines": {
         "node": ">=21.0.0"
@@ -1920,9 +1920,9 @@
       }
     },
     "node_modules/openvino-node": {
-      "version": "2024.5.0-0",
-      "resolved": "https://registry.npmjs.org/openvino-node/-/openvino-node-2024.5.0-0.tgz",
-      "integrity": "sha512-SgvHH3OdOXyMu5iZx0oBFWn7yIu3uB54IIfmXFKlyhHbSjO+3ph+DauUdlUkp2DGETR7bzq7+cPyyroeOF7qqQ==",
+      "version": "2024.6.0",
+      "resolved": "https://registry.npmjs.org/openvino-node/-/openvino-node-2024.6.0.tgz",
+      "integrity": "sha512-EQ0kdklsac3rfJTv6jUc9UIR0IG/YyIMOeq40+EYS0wozQ0mp4aQGBJRsT30SaEM4Ct797F9Mq+v9PjHxlJvcw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/samples/js/node/package.json
+++ b/samples/js/node/package.json
@@ -8,7 +8,7 @@
     "args": "^5.0.3",
     "eslint": "^8.39.0",
     "https-proxy-agent": "^7.0.2",
-    "openvino-node": "^2024.5.0-0",
+    "openvino-node": "^2024.6.0",
     "@napi-rs/canvas": "^0.1.59"
   },
   "scripts": {

--- a/src/bindings/js/node/package-lock.json
+++ b/src/bindings/js/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-node",
-  "version": "2024.5.0-0",
+  "version": "2024.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-node",
-      "version": "2024.5.0-0",
+      "version": "2024.6.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvino-node",
-  "version": "2024.5.0-0",
+  "version": "2024.6.0",
   "description": "OpenVINO™ utils for using from Node.js environment",
   "repository": {
     "url": "git+https://github.com/openvinotoolkit/openvino.git",
@@ -44,7 +44,6 @@
     "tar-fs": "^3.0.4"
   },
   "binary": {
-    "version": "2024.5.0",
     "module_path": "./bin/",
     "remote_path": "./repositories/openvino/nodejs_bindings/{version}/{platform}/",
     "package_name": "openvino_nodejs_bindings_{platform}_{version}_{arch}.tar.gz",


### PR DESCRIPTION
### Details:
 - update openvino-node package version to 2024.6.0
 - update openvino-node to 2024.6.0 in samples
