### PR TITLE
[core] Result node may uses inputs names on creation

### DIFF
--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -2296,7 +2296,7 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsForParameterAndResult)
         auto sin = make_shared<opset10::Sin>(param_1);
         sin->set_friendly_name("sine");
         sin->get_output_tensor(0).add_names({"sine:0"});
-        auto result_sin = make_shared<opset10::Result>(sin, false);
+        auto result_sin = make_shared<opset10::Result>(sin);
         model = make_shared<Model>(result_sin, ParameterVector{param_1});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
@@ -2389,12 +2389,13 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsMultiParam) {
         auto converted_mul = make_shared<opset10::Convert>(mul, element::f64);
         auto sin = make_shared<opset10::Sin>(convert_1);
 
+        add->get_output_tensor(0).add_names({"add:0"});
+        mul->get_output_tensor(0).add_names({"mul:0"});
+        sin->get_output_tensor(0).add_names({"sine:0"});
+
         auto result_add = make_shared<opset10::Result>(converted_add);
         auto result_mul = make_shared<opset10::Result>(converted_mul);
         auto result_sin = make_shared<opset10::Result>(sin);
-        result_add->get_output_tensor(0).add_names({"add:0"});
-        result_mul->get_output_tensor(0).add_names({"mul:0"});
-        result_sin->get_output_tensor(0).add_names({"sine:0"});
 
         model_ref = make_shared<Model>(ResultVector{result_add, result_mul, result_sin},
                                        ParameterVector{param_1, param_2, param_3, param_4});

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -2296,7 +2296,7 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsForParameterAndResult)
         auto sin = make_shared<opset10::Sin>(param_1);
         sin->set_friendly_name("sine");
         sin->get_output_tensor(0).add_names({"sine:0"});
-        auto result_sin = make_shared<opset10::Result>(sin);
+        auto result_sin = make_shared<opset10::Result>(sin, false);
         model = make_shared<Model>(result_sin, ParameterVector{param_1});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
@@ -2389,13 +2389,12 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsMultiParam) {
         auto converted_mul = make_shared<opset10::Convert>(mul, element::f64);
         auto sin = make_shared<opset10::Sin>(convert_1);
 
-        add->get_output_tensor(0).add_names({"add:0"});
-        mul->get_output_tensor(0).add_names({"mul:0"});
-        sin->get_output_tensor(0).add_names({"sine:0"});
-
         auto result_add = make_shared<opset10::Result>(converted_add);
         auto result_mul = make_shared<opset10::Result>(converted_mul);
         auto result_sin = make_shared<opset10::Result>(sin);
+        result_add->get_output_tensor(0).add_names({"add:0"});
+        result_mul->get_output_tensor(0).add_names({"mul:0"});
+        result_sin->get_output_tensor(0).add_names({"sine:0"});
 
         model_ref = make_shared<Model>(ResultVector{result_add, result_mul, result_sin},
                                        ParameterVector{param_1, param_2, param_3, param_4});
@@ -2441,9 +2440,6 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsSingleNodeMultipleOutp
         auto convert_1 = make_shared<opset10::Convert>(param_1, element::f32);
         auto axis = opset10::Constant::create(element::i32, Shape{}, {0});
         auto split = make_shared<opset10::Split>(convert_1, axis, 3);
-        split->get_output_tensor(0).add_names({"split:0"});
-        split->get_output_tensor(1).add_names({"split:1"});
-        split->get_output_tensor(2).add_names({"split:2"});
 
         auto convert_split_0 = make_shared<opset10::Convert>(split->output(0), element::f64);
         auto convert_split_1 = make_shared<opset10::Convert>(split->output(1), element::f64);
@@ -2567,7 +2563,6 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsMultiSubgraphs) {
         if_op->set_input(convert_1, param_1_then, param_1_else);
         if_op->set_input(convert_2, param_2_then, param_2_else);
         auto result = if_op->set_output(result_then, result_else);
-        result.add_names({"if_result:0"});
         auto converted_result = make_shared<opset10::Convert>(result, element::f64);
         converted_result->get_output_tensor(0).add_names({"if_result:0"});
 

--- a/src/core/include/openvino/op/result.hpp
+++ b/src/core/include/openvino/op/result.hpp
@@ -67,7 +67,8 @@ public:
     /// \brief Allows a value to be used as a function result.
     ///
     /// \param arg Node that produces the input tensor.
-    Result(const Output<Node>& arg);
+    /// \param use_input_names  When true Result will use input node tensor names as output names (Default: true).
+    Result(const Output<Node>& arg, bool use_input_names = true);
 
     void validate_and_infer_types() override;
 

--- a/src/core/include/openvino/op/result.hpp
+++ b/src/core/include/openvino/op/result.hpp
@@ -67,8 +67,13 @@ public:
     /// \brief Allows a value to be used as a function result.
     ///
     /// \param arg Node that produces the input tensor.
-    /// \param use_input_names  When true Result will use input node tensor names as output names (Default: false).
-    Result(const Output<Node>& arg, bool use_input_names = false);
+    Result(const Output<Node>& arg);
+
+    /// \brief Allows a value to be used as a function result.
+    ///
+    /// \param arg Node that produces the input tensor.
+    /// \param use_input_names  When true Result will use input node tensor names as Result's output names.
+    Result(const Output<Node>& arg, bool use_input_names);
 
     void validate_and_infer_types() override;
 

--- a/src/core/include/openvino/op/result.hpp
+++ b/src/core/include/openvino/op/result.hpp
@@ -67,8 +67,8 @@ public:
     /// \brief Allows a value to be used as a function result.
     ///
     /// \param arg Node that produces the input tensor.
-    /// \param use_input_names  When true Result will use input node tensor names as output names (Default: true).
-    Result(const Output<Node>& arg, bool use_input_names = true);
+    /// \param use_input_names  When true Result will use input node tensor names as output names (Default: false).
+    Result(const Output<Node>& arg, bool use_input_names = false);
 
     void validate_and_infer_types() override;
 

--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -949,8 +949,8 @@ ov::Output<ov::Node> ov::Model::add_output(const ov::Output<ov::Node>& port) {
             return input.get_node()->output(0);
         }
     }
-    auto result = std::make_shared<ov::op::v0::Result>(port);
-    m_results.push_back(result);
+    m_results.emplace_back(std::make_shared<ov::op::v0::Result>(port, true));
+    auto& result = m_results.back();
     if (m_shared_rt_info->get_use_topological_cache()) {
         if (cache_valid()) {
             // Full update of topological cache is not needed, 'result' can be just inserted to the end

--- a/src/core/src/node_vector.cpp
+++ b/src/core/src/node_vector.cpp
@@ -29,7 +29,7 @@ ov::ResultVector ov::as_result_vector(const OutputVector& values) {
     for (const auto& value : values) {
         std::shared_ptr<Node> node = value.get_node_shared_ptr();
         result.push_back(ov::is_type<ov::op::v0::Result>(node) ? ov::as_type_ptr<ov::op::v0::Result>(node)
-                                                               : std::make_shared<ov::op::v0::Result>(value));
+                                                               : std::make_shared<ov::op::v0::Result>(value, true));
     }
     return result;
 }

--- a/src/core/src/op/result.cpp
+++ b/src/core/src/op/result.cpp
@@ -10,13 +10,19 @@
 
 #include "itt.hpp"
 #include "openvino/core/descriptor_tensor.hpp"
+#include "openvino/op/util/op_types.hpp"
 
 namespace ov {
 namespace op {
 namespace v0 {
 
-Result::Result(const Output<Node>& arg) : Op({arg}) {
+Result::Result(const Output<Node>& arg, bool use_input_names) : Op({arg}) {
     constructor_validate_and_infer_types();
+
+    if (use_input_names && !util::is_parameter(arg.get_node())) {
+        // On create use inputs names which will be used as model output names (except Paramater, model's inputs names).
+        get_output_tensor(0).add_names(get_input_tensor(0).get_names());
+    }
 }
 
 void Result::validate_and_infer_types() {

--- a/src/core/src/op/result.cpp
+++ b/src/core/src/op/result.cpp
@@ -16,9 +16,11 @@ namespace ov {
 namespace op {
 namespace v0 {
 
-Result::Result(const Output<Node>& arg, bool use_input_names) : Op({arg}) {
+Result::Result(const Output<Node>& arg) : Op({arg}) {
     constructor_validate_and_infer_types();
+}
 
+Result::Result(const Output<Node>& arg, bool use_input_names) : Result(arg) {
     if (use_input_names && !util::is_parameter(arg.get_node())) {
         // On create use inputs names which will be used as model output names (except Paramater, model's inputs names).
         get_output_tensor(0).add_names(get_input_tensor(0).get_names());

--- a/src/core/tests/preprocess.cpp
+++ b/src/core/tests/preprocess.cpp
@@ -2079,7 +2079,7 @@ TEST(pre_post_process, postprocess_one_node_many_outputs) {
     ResultVector results;
     for (size_t i = 0; i < op->get_num_splits(); i++) {
         op->output(i).set_names({"tensor_Split" + std::to_string(i)});
-        auto res = std::make_shared<op::v0::Result>(op->output(i));
+        auto res = std::make_shared<op::v0::Result>(op->output(i), false);
         results.emplace_back(res);
     }
     auto model = std::make_shared<Model>(ResultVector{results}, ParameterVector{data1});

--- a/src/core/tests/preprocess.cpp
+++ b/src/core/tests/preprocess.cpp
@@ -2150,6 +2150,45 @@ TEST(pre_post_process, postprocess_one_node_many_outputs_results_created_by_mode
     EXPECT_EQ(model->get_results()[2]->input(0).get_source_output().get_node()->get_friendly_name(), "Split.2");
 }
 
+TEST(pre_post_process, postprocess_one_node_many_outputs_results_created_or_added_by_model) {
+    auto data1 = std::make_shared<op::v0::Parameter>(element::i32, Shape{3});
+    auto c1 = opset8::Constant::create(element::i32, Shape{}, {0});
+    auto op = std::make_shared<opset8::Split>(data1, c1, 3);
+    op->set_friendly_name("Split");
+    for (size_t i = 0; i < op->get_output_size(); ++i) {
+        op->output(i).set_names({"tensor_Split" + std::to_string(i)});
+    }
+
+    OutputVector outputs{std::make_shared<op::v0::Result>(op->output(0)), op->output(1)};
+
+    auto model = std::make_shared<Model>(outputs, ParameterVector{data1});
+    model->add_output(op->output(2));
+    // Set tensor name to model output 0
+    model->output(0).set_names({"output_split0"});
+    EXPECT_EQ(model->output(0).get_tensor().get_names().count("output_split0"), 1);
+    // Result input has still tensor_split0 names from split op
+    EXPECT_EQ(model->output(0).get_node()->get_input_tensor(0).get_names().count("tensor_Split0"), 1);
+    EXPECT_EQ(model->output(1).get_tensor().get_names().count("tensor_Split1"), 1);
+    EXPECT_EQ(model->output(2).get_tensor().get_names().count("tensor_Split2"), 1);
+
+    auto p = PrePostProcessor(model);
+    p.output(0).tensor().set_element_type(element::f32);
+    p.output(2).tensor().set_element_type(element::f32);
+    model = p.build();
+    EXPECT_EQ(model->get_results().size(), 3);
+
+    // output 0 by user,not use input nodes names as its own, modified by PPP (tensor_Split0 is on split output)
+    EXPECT_EQ(model->output(0).get_tensor().get_names().count("tensor_Split0"), 0);
+    EXPECT_EQ(model->output(0).get_tensor().get_names().count("output_split0"), 1);
+    // output 1 created by model, assume its names is output name, not modified by PPP
+    EXPECT_EQ(model->output(1).get_tensor().get_names().count("tensor_Split1"), 1);
+    // output 2 created by model, assume its names is output name, modified by PPP
+    EXPECT_EQ(model->output(2).get_tensor().get_names().count("tensor_Split2"), 1);
+    EXPECT_EQ(model->get_results()[0]->input(0).get_source_output().get_node()->get_friendly_name(), "Split.0");
+    EXPECT_EQ(model->get_results()[1]->input(0).get_source_output().get_node()->get_friendly_name(), "Split");
+    EXPECT_EQ(model->get_results()[2]->input(0).get_source_output().get_node()->get_friendly_name(), "Split.2");
+}
+
 TEST(pre_post_process, postprocess_nothing_applied) {
     auto data1 = std::make_shared<op::v0::Parameter>(element::i32, Shape{1, 3, 10, 20});
     auto c1 = opset8::Constant::create(element::i32, Shape{}, {1});

--- a/src/core/tests/type_prop/result.cpp
+++ b/src/core/tests/type_prop/result.cpp
@@ -10,6 +10,7 @@
 namespace ov {
 namespace test {
 
+using ov::op::v0::Constant;
 using ov::op::v0::Parameter;
 using std::make_shared;
 using testing::UnorderedElementsAre;
@@ -135,7 +136,7 @@ TEST_F(TypePropResultV0Test, preserve_specific_name_on_input_replace) {
     const auto a = std::make_shared<Parameter>(element::f32, PartialShape::dynamic());
     a->get_output_tensor(0).set_names({"input a"});
 
-    const auto result = make_op(a);
+    const auto result = make_op(a, true);
     result->output(0).set_names({"out"});
 
     EXPECT_THAT(result->input(0).get_tensor().get_names(), UnorderedElementsAre("out", "input a"));
@@ -150,6 +151,24 @@ TEST_F(TypePropResultV0Test, preserve_specific_name_on_input_replace) {
     EXPECT_THAT(result->input(0).get_tensor().get_names(), UnorderedElementsAre("input b", "out"));
     EXPECT_THAT(result->output(0).get_names(), UnorderedElementsAre("out"));
     EXPECT_THAT(a->output(0).get_names(), UnorderedElementsAre("input a"));
+}
+
+TEST_F(TypePropResultV0Test, take_input_node_names) {
+    const auto c = std::make_shared<Constant>(element::f32, Shape{2}, std::vector<float>{2.f, 1.f});
+    c->get_output_tensor(0).set_names({"constant data"});
+    const auto result = make_op(c, true);
+
+    EXPECT_THAT(result->input(0).get_tensor().get_names(), UnorderedElementsAre("constant data"));
+    EXPECT_THAT(result->output(0).get_names(), UnorderedElementsAre("constant data"));
+
+    const auto new_const = std::make_shared<Constant>(element::f32, Shape{2}, std::vector<float>{0.f, 0.f});
+
+    result->input(0).replace_source_output(new_const);
+    result->validate_and_infer_types();
+
+    EXPECT_THAT(c->get_output_tensor(0).get_names(), testing::IsEmpty());
+    EXPECT_THAT(result->get_input_tensor(0).get_names(), UnorderedElementsAre("constant data"));
+    EXPECT_THAT(result->get_output_tensor(0).get_names(), UnorderedElementsAre("constant data"));
 }
 }  // namespace test
 }  // namespace ov

--- a/src/frontends/ir/src/ir_deserializer.cpp
+++ b/src/frontends/ir/src/ir_deserializer.cpp
@@ -1025,17 +1025,6 @@ std::shared_ptr<ov::Node> ov::XmlDeserializer::create_node(const std::vector<ov:
                 ++index;
             }
         }
-
-        // The IR does not store information about dedicated output names for Result node (model output),
-        // assume all names from parent node are Result's (model's) tensor names.
-        //  Consider adding dedicated RT info with information about Result's output names.
-        if (auto result = ov::as_type<ov::op::v0::Result>(ovNode.get())) {
-            if (!ov::op::util::is_parameter(result->get_input_source_output(0).get_node())) {
-                // Copy names if parent node is not parameter, model's input names should not be dedicated
-                // output names as they could be removed from Parameter's tensor during model transformations.
-                ov::descriptor::copy_tensor_names(result->get_output_tensor(0), result->get_input_tensor(0));
-            }
-        }
     }
 
     return ovNode;

--- a/src/frontends/onnx/frontend/src/input_model.cpp
+++ b/src/frontends/onnx/frontend/src/input_model.cpp
@@ -533,13 +533,6 @@ void InputModel::add_tensor_names(std::shared_ptr<Model>& model) {
             it->add_names(tensor_names.second);
         }
     }
-
-    // Set model output names
-    for (auto&& result : model->get_results()) {
-        if (!is_type<op::v0::Parameter>(result->get_input_source_output(0).get_node())) {
-            result->get_output_tensor(0).add_names(result->get_input_tensor(0).get_names());
-        }
-    }
 }
 
 void InputModel::reshape_model_inputs(std::shared_ptr<Model>& model) {

--- a/src/inference/src/model_reader.cpp
+++ b/src/inference/src/model_reader.cpp
@@ -86,7 +86,7 @@ void update_v10_model(std::shared_ptr<ov::Model>& model, bool frontendMode = fal
                                 "Model operation names have collisions with tensor names.",
                                 " Please use MO to generate new IR version, it should allow to avoid the issue");
                 leaf_names.emplace(res_name, nullptr);
-                result->output(0).get_tensor().add_names({std::move(res_name)});
+                result->input(0).get_tensor().add_names({std::move(res_name)});
             }
             for (const auto& param : model->get_parameters()) {
                 const auto& param_name = param->get_friendly_name();

--- a/src/inference/src/model_reader.cpp
+++ b/src/inference/src/model_reader.cpp
@@ -86,7 +86,7 @@ void update_v10_model(std::shared_ptr<ov::Model>& model, bool frontendMode = fal
                                 "Model operation names have collisions with tensor names.",
                                 " Please use MO to generate new IR version, it should allow to avoid the issue");
                 leaf_names.emplace(res_name, nullptr);
-                result->input(0).get_tensor().add_names({std::move(res_name)});
+                result->output(0).get_tensor().add_names({std::move(res_name)});
             }
             for (const auto& param : model->get_parameters()) {
                 const auto& param_name = param->get_friendly_name();


### PR DESCRIPTION
### Details:
 - The Result node may use inputs names when created. Creation such Result assume as previous layer is model output.
 - The model when created from outputs and the outputs are note Result node, then create results and take its names as model output names.
 - The Result has option to enable/disable use inputs names as it owns. If names not used they still be visible as output names if Result has no dedicated names but if Result is connect to other input these names stay on origin input.

### Tickets:
 - CVS-159672
