### PR TITLE
[Py OV] Fix openvino.Model mocked object parameters

### DIFF
--- a/src/bindings/python/src/openvino/_ov_api.py
+++ b/src/bindings/python/src/openvino/_ov_api.py
@@ -24,7 +24,12 @@ from openvino.runtime.utils.data_helpers import (
 )
 
 
-class Model:
+class ModelMeta(type):
+    def __dir__(cls) -> list:
+        return list(set(cls.__dict__.keys()) | set(dir(ModelBase)))
+
+
+class Model(object, metaclass=ModelMeta):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if args and not kwargs:
             if isinstance(args[0], ModelBase):
@@ -66,6 +71,10 @@ class Model:
 
     def __repr__(self) -> str:
         return self.__model.__repr__()
+
+    def __dir__(self) -> list:
+        wrapper_methods = ["__copy__", "__deepcopy__", "__dict__", "__enter__", "__exit__", "__getattr__", "__weakref__"]
+        return dir(self.__model) + wrapper_methods
 
 
 class InferRequest(_InferRequestWrapper):

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -849,3 +849,11 @@ def test_tempdir_save_load_error():
         with tempfile.TemporaryDirectory() as model_save_dir:
             save_model(mem_model, f"{model_save_dir}/model.xml")
             _ = Core().read_model(f"{model_save_dir}/model.xml")
+
+
+def test_model_dir():
+    model = generate_add_model()
+    num_of_attrs = 83
+
+    assert type(dir(model)) == list
+    assert len(dir(model)) == num_of_attrs

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -856,4 +856,4 @@ def test_model_dir():
     num_of_attrs = 83
 
     assert type(dir(model)) == list
-    assert len(dir(model)) == num_of_attrs
+    assert len(dir(model)) >= num_of_attrs


### PR DESCRIPTION
### Details:
 - Overload `dir()` method for class objects. Add meta class `ModelMeta` and overload `dir()`
 - Add test for checking model attributes usind `dir()`

### Tickets:
 - [CVS-160178](https://jira.devtools.intel.com/browse/CVS-160178)
