### PR TITLE
Switch metrics collection to a separate runner

### DIFF
--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # at 00:00 on the 1st day of every month
     - cron: '0 0 1 * *'
- 
+
 permissions: read-all
 
 jobs:
@@ -61,8 +61,8 @@ jobs:
           cache-path: ${{ env.CCACHE_PATH }}
           recursive: true
           key: '.'
-          
-          
+
+
   Cleanup_ccache_win:
     name: Cleanup Windows ccache
     runs-on: 'aks-win-4-cores-8gb'

--- a/.github/workflows/export_workflow_metrics.yml
+++ b/.github/workflows/export_workflow_metrics.yml
@@ -34,7 +34,7 @@ permissions: read-all
 jobs:
   export-workflow-metrics:
     name: Export finished workflow metrics
-    runs-on: aks-linux-2-cores-8gb
+    runs-on: aks-linux-2-cores-8gb-stats
     if: ${{ github.repository_owner == 'openvinotoolkit' }}
 
     steps:

--- a/.github/workflows/workflow_rerunner.yml
+++ b/.github/workflows/workflow_rerunner.yml
@@ -29,7 +29,7 @@ jobs:
     name: Rerun Workflow
     # Run only for the failed workflows in openvinotoolkit org
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.repository_owner == 'openvinotoolkit' }}
-    runs-on: aks-linux-2-cores-8gb
+    runs-on: aks-linux-2-cores-8gb-stats
     permissions:
       actions: write
       contents: read
@@ -70,7 +70,7 @@ jobs:
   rerunner_tests:
     name: Rerunner Tests
     if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'openvinotoolkit' }}
-    runs-on: aks-linux-2-cores-8gb
+    runs-on: aks-linux-2-cores-8gb-stats
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -96,9 +96,9 @@ jobs:
         working-directory: ${{ github.workspace }}/.github/scripts/workflow_rerun
         run: |
           export PYTHONPATH=${{ github.workspace }}/.github/scripts/workflow_rerun:${{ github.workspace }}/.github/scripts:$PYTHONPATH
-          
+
           # Need to get a run id with successful status for log analyzing
           # cannot lock a run id as logs get deleted after some time
           run_id=$(python3 -c "from github import Github, Auth; import os; github=Github(auth=Auth.Token(token=os.environ.get('GITHUB_TOKEN'))); repo = github.get_repo('${GITHUB_REPOSITORY}'); run_id = repo.get_workflow_runs(status='success')[0].id; print(run_id)")
-          
+
           python3 rerunner.py --repository-name ${GITHUB_REPOSITORY} --run-id $run_id --dry-run


### PR DESCRIPTION
### Details:
Metrics collection generates a lot of workflows, and they fight for runners with regular test jobs. This PR fixes that.
