### PR TITLE
[Snippets] Fixed SplitDimensionM pass for Subgraphs with dynamic params

### DIFF
--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -221,6 +221,15 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_AlmostAllThreads) {
     run();
 }
 
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_SplitM_DynamicParameter) {
+    const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 16, 128, -1}, {1, 128, 16, 64}},
+                                std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), false, false);
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    config.set_concurrency(32);
+    run();
+}
+
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHASelect_SplitM) {
     const auto& f = MHASelectSplitMFunction(std::vector<PartialShape>{{8, 512, 18}, {8, 18, 64}, {1, 512, 64}, {1, 1, 64}, {8, 64, 512}},
                                             std::vector<Shape>{{8, 2, 256, 18}, {8, 1, 18, 64}, {1, 2, 256, 64}, {1, 1, 1, 64},


### PR DESCRIPTION
### Details:
 - *Currently, the pass `SplitDimensionM` supports only static inputs of Subgraphs because the pass inserts `Reshape` ops with const shapes. In some cases (the case from the ticket), MatMul may have static output shape but some parameters - dynamic shape. Then `SplitDimensionM` should not call `split` method. The PR added check with early `return` to cover such cases*

### Tickets:
 - *159661*
