### PR TITLE
[GPU] Fix scale and zp calculation as inf/nan for dynamic_quantize_gpu_kv_cache kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -88,7 +88,7 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     min_value = work_group_reduce_min(min_value);
     max_value = work_group_reduce_max(max_value);
     // If the range of input data is zero, it is adjusted to the minimum value(0.001).
-    half diff_value = max_value == min_value ? ((max_value + grp_max) - min_value) : (max_value - min_value);
+    half diff_value = max_value == min_value ? (grp_max) : (max_value - min_value);
     ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((CHAR_MAX - CHAR_MIN) / diff_value);
     ACCUMULATOR_TYPE zp_tmp = (ACCUMULATOR_TYPE)(-min_value * scale_tmp) - CHAR_MAX;
     OUTPUT1_TYPE scale = (OUTPUT1_TYPE)(scale_tmp);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_kv_cache.cl
@@ -11,7 +11,7 @@
 
 
 #if OUTPUT_DIMS != 4
-#error "dynamic_quantize_gpu_opt.cl: Unsupported output dimension"
+#error "dynamic_quantize_gpu_kv_cache.cl: Unsupported output dimension"
 #endif
 
 #define VLOAD_N CAT(vload, VEC_SIZE)
@@ -64,6 +64,8 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
     // The innermost dimension is always processed in the loop inside the kernel
     const uint x = 0;
 
+    half grp_max = 0.001h;
+    half grp_min = 0.001h;
     half max_value = INPUT0_VAL_MIN;
     half min_value = INPUT0_VAL_MAX;
 
@@ -79,15 +81,23 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
         max_value = fmax(max_value, fabs(val[i]));
 #endif
     }
+#if ASYMMETRIC_QUANTIZATION
+    max_value = fmax(max_value, grp_max);
+    min_value = fmin(min_value, grp_min);
+#else
+    max_value = fmax(max_value, grp_max);
+#endif
 
 #if ASYMMETRIC_QUANTIZATION
     min_value = work_group_reduce_min(min_value);
     max_value = work_group_reduce_max(max_value);
-    ACCUMULATOR_TYPE scale = (ACCUMULATOR_TYPE)((CHAR_MAX - CHAR_MIN) / (max_value - min_value));
-    ACCUMULATOR_TYPE zp = (ACCUMULATOR_TYPE)(-min_value * scale) - CHAR_MAX;
+    ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((CHAR_MAX - CHAR_MIN) / (max_value - min_value));
+    ACCUMULATOR_TYPE zp_tmp = (ACCUMULATOR_TYPE)(-min_value * scale_tmp) - CHAR_MAX;
+    OUTPUT1_TYPE scale = (OUTPUT1_TYPE)(scale_tmp);
+    OUTPUT1_TYPE zp = (OUTPUT1_TYPE)(zp_tmp);
 #else
     max_value = work_group_reduce_max(max_value);
-    ACCUMULATOR_TYPE scale = 127.0h / max_value;
+    OUTPUT1_TYPE scale = 127.0h / max_value;
 #endif
 
 #ifdef APPEND_MODE
@@ -112,7 +122,7 @@ KERNEL(dynamic_quantize_gpu_kv_cache)(
 #if GROUP_SCALES_WITH_ZP
         output_scale[scale_idx + 1] = zp;
 #else
-        output_zp[scale_idx] = zp;
+        output_zp[scale_idx] = convert_char_rte(zp);
 #endif
 #else
         output_scale[scale_idx] = 1.0h / scale;

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_ref.cl
@@ -104,7 +104,7 @@ KERNEL(dynamic_quantize_gpu_ref)(
 
 #if ASYMMETRIC_QUANTIZATION
     // If the range of input data is zero, it is adjusted to the minimum value(0.001).
-     half diff_value = max_val == min_val ? ((max_val + grp_max) - min_val) : (max_val - min_val);
+     half diff_value = max_val == min_val ? (grp_max) : (max_val - min_val);
     ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((CHAR_MAX - CHAR_MIN) / diff_value);
 #   if UNSIGNED_OUTPUT
     ACCUMULATOR_TYPE zp_tmp = (ACCUMULATOR_TYPE)(-min_val * scale_tmp);

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/dynamic_quantize_gpu_ref.cl
@@ -52,6 +52,8 @@ KERNEL(dynamic_quantize_gpu_ref)(
     const uint scale_idx = OUTPUT1_GET_INDEX_SAFE(b, f, out_y, x);
 #endif
 
+    half grp_max = 0.001h;
+    half grp_min = 0.001h;
     half max_val = INPUT0_VAL_MIN;
     half min_val = INPUT0_VAL_MAX;
     for (int b_off = 0; b_off < (GROUP_SIZE_DIM0 == 1 ? 1 : INPUT0_BATCH_NUM); b_off++) {
@@ -62,8 +64,8 @@ KERNEL(dynamic_quantize_gpu_ref)(
         const uint offset = INPUT0_GET_INDEX(b + b_off, f + f_off, y + y_off, x);
         half val = input[offset];
 #if ASYMMETRIC_QUANTIZATION
-        max_val = fmax(max_value, val);
-        min_val = fmin(min_value, val);
+        max_val = fmax(max_val, val);
+        min_val = fmin(min_val, val);
 #else
         half abs_val = fabs(val);
         max_val = fmax(max_val, abs_val);
@@ -97,14 +99,22 @@ KERNEL(dynamic_quantize_gpu_ref)(
     }
     }
     }
+#if ASYMMETRIC_QUANTIZATION
+    max_val = fmax(max_val, grp_max);
+    min_val = fmin(min_val, grp_min);
+#else
+    max_val = fmax(max_val, grp_max);
+#endif
 
 #if ASYMMETRIC_QUANTIZATION
-    OUTPUT1_TYPE scale = (OUTPUT1_TYPE)((CHAR_MAX - CHAR_MIN) / (max_val - min_val));
+    ACCUMULATOR_TYPE scale_tmp = (ACCUMULATOR_TYPE)((CHAR_MAX - CHAR_MIN) / (max_val - min_val));
 #   if UNSIGNED_OUTPUT
-    OUTPUT1_TYPE zp = (OUTPUT1_TYPE)(-min_val * scale);
+    ACCUMULATOR_TYPE zp_tmp = (ACCUMULATOR_TYPE)(-min_val * scale_tmp);
 #   else // !UNSIGNED_OUTPUT
-    OUTPUT1_TYPE zp = (OUTPUT1_TYPE)(-min_val * scale) - CHAR_MAX;
+    ACCUMULATOR_TYPE zp_tmp = (ACCUMULATOR_TYPE)(-min_val * scale_tmp) - CHAR_MAX;
 #   endif
+    OUTPUT1_TYPE scale = (OUTPUT1_TYPE)(scale_tmp);
+    OUTPUT1_TYPE zp = (OUTPUT1_TYPE)(zp_tmp);
 #else  // !ASYMMETRIC_QUANTIZATION
     max_val = work_group_reduce_max(max_val);
     OUTPUT1_TYPE scale = 127.0h / max_val;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_ref.cpp
@@ -56,6 +56,9 @@ JitConstants DynamicQuantizeKernelRef::GetJitConstants(const dynamic_quantize_pa
     jit.AddConstant(MakeJitConstant("GROUP_SCALES_WITH_ZP", params.combine_scales_and_zp));
     jit.AddConstant(MakeJitConstant("UNSIGNED_OUTPUT", params.outputs[0].GetDType() == Datatype::UINT8 ? 1 : 0));
 
+    // Use FP32 accumulator type for scale/zp calculation
+    jit.Merge(MakeTypeJitConstants(Datatype::F32, "ACCUMULATOR"));
+
     auto group_sizes = params.group_sizes;
     group_sizes.resize(std::min((size_t)4, group_sizes.size()), 1);
 


### PR DESCRIPTION
### Details:
 - If the inner most dim values of the input are all zero, the issue of scale/zp calculation as inf/nan occurs because min and max_value calculation also becomes zero.
 - Fix scale and zp calculation as inf/nan for `dynamic_quantize_gpu_kv_cache`_kernel
 - Update accumulator type to prevent overflow for scale/zp calculation for `dynamic_quantize_gpu_ref` kernel
 - Fix existing typo for kernels

### Tickets:
 - 160043
