### PR TITLE
Don't include developer package multiple times

### DIFF
--- a/cmake/templates/OpenVINODeveloperPackageConfig.cmake.in
+++ b/cmake/templates/OpenVINODeveloperPackageConfig.cmake.in
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if(OpenVINODeveloperPackage_FOUND)
+    return()
+endif()
+
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)

--- a/cmake/templates/OpenVINODeveloperPackageConfigRelocatable.cmake.in
+++ b/cmake/templates/OpenVINODeveloperPackageConfigRelocatable.cmake.in
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if(OpenVINODeveloperPackage_FOUND)
+    return()
+endif()
+
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)


### PR DESCRIPTION
### Details:
 - In case of GenAI we include developer packages two times: GenAI and Tokenizers 
