### PR TITLE
Fix performance inefficiencies coverity scan issues in CPU plugin

### DIFF
--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -132,7 +132,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<ov::Model>& model,
                                                                     ov::hint::SchedulingCoreType::ANY_CORE,
                                                                     false,
                                                                     true,
-                                                                    sub_streams_table,
+                                                                    std::move(sub_streams_table),
                                                                     sub_cfg.streamsRankTable[i]};
             m_sub_compiled_models.push_back(
                 std::make_shared<CompiledModel>(model, plugin, sub_cfg, loaded_from_cache, m_sub_memory_manager));

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -311,7 +311,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             }
         } else if (key == ov::cache_encryption_callbacks.name()) {
             try {
-                auto encryption_callbacks = val.as<EncryptionCallbacks>();
+                const auto& encryption_callbacks = val.as<EncryptionCallbacks>();
                 cacheEncrypt = encryption_callbacks.encrypt;
                 cacheDecrypt = encryption_callbacks.decrypt;
             } catch (ov::Exception&) {

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -84,7 +84,7 @@ Memory::Memory(const dnnl::engine& eng, const MemoryDesc& desc, const void* data
 Memory::Memory(const dnnl::engine& eng, MemoryDescPtr desc, MemoryBlockPtr block)
     : m_eng(eng),
       m_pMemDesc(desc),
-      m_blockHandle(block, this),
+      m_blockHandle(std::move(block), this),
       dnnlMemHandle(this) {
     if (desc->getPrecision() == element::string) {
         OPENVINO_THROW("[CPU] Memory object can't be created for string data.");
@@ -95,7 +95,7 @@ Memory::Memory(const dnnl::engine& eng, MemoryDescPtr desc, MemoryBlockPtr block
 }
 
 Memory::Memory(const dnnl::engine& eng, const MemoryDesc& desc, MemoryBlockPtr block)
-    : Memory::Memory(eng, desc.clone(), block) {}
+    : Memory::Memory(eng, desc.clone(), std::move(block)) {}
 
 size_t Memory::getSize() const {
     auto size = getDesc().getCurrentMemSize();
@@ -636,7 +636,7 @@ MemoryPtr split_horizontal(const dnnl::engine& eng,
         prec.size();
 
     // create new shape for target memory
-    VectorDims new_dims = dims;
+    VectorDims new_dims = std::move(dims);
     new_dims[dim] = splited_dim_vec[w_rank];
 
     auto new_desc = desc->cloneWithNewDims(new_dims, true);
@@ -661,7 +661,7 @@ MemoryPtr split_vertical(const dnnl::engine& eng,
                          int w_size,
                          bool need_fill) {
     auto desc = src->getDescPtr();
-    auto shape = src->getShape();
+    const auto& shape = src->getShape();
     auto dims = shape.getDims();
     auto prec = src->getPrecision();
     if (dim < 0) {

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -592,14 +592,14 @@ bool mbind_move(const dnnl::memory mem, int numaNodeID) {
 }
 
 MemoryPtr split_horizontal(const dnnl::engine& eng,
-                           const MemoryPtr src,
+                           const MemoryPtr& src,
                            int dim,
                            int w_rank,
                            int w_size,
                            bool need_fill) {
     auto desc = src->getDescPtr();
     auto shape = src->getShape();
-    auto dims = shape.getDims();
+    const auto& dims = shape.getDims();
     auto prec = src->getPrecision();
     if (dim < 0) {
         dim += dims.size();
@@ -636,7 +636,7 @@ MemoryPtr split_horizontal(const dnnl::engine& eng,
         prec.size();
 
     // create new shape for target memory
-    VectorDims new_dims = std::move(dims);
+    VectorDims new_dims = dims;
     new_dims[dim] = splited_dim_vec[w_rank];
 
     auto new_desc = desc->cloneWithNewDims(new_dims, true);
@@ -655,14 +655,14 @@ MemoryPtr split_horizontal(const dnnl::engine& eng,
 }
 
 MemoryPtr split_vertical(const dnnl::engine& eng,
-                         const MemoryPtr src,
+                         const MemoryPtr& src,
                          int dim,
                          int w_rank,
                          int w_size,
                          bool need_fill) {
     auto desc = src->getDescPtr();
     const auto& shape = src->getShape();
-    auto dims = shape.getDims();
+    const auto& dims = shape.getDims();
     auto prec = src->getPrecision();
     if (dim < 0) {
         dim += dims.size();

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -122,7 +122,7 @@ using MemoryBlockCPtr = std::shared_ptr<const IMemoryBlockObserver>;
 
 class DnnlMemBlockHandle {
 public:
-    DnnlMemBlockHandle(MemoryBlockPtr pBlock, Memory* pMem) : m_pMemBlock(pBlock), m_pMem(pMem) {
+    DnnlMemBlockHandle(MemoryBlockPtr pBlock, Memory* pMem) : m_pMemBlock(std::move(pBlock)), m_pMem(pMem) {
         if (m_pMemBlock) {
             m_pMemBlock->registerMemory(m_pMem);
         }

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -447,13 +447,13 @@ bool mbind_move(const MemoryCPtr mem, int numaNodeID);
 bool mbind_move(const dnnl::memory mem, int numaNodeID);
 
 MemoryPtr split_horizontal(const dnnl::engine& eng,
-                           const MemoryPtr src,
+                           const MemoryPtr& src,
                            int dim,
                            int w_rank,
                            int w_size,
                            bool need_fill = true);
 MemoryPtr split_vertical(const dnnl::engine& eng,
-                         const MemoryPtr src,
+                         const MemoryPtr& src,
                          int dim,
                          int w_rank,
                          int w_size,

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -300,7 +300,7 @@ void Edge::allocate(MemoryBlockPtr memBlock) {
 
     auto allocateFunc = [OV_CAPTURE_CPY_AND_THIS](const MemoryDesc& inputDesc) -> MemoryPtr {
         auto parentPtr = getParent();
-        return std::make_shared<Memory>(parentPtr->getEngine(), inputDesc, memBlock);
+        return std::make_shared<Memory>(parentPtr->getEngine(), inputDesc, std::move(memBlock));
     };
 
     allocateCommon(allocateFunc);

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -193,7 +193,7 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model>& model,
     }
 
     // Add stub output node for unused data
-    for (auto unusedOutput : unusedOutputs) {
+    for (const auto& unusedOutput : unusedOutputs) {
         auto parentNode = op2node[unusedOutput.get_node_shared_ptr()];
         const auto port = unusedOutput.get_index();
         const auto nodeName =

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -19,7 +19,7 @@ GraphContext::GraphContext(const Config& config,
       weightsCache(std::move(w_cache)),
       isGraphQuantizedFlag(isGraphQuantized),
       streamExecutor(streamExecutor),
-      subMemoryManager(sub_memory_manager),
+      subMemoryManager(std::move(sub_memory_manager)),
       memoryStatesRegister(std::make_shared<node::MemoryStatesRegister>()),
       networkMemoryControl(std::make_shared<NetworkMemoryControl>()) {
     rtParamsCache = std::make_shared<MultiCache>(config.rtCacheCapacity);

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -273,7 +273,7 @@ void SyncInferRequest::change_default_ptr(Graph& graph) {
                                                            :  // then swap internal buffer to avoid data corruption
                         controlBlock.currentMemBlock();       // else reuse the existing buffer
 
-                outputMemBlock->setMemBlockResize(memBlock);
+                outputMemBlock->setMemBlockResize(std::move(memBlock));
                 DEBUG_LOG("reset proxy ",
                           outputMemBlock,
                           ", actual ",

--- a/src/plugins/intel_cpu/src/memory_control.cpp
+++ b/src/plugins/intel_cpu/src/memory_control.cpp
@@ -16,7 +16,9 @@ namespace {
 
 class StaticPartitionMemoryBlock : public IMemoryBlockObserver {
 public:
-    StaticPartitionMemoryBlock(MemoryBlockPtr pBlock, ptrdiff_t offset) : m_pBlock(pBlock), m_offset(offset) {
+    StaticPartitionMemoryBlock(MemoryBlockPtr pBlock, ptrdiff_t offset)
+        : m_pBlock(std::move(pBlock)),
+          m_offset(offset) {
         OPENVINO_ASSERT(m_pBlock, "Memory block is uninitialized");
     }
 
@@ -410,7 +412,7 @@ edgeClusters MemoryControl::findEdgeClusters(const std::vector<EdgePtr>& graphEd
 }
 
 MemoryControl& NetworkMemoryControl::createMemoryControlUnit(std::vector<size_t> syncInds) {
-    m_controlUnits.emplace_back(std::unique_ptr<MemoryControl>(new MemoryControl(syncInds)));
+    m_controlUnits.emplace_back(std::unique_ptr<MemoryControl>(new MemoryControl(std::move(syncInds))));
     return *(m_controlUnits.back());
 }
 

--- a/src/plugins/intel_cpu/src/nodes/composite.cpp
+++ b/src/plugins/intel_cpu/src/nodes/composite.cpp
@@ -46,7 +46,7 @@ void Composite::selectOptimalPrimitiveDescriptor() {
     for (size_t i = 0; i < getParentEdges().size(); i++) {
         auto desc = getParentOutputMemDesc(getParentEdgeAt(i));
         inConfs.emplace_back(desc);
-        graphInputConfig.emplace_back(node::Input::InputConfig{desc, true});
+        graphInputConfig.emplace_back(node::Input::InputConfig{std::move(desc), true});
     }
 
     std::vector<Input::OutputConfig> graphOutputConfig;
@@ -65,7 +65,7 @@ void Composite::selectOptimalPrimitiveDescriptor() {
         outConfs.emplace_back(desc);
     }
 
-    const NodeConfig config(inConfs, outConfs);
+    const NodeConfig config(std::move(inConfs), std::move(outConfs));
 
     supportedPrimitiveDescriptors.clear();
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::undef);
@@ -99,7 +99,7 @@ void Composite::execute(dnnl::stream) {
 }
 
 void Composite::executeDynamicImpl(dnnl::stream strm) {
-    execute(strm);
+    execute(std::move(strm));
 
     // since the shape inference is not performed for the composite node
     // a memory of the extra child edges, attached to the output ports

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -614,8 +614,8 @@ void FullyConnected::needSplitMemoryForTensorParallel() {
         } else {
             tp_cfg.cached_zeropoint =
                 attrs.weightsNonTransposed
-                    ? split_vertical(context->getEngine(), std::move(zeropoint_mem), 0, tp_cfg.w_rank, tp_cfg.w_size)
-                    : split_horizontal(context->getEngine(), std::move(zeropoint_mem), 0, tp_cfg.w_rank, tp_cfg.w_size);
+                    ? split_vertical(context->getEngine(), zeropoint_mem, 0, tp_cfg.w_rank, tp_cfg.w_size)
+                    : split_horizontal(context->getEngine(), zeropoint_mem, 0, tp_cfg.w_rank, tp_cfg.w_size);
         }
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -220,7 +220,7 @@ void FullyConnected::needPrepareParamsForTensorParallel() {
         };
 
         int dim = -1;
-        auto dst_shape = dstMemoryBuffer->getShape();
+        const auto& dst_shape = dstMemoryBuffer->getShape();
         auto dst_desc = dstMemoryBuffer->getDescPtr();
         auto dims = dst_shape.getDims();
         if (dim < 0) {
@@ -614,8 +614,8 @@ void FullyConnected::needSplitMemoryForTensorParallel() {
         } else {
             tp_cfg.cached_zeropoint =
                 attrs.weightsNonTransposed
-                    ? split_vertical(context->getEngine(), zeropoint_mem, 0, tp_cfg.w_rank, tp_cfg.w_size)
-                    : split_horizontal(context->getEngine(), zeropoint_mem, 0, tp_cfg.w_rank, tp_cfg.w_size);
+                    ? split_vertical(context->getEngine(), std::move(zeropoint_mem), 0, tp_cfg.w_rank, tp_cfg.w_size)
+                    : split_horizontal(context->getEngine(), std::move(zeropoint_mem), 0, tp_cfg.w_rank, tp_cfg.w_size);
         }
     }
 }
@@ -625,7 +625,7 @@ void FullyConnected::needUpdateTensorParalelConfig() {
     // 1. weight shape is dynamic
     // 2. last dim can be splited.
     if (tp_cfg.enable_tensor_parallel) {
-        auto& shape = getSrcMemoryAtPort(WEIGHTS)->getShape();
+        const auto& shape = getSrcMemoryAtPort(WEIGHTS)->getShape();
         if (shape.isDynamic()) {
             tp_cfg.enable_tensor_parallel = false;
         } else if (shape.getDims()[0] < static_cast<size_t>(tp_cfg.w_size)) {

--- a/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
+++ b/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
@@ -226,7 +226,7 @@ public:
             if (blkN) {
                 auto shared_atomic = std::make_shared<std::atomic_int>(0);
                 auto& work = works[ithr];
-                work.sync_flag = shared_atomic;
+                work.sync_flag = std::move(shared_atomic);
                 work.blk_K_size = cache_blk_k_size;
 
                 work.n0 = (start_blkN)*REG_BLK_N_SIZE;

--- a/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
+++ b/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
@@ -224,9 +224,8 @@ public:
                 blkN++;
             }
             if (blkN) {
-                auto shared_atomic = std::make_shared<std::atomic_int>(0);
                 auto& work = works[ithr];
-                work.sync_flag = std::move(shared_atomic);
+                work.sync_flag = std::make_shared<std::atomic_int>(0);
                 work.blk_K_size = cache_blk_k_size;
 
                 work.n0 = (start_blkN)*REG_BLK_N_SIZE;

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -192,7 +192,7 @@ void Pad::createPrimitive() {
         prepareParams();
         if (padValue) {
             // restore original memory object
-            srcMemory[PAD_VALUE_ID] = padValue;
+            srcMemory[PAD_VALUE_ID] = std::move(padValue);
         }
 
         updateLastInputDims();

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -296,7 +296,7 @@ void Reorder::createReorderPrimitive(const DnnlMemoryDescPtr& srcDesc, const Dnn
     // useful in situations when rank in IR does not much rank that is required by the oneDNN primitive,
     // but the input tensor can be reshaped (e.g. weights for grouped convolutions, biases etc.)
     if (srcDesc->hasLayoutType(LayoutType::ncsp) && srcDesc->getShape().getRank() != dstDesc->getShape().getRank()) {
-        const auto newDims = dstDesc->getShape().getStaticDims();
+        const auto& newDims = dstDesc->getShape().getStaticDims();
         const auto newFormat = DnnlExtensionUtils::GetPlainFormatByRank(newDims.size());
 
         src_desc = dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(newDims),
@@ -309,7 +309,7 @@ void Reorder::createReorderPrimitive(const DnnlMemoryDescPtr& srcDesc, const Dnn
                     "OneDNN doesn't support reorder with different ranks.");
     auto result = getReorderPrim(context->getParamsCache(), getEngine(), src_desc, dst_desc);
     CPU_NODE_ASSERT(result, "could not create reorder primitive: unsupported reorder case.");
-    prim = result;
+    prim = std::move(result);
 
     selectedPD->setImplementationType(
         parse_impl_name(DnnlExtensionUtils::query_impl_info_str(prim.get_primitive_desc())));

--- a/src/plugins/intel_cpu/src/nodes/reorder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorder.cpp
@@ -307,9 +307,8 @@ void Reorder::createReorderPrimitive(const DnnlMemoryDescPtr& srcDesc, const Dnn
     DEBUG_LOG("CreateReorderPrimitive is called for node", getName(), " src desc: ", src_desc, " dst_desc: ", dst_desc);
     CPU_NODE_ASSERT(src_desc.get_ndims() == dst_desc.get_ndims(),
                     "OneDNN doesn't support reorder with different ranks.");
-    auto result = getReorderPrim(context->getParamsCache(), getEngine(), src_desc, dst_desc);
-    CPU_NODE_ASSERT(result, "could not create reorder primitive: unsupported reorder case.");
-    prim = std::move(result);
+    prim = getReorderPrim(context->getParamsCache(), getEngine(), src_desc, dst_desc);
+    CPU_NODE_ASSERT(prim, "could not create reorder primitive: unsupported reorder case.");
 
     selectedPD->setImplementationType(
         parse_impl_name(DnnlExtensionUtils::query_impl_info_str(prim.get_primitive_desc())));

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.h
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.h
@@ -23,7 +23,7 @@ public:
         return false;
     }
     void executeDynamicImpl(dnnl::stream strm) override {
-        execute(strm);
+        execute(std::move(strm));
     }
     void initSupportedPrimitiveDescriptors() override;
     void execute(dnnl::stream strm) override;

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -1030,7 +1030,7 @@ void RNN::prepareMemory(const DnnlMemoryDescPtr& new_desc, size_t idx) {
         res_ptr = create();
     }
 
-    internalBlobMemory[idx] = res_ptr;
+    internalBlobMemory[idx] = std::move(res_ptr);
 }
 
 void RNN::copyWeightsData() {

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_pack.cpp
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_pack.cpp
@@ -55,7 +55,7 @@ bool StringTensorPack::needPrepareParams() const {
 }
 
 void StringTensorPack::executeDynamicImpl(dnnl::stream strm) {
-    execute(strm);
+    execute(std::move(strm));
 }
 
 template <class T_idx>

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_unpack.cpp
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_unpack.cpp
@@ -64,7 +64,7 @@ void StringTensorUnpack::executeDynamicImpl(dnnl::stream strm) {
         totalCharLength += srcData[i].length();
     }
     redefineOutputMemory({srcDataDims, srcDataDims, {totalCharLength}});
-    execute(strm);
+    execute(std::move(strm));
 }
 
 void StringTensorUnpack::execute(dnnl::stream strm) {

--- a/src/plugins/intel_cpu/src/partitioned_mem_blk.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_blk.h
@@ -19,7 +19,7 @@ public:
                            size_t total_chunks = 1,
                            ptrdiff_t offset_chunks = 0,
                            size_t size_chunks = 1)
-        : m_pBlock(pBlock),
+        : m_pBlock(std::move(pBlock)),
           m_total_chunks(total_chunks),
           m_offset_chunks(offset_chunks),
           m_size_chunks(size_chunks) {

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -544,7 +544,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model_str
     CacheDecrypt decrypt{codec_xor};
     bool decript_from_string = false;
     if (config.count(ov::cache_encryption_callbacks.name())) {
-        auto encryption_callbacks = config.at(ov::cache_encryption_callbacks.name()).as<EncryptionCallbacks>();
+        const auto& encryption_callbacks = config.at(ov::cache_encryption_callbacks.name()).as<EncryptionCallbacks>();
         decrypt.m_decrypt_str = encryption_callbacks.decrypt;
         decript_from_string = true;
     }

--- a/src/plugins/intel_cpu/src/proxy_mem_blk.cpp
+++ b/src/plugins/intel_cpu/src/proxy_mem_blk.cpp
@@ -14,7 +14,7 @@ void ProxyMemoryBlock::setMemBlock(std::shared_ptr<IMemoryBlock> pBlock) {
         return;
     }
 
-    m_pMemBlock = pBlock;
+    m_pMemBlock = std::move(pBlock);
     notifyUpdate();
 }
 
@@ -24,7 +24,7 @@ void ProxyMemoryBlock::setMemBlockResize(std::shared_ptr<IMemoryBlock> pBlock) {
         return;
     }
 
-    m_pMemBlock = pBlock;
+    m_pMemBlock = std::move(pBlock);
     m_pMemBlock->resize(m_size);
     notifyUpdate();
 }

--- a/src/plugins/intel_cpu/src/proxy_mem_blk.h
+++ b/src/plugins/intel_cpu/src/proxy_mem_blk.h
@@ -17,7 +17,7 @@ public:
     ProxyMemoryBlock() : m_pOrigBlock(std::make_shared<MemoryBlockWithReuse>()), m_pMemBlock(m_pOrigBlock) {}
     explicit ProxyMemoryBlock(std::shared_ptr<IMemoryBlock> pBlock) {
         OPENVINO_ASSERT(pBlock, "Memory block is uninitialized");
-        m_pMemBlock = pBlock;
+        m_pMemBlock = std::move(pBlock);
     }
 
     void* getRawPtr() const noexcept override;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.hpp
@@ -13,7 +13,7 @@ namespace node {
 
 class RMSNormShapeInferFactory : public ShapeInferFactory {
 public:
-    RMSNormShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(op) {}
+    RMSNormShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     ShapeInferPtr makeShapeInfer() const override;
 
 private:


### PR DESCRIPTION
### Details:
 - Fix "COPY_INSTEAD_OF_MOVE" coverity scans: 1560671, 1560670, 1560668, 1560667, 1560666, 1560059, 1560057, 1560055, 1560054, 1560052, 1560051, 1560050, 1560047, 1560046, 1560045, 1560043, 1560042, 1560041, 1559840, 1559804, 1559802, 1559777, 1559761, 1559697, 1559559, 1559558, 1559557, 1559556, 1559553, 1559552, 1559549, 1559547, 1559545, 1559543, 1559542, 1559539
 - Fix "Use of auto that causes a copy" coverity scans: 1560673, 1560669, 1560044, 1559820, 1559817, 1559561, 1559560, 1559555, 1559544, 1559540
### Tickets:
 - [CVS-153062](https://jira.devtools.intel.com/browse/CVS-153062)
