### PR TITLE
[JAX FE] Remove jax reqs from common requirements file

### DIFF
--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -21,11 +21,8 @@ pytest>=5.0,<8.4
 pytest-dependency==0.5.1
 pytest-html==4.1.1
 pytest-timeout==2.3.1
-jax<=0.4.36
-jaxlib<=0.4.36
 kornia==0.7.0
 networkx<=3.3
-flax<=0.10.2
 
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch~=2.5.1; platform_system != "Darwin" or platform_machine != "x86_64"

--- a/tests/layer_tests/requirements.txt
+++ b/tests/layer_tests/requirements.txt
@@ -16,5 +16,3 @@ pytest
 defusedxml
 tensorflow
 tensorflow-addons; python_version <= '3.10'
-jax; sys_platform == "linux" and platform_machine == "x86_64" # https://jax.readthedocs.io/en/latest/installation.html#pip-installation-cpu - wheels are for "x86_64" only
-jaxlib; sys_platform == "linux" and platform_machine == "x86_64" # https://jax.readthedocs.io/en/latest/installation.html#pip-installation-cpu - wheels are for "x86_64" only


### PR DESCRIPTION
**Details:** We no longer need jax reqs in common requirements files after separation into requirements_jax

**Ticket:** TBD
