### PR TITLE
[GPU][MTL] Resolve long token performance regression in MTL 125H plat…

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -169,7 +169,7 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
     GPU_DEBUG_IF(debug_config->disable_fc_swiglu_fusion == 1)
         disable_fc_swiglu_fusion = true;
     // Apply only for high performant GPU
-    if (disable_fc_swiglu_fusion || p.get_engine().get_device_info().execution_units_count < 128)
+    if (disable_fc_swiglu_fusion || p.get_engine().get_device_info().execution_units_count < 112)
         return;
 
     if (p.get_engine().get_device_info().supports_immad)

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -926,7 +926,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             disable_fc_swiglu_fusion = true;
         // mlp fusion is only supported for cldnn on high performant GPUis
         bool fuse_mlp_swiglu = !device_info.supports_immad &&
-                               device_info.execution_units_count >= 128 &&
+                               device_info.execution_units_count >= 112 &&
                                !disable_fc_swiglu_fusion;
         if (!disable_horizontal_fc_fusion)
             manager.register_pass<ov::intel_gpu::FullyConnectedHorizontalFusion>(fuse_mlp_swiglu);


### PR DESCRIPTION
### Details:

  - PR27831 enable MLP fusion in cldnn, it can improve performance, but it is not enabled in MTL 125H due to EU number is 112. So there should be no performance improvement, but PR26940, which integrate dynamic quantization, causes MTL 125H first token performance drop about 8% for 6K input token size. If we enable MLP fusion in MTL 125H, the performance regression will disappear.

 - test result:
    
![image](https://github.com/user-attachments/assets/83500404-4e41-4e2a-8e6e-457a40e38d90)

<html xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:dt="uuid:C2F41010-65B3-11d1-A29F-00AA00C14882"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=OneNote.File>
<meta name=Generator content="Microsoft OneNote 15">
</head>

<body lang=en-US style='font-family:Calibri;font-size:11.0pt'>
<!--StartFragment-->

<div style='direction:ltr'>


Test cases | First token   latency | Commit id
-- | -- | --
PR27900, before   MLP fusion | 22297.2 ms | 536bd69ed66a57869aa6d3bbe06692217997e67e
PR27831, MLP   fusion PR but  MLP fusion is   disabled by EU < 128 | 22783.2 ms | bf62609711227605d381bedfcd993e6c60475975
PR26940   [GPU] Integrate dynamic quantization for onednn | 24395.8 ms | b840082ac11b1608f349d9554b020498c328164f
PR26940    + patch to enable   MLP on MTL 125H (112 EUs) | 22875.3 ms | b840082ac11b1608f349d9554b020498c328164f



</div>

<!--EndFragment-->
</body>

</html>


### Tickets:
 - *[CVS-159322](https://jira.devtools.intel.com/browse/CVS-159322)*
