### PR TITLE
fix coverity scan issue CID 1537543

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -708,7 +708,7 @@ std::vector<std::vector<int>> generate_stream_info(const int streams,
                                                            ov::hint::SchedulingCoreType::ANY_CORE,
                                                            false,
                                                            cpu_pinning,
-                                                           streams_info_table};
+                                                           std::move(streams_info_table)};
 
     return proc_type_table;
 }


### PR DESCRIPTION
### Details:
 - *fix coverity scan issue CID 1537543*

    config.streamExecutorConfig = IStreamsExecutor::Config{"CPUStreamsExecutor",
706                                                           config.streams,
707                                                           config.threadsPerStream,
708                                                           ov::hint::SchedulingCoreType::ANY_CORE,
709                                                           false,
710                                                           cpu_pinning,
     	
CID 1537543: (#1 of 1): COPY_INSTEAD_OF_MOVE (COPY_INSTEAD_OF_MOVE)
1. copy_constructor_call: streams_info_table is passed-by-value as parameter to ov::threading::IStreamsExecutor::Config::Config(std::string, int, int, ov::hint::SchedulingCoreType, bool, bool, std::vector<std::vector<int, std::allocator<int> >, std::allocator<std::vector<int, std::allocator<int> > > >, std::vector<int, std::allocator<int> >) when it could be moved instead.
     	Use std::move(streams_info_table) instead of streams_info_table.
711                                                           streams_info_table};
712

### Tickets:
 - *ticket-id*
