### PR TITLE
[NPU] Fix compiler clang build (#27405)

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/prefix.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/prefix.hpp
@@ -11,9 +11,9 @@ namespace intel_npu {
 //
 // Prefix for ReadValue and Assign operations in compiler.
 //
-#define READVALUE_PREFIX    std::string("vpux_ie_read_value_")
-#define ASSIGN_PREFIX       std::string("vpux_ie_assign_")
-#define SHAPE_TENSOR_PREFIX std::string("vpux_ie_shape_")
+constexpr std::string_view READVALUE_PREFIX = "vpux_ie_read_value_";
+constexpr std::string_view ASSIGN_PREFIX = "vpux_ie_assign_";
+constexpr std::string_view SHAPE_TENSOR_PREFIX = "vpux_ie_shape_";
 
 inline bool isStateInputName(const std::string& name) {
     return !name.compare(0, READVALUE_PREFIX.length(), READVALUE_PREFIX);
@@ -23,10 +23,6 @@ inline bool isStateOutputName(const std::string& name) {
 }
 inline bool isShapeTensorName(const std::string& name) {
     return !name.compare(0, SHAPE_TENSOR_PREFIX.length(), SHAPE_TENSOR_PREFIX);
-}
-
-inline std::string stateOutputToStateInputName(const std::string& name) {
-    return READVALUE_PREFIX + name.substr(ASSIGN_PREFIX.length());
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -396,7 +396,6 @@ ze_graph_handle_t ZeGraphExtWrappers<TableExtension>::getGraphHandle(
     const uint32_t& flags) const {
     ze_graph_handle_t graphHandle;
 
-    _logger.info("compileIR Using extension version: %s", typeid(TableExtension).name());
     createGraph(std::move(serializedIR), buildFlags, flags, &graphHandle);
 
     return graphHandle;


### PR DESCRIPTION
### Details:
Duplicating https://github.com/openvinotoolkit/openvino/pull/27405 for branch [releases/2024/5](https://github.com/openvinotoolkit/openvino/tree/releases/2024/5)
 - *Change from define to constexpr and remove unused code*
 - *Fix clang build*

### Tickets:
 - *E-146067*