### PR TITLE
fix coverity scan issue CID 1568643

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -195,9 +195,14 @@ CPU::CPU() {
             for (int i = 0; i < static_cast<int>(socket_list.size()); i++) {
                 sockets_map.insert(std::pair<int, int>(socket_list[i], i));
             }
+            int current_numa_nodes = 0;
+            {
+                std::lock_guard<std::mutex> lock{_cpu_mutex};
+                current_numa_nodes = _numa_nodes;
+            }
             for (int i = 0; i < static_cast<int>(numa_node_list.size()); i++) {
                 for (int j = 0; j < static_cast<int>(numa_node_list[i].size()); j++) {
-                    numa_node_map.insert(std::pair<int, int>(numa_node_list[i][j], i * _numa_nodes / _sockets + j));
+                    numa_node_map.insert(std::pair<int, int>(numa_node_list[i][j], i * current_numa_nodes / _sockets + j));
                 }
             }
             for (size_t i = 0; i < valid_cpu_mapping_table.size(); i++) {

--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -195,14 +195,14 @@ CPU::CPU() {
             for (int i = 0; i < static_cast<int>(socket_list.size()); i++) {
                 sockets_map.insert(std::pair<int, int>(socket_list[i], i));
             }
-            int current_numa_nodes = 0;
+            int cur_numa_nodes = 0;
             {
                 std::lock_guard<std::mutex> lock{_cpu_mutex};
-                current_numa_nodes = _numa_nodes;
+                cur_numa_nodes = _numa_nodes;
             }
             for (int i = 0; i < static_cast<int>(numa_node_list.size()); i++) {
                 for (int j = 0; j < static_cast<int>(numa_node_list[i].size()); j++) {
-                    numa_node_map.insert(std::pair<int, int>(numa_node_list[i][j], i * current_numa_nodes / _sockets + j));
+                    numa_node_map.insert(std::pair<int, int>(numa_node_list[i][j], i * cur_numa_nodes / _sockets + j));
                 }
             }
             for (size_t i = 0; i < valid_cpu_mapping_table.size(); i++) {


### PR DESCRIPTION
### Details:
 - *fix coverity scan issue CID 1568643*

198            for (int i = 0; i < static_cast<int>(numa_node_list.size()); i++) {
     	40. Condition j < static_cast<int>(numa_node_list[i]->size()), taking true branch.
199                for (int j = 0; j < static_cast<int>(numa_node_list[i].size()); j++) {
     	
CID 1568643: (#1 of 1): Data race condition (MISSING_LOCK)
41. missing_lock: Accessing this->this->_numa_nodes without holding lock ov::CPU._cpu_mutex. Elsewhere, ov::CPU._numa_nodes is written to with CPU._cpu_mutex held 1 out of 1 times.
200                    numa_node_map.insert(std::pair<int, int>(numa_node_list[i][j], i * _numa_nodes / _sockets + j));
201                }
202            }

### Tickets:
 - *ticket-id*
