### PR TITLE
[Py OV] Replace imports of openvino.runtime in openvino module

### DIFF
--- a/src/bindings/python/src/openvino/frontend/frontend.py
+++ b/src/bindings/python/src/openvino/frontend/frontend.py
@@ -7,7 +7,7 @@ from typing import Union
 from openvino._pyopenvino import FrontEnd as FrontEndBase
 from openvino._pyopenvino import FrontEndManager as FrontEndManagerBase
 from openvino._pyopenvino import InputModel
-from openvino.runtime import Model
+from openvino import Model
 
 
 class FrontEnd(FrontEndBase):

--- a/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/jax/jaxpr_decoder.py
@@ -6,7 +6,7 @@
 
 import jax.core
 from openvino.frontend.jax.py_jax_frontend import _FrontEndJaxDecoder as Decoder
-from openvino.runtime import PartialShape, Type as OVType, OVAny
+from openvino import PartialShape, Type as OVType, OVAny
 from openvino.frontend.jax.utils import jax_array_to_ov_const, get_ov_type_for_value, \
     ivalue_to_constant, param_to_constants
 

--- a/src/bindings/python/src/openvino/frontend/jax/utils.py
+++ b/src/bindings/python/src/openvino/frontend/jax/utils.py
@@ -8,7 +8,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from openvino.frontend.jax.passes import filter_element, filter_ivalue, filter_param
-from openvino.runtime import op, Type as OVType, Shape, OVAny
+from openvino import op, Type as OVType, Shape, OVAny
 
 numpy_to_ov_type_map = {
     np.float32: OVType.f32,

--- a/src/bindings/python/src/openvino/frontend/pytorch/fx_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/fx_decoder.py
@@ -10,7 +10,7 @@ import inspect
 
 from openvino.frontend.pytorch.py_pytorch_frontend import _FrontEndPytorchDecoder as Decoder
 from openvino.frontend.pytorch.py_pytorch_frontend import _Type as DecoderType
-from openvino.runtime import PartialShape, Type as OVType, OVAny, Shape
+from openvino import PartialShape, Type as OVType, OVAny, Shape
 from openvino.frontend.pytorch.utils import make_constant, fetch_attr, pt_to_ov_type_map, torch_tensor_to_ov_const
 
 logger = logging.getLogger(__name__)

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend.py
@@ -18,7 +18,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 from torch._decomp import decomposition_table, get_decompositions
 
 from openvino.frontend import FrontEndManager
-from openvino.runtime import Core, Type, PartialShape
+from openvino import Core, Type, PartialShape
 from openvino.frontend.pytorch.ts_decoder import TorchScriptPythonDecoder
 from openvino.frontend.pytorch.torchdynamo import decompositions
 from openvino.frontend.pytorch.torchdynamo.decompositions import get_aot_decomposition_list, get_inf_decomposition_list
@@ -27,7 +27,7 @@ from openvino.frontend.pytorch.torchdynamo.execute import execute, execute_cache
 from openvino.frontend.pytorch.torchdynamo.compile import cached_model_name, openvino_compile_cached_model
 from openvino.frontend.pytorch.torchdynamo.backend_utils import _get_cache_dir, _get_device, _get_model_caching, _get_decompositions, _get_aot_autograd
 
-from openvino.runtime import Core, Type, PartialShape
+from openvino import Core, Type, PartialShape
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend_utils.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/backend_utils.py
@@ -5,7 +5,7 @@
 # mypy: ignore-errors
 
 from typing import Optional, Any
-from openvino.runtime import Core
+from openvino import Core
 
 
 def _get_device(options) -> Optional[Any]:

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/compile.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/compile.py
@@ -14,7 +14,7 @@ from torch.fx import GraphModule
 
 from openvino.frontend import FrontEndManager
 from openvino.frontend.pytorch.fx_decoder import TorchFXPythonDecoder
-from openvino.runtime import Core, Type, PartialShape, serialize
+from openvino import Core, Type, PartialShape, serialize
 from openvino.frontend.pytorch.torchdynamo.backend_utils import _get_cache_dir, _get_device, _get_config, _is_cache_dir_in_config
 
 from typing import Callable, Optional

--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py
@@ -20,7 +20,7 @@ from openvino.frontend import FrontEndManager
 from openvino.frontend.pytorch.fx_decoder import TorchFXPythonDecoder
 from openvino.frontend.pytorch.torchdynamo.partition import Partitioner
 from openvino.frontend.pytorch.torchdynamo.compile import openvino_compile
-from openvino.runtime import Core, Type, PartialShape
+from openvino import Core, Type, PartialShape
 from openvino.frontend.pytorch.torchdynamo.backend_utils import _get_cache_dir, _get_device, _get_aot_autograd
 
 from typing import Callable, Optional, Any

--- a/src/bindings/python/src/openvino/frontend/pytorch/ts_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/ts_decoder.py
@@ -6,7 +6,7 @@
 
 from openvino.frontend.pytorch.py_pytorch_frontend import _FrontEndPytorchDecoder as Decoder
 from openvino.frontend.pytorch.py_pytorch_frontend import _Type as DecoderType
-from openvino.runtime import op, PartialShape, Type as OVType, OVAny
+from openvino import op, PartialShape, Type as OVType, OVAny
 from openvino.frontend.pytorch.utils import (
     ivalue_to_constant,
     get_value_from_getattr,
@@ -15,7 +15,7 @@ from openvino.frontend.pytorch.utils import (
     convert_quantized_tensor,
     graph_has_ops,
 )
-from openvino.runtime import opset11 as ops
+from openvino import opset11 as ops
 from openvino.frontend.pytorch import quantized, patch_model
 from openvino.frontend.pytorch.module_extension import ModuleExtension
 

--- a/src/bindings/python/src/openvino/frontend/pytorch/utils.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/utils.py
@@ -7,8 +7,8 @@
 import torch
 import numpy as np
 
-from openvino.runtime import op, Type as OVType, Shape, Tensor
-from openvino.runtime import opset11 as ops
+from openvino import op, Type as OVType, Shape, Tensor
+from openvino import opset11 as ops
 
 
 def make_constant(*args, **kwargs):

--- a/src/bindings/python/src/openvino/frontend/tensorflow/node_decoder.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/node_decoder.py
@@ -7,7 +7,7 @@
 import numpy as np
 import tensorflow as tf
 from openvino.frontend.tensorflow.py_tensorflow_frontend import _FrontEndDecoderBase as DecoderBase
-from openvino.runtime import PartialShape, Type, OVAny, Tensor
+from openvino import PartialShape, Type, OVAny, Tensor
 
 
 def tf_type_to_ov_type(tf_type_int):

--- a/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
+++ b/src/bindings/python/src/openvino/frontend/tensorflow/utils.py
@@ -8,7 +8,7 @@
 import logging as log
 import numpy as np
 import sys
-from openvino.runtime import PartialShape, Dimension, Type
+from openvino import PartialShape, Dimension, Type
 from packaging.version import parse, Version
 from typing import List, Dict, Union
 

--- a/src/bindings/python/src/openvino/helpers/packing.py
+++ b/src/bindings/python/src/openvino/helpers/packing.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 from typing import Union
-from openvino.runtime import Type, Shape
+from openvino import Type, Shape
 
 
 def pack_data(array: np.ndarray, type: Type) -> np.ndarray:

--- a/src/bindings/python/src/openvino/opset1/ops.py
+++ b/src/bindings/python/src/openvino/opset1/ops.py
@@ -8,17 +8,17 @@ from typing import List, Optional, Union, get_args
 import numpy as np
 from functools import partial
 
-from openvino.runtime import Node, PartialShape, Type
+from openvino import Node, PartialShape, Type
 from openvino.op import Constant, Parameter, tensor_iterator
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op
-from openvino.runtime.utils.input_validation import (
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import binary_op, nameable_op, unary_op
+from openvino.utils.input_validation import (
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.node_factory import NodeFactory
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import NodeFactory
+from openvino.utils.types import (
     NodeInput,
     NumericData,
     NumericType,

--- a/src/bindings/python/src/openvino/opset10/ops.py
+++ b/src/bindings/python/src/openvino/opset10/ops.py
@@ -6,10 +6,10 @@
 from functools import partial
 from typing import List, Optional
 
-from openvino.runtime import Node
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.utils.types import (
+from openvino import Node
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import nameable_op
+from openvino.utils.types import (
     NodeInput,
     as_nodes,
     as_node,

--- a/src/bindings/python/src/openvino/opset11/ops.py
+++ b/src/bindings/python/src/openvino/opset11/ops.py
@@ -6,10 +6,10 @@
 from functools import partial
 from typing import List, Optional
 
-from openvino.runtime import Node
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.utils.types import (
+from openvino import Node
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import nameable_op
+from openvino.utils.types import (
     NodeInput,
     as_nodes,
 )

--- a/src/bindings/python/src/openvino/opset12/ops.py
+++ b/src/bindings/python/src/openvino/opset12/ops.py
@@ -6,10 +6,10 @@
 from functools import partial
 from typing import Optional
 
-from openvino.runtime import Node
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.utils.types import (
+from openvino import Node
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import nameable_op
+from openvino.utils.types import (
     NodeInput,
     as_nodes,
     as_node,

--- a/src/bindings/python/src/openvino/opset13/ops.py
+++ b/src/bindings/python/src/openvino/opset13/ops.py
@@ -11,12 +11,12 @@ import numpy as np
 
 log = logging.getLogger(__name__)
 
-from openvino.runtime import Node, Shape, Type, Output, Tensor
+from openvino import Node, Shape, Type, Output, Tensor
 from openvino.op import Constant, Result
 from openvino.opset1 import convert_like
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op, overloading
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import binary_op, nameable_op, unary_op, overloading
+from openvino.utils.types import (
     NumericData,
     NodeInput,
     NumericType,

--- a/src/bindings/python/src/openvino/opset14/ops.py
+++ b/src/bindings/python/src/openvino/opset14/ops.py
@@ -7,11 +7,11 @@ from functools import partial
 
 from typing import Union, Optional, List
 
-from openvino.runtime import Node, Type
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.types import TensorShape
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.utils.types import NodeInput, as_node, as_nodes
+from openvino import Node, Type
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.types import TensorShape
+from openvino.utils.decorators import nameable_op
+from openvino.utils.types import NodeInput, as_node, as_nodes
 
 _get_node_factory_opset14 = partial(_get_node_factory, "opset14")
 

--- a/src/bindings/python/src/openvino/opset15/ops.py
+++ b/src/bindings/python/src/openvino/opset15/ops.py
@@ -7,12 +7,12 @@ from functools import partial
 from typing import List, Literal, Optional
 
 import numpy as np
-from openvino.runtime import Node, Type
+from openvino import Node, Type
 from openvino.opset1 import convert_like
 from openvino.opset14 import constant
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op
-from openvino.runtime.utils.types import NodeInput, as_nodes
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import binary_op, nameable_op
+from openvino.utils.types import NodeInput, as_nodes
 
 _get_node_factory_opset15 = partial(_get_node_factory, "opset15")
 

--- a/src/bindings/python/src/openvino/opset16/ops.py
+++ b/src/bindings/python/src/openvino/opset16/ops.py
@@ -6,10 +6,10 @@
 from functools import partial
 from typing import Optional
 
-from openvino.runtime import Node
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.types import NodeInput, as_nodes
+from openvino import Node
+from openvino.utils.decorators import nameable_op
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.types import NodeInput, as_nodes
 
 _get_node_factory_opset16 = partial(_get_node_factory, "opset16")
 

--- a/src/bindings/python/src/openvino/opset2/ops.py
+++ b/src/bindings/python/src/openvino/opset2/ops.py
@@ -9,18 +9,17 @@ import numpy as np
 from functools import partial
 import warnings
 
-from openvino.runtime import Node, Shape
+from openvino import Node, Shape
 from openvino.op import Constant, Parameter
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op
-from openvino.runtime.utils.input_validation import (
+from openvino.utils.decorators import binary_op, nameable_op, unary_op
+from openvino.utils.input_validation import (
     assert_list_of_ints,
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.node_factory import NodeFactory
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import NodeFactory, _get_node_factory
+from openvino.utils.types import (
     NodeInput,
     NumericData,
     NumericType,

--- a/src/bindings/python/src/openvino/opset3/ops.py
+++ b/src/bindings/python/src/openvino/opset3/ops.py
@@ -8,18 +8,17 @@ from typing import Callable, Iterable, List, Optional, Set, Union
 import numpy as np
 from functools import partial
 
-from openvino.runtime import Node, Shape
+from openvino import Node, Shape
 from openvino.op import Constant, Parameter
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op
-from openvino.runtime.utils.input_validation import (
+from openvino.utils.decorators import binary_op, nameable_op, unary_op
+from openvino.utils.input_validation import (
     assert_list_of_ints,
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.node_factory import NodeFactory
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import NodeFactory, _get_node_factory
+from openvino.utils.types import (
     NodeInput,
     NumericData,
     NumericType,

--- a/src/bindings/python/src/openvino/opset4/ops.py
+++ b/src/bindings/python/src/openvino/opset4/ops.py
@@ -8,18 +8,17 @@ from typing import Callable, Iterable, List, Optional, Set, Union
 import numpy as np
 from functools import partial
 
-from openvino.runtime import Node, Shape
+from openvino import Node, Shape
 from openvino.op import Constant, Parameter
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op
-from openvino.runtime.utils.input_validation import (
+from openvino.utils.decorators import binary_op, nameable_op, unary_op
+from openvino.utils.input_validation import (
     assert_list_of_ints,
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.node_factory import NodeFactory
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import NodeFactory, _get_node_factory
+from openvino.utils.types import (
     NodeInput,
     NumericData,
     NumericType,

--- a/src/bindings/python/src/openvino/opset5/ops.py
+++ b/src/bindings/python/src/openvino/opset5/ops.py
@@ -8,18 +8,17 @@ from typing import Callable, Iterable, List, Optional, Set, Union
 import numpy as np
 from functools import partial
 
-from openvino.runtime import Node, Shape
+from openvino import Node, Shape
 from openvino.op import Constant, Parameter, loop
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op
-from openvino.runtime.utils.input_validation import (
+from openvino.utils.decorators import binary_op, nameable_op, unary_op
+from openvino.utils.input_validation import (
     assert_list_of_ints,
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.node_factory import NodeFactory
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import NodeFactory, _get_node_factory
+from openvino.utils.types import (
     NodeInput,
     NumericData,
     NumericType,

--- a/src/bindings/python/src/openvino/opset6/ops.py
+++ b/src/bindings/python/src/openvino/opset6/ops.py
@@ -9,13 +9,13 @@ from typing import Optional, Union
 
 from functools import partial, singledispatch
 
-from openvino.runtime import Node, Type, PartialShape, Output, Shape
+from openvino import Node, Type, PartialShape, Output, Shape
 from openvino.op import assign, Constant, Parameter
 from openvino.op import read_value as _read_value
 from openvino.op.util import VariableInfo, Variable
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import nameable_op, overloading
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import nameable_op, overloading
+from openvino.utils.types import (
     NodeInput,
     NumericType,
     TensorShape,

--- a/src/bindings/python/src/openvino/opset7/ops.py
+++ b/src/bindings/python/src/openvino/opset7/ops.py
@@ -7,18 +7,17 @@ from functools import partial
 from typing import Callable, Iterable, List, Optional, Set, Union
 
 import numpy as np
-from openvino.runtime import Node, Shape
+from openvino import Node, Shape
 from openvino.op import Constant, Parameter
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import binary_op, nameable_op, unary_op
-from openvino.runtime.utils.input_validation import (
+from openvino.utils.decorators import binary_op, nameable_op, unary_op
+from openvino.utils.input_validation import (
     assert_list_of_ints,
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.node_factory import NodeFactory
-from openvino.runtime.utils.types import (
+from openvino.utils.node_factory import NodeFactory, _get_node_factory
+from openvino.utils.types import (
     NodeInput,
     NumericData,
     NumericType,

--- a/src/bindings/python/src/openvino/opset8/ops.py
+++ b/src/bindings/python/src/openvino/opset8/ops.py
@@ -9,15 +9,15 @@ from typing import List, Optional, Tuple
 import numpy as np
 from openvino.exceptions import UserInputError
 from openvino.op import Constant, Parameter, if_op
-from openvino.runtime import Node
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.utils.input_validation import (
+from openvino import Node
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import nameable_op
+from openvino.utils.input_validation import (
     check_valid_attributes,
     is_non_negative_value,
     is_positive_value,
 )
-from openvino.runtime.utils.types import (
+from openvino.utils.types import (
     NodeInput,
     TensorShape,
     as_node,

--- a/src/bindings/python/src/openvino/opset9/ops.py
+++ b/src/bindings/python/src/openvino/opset9/ops.py
@@ -7,10 +7,10 @@ from functools import partial
 from typing import Optional
 
 import numpy as np
-from openvino.runtime import Node
-from openvino.runtime.opset_utils import _get_node_factory
-from openvino.runtime.utils.decorators import nameable_op
-from openvino.runtime.utils.types import (
+from openvino import Node
+from openvino.utils.node_factory import _get_node_factory
+from openvino.utils.decorators import nameable_op
+from openvino.utils.types import (
     NodeInput,
     as_nodes,
     as_node,

--- a/src/bindings/python/src/openvino/preprocess/torchvision/preprocess_converter.py
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/preprocess_converter.py
@@ -5,7 +5,7 @@
 from typing import Callable, Any, Union
 import logging
 
-import openvino.runtime as ov
+import openvino as ov
 
 
 class PreprocessConverter():

--- a/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/torchvision_preprocessing.py
@@ -20,10 +20,10 @@ import torch
 import torchvision.transforms as transforms
 from torchvision.transforms import InterpolationMode
 
-import openvino.runtime as ov
-import openvino.runtime.opset11 as ops
-from openvino.runtime import Layout, Type
-from openvino.runtime.utils.decorators import custom_preprocess_function
+import openvino as ov
+import openvino.opset11 as ops
+from openvino import Layout, Type
+from openvino.utils.decorators import custom_preprocess_function
 from openvino.preprocess import PrePostProcessor, ResizeAlgorithm, ColorFormat
 
 

--- a/src/bindings/python/src/openvino/utils/broadcasting.py
+++ b/src/bindings/python/src/openvino/utils/broadcasting.py
@@ -5,7 +5,7 @@
 import logging
 from typing import Optional
 
-from openvino.runtime import AxisSet
+from openvino import AxisSet
 from openvino.utils.types import (
     TensorShape,
 )

--- a/src/bindings/python/src/openvino/utils/decorators.py
+++ b/src/bindings/python/src/openvino/utils/decorators.py
@@ -6,7 +6,7 @@ from functools import wraps
 from inspect import signature
 from typing import Any, Callable, Dict, Optional, Union, get_origin, get_args
 
-from openvino.runtime import Node, Output
+from openvino import Node, Output
 from openvino.utils.types import NodeInput, as_node, as_nodes
 
 

--- a/src/bindings/python/src/openvino/utils/input_validation.py
+++ b/src/bindings/python/src/openvino/utils/input_validation.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 import numpy as np
 
-from openvino.runtime.exceptions import UserInputError
+from openvino.exceptions import UserInputError
 
 log = logging.getLogger(__name__)
 

--- a/src/bindings/python/src/openvino/utils/node_factory.py
+++ b/src/bindings/python/src/openvino/utils/node_factory.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 from openvino._pyopenvino import NodeFactory as _NodeFactory
 
-from openvino.runtime import Node, Output, Extension
+from openvino import Node, Output, Extension
 
-from openvino.runtime.exceptions import UserInputError
+from openvino.exceptions import UserInputError
 
 DEFAULT_OPSET = "opset13"
 

--- a/src/bindings/python/src/openvino/utils/reduction.py
+++ b/src/bindings/python/src/openvino/utils/reduction.py
@@ -4,7 +4,7 @@
 
 from typing import Iterable, Optional
 
-from openvino.runtime import Node
+from openvino import Node
 
 
 def get_reduction_axes(node: Node, reduction_axes: Optional[Iterable[int]]) -> Iterable[int]:

--- a/src/bindings/python/src/openvino/utils/types.py
+++ b/src/bindings/python/src/openvino/utils/types.py
@@ -9,8 +9,8 @@ from typing import List, Union, Optional
 
 import numpy as np
 
-from openvino.runtime.exceptions import OVTypeError
-from openvino.runtime import Node, Shape, Output, Type
+from openvino.exceptions import OVTypeError
+from openvino import Node, Shape, Output, Type
 from openvino.op import Constant
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### Details:
 - Replace imports of openvino.runtime in openvino module

### Tickets:
Part of [openvino.runtime deprecation](https://jira.devtools.intel.com/browse/CVS-129450)
