### PR TITLE
[PyOV] Remove `six` package

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -21,6 +21,5 @@ h5py>=3.1.0,<3.13.0
 docopt~=0.6.2
 paddlepaddle==2.6.2
 tensorflow>=1.15.5,<2.18.0
-six~=1.16.0
 protobuf>=3.18.1,<4.0.0
 onnx==1.17.0

--- a/src/frontends/paddle/tests/requirements.txt
+++ b/src/frontends/paddle/tests/requirements.txt
@@ -2,5 +2,4 @@
 -c ../../../bindings/python/constraints.txt
 protobuf
 numpy
-six
 paddlepaddle


### PR DESCRIPTION
### Details:
 - I can't see any usages of `six` package in the repo (besides docs, but these have their own requirements)
 - `six` is a package for compatibility between Python 2 and Python 3
 - **Running CI to make sure it's not used anywhere, seems to be a leftover**

### Tickets:
 - N/A
