### PR TITLE
Skip ONNX layer test cases that depend on openvino.tools.mo

### DIFF
--- a/tests/layer_tests/onnx_tests/test_abs.py
+++ b/tests/layer_tests/onnx_tests/test_abs.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestAbs(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_abs.py
+++ b/tests/layer_tests/onnx_tests/test_abs.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestAbs(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_and.py
+++ b/tests/layer_tests/onnx_tests/test_and.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestAnd(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_and.py
+++ b/tests/layer_tests/onnx_tests/test_and.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestAnd(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_argmax.py
+++ b/tests/layer_tests/onnx_tests/test_argmax.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestArgMax(OnnxRuntimeLayerTest):
     def create_net(self, shape, axis, keepdims, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_argmax.py
+++ b/tests/layer_tests/onnx_tests/test_argmax.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestArgMax(OnnxRuntimeLayerTest):
     def create_net(self, shape, axis, keepdims, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_ceil.py
+++ b/tests/layer_tests/onnx_tests/test_ceil.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestCeil(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_ceil.py
+++ b/tests/layer_tests/onnx_tests/test_ceil.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestCeil(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_clip.py
+++ b/tests/layer_tests/onnx_tests/test_clip.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestClip(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version, opset, min=None, max=None):
         """

--- a/tests/layer_tests/onnx_tests/test_clip.py
+++ b/tests/layer_tests/onnx_tests/test_clip.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestClip(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version, opset, min=None, max=None):
         """

--- a/tests/layer_tests/onnx_tests/test_concat.py
+++ b/tests/layer_tests/onnx_tests/test_concat.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestConcat(OnnxRuntimeLayerTest):
     # TODO Add test with default values (axis=0)
     def create_concat_net_const(self, input_shape, output_shape, axis, ir_version):

--- a/tests/layer_tests/onnx_tests/test_concat.py
+++ b/tests/layer_tests/onnx_tests/test_concat.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestConcat(OnnxRuntimeLayerTest):
     # TODO Add test with default values (axis=0)
     def create_concat_net_const(self, input_shape, output_shape, axis, ir_version):

--- a/tests/layer_tests/onnx_tests/test_conv.py
+++ b/tests/layer_tests/onnx_tests/test_conv.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestConv(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_conv.py
+++ b/tests/layer_tests/onnx_tests/test_conv.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestConv(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_cumsum.py
+++ b/tests/layer_tests/onnx_tests/test_cumsum.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
@@ -20,7 +22,6 @@ def cumsum(a, axis=None, exclusive=False, reverse=False):
     return res
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestCumSum(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version, axis=None, reverse=None, exclusive=None):
         """

--- a/tests/layer_tests/onnx_tests/test_cumsum.py
+++ b/tests/layer_tests/onnx_tests/test_cumsum.py
@@ -20,6 +20,7 @@ def cumsum(a, axis=None, exclusive=False, reverse=False):
     return res
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestCumSum(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version, axis=None, reverse=None, exclusive=None):
         """

--- a/tests/layer_tests/onnx_tests/test_dequantize_linear.py
+++ b/tests/layer_tests/onnx_tests/test_dequantize_linear.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestDequantizeLinear(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_dequantize_linear.py
+++ b/tests/layer_tests/onnx_tests/test_dequantize_linear.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestDequantizeLinear(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_elu.py
+++ b/tests/layer_tests/onnx_tests/test_elu.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestElu(OnnxRuntimeLayerTest):
     def create_net(self, shape, alpha, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_elu.py
+++ b/tests/layer_tests/onnx_tests/test_elu.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestElu(OnnxRuntimeLayerTest):
     def create_net(self, shape, alpha, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_embedding_bag.py
+++ b/tests/layer_tests/onnx_tests/test_embedding_bag.py
@@ -23,6 +23,7 @@ class PytorchLayerTest(CommonLayerTest):
         return {'output': self.torch_model(*self.var).detach().numpy()}
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class EmbeddingBagModel(torch.nn.Module):
     def __init__(self, n, m, indices_shape=None, per_sample_weights=False, mode="sum"):
         super(EmbeddingBagModel, self).__init__()

--- a/tests/layer_tests/onnx_tests/test_embedding_bag.py
+++ b/tests/layer_tests/onnx_tests/test_embedding_bag.py
@@ -5,6 +5,8 @@ import os
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 import torch
 import torch.nn as nn
 from common.layer_test_class import CommonLayerTest, check_ir_version
@@ -23,7 +25,6 @@ class PytorchLayerTest(CommonLayerTest):
         return {'output': self.torch_model(*self.var).detach().numpy()}
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class EmbeddingBagModel(torch.nn.Module):
     def __init__(self, n, m, indices_shape=None, per_sample_weights=False, mode="sum"):
         super(EmbeddingBagModel, self).__init__()

--- a/tests/layer_tests/onnx_tests/test_floor.py
+++ b/tests/layer_tests/onnx_tests/test_floor.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestFloor(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_floor.py
+++ b/tests/layer_tests/onnx_tests/test_floor.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestFloor(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_gather.py
+++ b/tests/layer_tests/onnx_tests/test_gather.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestGather(OnnxRuntimeLayerTest):
     def create_net(self, shape, axis, indices, output_shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_gather.py
+++ b/tests/layer_tests/onnx_tests/test_gather.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestGather(OnnxRuntimeLayerTest):
     def create_net(self, shape, axis, indices, output_shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestHardSigmoid(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_hard_sigmoid.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestHardSigmoid(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_identity.py
+++ b/tests/layer_tests/onnx_tests/test_identity.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestIdentity(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_identity.py
+++ b/tests/layer_tests/onnx_tests/test_identity.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestIdentity(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_leaky_relu.py
+++ b/tests/layer_tests/onnx_tests/test_leaky_relu.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestLeakyRelu(OnnxRuntimeLayerTest):
     def create_net(self, shape, alpha, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_leaky_relu.py
+++ b/tests/layer_tests/onnx_tests/test_leaky_relu.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestLeakyRelu(OnnxRuntimeLayerTest):
     def create_net(self, shape, alpha, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_log.py
+++ b/tests/layer_tests/onnx_tests/test_log.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestLog(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_log.py
+++ b/tests/layer_tests/onnx_tests/test_log.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestLog(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_logsoftmax.py
+++ b/tests/layer_tests/onnx_tests/test_logsoftmax.py
@@ -34,6 +34,7 @@ def get_flatten_shape(src_shape, axis):
     return [fst_dim, snd_dim]
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestLog(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_logsoftmax.py
+++ b/tests/layer_tests/onnx_tests/test_logsoftmax.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
@@ -34,7 +36,6 @@ def get_flatten_shape(src_shape, axis):
     return [fst_dim, snd_dim]
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestLog(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_lrn.py
+++ b/tests/layer_tests/onnx_tests/test_lrn.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestLRN(OnnxRuntimeLayerTest):
     def create_net(self, shape, alpha, beta, bias, size, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_lrn.py
+++ b/tests/layer_tests/onnx_tests/test_lrn.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestLRN(OnnxRuntimeLayerTest):
     def create_net(self, shape, alpha, beta, bias, size, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_neg.py
+++ b/tests/layer_tests/onnx_tests/test_neg.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestNeg(OnnxRuntimeLayerTest):
     def create_neg(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_neg.py
+++ b/tests/layer_tests/onnx_tests/test_neg.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestNeg(OnnxRuntimeLayerTest):
     def create_neg(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_non_zero.py
+++ b/tests/layer_tests/onnx_tests/test_non_zero.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestNonZero(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_non_zero.py
+++ b/tests/layer_tests/onnx_tests/test_non_zero.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestNonZero(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_not.py
+++ b/tests/layer_tests/onnx_tests/test_not.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestNot(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_not.py
+++ b/tests/layer_tests/onnx_tests/test_not.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestNot(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_or.py
+++ b/tests/layer_tests/onnx_tests/test_or.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestOr(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_or.py
+++ b/tests/layer_tests/onnx_tests/test_or.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestOr(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_pad.py
+++ b/tests/layer_tests/onnx_tests/test_pad.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestPad(OnnxRuntimeLayerTest):
     def create_net(self, shape, mode, pads, value, ir_version, opset=None):
         """

--- a/tests/layer_tests/onnx_tests/test_pad.py
+++ b/tests/layer_tests/onnx_tests/test_pad.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestPad(OnnxRuntimeLayerTest):
     def create_net(self, shape, mode, pads, value, ir_version, opset=None):
         """

--- a/tests/layer_tests/onnx_tests/test_pooling.py
+++ b/tests/layer_tests/onnx_tests/test_pooling.py
@@ -13,6 +13,7 @@ def float_array(x):
     return np.array(x, dtype=float)
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestPooling(OnnxRuntimeLayerTest):
     def create_net(self, shape, kernel_shape, pads, strides, op, ir_version, count_include_pad=None,
                    auto_pad=None,

--- a/tests/layer_tests/onnx_tests/test_pooling.py
+++ b/tests/layer_tests/onnx_tests/test_pooling.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
@@ -13,7 +15,6 @@ def float_array(x):
     return np.array(x, dtype=float)
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestPooling(OnnxRuntimeLayerTest):
     def create_net(self, shape, kernel_shape, pads, strides, op, ir_version, count_include_pad=None,
                    auto_pad=None,

--- a/tests/layer_tests/onnx_tests/test_prelu.py
+++ b/tests/layer_tests/onnx_tests/test_prelu.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestPRelu(OnnxRuntimeLayerTest):
     def create_net(self, shape, slope_shape, precision, ir_version, opset=None):
         """

--- a/tests/layer_tests/onnx_tests/test_prelu.py
+++ b/tests/layer_tests/onnx_tests/test_prelu.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestPRelu(OnnxRuntimeLayerTest):
     def create_net(self, shape, slope_shape, precision, ir_version, opset=None):
         """

--- a/tests/layer_tests/onnx_tests/test_reduce.py
+++ b/tests/layer_tests/onnx_tests/test_reduce.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestReduce(OnnxRuntimeLayerTest):
     def create_reduce(self, shape, reshapped_shape, op, axes, keep_dims, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_reduce.py
+++ b/tests/layer_tests/onnx_tests/test_reduce.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestReduce(OnnxRuntimeLayerTest):
     def create_reduce(self, shape, reshapped_shape, op, axes, keep_dims, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_reduce_lp.py
+++ b/tests/layer_tests/onnx_tests/test_reduce_lp.py
@@ -5,13 +5,14 @@ import platform
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestReduceL1L2(OnnxRuntimeLayerTest):
     def create_reduce_lp(self, shape, axes, keep_dims, reduce_p, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_reduce_lp.py
+++ b/tests/layer_tests/onnx_tests/test_reduce_lp.py
@@ -11,6 +11,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestReduceL1L2(OnnxRuntimeLayerTest):
     def create_reduce_lp(self, shape, axes, keep_dims, reduce_p, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_relu.py
+++ b/tests/layer_tests/onnx_tests/test_relu.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestRelu(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_relu.py
+++ b/tests/layer_tests/onnx_tests/test_relu.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestRelu(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_reshape.py
+++ b/tests/layer_tests/onnx_tests/test_reshape.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestReshape(OnnxRuntimeLayerTest):
     def create_reshape_net(self, input_shape, output_shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_reshape.py
+++ b/tests/layer_tests/onnx_tests/test_reshape.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestReshape(OnnxRuntimeLayerTest):
     def create_reshape_net(self, input_shape, output_shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_resize.py
+++ b/tests/layer_tests/onnx_tests/test_resize.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
@@ -12,7 +14,6 @@ from openvino.tools.mo.middle.passes.convert_data_type import data_type_str_to_n
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestResize(OnnxRuntimeLayerTest):
     def create_resize_net(self, input_shape, output_shape, scales, sizes,
                           coordinate_transformation_mode, cubic_coeff_a, mode,

--- a/tests/layer_tests/onnx_tests/test_resize.py
+++ b/tests/layer_tests/onnx_tests/test_resize.py
@@ -12,6 +12,7 @@ from openvino.tools.mo.middle.passes.convert_data_type import data_type_str_to_n
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestResize(OnnxRuntimeLayerTest):
     def create_resize_net(self, input_shape, output_shape, scales, sizes,
                           coordinate_transformation_mode, cubic_coeff_a, mode,

--- a/tests/layer_tests/onnx_tests/test_roi_align.py
+++ b/tests/layer_tests/onnx_tests/test_roi_align.py
@@ -10,6 +10,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestROIAlign(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_roi_align.py
+++ b/tests/layer_tests/onnx_tests/test_roi_align.py
@@ -5,12 +5,13 @@ import platform
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestROIAlign(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_scatter.py
+++ b/tests/layer_tests/onnx_tests/test_scatter.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestScatters(OnnxRuntimeLayerTest):
     op = None
 

--- a/tests/layer_tests/onnx_tests/test_scatter.py
+++ b/tests/layer_tests/onnx_tests/test_scatter.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestScatters(OnnxRuntimeLayerTest):
     op = None
 

--- a/tests/layer_tests/onnx_tests/test_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_sigmoid.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestSigmoid(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_sigmoid.py
+++ b/tests/layer_tests/onnx_tests/test_sigmoid.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestSigmoid(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_sign.py
+++ b/tests/layer_tests/onnx_tests/test_sign.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestSign(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_sign.py
+++ b/tests/layer_tests/onnx_tests/test_sign.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestSign(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_softmax.py
+++ b/tests/layer_tests/onnx_tests/test_softmax.py
@@ -34,6 +34,7 @@ def get_flatten_shape(src_shape, axis):
     return [fst_dim, snd_dim]
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestSoftmax(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_softmax.py
+++ b/tests/layer_tests/onnx_tests/test_softmax.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
@@ -34,7 +36,6 @@ def get_flatten_shape(src_shape, axis):
     return [fst_dim, snd_dim]
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestSoftmax(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_softplus.py
+++ b/tests/layer_tests/onnx_tests/test_softplus.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestSoftplus(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_softplus.py
+++ b/tests/layer_tests/onnx_tests/test_softplus.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestSoftplus(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_softsign.py
+++ b/tests/layer_tests/onnx_tests/test_softsign.py
@@ -8,6 +8,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestSoftsign(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_softsign.py
+++ b/tests/layer_tests/onnx_tests/test_softsign.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestSoftsign(OnnxRuntimeLayerTest):
     def create_net(self, shape, ir_version):
         """

--- a/tests/layer_tests/onnx_tests/test_sqrt.py
+++ b/tests/layer_tests/onnx_tests/test_sqrt.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestSqrt(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_sqrt.py
+++ b/tests/layer_tests/onnx_tests/test_sqrt.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestSqrt(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_trigonometry.py
+++ b/tests/layer_tests/onnx_tests/test_trigonometry.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestTrigonomery(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_trigonometry.py
+++ b/tests/layer_tests/onnx_tests/test_trigonometry.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestTrigonomery(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_where.py
+++ b/tests/layer_tests/onnx_tests/test_where.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestWhere(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_where.py
+++ b/tests/layer_tests/onnx_tests/test_where.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestWhere(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_xor.py
+++ b/tests/layer_tests/onnx_tests/test_xor.py
@@ -9,6 +9,7 @@ from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 from unit_tests.utils.graph import build_graph
 
 
+@pytest.mark.skip(reason="Ticket - 157136")
 class TestXor(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():

--- a/tests/layer_tests/onnx_tests/test_xor.py
+++ b/tests/layer_tests/onnx_tests/test_xor.py
@@ -3,13 +3,14 @@
 
 import numpy as np
 import pytest
+pytest.importorskip("openvino.tools.mo", reason="Ticket - 157136")
+
 from common.layer_test_class import check_ir_version
 from common.onnx_layer_test_class import OnnxRuntimeLayerTest, onnx_make_model
 
 from unit_tests.utils.graph import build_graph
 
 
-@pytest.mark.skip(reason="Ticket - 157136")
 class TestXor(OnnxRuntimeLayerTest):
     def _prepare_input(self, inputs_dict):
         for input in inputs_dict.keys():


### PR DESCRIPTION
### Details:
To avoid disabling ONNX tests in CI completely (there are only 42 failures with openvino-dev removed vs 794 passes), it would be better to skip each failing test case individually (plus it makes it more convenient to re-enable later)

### Tickets:
 - CVS-157136
