### PR TITLE
fix coverity scan issue CID 1529754

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -235,7 +235,7 @@ CPU::CPU() {
 
     if (!get_info_linux(cache_info_mode)) {
         parse_cache_info_linux(system_info_table,
-                               node_info_table,
+                               std::move(node_info_table),
                                _processors,
                                _numa_nodes,
                                _sockets,
@@ -249,7 +249,7 @@ CPU::CPU() {
          (_proc_type_table[0][ALL_PROC] != _proc_type_table[0][EFFICIENT_CORE_PROC]))) {
         if (!get_info_linux(freq_info_mode)) {
             parse_freq_info_linux(system_info_table,
-                                  node_info_table,
+                                  std::move(node_info_table),
                                   _processors,
                                   _numa_nodes,
                                   _sockets,


### PR DESCRIPTION
### Details:
 - *item1*
	
CID 1529754: (#1 of 1): COPY_INSTEAD_OF_MOVE (COPY_INSTEAD_OF_MOVE)
1. copy_constructor_call: node_info_table is passed-by-value as parameter to parse_freq_info_linux when it could be moved instead.
     	Use std::move(node_info_table) instead of node_info_table.
221                                  node_info_table,
222                                  _processors,
223                                  _numa_nodes,
224                                  _sockets,
225                                  _cores,
226                                  _proc_type_table,
227                                  _cpu_mapping_table);

### Tickets:
 - *ticket-id*
