### PR TITLE
[tests/requirements] Newer pytest for python >=3.10

### DIFF
--- a/tests/requirements_pytorch
+++ b/tests/requirements_pytorch
@@ -14,7 +14,8 @@ torchaudio==2.2.2; platform_system == "Darwin" and platform_machine == "x86_64"
 # transformers 4.45.1 is available
 # but optimum still requires <4.45.0
 transformers==4.44.2
-pytest==7.0.1
+pytest==7.0.1; python_version < '3.10'
+pytest==7.2.0; python_version >= '3.10'
 pytest-html==4.1.1
 pytest-xdist[psutil]==3.6.1
 defusedxml==0.7.1

--- a/tests/requirements_tensorflow
+++ b/tests/requirements_tensorflow
@@ -4,7 +4,8 @@
 # tensorflow 2.16.2 depends on numpy<2.0.0 and >=1.26.0; python_version >= "3.12"
 numpy==1.26.4; python_version < "3.12" or platform_system == "Darwin" and platform_machine == "x86_64"
 numpy==2.0.2; python_version >= "3.12" and (platform_system != "Darwin" or platform_machine != "x86_64")
-pytest==7.0.1
+pytest==7.0.1; python_version < '3.10'
+pytest==7.2.0; python_version >= '3.10'
 pytest-xdist[psutil]==3.6.1
 pytest-html==4.1.1
 transformers==4.45.1


### PR DESCRIPTION
### Details:
To align with internal tests requirements and avoid E2E failures (AttributeError: 'Config' object has no attribute '_metadata')