### PR TITLE
Fix msvc version to cover v143 toolset

### DIFF
--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -114,7 +114,7 @@ macro(ov_check_compiler_supports_sve flags)
     set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS_INIT} ${flags}")
 
     # Check if the source code compiles with the given flags for C++
-    CHECK_CXX_SOURCE_COMPILES("${SVE_CODE}" CXX_HAS_SVE)            
+    CHECK_CXX_SOURCE_COMPILES("${SVE_CODE}" CXX_HAS_SVE)
 
     # If the compilation test is successful, set appropriate variables indicating support
     if(CXX_HAS_SVE)
@@ -278,7 +278,7 @@ macro(ov_arm_sve_optimization_flags flags)
     else()
         if(AARCH64)
             set(${flags} -O2)
-        
+
             # Add flag for SVE if supported
             if(CXX_SVE_FOUND)
                 list(APPEND ${flags} -march=armv8-a+sve)
@@ -457,8 +457,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
     # Workaround for an MSVC compiler issue in some versions of Visual Studio 2022.
     # The issue involves a null dereference to a mutex. For details, refer to link https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
-    if(MSVC AND MSVC_VERSION GREATER_EQUAL 1930 AND MSVC_VERSION LESS 1941)
-	ov_add_compiler_flags(/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
+    if(MSVC AND MSVC_VERSION GREATER_EQUAL 1930 AND MSVC_VERSION LESS 1950)
+        ov_add_compiler_flags(/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
     endif()
 
     if(AARCH64 AND NOT MSVC_VERSION LESS 1930)

--- a/cmake/developer_package/compile_flags/os_flags.cmake
+++ b/cmake/developer_package/compile_flags/os_flags.cmake
@@ -457,7 +457,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 
     # Workaround for an MSVC compiler issue in some versions of Visual Studio 2022.
     # The issue involves a null dereference to a mutex. For details, refer to link https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710
-    if(MSVC AND MSVC_VERSION GREATER_EQUAL 1930 AND MSVC_VERSION LESS 1950)
+    if(MSVC AND MSVC_VERSION GREATER_EQUAL 1930)
         ov_add_compiler_flags(/D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR)
     endif()
 


### PR DESCRIPTION
### Details:
 - Fix MSVC version to cover all compiler versions of v143 toolset
 https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html

### Tickets:
 - CVS-158167
 - CVS-159653
