### PR TITLE
[LPT] ConcatTransformation: support scalar equal DQ propagation through dynamic dimension

### DIFF
--- a/src/common/low_precision_transformations/tests/concat_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/concat_transformation.cpp
@@ -128,6 +128,110 @@ const std::vector<ConcatTransformationTestValues> testValues = {
             {ov::element::f32, {128.f}, {0.1f}}
         }
     },
+    // dynamic concatenation axis, but the same per-tensor values
+    {
+        {{1, -1, 4, 4}, {1, -1, 4, 4}},
+        std::int64_t{1},
+        LayerTransformation::createParamsU8I8(),
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {128.f}, {0.1f}}
+            }
+        },
+        {
+            ov::element::u8,
+            {{}, {}},
+            ov::element::u8,
+            {ov::element::f32, {128.f}, {0.1f}}
+        }
+    },
+    // dynamic concatenation axis, but the same per-tensor values
+    {
+        {{1, -1, 4, 4}, {1, -1, 4, 4}},
+        std::int64_t{1},
+        LayerTransformation::createParamsU8I8(),
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {}, {{0.1f}, ov::element::f32, {1, 1, 1}}},
+                {ov::element::f32, {}, {{0.1f}, ov::element::f32, {1, 1, 1}}}
+            }
+        },
+        {
+            ov::element::u8,
+            {{}, {}},
+            ov::element::u8,
+            {ov::element::f32, {}, {0.1f}}
+        }
+    },
+    // dynamic concatenation axis, dq don't match
+    {
+        {{1, -1, 4, 4}, {1, -1, 4, 4}},
+        std::int64_t{1},
+        LayerTransformation::createParamsU8I8(),
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {}, {0.1f}}
+            }
+        },
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {}, {0.1f}}
+            },
+            ov::element::f32,
+            {}
+        }
+    },
+    // dynamic concatenation axis, different per-tensor values
+    {
+        {{1, -1, 4, 4}, {1, -1, 4, 4}},
+        std::int64_t{1},
+        LayerTransformation::createParamsU8I8(),
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {128.f}, {10.f}}
+            }
+        },
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {128.f}, {10.f}}
+            },
+            ov::element::f32,
+            {}
+        }
+    },
+    // dynamic output concatenation axis, but one input dim is static
+    {
+        {{1, -1, 4, 4}, {1, 3, 4, 4}},
+        std::int64_t{1},
+        LayerTransformation::createParamsU8I8(),
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {{128.f, 64.f, 128.f}}, {{10.f, 1.f, 10.f}}}
+            }
+        },
+        {
+            ov::element::u8,
+            {
+                {ov::element::f32, {128.f}, {0.1f}},
+                {ov::element::f32, {{128.f, 64.f, 128.f}}, {{10.f, 1.f, 10.f}}}
+            },
+            ov::element::f32,
+            {}
+        }
+    },
     {
         {{1, 3, 4, 4}, {1, 3, 4, 4}},
         std::int64_t{1},


### PR DESCRIPTION
### Details:
Currently, `ConcatTransformation` doesn't support DQ propagation if `concat->get_out_partial_shape()[axis}.is_dynamic()`. However, it is theoretically possible to propagate the DQ if all dequantization constants are **scalar and equal**. This PR introduces this support.

### Tickets:
 - *CVS-160325*
