### PR TITLE
[intel-npu] Adding new read-only property: NPU_COMPILER_VERSION

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -170,7 +170,7 @@ offer a limited set of supported OpenVINO features.
          ov::intel_npu::device_alloc_mem_size
          ov::intel_npu::device_total_mem_size
          ov::intel_npu::driver_version
-         ov::intel_npu::compiler_api_version
+         ov::intel_npu::compiler_version
 
 
 .. note::

--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/npu-device.rst
@@ -170,6 +170,7 @@ offer a limited set of supported OpenVINO features.
          ov::intel_npu::device_alloc_mem_size
          ov::intel_npu::device_total_mem_size
          ov::intel_npu::driver_version
+         ov::intel_npu::compiler_api_version
 
 
 .. note::

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -328,6 +328,7 @@ void regmodule_properties(py::module m) {
     wrap_property_RO(m_intel_npu, ov::intel_npu::device_alloc_mem_size, "device_alloc_mem_size");
     wrap_property_RO(m_intel_npu, ov::intel_npu::device_total_mem_size, "device_total_mem_size");
     wrap_property_RO(m_intel_npu, ov::intel_npu::driver_version, "driver_version");
+    wrap_property_RO(m_intel_npu, ov::intel_npu::compiler_version, "compiler_version");
 
     wrap_property_RW(m_intel_npu, ov::intel_npu::compilation_mode_params, "compilation_mode_params");
     wrap_property_RW(m_intel_npu, ov::intel_npu::turbo, "turbo");

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -194,6 +194,7 @@ def test_conflicting_enum(proxy_enums, expected_values):
         (intel_npu.device_alloc_mem_size, "NPU_DEVICE_ALLOC_MEM_SIZE"),
         (intel_npu.device_total_mem_size, "NPU_DEVICE_TOTAL_MEM_SIZE"),
         (intel_npu.driver_version, "NPU_DRIVER_VERSION"),
+        (intel_npu.compiler_version, "NPU_COMPILER_VERSION"),
     ],
 )
 def test_properties_ro(ov_property_ro, expected_value):

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -54,6 +54,14 @@ static constexpr ov::Property<uint64_t, ov::PropertyMutability::RO> device_total
 static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> driver_version{"NPU_DRIVER_VERSION"};
 
 /**
+ * @brief [Only for NPU plugin]
+ * Type: uint32_t
+ * Read-only property to get NPU compiler API version
+ * @ingroup ov_runtime_npu_prop_cpp_api
+ */
+static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> compiler_api_version{"NPU_COMPILER_API_VERSION"};
+
+/**
  * @brief [Only for NPU compiler]
  * Type: std::string
  * Set various parameters supported by the NPU compiler.

--- a/src/inference/include/openvino/runtime/intel_npu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_npu/properties.hpp
@@ -56,10 +56,10 @@ static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> driver_versi
 /**
  * @brief [Only for NPU plugin]
  * Type: uint32_t
- * Read-only property to get NPU compiler API version
+ * Read-only property to get NPU compiler version. Composite of Major (16bit MSB) and Minor (16bit LSB)
  * @ingroup ov_runtime_npu_prop_cpp_api
  */
-static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> compiler_api_version{"NPU_COMPILER_API_VERSION"};
+static constexpr ov::Property<uint32_t, ov::PropertyMutability::RO> compiler_version{"NPU_COMPILER_VERSION"};
 
 /**
  * @brief [Only for NPU compiler]

--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -171,7 +171,7 @@ The following properties are supported:
 | `ov::intel_npu::device_alloc_mem_size`/</br>`NPU_DEVICE_ALLOC_MEM_SIZE` | RO | Size of already allocated NPU DDR memory | `N/A` | `N/A` |
 | `ov::intel_npu::device_total_mem_size`/</br>`NPU_DEVICE_TOTAL_MEM_SIZE` | RO | Size of available NPU DDR memory | `N/A` | `N/A` |
 | `ov::intel_npu::driver_version`/</br>`NPU_DRIVER_VERSION` | RO | NPU driver version. | `N/A` | `N/A` |
-| `ov::intel_npu::compiler_api_version`/</br>`NPU_COMPILER_API_VERSION` | RO | NPU compiler API version. MSB 16 bits are Major version, LSB 16 bits are Minor version | `N/A` | `N/A` |
+| `ov::intel_npu::compiler_version`/</br>`NPU_COMPILER_VERSION` | RO | NPU compiler version. MSB 16 bits are Major version, LSB 16 bits are Minor version | `N/A` | `N/A` |
 | `ov::intel_npu::compilation_mode_params`/</br>`NPU_COMPILATION_MODE_PARAMS` | RW | Set various parameters supported by the NPU compiler. (See bellow) | `<std::string>`| `N/A` |
 | `ov::intel_npu::turbo`/</br>`NPU_TURBO` | RW | Set Turbo mode on/off | `YES`/ `NO`| `NO` |
 | `ov::intel_npu::tiles`/</br>`NPU_TILES` | RW | Sets the number of npu tiles to compile the model for | `[0-]` | `-1` |

--- a/src/plugins/intel_npu/README.md
+++ b/src/plugins/intel_npu/README.md
@@ -171,6 +171,7 @@ The following properties are supported:
 | `ov::intel_npu::device_alloc_mem_size`/</br>`NPU_DEVICE_ALLOC_MEM_SIZE` | RO | Size of already allocated NPU DDR memory | `N/A` | `N/A` |
 | `ov::intel_npu::device_total_mem_size`/</br>`NPU_DEVICE_TOTAL_MEM_SIZE` | RO | Size of available NPU DDR memory | `N/A` | `N/A` |
 | `ov::intel_npu::driver_version`/</br>`NPU_DRIVER_VERSION` | RO | NPU driver version. | `N/A` | `N/A` |
+| `ov::intel_npu::compiler_api_version`/</br>`NPU_COMPILER_API_VERSION` | RO | NPU compiler API version. MSB 16 bits are Major version, LSB 16 bits are Minor version | `N/A` | `N/A` |
 | `ov::intel_npu::compilation_mode_params`/</br>`NPU_COMPILATION_MODE_PARAMS` | RW | Set various parameters supported by the NPU compiler. (See bellow) | `<std::string>`| `N/A` |
 | `ov::intel_npu::turbo`/</br>`NPU_TURBO` | RW | Set Turbo mode on/off | `YES`/ `NO`| `NO` |
 | `ov::intel_npu::tiles`/</br>`NPU_TILES` | RW | Sets the number of npu tiles to compile the model for | `[0-]` | `-1` |

--- a/src/plugins/intel_npu/src/al/include/intel_npu/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/icompiler.hpp
@@ -71,6 +71,14 @@ public:
      */
     virtual NetworkMetadata parse(const std::vector<uint8_t>& network, const Config& config) const = 0;
 
+    /**
+     * @brief Returns the compiler API version
+     * @return composite uint32_t value of compiler api version.
+     *         MSB 16 bits = Major version
+     *         LSB 16bits = Minor version
+     */
+    virtual uint32_t get_api_version() const = 0;
+
     virtual std::vector<ov::ProfilingInfo> process_profiling_output(const std::vector<uint8_t>& profData,
                                                                     const std::vector<uint8_t>& network,
                                                                     const Config& config) const = 0;

--- a/src/plugins/intel_npu/src/al/include/intel_npu/icompiler.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/icompiler.hpp
@@ -72,12 +72,12 @@ public:
     virtual NetworkMetadata parse(const std::vector<uint8_t>& network, const Config& config) const = 0;
 
     /**
-     * @brief Returns the compiler API version
-     * @return composite uint32_t value of compiler api version.
+     * @brief Returns the compiler version
+     * @return composite uint32_t value of compiler version.
      *         MSB 16 bits = Major version
      *         LSB 16bits = Minor version
      */
-    virtual uint32_t get_api_version() const = 0;
+    virtual uint32_t get_version() const = 0;
 
     virtual std::vector<ov::ProfilingInfo> process_profiling_output(const std::vector<uint8_t>& profData,
                                                                     const std::vector<uint8_t>& network,

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/icompiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/icompiler_adapter.hpp
@@ -14,7 +14,7 @@ public:
                                             const Config& config) const = 0;
     virtual std::shared_ptr<IGraph> parse(std::vector<uint8_t> network, const Config& config) const = 0;
     virtual ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const = 0;
-    virtual uint32_t getApiVersion() const = 0;
+    virtual uint32_t get_version() const = 0;
 
     virtual ~ICompilerAdapter() = default;
 };

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/icompiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/icompiler_adapter.hpp
@@ -14,6 +14,7 @@ public:
                                             const Config& config) const = 0;
     virtual std::shared_ptr<IGraph> parse(std::vector<uint8_t> network, const Config& config) const = 0;
     virtual ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const = 0;
+    virtual uint32_t getApiVersion() const = 0;
 
     virtual ~ICompilerAdapter() = default;
 };

--- a/src/plugins/intel_npu/src/compiler_adapter/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/driver_compiler_adapter.hpp
@@ -27,7 +27,7 @@ public:
 
     ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const override;
 
-    uint32_t getApiVersion() const override;
+    uint32_t get_version() const override;
 
 private:
     /**

--- a/src/plugins/intel_npu/src/compiler_adapter/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/driver_compiler_adapter.hpp
@@ -27,6 +27,8 @@ public:
 
     ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const override;
 
+    uint32_t getApiVersion() const override;
+
 private:
     /**
      * @brief Serialize input / output information to string format.

--- a/src/plugins/intel_npu/src/compiler_adapter/include/plugin_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/plugin_compiler_adapter.hpp
@@ -25,7 +25,7 @@ public:
 
     ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const override;
 
-    uint32_t getApiVersion() const override;
+    uint32_t get_version() const override;
 
 private:
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;

--- a/src/plugins/intel_npu/src/compiler_adapter/include/plugin_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/plugin_compiler_adapter.hpp
@@ -25,6 +25,8 @@ public:
 
     ov::SupportedOpsMap query(const std::shared_ptr<const ov::Model>& model, const Config& config) const override;
 
+    uint32_t getApiVersion() const override;
+
 private:
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -253,6 +253,10 @@ ov::SupportedOpsMap DriverCompilerAdapter::query(const std::shared_ptr<const ov:
     return result;
 }
 
+uint32_t DriverCompilerAdapter::getApiVersion() const {
+    return _zeroInitStruct->getCompilerApiVersion();
+}
+
 /**
  * @brief Place xml + weights in sequential memory
  * @details Format of the memory:

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -253,8 +253,8 @@ ov::SupportedOpsMap DriverCompilerAdapter::query(const std::shared_ptr<const ov:
     return result;
 }
 
-uint32_t DriverCompilerAdapter::getApiVersion() const {
-    return _zeroInitStruct->getCompilerApiVersion();
+uint32_t DriverCompilerAdapter::get_version() const {
+    return _zeroInitStruct->getCompilerVersion();
 }
 
 /**

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -132,4 +132,8 @@ ov::SupportedOpsMap PluginCompilerAdapter::query(const std::shared_ptr<const ov:
     return _compiler->query(model, config);
 }
 
+uint32_t PluginCompilerAdapter::getApiVersion() const {
+    return _compiler->get_api_version();
+}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_compiler_adapter.cpp
@@ -132,8 +132,8 @@ ov::SupportedOpsMap PluginCompilerAdapter::query(const std::shared_ptr<const ov:
     return _compiler->query(model, config);
 }
 
-uint32_t PluginCompilerAdapter::getApiVersion() const {
-    return _compiler->get_api_version();
+uint32_t PluginCompilerAdapter::get_version() const {
+    return _compiler->get_version();
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -454,14 +454,14 @@ Plugin::Plugin()
           [&](const Config& config) {
               return _metrics->GetDriverVersion();
           }}},
-        {ov::intel_npu::compiler_api_version.name(),
+        {ov::intel_npu::compiler_version.name(),
          {true,
           ov::PropertyMutability::RO,
           [&](const Config& config) {
               /// create dummy compiler
               CompilerAdapterFactory compilerAdapterFactory;
               auto dummyCompiler = compilerAdapterFactory.getCompiler(_backends->getIEngineBackend(), config);
-              return dummyCompiler->getApiVersion();
+              return dummyCompiler->get_version();
           }}},
         {ov::intel_npu::compilation_mode_params.name(),
          {true,

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -454,6 +454,15 @@ Plugin::Plugin()
           [&](const Config& config) {
               return _metrics->GetDriverVersion();
           }}},
+        {ov::intel_npu::compiler_api_version.name(),
+         {true,
+          ov::PropertyMutability::RO,
+          [&](const Config& config) {
+              /// create dummy compiler
+              CompilerAdapterFactory compilerAdapterFactory;
+              auto dummyCompiler = compilerAdapterFactory.getCompiler(_backends->getIEngineBackend(), config);
+              return dummyCompiler->getApiVersion();
+          }}},
         {ov::intel_npu::compilation_mode_params.name(),
          {true,
           ov::PropertyMutability::RW,

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -49,8 +49,8 @@ public:
     inline uint32_t getDriverVersion() const {
         return driver_properties.driverVersion;
     }
-    inline uint32_t getCompilerApiVersion() const {
-        return compiler_api_version;
+    inline uint32_t getCompilerVersion() const {
+        return compiler_version;
     }
     inline uint32_t getMutableCommandListVersion() const {
         return mutable_command_list_version;
@@ -89,7 +89,7 @@ private:
 
     ze_api_version_t ze_drv_api_version = {};
 
-    uint32_t compiler_api_version = 0;
+    uint32_t compiler_version = 0;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -49,6 +49,9 @@ public:
     inline uint32_t getDriverVersion() const {
         return driver_properties.driverVersion;
     }
+    inline uint32_t getCompilerApiVersion() const {
+        return compiler_api_version;
+    }
     inline uint32_t getMutableCommandListVersion() const {
         return mutable_command_list_version;
     }
@@ -85,6 +88,8 @@ private:
     uint32_t mutable_command_list_version = 0;
 
     ze_api_version_t ze_drv_api_version = {};
+
+    uint32_t compiler_api_version = 0;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -318,7 +318,7 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     graph_props.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
     auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &graph_props);
     THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
-    compiler_api_version = ZE_MAKE_VERSION(graph_props.compilerVersion.major, graph_props.compilerVersion.minor);
+    compiler_version = ZE_MAKE_VERSION(graph_props.compilerVersion.major, graph_props.compilerVersion.minor);
 }
 
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -312,6 +312,13 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     ze_context_desc_t context_desc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, 0, 0};
     THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     log.debug("ZeroInitStructsHolder initialize complete");
+
+    // Obtain compiler-in-driver (vcl) version
+    ze_device_graph_properties_t graph_props;
+    graph_props.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
+    auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &graph_props);
+    THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
+    compiler_api_version = ZE_MAKE_VERSION(graph_props.compilerVersion.major, graph_props.compilerVersion.minor);
 }
 
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {


### PR DESCRIPTION
### Details:
 - extending compiler adapter interfaces with getApiVersion functions
 - adding new public read-only property to expose compiler api version

### Tickets:
 - *EISW-151484*
