### PR TITLE
[GPU] fix activation oooq execution order issue when in shape_of subgraph

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cpu/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/activation.cpp
@@ -148,6 +148,16 @@ struct activation_impl : public typed_primitive_impl<activation> {
             }
         }
 
+        auto& dominators = instance.get_node().get_dependant_shape_of_nodes();
+        for (auto& dep : instance.dependencies()) {
+            auto& dep_dominators = dep.first->get_node().get_dependant_shape_of_nodes();
+            std::vector<const program_node*> intersection;
+            std::set_intersection(dominators.begin(), dominators.end(), dep_dominators.begin(), dep_dominators.end(), std::back_inserter(intersection));
+            for (auto& dep_node : intersection) {
+                instance.get_network().get_primitive_event(dep_node->id())->wait();
+            }
+        }
+
         if (!op) {
             switch (activation_function) {
             case activation_func::pow:


### PR DESCRIPTION
### Details:
 - When an cpu activation impl is executed with a dependency of a gpu impl and both of which are in the same subgraph of ShapeOf, the dependency will be ignore, which cause the result error.
 - This fix introduces a search across all dependencies, assessing whether the activation implementation and its dependency exist within the same subgraph. If this condition is met, a 'wait()' operation will be executed.


### Tickets:
 - *CVS-156037*
