### PR TITLE
Add WA for MSVC compiler mutex constructor issue with VS2022

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -455,6 +455,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Build with multiple processes
     ov_add_compiler_flags(/MP)
 
+    # Workaround for an MSVC compiler issue in some versions of Visual Studio 2022.
+    # The issue involves a null dereference to a mutex. For details, refer to link https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
+    if(MSVC AND MSVC_VERSION GREATER_EQUAL 1930 AND MSVC_VERSION LESS 1941)
+	ov_add_compiler_flags(/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    endif()
+
     if(AARCH64 AND NOT MSVC_VERSION LESS 1930)
         # otherwise, _ARM64_EXTENDED_INTRINSICS is defined, which defines 'mvn' macro
         ov_add_compiler_flags(/D_ARM64_DISTINCT_NEON_TYPES)


### PR DESCRIPTION
### Details:
 - This issue is a MSVC compiler bug affecting certain versions of Visual Studio 2022. When using std::mutex a null dereference may occur, leading to a silent crash in Release mode.
 - Adding the compiler option "/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR" serves as a workaround for this problem.

Reference:
https://hydrogenaud.io/index.php/topic,126070.0.html
https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710

### Tickets:
 - CVS-159684
 
