### PR TITLE
update fix for coverity scan issue 1568450

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -221,12 +221,14 @@ CPU::CPU() {
         } else {
             _processors = valid_cpu_mapping_table.size();
             _cpu_mapping_table.swap(valid_cpu_mapping_table);
-            std::lock_guard<std::mutex> lock{_cpu_mutex};
-            update_valid_processor_linux(std::move(phy_core_list),
-                                         _numa_nodes,
-                                         _cores,
-                                         _proc_type_table,
-                                         _cpu_mapping_table);
+            {
+                std::lock_guard<std::mutex> lock{_cpu_mutex};
+                update_valid_processor_linux(std::move(phy_core_list),
+                                             _numa_nodes,
+                                             _cores,
+                                             _proc_type_table,
+                                             _cpu_mapping_table);
+            }
             return 0;
         }
     };

--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -219,9 +219,9 @@ CPU::CPU() {
         } else if (valid_cpu_mapping_table.size() == (unsigned)_processors) {
             return 0;
         } else {
-            std::lock_guard<std::mutex> lock{_cpu_mutex};
             _processors = valid_cpu_mapping_table.size();
             _cpu_mapping_table.swap(valid_cpu_mapping_table);
+            std::lock_guard<std::mutex> lock{_cpu_mutex};
             update_valid_processor_linux(std::move(phy_core_list),
                                          _numa_nodes,
                                          _cores,


### PR DESCRIPTION
### Details:
 - *fix below coverity scan issue*

*** CID 1568450: Concurrent data access violations (MISSING_LOCK)
/openvino/src/inference/src/os/lin/lin_system_conf.cpp: 225 in ov::CPU::CPU()::[lambda() (instance 2)]::operator ()() const()
219 return -1;
220 } else if (valid_cpu_mapping_table.size() == (unsigned)_processors) {
221 return 0;
222 } else {
223 _processors = valid_cpu_mapping_table.size();
224 _cpu_mapping_table.swap(valid_cpu_mapping_table);

CID 1568450:  Concurrent data access violations  (MISSING_LOCK)
Accessing "this->this->_proc_type_table" without holding lock "ov::CPU._cpu_mutex". Elsewhere, "ov::CPU._proc_type_table" is written to with "CPU._cpu_mutex" held 2 out of 3 times.
225 update_valid_processor_linux(std::move(phy_core_list),
226 _numa_nodes,
227 _cores,
228 _proc_type_table,
229 _cpu_mapping_table);
230 return 0;

### Tickets:
 - *CID 1568450*
