### PR TITLE
[Snippets] Added type support to LoopPort

### DIFF
--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -25,8 +25,6 @@ using LoopInfoPtr = std::shared_ptr<LoopInfo>;
  */
 class LoopInfo : public std::enable_shared_from_this<LoopInfo> {
 public:
-    enum {UNDEFINED_DIM_IDX = std::numeric_limits<size_t>::max()};
-
     LoopInfo() = default;
     LoopInfo(size_t work_amount, size_t increment, const std::vector<LoopPort>& entries, const std::vector<LoopPort>& exits);
     LoopInfo(size_t work_amount, size_t increment, const std::vector<ExpressionPort>& entries, const std::vector<ExpressionPort>& exits);
@@ -66,7 +64,7 @@ public:
 
     /**
      * @brief Returns dimension index if dimension indices for all input and output ports are equal.
-     *        Otherwise returns UNDEFINED_DIM_IDX.
+     *        Otherwise returns LoopPort::UNDEFINED_DIM_IDX.
      * @return index
      */
     size_t get_dim_idx() const;

--- a/src/common/snippets/include/snippets/lowered/loop_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_port.hpp
@@ -54,6 +54,7 @@ public:
     template<LoopPort::Type T,
              typename std::enable_if<T == Type::Incremented || T == Type::NotIncremented, bool>::type = true>
     void convert_to_type() {
+        OPENVINO_ASSERT(is_processed(), "NotProcessed LoopPort cannot change type!");
         m_type = T;
     }
 

--- a/src/common/snippets/include/snippets/lowered/loop_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_port.hpp
@@ -24,11 +24,20 @@ struct LoopPort {
     friend bool operator!=(const LoopPort& lhs, const LoopPort& rhs);
     friend bool operator<(const LoopPort& lhs, const LoopPort& rhs);
 
-    std::shared_ptr<ExpressionPort> expr_port = {};
+    const std::shared_ptr<ExpressionPort>& get_expr_port() const { return m_expr_port; }
+    bool is_incremented() const { return m_is_incremented; }
+    size_t get_dim_idx() const { return m_dim_idx; }
+
+    void set_expr_port(std::shared_ptr<ExpressionPort> p);
+    void set_is_incremented(bool is_inc);
+    void set_dim_idx(size_t idx);
+
+private:
+    std::shared_ptr<ExpressionPort> m_expr_port = {};
     // True if after each Loop iteration the corresponding data pointer should be incremented.
     // Otherwise, the data pointer shift is skipped
-    bool is_incremented = true;
-    size_t dim_idx = 0; // The numeration starts from the end (dim_idx = 0 -> is the most inner dimension)
+    bool m_is_incremented = true;
+    size_t m_dim_idx = 0; // The numeration starts from the end (dim_idx = 0 -> is the most inner dimension)
 };
 
 } // namespace lowered

--- a/src/common/snippets/include/snippets/lowered/loop_port.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_port.hpp
@@ -6,17 +6,25 @@
 
 #include "snippets/lowered/expression_port.hpp"
 #include "snippets/lowered/expression.hpp"
+#include "snippets/utils/utils.hpp"
 
 
 namespace ov {
 namespace snippets {
 namespace lowered {
 
-/* The structure describes port of Loop: expression port that connected to Expressions from other Loops.
+/* The class describes port of Loop: expression port that connected to Expressions from other Loops.
  */
-struct LoopPort {
+class LoopPort {
+public:
+    enum class Type {
+        Incremented,    // Loop port which data ptr should be incremented after each Loop iteration
+        NotIncremented, // Loop port which data ptr should not be to avoid double increment
+        NotProcessed,   // LoopPort which doesn't process the dim by `dim_idx` and is used only for Loop bound definition
+    };
+
     LoopPort() = default;
-    LoopPort(const ExpressionPort& port, bool is_incremented = true, size_t dim_idx = 0);
+    LoopPort(const ExpressionPort& port, size_t dim_idx = 0, Type type = Type::Incremented);
 
     std::shared_ptr<LoopPort> clone_with_new_expr(const ExpressionPtr& new_expr) const;
 
@@ -25,20 +33,35 @@ struct LoopPort {
     friend bool operator<(const LoopPort& lhs, const LoopPort& rhs);
 
     const std::shared_ptr<ExpressionPort>& get_expr_port() const { return m_expr_port; }
-    bool is_incremented() const { return m_is_incremented; }
+    Type get_type() const { return m_type; }
     size_t get_dim_idx() const { return m_dim_idx; }
 
     void set_expr_port(std::shared_ptr<ExpressionPort> p);
-    void set_is_incremented(bool is_inc);
+    void set_type(Type type);
     void set_dim_idx(size_t idx);
 
 private:
     std::shared_ptr<ExpressionPort> m_expr_port = {};
-    // True if after each Loop iteration the corresponding data pointer should be incremented.
-    // Otherwise, the data pointer shift is skipped
-    bool m_is_incremented = true;
     size_t m_dim_idx = 0; // The numeration starts from the end (dim_idx = 0 -> is the most inner dimension)
+    Type m_type = Type::Incremented;
 };
+
+inline std::ostream& operator<<(std::ostream& out, const LoopPort::Type& type) {
+    switch (type) {
+    case LoopPort::Type::Incremented:
+        out << "Incremented";
+        break;
+    case LoopPort::Type::NotIncremented:
+        out << "NotIncremented";
+        break;
+    case LoopPort::Type::NotProcessed:
+        out << "NotProcessed";
+        break;
+    default:
+        OPENVINO_THROW("Unknown LoopPort Type");
+    }
+    return out;
+}
 
 } // namespace lowered
 } // namespace snippets

--- a/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_buffers.hpp
@@ -32,8 +32,8 @@ private:
                    const LinearIR::constExprIt& begin_it,
                    const LinearIR::constExprIt& end_it,
                    const LoopManagerPtr& loop_manager,
-                   const std::vector<LoopPort>& loop_entries,
-                   const std::vector<LoopPort>& loop_exits) const;
+                   const std::vector<ExpressionPort>& loop_entries,
+                   const std::vector<ExpressionPort>& loop_exits) const;
 
     static LinearIR::constExprIt insertion_position(const LinearIR& linear_ir,
                                                     const LoopManagerPtr& loop_manager,

--- a/src/common/snippets/src/lowered/expressions/buffer_expression.cpp
+++ b/src/common/snippets/src/lowered/expressions/buffer_expression.cpp
@@ -77,10 +77,10 @@ void BufferExpression::init_allocation_size(const std::shared_ptr<LoopManager>& 
     const auto& subtensor = ov::snippets::utils::get_projected_subtensor(parent_port);
 
     auto hard_equal = [&parent_port](const LoopPort& port) {
-        return *port.expr_port == parent_port;
+        return *port.get_expr_port() == parent_port;
     };
     auto soft_equal = [&](const LoopPort& loop_port) {
-        const auto& port = *loop_port.expr_port;
+        const auto& port = *loop_port.get_expr_port();
         // Check semantic of LoopPort
         if (parent_port.get_index() != port.get_index() ||
             port.get_expr()->get_node()->get_type_info() != parent_port.get_expr()->get_node()->get_type_info())
@@ -109,8 +109,8 @@ void BufferExpression::init_allocation_size(const std::shared_ptr<LoopManager>& 
             OPENVINO_ASSERT(it != output_ports.end(), "compute_allocation_shape: output port of parent loop can not be found");
         }
         const auto& loop_port = *it;
-        const auto& dim_idx = loop_port.dim_idx;
-        if (loop_port.is_incremented && dim_idx < rank) {
+        const auto& dim_idx = loop_port.get_dim_idx();
+        if (loop_port.is_incremented() && dim_idx < rank) {
             if (const auto& unified_loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop_info))
                 m_allocation_size = utils::dynamic_safe_mul(m_allocation_size, unified_loop_info->get_work_amount());
             else if (const auto& expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_info))

--- a/src/common/snippets/src/lowered/expressions/buffer_expression.cpp
+++ b/src/common/snippets/src/lowered/expressions/buffer_expression.cpp
@@ -110,7 +110,7 @@ void BufferExpression::init_allocation_size(const std::shared_ptr<LoopManager>& 
         }
         const auto& loop_port = *it;
         const auto& dim_idx = loop_port.get_dim_idx();
-        if (loop_port.is_incremented() && dim_idx < rank) {
+        if (loop_port.get_type() != LoopPort::Type::NotProcessed && dim_idx < rank) {
             if (const auto& unified_loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop_info))
                 m_allocation_size = utils::dynamic_safe_mul(m_allocation_size, unified_loop_info->get_work_amount());
             else if (const auto& expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_info))

--- a/src/common/snippets/src/lowered/expressions/buffer_expression.cpp
+++ b/src/common/snippets/src/lowered/expressions/buffer_expression.cpp
@@ -109,8 +109,10 @@ void BufferExpression::init_allocation_size(const std::shared_ptr<LoopManager>& 
             OPENVINO_ASSERT(it != output_ports.end(), "compute_allocation_shape: output port of parent loop can not be found");
         }
         const auto& loop_port = *it;
+        if (!loop_port.is_processed())
+            continue;
         const auto& dim_idx = loop_port.get_dim_idx();
-        if (loop_port.get_type() != LoopPort::Type::NotProcessed && dim_idx < rank) {
+        if (dim_idx < rank) {
             if (const auto& unified_loop_info = ov::as_type_ptr<UnifiedLoopInfo>(loop_info))
                 m_allocation_size = utils::dynamic_safe_mul(m_allocation_size, unified_loop_info->get_work_amount());
             else if (const auto& expanded_loop_info = ov::as_type_ptr<ExpandedLoopInfo>(loop_info))

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -19,9 +19,9 @@ LoopInfo::LoopInfo(size_t work_amount, size_t increment, const std::vector<Expre
     m_input_ports.reserve(entries.size());
     m_output_ports.reserve(exits.size());
     for (const auto& port : entries)
-        m_input_ports.emplace_back(port);
+        m_input_ports.push_back(LoopPort::create(port));
     for (const auto& port : exits)
-        m_output_ports.emplace_back(port);
+        m_output_ports.push_back(LoopPort::create(port));
 }
 
 bool LoopInfo::is_dynamic() const {
@@ -37,7 +37,7 @@ size_t LoopInfo::get_dim_idx() const {
         std::all_of(m_output_ports.begin(), m_output_ports.end(), equal_dim_idxes)) {
         return m_input_ports[0].get_dim_idx();
     } else {
-        return UNDEFINED_DIM_IDX;
+        return LoopPort::UNDEFINED_DIM_IDX;
     }
 }
 

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -19,9 +19,9 @@ LoopInfo::LoopInfo(size_t work_amount, size_t increment, const std::vector<Expre
     m_input_ports.reserve(entries.size());
     m_output_ports.reserve(exits.size());
     for (const auto& port : entries)
-        m_input_ports.push_back(LoopPort::create(port));
+        m_input_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port));
     for (const auto& port : exits)
-        m_output_ports.push_back(LoopPort::create(port));
+        m_output_ports.push_back(LoopPort::create<LoopPort::Type::Incremented>(port));
 }
 
 bool LoopInfo::is_dynamic() const {
@@ -30,12 +30,20 @@ bool LoopInfo::is_dynamic() const {
 
 size_t LoopInfo::get_dim_idx() const {
     OPENVINO_ASSERT(!m_input_ports.empty(), "Loop info must have at least one input port");
-    auto equal_dim_idxes = [&](const LoopPort& p) {
-        return p.get_type() == LoopPort::Type::NotProcessed || p.get_dim_idx() == m_input_ports[0].get_dim_idx();
-    };
+
+    auto is_processed = [](const LoopPort& p) { return p.is_processed(); };
+    auto is_processed_it = std::find_if(m_input_ports.begin(), m_input_ports.end(), is_processed);
+    if (is_processed_it == m_input_ports.end()) {
+        is_processed_it = std::find_if(m_output_ports.begin(), m_output_ports.end(), is_processed);
+        if (is_processed_it == m_output_ports.end())
+            return LoopPort::UNDEFINED_DIM_IDX;
+    }
+    const auto dim_idx = is_processed_it->get_dim_idx();
+
+    auto equal_dim_idxes = [&](const LoopPort& p) { return !p.is_processed() || p.get_dim_idx() == dim_idx; };
     if (std::all_of(m_input_ports.begin(), m_input_ports.end(), equal_dim_idxes) &&
         std::all_of(m_output_ports.begin(), m_output_ports.end(), equal_dim_idxes)) {
-        return m_input_ports[0].get_dim_idx();
+        return dim_idx;
     } else {
         return LoopPort::UNDEFINED_DIM_IDX;
     }
@@ -60,7 +68,7 @@ size_t LoopInfo::get_increment() const {
 std::vector<bool> LoopInfo::get_is_incremented() const {
     std::vector<bool> values;
     values.reserve(get_input_count() + get_output_count());
-    iterate_through_ports([&values](const LoopPort& port) { values.push_back(port.get_type() == LoopPort::Type::Incremented); });
+    iterate_through_ports([&values](const LoopPort& port) { values.push_back(port.is_incremented()); });
     return values;
 }
 
@@ -81,10 +89,7 @@ void LoopInfo::set_increment(size_t increment) {
 }
 
 void LoopInfo::set_dim_idx(size_t dim_idx) {
-    auto setter = [dim_idx](LoopPort& port) {
-        if (port.get_type() != LoopPort::Type::NotProcessed)
-            port.set_dim_idx(dim_idx);
-    };
+    auto setter = [dim_idx](LoopPort& port) { if (port.is_processed()) port.set_dim_idx(dim_idx); };
     std::for_each(m_input_ports.begin(), m_input_ports.end(), setter);
     std::for_each(m_output_ports.begin(), m_output_ports.end(), setter);
 }

--- a/src/common/snippets/src/lowered/loop_info.cpp
+++ b/src/common/snippets/src/lowered/loop_info.cpp
@@ -31,11 +31,11 @@ bool LoopInfo::is_dynamic() const {
 size_t LoopInfo::get_dim_idx() const {
     OPENVINO_ASSERT(!m_input_ports.empty(), "Loop info must have at least one input port");
     auto equal_dim_idxes = [&](const LoopPort& p) {
-        return !p.is_incremented || p.dim_idx == m_input_ports[0].dim_idx;
+        return !p.is_incremented() || p.get_dim_idx() == m_input_ports[0].get_dim_idx();
     };
     if (std::all_of(m_input_ports.begin(), m_input_ports.end(), equal_dim_idxes) &&
         std::all_of(m_output_ports.begin(), m_output_ports.end(), equal_dim_idxes)) {
-        return m_input_ports[0].dim_idx;
+        return m_input_ports[0].get_dim_idx();
     } else {
         return UNDEFINED_DIM_IDX;
     }
@@ -60,7 +60,7 @@ size_t LoopInfo::get_increment() const {
 std::vector<bool> LoopInfo::get_is_incremented() const {
     std::vector<bool> values;
     values.reserve(get_input_count() + get_output_count());
-    iterate_through_ports([&values](const LoopPort& port) { values.push_back(port.is_incremented); });
+    iterate_through_ports([&values](const LoopPort& port) { values.push_back(port.is_incremented()); });
     return values;
 }
 
@@ -81,14 +81,14 @@ void LoopInfo::set_increment(size_t increment) {
 }
 
 void LoopInfo::set_dim_idx(size_t dim_idx) {
-    auto setter = [dim_idx](LoopPort& port) { port.dim_idx = dim_idx; };
+    auto setter = [dim_idx](LoopPort& port) { port.set_dim_idx(dim_idx); };
     std::for_each(m_input_ports.begin(), m_input_ports.end(), setter);
     std::for_each(m_output_ports.begin(), m_output_ports.end(), setter);
 }
 
 template<>
 std::vector<LoopPort>::iterator LoopInfo::find_loop_port(const LoopPort& loop_port) {
-    auto& ports = loop_port.expr_port->get_type() == ExpressionPort::Input ? m_input_ports : m_output_ports;
+    auto& ports = loop_port.get_expr_port()->get_type() == ExpressionPort::Input ? m_input_ports : m_output_ports;
     const auto it = std::find_if(ports.begin(), ports.end(),
                                  [&loop_port](const LoopPort& port) { return port == loop_port; });
     OPENVINO_ASSERT(it != ports.end(), "Failed find_loop_port: existing loop port has not been found");
@@ -99,7 +99,7 @@ template<>
 std::vector<LoopPort>::iterator LoopInfo::find_loop_port(const ExpressionPort& expr_port) {
     auto& ports = expr_port.get_type() == ExpressionPort::Input ? m_input_ports : m_output_ports;
     const auto it = std::find_if(ports.begin(), ports.end(),
-                                [&expr_port](const LoopPort& port) { return *port.expr_port == expr_port; });
+                                [&expr_port](const LoopPort& port) { return *port.get_expr_port() == expr_port; });
     return it;
 }
 
@@ -118,7 +118,7 @@ namespace {
 void validate_new_target_ports(const std::vector<LoopPort>& target_ports, ExpressionPort::Type target_type) {
     OPENVINO_ASSERT(target_ports.empty() ||
                     std::all_of(target_ports.cbegin(), target_ports.cend(),
-                                [&target_type](const LoopPort& target_port) { return target_type == target_port.expr_port->get_type(); }));
+                                [&target_type](const LoopPort& target_port) { return target_type == target_port.get_expr_port()->get_type(); }));
 }
 void validate_new_target_ports(const std::vector<ExpressionPort>& target_ports, ExpressionPort::Type target_type) {
     OPENVINO_ASSERT(target_ports.empty() ||
@@ -128,7 +128,7 @@ void validate_new_target_ports(const std::vector<ExpressionPort>& target_ports, 
 } // namespace
 
 void LoopInfo::replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports) {
-    const auto& actual_port_type = actual_port.expr_port->get_type();
+    const auto& actual_port_type = actual_port.get_expr_port()->get_type();
     validate_new_target_ports(target_ports, actual_port_type);
 
     auto& ports = actual_port_type == ExpressionPort::Input ? m_input_ports : m_output_ports;
@@ -153,7 +153,7 @@ void LoopInfo::replace_with_new_ports(const ExpressionPort& actual_port, const s
     std::transform(target_loop_ports.begin(), target_loop_ports.end(), target_ports.begin(), target_loop_ports.begin(),
                    [](LoopPort loop_port, const ExpressionPort& expr_port) {
                        LoopPort copy = std::move(loop_port);  // to save loop port parameters
-                       copy.expr_port = std::make_shared<ExpressionPort>(expr_port);
+                       copy.set_expr_port(std::make_shared<ExpressionPort>(expr_port));
                        return copy;
                    });
     port_it = ports.erase(port_it);
@@ -164,7 +164,7 @@ std::vector<LoopPort> LoopInfo::clone_loop_ports(const ExpressionMap& expr_map, 
     std::vector<LoopPort> cloned_port_points;
     cloned_port_points.reserve(loop_ports.size());
     for (const auto& p : loop_ports) {
-        const auto& expr = p.expr_port->get_expr().get();
+        const auto& expr = p.get_expr_port()->get_expr().get();
         OPENVINO_ASSERT(expr_map.count(expr), "Can't clone LoopInfo: old expression is not in the map");
         const auto& new_expr = expr_map.at(expr);
         cloned_port_points.emplace_back(*p.clone_with_new_expr(new_expr));
@@ -309,8 +309,8 @@ std::vector<size_t> get_port_index_order(const std::vector<LoopPort>& ports) {
     std::iota(new_indexes.begin(), new_indexes.end(), 0);
     std::sort(new_indexes.begin(), new_indexes.end(),
         [ports](size_t l, size_t r) {
-            const auto& expr_port_l = ports[l].expr_port;
-            const auto& expr_port_r = ports[r].expr_port;
+            const auto& expr_port_l = ports[l].get_expr_port();
+            const auto& expr_port_r = ports[r].get_expr_port();
             if (expr_port_l->get_expr() == expr_port_r->get_expr())
                 return expr_port_l->get_index() < expr_port_r->get_index();
             return expr_port_l->get_expr()->get_exec_num() < expr_port_r->get_expr()->get_exec_num();
@@ -340,7 +340,7 @@ UnifiedLoopInfo::LoopPortInfo UnifiedLoopInfo::get_loop_port_info(const Expressi
     const auto& ports = is_input ? m_input_ports : m_output_ports;
     const auto& descs = is_input ? m_input_port_descs : m_output_port_descs;
     const auto it = std::find_if(ports.begin(), ports.end(),
-                                [&expr_port](const LoopPort& port) { return *port.expr_port == expr_port; });
+                                [&expr_port](const LoopPort& port) { return *port.get_expr_port() == expr_port; });
     const auto index = static_cast<size_t>(std::distance(ports.cbegin(), it));
     OPENVINO_ASSERT(index < ports.size() && index < descs.size(), "LoopPortInfo has not been found!");
     return {ports[index], descs[index]};
@@ -354,10 +354,10 @@ void UnifiedLoopInfo::replace_with_cloned_descs(size_t actual_port_idx, size_t n
 }
 
 void UnifiedLoopInfo::replace_with_new_ports(const LoopPort& actual_port, const std::vector<LoopPort>& target_ports) {
-    const auto& actual_port_type = actual_port.expr_port->get_type();
+    const auto& actual_port_type = actual_port.get_expr_port()->get_type();
     validate_new_target_ports(target_ports, actual_port_type);
 
-    const auto is_input = actual_port.expr_port->get_type() == ExpressionPort::Input;
+    const auto is_input = actual_port.get_expr_port()->get_type() == ExpressionPort::Input;
     auto& ports = is_input ? m_input_ports : m_output_ports;
     auto port_it = find_loop_port(actual_port);
 

--- a/src/common/snippets/src/lowered/loop_manager.cpp
+++ b/src/common/snippets/src/lowered/loop_manager.cpp
@@ -93,7 +93,7 @@ std::pair<LinearIR::constExprIt, LinearIR::constExprIt> LoopManager::get_loop_bo
     OPENVINO_ASSERT(!entries.empty(), "Loop must have input ports");
     OPENVINO_ASSERT(!exits.empty(), "Loop must have output ports");
 
-    const auto& entry_expr = entries.front().expr_port->get_expr();
+    const auto& entry_expr = entries.front().get_expr_port()->get_expr();
     auto loop_begin_pos = linear_ir.find(entry_expr);
     // Some operations in Loop can be before first input ports: Scalars, VectorBuffer.
     // We should iterate by them till the expr is in the corresponding Loop
@@ -103,7 +103,7 @@ std::pair<LinearIR::constExprIt, LinearIR::constExprIt> LoopManager::get_loop_bo
         prev_loop_ids = (*std::prev(loop_begin_pos))->get_loop_ids();
     }
 
-    const auto& exit_expr = exits.back().expr_port->get_expr();
+    const auto& exit_expr = exits.back().get_expr_port()->get_expr();
     auto loop_end_pos = std::next(linear_ir.find_after(loop_begin_pos, exit_expr));
     // There might be LoopEnd with another `loop_id` but in the target Loop as well.
     auto current_loop_ids = (*loop_end_pos)->get_loop_ids();
@@ -312,14 +312,14 @@ void LoopManager::fuse_loop_ports(std::vector<LoopPort>& output_ports,
 
     std::vector<LoopPort> new_output_ports;
     for (const auto& output_port : output_ports) {
-        const auto consumers_inputs = output_port.expr_port->get_connected_ports();
+        const auto consumers_inputs = output_port.get_expr_port()->get_connected_ports();
 
         std::set<LoopPort> mapped_input_ports;
         std::set<ExpressionPtr> outside_consumers;
         for (const auto& consumer_input : consumers_inputs) {
             const auto input_port_it = std::find_if(input_ports.begin(), input_ports.end(),
                                                      [&consumer_input](const LoopPort& port) {
-                                                             return *port.expr_port.get() == consumer_input;
+                                                             return *port.get_expr_port().get() == consumer_input;
                                                          });
             if (input_port_it != input_ports.end()) {
                 mapped_input_ports.insert(*input_port_it);

--- a/src/common/snippets/src/lowered/loop_port.cpp
+++ b/src/common/snippets/src/lowered/loop_port.cpp
@@ -12,25 +12,39 @@ namespace snippets {
 namespace lowered {
 
 LoopPort::LoopPort(const ExpressionPort& port, bool is_incremented, size_t dim_idx)
-    : expr_port(std::make_shared<ExpressionPort>(port)), is_incremented(is_incremented), dim_idx(dim_idx) {
-    OPENVINO_ASSERT(dim_idx < port.get_descriptor_ptr()->get_shape().size(),
-                    "LoopPort dim_idx (",
-                    dim_idx,
-                    ") must be less than the corresponding expression port shape rank (",
-                    port.get_descriptor_ptr()->get_shape().size(),
-                    ")");
+    : m_expr_port(std::make_shared<ExpressionPort>(port)), m_is_incremented(is_incremented) {
+    set_dim_idx(dim_idx);
 }
 
 std::shared_ptr<LoopPort> LoopPort::clone_with_new_expr(const ExpressionPtr& new_expr) const {
     auto new_loop_port = std::make_shared<LoopPort>(*this);
-    new_loop_port->expr_port = expr_port->clone_with_new_expr(new_expr);
+    new_loop_port->m_expr_port = m_expr_port->clone_with_new_expr(new_expr);
     return new_loop_port;
+}
+
+void LoopPort::set_expr_port(std::shared_ptr<ExpressionPort> p) {
+    OPENVINO_ASSERT(p, "Expression port is missed");
+    m_expr_port = std::move(p);
+}
+
+void LoopPort::set_is_incremented(bool is_inc) {
+    m_is_incremented = is_inc;
+}
+
+void LoopPort::set_dim_idx(size_t idx) {
+    OPENVINO_ASSERT(idx < m_expr_port->get_descriptor_ptr()->get_shape().size(),
+                    "LoopPort dim_idx (",
+                    idx,
+                    ") must be less than the corresponding expression port shape rank (",
+                    m_expr_port->get_descriptor_ptr()->get_shape().size(),
+                    ")");
+    m_dim_idx = idx;
 }
 
 bool operator==(const LoopPort& lhs, const LoopPort& rhs) {
     if (&lhs == &rhs)
         return true;
-    return *lhs.expr_port == *rhs.expr_port && lhs.is_incremented == rhs.is_incremented && lhs.dim_idx == rhs.dim_idx;
+    return *lhs.m_expr_port == *rhs.m_expr_port && lhs.m_is_incremented == rhs.m_is_incremented && lhs.m_dim_idx == rhs.m_dim_idx;
 }
 
 bool operator!=(const LoopPort& lhs, const LoopPort& rhs) {
@@ -38,10 +52,10 @@ bool operator!=(const LoopPort& lhs, const LoopPort& rhs) {
 }
 
 bool operator<(const LoopPort& lhs, const LoopPort& rhs) {
-    return (*lhs.expr_port < *rhs.expr_port) ||
-           (*lhs.expr_port == *rhs.expr_port &&
-            (lhs.is_incremented < rhs.is_incremented ||
-             (lhs.is_incremented == rhs.is_incremented && lhs.dim_idx < rhs.dim_idx)));
+    return (*lhs.m_expr_port < *rhs.m_expr_port) ||
+           (*lhs.m_expr_port == *rhs.m_expr_port &&
+            (lhs.m_is_incremented < rhs.m_is_incremented ||
+             (lhs.m_is_incremented == rhs.m_is_incremented && lhs.m_dim_idx < rhs.m_dim_idx)));
 }
 
 } // namespace lowered

--- a/src/common/snippets/src/lowered/loop_port.cpp
+++ b/src/common/snippets/src/lowered/loop_port.cpp
@@ -34,7 +34,7 @@ void LoopPort::set_type(Type type) {
 
 void LoopPort::set_dim_idx(size_t idx) {
     if (get_type() == LoopPort::Type::NotProcessed) {
-        OPENVINO_ASSERT(idx == LoopInfo::UNDEFINED_DIM_IDX, "NotProcessed LoopPort cah have only UNDEFINED_DIM_IDX");
+        OPENVINO_ASSERT(idx == UNDEFINED_DIM_IDX, "NotProcessed LoopPort cah have only UNDEFINED_DIM_IDX");
     } else {
         OPENVINO_ASSERT(idx < m_expr_port->get_descriptor_ptr()->get_shape().size(),
                         "LoopPort dim_idx (",

--- a/src/common/snippets/src/lowered/loop_port.cpp
+++ b/src/common/snippets/src/lowered/loop_port.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "snippets/lowered/loop_port.hpp"
+#include "snippets/lowered/loop_info.hpp"
 
 #include "snippets/utils/utils.hpp"
 
@@ -11,8 +12,8 @@ namespace ov {
 namespace snippets {
 namespace lowered {
 
-LoopPort::LoopPort(const ExpressionPort& port, bool is_incremented, size_t dim_idx)
-    : m_expr_port(std::make_shared<ExpressionPort>(port)), m_is_incremented(is_incremented) {
+LoopPort::LoopPort(const ExpressionPort& port, size_t dim_idx, Type type)
+    : m_expr_port(std::make_shared<ExpressionPort>(port)), m_type(type)  {
     set_dim_idx(dim_idx);
 }
 
@@ -27,24 +28,28 @@ void LoopPort::set_expr_port(std::shared_ptr<ExpressionPort> p) {
     m_expr_port = std::move(p);
 }
 
-void LoopPort::set_is_incremented(bool is_inc) {
-    m_is_incremented = is_inc;
+void LoopPort::set_type(Type type) {
+    m_type = type;
 }
 
 void LoopPort::set_dim_idx(size_t idx) {
-    OPENVINO_ASSERT(idx < m_expr_port->get_descriptor_ptr()->get_shape().size(),
-                    "LoopPort dim_idx (",
-                    idx,
-                    ") must be less than the corresponding expression port shape rank (",
-                    m_expr_port->get_descriptor_ptr()->get_shape().size(),
-                    ")");
+    if (get_type() == LoopPort::Type::NotProcessed) {
+        OPENVINO_ASSERT(idx == LoopInfo::UNDEFINED_DIM_IDX, "NotProcessed LoopPort cah have only UNDEFINED_DIM_IDX");
+    } else {
+        OPENVINO_ASSERT(idx < m_expr_port->get_descriptor_ptr()->get_shape().size(),
+                        "LoopPort dim_idx (",
+                        idx,
+                        ") must be less than the corresponding expression port shape rank (",
+                        m_expr_port->get_descriptor_ptr()->get_shape().size(),
+                        ")");
+    }
     m_dim_idx = idx;
 }
 
 bool operator==(const LoopPort& lhs, const LoopPort& rhs) {
     if (&lhs == &rhs)
         return true;
-    return *lhs.m_expr_port == *rhs.m_expr_port && lhs.m_is_incremented == rhs.m_is_incremented && lhs.m_dim_idx == rhs.m_dim_idx;
+    return *lhs.m_expr_port == *rhs.m_expr_port && lhs.m_type == rhs.m_type && lhs.m_dim_idx == rhs.m_dim_idx;
 }
 
 bool operator!=(const LoopPort& lhs, const LoopPort& rhs) {
@@ -54,8 +59,8 @@ bool operator!=(const LoopPort& lhs, const LoopPort& rhs) {
 bool operator<(const LoopPort& lhs, const LoopPort& rhs) {
     return (*lhs.m_expr_port < *rhs.m_expr_port) ||
            (*lhs.m_expr_port == *rhs.m_expr_port &&
-            (lhs.m_is_incremented < rhs.m_is_incremented ||
-             (lhs.m_is_incremented == rhs.m_is_incremented && lhs.m_dim_idx < rhs.m_dim_idx)));
+            (lhs.m_type < rhs.m_type ||
+             (lhs.m_type == rhs.m_type && lhs.m_dim_idx < rhs.m_dim_idx)));
 }
 
 } // namespace lowered

--- a/src/common/snippets/src/lowered/loop_port.cpp
+++ b/src/common/snippets/src/lowered/loop_port.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "snippets/lowered/loop_port.hpp"
-#include "snippets/lowered/loop_info.hpp"
 
 #include "snippets/utils/utils.hpp"
 
@@ -23,18 +22,35 @@ std::shared_ptr<LoopPort> LoopPort::clone_with_new_expr(const ExpressionPtr& new
     return new_loop_port;
 }
 
+bool LoopPort::is_processed() const {
+    switch (m_type) {
+        case Type::Incremented:
+        case Type::NotIncremented:
+            return true;
+        case Type::NotProcessed:
+            return false;
+        default:
+            OPENVINO_THROW("Unknown LoopPort type");
+    }
+}
+
+bool LoopPort::is_incremented() const {
+    return m_type == Type::Incremented;
+}
+
+size_t LoopPort::get_dim_idx() const {
+    OPENVINO_ASSERT(is_processed(), "NotProcessed LoopPort cannot call `get_dim_idx()`");
+    return m_dim_idx;
+}
+
 void LoopPort::set_expr_port(std::shared_ptr<ExpressionPort> p) {
     OPENVINO_ASSERT(p, "Expression port is missed");
     m_expr_port = std::move(p);
 }
 
-void LoopPort::set_type(Type type) {
-    m_type = type;
-}
-
 void LoopPort::set_dim_idx(size_t idx) {
-    if (get_type() == LoopPort::Type::NotProcessed) {
-        OPENVINO_ASSERT(idx == UNDEFINED_DIM_IDX, "NotProcessed LoopPort cah have only UNDEFINED_DIM_IDX");
+    if (!is_processed()) {
+        OPENVINO_ASSERT(idx == UNDEFINED_DIM_IDX, "NotProcessed LoopPort can have only UNDEFINED_DIM_IDX");
     } else {
         OPENVINO_ASSERT(idx < m_expr_port->get_descriptor_ptr()->get_shape().size(),
                         "LoopPort dim_idx (",
@@ -62,6 +78,24 @@ bool operator<(const LoopPort& lhs, const LoopPort& rhs) {
             (lhs.m_type < rhs.m_type ||
              (lhs.m_type == rhs.m_type && lhs.m_dim_idx < rhs.m_dim_idx)));
 }
+
+std::ostream& operator<<(std::ostream& out, const LoopPort::Type& type) {
+    switch (type) {
+    case LoopPort::Type::Incremented:
+        out << "Incremented";
+        break;
+    case LoopPort::Type::NotIncremented:
+        out << "NotIncremented";
+        break;
+    case LoopPort::Type::NotProcessed:
+        out << "NotProcessed";
+        break;
+    default:
+        OPENVINO_THROW("Unknown LoopPort Type");
+    }
+    return out;
+}
+
 
 } // namespace lowered
 } // namespace snippets

--- a/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
+++ b/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
@@ -18,21 +18,21 @@ namespace snippets {
 namespace lowered {
 namespace pass {
 using namespace ov::snippets::utils;
+using PortType = LoopPort::Type;
 
-snippets::lowered::SpecificIterationHandlers BrgemmBlockingBase::get_default_blocking_loop_handlers(size_t work_amount,
-                                                                                                    size_t block_size) {
+lowered::SpecificIterationHandlers BrgemmBlockingBase::get_default_blocking_loop_handlers(size_t work_amount, size_t block_size) {
     OPENVINO_ASSERT(block_size != 0, "block size must be non zero");
     SpecificIterationHandlers handlers;
-    const auto tail_size = snippets::utils::is_dynamic_value(work_amount) ? snippets::utils::get_dynamic_value<size_t>() : work_amount % block_size;
+    const auto tail_size = utils::is_dynamic_value(work_amount) ? utils::get_dynamic_value<size_t>() : work_amount % block_size;
     if (tail_size != 0)
-        handlers.register_pass<snippets::lowered::SpecificLoopIterType::LAST_ITER, snippets::lowered::pass::UpdateSubtensors>(tail_size);
+        handlers.register_pass<lowered::SpecificLoopIterType::LAST_ITER, lowered::pass::UpdateSubtensors>(tail_size);
     return handlers;
 }
 
-bool BrgemmBlockingBase::blocking_loop_exists(const snippets::lowered::LoopManagerPtr& loop_manager,
+bool BrgemmBlockingBase::blocking_loop_exists(const lowered::LoopManagerPtr& loop_manager,
                                               const ExpressionPtr& brgemm_expr) {
     auto check_port = [&](const LoopPort& p) {
-        return p.get_expr_port()->get_expr() == brgemm_expr && ov::snippets::utils::one_of(p.get_dim_idx(), 0ul, 1ul);
+        return p.get_expr_port()->get_expr() == brgemm_expr && one_of(p.get_dim_idx(), 0ul, 1ul);
     };
     const auto& loop_ids = brgemm_expr->get_loop_ids();
     for (const auto& id : loop_ids) {
@@ -45,37 +45,37 @@ bool BrgemmBlockingBase::blocking_loop_exists(const snippets::lowered::LoopManag
     return false;
 }
 
-void BrgemmBlockingBase::mark_m_blocking(const snippets::lowered::LoopManagerPtr& loop_manager,
-                                         snippets::lowered::LinearIR::constExprIt loop_begin,
-                                         snippets::lowered::LinearIR::constExprIt loop_end,
-                                         const std::vector<snippets::lowered::LoopPort>& entries,
-                                         const std::vector<snippets::lowered::LoopPort>& exits,
+void BrgemmBlockingBase::mark_m_blocking(const LoopManagerPtr& loop_manager,
+                                         LinearIR::constExprIt loop_begin,
+                                         LinearIR::constExprIt loop_end,
+                                         const std::vector<LoopPort>& entries,
+                                         const std::vector<LoopPort>& exits,
                                          size_t block_size_m) {
-    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[0].get_expr_port());
+    const auto planar_dims = get_planar_vdims(*entries[0].get_expr_port());
     const auto m = *++planar_dims.rbegin();
     const auto id = loop_manager->mark_loop(loop_begin, loop_end, m, block_size_m, entries, exits, false);
     loop_manager->get_loop_info<UnifiedLoopInfo>(id)->set_handlers(get_m_loop_handlers(m, block_size_m));
 }
 
-void BrgemmBlockingBase::mark_n_blocking(const snippets::lowered::LoopManagerPtr& loop_manager,
-                                         snippets::lowered::LinearIR::constExprIt loop_begin,
-                                         snippets::lowered::LinearIR::constExprIt loop_end,
-                                         const std::vector<snippets::lowered::LoopPort>& entries,
-                                         const std::vector<snippets::lowered::LoopPort>& exits,
+void BrgemmBlockingBase::mark_n_blocking(const LoopManagerPtr& loop_manager,
+                                         LinearIR::constExprIt loop_begin,
+                                         LinearIR::constExprIt loop_end,
+                                         const std::vector<LoopPort>& entries,
+                                         const std::vector<LoopPort>& exits,
                                          size_t block_size_n) {
-    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[1].get_expr_port());
+    const auto planar_dims = get_planar_vdims(*entries[1].get_expr_port());
     const auto n = *planar_dims.rbegin();
     const auto id = loop_manager->mark_loop(loop_begin, loop_end, n, block_size_n, entries, exits, false);
     loop_manager->get_loop_info<UnifiedLoopInfo>(id)->set_handlers(get_n_loop_handlers(n, block_size_n));
 }
 
-void BrgemmBlockingBase::mark_k_blocking(const snippets::lowered::LoopManagerPtr& loop_manager,
-                                         snippets::lowered::LinearIR::constExprIt loop_begin,
-                                         snippets::lowered::LinearIR::constExprIt loop_end,
-                                         const std::vector<snippets::lowered::LoopPort>& entries,
-                                         const std::vector<snippets::lowered::LoopPort>& exits,
+void BrgemmBlockingBase::mark_k_blocking(const LoopManagerPtr& loop_manager,
+                                         LinearIR::constExprIt loop_begin,
+                                         LinearIR::constExprIt loop_end,
+                                         const std::vector<LoopPort>& entries,
+                                         const std::vector<LoopPort>& exits,
                                          size_t block_size_k) {
-    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[0].get_expr_port());
+    const auto planar_dims = get_planar_vdims(*entries[0].get_expr_port());
     const auto k = *planar_dims.rbegin();
     const auto id = loop_manager->mark_loop(loop_begin, loop_end, k, block_size_k, entries, exits, false);
     loop_manager->get_loop_info<UnifiedLoopInfo>(id)->set_handlers(get_k_loop_handlers(k, block_size_k));
@@ -101,21 +101,21 @@ size_t BrgemmBlockingBase::get_default_k_blk(size_t k) const {
     return !utils::is_dynamic_value(k) && k > 1024 ? 1024 : 512;
 }
 
-std::tuple<size_t, size_t, size_t> BrgemmBlockingBase::get_blocking_params(const ov::snippets::lowered::ExpressionPtr& brgemm_expr) const {
+std::tuple<size_t, size_t, size_t> BrgemmBlockingBase::get_blocking_params(const ExpressionPtr& brgemm_expr) const {
     size_t m, n, k;
     std::tie(m, n, k) = get_brgemm_dimensions(brgemm_expr);
 
     // Ticket: 113745
     // TODO: extend block size selection heuristics
     auto get_block_size = [](const size_t dim, const size_t default_blk) {
-        if (!snippets::utils::is_dynamic_value(dim) && dim <= default_blk)
+        if (!utils::is_dynamic_value(dim) && dim <= default_blk)
             return get_full_dim_value();
         return default_blk;
     };
     return std::make_tuple(get_block_size(m, get_default_m_blk(m)), get_block_size(n, get_default_n_blk(n)), get_block_size(k, get_default_k_blk(k)));
 }
 
-std::tuple<size_t, size_t, size_t> BrgemmBlockingBase::get_brgemm_dimensions(const ov::snippets::lowered::ExpressionPtr& brgemm_expr) {
+std::tuple<size_t, size_t, size_t> BrgemmBlockingBase::get_brgemm_dimensions(const ExpressionPtr& brgemm_expr) {
     OPENVINO_ASSERT(brgemm_expr, "Brgemm expression is nullptr!");
     const auto& in_0_desc = brgemm_expr->get_input_port_descriptor(0);
     const auto& in_1_desc = brgemm_expr->get_input_port_descriptor(1);
@@ -134,33 +134,33 @@ std::tuple<size_t, size_t, size_t> BrgemmBlockingBase::get_brgemm_dimensions(con
     return std::make_tuple(m, n, k);
 }
 
-bool BrgemmBlockingBase::mark_blocking_loops(snippets::lowered::LinearIR& linear_ir,
-                                             const snippets::lowered::LinearIR::constExprIt& brgemm_it,
+bool BrgemmBlockingBase::mark_blocking_loops(LinearIR& linear_ir,
+                                             const LinearIR::constExprIt& brgemm_it,
                                              size_t m_block,
                                              size_t n_block,
                                              size_t k_block) {
     const auto& brgemm_expr = *brgemm_it;
-    brgemm_expr->get_input_port_descriptor(0)->set_subtensor(ov::snippets::VectorDims{m_block, k_block});
-    brgemm_expr->get_input_port_descriptor(1)->set_subtensor(ov::snippets::VectorDims{k_block, n_block});
-    brgemm_expr->get_output_port_descriptor(0)->set_subtensor(ov::snippets::VectorDims{m_block, n_block});
+    brgemm_expr->get_input_port_descriptor(0)->set_subtensor(VectorDims{m_block, k_block});
+    brgemm_expr->get_input_port_descriptor(1)->set_subtensor(VectorDims{k_block, n_block});
+    brgemm_expr->get_output_port_descriptor(0)->set_subtensor(VectorDims{m_block, n_block});
 
     const auto& loop_manager = linear_ir.get_loop_manager();
-    if (!ov::snippets::utils::is_full_dim_value(k_block)) {
-        const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 0),
-                                            LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1), 1)};
-        const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_output_port(0))};
+    if (!is_full_dim_value(k_block)) {
+        const std::vector<LoopPort> entries{LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(0), 0),
+                                            LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1), 1)};
+        const std::vector<LoopPort> exits{LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_output_port(0))};
         mark_k_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, k_block);
     }
-    if (!ov::snippets::utils::is_full_dim_value(n_block)) {
-        const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(0)),
-                                            LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1))};
-        const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0))};
+    if (!is_full_dim_value(n_block)) {
+        const std::vector<LoopPort> entries{LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(0)),
+                                            LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1))};
+        const std::vector<LoopPort> exits{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0))};
         mark_n_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, n_block);
     }
-    if (!ov::snippets::utils::is_full_dim_value(m_block)) {
-        const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 1),
-                                            LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(1))};
-        const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0), 1)};
+    if (!is_full_dim_value(m_block)) {
+        const std::vector<LoopPort> entries{LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(0), 1),
+                                            LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(1))};
+        const std::vector<LoopPort> exits{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0), 1)};
         mark_m_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, m_block);
     }
     return true;

--- a/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
+++ b/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
@@ -146,21 +146,21 @@ bool BrgemmBlockingBase::mark_blocking_loops(snippets::lowered::LinearIR& linear
 
     const auto& loop_manager = linear_ir.get_loop_manager();
     if (!ov::snippets::utils::is_full_dim_value(k_block)) {
-        const std::vector<LoopPort> entries{LoopPort::create(brgemm_expr->get_input_port(0), 0),
-                                            LoopPort::create(brgemm_expr->get_input_port(1), 1)};
+        const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 0),
+                                            LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1), 1)};
         const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_output_port(0))};
         mark_k_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, k_block);
     }
     if (!ov::snippets::utils::is_full_dim_value(n_block)) {
         const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(0)),
-                                            LoopPort::create(brgemm_expr->get_input_port(1))};
-        const std::vector<LoopPort> exits{LoopPort::create(brgemm_expr->get_output_port(0))};
+                                            LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1))};
+        const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0))};
         mark_n_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, n_block);
     }
     if (!ov::snippets::utils::is_full_dim_value(m_block)) {
-        const std::vector<LoopPort> entries{LoopPort::create(brgemm_expr->get_input_port(0), 1),
+        const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 1),
                                             LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(1))};
-        const std::vector<LoopPort> exits{LoopPort::create(brgemm_expr->get_output_port(0), 1)};
+        const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0), 1)};
         mark_m_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, m_block);
     }
     return true;

--- a/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
+++ b/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
@@ -32,7 +32,7 @@ snippets::lowered::SpecificIterationHandlers BrgemmBlockingBase::get_default_blo
 bool BrgemmBlockingBase::blocking_loop_exists(const snippets::lowered::LoopManagerPtr& loop_manager,
                                               const ExpressionPtr& brgemm_expr) {
     auto check_port = [&](const LoopPort& p) {
-        return p.expr_port->get_expr() == brgemm_expr && ov::snippets::utils::one_of(p.dim_idx, 0ul, 1ul);
+        return p.get_expr_port()->get_expr() == brgemm_expr && ov::snippets::utils::one_of(p.get_dim_idx(), 0ul, 1ul);
     };
     const auto& loop_ids = brgemm_expr->get_loop_ids();
     for (const auto& id : loop_ids) {
@@ -51,7 +51,7 @@ void BrgemmBlockingBase::mark_m_blocking(const snippets::lowered::LoopManagerPtr
                                          const std::vector<snippets::lowered::LoopPort>& entries,
                                          const std::vector<snippets::lowered::LoopPort>& exits,
                                          size_t block_size_m) {
-    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[0].expr_port);
+    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[0].get_expr_port());
     const auto m = *++planar_dims.rbegin();
     const auto id = loop_manager->mark_loop(loop_begin, loop_end, m, block_size_m, 1, entries, exits, false);
     loop_manager->get_loop_info<UnifiedLoopInfo>(id)->set_handlers(get_m_loop_handlers(m, block_size_m));
@@ -63,7 +63,7 @@ void BrgemmBlockingBase::mark_n_blocking(const snippets::lowered::LoopManagerPtr
                                          const std::vector<snippets::lowered::LoopPort>& entries,
                                          const std::vector<snippets::lowered::LoopPort>& exits,
                                          size_t block_size_n) {
-    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[1].expr_port);
+    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[1].get_expr_port());
     const auto n = *planar_dims.rbegin();
     const auto id = loop_manager->mark_loop(loop_begin, loop_end, n, block_size_n, 0, entries, exits, false);
     loop_manager->get_loop_info<UnifiedLoopInfo>(id)->set_handlers(get_n_loop_handlers(n, block_size_n));
@@ -75,7 +75,7 @@ void BrgemmBlockingBase::mark_k_blocking(const snippets::lowered::LoopManagerPtr
                                          const std::vector<snippets::lowered::LoopPort>& entries,
                                          const std::vector<snippets::lowered::LoopPort>& exits,
                                          size_t block_size_k) {
-    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[0].expr_port);
+    const auto planar_dims = ov::snippets::utils::get_planar_vdims(*entries[0].get_expr_port());
     const auto k = *planar_dims.rbegin();
     const auto id = loop_manager->mark_loop(loop_begin, loop_end, k, block_size_k, entries, exits, false);
     loop_manager->get_loop_info<UnifiedLoopInfo>(id)->set_handlers(get_k_loop_handlers(k, block_size_k));

--- a/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
+++ b/src/common/snippets/src/lowered/pass/brgemm_blocking.cpp
@@ -146,21 +146,21 @@ bool BrgemmBlockingBase::mark_blocking_loops(snippets::lowered::LinearIR& linear
 
     const auto& loop_manager = linear_ir.get_loop_manager();
     if (!ov::snippets::utils::is_full_dim_value(k_block)) {
-        const std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), 0),
-                                            LoopPort(brgemm_expr->get_input_port(1), 1)};
-        const std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)};
+        const std::vector<LoopPort> entries{LoopPort::create(brgemm_expr->get_input_port(0), 0),
+                                            LoopPort::create(brgemm_expr->get_input_port(1), 1)};
+        const std::vector<LoopPort> exits{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_output_port(0))};
         mark_k_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, k_block);
     }
     if (!ov::snippets::utils::is_full_dim_value(n_block)) {
-        const std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed),
-                                            LoopPort(brgemm_expr->get_input_port(1))};
-        const std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0))};
+        const std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(0)),
+                                            LoopPort::create(brgemm_expr->get_input_port(1))};
+        const std::vector<LoopPort> exits{LoopPort::create(brgemm_expr->get_output_port(0))};
         mark_n_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, n_block);
     }
     if (!ov::snippets::utils::is_full_dim_value(m_block)) {
-        const std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), 1),
-                                            LoopPort(brgemm_expr->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)};
-        const std::vector<LoopPort> exits{LoopPort(brgemm_expr->get_output_port(0), 1)};
+        const std::vector<LoopPort> entries{LoopPort::create(brgemm_expr->get_input_port(0), 1),
+                                            LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(1))};
+        const std::vector<LoopPort> exits{LoopPort::create(brgemm_expr->get_output_port(0), 1)};
         mark_m_blocking(loop_manager, brgemm_it, std::next(brgemm_it), entries, exits, m_block);
     }
     return true;

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -96,10 +96,10 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     size_t loop_port_idx = 0;
     loop_info->iterate_through_infos([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
-        if (resetting_data_indexes.count(loop_port_idx)) {
+        if (resetting_data_indexes.count(loop_port_idx) && loop_port.get_type() != LoopPort::Type::NotProcessed) {
             shifts.ptr_increment = 0;
             shifts.finalization_offset = 0;
-            loop_port.set_is_incremented(false);
+            loop_port.set_type(LoopPort::Type::NotIncremented);
         }
         ++loop_port_idx;
     });

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -96,10 +96,10 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
     const auto loop_info = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_end->get_id());
     size_t loop_port_idx = 0;
     loop_info->iterate_through_infos([&resetting_data_indexes, &loop_port_idx](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& shifts) {
-        if (resetting_data_indexes.count(loop_port_idx) && loop_port.get_type() != LoopPort::Type::NotProcessed) {
+        if (resetting_data_indexes.count(loop_port_idx) && loop_port.is_processed()) {
             shifts.ptr_increment = 0;
             shifts.finalization_offset = 0;
-            loop_port.set_type(LoopPort::Type::NotIncremented);
+            loop_port.convert_to_type<LoopPort::Type::NotIncremented>();
         }
         ++loop_port_idx;
     });

--- a/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
+++ b/src/common/snippets/src/lowered/pass/clean_repeated_ptr_shifts.cpp
@@ -99,7 +99,7 @@ bool CleanRepeatedDataPointerShifts::reuse_increments(const LoopManagerPtr& loop
         if (resetting_data_indexes.count(loop_port_idx)) {
             shifts.ptr_increment = 0;
             shifts.finalization_offset = 0;
-            loop_port.is_incremented = false;
+            loop_port.set_is_incremented(false);
         }
         ++loop_port_idx;
     });

--- a/src/common/snippets/src/lowered/pass/define_buffer_clusters.cpp
+++ b/src/common/snippets/src/lowered/pass/define_buffer_clusters.cpp
@@ -134,8 +134,8 @@ void DefineBufferClusters::parse_loop(const LoopManagerPtr& loop_manager, const 
             const auto out_path = MarkInvariantShapePath::getInvariantPortShapePath(*output_buffer_port_info.port.get_expr_port());
             //  - Memory can be reused if there are the same loop pointer increments (data size, final offsets, ptr increments).
             //    For that, loop ports with buffers should be on the same shape-path and have the same value of `is_incremented`.
-            const auto in_is_incremented = input_buffer_port_info.port.get_type() == LoopPort::Type::Incremented;
-            const auto out_is_incremented = output_buffer_port_info.port.get_type() == LoopPort::Type::Incremented;
+            const auto in_is_incremented = input_buffer_port_info.port.is_incremented();
+            const auto out_is_incremented = output_buffer_port_info.port.is_incremented();
             if (in_path != out_path || in_is_incremented != out_is_incremented)
                 continue;
 
@@ -176,8 +176,7 @@ void DefineBufferClusters::parse_nested_loops(const LoopManagerPtr& loop_manager
     auto can_be_data_ptr_proportionally_shifted = [](const LoopPortInfo& outer_port_info, const LoopPortInfo& inner_port_info) {
         // Outer Buffer ptr should be shifted to emulate "window" sliding
         const auto& outer_desc = outer_port_info.desc;
-        if (outer_port_info.port.get_type() != LoopPort::Type::Incremented ||
-            (!utils::is_dynamic_value(outer_desc.ptr_increment) && outer_desc.ptr_increment == 0))
+        if (!outer_port_info.port.is_incremented() || (!utils::is_dynamic_value(outer_desc.ptr_increment) && outer_desc.ptr_increment == 0))
             return false;
 
         OPENVINO_ASSERT(inner_port_info.port.get_expr_port() && outer_port_info.port.get_expr_port(), "Expression ports are nullptr!");

--- a/src/common/snippets/src/lowered/pass/define_buffer_clusters.cpp
+++ b/src/common/snippets/src/lowered/pass/define_buffer_clusters.cpp
@@ -74,7 +74,7 @@ std::pair<DefineBufferClusters::BufferMap, DefineBufferClusters::BufferMap> Defi
     BufferMap input_buffers;
     const auto& loop_inputs = loop_info->get_input_ports_info();
     for (const auto& port_info : loop_inputs) {
-        const auto& buffer_expr = ov::as_type_ptr<BufferExpression>(port_info.port.expr_port->get_port_connector_ptr()->get_source().get_expr());
+        const auto& buffer_expr = ov::as_type_ptr<BufferExpression>(port_info.port.get_expr_port()->get_port_connector_ptr()->get_source().get_expr());
         if (!is_direct_buffer(buffer_expr, loop_expr))
             continue;
         if (input_buffers.count(buffer_expr) > 0) {
@@ -89,7 +89,7 @@ std::pair<DefineBufferClusters::BufferMap, DefineBufferClusters::BufferMap> Defi
     BufferMap output_buffers;
     const auto& loop_outputs = loop_info->get_output_ports_info();
     for (const auto& port_info : loop_outputs) {
-        const auto& consumer_inputs = port_info.port.expr_port->get_port_connector_ptr()->get_consumers();
+        const auto& consumer_inputs = port_info.port.get_expr_port()->get_port_connector_ptr()->get_consumers();
         for (const auto& consumer_input : consumer_inputs) {
             const auto& buffer_expr = ov::as_type_ptr<BufferExpression>(consumer_input.get_expr());
             if (!is_direct_buffer(buffer_expr, loop_expr))
@@ -130,11 +130,11 @@ void DefineBufferClusters::parse_loop(const LoopManagerPtr& loop_manager, const 
             if ((input_buffer_expr->get_data_type().size() < output_buffer_expr->get_data_type().size()))
                 continue;
 
-            const auto in_path = MarkInvariantShapePath::getInvariantPortShapePath(*input_buffer_port_info.port.expr_port);
-            const auto out_path = MarkInvariantShapePath::getInvariantPortShapePath(*output_buffer_port_info.port.expr_port);
+            const auto in_path = MarkInvariantShapePath::getInvariantPortShapePath(*input_buffer_port_info.port.get_expr_port());
+            const auto out_path = MarkInvariantShapePath::getInvariantPortShapePath(*output_buffer_port_info.port.get_expr_port());
             //  - Memory can be reused if there are the same loop pointer increments (data size, final offsets, ptr increments).
             //    For that, loop ports with buffers should be on the same shape-path and have the same value of `is_incremented`.
-            if (in_path != out_path || input_buffer_port_info.port.is_incremented != output_buffer_port_info.port.is_incremented)
+            if (in_path != out_path || input_buffer_port_info.port.is_incremented() != output_buffer_port_info.port.is_incremented())
                 continue;
 
             //  - Memory can be shared if Buffer has the same allocation size.
@@ -174,13 +174,13 @@ void DefineBufferClusters::parse_nested_loops(const LoopManagerPtr& loop_manager
     auto can_be_data_ptr_proportionally_shifted = [](const LoopPortInfo& outer_port_info, const LoopPortInfo& inner_port_info) {
         // Outer Buffer ptr should be shifted to emulate "window" sliding
         const auto& outer_desc = outer_port_info.desc;
-        if (!outer_port_info.port.is_incremented || (!utils::is_dynamic_value(outer_desc.ptr_increment) && outer_desc.ptr_increment == 0))
+        if (!outer_port_info.port.is_incremented() || (!utils::is_dynamic_value(outer_desc.ptr_increment) && outer_desc.ptr_increment == 0))
             return false;
 
-        OPENVINO_ASSERT(inner_port_info.port.expr_port && outer_port_info.port.expr_port, "Expression ports are nullptr!");
+        OPENVINO_ASSERT(inner_port_info.port.get_expr_port() && outer_port_info.port.get_expr_port(), "Expression ports are nullptr!");
         // we can be sure that these data pointers will be proportionally shifted if they're on the same invariant shape path
-        return MarkInvariantShapePath::getInvariantPortShapePath(*inner_port_info.port.expr_port) ==
-               MarkInvariantShapePath::getInvariantPortShapePath(*outer_port_info.port.expr_port);
+        return MarkInvariantShapePath::getInvariantPortShapePath(*inner_port_info.port.get_expr_port()) ==
+               MarkInvariantShapePath::getInvariantPortShapePath(*outer_port_info.port.get_expr_port());
     };
 
     const auto outer_loop_begin = ov::as_type_ptr<op::LoopEnd>(outer_loop_end_expr_it->get()->get_node())->get_loop_begin();
@@ -242,7 +242,7 @@ bool DefineBufferClusters::init_buffer_last_loop_port_info(const LoopManagerPtr&
         const auto consumers = buffer_out->get_consumers();
         for (const auto& consumer : consumers) {
             if (const auto& direct_loop = get_direct_loop_for_buffer_out(buffer_expr, consumer.get_expr())) {
-                const auto loop_order = direct_loop->get_output_ports().back().expr_port->get_expr()->get_exec_num();
+                const auto loop_order = direct_loop->get_output_ports().back().get_expr_port()->get_expr()->get_exec_num();
                 if (loop_order > last_loop_exec_order) {
                     OPENVINO_ASSERT(direct_loop->is_loop_port(consumer), "Consumer of Buffer from another loop must be loop port");
                     port_info = direct_loop->get_loop_port_info(consumer);

--- a/src/common/snippets/src/lowered/pass/extract_loop_invariants.cpp
+++ b/src/common/snippets/src/lowered/pass/extract_loop_invariants.cpp
@@ -24,8 +24,8 @@ std::vector<size_t> get_reordered_loop_ids(const LoopManagerPtr& loop_manager) {
         loop_ids_need_extract.push_back(p.first);
 
     auto sorter = [&](size_t lhs, size_t rhs) {
-        const auto lhs_last_expr = loop_manager->get_loop_info(lhs)->get_output_ports().back().expr_port->get_expr();
-        const auto rhs_last_expr = loop_manager->get_loop_info(rhs)->get_output_ports().back().expr_port->get_expr();
+        const auto lhs_last_expr = loop_manager->get_loop_info(lhs)->get_output_ports().back().get_expr_port()->get_expr();
+        const auto rhs_last_expr = loop_manager->get_loop_info(rhs)->get_output_ports().back().get_expr_port()->get_expr();
         // If last output loop ports are the same expressions - first executive Loop has inner ID in expression loop IDs.
         if (lhs_last_expr == rhs_last_expr) {
             for (const auto& id : lhs_last_expr->get_loop_ids()) {
@@ -50,9 +50,9 @@ void remove_last_loop_id(const std::shared_ptr<Expression>& expr) {
 }
 
 int64_t get_stride_after_move_outer(const LoopPort& loop_port) {
-    const auto& expr_port = loop_port.expr_port;
+    const auto& expr_port = loop_port.get_expr_port();
     const auto& shape = expr_port->get_descriptor_ptr()->get_shape();
-    size_t shape_dim_idx = utils::get_dim_idx(*expr_port, loop_port.dim_idx);
+    size_t shape_dim_idx = utils::get_dim_idx(*expr_port, loop_port.get_dim_idx());
     int64_t stride = utils::get_stride(shape_dim_idx, shape);
     if (utils::is_dynamic_value(stride) || utils::is_dynamic_value(shape[shape_dim_idx])) {
         return utils::get_dynamic_value<int64_t>();
@@ -150,7 +150,7 @@ std::vector<ExpressionPtr> get_loop_input_exprs(const std::vector<LoopPort>& loo
     std::vector<ExpressionPtr> input_exprs;
     std::unordered_set<ExpressionPtr> seen_exprs;
     for (size_t port_num = 0; port_num < loop_in_ports.size(); ++port_num) {
-        const auto& expr = loop_in_ports[port_num].expr_port->get_expr();
+        const auto& expr = loop_in_ports[port_num].get_expr_port()->get_expr();
         if (seen_exprs.count(expr) == 0) {
             input_exprs.push_back(expr);
             seen_exprs.insert(expr);

--- a/src/common/snippets/src/lowered/pass/extract_loop_invariants.cpp
+++ b/src/common/snippets/src/lowered/pass/extract_loop_invariants.cpp
@@ -89,7 +89,7 @@ bool is_extraction_applicable(const ExpressionPtr& expr, const UnifiedLoopInfoPt
         if (is_loop_port) {
             // stride is not 1 after move to outside, then should not extract.
             const auto& loop_port = inner_loop_info->get_loop_port(expr_input_ports[i]);
-            if (get_stride_after_move_outer(loop_port) != 1) {
+            if (loop_port.get_type() == LoopPort::Type::NotProcessed || get_stride_after_move_outer(loop_port) != 1) {
                 return false;
             }
         }

--- a/src/common/snippets/src/lowered/pass/extract_loop_invariants.cpp
+++ b/src/common/snippets/src/lowered/pass/extract_loop_invariants.cpp
@@ -89,7 +89,7 @@ bool is_extraction_applicable(const ExpressionPtr& expr, const UnifiedLoopInfoPt
         if (is_loop_port) {
             // stride is not 1 after move to outside, then should not extract.
             const auto& loop_port = inner_loop_info->get_loop_port(expr_input_ports[i]);
-            if (loop_port.get_type() == LoopPort::Type::NotProcessed || get_stride_after_move_outer(loop_port) != 1) {
+            if (!loop_port.is_processed() || get_stride_after_move_outer(loop_port) != 1) {
                 return false;
             }
         }

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -26,18 +26,18 @@ bool FuseLoops::loop_ports_are_compatible(const LoopInfoPtr& loop_upper,
                                           const LoopInfoPtr& loop_lower) {
     auto found_port = [](const std::vector<LoopPort>& loop_ports, const ExpressionPort& target_port) {
         return std::find_if(loop_ports.cbegin(), loop_ports.cend(),
-                            [&target_port](const LoopPort& loop_port) {return *(loop_port.expr_port.get()) == target_port; });
+                            [&target_port](const LoopPort& loop_port) {return *(loop_port.get_expr_port().get()) == target_port; });
     };
     const auto& upper_exit_ports = loop_upper->get_output_ports();
     const auto& lower_entry_ports = loop_lower->get_input_ports();
     for (const auto& lower_entry_port : lower_entry_ports) {
-        const auto& src_port = lower_entry_port.expr_port->get_port_connector_ptr()->get_source();
+        const auto& src_port = lower_entry_port.get_expr_port()->get_port_connector_ptr()->get_source();
         const auto upper_exit_port_it = found_port(upper_exit_ports, src_port);
         if (upper_exit_port_it != upper_exit_ports.cend()) {
             const auto& upper_exit_port = *upper_exit_port_it;
-            if (!lower_entry_port.is_incremented || !upper_exit_port.is_incremented)
+            if (!lower_entry_port.is_incremented() || !upper_exit_port.is_incremented())
                 return false;
-            if (lower_entry_port.dim_idx != upper_exit_port.dim_idx)
+            if (lower_entry_port.get_dim_idx() != upper_exit_port.get_dim_idx())
                 return false;
         }
     }
@@ -113,7 +113,7 @@ bool FuseLoops::fuse_upper_into_current(LinearIR& linear_ir, const LoopManagerPt
     bool is_fusion_allowed = true;
     for (size_t i = 0; i < loop_target->get_output_ports().size() && is_fusion_allowed; ++i) {
         const auto target_output_port = loop_target->get_output_ports()[i];
-        const auto consumer_inputs = target_output_port.expr_port->get_connected_ports();
+        const auto consumer_inputs = target_output_port.get_expr_port()->get_connected_ports();
         for (const auto& consumer_input : consumer_inputs) {
             const auto& consumer = consumer_input.get_expr();
             if (ov::is_type<ov::op::v0::Result>(consumer->get_node()) || consumer == current_input_port->get_expr())
@@ -157,7 +157,7 @@ bool FuseLoops::fuse_lower_into_current(LinearIR& linear_ir, const LoopManagerPt
     bool is_fusion_allowed = true;
     for (size_t i = 0; i < loop_target->get_input_ports().size() && is_fusion_allowed; ++i) {
         const auto target_entry_port = loop_target->get_input_ports()[i];
-        const auto parent_expr_output = *target_entry_port.expr_port->get_connected_ports().begin();
+        const auto parent_expr_output = *target_entry_port.get_expr_port()->get_connected_ports().begin();
         const auto& parent_expr = parent_expr_output.get_expr();
         if (ov::is_type<ov::op::v0::Parameter>(parent_expr->get_node()) || parent_expr == current_output_port->get_expr())
             continue;
@@ -221,7 +221,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                 bool was_fusion_up = false;
                 for (size_t in_port = 0; !was_fusion_up && in_port < input_ports.size(); ++in_port) {
                     const auto& input_port = input_ports[in_port];
-                    const auto parent_expr_output = *input_port.expr_port->get_connected_ports().begin();
+                    const auto parent_expr_output = *input_port.get_expr_port()->get_connected_ports().begin();
                     const auto& parent_expr = parent_expr_output.get_expr();
                     const auto parent = parent_expr->get_node();
                     if (ov::is_type<ov::op::v0::Constant>(parent) ||
@@ -247,7 +247,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                     const auto upper_loop_id = upper_loop_ids[loop_idx];
                     OPENVINO_ASSERT(current_loop_id != upper_loop_id,
                                     "Loops cannot have parents of input ports with the same identifier (", upper_loop_id, ")");
-                    if (fuse_upper_into_current(linear_ir, loop_manager, input_port.expr_port, current_loop_id, upper_loop_id,
+                    if (fuse_upper_into_current(linear_ir, loop_manager, input_port.get_expr_port(), current_loop_id, upper_loop_id,
                                                 current_loop_begin_pos, current_loop_end_pos)) {
                         was_fusion_up = true;
                         prev_fused_loops.insert(current_loop_id);
@@ -266,7 +266,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                 const auto& output_ports = current_loop_info->get_output_ports();
                 for (size_t out_port = 0; !was_fusion_down && out_port < output_ports.size(); ++out_port) {
                     const auto& output_port = output_ports[out_port];
-                    const auto consumer_exprs_inputs = output_port.expr_port->get_connected_ports();
+                    const auto consumer_exprs_inputs = output_port.get_expr_port()->get_connected_ports();
                     for (const auto& consumer_expr_input : consumer_exprs_inputs) {
                         const auto& consumer_expr = consumer_expr_input.get_expr();
                         const auto consumer = consumer_expr->get_node();
@@ -294,7 +294,7 @@ bool FuseLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, l
                         if (current_loop_id == lower_loop_id)
                             continue;
 
-                        if (fuse_lower_into_current(linear_ir, loop_manager, output_port.expr_port, current_loop_id, lower_loop_id,
+                        if (fuse_lower_into_current(linear_ir, loop_manager, output_port.get_expr_port(), current_loop_id, lower_loop_id,
                                                     current_loop_begin_pos, current_loop_end_pos)) {
                             was_fusion_down = true;
                             prev_fused_loops.insert(current_loop_id);

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -35,7 +35,7 @@ bool FuseLoops::loop_ports_are_compatible(const LoopInfoPtr& loop_upper,
         const auto upper_exit_port_it = found_port(upper_exit_ports, src_port);
         if (upper_exit_port_it != upper_exit_ports.cend()) {
             const auto& upper_exit_port = *upper_exit_port_it;
-            if (!lower_entry_port.is_incremented() || !upper_exit_port.is_incremented())
+            if (!utils::everyone_is(LoopPort::Type::Incremented, lower_entry_port.get_type(), upper_exit_port.get_type()))
                 return false;
             if (lower_entry_port.get_dim_idx() != upper_exit_port.get_dim_idx())
                 return false;

--- a/src/common/snippets/src/lowered/pass/fuse_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/fuse_loops.cpp
@@ -35,7 +35,7 @@ bool FuseLoops::loop_ports_are_compatible(const LoopInfoPtr& loop_upper,
         const auto upper_exit_port_it = found_port(upper_exit_ports, src_port);
         if (upper_exit_port_it != upper_exit_ports.cend()) {
             const auto& upper_exit_port = *upper_exit_port_it;
-            if (!utils::everyone_is(LoopPort::Type::Incremented, lower_entry_port.get_type(), upper_exit_port.get_type()))
+            if (!lower_entry_port.is_incremented() || !upper_exit_port.is_incremented())
                 return false;
             if (lower_entry_port.get_dim_idx() != upper_exit_port.get_dim_idx())
                 return false;

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -17,14 +17,14 @@ namespace pass {
 
 namespace {
 inline void init_is_incremented(LoopPort& port) {
-    const auto& expr = port.expr_port->get_expr();
+    const auto& expr = port.get_expr_port()->get_expr();
     if (!std::dynamic_pointer_cast<modifier::MemoryAccess>(expr->get_node())) {
-        port.is_incremented = false;
+        port.set_is_incremented(false);
     }
 }
 
 inline int64_t get_data_size(const LoopPort& loop_port) {
-    const auto& expr_port = loop_port.expr_port;
+    const auto& expr_port = loop_port.get_expr_port();
     if (expr_port->get_type() == ExpressionPort::Input) {
         return static_cast<int64_t>(expr_port->get_expr()->get_node()->get_input_element_type(expr_port->get_index()).size());
     } else if (expr_port->get_type() == ExpressionPort::Output) {

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -19,7 +19,7 @@ namespace {
 inline void init_is_incremented(LoopPort& port) {
     const auto& expr = port.get_expr_port()->get_expr();
     if (!std::dynamic_pointer_cast<modifier::MemoryAccess>(expr->get_node())) {
-        port.set_is_incremented(false);
+        port.set_type(LoopPort::Type::NotIncremented);
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/init_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/init_loops.cpp
@@ -19,7 +19,7 @@ namespace {
 inline void init_is_incremented(LoopPort& port) {
     const auto& expr = port.get_expr_port()->get_expr();
     if (!std::dynamic_pointer_cast<modifier::MemoryAccess>(expr->get_node())) {
-        port.set_type(LoopPort::Type::NotIncremented);
+        port.convert_to_type<LoopPort::Type::NotIncremented>();
     }
 }
 

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -72,12 +72,11 @@ void InsertBuffers::insertion(LinearIR& linear_ir,
                               const LinearIR::constExprIt& begin_it,
                               const LinearIR::constExprIt& end_it,
                               const LoopManagerPtr& loop_manager,
-                              const std::vector<LoopPort>& loop_entries,
-                              const std::vector<LoopPort>& loop_exits) const {
-    for (const auto& input_port : loop_entries) {
-        const auto& entry_port = input_port.get_expr_port();
-        const auto& expr = entry_port->get_expr();
-        const auto port_idx = entry_port->get_index();
+                              const std::vector<ExpressionPort>& loop_entries,
+                              const std::vector<ExpressionPort>& loop_exits) const {
+    for (const auto& entry_port : loop_entries) {
+        const auto& expr = entry_port.get_expr();
+        const auto port_idx = entry_port.get_index();
         const auto node = expr->get_node();
         auto parent_expr_output = expr->get_input_port_connector(port_idx)->get_source();
         auto parent_expr = parent_expr_output.get_expr();
@@ -116,17 +115,16 @@ void InsertBuffers::insertion(LinearIR& linear_ir,
             //          Need to insert between 2nd and 4th Loops - after 2nd Loop
             const auto pos = insertion_position(linear_ir, loop_manager, parent_expr, expr);
             const auto buffer = std::make_shared<op::Buffer>(parent->output(parent_port));
-            const auto buffer_consumer = has_shape_infer_parent ? top_shape_infer_expr->get_input_port(0)  : *entry_port;
+            const auto buffer_consumer = has_shape_infer_parent ? top_shape_infer_expr->get_input_port(0)  : entry_port;
             linear_ir.insert_node(buffer, std::vector<ExpressionPort>{ parent_expr_output }, buffer_loop_ids, false, pos, { buffer_consumer  });
         }
     }
 
-    for (const auto& output_port : loop_exits) {
-        const auto& exit_port = output_port.get_expr_port();
-        const auto& expr = exit_port->get_expr();
-        const auto port_idx = exit_port->get_index();
+    for (const auto& exit_port : loop_exits) {
+        const auto& expr = exit_port.get_expr();
+        const auto port_idx = exit_port.get_index();
         const auto node = expr->get_node();
-        const auto output_connector = exit_port->get_port_connector_ptr();
+        const auto output_connector = exit_port.get_port_connector_ptr();
         const auto child_exprs_inputs = output_connector->get_consumers();
         const auto& current_loops = expr->get_loop_ids();
 
@@ -200,7 +198,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir,
             //             |    <- It should be new PortConnector
             //            Relu
             // Output port connector is automatically filled from PortDescriptor
-            linear_ir.insert_node(buffer, std::vector<ExpressionPort>{ *exit_port }, buffer_loop_ids, false, pos, { potential_consumers });
+            linear_ir.insert_node(buffer, std::vector<ExpressionPort>{ exit_port }, buffer_loop_ids, false, pos, { potential_consumers });
         }
     }
 }
@@ -213,8 +211,15 @@ bool InsertBuffers::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begi
         const auto loop_info = loop_data.second;
         const auto loop_entries = loop_info->get_input_ports();
         const auto loop_exits = loop_info->get_output_ports();
+
+        auto cvt_to_expr_ports = [](const std::vector<LoopPort>& loop_ports) {
+            std::vector<ExpressionPort> expr_ports(loop_ports.size());
+            std::transform(loop_ports.cbegin(), loop_ports.cend(), expr_ports.begin(),
+                           [](const LoopPort& loop_port) { return *loop_port.get_expr_port(); });
+            return expr_ports;
+        };
         // using begin() as expr_it because we work with LoopInfo, not expressions in Linear IR
-        insertion(linear_ir, begin, end, loop_manager, loop_entries, loop_exits);
+        insertion(linear_ir, begin, end, loop_manager, cvt_to_expr_ports(loop_entries), cvt_to_expr_ports(loop_exits));
     }
 
     for (auto expr_it = begin; expr_it != end; expr_it++) {
@@ -226,12 +231,12 @@ bool InsertBuffers::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begi
 
         const auto input_ports = ma->get_memory_access_input_ports();
         const auto output_ports = ma->get_memory_access_output_ports();
-        std::vector<LoopPort> loop_entries(input_ports.size()), loop_exits(output_ports.size());
+        std::vector<ExpressionPort> loop_entries(input_ports.size()), loop_exits(output_ports.size());
         for (const auto& p : input_ports) {
-            loop_entries[p.first] = LoopPort::create(expr->get_input_port(p.first));
+            loop_entries[p.first] = expr->get_input_port(p.first);
         }
         for (const auto& p : output_ports) {
-            loop_exits[p.first] = LoopPort::create(expr->get_output_port(p.first));
+            loop_exits[p.first] = expr->get_output_port(p.first);
         }
 
         insertion(linear_ir, expr_it, end, loop_manager, loop_entries, loop_exits);

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -228,10 +228,10 @@ bool InsertBuffers::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begi
         const auto output_ports = ma->get_memory_access_output_ports();
         std::vector<LoopPort> loop_entries(input_ports.size()), loop_exits(output_ports.size());
         for (const auto& p : input_ports) {
-            loop_entries[p.first] = expr->get_input_port(p.first);
+            loop_entries[p.first] = LoopPort::create(expr->get_input_port(p.first));
         }
         for (const auto& p : output_ports) {
-            loop_exits[p.first] = expr->get_output_port(p.first);
+            loop_exits[p.first] = LoopPort::create(expr->get_output_port(p.first));
         }
 
         insertion(linear_ir, expr_it, end, loop_manager, loop_entries, loop_exits);

--- a/src/common/snippets/src/lowered/pass/insert_buffers.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_buffers.cpp
@@ -75,7 +75,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir,
                               const std::vector<LoopPort>& loop_entries,
                               const std::vector<LoopPort>& loop_exits) const {
     for (const auto& input_port : loop_entries) {
-        const auto& entry_port = input_port.expr_port;
+        const auto& entry_port = input_port.get_expr_port();
         const auto& expr = entry_port->get_expr();
         const auto port_idx = entry_port->get_index();
         const auto node = expr->get_node();
@@ -122,7 +122,7 @@ void InsertBuffers::insertion(LinearIR& linear_ir,
     }
 
     for (const auto& output_port : loop_exits) {
-        const auto& exit_port = output_port.expr_port;
+        const auto& exit_port = output_port.get_expr_port();
         const auto& expr = exit_port->get_expr();
         const auto port_idx = exit_port->get_index();
         const auto node = expr->get_node();

--- a/src/common/snippets/src/lowered/pass/insert_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_loops.cpp
@@ -25,7 +25,7 @@ void InsertLoops::insertion(LinearIR& linear_ir, const LoopManagerPtr& loop_mana
     std::vector<PortConnectorPtr> loop_end_inputs;
     loop_end_inputs.reserve(in_num + out_num);
     loop_info->iterate_through_ports([&loop_end_inputs](const LoopPort& port) {
-        loop_end_inputs.push_back(port.expr_port->get_port_connector_ptr());
+        loop_end_inputs.push_back(port.get_expr_port()->get_port_connector_ptr());
     });
 
     const auto is_incremented = loop_info->get_is_incremented();

--- a/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_specific_iterations.cpp
@@ -131,7 +131,7 @@ LoopManager::LoopBounds InsertSpecificIterations::insert_copy_loop(LinearIR& lin
         new_ports.resize(ports.size());
         for (size_t i = 0; i < ports.size(); ++i) {
             const auto& port = ports[i];
-            new_ports[i] = *port.clone_with_new_expr(expression_map[port.expr_port->get_expr().get()]);
+            new_ports[i] = *port.clone_with_new_expr(expression_map[port.get_expr_port()->get_expr().get()]);
         }
     };
     const auto original_loop_info = loop_manager->get_loop_info(loop_id);

--- a/src/common/snippets/src/lowered/pass/mha_parallel_wa_optimizer.cpp
+++ b/src/common/snippets/src/lowered/pass/mha_parallel_wa_optimizer.cpp
@@ -105,7 +105,7 @@ std::unordered_set<lowered::ExpressionPtr> MHAParallelWAOptimizer::find_applicab
             return false;
         bool loop_by_m = true;
         outermost_loop->iterate_through_ports([&loop_by_m](const lowered::LoopPort& port) {
-            if (port.get_type() != LoopPort::Type::NotProcessed && port.get_dim_idx() != m_dim_M_idx)
+            if (port.is_processed() && port.get_dim_idx() != m_dim_M_idx)
                 loop_by_m = false;
         });
         return loop_by_m;

--- a/src/common/snippets/src/lowered/pass/mha_parallel_wa_optimizer.cpp
+++ b/src/common/snippets/src/lowered/pass/mha_parallel_wa_optimizer.cpp
@@ -105,7 +105,7 @@ std::unordered_set<lowered::ExpressionPtr> MHAParallelWAOptimizer::find_applicab
             return false;
         bool loop_by_m = true;
         outermost_loop->iterate_through_ports([&loop_by_m](const lowered::LoopPort& port) {
-            if (port.is_incremented && port.dim_idx != m_dim_M_idx)
+            if (port.is_incremented() && port.get_dim_idx() != m_dim_M_idx)
                 loop_by_m = false;
         });
         return loop_by_m;

--- a/src/common/snippets/src/lowered/pass/mha_parallel_wa_optimizer.cpp
+++ b/src/common/snippets/src/lowered/pass/mha_parallel_wa_optimizer.cpp
@@ -105,7 +105,7 @@ std::unordered_set<lowered::ExpressionPtr> MHAParallelWAOptimizer::find_applicab
             return false;
         bool loop_by_m = true;
         outermost_loop->iterate_through_ports([&loop_by_m](const lowered::LoopPort& port) {
-            if (port.is_incremented() && port.get_dim_idx() != m_dim_M_idx)
+            if (port.get_type() != LoopPort::Type::NotProcessed && port.get_dim_idx() != m_dim_M_idx)
                 loop_by_m = false;
         });
         return loop_by_m;

--- a/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
+++ b/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
@@ -56,7 +56,7 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
     // First step: set new dim value to the corresponding input_ports' dimensions
     if (most_outer_loop) {
         for (const auto& port : loop_info->get_input_ports()) {
-            if (port.get_type() != LoopPort::Type::NotProcessed) {
+            if (port.is_processed()) {
                 const auto& expr = port.get_expr_port()->get_expr();
                 const auto& desc = port.get_expr_port()->get_descriptor_ptr();
                 auto subtensor = desc->get_subtensor();
@@ -77,7 +77,7 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
     }
 
     auto update_only_dim_idx_with_subtensor_value = [&](const LoopPort& port) {
-        if (port.get_type() != LoopPort::Type::NotProcessed) {
+        if (port.is_processed()) {
             const auto desc = port.get_expr_port()->get_descriptor_ptr();
             const auto expr = port.get_expr_port()->get_expr();
             const auto parent_desc = expr->get_input_port_connector(port.get_expr_port()->get_index())->get_source().get_descriptor_ptr();

--- a/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
+++ b/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
@@ -56,8 +56,7 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
     // First step: set new dim value to the corresponding input_ports' dimensions
     if (most_outer_loop) {
         for (const auto& port : loop_info->get_input_ports()) {
-            const auto& reg_type = port.get_expr_port()->get_descriptor_ptr()->get_reg().type;
-            if ((port.is_incremented() && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
+            if (port.get_type() != LoopPort::Type::NotProcessed) {
                 const auto& expr = port.get_expr_port()->get_expr();
                 const auto& desc = port.get_expr_port()->get_descriptor_ptr();
                 auto subtensor = desc->get_subtensor();
@@ -78,8 +77,7 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
     }
 
     auto update_only_dim_idx_with_subtensor_value = [&](const LoopPort& port) {
-        const auto& reg_type = port.get_expr_port()->get_descriptor_ptr()->get_reg().type;
-        if ((port.is_incremented() && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
+        if (port.get_type() != LoopPort::Type::NotProcessed) {
             const auto desc = port.get_expr_port()->get_descriptor_ptr();
             const auto expr = port.get_expr_port()->get_expr();
             const auto parent_desc = expr->get_input_port_connector(port.get_expr_port()->get_index())->get_source().get_descriptor_ptr();

--- a/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
+++ b/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
@@ -56,42 +56,42 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
     // First step: set new dim value to the corresponding input_ports' dimensions
     if (most_outer_loop) {
         for (const auto& port : loop_info->get_input_ports()) {
-            const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().type;
-            if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
-                const auto& expr = port.expr_port->get_expr();
-                const auto& desc = port.expr_port->get_descriptor_ptr();
+            const auto& reg_type = port.get_expr_port()->get_descriptor_ptr()->get_reg().type;
+            if ((port.is_incremented() && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
+                const auto& expr = port.get_expr_port()->get_expr();
+                const auto& desc = port.get_expr_port()->get_descriptor_ptr();
                 auto subtensor = desc->get_subtensor();
-                if (port.dim_idx < desc->get_subtensor().size()) {
-                    desc->set_subtensor_dim(port.dim_idx, new_dim_value);
+                if (port.get_dim_idx() < desc->get_subtensor().size()) {
+                    desc->set_subtensor_dim(port.get_dim_idx(), new_dim_value);
                 }
 
-                const auto parent_desc = expr->get_input_port_connector(port.expr_port->get_index())->get_source().get_descriptor_ptr();
+                const auto parent_desc = expr->get_input_port_connector(port.get_expr_port()->get_index())->get_source().get_descriptor_ptr();
                 const auto& parent_shape = parent_desc->get_shape();
                 if (original_shapes.find(parent_desc) == original_shapes.end()) {
                     original_shapes[parent_desc] = parent_shape;
                 }
                 auto new_shape = parent_shape;
-                new_shape[*(desc->get_layout().rbegin() + port.dim_idx)] = new_dim_value;
+                new_shape[*(desc->get_layout().rbegin() + port.get_dim_idx())] = new_dim_value;
                 parent_desc->set_shape(new_shape);
             }
         }
     }
 
     auto update_only_dim_idx_with_subtensor_value = [&](const LoopPort& port) {
-        const auto& reg_type = port.expr_port->get_descriptor_ptr()->get_reg().type;
-        if ((port.is_incremented && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
-            const auto desc = port.expr_port->get_descriptor_ptr();
-            const auto expr = port.expr_port->get_expr();
-            const auto parent_desc = expr->get_input_port_connector(port.expr_port->get_index())->get_source().get_descriptor_ptr();
+        const auto& reg_type = port.get_expr_port()->get_descriptor_ptr()->get_reg().type;
+        if ((port.is_incremented() && reg_type == RegType::gpr) || (reg_type == RegType::vec)) {
+            const auto desc = port.get_expr_port()->get_descriptor_ptr();
+            const auto expr = port.get_expr_port()->get_expr();
+            const auto parent_desc = expr->get_input_port_connector(port.get_expr_port()->get_index())->get_source().get_descriptor_ptr();
 
             const auto& parent_shape = parent_desc->get_shape();
             const auto& desc_subtensor = desc->get_subtensor();
-            if (port.dim_idx < desc_subtensor.size()) {
+            if (port.get_dim_idx() < desc_subtensor.size()) {
                 if (original_shapes.find(parent_desc) == original_shapes.end()) {
                     original_shapes[parent_desc] = parent_shape;
                 }
                 auto new_shape = parent_shape;
-                new_shape[*(desc->get_layout().rbegin() + port.dim_idx)] = *(desc_subtensor.rbegin() + port.dim_idx);
+                new_shape[*(desc->get_layout().rbegin() + port.get_dim_idx())] = *(desc_subtensor.rbegin() + port.get_dim_idx());
                 parent_desc->set_shape(new_shape);
             }
         }

--- a/src/common/snippets/src/lowered/pass/set_buffer_reg_group.cpp
+++ b/src/common/snippets/src/lowered/pass/set_buffer_reg_group.cpp
@@ -30,13 +30,13 @@ size_t SetBufferRegGroup::get_buffer_idx(const BufferExpressionPtr& target, cons
 bool SetBufferRegGroup::can_be_in_one_reg_group(const UnifiedLoopInfo::LoopPortInfo& lhs_info,
                                                 const UnifiedLoopInfo::LoopPortInfo& rhs_info) {
     const auto equal_element_type_sizes = lhs_info.desc.data_size == rhs_info.desc.data_size;
-    OPENVINO_ASSERT(lhs_info.port.expr_port && rhs_info.port.expr_port, "Expression ports are nullptr!");
+    OPENVINO_ASSERT(lhs_info.port.get_expr_port() && rhs_info.port.get_expr_port(), "Expression ports are nullptr!");
     const auto equal_invariant_shape_paths =
-        MarkInvariantShapePath::getInvariantPortShapePath(*lhs_info.port.expr_port) ==
-        MarkInvariantShapePath::getInvariantPortShapePath(*rhs_info.port.expr_port);
-    const auto equal_is_incremented = lhs_info.port.is_incremented == rhs_info.port.is_incremented;
+        MarkInvariantShapePath::getInvariantPortShapePath(*lhs_info.port.get_expr_port()) ==
+        MarkInvariantShapePath::getInvariantPortShapePath(*rhs_info.port.get_expr_port());
+    const auto equal_is_incremented = lhs_info.port.is_incremented() == rhs_info.port.is_incremented();
     return equal_invariant_shape_paths && equal_is_incremented &&
-           (equal_element_type_sizes || !lhs_info.port.is_incremented || (lhs_info.desc.ptr_increment == 0 && lhs_info.desc.finalization_offset == 0));
+           (equal_element_type_sizes || !lhs_info.port.is_incremented() || (lhs_info.desc.ptr_increment == 0 && lhs_info.desc.finalization_offset == 0));
 }
 
 bool SetBufferRegGroup::are_adjacent(const BufferMap::value_type& lhs, const BufferMap::value_type& rhs) {
@@ -113,7 +113,7 @@ SetBufferRegGroup::BufferMap SetBufferRegGroup::get_buffer_loop_neighbours(const
 
     const auto& loop_inputs = loop_info->get_input_ports_info();
     for (const auto& port_info : loop_inputs) {
-        const auto& parent_output = port_info.port.expr_port->get_port_connector_ptr()->get_source().get_expr();
+        const auto& parent_output = port_info.port.get_expr_port()->get_port_connector_ptr()->get_source().get_expr();
         if (const auto buffer_expr = ov::as_type_ptr<BufferExpression>(parent_output)) {
             if (buffer_neighbours.count(buffer_expr) > 0) {
                 const auto& port_desc = port_info.desc;
@@ -127,7 +127,7 @@ SetBufferRegGroup::BufferMap SetBufferRegGroup::get_buffer_loop_neighbours(const
 
     const auto& loop_outputs = loop_info->get_output_ports_info();
     for (const auto& port_info : loop_outputs) {
-        const auto& consumer_inputs = port_info.port.expr_port->get_port_connector_ptr()->get_consumers();
+        const auto& consumer_inputs = port_info.port.get_expr_port()->get_port_connector_ptr()->get_consumers();
         for (const auto& consumer_input : consumer_inputs) {
             const auto& child_expr = consumer_input.get_expr();
             if (const auto buffer_expr = ov::as_type_ptr<BufferExpression>(child_expr))

--- a/src/common/snippets/src/lowered/pass/set_buffer_reg_group.cpp
+++ b/src/common/snippets/src/lowered/pass/set_buffer_reg_group.cpp
@@ -34,8 +34,8 @@ bool SetBufferRegGroup::can_be_in_one_reg_group(const UnifiedLoopInfo::LoopPortI
     const auto equal_invariant_shape_paths =
         MarkInvariantShapePath::getInvariantPortShapePath(*lhs_info.port.get_expr_port()) ==
         MarkInvariantShapePath::getInvariantPortShapePath(*rhs_info.port.get_expr_port());
-    const auto lhs_is_incremented = lhs_info.port.get_type() == LoopPort::Type::Incremented;
-    const auto rhs_is_incremented = rhs_info.port.get_type() == LoopPort::Type::Incremented;
+    const auto lhs_is_incremented = lhs_info.port.is_incremented();
+    const auto rhs_is_incremented = rhs_info.port.is_incremented();
     const auto equal_is_incremented = lhs_is_incremented == rhs_is_incremented;
     return equal_invariant_shape_paths && equal_is_incremented &&
            (equal_element_type_sizes || !lhs_is_incremented || (lhs_info.desc.ptr_increment == 0 && lhs_info.desc.finalization_offset == 0));

--- a/src/common/snippets/src/lowered/pass/set_buffer_reg_group.cpp
+++ b/src/common/snippets/src/lowered/pass/set_buffer_reg_group.cpp
@@ -34,9 +34,11 @@ bool SetBufferRegGroup::can_be_in_one_reg_group(const UnifiedLoopInfo::LoopPortI
     const auto equal_invariant_shape_paths =
         MarkInvariantShapePath::getInvariantPortShapePath(*lhs_info.port.get_expr_port()) ==
         MarkInvariantShapePath::getInvariantPortShapePath(*rhs_info.port.get_expr_port());
-    const auto equal_is_incremented = lhs_info.port.is_incremented() == rhs_info.port.is_incremented();
+    const auto lhs_is_incremented = lhs_info.port.get_type() == LoopPort::Type::Incremented;
+    const auto rhs_is_incremented = rhs_info.port.get_type() == LoopPort::Type::Incremented;
+    const auto equal_is_incremented = lhs_is_incremented == rhs_is_incremented;
     return equal_invariant_shape_paths && equal_is_incremented &&
-           (equal_element_type_sizes || !lhs_info.port.is_incremented() || (lhs_info.desc.ptr_increment == 0 && lhs_info.desc.finalization_offset == 0));
+           (equal_element_type_sizes || !lhs_is_incremented || (lhs_info.desc.ptr_increment == 0 && lhs_info.desc.finalization_offset == 0));
 }
 
 bool SetBufferRegGroup::are_adjacent(const BufferMap::value_type& lhs, const BufferMap::value_type& rhs) {

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -47,7 +47,7 @@ bool SplitLoops::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, 
         const auto& loop_id = loop_ids.front();
         const auto loop = loop_manager->get_loop_info<UnifiedLoopInfo>(loop_id);
         for (const auto& input_port : loop->get_input_ports()) {
-            const auto& parent_port = input_port.expr_port->get_port_connector_ptr()->get_source();
+            const auto& parent_port = input_port.get_expr_port()->get_port_connector_ptr()->get_source();
             const auto& parent_expr = parent_port.get_expr();
             const auto& parent_loop_ids = parent_expr->get_loop_ids();
             if (parent_loop_ids.empty())

--- a/src/common/snippets/src/lowered/pass/split_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/split_loops.cpp
@@ -23,7 +23,7 @@ bool SplitLoops::can_be_split(const UnifiedLoopInfoPtr& loop_to_split, const Uni
     const auto current_dim_idx = loop_to_split->get_dim_idx();
     const auto parent_dim_idx = loop_to_fuse->get_dim_idx();
     const auto& handlers = loop_to_split->get_handlers();
-    const bool equal_dim_idxes = current_dim_idx != LoopInfo::UNDEFINED_DIM_IDX && current_dim_idx == parent_dim_idx;
+    const bool equal_dim_idxes = current_dim_idx != LoopPort::UNDEFINED_DIM_IDX && current_dim_idx == parent_dim_idx;
     const bool only_main_body = handlers.get_passes<SpecificLoopIterType::FIRST_ITER>().empty() &&
                                 handlers.get_passes<SpecificLoopIterType::LAST_ITER>().empty();
     return loop_to_split->get_work_amount() == loop_to_fuse->get_work_amount() &&
@@ -141,7 +141,7 @@ bool SplitLoops::TransformInnerSplitLoop::run(LinearIR& linear_ir, LinearIR::con
     const auto& loop_manager = linear_ir.get_loop_manager();
     const auto& outer_loop_info = loop_manager->get_loop_info<ExpandedLoopInfo>(loop_end->get_id());
     const auto current_dim_idx = outer_loop_info->get_dim_idx();
-    OPENVINO_ASSERT(current_dim_idx != LoopInfo::UNDEFINED_DIM_IDX,
+    OPENVINO_ASSERT(current_dim_idx != LoopPort::UNDEFINED_DIM_IDX,
                     "Outer splitted loop unexpectedly iterates by several dimension indices");
 
     bool modified = false;

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -117,7 +117,8 @@ void validate_loop_end(const ExpressionPtr& expr, const LinearIR& linear_ir) {
     const auto& final_offsets = loop_end->get_finalization_offsets();
     auto validate_loop_ports = [&](const std::vector<UnifiedLoopInfo::LoopPortInfo>& loop_port_infos, size_t shift = 0) {
         for (size_t i = 0; i < loop_port_infos.size(); ++i) {
-            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].port.is_incremented() &&
+            const auto is_port_incremented = loop_port_infos[i].port.get_type() == LoopPort::Type::Incremented;
+            OPENVINO_ASSERT(is_incremented[i + shift] == is_port_incremented &&
                             ptr_increments[i + shift] == loop_port_infos[i].desc.ptr_increment &&
                             final_offsets[i + shift] == loop_port_infos[i].desc.finalization_offset,
                             "Incompatible data ptr shifts in LoopEnd and the corresponding LoopInfo");

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -117,8 +117,7 @@ void validate_loop_end(const ExpressionPtr& expr, const LinearIR& linear_ir) {
     const auto& final_offsets = loop_end->get_finalization_offsets();
     auto validate_loop_ports = [&](const std::vector<UnifiedLoopInfo::LoopPortInfo>& loop_port_infos, size_t shift = 0) {
         for (size_t i = 0; i < loop_port_infos.size(); ++i) {
-            const auto is_port_incremented = loop_port_infos[i].port.get_type() == LoopPort::Type::Incremented;
-            OPENVINO_ASSERT(is_incremented[i + shift] == is_port_incremented &&
+            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].port.is_incremented() &&
                             ptr_increments[i + shift] == loop_port_infos[i].desc.ptr_increment &&
                             final_offsets[i + shift] == loop_port_infos[i].desc.finalization_offset,
                             "Incompatible data ptr shifts in LoopEnd and the corresponding LoopInfo");

--- a/src/common/snippets/src/lowered/pass/validate.cpp
+++ b/src/common/snippets/src/lowered/pass/validate.cpp
@@ -117,7 +117,7 @@ void validate_loop_end(const ExpressionPtr& expr, const LinearIR& linear_ir) {
     const auto& final_offsets = loop_end->get_finalization_offsets();
     auto validate_loop_ports = [&](const std::vector<UnifiedLoopInfo::LoopPortInfo>& loop_port_infos, size_t shift = 0) {
         for (size_t i = 0; i < loop_port_infos.size(); ++i) {
-            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].port.is_incremented &&
+            OPENVINO_ASSERT(is_incremented[i + shift] == loop_port_infos[i].port.is_incremented() &&
                             ptr_increments[i + shift] == loop_port_infos[i].desc.ptr_increment &&
                             final_offsets[i + shift] == loop_port_infos[i].desc.finalization_offset,
                             "Incompatible data ptr shifts in LoopEnd and the corresponding LoopInfo");

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -68,7 +68,7 @@ void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manage
         // Validate that iteration dimnsion is broadcastable
         std::set<size_t> unique_dimensions;
         loop_info->iterate_through_ports([&unique_dimensions](const LoopPort& loop_port) {
-            if (loop_port.is_incremented()) {
+            if (loop_port.get_type() != LoopPort::Type::NotProcessed) {
                 const auto is_input = loop_port.get_expr_port()->get_type() == ExpressionPort::Input;
                 const auto planar_shape = is_input ? ov::snippets::utils::get_planar_vdims(*loop_port.get_expr_port())
                                                    : ov::snippets::utils::get_preordered_vdims(*loop_port.get_expr_port());

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -32,7 +32,7 @@ void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manage
     std::vector<size_t> dim_indexes;
 
     auto validate_loop_port = [&loop_manager, &dim_indexes, &validated_nested_loops, &is_already_verified](const LoopPort& loop_port) {
-        const auto expr = loop_port.expr_port->get_expr();
+        const auto expr = loop_port.get_expr_port()->get_expr();
         const auto& loop_ids = expr->get_loop_ids();
         // If loop_ids of the current port is subsequence of already validated IDs, skip
         if (is_already_verified(loop_ids))
@@ -68,11 +68,11 @@ void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manage
         // Validate that iteration dimnsion is broadcastable
         std::set<size_t> unique_dimensions;
         loop_info->iterate_through_ports([&unique_dimensions](const LoopPort& loop_port) {
-            if (loop_port.is_incremented) {
-                const auto is_input = loop_port.expr_port->get_type() == ExpressionPort::Input;
-                const auto planar_shape = is_input ? ov::snippets::utils::get_planar_vdims(*loop_port.expr_port)
-                                                   : ov::snippets::utils::get_preordered_vdims(*loop_port.expr_port);
-                const auto& dim = *(planar_shape.rbegin() + loop_port.dim_idx);
+            if (loop_port.is_incremented()) {
+                const auto is_input = loop_port.get_expr_port()->get_type() == ExpressionPort::Input;
+                const auto planar_shape = is_input ? ov::snippets::utils::get_planar_vdims(*loop_port.get_expr_port())
+                                                   : ov::snippets::utils::get_preordered_vdims(*loop_port.get_expr_port());
+                const auto& dim = *(planar_shape.rbegin() + loop_port.get_dim_idx());
                 // Since dim == 1 can be broadcasted to any value, it's not necessary to add it to unique dims
                 if (!utils::is_dynamic_value(dim) && dim != 1)
                     unique_dimensions.insert(dim);

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -45,7 +45,7 @@ void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manage
             const auto id = loop_ids[i];
             const auto dim_idx = loop_manager->get_loop_info(id)->get_dim_idx();
             // if the loop has different dimension indexes, it don't have to meet the split loop related requirements
-            if (dim_idx == LoopInfo::UNDEFINED_DIM_IDX)
+            if (dim_idx == LoopPort::UNDEFINED_DIM_IDX)
                 continue;
             if (i > 0) {
                 if (std::find(dim_indexes.cbegin(), dim_indexes.cend(), dim_idx) != dim_indexes.cend()) {

--- a/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
+++ b/src/common/snippets/src/lowered/pass/validate_unified_loops.cpp
@@ -65,10 +65,10 @@ void ValidateUnifiedLoops::validate_loop_infos(const LoopManagerPtr& loop_manage
         OPENVINO_ASSERT(loop_info, "ValidateUnifiedLoops expects only UnifiedLoopInfo in LoopManager");
         loop_info->iterate_through_ports(validate_loop_port);
 
-        // Validate that iteration dimnsion is broadcastable
+        // Validate that iteration dimension is broadcastable
         std::set<size_t> unique_dimensions;
         loop_info->iterate_through_ports([&unique_dimensions](const LoopPort& loop_port) {
-            if (loop_port.get_type() != LoopPort::Type::NotProcessed) {
+            if (loop_port.is_processed()) {
                 const auto is_input = loop_port.get_expr_port()->get_type() == ExpressionPort::Input;
                 const auto planar_shape = is_input ? ov::snippets::utils::get_planar_vdims(*loop_port.get_expr_port())
                                                    : ov::snippets::utils::get_preordered_vdims(*loop_port.get_expr_port());

--- a/src/common/snippets/src/utils/loop_utils.cpp
+++ b/src/common/snippets/src/utils/loop_utils.cpp
@@ -13,17 +13,17 @@ namespace utils {
 using namespace ov::snippets::lowered;
 namespace {
 inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount, size_t port_count) {
-    if (!loop_port.is_incremented)
+    if (!loop_port.is_incremented())
         return 0;
 
-    const auto& expr_port = loop_port.expr_port;
+    const auto& expr_port = loop_port.get_expr_port();
     const auto& layout = expr_port->get_descriptor_ptr()->get_layout();
     const auto& shape = expr_port->get_descriptor_ptr()->get_shape();
     size_t dim = 0;
     if (expr_port->get_type() == ExpressionPort::Input) {
-        dim = get_input_dim_idx(layout, loop_port.dim_idx);
+        dim = get_input_dim_idx(layout, loop_port.get_dim_idx());
     } else if (expr_port->get_type() == ExpressionPort::Output) {
-        dim = get_output_dim_idx(layout, loop_port.dim_idx);
+        dim = get_output_dim_idx(layout, loop_port.get_dim_idx());
     } else {
         OPENVINO_THROW("Unsupported expression port type!");
     }
@@ -47,12 +47,12 @@ inline int64_t get_finalization_offset(size_t work_amount, int64_t ptr_increment
 inline void init_work_amount(const LoopInfoPtr& loop_info) {
     size_t work_amount = 1;
     loop_info->iterate_through_ports([&work_amount](const LoopPort& loop_port) {
-        if (loop_port.is_incremented) {
-            const auto& desc = loop_port.expr_port->get_descriptor_ptr();
+        if (loop_port.is_incremented()) {
+            const auto& desc = loop_port.get_expr_port()->get_descriptor_ptr();
             const auto& shape = desc->get_shape();
             const auto& layout = desc->get_layout();
-            const auto is_input = loop_port.expr_port->get_type() == ExpressionPort::Input;
-            const auto dim_idx = is_input ? get_input_dim_idx(layout, loop_port.dim_idx) : get_output_dim_idx(layout, loop_port.dim_idx);
+            const auto is_input = loop_port.get_expr_port()->get_type() == ExpressionPort::Input;
+            const auto dim_idx = is_input ? get_input_dim_idx(layout, loop_port.get_dim_idx()) : get_output_dim_idx(layout, loop_port.get_dim_idx());
             OPENVINO_ASSERT(broadcast_merge_dim(work_amount, work_amount, shape[dim_idx]),
                             "Failed to broadcast work_amount");
         }
@@ -69,7 +69,7 @@ void update_data_pointer_shifts(const UnifiedLoopInfoPtr& loop_info) {
 
     auto update_shifts = [&work_amount, &input_count, &output_count](LoopPort& loop_port, UnifiedLoopInfo::LoopPortDesc& ptr_shifts_params) {
         ptr_shifts_params.ptr_increment = get_ptr_increment(loop_port, work_amount,
-                                                            loop_port.expr_port->get_type() == ExpressionPort::Input ? input_count : output_count);
+                                                            loop_port.get_expr_port()->get_type() == ExpressionPort::Input ? input_count : output_count);
         ptr_shifts_params.finalization_offset = get_finalization_offset(work_amount, ptr_shifts_params.ptr_increment);
     };
     loop_info->iterate_through_infos(update_shifts);

--- a/src/common/snippets/src/utils/loop_utils.cpp
+++ b/src/common/snippets/src/utils/loop_utils.cpp
@@ -13,7 +13,7 @@ namespace utils {
 using namespace ov::snippets::lowered;
 namespace {
 inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount, size_t port_count) {
-    if (loop_port.get_type() != LoopPort::Type::Incremented)
+    if (!loop_port.is_incremented())
         return 0;
 
     const auto& expr_port = loop_port.get_expr_port();
@@ -47,7 +47,7 @@ inline int64_t get_finalization_offset(size_t work_amount, int64_t ptr_increment
 inline void init_work_amount(const LoopInfoPtr& loop_info) {
     size_t work_amount = 1;
     loop_info->iterate_through_ports([&work_amount](const LoopPort& loop_port) {
-        if (loop_port.get_type() == LoopPort::Type::Incremented) {
+        if (loop_port.is_processed()) {
             const auto& desc = loop_port.get_expr_port()->get_descriptor_ptr();
             const auto& shape = desc->get_shape();
             const auto& layout = desc->get_layout();

--- a/src/common/snippets/src/utils/loop_utils.cpp
+++ b/src/common/snippets/src/utils/loop_utils.cpp
@@ -13,7 +13,7 @@ namespace utils {
 using namespace ov::snippets::lowered;
 namespace {
 inline int64_t get_ptr_increment(const LoopPort& loop_port, size_t work_amount, size_t port_count) {
-    if (!loop_port.is_incremented())
+    if (loop_port.get_type() != LoopPort::Type::Incremented)
         return 0;
 
     const auto& expr_port = loop_port.get_expr_port();
@@ -47,7 +47,7 @@ inline int64_t get_finalization_offset(size_t work_amount, int64_t ptr_increment
 inline void init_work_amount(const LoopInfoPtr& loop_info) {
     size_t work_amount = 1;
     loop_info->iterate_through_ports([&work_amount](const LoopPort& loop_port) {
-        if (loop_port.is_incremented()) {
+        if (loop_port.get_type() == LoopPort::Type::Incremented) {
             const auto& desc = loop_port.get_expr_port()->get_descriptor_ptr();
             const auto& shape = desc->get_shape();
             const auto& layout = desc->get_layout();

--- a/src/common/snippets/tests/src/lir_comparator.cpp
+++ b/src/common/snippets/tests/src/lir_comparator.cpp
@@ -182,7 +182,8 @@ LIRComparator::Result LIRComparator::compare_loop_ports(const std::vector<LoopPo
     for (size_t i = 0; i < loop_ports.size(); ++i) {
         const std::string prefix = "Loop port " + std::to_string(i) + ": ";
         COMPARE(prefix + "type", loop_ports[i].get_type(), loop_ports_ref[i].get_type());
-        COMPARE(prefix + "dim_idx", loop_ports[i].get_dim_idx(), loop_ports_ref[i].get_dim_idx());
+        if (loop_ports[i].is_processed())
+            COMPARE(prefix + "dim_idx", loop_ports[i].get_dim_idx(), loop_ports_ref[i].get_dim_idx());
         PROPAGATE_ERROR(prefix + "expr_port", compare_expression_ports(*loop_ports[i].get_expr_port(), *loop_ports_ref[i].get_expr_port()));
     }
     return Result::ok();

--- a/src/common/snippets/tests/src/lir_comparator.cpp
+++ b/src/common/snippets/tests/src/lir_comparator.cpp
@@ -175,9 +175,9 @@ LIRComparator::Result LIRComparator::compare_loop_ports(const std::vector<LoopPo
     COMPARE("Loop ports size", loop_ports.size(), loop_ports_ref.size());
     for (size_t i = 0; i < loop_ports.size(); ++i) {
         const std::string prefix = "Loop port " + std::to_string(i) + ": ";
-        COMPARE(prefix + "is_incremented", loop_ports[i].is_incremented, loop_ports_ref[i].is_incremented);
-        COMPARE(prefix + "dim_idx", loop_ports[i].dim_idx, loop_ports_ref[i].dim_idx);
-        PROPAGATE_ERROR(prefix + "expr_port", compare_expression_ports(*loop_ports[i].expr_port, *loop_ports_ref[i].expr_port));
+        COMPARE(prefix + "is_incremented", loop_ports[i].is_incremented(), loop_ports_ref[i].is_incremented());
+        COMPARE(prefix + "dim_idx", loop_ports[i].get_dim_idx(), loop_ports_ref[i].get_dim_idx());
+        PROPAGATE_ERROR(prefix + "expr_port", compare_expression_ports(*loop_ports[i].get_expr_port(), *loop_ports_ref[i].get_expr_port()));
     }
     return Result::ok();
 }

--- a/src/common/snippets/tests/src/lir_comparator.cpp
+++ b/src/common/snippets/tests/src/lir_comparator.cpp
@@ -31,6 +31,12 @@ inline string to_string(const SpecificLoopIterType& type) {
     ss << type;
     return ss.str();
 }
+
+inline string to_string(const LoopPort::Type& type) {
+    stringstream ss;
+    ss << type;
+    return ss.str();
+}
 } // namespace std
 
 namespace ov {
@@ -175,7 +181,7 @@ LIRComparator::Result LIRComparator::compare_loop_ports(const std::vector<LoopPo
     COMPARE("Loop ports size", loop_ports.size(), loop_ports_ref.size());
     for (size_t i = 0; i < loop_ports.size(); ++i) {
         const std::string prefix = "Loop port " + std::to_string(i) + ": ";
-        COMPARE(prefix + "is_incremented", loop_ports[i].is_incremented(), loop_ports_ref[i].is_incremented());
+        COMPARE(prefix + "type", loop_ports[i].get_type(), loop_ports_ref[i].get_type());
         COMPARE(prefix + "dim_idx", loop_ports[i].get_dim_idx(), loop_ports_ref[i].get_dim_idx());
         PROPAGATE_ERROR(prefix + "expr_port", compare_expression_ports(*loop_ports[i].get_expr_port(), *loop_ports_ref[i].get_expr_port()));
     }

--- a/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
@@ -63,10 +63,10 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = multiply.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort::create((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -82,9 +82,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_input_port(0)),
-                                                                           LoopPort::create((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0)),
+                                                                           LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(1))},
+                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
     }
 }
 
@@ -121,9 +121,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = scalar.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -139,9 +139,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_input_port(0)),
-                                                                           LoopPort::create((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0)),
+                                                                           LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(1))},
+                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
     }
 }
 
@@ -184,19 +184,19 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin = multiply.first;
         auto end = result1.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 16, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort::create((*add.first)->get_input_port(0)),
-                                                                       LoopPort::create((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0)),
-                                                                       LoopPort::create((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0)),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
         linear_ir->get_loop_manager()->mark_loop(begin, end, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0), 1),
-                                                                       LoopPort::create((*multiply.first)->get_input_port(1), 1),
-                                                                       LoopPort::create((*add.first)->get_input_port(0), 1),
-                                                                       LoopPort::create((*sub.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1),
-                                                                       LoopPort::create((*sub.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0), 1),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1), 1),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
     {
@@ -214,21 +214,25 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto result1 = linear_ir_ref->push_node<ov::opset10::Result>(sub.second);
         auto begin_inner = add.first;
         auto end_inner = result1.first;
-        linear_ir_ref->get_loop_manager()->mark_loop(begin_inner, end_inner, 16, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0), 0),
-                                                                           LoopPort::create((*add.first)->get_input_port(1), 0),
-                                                                           LoopPort::create((*sub.first)->get_input_port(0), 0)},
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 0),
-                                                                           LoopPort::create((*sub.first)->get_output_port(0), 0)});
-        auto begin_outer = multiply.first;
-        auto end_outer = result1.first;
-        linear_ir_ref->get_loop_manager()->mark_loop(begin_outer, end_outer, 3, 1,
-                                                     std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0), 1),
-                                                                           LoopPort::create((*multiply.first)->get_input_port(1), 1),
-                                                                           LoopPort::create((*add.first)->get_input_port(0), 1),
-                                                                           LoopPort::create((*sub.first)->get_input_port(0), 1)},
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1),
-                                                                           LoopPort::create((*sub.first)->get_output_port(0), 1)});
+        {
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 0),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0),
+                                                          LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0), 0)};
+            linear_ir_ref->get_loop_manager()->mark_loop(begin_inner, end_inner, 16, vector_size, entry_ports, exit_ports);
+        }
+        {
+            auto begin_outer = multiply.first;
+            auto end_outer = result1.first;
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0), 1),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1), 1),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1),
+                                                          LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0), 1)};
+            linear_ir_ref->get_loop_manager()->mark_loop(begin_outer, end_outer, 3, 1, entry_ports, exit_ports);
+        }
     }
 }
 
@@ -259,14 +263,20 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         auto add = linear_ir->push_node<ov::opset10::Add>(param_0.second, broadcastmove.second);
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
-        linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0), 0),
-                                                                       LoopPort::create((*add.first)->get_input_port(0), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 0)});
-        linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0), 1),
-                                                                       LoopPort::create((*add.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1)});
+
+        {
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0)};
+            linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 512, vector_size, entry_ports, exit_ports);
+        }
+        {
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0), 1),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1)};
+            linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 3, 1, entry_ports, exit_ports);
+        }
+
         linear_ir->set_loop_depth(2);
     }
     {
@@ -277,14 +287,19 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         auto add = linear_ir_ref->push_node<ov::opset10::Add>(param_0.second, broadcastmove.second);
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
-        linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0), 0),
-                                                                           LoopPort::create((*add.first)->get_input_port(1), 0)},
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 0)});
-        linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 3, 1,
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0), 1),
-                                                                           LoopPort::create((*add.first)->get_input_port(1), 1)},
-                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1)});
+
+        {
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 0),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0)};
+            linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 512, vector_size, entry_ports, exit_ports);
+        }
+        {
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1),
+                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1)};
+            linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 3, 1, entry_ports, exit_ports);
+        }
     }
 }
 
@@ -312,12 +327,18 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsImpossible) {
         init_expr_descriptors(*load_reshape.first, {subtensor, subtensor}, {order, layout});
         init_expr_descriptors(*store.first, {subtensor, subtensor}, {layout, layout});
         auto result = linear_ir->push_node<ov::opset10::Result>(store.second);
-        linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 32, 1,
-                                                 std::vector<LoopPort>{LoopPort::create((*load_reshape.first)->get_input_port(0), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create((*store.first)->get_output_port(0), 0)});
-        linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 1, 1,
-                                                 std::vector<LoopPort>{LoopPort::create((*load_reshape.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort::create((*store.first)->get_output_port(0), 1)});
+
+        {
+            const auto entry_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*load_reshape.first)->get_input_port(0), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*store.first)->get_output_port(0), 0)};
+            linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 32, 1, entry_ports, exit_ports);
+        }
+        {
+            const auto entry_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*load_reshape.first)->get_input_port(0), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*store.first)->get_output_port(0), 1)};
+            linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 1, 1, entry_ports, exit_ports);
+        }
+
         linear_ir->set_loop_depth(2);
     }
 }
@@ -352,17 +373,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         const auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir->get_loop_manager();
         loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_input_port(0)),
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_input_port(0)),
                                                       LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort::create((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0)),
+                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0))},
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort::create((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0)),
+                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0))},
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir, linear_ir->begin(), linear_ir->end());
     }
     {
@@ -377,17 +398,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir_ref->get_loop_manager();
         loop_manager->mark_loop(matmul.first, add.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_input_port(0)),
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_input_port(0)),
                                                       LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
-                                                      LoopPort::create((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
+                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
-                                                      LoopPort::create((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
+                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir_ref, linear_ir_ref->begin(), linear_ir_ref->end());
     }
 }
@@ -457,19 +478,20 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         auto result = linear_ir->push_node<ov::opset10::Result>(multiply.second);
         // 3 inner loop
         linear_ir->get_loop_manager()->mark_loop(max.first, hmax.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*max.first)->get_input_port(0), 0),
-                                                                       LoopPort::create((*max.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create((*max.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(sub.first, hsum.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*sub.first)->get_input_port(0), 0),
-                                                                       LoopPort::create((*sub.first)->get_input_port(1), 0),
-                                                                       LoopPort::create((*add.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create((*exp.first)->get_output_port(0), 0),
-                                                                       LoopPort::create((*add.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(1), 0),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*exp.first)->get_output_port(0), 0),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(multiply.first, result.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0), 0),
-                                                                       LoopPort::create((*multiply.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(
+                                                    (*multiply.first)->get_output_port(0), 0)});
         // outer loop info
         const auto loop_begin = std::make_shared<ov::snippets::op::LoopBegin>();
         auto loop_begin_expr = linear_ir->insert_node(loop_begin, std::vector<PortConnectorPtr>{}, {}, false, max.first);
@@ -477,10 +499,11 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                 std::vector<LoopPort>{LoopPort::create((*max.first)->get_input_port(0), 1),
-                                                                       LoopPort::create((*max.first)->get_input_port(1), 0),
-                                                                       LoopPort::create((*add.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(0), 1),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(1), 0),
+                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(
+                                                    (*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
         linear_ir->set_loop_depth(2);
     }
@@ -510,10 +533,11 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir_ref->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir_ref->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                     std::vector<LoopPort>{LoopPort::create((*max.first)->get_input_port(0), 1),
-                                                                           LoopPort::create((*max.first)->get_input_port(1), 0),
-                                                                           LoopPort::create((*add.first)->get_input_port(1), 0)},
-                                                     std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_output_port(0), 1)});
+                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(0), 1),
+                                                                           LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(1), 0),
+                                                                           LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(
+                                                        (*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
     }
 }

--- a/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
@@ -16,6 +16,7 @@ namespace snippets {
 
 using namespace ov::snippets::lowered;
 using namespace ov::snippets::lowered::pass;
+using PortType = LoopPort::Type;
 
 class ExtractLoopInvariantsTest : public LoweredPassTestsF {
 public:
@@ -63,10 +64,10 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = multiply.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -82,9 +83,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0)),
-                                                                           LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0)),
+                                                                           LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1))},
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
     }
 }
 
@@ -121,9 +122,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = scalar.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -139,9 +140,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0)),
-                                                                           LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0)),
+                                                                           LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1))},
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
     }
 }
 
@@ -184,19 +185,19 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin = multiply.first;
         auto end = result1.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 16, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0)),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0)),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0))});
         linear_ir->get_loop_manager()->mark_loop(begin, end, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0), 1),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1), 1),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 1),
+                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1), 1),
+                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
     {
@@ -215,22 +216,22 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin_inner = add.first;
         auto end_inner = result1.first;
         {
-            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 0),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 0)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0),
-                                                          LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0), 0)};
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                            LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0),
+                                                            LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0),
+                                                          LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 0)};
             linear_ir_ref->get_loop_manager()->mark_loop(begin_inner, end_inner, 16, vector_size, entry_ports, exit_ports);
         }
         {
             auto begin_outer = multiply.first;
             auto end_outer = result1.first;
-            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0), 1),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1), 1),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 1)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1),
-                                                          LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_output_port(0), 1)};
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 1),
+                                                            LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1), 1),
+                                                            LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1),
+                                                            LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1),
+                                                          LoopPort::create<PortType::Incremented>((*sub.first)->get_output_port(0), 1)};
             linear_ir_ref->get_loop_manager()->mark_loop(begin_outer, end_outer, 3, 1, entry_ports, exit_ports);
         }
     }
@@ -265,15 +266,15 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
 
         {
-            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 0)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0)};
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 0),
+                                                            LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)};
             linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 512, vector_size, entry_ports, exit_ports);
         }
         {
-            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0), 1),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1)};
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0), 1),
+                                                            LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1)};
             linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 3, 1, entry_ports, exit_ports);
         }
 
@@ -289,15 +290,15 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
 
         {
-            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 0),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0)};
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 0),
+                                                            LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)};
             linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 512, vector_size, entry_ports, exit_ports);
         }
         {
-            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0), 1),
-                                                            LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 1)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 1)};
+            const auto entry_ports =  std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0), 1),
+                                                            LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 1)};
             linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 3, 1, entry_ports, exit_ports);
         }
     }
@@ -329,13 +330,13 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsImpossible) {
         auto result = linear_ir->push_node<ov::opset10::Result>(store.second);
 
         {
-            const auto entry_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*load_reshape.first)->get_input_port(0), 0)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*store.first)->get_output_port(0), 0)};
+            const auto entry_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*load_reshape.first)->get_input_port(0), 0)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*store.first)->get_output_port(0), 0)};
             linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 32, 1, entry_ports, exit_ports);
         }
         {
-            const auto entry_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*load_reshape.first)->get_input_port(0), 1)};
-            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*store.first)->get_output_port(0), 1)};
+            const auto entry_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*load_reshape.first)->get_input_port(0), 1)};
+            const auto exit_ports = std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*store.first)->get_output_port(0), 1)};
             linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 1, 1, entry_ports, exit_ports);
         }
 
@@ -373,17 +374,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         const auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir->get_loop_manager();
         loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_input_port(0)),
-                                                      LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0)),
+                                                      LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0)),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0))},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*broadcastmove.first)->get_input_port(0)),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0))},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir, linear_ir->begin(), linear_ir->end());
     }
     {
@@ -398,17 +399,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir_ref->get_loop_manager();
         loop_manager->mark_loop(matmul.first, add.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_input_port(0)),
-                                                      LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0)),
+                                                      LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
-                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
-                                                      LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
+                                                      LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir_ref, linear_ir_ref->begin(), linear_ir_ref->end());
     }
 }
@@ -478,20 +479,19 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         auto result = linear_ir->push_node<ov::opset10::Result>(multiply.second);
         // 3 inner loop
         linear_ir->get_loop_manager()->mark_loop(max.first, hmax.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(0), 0),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*max.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*max.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*max.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(sub.first, hsum.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(0), 0),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*sub.first)->get_input_port(1), 0),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*exp.first)->get_output_port(0), 0),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*sub.first)->get_input_port(1), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*exp.first)->get_output_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(multiply.first, result.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(0), 0),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*multiply.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(
-                                                    (*multiply.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*multiply.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_output_port(0), 0)});
         // outer loop info
         const auto loop_begin = std::make_shared<ov::snippets::op::LoopBegin>();
         auto loop_begin_expr = linear_ir->insert_node(loop_begin, std::vector<PortConnectorPtr>{}, {}, false, max.first);
@@ -499,11 +499,10 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(0), 1),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(1), 0),
-                                                                       LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(
-                                                    (*multiply.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*max.first)->get_input_port(0), 1),
+                                                                       LoopPort::create<PortType::Incremented>((*max.first)->get_input_port(1), 0),
+                                                                       LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
         linear_ir->set_loop_depth(2);
     }
@@ -533,11 +532,10 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir_ref->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir_ref->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(0), 1),
-                                                                           LoopPort::create<LoopPort::Type::Incremented>((*max.first)->get_input_port(1), 0),
-                                                                           LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1), 0)},
-                                                     std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(
-                                                        (*multiply.first)->get_output_port(0), 1)});
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*max.first)->get_input_port(0), 1),
+                                                                           LoopPort::create<PortType::Incremented>((*max.first)->get_input_port(1), 0),
+                                                                           LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
     }
 }

--- a/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
@@ -63,10 +63,10 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = multiply.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort::create((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -82,9 +82,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithParams) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort((*sub.first)->get_input_port(0)),
-                                                                           LoopPort((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_input_port(0)),
+                                                                           LoopPort::create((*sub.first)->get_input_port(1))},
+                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
     }
 }
 
@@ -121,9 +121,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = scalar.first;
         auto end = result.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
         linear_ir->set_loop_depth(1);
     }
     {
@@ -139,9 +139,9 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsWithScalar) {
         auto begin = sub.first;
         auto end = result.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin, end, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort((*sub.first)->get_input_port(0)),
-                                                                           LoopPort((*sub.first)->get_input_port(1))},
-                                                     std::vector<LoopPort>{LoopPort((*sub.first)->get_output_port(0))});
+                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_input_port(0)),
+                                                                           LoopPort::create((*sub.first)->get_input_port(1))},
+                                                     std::vector<LoopPort>{LoopPort::create((*sub.first)->get_output_port(0))});
     }
 }
 
@@ -184,19 +184,19 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin = multiply.first;
         auto end = result1.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 16, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0)),
-                                                                       LoopPort((*multiply.first)->get_input_port(1)),
-                                                                       LoopPort((*add.first)->get_input_port(0)),
-                                                                       LoopPort((*sub.first)->get_input_port(0))},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0)),
-                                                                       LoopPort((*sub.first)->get_output_port(0))});
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort::create((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort::create((*add.first)->get_input_port(0)),
+                                                                       LoopPort::create((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0)),
+                                                                       LoopPort::create((*sub.first)->get_output_port(0))});
         linear_ir->get_loop_manager()->mark_loop(begin, end, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), 1),
-                                                                       LoopPort((*multiply.first)->get_input_port(1), 1),
-                                                                       LoopPort((*add.first)->get_input_port(0), 1),
-                                                                       LoopPort((*sub.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1),
-                                                                       LoopPort((*sub.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0), 1),
+                                                                       LoopPort::create((*multiply.first)->get_input_port(1), 1),
+                                                                       LoopPort::create((*add.first)->get_input_port(0), 1),
+                                                                       LoopPort::create((*sub.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1),
+                                                                       LoopPort::create((*sub.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
     {
@@ -215,20 +215,20 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin_inner = add.first;
         auto end_inner = result1.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin_inner, end_inner, 16, vector_size,
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), 0),
-                                                                           LoopPort((*add.first)->get_input_port(1), 0),
-                                                                           LoopPort((*sub.first)->get_input_port(0), 0)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 0),
-                                                                           LoopPort((*sub.first)->get_output_port(0), 0)});
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0), 0),
+                                                                           LoopPort::create((*add.first)->get_input_port(1), 0),
+                                                                           LoopPort::create((*sub.first)->get_input_port(0), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 0),
+                                                                           LoopPort::create((*sub.first)->get_output_port(0), 0)});
         auto begin_outer = multiply.first;
         auto end_outer = result1.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin_outer, end_outer, 3, 1,
-                                                     std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), 1),
-                                                                           LoopPort((*multiply.first)->get_input_port(1), 1),
-                                                                           LoopPort((*add.first)->get_input_port(0), 1),
-                                                                           LoopPort((*sub.first)->get_input_port(0), 1)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1),
-                                                                           LoopPort((*sub.first)->get_output_port(0), 1)});
+                                                     std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0), 1),
+                                                                           LoopPort::create((*multiply.first)->get_input_port(1), 1),
+                                                                           LoopPort::create((*add.first)->get_input_port(0), 1),
+                                                                           LoopPort::create((*sub.first)->get_input_port(0), 1)},
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1),
+                                                                           LoopPort::create((*sub.first)->get_output_port(0), 1)});
     }
 }
 
@@ -260,13 +260,13 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0), 0),
-                                                                       LoopPort((*add.first)->get_input_port(0), 0)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0), 0),
+                                                                       LoopPort::create((*add.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0), 1),
-                                                                       LoopPort((*add.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0), 1),
+                                                                       LoopPort::create((*add.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
     {
@@ -278,13 +278,13 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), 0),
-                                                                           LoopPort((*add.first)->get_input_port(1), 0)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 0)});
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0), 0),
+                                                                           LoopPort::create((*add.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 0)});
         linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 3, 1,
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), 1),
-                                                                           LoopPort((*add.first)->get_input_port(1), 1)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1)});
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0), 1),
+                                                                           LoopPort::create((*add.first)->get_input_port(1), 1)},
+                                                     std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0), 1)});
     }
 }
 
@@ -313,11 +313,11 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsImpossible) {
         init_expr_descriptors(*store.first, {subtensor, subtensor}, {layout, layout});
         auto result = linear_ir->push_node<ov::opset10::Result>(store.second);
         linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 32, 1,
-                                                 std::vector<LoopPort>{LoopPort((*load_reshape.first)->get_input_port(0), 0)},
-                                                 std::vector<LoopPort>{LoopPort((*store.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create((*load_reshape.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create((*store.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 1, 1,
-                                                 std::vector<LoopPort>{LoopPort((*load_reshape.first)->get_input_port(0), 1)},
-                                                 std::vector<LoopPort>{LoopPort((*store.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create((*load_reshape.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort::create((*store.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
 }
@@ -352,17 +352,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         const auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir->get_loop_manager();
         loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0)),
-                                                      LoopPort((*matmul.first)->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
-                                std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_input_port(0)),
+                                                      LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0)),
+                                                      LoopPort::create((*add.first)->get_input_port(0))},
+                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0)),
-                                                      LoopPort((*add.first)->get_input_port(0))},
-                                std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create((*broadcastmove.first)->get_input_port(0)),
+                                                      LoopPort::create((*add.first)->get_input_port(0))},
+                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir, linear_ir->begin(), linear_ir->end());
     }
     {
@@ -377,17 +377,17 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         const auto& loop_manager = linear_ir_ref->get_loop_manager();
         loop_manager->mark_loop(matmul.first, add.first, 128, block_size, 1,
-                                std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0)),
-                                                      LoopPort((*matmul.first)->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
-                                std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_input_port(0)),
+                                                      LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 64, vector_size, 0,
-                                std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0)),
-                                                      LoopPort((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
+                                                      LoopPort::create((*add.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 128, 1, 1,
-                                std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0)),
-                                                      LoopPort((*add.first)->get_input_port(1))},
-                                std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0))});
+                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
+                                                      LoopPort::create((*add.first)->get_input_port(1))},
+                                std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
         ov::snippets::lowered::pass::SplitLoops().run(*linear_ir_ref, linear_ir_ref->begin(), linear_ir_ref->end());
     }
 }
@@ -457,19 +457,19 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         auto result = linear_ir->push_node<ov::opset10::Result>(multiply.second);
         // 3 inner loop
         linear_ir->get_loop_manager()->mark_loop(max.first, hmax.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), 0),
-                                                                       LoopPort((*max.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create((*max.first)->get_input_port(0), 0),
+                                                                       LoopPort::create((*max.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create((*max.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(sub.first, hsum.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*sub.first)->get_input_port(0), 0),
-                                                                       LoopPort((*sub.first)->get_input_port(1), 0),
-                                                                       LoopPort((*add.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort((*exp.first)->get_output_port(0), 0),
-                                                                       LoopPort((*add.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create((*sub.first)->get_input_port(0), 0),
+                                                                       LoopPort::create((*sub.first)->get_input_port(1), 0),
+                                                                       LoopPort::create((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create((*exp.first)->get_output_port(0), 0),
+                                                                       LoopPort::create((*add.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(multiply.first, result.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), 0),
-                                                                       LoopPort((*multiply.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), 0)});
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort::create((*multiply.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_output_port(0), 0)});
         // outer loop info
         const auto loop_begin = std::make_shared<ov::snippets::op::LoopBegin>();
         auto loop_begin_expr = linear_ir->insert_node(loop_begin, std::vector<PortConnectorPtr>{}, {}, false, max.first);
@@ -477,10 +477,10 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), 1),
-                                                                       LoopPort((*max.first)->get_input_port(1), 0),
-                                                                       LoopPort((*add.first)->get_input_port(1), 0)},
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), 1)});
+                                                 std::vector<LoopPort>{LoopPort::create((*max.first)->get_input_port(0), 1),
+                                                                       LoopPort::create((*max.first)->get_input_port(1), 0),
+                                                                       LoopPort::create((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
         linear_ir->set_loop_depth(2);
     }
@@ -510,10 +510,10 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir_ref->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir_ref->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                     std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), 1),
-                                                                           LoopPort((*max.first)->get_input_port(1), 0),
-                                                                           LoopPort((*add.first)->get_input_port(1), 0)},
-                                                     std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), 1)});
+                                                     std::vector<LoopPort>{LoopPort::create((*max.first)->get_input_port(0), 1),
+                                                                           LoopPort::create((*max.first)->get_input_port(1), 0),
+                                                                           LoopPort::create((*add.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort::create((*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
     }
 }

--- a/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/extracted_loop_invariants.cpp
@@ -184,19 +184,19 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin = multiply.first;
         auto end = result1.first;
         linear_ir->get_loop_manager()->mark_loop(begin, end, 16, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), true, 0),
-                                                                       LoopPort((*multiply.first)->get_input_port(1), true, 0),
-                                                                       LoopPort((*add.first)->get_input_port(0), true, 0),
-                                                                       LoopPort((*sub.first)->get_input_port(0), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 0),
-                                                                       LoopPort((*sub.first)->get_output_port(0), true, 0)});
+                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0)),
+                                                                       LoopPort((*multiply.first)->get_input_port(1)),
+                                                                       LoopPort((*add.first)->get_input_port(0)),
+                                                                       LoopPort((*sub.first)->get_input_port(0))},
+                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0)),
+                                                                       LoopPort((*sub.first)->get_output_port(0))});
         linear_ir->get_loop_manager()->mark_loop(begin, end, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), true, 1),
-                                                                       LoopPort((*multiply.first)->get_input_port(1), true, 1),
-                                                                       LoopPort((*add.first)->get_input_port(0), true, 1),
-                                                                       LoopPort((*sub.first)->get_input_port(0), true, 1)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 1),
-                                                                       LoopPort((*sub.first)->get_output_port(0), true, 1)});
+                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), 1),
+                                                                       LoopPort((*multiply.first)->get_input_port(1), 1),
+                                                                       LoopPort((*add.first)->get_input_port(0), 1),
+                                                                       LoopPort((*sub.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1),
+                                                                       LoopPort((*sub.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
     {
@@ -215,20 +215,20 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsOutputLoopUpdateNotNeed
         auto begin_inner = add.first;
         auto end_inner = result1.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin_inner, end_inner, 16, vector_size,
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), true, 0),
-                                                                           LoopPort((*add.first)->get_input_port(1), true, 0),
-                                                                           LoopPort((*sub.first)->get_input_port(0), true, 0)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 0),
-                                                                           LoopPort((*sub.first)->get_output_port(0), true, 0)});
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), 0),
+                                                                           LoopPort((*add.first)->get_input_port(1), 0),
+                                                                           LoopPort((*sub.first)->get_input_port(0), 0)},
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 0),
+                                                                           LoopPort((*sub.first)->get_output_port(0), 0)});
         auto begin_outer = multiply.first;
         auto end_outer = result1.first;
         linear_ir_ref->get_loop_manager()->mark_loop(begin_outer, end_outer, 3, 1,
-                                                     std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), true, 1),
-                                                                           LoopPort((*multiply.first)->get_input_port(1), true, 1),
-                                                                           LoopPort((*add.first)->get_input_port(0), true, 1),
-                                                                           LoopPort((*sub.first)->get_input_port(0), true, 1)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 1),
-                                                                           LoopPort((*sub.first)->get_output_port(0), true, 1)});
+                                                     std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), 1),
+                                                                           LoopPort((*multiply.first)->get_input_port(1), 1),
+                                                                           LoopPort((*add.first)->get_input_port(0), 1),
+                                                                           LoopPort((*sub.first)->get_input_port(0), 1)},
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1),
+                                                                           LoopPort((*sub.first)->get_output_port(0), 1)});
     }
 }
 
@@ -260,13 +260,13 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir->push_node<ov::opset10::Result>(add.second);
         linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 512, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0), true, 0),
-                                                                       LoopPort((*add.first)->get_input_port(0), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 0)});
+                                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0), 0),
+                                                                       LoopPort((*add.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(broadcastmove.first, result.first, 3, 1,
-                                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0), true, 1),
-                                                                       LoopPort((*add.first)->get_input_port(0), true, 1)},
-                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 1)});
+                                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0), 1),
+                                                                       LoopPort((*add.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
     {
@@ -278,13 +278,13 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsFromInnermostToLoopOuts
         init_expr_descriptors(*add.first, {subtensor, subtensor, subtensor}, {layout, layout, layout});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add.second);
         linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 512, vector_size,
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), true, 0),
-                                                                           LoopPort((*add.first)->get_input_port(1), true, 0)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 0)});
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), 0),
+                                                                           LoopPort((*add.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 0)});
         linear_ir_ref->get_loop_manager()->mark_loop(add.first, result.first, 3, 1,
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), true, 1),
-                                                                           LoopPort((*add.first)->get_input_port(1), true, 1)},
-                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), true, 1)});
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0), 1),
+                                                                           LoopPort((*add.first)->get_input_port(1), 1)},
+                                                     std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0), 1)});
     }
 }
 
@@ -313,11 +313,11 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsImpossible) {
         init_expr_descriptors(*store.first, {subtensor, subtensor}, {layout, layout});
         auto result = linear_ir->push_node<ov::opset10::Result>(store.second);
         linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 32, 1,
-                                                 std::vector<LoopPort>{LoopPort((*load_reshape.first)->get_input_port(0), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*store.first)->get_output_port(0), true, 0)});
+                                                 std::vector<LoopPort>{LoopPort((*load_reshape.first)->get_input_port(0), 0)},
+                                                 std::vector<LoopPort>{LoopPort((*store.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(load_reshape.first, result.first, 1, 1,
-                                                 std::vector<LoopPort>{LoopPort((*load_reshape.first)->get_input_port(0), true, 1)},
-                                                 std::vector<LoopPort>{LoopPort((*store.first)->get_output_port(0), true, 1)});
+                                                 std::vector<LoopPort>{LoopPort((*load_reshape.first)->get_input_port(0), 1)},
+                                                 std::vector<LoopPort>{LoopPort((*store.first)->get_output_port(0), 1)});
         linear_ir->set_loop_depth(2);
     }
 }
@@ -353,7 +353,7 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         const auto& loop_manager = linear_ir->get_loop_manager();
         loop_manager->mark_loop(matmul.first, broadcastmove.first, 128, block_size, 1,
                                 std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0)),
-                                                      LoopPort((*matmul.first)->get_input_port(1), false)},
+                                                      LoopPort((*matmul.first)->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
                                 std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(broadcastmove.first, result.first, 64, vector_size, 0,
                                 std::vector<LoopPort>{LoopPort((*broadcastmove.first)->get_input_port(0)),
@@ -378,7 +378,7 @@ TEST_F(ExtractLoopInvariantsTest, ExtractedLoopInvariantsSplitLoops) {
         const auto& loop_manager = linear_ir_ref->get_loop_manager();
         loop_manager->mark_loop(matmul.first, add.first, 128, block_size, 1,
                                 std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0)),
-                                                      LoopPort((*matmul.first)->get_input_port(1), false)},
+                                                      LoopPort((*matmul.first)->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
                                 std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0))});
         loop_manager->mark_loop(add.first, result.first, 64, vector_size, 0,
                                 std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0)),
@@ -457,19 +457,19 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         auto result = linear_ir->push_node<ov::opset10::Result>(multiply.second);
         // 3 inner loop
         linear_ir->get_loop_manager()->mark_loop(max.first, hmax.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), true, 0),
-                                                                       LoopPort((*max.first)->get_input_port(1), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_output_port(0), true, 0)});
+                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), 0),
+                                                                       LoopPort((*max.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(sub.first, hsum.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*sub.first)->get_input_port(0), true, 0),
-                                                                       LoopPort((*sub.first)->get_input_port(1), true, 0),
-                                                                       LoopPort((*add.first)->get_input_port(1), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*exp.first)->get_output_port(0), true, 0),
-                                                                       LoopPort((*add.first)->get_output_port(0), true, 0)});
+                                                 std::vector<LoopPort>{LoopPort((*sub.first)->get_input_port(0), 0),
+                                                                       LoopPort((*sub.first)->get_input_port(1), 0),
+                                                                       LoopPort((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort((*exp.first)->get_output_port(0), 0),
+                                                                       LoopPort((*add.first)->get_output_port(0), 0)});
         linear_ir->get_loop_manager()->mark_loop(multiply.first, result.first, 1, vector_size,
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), true, 0),
-                                                                       LoopPort((*multiply.first)->get_input_port(1), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), true, 0)});
+                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_input_port(0), 0),
+                                                                       LoopPort((*multiply.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), 0)});
         // outer loop info
         const auto loop_begin = std::make_shared<ov::snippets::op::LoopBegin>();
         auto loop_begin_expr = linear_ir->insert_node(loop_begin, std::vector<PortConnectorPtr>{}, {}, false, max.first);
@@ -477,10 +477,10 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), true, 1),
-                                                                       LoopPort((*max.first)->get_input_port(1), true, 0),
-                                                                       LoopPort((*add.first)->get_input_port(1), true, 0)},
-                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), true, 1)});
+                                                 std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), 1),
+                                                                       LoopPort((*max.first)->get_input_port(1), 0),
+                                                                       LoopPort((*add.first)->get_input_port(1), 0)},
+                                                 std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
         linear_ir->set_loop_depth(2);
     }
@@ -510,10 +510,10 @@ TEST_F(ExtractLoopInvariantsRemoveLoopsTest, ExtractedLoopInvariantsAllExprsInLo
         std::vector<PortConnectorPtr> loop_end_inputs{(*loop_begin_expr)->get_output_port_connector(0)};
         auto loop_end_expr = linear_ir_ref->insert_node(loop_end, loop_end_inputs, {}, false, result.first);
         linear_ir_ref->get_loop_manager()->mark_loop(loop_begin_expr, result.first, 10, 1,
-                                                     std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), true, 1),
-                                                                           LoopPort((*max.first)->get_input_port(1), true, 0),
-                                                                           LoopPort((*add.first)->get_input_port(1), true, 0)},
-                                                     std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), true, 1)});
+                                                     std::vector<LoopPort>{LoopPort((*max.first)->get_input_port(0), 1),
+                                                                           LoopPort((*max.first)->get_input_port(1), 0),
+                                                                           LoopPort((*add.first)->get_input_port(1), 0)},
+                                                     std::vector<LoopPort>{LoopPort((*multiply.first)->get_output_port(0), 1)});
         loop_end->set_id((*loop_end_expr)->get_loop_ids().back());
     }
 }

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -24,6 +24,7 @@ using Snippets_TailProcessingTransformation = ::testing::Test;
 // [Inserted Loop number, [ptr_increments, final_offsets]
 using ref_map = std::map<size_t, std::pair<std::vector<int64_t>, std::vector<int64_t>>>;
 using namespace ov::snippets::lowered;
+using PortType = LoopPort::Type;
 
 constexpr static size_t vector_size = 16;
 
@@ -42,17 +43,17 @@ static void init_linear_ir(const std::vector<ov::Shape>& in_shapes, LinearIR& li
 
     const auto loop_manager = linear_ir.get_loop_manager();
     linear_ir.get_loop_manager()->mark_loop(matmul.first, add.first, in_shapes[0].front(), block_size,
-                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_input_port(0), 1),
-                                                                  LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_output_port(0), 1)});
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_input_port(0), 1),
+                                                                  LoopPort::create<PortType::NotProcessed>((*matmul.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*matmul.first)->get_output_port(0), 1)});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size, 0,
-                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
-                                                                  LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
+                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].front(), 1, 1,
-                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
-                                                                  LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(0)),
+                                                                  LoopPort::create<PortType::Incremented>((*add.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create<PortType::Incremented>((*add.first)->get_output_port(0))});
 }
 
 static void apply_transformations(LinearIR& linear_ir, const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& config) {

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -42,18 +42,17 @@ static void init_linear_ir(const std::vector<ov::Shape>& in_shapes, LinearIR& li
 
     const auto loop_manager = linear_ir.get_loop_manager();
     linear_ir.get_loop_manager()->mark_loop(matmul.first, add.first, in_shapes[0].front(), block_size,
-                                            std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0), 1),
-                                                                  LoopPort((*matmul.first)->get_input_port(1),
-                                                                    LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
-                                            std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0), 1)});
+                                            std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_input_port(0), 1),
+                                                                  LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_output_port(0), 1)});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size, 0,
-                                            std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0)),
-                                                                  LoopPort((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
+                                                                  LoopPort::create((*add.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].front(), 1, 1,
-                                            std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0)),
-                                                                  LoopPort((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
+                                                                  LoopPort::create((*add.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
 }
 
 static void apply_transformations(LinearIR& linear_ir, const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& config) {

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -41,10 +41,11 @@ static void init_linear_ir(const std::vector<ov::Shape>& in_shapes, LinearIR& li
     const auto result = linear_ir.push_node<ov::opset10::Result>(add.second);
 
     const auto loop_manager = linear_ir.get_loop_manager();
-    linear_ir.get_loop_manager()->mark_loop(matmul.first, add.first, in_shapes[0].front(), block_size, 1,
-                                            std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0)),
-                                                                  LoopPort((*matmul.first)->get_input_port(1), false)},
-                                            std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0))});
+    linear_ir.get_loop_manager()->mark_loop(matmul.first, add.first, in_shapes[0].front(), block_size,
+                                            std::vector<LoopPort>{LoopPort((*matmul.first)->get_input_port(0), 1),
+                                                                  LoopPort((*matmul.first)->get_input_port(1),
+                                                                    LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
+                                            std::vector<LoopPort>{LoopPort((*matmul.first)->get_output_port(0), 1)});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size, 0,
                                             std::vector<LoopPort>{LoopPort((*add.first)->get_input_port(0)),
                                                                   LoopPort((*add.first)->get_input_port(1))},

--- a/src/common/snippets/tests/src/lowered/pass/loop.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/loop.cpp
@@ -42,17 +42,17 @@ static void init_linear_ir(const std::vector<ov::Shape>& in_shapes, LinearIR& li
 
     const auto loop_manager = linear_ir.get_loop_manager();
     linear_ir.get_loop_manager()->mark_loop(matmul.first, add.first, in_shapes[0].front(), block_size,
-                                            std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_input_port(0), 1),
+                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_input_port(0), 1),
                                                                   LoopPort::create<LoopPort::Type::NotProcessed>((*matmul.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create((*matmul.first)->get_output_port(0), 1)});
+                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*matmul.first)->get_output_port(0), 1)});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].back(), vector_size, 0,
-                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
-                                                                  LoopPort::create((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
+                                                                  LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
     linear_ir.get_loop_manager()->mark_loop(add.first, result.first, in_shapes[2].front(), 1, 1,
-                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_input_port(0)),
-                                                                  LoopPort::create((*add.first)->get_input_port(1))},
-                                            std::vector<LoopPort>{LoopPort::create((*add.first)->get_output_port(0))});
+                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(0)),
+                                                                  LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_input_port(1))},
+                                            std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>((*add.first)->get_output_port(0))});
 }
 
 static void apply_transformations(LinearIR& linear_ir, const std::shared_ptr<ov::snippets::lowered::pass::PassConfig>& config) {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_base.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_base.cpp
@@ -195,7 +195,7 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         // Note: We check `is_incremented` attribute only for not incremented ports because
         //       this `is_incremented = true` can be changed by `CleanRepeatedDataPointerShifts` optimization
         auto check_port = [&](const ov::snippets::lowered::LoopPort& p) {
-            return p.dim_idx == 1;
+            return p.get_dim_idx() == 1;
         };
         OPENVINO_ASSERT(in_ports.size() > 1 && std::all_of(in_ports.cbegin(), in_ports.cend(), check_port) &&
                             out_ports.size() == 1 && check_port(out_ports.back()),
@@ -216,9 +216,9 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         // Note: We check `is_incremented` attribute only for not incremented ports because
         //       this `is_incremented = true` can be changed by `CleanRepeatedDataPointerShifts` optimization
         auto check_port = [&](const ov::snippets::lowered::LoopPort& p) {
-            return p.dim_idx == 0;
+            return p.get_dim_idx() == 0;
         };
-        OPENVINO_ASSERT(in_ports.size() >= 2 && !in_ports.front().is_incremented &&
+        OPENVINO_ASSERT(in_ports.size() >= 2 && !in_ports.front().is_incremented() &&
                             std::all_of(in_ports.cbegin(), in_ports.cend(), check_port) && out_ports.size() == 1 &&
                             check_port(out_ports.back()),
                         "Incorrect Loop by Brgemm dimension N");
@@ -242,8 +242,9 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         // Quick validation check: Should we check that port is really Brgemm port?
         // Note: We check `is_incremented` attribute only for not incremented ports because
         //       this `is_incremented = true` can be changed by `CleanRepeatedDataPointerShifts` optimization
-        OPENVINO_ASSERT(in_ports.size() >= 2 && in_ports.front().dim_idx == 0 && in_ports.back().dim_idx == 1 &&
-                            out_ports.size() == 1 && !out_ports.front().is_incremented,
+        OPENVINO_ASSERT(in_ports.size() >= 2 && in_ports.front().get_dim_idx() == 0 &&
+                            in_ports.back().get_dim_idx() == 1 && out_ports.size() == 1 &&
+                            !out_ports.front().is_incremented(),
                         "Incorrect Loop by Brgemm dimension K");
         K = current_expanded_loop_info->get_work_amount() > 0 ? current_expanded_loop_info->get_increment() : 0;
         input_pds[0]->set_subtensor_dim(0, K);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_base.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_base.cpp
@@ -182,6 +182,10 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         return loop_manager->get_loop_info<ov::snippets::lowered::ExpandedLoopInfo>(loop_ids[loop_idx++]);
     };
 
+    auto is_processed_port = [](const ov::snippets::lowered::LoopPort& p) {
+        return p.get_type() != ov::snippets::lowered::LoopPort::Type::NotProcessed;
+    };
+
     /* ------- Dimension M ----------*/
     if (ov::snippets::utils::is_full_dim_value(M)) {
         M = *++in0_shape.rbegin();
@@ -192,14 +196,12 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         // Quick validation check: Should we check that port is really Brgemm port?
         // If BrgemmCopyB in the Loop by M -> first input port will be BrgemmCopyB with `incremented=false`
         // to avoid extra checks, we validate only first input port
-        // Note: We check `is_incremented` attribute only for not incremented ports because
-        //       this `is_incremented = true` can be changed by `CleanRepeatedDataPointerShifts` optimization
         auto check_port = [&](const ov::snippets::lowered::LoopPort& p) {
-            return p.get_dim_idx() == 1;
+            return p.get_dim_idx() == 1 && is_processed_port(p);
         };
-        OPENVINO_ASSERT(in_ports.size() > 1 && std::all_of(in_ports.cbegin(), in_ports.cend(), check_port) &&
-                            out_ports.size() == 1 && check_port(out_ports.back()),
-                        "Incorrect Loop by Brgemm dimension M");
+        OPENVINO_ASSERT(
+            in_ports.size() > 1 && check_port(in_ports[0]) && out_ports.size() == 1 && check_port(out_ports[0]),
+            "Incorrect Loop by Brgemm dimension M");
         M = current_expanded_loop_info->get_work_amount() > 0 ? current_expanded_loop_info->get_increment() : 0;
         input_pds[0]->set_subtensor_dim(1, M);
         output_pds[0]->set_subtensor_dim(1, M);
@@ -213,13 +215,11 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         const auto& in_ports = current_expanded_loop_info->get_input_ports();
         const auto& out_ports = current_expanded_loop_info->get_output_ports();
         // Quick validation check: Should we check that port is really Brgemm port?
-        // Note: We check `is_incremented` attribute only for not incremented ports because
-        //       this `is_incremented = true` can be changed by `CleanRepeatedDataPointerShifts` optimization
         auto check_port = [&](const ov::snippets::lowered::LoopPort& p) {
-            return p.get_dim_idx() == 0;
+            return p.get_dim_idx() == 0 && is_processed_port(p);
         };
-        OPENVINO_ASSERT(in_ports.size() >= 2 && !in_ports.front().is_incremented() &&
-                            std::all_of(in_ports.cbegin(), in_ports.cend(), check_port) && out_ports.size() == 1 &&
+        OPENVINO_ASSERT(in_ports.size() >= 2 && !is_processed_port(in_ports.front()) &&
+                            std::all_of(in_ports.cbegin() + 1, in_ports.cend(), check_port) && out_ports.size() == 1 &&
                             check_port(out_ports.back()),
                         "Incorrect Loop by Brgemm dimension N");
         N = current_expanded_loop_info->get_work_amount() > 0 ? current_expanded_loop_info->get_increment() : 0;
@@ -240,11 +240,10 @@ void BrgemmBaseKernelExecutor::update_config(const ov::snippets::lowered::Expres
         const auto& in_ports = current_expanded_loop_info->get_input_ports();
         const auto& out_ports = current_expanded_loop_info->get_output_ports();
         // Quick validation check: Should we check that port is really Brgemm port?
-        // Note: We check `is_incremented` attribute only for not incremented ports because
-        //       this `is_incremented = true` can be changed by `CleanRepeatedDataPointerShifts` optimization
         OPENVINO_ASSERT(in_ports.size() >= 2 && in_ports.front().get_dim_idx() == 0 &&
-                            in_ports.back().get_dim_idx() == 1 && out_ports.size() == 1 &&
-                            !out_ports.front().is_incremented(),
+                            is_processed_port(in_ports.front()) && in_ports.back().get_dim_idx() == 1 &&
+                            is_processed_port(in_ports.back()) && out_ports.size() == 1 &&
+                            !is_processed_port(out_ports.front()),
                         "Incorrect Loop by Brgemm dimension K");
         K = current_expanded_loop_info->get_work_amount() > 0 ? current_expanded_loop_info->get_increment() : 0;
         input_pds[0]->set_subtensor_dim(0, K);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/adjust_brgemm_copy_b_loop_ports.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/adjust_brgemm_copy_b_loop_ports.cpp
@@ -31,7 +31,7 @@ bool pass::AdjustBrgemmCopyBLoopPorts::update_loop_info(
                  *  2) Zero padding is applied if N4k < 256 or N2k < 64
                  */
                 if (brgemm_utils::with_repacking(brg->get_type()) && precision != element::f32 &&
-                    loop_port.is_incremented()) {
+                    loop_port.get_type() == ov::snippets::lowered::LoopPort::Type::Incremented) {
                     // K blocking loop: account for zero padding
                     if (loop_port.get_dim_idx() == 1) {
                         const auto ptr_incr = loop_desc.ptr_increment;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/adjust_brgemm_copy_b_loop_ports.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/adjust_brgemm_copy_b_loop_ports.cpp
@@ -31,7 +31,7 @@ bool pass::AdjustBrgemmCopyBLoopPorts::update_loop_info(
                  *  2) Zero padding is applied if N4k < 256 or N2k < 64
                  */
                 if (brgemm_utils::with_repacking(brg->get_type()) && precision != element::f32 &&
-                    loop_port.get_type() == ov::snippets::lowered::LoopPort::Type::Incremented) {
+                    loop_port.is_incremented()) {
                     // K blocking loop: account for zero padding
                     if (loop_port.get_dim_idx() == 1) {
                         const auto ptr_incr = loop_desc.ptr_increment;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
@@ -122,13 +122,13 @@ bool BrgemmCPUBlocking::mark_blocking_loops(LinearIR& linear_ir,
             loop_info->replace_with_new_ports(in_ports[1], {in_ports[1], new_port});
         };
         if (!is_full_dim_value(m_block))
-            update_loop_info({compens_port, false, 1});
+            update_loop_info({compens_port, LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed});
 
         if (!is_full_dim_value(n_block))
-            update_loop_info({compens_port, true, 0});
+            update_loop_info({compens_port, 0});
 
         if (!is_full_dim_value(k_block))
-            update_loop_info({compens_port, false, 1});
+            update_loop_info({compens_port, 1, LoopPort::Type::NotIncremented});
     }
     return true;
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/brgemm_cpu_blocking.cpp
@@ -122,13 +122,13 @@ bool BrgemmCPUBlocking::mark_blocking_loops(LinearIR& linear_ir,
             loop_info->replace_with_new_ports(in_ports[1], {in_ports[1], new_port});
         };
         if (!is_full_dim_value(m_block))
-            update_loop_info({compens_port, LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed});
+            update_loop_info(LoopPort::create<LoopPort::Type::NotProcessed>(compens_port));
 
         if (!is_full_dim_value(n_block))
-            update_loop_info({compens_port, 0});
+            update_loop_info(LoopPort::create<LoopPort::Type::Incremented>(compens_port, 0));
 
         if (!is_full_dim_value(k_block))
-            update_loop_info({compens_port, 1, LoopPort::Type::NotIncremented});
+            update_loop_info(LoopPort::create<LoopPort::Type::NotIncremented>(compens_port, 1));
     }
     return true;
 }

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/lowered/set_tpp_leading_dim.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/lowered/set_tpp_leading_dim.cpp
@@ -16,6 +16,7 @@ namespace tpp {
 namespace pass {
 namespace {
 using ExpressionPort = snippets::lowered::ExpressionPort;
+using LoopPort = snippets::lowered::LoopPort;
 // Note: Buffer is directly connected to the port if it remains in the same loops with the port's expression
 //  Directly connected Buffers store data densely, so strides are defined by subternsor dims
 //  Indirectly connected Buffers (with loops between the expr and Buffer) store data according
@@ -23,8 +24,8 @@ using ExpressionPort = snippets::lowered::ExpressionPort;
 bool has_directly_connected_buffer(const ExpressionPort& port, const snippets::lowered::LoopManagerPtr& loop_mngr) {
     auto accepted_loops = [&loop_mngr, &port](const std::vector<size_t>& orig, const std::vector<size_t>& connect) {
         size_t connect_idx = 0;
-        auto pred = [&port](const snippets::lowered::LoopPort& loop_port ) {
-            return *loop_port.expr_port == port;
+        auto pred = [&port](const LoopPort& loop_port ) {
+            return *loop_port.get_expr_port() == port;
         };
         for (const auto orig_loop : orig) {
             if (connect_idx < connect.size() && orig_loop == connect[connect_idx]) {
@@ -39,7 +40,7 @@ bool has_directly_connected_buffer(const ExpressionPort& port, const snippets::l
                                                            loop_info->get_input_ports() :
                                                            loop_info->get_output_ports();
             const auto& found = std::find_if(border_points.begin(), border_points.end(), pred);
-            if (found == border_points.end() || found->is_incremented)
+            if (found == border_points.end() || found->get_type() == LoopPort::Type::Incremented)
                 return false;
         }
         return true;

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/lowered/set_tpp_leading_dim.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/lowered/set_tpp_leading_dim.cpp
@@ -40,7 +40,7 @@ bool has_directly_connected_buffer(const ExpressionPort& port, const snippets::l
                                                            loop_info->get_input_ports() :
                                                            loop_info->get_output_ports();
             const auto& found = std::find_if(border_points.begin(), border_points.end(), pred);
-            if (found == border_points.end() || found->get_type() == LoopPort::Type::Incremented)
+            if (found == border_points.end() || found->is_incremented())
                 return false;
         }
         return true;

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -56,8 +56,8 @@ void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
     if (k_block) {
         const auto loop_info =
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(k, k_blk,
-                std::vector<LoopPort>{LoopPort::create(brgemm_expr->get_input_port(0), 0),
-                                      LoopPort::create(brgemm_expr->get_input_port(1), 1)},
+                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 0),
+                                      LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1), 1)},
                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_output_port(0))},
                 get_k_loop_handlers(k, k_block, backend));
         linear_ir->get_loop_manager()->add_loop_info(loop_info);
@@ -66,18 +66,18 @@ void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(n, n_blk,
                 std::vector<LoopPort>{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(0)),
-                                      LoopPort::create(brgemm_expr->get_input_port(1))},
-                std::vector<LoopPort>{LoopPort::create(brgemm_expr->get_output_port(0))},
+                                      LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1))},
+                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0))},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(n, n_block)));
     }
     if (m_block) {
-        std::vector<LoopPort> entries{LoopPort::create(brgemm_expr->get_input_port(0), 1)};
+        std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 1)};
         for (size_t i = 1; i < brgemm_expr->get_input_count(); ++i)
             entries.push_back(LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(i)));
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk,
                 entries,
-                std::vector<LoopPort>{LoopPort::create(brgemm_expr->get_output_port(0), 1)},
+                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0), 1)},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_block)));
     }
 }
@@ -314,9 +314,9 @@ TEST_F(BrgemmCPUBlockingTest, AMX) {
         init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, get_default_subtensor(), {m_blk, n_blk}});
         create_brgemm_loop_infos(linear_ir_ref, brgemm_expr, m, 0, k, k_blk, n, n_blk);
 
-        std::vector<LoopPort> entries {LoopPort::create(brgemm_expr->get_input_port(0), 1),
+        std::vector<LoopPort> entries {LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 1),
                                        LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(1))};
-        std::vector<LoopPort> exits {LoopPort::create(brgemm_expr->get_output_port(0), 1)};
+        std::vector<LoopPort> exits {LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0), 1)};
         auto handlers = BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_blk);
         linear_ir_ref->get_loop_manager()->
             add_loop_info(std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk, entries, exits, handlers));

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -56,28 +56,28 @@ void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
     if (k_block) {
         const auto loop_info =
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(k, k_blk,
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_input_port(0)),
-                                      LoopPort(brgemm_expr->get_input_port(1), true, 1)},
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0), false)},
+                std::vector<LoopPort>{LoopPort(brgemm_expr->get_input_port(0), 0),
+                                      LoopPort(brgemm_expr->get_input_port(1), 1)},
+                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
                 get_k_loop_handlers(k, k_block, backend));
         linear_ir->get_loop_manager()->add_loop_info(loop_info);
     }
     if (n_block) {
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(n, n_blk,
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_input_port(0), false),
+                std::vector<LoopPort>{LoopPort(brgemm_expr->get_input_port(0), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed),
                                       LoopPort(brgemm_expr->get_input_port(1))},
                 std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0))},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(n, n_block)));
     }
     if (m_block) {
-        std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), true, 1)};
+        std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), 1)};
         for (size_t i = 1; i < brgemm_expr->get_input_count(); ++i)
-            entries.emplace_back(brgemm_expr->get_input_port(i), false, 1);
+            entries.emplace_back(brgemm_expr->get_input_port(i), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed);
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk,
                 entries,
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0), true, 1)},
+                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0), 1)},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_block)));
     }
 }
@@ -269,8 +269,8 @@ TEST_F(BrgemmCPUBlockingTest, WithCompensations) {
             loop_info->replace_with_new_ports(in_ports[1], {in_ports[1], new_port});
         };
         const auto& compens_port = brgemm_expr->get_input_port(2);
-        update_loop_info(1, {compens_port, true, 0});
-        update_loop_info(0, {compens_port, false, 1});
+        update_loop_info(1, {compens_port, 0});
+        update_loop_info(0, {compens_port, 1, LoopPort::Type::NotIncremented});
 
         brgemm_expr->set_loop_ids({2, 1, 0});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
@@ -314,9 +314,9 @@ TEST_F(BrgemmCPUBlockingTest, AMX) {
         init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, get_default_subtensor(), {m_blk, n_blk}});
         create_brgemm_loop_infos(linear_ir_ref, brgemm_expr, m, 0, k, k_blk, n, n_blk);
 
-        std::vector<LoopPort> entries {LoopPort(brgemm_expr->get_input_port(0), true, 1),
-                                       LoopPort(brgemm_expr->get_input_port(1), false, 1)};
-        std::vector<LoopPort> exits {LoopPort(brgemm_expr->get_output_port(0), true, 1)};
+        std::vector<LoopPort> entries {LoopPort(brgemm_expr->get_input_port(0), 1),
+                                       LoopPort(brgemm_expr->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)};
+        std::vector<LoopPort> exits {LoopPort(brgemm_expr->get_output_port(0), 1)};
         auto handlers = BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_blk);
         linear_ir_ref->get_loop_manager()->
             add_loop_info(std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk, entries, exits, handlers));

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -56,28 +56,28 @@ void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
     if (k_block) {
         const auto loop_info =
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(k, k_blk,
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_input_port(0), 0),
-                                      LoopPort(brgemm_expr->get_input_port(1), 1)},
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)},
+                std::vector<LoopPort>{LoopPort::create(brgemm_expr->get_input_port(0), 0),
+                                      LoopPort::create(brgemm_expr->get_input_port(1), 1)},
+                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_output_port(0))},
                 get_k_loop_handlers(k, k_block, backend));
         linear_ir->get_loop_manager()->add_loop_info(loop_info);
     }
     if (n_block) {
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(n, n_blk,
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_input_port(0), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed),
-                                      LoopPort(brgemm_expr->get_input_port(1))},
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0))},
+                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(0)),
+                                      LoopPort::create(brgemm_expr->get_input_port(1))},
+                std::vector<LoopPort>{LoopPort::create(brgemm_expr->get_output_port(0))},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(n, n_block)));
     }
     if (m_block) {
-        std::vector<LoopPort> entries{LoopPort(brgemm_expr->get_input_port(0), 1)};
+        std::vector<LoopPort> entries{LoopPort::create(brgemm_expr->get_input_port(0), 1)};
         for (size_t i = 1; i < brgemm_expr->get_input_count(); ++i)
-            entries.emplace_back(brgemm_expr->get_input_port(i), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed);
+            entries.push_back(LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(i)));
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk,
                 entries,
-                std::vector<LoopPort>{LoopPort(brgemm_expr->get_output_port(0), 1)},
+                std::vector<LoopPort>{LoopPort::create(brgemm_expr->get_output_port(0), 1)},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_block)));
     }
 }
@@ -269,8 +269,8 @@ TEST_F(BrgemmCPUBlockingTest, WithCompensations) {
             loop_info->replace_with_new_ports(in_ports[1], {in_ports[1], new_port});
         };
         const auto& compens_port = brgemm_expr->get_input_port(2);
-        update_loop_info(1, {compens_port, 0});
-        update_loop_info(0, {compens_port, 1, LoopPort::Type::NotIncremented});
+        update_loop_info(1, LoopPort::create<LoopPort::Type::Incremented>(compens_port, 0));
+        update_loop_info(0, LoopPort::create<LoopPort::Type::NotIncremented>(compens_port, 1));
 
         brgemm_expr->set_loop_ids({2, 1, 0});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
@@ -314,9 +314,9 @@ TEST_F(BrgemmCPUBlockingTest, AMX) {
         init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, get_default_subtensor(), {m_blk, n_blk}});
         create_brgemm_loop_infos(linear_ir_ref, brgemm_expr, m, 0, k, k_blk, n, n_blk);
 
-        std::vector<LoopPort> entries {LoopPort(brgemm_expr->get_input_port(0), 1),
-                                       LoopPort(brgemm_expr->get_input_port(1), LoopInfo::UNDEFINED_DIM_IDX, LoopPort::Type::NotProcessed)};
-        std::vector<LoopPort> exits {LoopPort(brgemm_expr->get_output_port(0), 1)};
+        std::vector<LoopPort> entries {LoopPort::create(brgemm_expr->get_input_port(0), 1),
+                                       LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(1))};
+        std::vector<LoopPort> exits {LoopPort::create(brgemm_expr->get_output_port(0), 1)};
         auto handlers = BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_blk);
         linear_ir_ref->get_loop_manager()->
             add_loop_info(std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk, entries, exits, handlers));

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -24,6 +24,7 @@ using namespace ov::snippets::lowered;
 using namespace ov::snippets::lowered::pass;
 using namespace ov::snippets;
 using BRGEMM_TYPE = intel_cpu::brgemm_utils::BRGEMM_TYPE;
+using PortType = LoopPort::Type;
 
 namespace {
 enum class BACKEND_TYPE{CPU, TPP};
@@ -56,28 +57,28 @@ void create_brgemm_loop_infos(const LinearIRPtr& linear_ir,
     if (k_block) {
         const auto loop_info =
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(k, k_blk,
-                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 0),
-                                      LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1), 1)},
-                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_output_port(0))},
+                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(0), 0),
+                                      LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1), 1)},
+                std::vector<LoopPort>{LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_output_port(0))},
                 get_k_loop_handlers(k, k_block, backend));
         linear_ir->get_loop_manager()->add_loop_info(loop_info);
     }
     if (n_block) {
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(n, n_blk,
-                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(0)),
-                                      LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(1))},
-                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0))},
+                std::vector<LoopPort>{LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(0)),
+                                      LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(1))},
+                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0))},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(n, n_block)));
     }
     if (m_block) {
-        std::vector<LoopPort> entries{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 1)};
+        std::vector<LoopPort> entries{LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(0), 1)};
         for (size_t i = 1; i < brgemm_expr->get_input_count(); ++i)
-            entries.push_back(LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(i)));
+            entries.push_back(LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(i)));
         linear_ir->get_loop_manager()->add_loop_info(
             std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk,
                 entries,
-                std::vector<LoopPort>{LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0), 1)},
+                std::vector<LoopPort>{LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0), 1)},
                 BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_block)));
     }
 }
@@ -269,8 +270,8 @@ TEST_F(BrgemmCPUBlockingTest, WithCompensations) {
             loop_info->replace_with_new_ports(in_ports[1], {in_ports[1], new_port});
         };
         const auto& compens_port = brgemm_expr->get_input_port(2);
-        update_loop_info(1, LoopPort::create<LoopPort::Type::Incremented>(compens_port, 0));
-        update_loop_info(0, LoopPort::create<LoopPort::Type::NotIncremented>(compens_port, 1));
+        update_loop_info(1, LoopPort::create<PortType::Incremented>(compens_port, 0));
+        update_loop_info(0, LoopPort::create<PortType::NotIncremented>(compens_port, 1));
 
         brgemm_expr->set_loop_ids({2, 1, 0});
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(brgemm.second);
@@ -314,9 +315,9 @@ TEST_F(BrgemmCPUBlockingTest, AMX) {
         init_expr_descriptors(brgemm_expr, {{m_blk, k_blk}, {k_blk, n_blk}, get_default_subtensor(), {m_blk, n_blk}});
         create_brgemm_loop_infos(linear_ir_ref, brgemm_expr, m, 0, k, k_blk, n, n_blk);
 
-        std::vector<LoopPort> entries {LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_input_port(0), 1),
-                                       LoopPort::create<LoopPort::Type::NotProcessed>(brgemm_expr->get_input_port(1))};
-        std::vector<LoopPort> exits {LoopPort::create<LoopPort::Type::Incremented>(brgemm_expr->get_output_port(0), 1)};
+        std::vector<LoopPort> entries {LoopPort::create<PortType::Incremented>(brgemm_expr->get_input_port(0), 1),
+                                       LoopPort::create<PortType::NotProcessed>(brgemm_expr->get_input_port(1))};
+        std::vector<LoopPort> exits {LoopPort::create<PortType::Incremented>(brgemm_expr->get_output_port(0), 1)};
         auto handlers = BrgemmBlockingBase::get_default_blocking_loop_handlers(m, m_blk);
         linear_ir_ref->get_loop_manager()->
             add_loop_info(std::make_shared<ov::snippets::lowered::UnifiedLoopInfo>(m, m_blk, entries, exits, handlers));


### PR DESCRIPTION
### Details:
 - *Moved fields of the class `LoopPort` to private section and added getters/setters*
 - *Implemented `Type` to `LoopPort` to distinguish not incremented ports due to double ptr increment and not incremented ports of Brgemm.*
 - *These changes fix inefficient calculation of Buffer allocation size in dynamic MHA Subgraphs. More details are described in the ticket 159913*

### Tickets:
 - *157326*
 - *159913*
