### PR TITLE
[CPU][ARM] Fixed cvt_copy fast path for mha_single_token_kernel

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
@@ -69,8 +69,8 @@ void cvt_copy(TA* dst, TB* src, size_t n) {
 }
 
 #if defined(OPENVINO_ARCH_ARM64)
-#if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
-#if defined(HAVE_SVE)
+#    if defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#        if defined(HAVE_SVE)
 template <>
 void cvt_copy(ov::float16* dst, ov::float16* src, size_t n) {
     size_t i = 0;
@@ -87,7 +87,7 @@ void cvt_copy(ov::float16* dst, ov::float16* src, size_t n) {
         i += inc;
     }
 }
-#else // NEON
+#        else   // NEON
 template <>
 void cvt_copy(ov::float16* dst, ov::float16* src, size_t n) {
     size_t i = 0;
@@ -99,10 +99,10 @@ void cvt_copy(ov::float16* dst, ov::float16* src, size_t n) {
         dst[i] = src[i];
     }
 }
-#endif // defined(HAVE_SVE)
-#endif // defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
+#        endif  // defined(HAVE_SVE)
+#    endif      // defined(__ARM_FEATURE_FP16_VECTOR_ARITHMETIC)
 
-#if defined(HAVE_SVE)
+#    if defined(HAVE_SVE)
 template <>
 void cvt_copy(float* dst, float* src, size_t n) {
     size_t i = 0;
@@ -120,7 +120,7 @@ void cvt_copy(float* dst, float* src, size_t n) {
         i += inc;
     }
 }
-#else // NEON
+#    else   // NEON
 template <>
 void cvt_copy(float* dst, float* src, size_t n) {
     size_t i = 0;
@@ -132,8 +132,8 @@ void cvt_copy(float* dst, float* src, size_t n) {
         dst[i] = src[i];
     }
 }
-#endif // defined(HAVE_SVE)
-#endif // defined(OPENVINO_ARCH_ARM64)
+#    endif  // defined(HAVE_SVE)
+#endif      // defined(OPENVINO_ARCH_ARM64)
 
 template <typename T>
 static void attn_acc_value(float* out, float weight, T* v, size_t S, float* scale, float* zp) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/concat_sdp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/concat_sdp.cpp
@@ -31,6 +31,13 @@ const std::vector<std::vector<InputShape>> inputShapes = {
         // B, H, L0, S
         {{-1, 8, -1, 64}, {{4, 8, 0, 64}, {4, 8, 10, 64}, {4, 8, 11, 64}, {4, 8, 12, 64}, {4, 8, 13, 64}}},
     },
+    // big batch to check cvt_copy fast-path inside mha_single_token_kernel
+    {
+        // B, H, L1, S
+        {{-1, 8, -1, 64}, {{129, 8, 10, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}}},
+        // B, H, L0, S
+        {{-1, 8, -1, 64}, {{129, 8, 0, 64}, {129, 8, 10, 64}, {129, 8, 11, 64}, {129, 8, 12, 64}, {129, 8, 13, 64}}},
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConcatSDPTest,

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/concat_sdp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/concat_sdp.cpp
@@ -31,6 +31,13 @@ const std::vector<std::vector<InputShape>> inputShapes = {
         // B, H, L0, S
         {{-1, 8, -1, 64}, {{4, 8, 0, 64}, {4, 8, 10, 64}, {4, 8, 11, 64}, {4, 8, 12, 64}, {4, 8, 13, 64}}},
     },
+    // big batch to check cvt_copy fast-path inside mha_single_token_kernel
+    {
+        // B, H, L1, S
+        {{-1, 8, -1, 64}, {{129, 8, 10, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}}},
+        // B, H, L0, S
+        {{-1, 8, -1, 64}, {{129, 8, 0, 64}, {129, 8, 10, 64}, {129, 8, 11, 64}, {129, 8, 12, 64}, {129, 8, 13, 64}}},
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConcatSDPTest,

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/concat_sdp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/concat_sdp.cpp
@@ -31,6 +31,13 @@ const std::vector<std::vector<InputShape>> inputShapes = {
         // B, H, L0, S
         {{-1, 8, -1, 64}, {{4, 8, 0, 64}, {4, 8, 10, 64}, {4, 8, 11, 64}, {4, 8, 12, 64}, {4, 8, 13, 64}}},
     },
+    // big batch to check cvt_copy fast-path inside mha_single_token_kernel
+    {
+        // B, H, L1, S
+        {{-1, 8, -1, 64}, {{129, 8, 10, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}, {129, 8, 1, 64}}},
+        // B, H, L0, S
+        {{-1, 8, -1, 64}, {{129, 8, 0, 64}, {129, 8, 10, 64}, {129, 8, 11, 64}, {129, 8, 12, 64}, {129, 8, 13, 64}}},
+    },
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_ConcatSDPTest,


### PR DESCRIPTION
### Details:
 - This PR fixes incorrect cvt_copy rountine behavior inside mha_single_token kenrel on ARM platforms. In case __ARM_FEATURE_FP16_VECTOR_ARITHMETIC is defined on the system and fp32 inference scalar code path is chosen.
 - Additionally cvt_copy impl is refactored via template specialization for better readability 
 - Follow-up after https://github.com/openvinotoolkit/openvino/pull/28182
