### PR TITLE
Disable constexpr mutex constructors for MSVC

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// https://developercommunity.visualstudio.com/t/Crash-SEGV-in-mutex-lock/10679088#T-N10680013
+#if defined(_WIN32) || defined(_WIN64)
+    #define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+#endif
+
 #include "core_impl.hpp"
 
 #include <memory>

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -3,8 +3,8 @@
 //
 
 // https://developercommunity.visualstudio.com/t/Crash-SEGV-in-mutex-lock/10679088#T-N10680013
-#if defined(_WIN32) || defined(_WIN64)
-    #define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+#if defined(_MSC_VER)
+#    define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
 #endif
 
 #include "core_impl.hpp"

--- a/src/inference/src/dev/threading/executor_manager.cpp
+++ b/src/inference/src/dev/threading/executor_manager.cpp
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// https://developercommunity.visualstudio.com/t/Crash-SEGV-in-mutex-lock/10679088#T-N10680013
+#if defined(_WIN32) || defined(_WIN64)
+    #define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+#endif
+
 #include "openvino/runtime/threading/executor_manager.hpp"
 
 #include "openvino/core/parallel.hpp"

--- a/src/inference/src/dev/threading/executor_manager.cpp
+++ b/src/inference/src/dev/threading/executor_manager.cpp
@@ -3,8 +3,8 @@
 //
 
 // https://developercommunity.visualstudio.com/t/Crash-SEGV-in-mutex-lock/10679088#T-N10680013
-#if defined(_WIN32) || defined(_WIN64)
-    #define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
+#if defined(_MSC_VER)
+#    define _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR
 #endif
 
 #include "openvino/runtime/threading/executor_manager.hpp"


### PR DESCRIPTION
### Details:
 - In specific scenarios (customer script) a segfault happens when constructing `std::lock_guard<std::mutex>`
 - The issue is linked to VC 22
 - The origin of the issue lies within the environment, a mismatch between VS used to build and VS runtime
 - Disabling constexpr mutex constructors for MSVC specifically fixes the issue
 - More info: https://developercommunity.visualstudio.com/t/Crash-SEGV-in-mutex-lock/10679088#T-N10680013

### Tickets:
 - CVS-159653