### PR TITLE
[CMAKE] Fix to Api validator for older cmake versions

### DIFF
--- a/cmake/developer_package/api_validator/api_validator.cmake
+++ b/cmake/developer_package/api_validator/api_validator.cmake
@@ -30,14 +30,6 @@ can't find Windows SDK version. Try to use vcvarsall.bat script")
                       "${PROGRAMFILES}/Windows Kits/10/bin/x64")
     endif()
 
-    # check UniversalCRTSdkDir env variable
-    if(DEFINED ENV{WindowsSdkBinPath})
-        file(TO_CMAKE_PATH $ENV{WindowsSdkBinPath} UNIVERSAL_SDK_BIN_PATH)
-
-        list(APPEND WDK_PATHS "${UNIVERSAL_SDK_BIN_PATH}/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/x64"
-                              "${UNIVERSAL_SDK_BIN_PATH}/x64")
-    endif()
-
     if(WDK_PATHS)
         message(STATUS "Trying to find apivalidator in: ")
         foreach(wdk_path IN LISTS WDK_PATHS)

--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -42,6 +42,8 @@ ov_option (ENABLE_THREAD_SANITIZER "enable checking data races via ThreadSanitiz
 
 ov_dependent_option (ENABLE_COVERAGE "enable code coverage" OFF "CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG" OFF)
 
+ov_dependent_option (ENABLE_API_VALIDATOR "Enables API Validator usage" ON "WIN32" OFF)
+
 # Defines CPU capabilities
 
 ov_dependent_option (ENABLE_SSE42 "Enable SSE4.2 optimizations" ON "X86_64 OR (X86 AND NOT EMSCRIPTEN)" OFF)

--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -208,8 +208,6 @@ ov_dependent_option(ENABLE_JS "Enables JS API building" ${ENABLE_JS_DEFAULT} "NO
 
 ov_option(ENABLE_OPENVINO_DEBUG "Enable output for OPENVINO_DEBUG statements" OFF)
 
-ov_dependent_option (ENABLE_API_VALIDATOR "Enables API Validator usage" ON "WIN32" OFF)
-
 if(NOT BUILD_SHARED_LIBS AND ENABLE_OV_TF_FRONTEND)
     set(FORCE_FRONTENDS_USE_PROTOBUF ON)
 else()

--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -66,7 +66,11 @@ else()
   message(WARNING "Unknown C++ build setup - No explicit filesystem linker setting set")
 endif()
 
-target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} PUBLIC openvino::pugixml $<WIN32:Shlwapi> ${STD_FS_LIB})
+target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} PUBLIC openvino::pugixml ${STD_FS_LIB})
+if (WIN32)
+    target_link_libraries(${TARGET_NAME} PRIVATE Shlwapi)
+endif()
+
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${UTIL_INCLUDE_DIR}>)
 
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})

--- a/src/common/util/CMakeLists.txt
+++ b/src/common/util/CMakeLists.txt
@@ -37,46 +37,36 @@ add_library(${TARGET_NAME} STATIC ${LIBRARY_SRC} ${PUBLIC_HEADERS})
 add_library(openvino::util ALIAS ${TARGET_NAME})
 set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME util)
 
-file(
-    WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-    "#include <experimental/filesystem>\nint main(int argc, char ** argv) {\n  std::experimental::filesystem::path p(argv[0]);\n  return p.string().length();\n}"
-  )
-  try_compile(
-    STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
-    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-    COMPILE_DEFINITIONS -std=c++11)
-  try_compile(
-    STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
-    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-    COMPILE_DEFINITIONS -std=c++11
-    LINK_LIBRARIES stdc++fs)
-  try_compile(
-    STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
-    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
-    COMPILE_DEFINITIONS -std=c++11
-    LINK_LIBRARIES c++fs)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+    "#include <experimental/filesystem>\nint main(int argc, char ** argv) {\n  std::experimental::filesystem::path p(argv[0]);\n  return p.string().length();\n}")
 
-if(MSVC)
-  message(INFO "MSVC - No explicit filesystem linker setting required.")
-  set(STD_FS_LIB "")
+try_compile(STD_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}
+            SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+            COMPILE_DEFINITIONS -std=c++11)
+try_compile(STD_FS_NEEDS_STDCXXFS ${CMAKE_CURRENT_BINARY_DIR}
+            SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+            COMPILE_DEFINITIONS -std=c++11
+            LINK_LIBRARIES stdc++fs)
+try_compile(STD_FS_NEEDS_CXXFS ${CMAKE_CURRENT_BINARY_DIR}
+            SOURCES ${CMAKE_CURRENT_BINARY_DIR}/main.cpp
+            COMPILE_DEFINITIONS -std=c++11
+            LINK_LIBRARIES c++fs)
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  message(STATUS "MSVC - No explicit filesystem linker setting required.")
 elseif(STD_FS_NEEDS_STDCXXFS)
-  message(INFO "STD_FS_NEEDS_STDCXXFS - Add explicit filesystem linker setting: 'stdc++fs'.")
+  message(STATUS "STD_FS_NEEDS_STDCXXFS - Add explicit filesystem linker setting: 'stdc++fs'.")
   set(STD_FS_LIB stdc++fs)
 elseif(STD_FS_NEEDS_CXXFS)
-  message(INFO "STD_FS_NEEDS_CXXFS - Add explicit filesystem linker setting: 'c++fs'.")
+  message(STATUS "STD_FS_NEEDS_CXXFS - Add explicit filesystem linker setting: 'c++fs'.")
   set(STD_FS_LIB c++fs)
 elseif(STD_FS_NO_LIB_NEEDED)
-  message(INFO "STD_FS_NO_LIB_NEEDED - No explicit filesystem linker setting required.")
-  set(STD_FS_LIB "")
+  message(STATUS "STD_FS_NO_LIB_NEEDED - No explicit filesystem linker setting required.")
 else()
   message(WARNING "Unknown C++ build setup - No explicit filesystem linker setting set")
-  set(STD_FS_LIB "")
 endif()
 
-target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} PUBLIC openvino::pugixml  ${STD_FS_LIB} )
-if (WIN32)
-    target_link_libraries(${TARGET_NAME} PRIVATE Shlwapi)
-endif()
+target_link_libraries(${TARGET_NAME} PRIVATE ${CMAKE_DL_LIBS} PUBLIC openvino::pugixml $<WIN32:Shlwapi> ${STD_FS_LIB})
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${UTIL_INCLUDE_DIR}>)
 
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})


### PR DESCRIPTION
### Details:
 - Required to merge https://github.com/openvinotoolkit/openvino.genai/pull/1402
 - For some reason we have recursion if we have 2 functions with name `ov_add_api_validator_post_build_step` and `_ov_add_api_validator_post_build_step`