### PR TITLE
Fixed build with system level-zero

### DIFF
--- a/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
@@ -46,6 +46,8 @@ ov_install_static_lib(level-zero-headers ${NPU_PLUGIN_COMPONENT})
 if(TARGET ze_loader)
     ov_developer_package_export_targets(TARGET ze_loader)
     ov_install_static_lib(ze_loader ${NPU_PLUGIN_COMPONENT})
+    
+    add_dependency(${TARGET_NAME} ze_loader)
 
     # TODO: remove once https://github.com/oneapi-src/level-zero/pull/243 is merged and made a part of official release
     ov_developer_package_export_targets(TARGET utils)

--- a/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(openvino::npu_zero_utils ALIAS ${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME npu_zero_utils)
 
 add_library(level-zero-headers INTERFACE)
-set_property(TARGET level-zero-headers APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<BUILD_INTERFACE:${OpenVINO_SOURCE_DIR}/thirdparty/level_zero/level-zero/include>)
+set_property(TARGET level-zero-headers APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:LevelZero::LevelZero,INTERFACE_INCLUDE_DIRECTORIES>)
 add_library(LevelZero::Headers ALIAS level-zero-headers)
 
 target_include_directories(${TARGET_NAME}
@@ -30,6 +30,7 @@ target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime::dev)
 #
 # targets install
 #
+
 ov_install_static_lib(${TARGET_NAME} ${NPU_PLUGIN_COMPONENT})
 
 ov_developer_package_export_targets(TARGET openvino::npu_zero_utils
@@ -41,3 +42,12 @@ ov_install_static_lib(level-zero-ext ${NPU_PLUGIN_COMPONENT})
 
 ov_developer_package_export_targets(TARGET level-zero-headers)
 ov_install_static_lib(level-zero-headers ${NPU_PLUGIN_COMPONENT})
+
+if(TARGET ze_loader)
+    ov_developer_package_export_targets(TARGET ze_loader)
+    ov_install_static_lib(ze_loader ${NPU_PLUGIN_COMPONENT})
+
+    # TODO: remove once https://github.com/oneapi-src/level-zero/pull/243 is merged and made a part of official release
+    ov_developer_package_export_targets(TARGET utils)
+    ov_install_static_lib(utils ${NPU_PLUGIN_COMPONENT})
+endif()

--- a/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
+++ b/src/plugins/intel_npu/src/utils/src/zero/CMakeLists.txt
@@ -47,7 +47,7 @@ if(TARGET ze_loader)
     ov_developer_package_export_targets(TARGET ze_loader)
     ov_install_static_lib(ze_loader ${NPU_PLUGIN_COMPONENT})
     
-    add_dependency(${TARGET_NAME} ze_loader)
+    add_dependencies(${TARGET_NAME} ze_loader)
 
     # TODO: remove once https://github.com/oneapi-src/level-zero/pull/243 is merged and made a part of official release
     ov_developer_package_export_targets(TARGET utils)

--- a/thirdparty/dependencies.cmake
+++ b/thirdparty/dependencies.cmake
@@ -80,7 +80,7 @@ if(ENABLE_INTEL_NPU)
         endif()
     endif()
 
-    if(NOT libze_loader_FOUND)
+    if(NOT level_zero_FOUND)
         add_subdirectory(thirdparty/level_zero EXCLUDE_FROM_ALL)
         add_library(LevelZero::LevelZero ALIAS ze_loader)
     endif()


### PR DESCRIPTION
### Details:
 - When system level-zero is used, we cannot rely on submodule.
 - It's a regression after https://github.com/openvinotoolkit/openvino/pull/27659