### PR TITLE
DOCS: updated link to GenAI to point to release 2024.6 branch

### DIFF
--- a/docs/notebooks/multilora-image-generation-with-output.rst
+++ b/docs/notebooks/multilora-image-generation-with-output.rst
@@ -210,7 +210,7 @@ generative models as it already includes all the core functionality.
 
 ``openvino_genai.Text2ImagePipeline`` class supports inference of
 `Diffusers
-models <https://github.com/openvinotoolkit/openvino.genai/blob/master/src/docs/SUPPORTED_MODELS.md#text-2-image-models>`__.
+models <https://github.com/openvinotoolkit/openvino.genai/blob/releases/2024/6/src/docs/SUPPORTED_MODELS.md#text-2-image-models>`__.
 For pipeline initialization, we should provide directory with converted
 by Optimum Intel pipeline and specify inference device. Optionally, we
 can provide configuration for LoRA Adapters using ``adapter_config``.


### PR DESCRIPTION
### Details:
 - We plan to move this file in GenAI
 - Secondly, it should point to releases/2024/6 as on master we support more models