### PR TITLE
[Py OV] Update py API tests with imports from openvino directly

### DIFF
--- a/src/bindings/python/tests/test_graph/test_affix_ops.py
+++ b/src/bindings/python/tests/test_graph/test_affix_ops.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 import re
 
-import openvino.runtime.opset13 as ov
+import openvino.opset13 as ov
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_basic.py
+++ b/src/bindings/python/tests/test_graph/test_basic.py
@@ -20,12 +20,12 @@ from openvino import (
     layout_helpers,
 )
 
-from openvino.runtime.op import Parameter, Constant
+from openvino.op import Parameter, Constant
 from openvino.op.util import VariableInfo, Variable
-from openvino.runtime import AxisVector, Coordinate, CoordinateDiff
+from openvino import AxisVector, Coordinate, CoordinateDiff
 from openvino._pyopenvino import DescriptorTensor
 
-from openvino.runtime.utils.types import get_element_type
+from openvino.utils.types import get_element_type
 from tests.utils.helpers import generate_model_with_memory
 
 

--- a/src/bindings/python/tests/test_graph/test_basic.py
+++ b/src/bindings/python/tests/test_graph/test_basic.py
@@ -6,8 +6,8 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset8 as ops
-import openvino.runtime as ov
+import openvino.opset8 as ops
+import openvino as ov
 
 from openvino import (
     Model,
@@ -21,7 +21,7 @@ from openvino import (
 )
 
 from openvino.runtime.op import Parameter, Constant
-from openvino.runtime.op.util import VariableInfo, Variable
+from openvino.op.util import VariableInfo, Variable
 from openvino.runtime import AxisVector, Coordinate, CoordinateDiff
 from openvino._pyopenvino import DescriptorTensor
 

--- a/src/bindings/python/tests/test_graph/test_col2im.py
+++ b/src/bindings/python/tests/test_graph/test_col2im.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Type
-import openvino.runtime.opset15 as ov
+import openvino.opset15 as ov
 import numpy as np
 import pytest
 

--- a/src/bindings/python/tests/test_graph/test_constant.py
+++ b/src/bindings/python/tests/test_graph/test_constant.py
@@ -5,9 +5,9 @@
 import numpy as np
 import openvino as ov
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import Type, PartialShape, Model, Strides, Tensor, compile_model
-from openvino.runtime.op import Constant
+from openvino.op import Constant
 from openvino.helpers import pack_data, unpack_data
 
 import pytest
@@ -306,7 +306,7 @@ def test_memory_sharing(shared_flag):
         assert not np.shares_memory(arr, ov_const.data)
 
 
-OPSETS = [ov.runtime.opset12, ov.runtime.opset13]
+OPSETS = [ov.opset12, ov.opset13]
 
 
 @pytest.mark.parametrize(("opset"), OPSETS)

--- a/src/bindings/python/tests/test_graph/test_convert_promote_types.py
+++ b/src/bindings/python/tests/test_graph/test_convert_promote_types.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset14 as ops
+import openvino.opset14 as ops
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_convolution.py
+++ b/src/bindings/python/tests/test_graph/test_convolution.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from openvino import Type
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 
 
 @pytest.mark.parametrize(("strides", "pads_begin", "pads_end", "dilations", "expected_shape"), [

--- a/src/bindings/python/tests/test_graph/test_core.py
+++ b/src/bindings/python/tests/test_graph/test_core.py
@@ -9,7 +9,7 @@ import pytest
 
 from openvino import Dimension, Model, PartialShape, Shape
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 
 
 def test_dimension():

--- a/src/bindings/python/tests/test_graph/test_create_op.py
+++ b/src/bindings/python/tests/test_graph/test_create_op.py
@@ -6,14 +6,14 @@ import numpy as np
 import pytest
 
 from openvino import PartialShape, Dimension, Model, Type
-from openvino.runtime.exceptions import UserInputError
+from openvino.exceptions import UserInputError
 from openvino.utils.types import make_constant_node
 
-import openvino.runtime.opset1 as ov_opset1
-import openvino.runtime.opset5 as ov_opset5
-import openvino.runtime.opset10 as ov_opset10
-import openvino.runtime.opset15 as ov_opset15
-import openvino.runtime.opset11 as ov
+import openvino.opset1 as ov_opset1
+import openvino.opset5 as ov_opset5
+import openvino.opset10 as ov_opset10
+import openvino.opset15 as ov_opset15
+import openvino.opset11 as ov
 from openvino.op.util import VariableInfo, Variable
 
 np_types = [np.float32, np.int32]

--- a/src/bindings/python/tests/test_graph/test_create_op.py
+++ b/src/bindings/python/tests/test_graph/test_create_op.py
@@ -7,14 +7,14 @@ import pytest
 
 from openvino import PartialShape, Dimension, Model, Type
 from openvino.runtime.exceptions import UserInputError
-from openvino.runtime.utils.types import make_constant_node
+from openvino.utils.types import make_constant_node
 
 import openvino.runtime.opset1 as ov_opset1
 import openvino.runtime.opset5 as ov_opset5
 import openvino.runtime.opset10 as ov_opset10
 import openvino.runtime.opset15 as ov_opset15
 import openvino.runtime.opset11 as ov
-from openvino.runtime.op.util import VariableInfo, Variable
+from openvino.op.util import VariableInfo, Variable
 
 np_types = [np.float32, np.int32]
 integral_np_types = [

--- a/src/bindings/python/tests/test_graph/test_ctc_loss.py
+++ b/src/bindings/python/tests/test_graph/test_ctc_loss.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_custom_op.py
+++ b/src/bindings/python/tests/test_graph/test_custom_op.py
@@ -9,8 +9,8 @@ from contextlib import nullcontext as does_not_raise
 
 from openvino import Op
 from openvino import CompiledModel, Model, Dimension, Shape, Tensor, compile_model, serialize
-from openvino.runtime import DiscreteTypeInfo
-import openvino.runtime.opset14 as ops
+from openvino import DiscreteTypeInfo
+import openvino.opset14 as ops
 
 from tests.utils.helpers import create_filenames_for_ir
 

--- a/src/bindings/python/tests/test_graph/test_data_movement.py
+++ b/src/bindings/python/tests/test_graph/test_data_movement.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Type, Shape
 
 

--- a/src/bindings/python/tests/test_graph/test_detection_output.py
+++ b/src/bindings/python/tests/test_graph/test_detection_output.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import pytest
 
 np_types = [np.float32, np.int32]

--- a/src/bindings/python/tests/test_graph/test_dft.py
+++ b/src/bindings/python/tests/test_graph/test_dft.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Type
-import openvino.runtime.opset10 as ov
+import openvino.opset10 as ov
 import numpy as np
 import pytest
 

--- a/src/bindings/python/tests/test_graph/test_dyn_attributes.py
+++ b/src/bindings/python/tests/test_graph/test_dyn_attributes.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import pytest
 
 

--- a/src/bindings/python/tests/test_graph/test_einsum.py
+++ b/src/bindings/python/tests/test_graph/test_einsum.py
@@ -2,11 +2,11 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import numpy as np
 import pytest
 
-from openvino.runtime.utils.types import get_element_type
+from openvino.utils.types import get_element_type
 
 
 def einsum_op_check(input_shapes: list, equation: str, data_type: np.dtype,

--- a/src/bindings/python/tests/test_graph/test_eye.py
+++ b/src/bindings/python/tests/test_graph/test_eye.py
@@ -2,12 +2,12 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import openvino.runtime.opset10 as ov
+import openvino.opset10 as ov
 import numpy as np
 import pytest
 
-from openvino.runtime.utils.types import get_element_type_str
-from openvino.runtime.utils.types import get_element_type
+from openvino.utils.types import get_element_type_str
+from openvino.utils.types import get_element_type
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_graph/test_fake_convert.py
+++ b/src/bindings/python/tests/test_graph/test_fake_convert.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import PartialShape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_gather.py
+++ b/src/bindings/python/tests/test_graph/test_gather.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Tensor, Type
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import numpy as np
 import pytest
 

--- a/src/bindings/python/tests/test_graph/test_identity.py
+++ b/src/bindings/python/tests/test_graph/test_identity.py
@@ -5,8 +5,8 @@
 import numpy as np
 import pytest
 
-from openvino.runtime.opset15 import parameter
-from openvino.runtime.opset16 import identity
+from openvino.opset15 import parameter
+from openvino.opset16 import identity
 from openvino import PartialShape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_idft.py
+++ b/src/bindings/python/tests/test_graph/test_idft.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Type
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import numpy as np
 import pytest
 

--- a/src/bindings/python/tests/test_graph/test_if.py
+++ b/src/bindings/python/tests/test_graph/test_if.py
@@ -4,10 +4,10 @@
 
 import pytest
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Model
 
-from openvino.runtime.op.util import InvariantInputDescription, BodyOutputDescription
+from openvino.op.util import InvariantInputDescription, BodyOutputDescription
 
 from tests.utils.helpers import compare_models
 

--- a/src/bindings/python/tests/test_graph/test_input_validation.py
+++ b/src/bindings/python/tests/test_graph/test_input_validation.py
@@ -5,8 +5,8 @@
 import numpy as np
 import pytest
 
-from openvino.runtime.exceptions import UserInputError
-from openvino.runtime.utils.input_validation import (
+from openvino.exceptions import UserInputError
+from openvino.utils.input_validation import (
     _check_value,
     check_valid_attribute,
     check_valid_attributes,

--- a/src/bindings/python/tests/test_graph/test_inverse.py
+++ b/src/bindings/python/tests/test_graph/test_inverse.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset14 as ops
+import openvino.opset14 as ops
 from openvino import PartialShape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_log_softmax.py
+++ b/src/bindings/python/tests/test_graph/test_log_softmax.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Shape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_loop.py
+++ b/src/bindings/python/tests/test_graph/test_loop.py
@@ -4,10 +4,10 @@
 
 import pytest
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Model, Shape
 
-from openvino.runtime.op.util import (
+from openvino.op.util import (
     InvariantInputDescription,
     BodyOutputDescription,
     SliceInputDescription,

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import pytest
 
-import openvino.runtime.opset10 as ops
+import openvino.opset10 as ops
 from openvino import Core, Model
 from openvino.passes import Manager, Serialize, ConstantFolding, Version
 

--- a/src/bindings/python/tests/test_graph/test_manager.py
+++ b/src/bindings/python/tests/test_graph/test_manager.py
@@ -48,23 +48,6 @@ def test_constant_folding():
     assert np.allclose(values_out, values_expected)
 
 
-def test_runtime_passes_manager():
-    import openvino.runtime.passes as rt
-    node_constant = ops.constant(np.array([[0.0, 0.1, -0.1], [-2.5, 2.5, 3.0]], dtype=np.float32))
-    node_ceil = ops.ceiling(node_constant)
-    model = Model(node_ceil, [], "TestModel")
-
-    assert count_ops_of_type(model, node_ceil) == 1
-    assert count_ops_of_type(model, node_constant) == 1
-
-    pass_manager = rt.Manager()
-    pass_manager.register_pass(rt.ConstantFolding())
-    pass_manager.run_passes(model)
-
-    assert count_ops_of_type(model, node_ceil) == 0
-    assert count_ops_of_type(model, node_constant) == 1
-
-
 # request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
 @pytest.fixture
 def prepare_ir_paths(request, tmp_path):

--- a/src/bindings/python/tests/test_graph/test_multinomial.py
+++ b/src/bindings/python/tests/test_graph/test_multinomial.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import PartialShape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_nms_rotated.py
+++ b/src/bindings/python/tests/test_graph/test_nms_rotated.py
@@ -5,10 +5,10 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ov_opset13
+import openvino.opset13 as ov_opset13
 
 from openvino import PartialShape, Dimension, Type
-from openvino.runtime.utils.types import make_constant_node
+from openvino.utils.types import make_constant_node
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_graph/test_node_factory.py
+++ b/src/bindings/python/tests/test_graph/test_node_factory.py
@@ -6,10 +6,10 @@ import numpy as np
 import pytest
 from sys import platform
 from openvino import compile_model, Model
-from openvino.runtime import Extension
-import openvino.runtime.opset8 as ov
-from openvino.runtime.exceptions import UserInputError
-from openvino.runtime.utils.node_factory import NodeFactory
+from openvino import Extension
+import openvino.opset8 as ov
+from openvino.exceptions import UserInputError
+from openvino.utils.node_factory import NodeFactory
 
 
 def test_node_factory_add():

--- a/src/bindings/python/tests/test_graph/test_normalization.py
+++ b/src/bindings/python/tests/test_graph/test_normalization.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from openvino import Type
-import openvino.runtime.opset13 as ov
+import openvino.opset13 as ov
 
 
 def test_lrn():

--- a/src/bindings/python/tests/test_graph/test_ops.py
+++ b/src/bindings/python/tests/test_graph/test_ops.py
@@ -8,10 +8,10 @@ import numpy as np
 import pytest
 from contextlib import nullcontext as does_not_raise
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Shape, Type
-from openvino.runtime import AxisSet
-from openvino.runtime.op import Constant, Parameter
+from openvino import AxisSet
+from openvino.op import Constant, Parameter
 
 
 @pytest.mark.parametrize(("ov_op", "expected_ov_str", "expected_type"), [

--- a/src/bindings/python/tests/test_graph/test_ops_binary.py
+++ b/src/bindings/python/tests/test_graph/test_ops_binary.py
@@ -9,8 +9,8 @@ import pytest
 import warnings
 
 from openvino import Type
-import openvino.runtime.opset13 as ov
-import openvino.runtime.opset15 as ov_opset15
+import openvino.opset13 as ov
+import openvino.opset15 as ov_opset15
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_graph/test_ops_embedding.py
+++ b/src/bindings/python/tests/test_graph/test_ops_embedding.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from openvino import Type
-from openvino.runtime import opset15
+from openvino import opset15
 
 
 def test_embedding_bag_offsets_15():

--- a/src/bindings/python/tests/test_graph/test_ops_fused.py
+++ b/src/bindings/python/tests/test_graph/test_ops_fused.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_ops_matmul.py
+++ b/src/bindings/python/tests/test_graph/test_ops_matmul.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_graph/test_ops_multioutput.py
+++ b/src/bindings/python/tests/test_graph/test_ops_multioutput.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 
 
 def test_split():

--- a/src/bindings/python/tests/test_graph/test_ops_reshape.py
+++ b/src/bindings/python/tests/test_graph/test_ops_reshape.py
@@ -2,12 +2,12 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import numpy as np
 import pytest
 
 from openvino import Type
-from openvino.runtime.utils.types import get_element_type
+from openvino.utils.types import get_element_type
 
 
 @pytest.mark.parametrize("op_name", ["ABC", "concat", "123456"])

--- a/src/bindings/python/tests/test_graph/test_ops_result.py
+++ b/src/bindings/python/tests/test_graph/test_ops_result.py
@@ -5,8 +5,8 @@
 import numpy as np
 
 from openvino import PartialShape, Model, Type
-import openvino.runtime.opset13 as ops
-from openvino.runtime.op import Result
+import openvino.opset13 as ops
+from openvino.op import Result
 
 
 def test_result():

--- a/src/bindings/python/tests/test_graph/test_ops_scatter.py
+++ b/src/bindings/python/tests/test_graph/test_ops_scatter.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ov
+import openvino.opset13 as ov
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_ops_scatter_nd_update.py
+++ b/src/bindings/python/tests/test_graph/test_ops_scatter_nd_update.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from openvino import PartialShape, Type
-from openvino.runtime import opset4, opset15
+from openvino import opset4, opset15
 
 scatter_version_opset = pytest.mark.parametrize("opset", [opset4, opset15])
 

--- a/src/bindings/python/tests/test_graph/test_ops_unary.py
+++ b/src/bindings/python/tests/test_graph/test_ops_unary.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import Shape, Type
 
 R_TOLERANCE = 1e-6  # global relative tolerance

--- a/src/bindings/python/tests/test_graph/test_ops_util_variable.py
+++ b/src/bindings/python/tests/test_graph/test_ops_util_variable.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import PartialShape, Type
-from openvino.runtime.op.util import VariableInfo, Variable
+from openvino.op.util import VariableInfo, Variable
 
 
 def test_info_as_property():

--- a/src/bindings/python/tests/test_graph/test_pad.py
+++ b/src/bindings/python/tests/test_graph/test_pad.py
@@ -6,7 +6,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ov
+import openvino.opset13 as ov
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_pooling.py
+++ b/src/bindings/python/tests/test_graph/test_pooling.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset14 as ov
+import openvino.opset14 as ov
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_preprocess.py
+++ b/src/bindings/python/tests/test_graph/test_preprocess.py
@@ -5,11 +5,11 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 
 from openvino import Core, Layout, Model, Shape, Tensor, Type
-from openvino.runtime.utils.decorators import custom_preprocess_function
-from openvino.runtime import Output
+from openvino.utils.decorators import custom_preprocess_function
+from openvino import Output
 from openvino.preprocess import PrePostProcessor, ColorFormat, ResizeAlgorithm, PaddingMode
 
 

--- a/src/bindings/python/tests/test_graph/test_proposal.py
+++ b/src/bindings/python/tests/test_graph/test_proposal.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Shape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_random_uniform.py
+++ b/src/bindings/python/tests/test_graph/test_random_uniform.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import openvino.runtime.opset8 as ops
+import openvino.opset8 as ops
 from openvino import Type
 
 

--- a/src/bindings/python/tests/test_graph/test_rdft.py
+++ b/src/bindings/python/tests/test_graph/test_rdft.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import openvino.runtime.opset10 as ov
+import openvino.opset10 as ov
 from openvino import Shape, Type
 import numpy as np
 import pytest

--- a/src/bindings/python/tests/test_graph/test_reduction.py
+++ b/src/bindings/python/tests/test_graph/test_reduction.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset10 as ov
+import openvino.opset10 as ov
 
 
 @pytest.mark.parametrize(

--- a/src/bindings/python/tests/test_graph/test_roll.py
+++ b/src/bindings/python/tests/test_graph/test_roll.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 import numpy as np
 
 

--- a/src/bindings/python/tests/test_graph/test_scaled_dot_product_attention.py
+++ b/src/bindings/python/tests/test_graph/test_scaled_dot_product_attention.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import PartialShape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_sequence_processing.py
+++ b/src/bindings/python/tests/test_graph/test_sequence_processing.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime as ov
+import openvino as ov
 
 
 @pytest.mark.parametrize(("depth", "on_value", "off_value", "axis", "expected_shape"), [

--- a/src/bindings/python/tests/test_graph/test_squeeze.py
+++ b/src/bindings/python/tests/test_graph/test_squeeze.py
@@ -2,8 +2,8 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import openvino.runtime.opset1 as ov_opset1
-import openvino.runtime.opset15 as ov_opset15
+import openvino.opset1 as ov_opset1
+import openvino.opset15 as ov_opset15
 import numpy as np
 import pytest
 

--- a/src/bindings/python/tests/test_graph/test_string_tensor_pack.py
+++ b/src/bindings/python/tests/test_graph/test_string_tensor_pack.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Type
-import openvino.runtime.opset15 as ov
+import openvino.opset15 as ov
 import pytest
 
 

--- a/src/bindings/python/tests/test_graph/test_string_tensor_unpack.py
+++ b/src/bindings/python/tests/test_graph/test_string_tensor_unpack.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Type, PartialShape, Dimension
-import openvino.runtime.opset15 as ov
+import openvino.opset15 as ov
 import pytest
 
 

--- a/src/bindings/python/tests/test_graph/test_swish.py
+++ b/src/bindings/python/tests/test_graph/test_swish.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 import pytest
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Shape, Type
 
 

--- a/src/bindings/python/tests/test_graph/test_tensor_iterator.py
+++ b/src/bindings/python/tests/test_graph/test_tensor_iterator.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
-import openvino.runtime.opset8 as ov
+import openvino.opset8 as ov
 from openvino import Model, Shape
 
-from openvino.runtime.op.util import (
+from openvino.op.util import (
     InvariantInputDescription,
     BodyOutputDescription,
     SliceInputDescription,

--- a/src/bindings/python/tests/test_graph/test_type_info.py
+++ b/src/bindings/python/tests/test_graph/test_type_info.py
@@ -5,9 +5,9 @@
 import numpy as np
 
 from openvino import Op
-from openvino.runtime import DiscreteTypeInfo, Shape
-import openvino.runtime.opset14 as ops
-from openvino.runtime.utils.node_factory import NodeFactory
+from openvino import DiscreteTypeInfo, Shape
+import openvino.opset14 as ops
+from openvino.utils.node_factory import NodeFactory
 
 
 class CustomAdd(Op):

--- a/src/bindings/python/tests/test_package_versions.py
+++ b/src/bindings/python/tests/test_package_versions.py
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import openvino.preprocess as ov_pre
-import openvino.runtime as ov_run
+import openvino as ov
 import openvino.frontend as ov_front
 import openvino._offline_transformations as ov_off_transf
 import openvino._pyopenvino as ov_py
 
 
 def test_get_version_match():
-    packages = [ov_run, ov_front, ov_pre, ov_off_transf, ov_py]
+    packages = [ov, ov_front, ov_pre, ov_off_transf, ov_py]
     versions = set()
 
     for package in packages:
@@ -20,7 +20,7 @@ def test_get_version_match():
 
 
 def test_dunder_version_match():
-    packages = [ov_run, ov_front, ov_pre, ov_off_transf]
+    packages = [ov, ov_front, ov_pre, ov_off_transf]
     versions = set()
 
     for package in packages:

--- a/src/bindings/python/tests/test_runtime/test_async_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_async_infer_request.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 import time
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import (
     Core,
     InferRequest,

--- a/src/bindings/python/tests/test_runtime/test_compiled_model.py
+++ b/src/bindings/python/tests/test_runtime/test_compiled_model.py
@@ -18,9 +18,8 @@ from tests.utils.helpers import (
     create_filenames_for_ir,
     create_filename_for_test)
 from openvino import Model, Shape, Core, Tensor, serialize
-from openvino.runtime import ConstOutput
+from openvino import ConstOutput
 
-import openvino.runtime.opset13 as ops
 import openvino.properties as props
 
 

--- a/src/bindings/python/tests/test_runtime/test_core.py
+++ b/src/bindings/python/tests/test_runtime/test_core.py
@@ -21,7 +21,7 @@ from openvino import (
 
 import openvino.properties as props
 import openvino.properties.hint as hints
-from openvino.runtime import Extension
+from openvino import Extension
 from tests.utils.helpers import (
     generate_image,
     generate_relu_compiled_model,

--- a/src/bindings/python/tests/test_runtime/test_deprecated_runtime.py
+++ b/src/bindings/python/tests/test_runtime/test_deprecated_runtime.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+from pathlib import Path
+from contextlib import nullcontext as does_not_raise
+
+
+import openvino.runtime as ov
+from openvino.runtime import (
+    Model,
+    Core,
+    AsyncInferQueue,
+    Strides,
+    Shape,
+    PartialShape,
+    serialize,
+    Type,
+)
+
+import openvino.runtime.opset13 as ops
+import openvino.runtime.opset8 as ops8
+from openvino.runtime.op import Constant, Parameter
+from openvino.runtime import Extension
+from openvino.runtime.exceptions import UserInputError
+from openvino.runtime.utils.node_factory import NodeFactory
+from openvino.runtime.utils.types import get_element_type
+
+from openvino.runtime.passes import Manager
+from tests.test_transformations.utils.utils import count_ops, PatternReplacement
+from tests.test_transformations.utils.utils import get_relu_model as get_relu_transformations_model, MyModelPass
+
+from tests.utils.helpers import (
+    generate_image,
+    generate_add_model,
+    get_relu_model,
+    create_filenames_for_ir,
+    generate_abs_compiled_model_with_data,
+)
+
+
+# request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
+def test_read_model_from_ir(request, tmp_path):
+    core = Core()
+    xml_path, bin_path = create_filenames_for_ir(request.node.name, tmp_path)
+    relu_model = get_relu_model()
+    serialize(relu_model, xml_path, bin_path)
+    model = core.read_model(model=xml_path, weights=bin_path)
+    assert isinstance(model, Model)
+
+    model = core.read_model(model=xml_path)
+    assert isinstance(model, Model)
+
+
+# request - https://docs.pytest.org/en/7.1.x/reference/reference.html#request
+def test_read_model_as_path(request, tmp_path):
+    core = Core()
+    xml_path, bin_path = create_filenames_for_ir(request.node.name, tmp_path, True, True)
+    relu_model = get_relu_model()
+    serialize(relu_model, xml_path, bin_path)
+
+    model = core.read_model(model=Path(xml_path), weights=Path(bin_path))
+    assert isinstance(model, Model)
+
+    model = core.read_model(model=xml_path, weights=Path(bin_path))
+    assert isinstance(model, Model)
+
+    model = core.read_model(model=Path(xml_path))
+    assert isinstance(model, Model)
+
+
+def test_infer_new_request_return_type(device):
+    core = Core()
+    model = get_relu_model()
+    img = generate_image()
+    compiled_model = core.compile_model(model, device)
+    res = compiled_model.infer_new_request({"data": img})
+    arr = res[list(res)[0]][0]
+
+    assert isinstance(arr, np.ndarray)
+    assert arr.itemsize == 4
+    assert arr.shape == (3, 32, 32)
+    assert arr.dtype == "float32"
+    assert arr.nbytes == 12288
+
+
+@pytest.mark.parametrize(("ov_type", "numpy_dtype"), [
+    (Type.f32, np.float32),
+    (Type.f64, np.float64),
+    (Type.f16, np.float16),
+    (Type.i8, np.int8),
+    (Type.u8, np.uint8),
+    (Type.i32, np.int32),
+    (Type.i16, np.int16),
+    (Type.u16, np.uint16),
+    (Type.i64, np.int64),
+])
+@pytest.mark.parametrize("share_inputs", [True, False])
+def test_infer_single_input(device, ov_type, numpy_dtype, share_inputs):
+    _, request, tensor1, array1 = generate_abs_compiled_model_with_data(device, ov_type, numpy_dtype)
+
+    request.infer(array1, share_inputs=share_inputs)
+    assert np.array_equal(request.get_output_tensor().data, np.abs(array1))
+
+    request.infer(tensor1, share_inputs=share_inputs)
+    assert np.array_equal(request.get_output_tensor().data, np.abs(tensor1.data))
+
+
+def test_infer_dynamic_model(device):
+    core = Core()
+
+    param = ops.parameter(PartialShape([-1, -1]))
+    model = Model(ops.relu(param), [param])
+    compiled_model = core.compile_model(model, device)
+    assert compiled_model.input().partial_shape.is_dynamic
+    request = compiled_model.create_infer_request()
+
+    shape1 = [1, 28]
+    request.infer([np.random.normal(size=shape1)])
+    assert request.get_input_tensor().shape == Shape(shape1)
+
+    shape2 = [1, 32]
+    request.infer([np.random.normal(size=shape2)])
+    assert request.get_input_tensor().shape == Shape(shape2)
+
+    shape3 = [1, 40]
+    request.infer(np.random.normal(size=shape3))
+    assert request.get_input_tensor().shape == Shape(shape3)
+
+
+def test_add_extension():
+    class EmptyExtension(Extension):
+        def __init__(self) -> None:
+            super().__init__()
+
+    core = Core()
+    core.add_extension(EmptyExtension())
+    core.add_extension([EmptyExtension(), EmptyExtension()])
+    model = get_relu_model()
+    assert isinstance(model, Model)
+
+
+def test_output_replace():
+    param = ops.parameter(PartialShape([1, 3, 22, 22]), name="parameter")
+    relu = ops.relu(param.output(0))
+    res = ops.result(relu.output(0), name="result")
+
+    exp = ops.exp(param.output(0))
+    relu.output(0).replace(exp.output(0))
+
+    assert res.input_value(0).get_node() == exp
+
+
+@pytest.mark.parametrize("share_inputs", [True, False])
+def test_infer_queue(device, share_inputs):
+    jobs = 8
+    num_request = 4
+    core = Core()
+    model = get_relu_model()
+    compiled_model = core.compile_model(model, device)
+    infer_queue = AsyncInferQueue(compiled_model, num_request)
+    jobs_done = [{"finished": False, "latency": 0} for _ in range(jobs)]
+
+    def callback(request, job_id):
+        jobs_done[job_id]["finished"] = True
+        jobs_done[job_id]["latency"] = request.latency
+
+    img = None
+
+    if not share_inputs:
+        img = generate_image()
+    infer_queue.set_callback(callback)
+    assert infer_queue.is_ready()
+
+    for i in range(jobs):
+        if share_inputs:
+            img = generate_image()
+        infer_queue.start_async({"data": img}, i, share_inputs=share_inputs)
+    infer_queue.wait_all()
+    assert all(job["finished"] for job in jobs_done)
+    assert all(job["latency"] > 0 for job in jobs_done)
+
+
+def test_model_reshape(device):
+    shape = Shape([1, 10])
+    param = ops.parameter(shape, dtype=np.float32)
+    model = Model(ops.relu(param), [param])
+    ref_shape = model.input().partial_shape
+    ref_shape[0] = 3
+    model.reshape(ref_shape)
+    core = Core()
+    compiled_model = core.compile_model(model, device)
+    assert compiled_model.input().partial_shape == ref_shape
+
+
+def test_model_get_raw_address():
+    model = generate_add_model()
+    model_with_same_addr = model
+    model_different = generate_add_model()
+
+    assert model._get_raw_address() == model_with_same_addr._get_raw_address()
+    assert model._get_raw_address() != model_different._get_raw_address()
+
+
+@pytest.mark.parametrize(
+    ("ov_type", "numpy_dtype"),
+    [
+        (ov.Type.f32, np.float32),
+        (ov.Type.f64, np.float64),
+        (ov.Type.f16, np.float16),
+        (ov.Type.bf16, np.float16),
+        (ov.Type.i8, np.int8),
+        (ov.Type.u8, np.uint8),
+        (ov.Type.i32, np.int32),
+        (ov.Type.u32, np.uint32),
+        (ov.Type.i16, np.int16),
+        (ov.Type.u16, np.uint16),
+        (ov.Type.i64, np.int64),
+        (ov.Type.u64, np.uint64),
+        (ov.Type.boolean, bool),
+    ],
+)
+def test_tensor_write_to_buffer(ov_type, numpy_dtype):
+    ov_tensor = ov.Tensor(ov_type, ov.Shape([1, 3, 32, 32]))
+    ones_arr = np.ones([1, 3, 32, 32], numpy_dtype)
+    ov_tensor.data[:] = ones_arr
+    assert np.array_equal(ov_tensor.data, ones_arr)
+
+
+def test_strides_iteration_methods():
+    data = np.array([1, 2, 3])
+    strides = Strides(data)
+
+    assert len(strides) == data.size
+    assert np.equal(strides, data).all()
+    assert np.equal([strides[i] for i in range(data.size)], data).all()
+
+    data2 = np.array([5, 6, 7])
+    for i in range(data2.size):
+        strides[i] = data2[i]
+
+    assert np.equal(strides, data2).all()
+
+
+def test_node_factory_add():
+    shape = [2, 2]
+    dtype = np.int8
+    parameter_a = ops8.parameter(shape, dtype=dtype, name="A")
+    parameter_b = ops8.parameter(shape, dtype=dtype, name="B")
+
+    factory = NodeFactory("opset1")
+    arguments = NodeFactory._arguments_as_outputs([parameter_a, parameter_b])
+    node = factory.create("Add", arguments, {})
+
+    assert node.get_type_name() == "Add"
+    assert node.get_output_size() == 1
+    assert list(node.get_output_shape(0)) == [2, 2]
+
+
+def test_node_factory_validate_missing_arguments():
+    factory = NodeFactory("opset1")
+
+    try:
+        factory.create(
+            "TopK", None, {"axis": 1, "mode": "max", "sort": "value"},
+        )
+    except UserInputError:
+        pass
+    else:
+        raise AssertionError("Validation of missing arguments has unexpectedly passed.")
+
+
+@pytest.mark.parametrize(("const", "args", "expectation"), [
+    (Constant, (Type.f32, Shape([3, 3]), list(range(9))), does_not_raise()),
+    (ops8.constant, (np.arange(9).reshape(3, 3), Type.f32), does_not_raise()),
+    (ops8.constant, (np.arange(9).reshape(3, 3), np.float32), does_not_raise()),
+    (ops8.constant, [None], pytest.raises(ValueError)),
+])
+def test_constant(const, args, expectation):
+    with expectation:
+        node = const(*args)
+        assert node.get_type_name() == "Constant"
+        assert node.get_output_size() == 1
+        assert list(node.get_output_shape(0)) == [3, 3]
+        assert node.get_output_element_type(0) == Type.f32
+        assert node.get_byte_size() == 36
+
+
+def test_opset_reshape():
+    element_type = Type.f32
+    shape = Shape([2, 3])
+    param1 = Parameter(element_type, shape)
+    node = ops8.reshape(param1, Shape([3, 2]), special_zero=False)
+
+    assert node.get_type_name() == "Reshape"
+    assert node.get_output_size() == 1
+    assert list(node.get_output_shape(0)) == [3, 2]
+    assert node.get_output_element_type(0) == element_type
+
+
+@pytest.mark.parametrize(
+    ("input_shape", "dtype", "new_shape", "axis_mapping", "mode"),
+    [
+        ((3,), np.int32, [3, 3], [], []),
+        ((4,), np.float32, [3, 4, 2, 4], [], []),
+        ((3,), np.int8, [3, 3], [[0]], ["EXPLICIT"]),
+    ],
+)
+def test_node_broadcast(input_shape, dtype, new_shape, axis_mapping, mode):
+    input_data = ops.parameter(input_shape, name="input_data", dtype=dtype)
+    node = ops.broadcast(input_data, new_shape, *axis_mapping, *mode)
+    assert node.get_type_name() == "Broadcast"
+    assert node.get_output_size() == 1
+    assert node.get_output_element_type(0) == get_element_type(dtype)
+    assert list(node.get_output_shape(0)) == new_shape
+
+
+def test_model_pass():
+    manager = Manager()
+    model_pass = manager.register_pass(MyModelPass())
+    manager.run_passes(get_relu_transformations_model())
+
+    assert model_pass.model_changed
+
+
+def test_runtime_graph_rewrite():
+    import openvino.runtime.passes as rt
+    model = get_relu_transformations_model()
+
+    manager = rt.Manager()
+    # check that register pass returns pass instance
+    anchor = manager.register_pass(rt.GraphRewrite())
+    anchor.add_matcher(PatternReplacement())
+    manager.run_passes(model)
+
+    assert count_ops(model, "Relu") == [2]

--- a/src/bindings/python/tests/test_runtime/test_experimental.py
+++ b/src/bindings/python/tests/test_runtime/test_experimental.py
@@ -5,9 +5,9 @@
 from openvino.experimental import evaluate_as_partial_shape, evaluate_both_bounds, set_element_type, set_tensor_type
 
 import pytest
-from openvino.runtime import Shape, PartialShape, Dimension, Type
-from openvino.runtime.op import Constant
-import openvino.runtime.opset13 as ops
+from openvino import Shape, PartialShape, Dimension, Type
+from openvino.op import Constant
+import openvino.opset13 as ops
 import numpy as np
 
 

--- a/src/bindings/python/tests/test_runtime/test_input_node.py
+++ b/src/bindings/python/tests/test_runtime/test_input_node.py
@@ -4,9 +4,9 @@
 
 import os
 import numpy as np
-from openvino.runtime import Input, RTMap
+from openvino import Input, RTMap
 from openvino._pyopenvino import DescriptorTensor
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 
 from openvino import Core, OVAny, Shape, PartialShape, Type, Tensor, Symbol
 from tests.utils.helpers import get_relu_model

--- a/src/bindings/python/tests/test_runtime/test_memory_modes.py
+++ b/src/bindings/python/tests/test_runtime/test_memory_modes.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from openvino import Tensor, Type
-from openvino.runtime.op import Constant
+from openvino.op import Constant
 
 from tests.utils.helpers import generate_image
 

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -11,7 +11,7 @@ from contextlib import nullcontext as does_not_raise
 from copy import copy
 import tempfile
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import (
     Core,
     Model,
@@ -26,8 +26,8 @@ from openvino import (
     serialize,
     save_model,
 )
-from openvino.runtime import Output
-from openvino.runtime.op.util import VariableInfo, Variable
+from openvino import Output
+from openvino.op.util import VariableInfo, Variable
 
 from tests.utils.helpers import (
     generate_add_model,
@@ -213,7 +213,7 @@ def test_get_sink_index(device):
     relu1.get_output_tensor(0).set_names({"relu_t1"})
     model = Model(relu1, [param], "TestModel")
 
-    # test get_sink_index with openvino.runtime.Node argument
+    # test get_sink_index with openvino.Node argument
     assign = ops.assign()
     assign2 = ops.assign()
     assign3 = ops.assign()
@@ -222,7 +222,7 @@ def test_get_sink_index(device):
     assert model.get_sink_index(assign_nodes[2]) == 2
     assert model.get_sink_index(relu1) == -1
 
-    # test get_sink_index with openvino.runtime.Output argument
+    # test get_sink_index with openvino.Output argument
     assign4 = ops.assign(relu1, "assign4")
     model.add_sinks([assign4])
     assert model.get_sink_index(assign4.output(0)) == 3

--- a/src/bindings/python/tests/test_runtime/test_nogil.py
+++ b/src/bindings/python/tests/test_runtime/test_nogil.py
@@ -11,7 +11,7 @@ import numpy as np
 import openvino.properties as props
 
 from openvino import Core, Model, AsyncInferQueue, PartialShape, Layout, serialize
-from openvino.runtime import opset13 as ops
+from openvino import opset13 as ops
 from openvino.preprocess import PrePostProcessor
 
 from tests import skip_devtest

--- a/src/bindings/python/tests/test_runtime/test_output_const_node.py
+++ b/src/bindings/python/tests/test_runtime/test_output_const_node.py
@@ -5,7 +5,7 @@
 import pytest
 from copy import copy, deepcopy
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import (
     Shape,
     PartialShape,
@@ -13,7 +13,7 @@ from openvino import (
     Core,
     OVAny,
 )
-from openvino.runtime import (
+from openvino import (
     ConstOutput,
     Output,
     RTMap,

--- a/src/bindings/python/tests/test_runtime/test_output_node.py
+++ b/src/bindings/python/tests/test_runtime/test_output_node.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import Type, Tensor, Symbol
 import numpy as np
 

--- a/src/bindings/python/tests/test_runtime/test_ovdict.py
+++ b/src/bindings/python/tests/test_runtime/test_ovdict.py
@@ -6,10 +6,10 @@ from collections.abc import Mapping
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import Core, CompiledModel, InferRequest, Model
-from openvino.runtime import ConstOutput
-from openvino.runtime.utils.data_helpers import OVDict
+from openvino import ConstOutput
+from openvino.utils.data_helpers import OVDict
 
 
 def _get_ovdict(

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -17,7 +17,7 @@ import openvino.properties.device as device
 import openvino.properties.log as log
 import openvino.properties.streams as streams
 from openvino import Core, Type, OVAny
-from openvino.runtime import properties
+from openvino import properties
 
 
 ###

--- a/src/bindings/python/tests/test_runtime/test_remote_api.py
+++ b/src/bindings/python/tests/test_runtime/test_remote_api.py
@@ -206,8 +206,8 @@ def test_roi_copy_host_to_device_gpu():
     random_arr = np.random.rand(*host_tensor_ref.shape).astype(np.float32)
     host_tensor_ref.data[:] = random_arr
 
-    begin_roi = ov.runtime.Coordinate([0, 0, 0])
-    end_roi = ov.runtime.Coordinate([3, 4, 4])
+    begin_roi = ov.Coordinate([0, 0, 0])
+    end_roi = ov.Coordinate([3, 4, 4])
     roi_host_tensor_ref = ov.Tensor(host_tensor_ref, begin_roi, end_roi)
 
     device_tensor = context.create_tensor(ov.Type.f32, ov.Shape([4, 4, 4]), {})
@@ -245,8 +245,8 @@ def test_roi_copy_device_to_host_gpu():
     random_arr = np.random.rand(*host_tensor_ref.shape).astype(np.float32)
     host_tensor_ref.data[:] = random_arr
 
-    begin_roi = ov.runtime.Coordinate([1, 2, 1])
-    end_roi = ov.runtime.Coordinate([3, 4, 4])
+    begin_roi = ov.Coordinate([1, 2, 1])
+    end_roi = ov.Coordinate([3, 4, 4])
     roi_host_tensor_ref = ov.Tensor(host_tensor_ref, begin_roi, end_roi)
 
     device_tensor = context.create_tensor(ov.Type.f32, ov.Shape([4, 4, 4]), {})

--- a/src/bindings/python/tests/test_runtime/test_stateful.py
+++ b/src/bindings/python/tests/test_runtime/test_stateful.py
@@ -15,7 +15,7 @@ from openvino import (
 )
 
 from tests.utils.helpers import generate_model_with_memory
-from openvino.runtime.utils.types import get_dtype
+from openvino.utils.types import get_dtype
 
 
 class Caller:

--- a/src/bindings/python/tests/test_runtime/test_string_infer.py
+++ b/src/bindings/python/tests/test_runtime/test_string_infer.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import (
     CompiledModel,
     InferRequest,

--- a/src/bindings/python/tests/test_runtime/test_sync_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_sync_infer_request.py
@@ -10,7 +10,7 @@ import pytest
 import datetime
 import openvino.properties as props
 
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino import (
     Core,
     CompiledModel,
@@ -22,7 +22,7 @@ from openvino import (
     Tensor,
     compile_model,
 )
-from openvino.runtime import ProfilingInfo
+from openvino import ProfilingInfo
 from openvino.preprocess import PrePostProcessor
 
 from tests.utils.helpers import (

--- a/src/bindings/python/tests/test_runtime/test_tensor.py
+++ b/src/bindings/python/tests/test_runtime/test_tensor.py
@@ -9,7 +9,7 @@ import sys
 import numpy as np
 
 import openvino as ov
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 from openvino.helpers import pack_data, unpack_data
 
 import pytest
@@ -480,7 +480,7 @@ def test_viewed_tensor(dtype, element_type):
     buffer = np.random.normal(size=(2, 16)).astype(dtype)
     fit = (dtype().nbytes * 8) / element_type.bitwidth
     tensor = ov.Tensor(buffer, (buffer.shape[0], int(buffer.shape[1] * fit)), element_type)
-    assert np.array_equal(tensor.data, buffer.view(ov.runtime.utils.types.get_dtype(element_type)))
+    assert np.array_equal(tensor.data, buffer.view(ov.utils.types.get_dtype(element_type)))
 
 
 def test_viewed_tensor_default_type():

--- a/src/bindings/python/tests/test_transformations/test_compression.py
+++ b/src/bindings/python/tests/test_transformations/test_compression.py
@@ -5,8 +5,8 @@
 from typing import List
 
 import numpy as np
-from openvino.runtime.op import Parameter, Constant
-from openvino.runtime.opset13 import add, multiply
+from openvino.op import Parameter, Constant
+from openvino.opset13 import add, multiply
 
 import openvino as ov
 from tests.utils.helpers import create_filenames_for_ir

--- a/src/bindings/python/tests/test_transformations/test_compression_4bit.py
+++ b/src/bindings/python/tests/test_transformations/test_compression_4bit.py
@@ -4,7 +4,7 @@
 
 
 import numpy as np
-from openvino.runtime import opset13 as opset
+from openvino import opset13 as opset
 
 import openvino as ov
 import pytest

--- a/src/bindings/python/tests/test_transformations/test_graph_rewrite.py
+++ b/src/bindings/python/tests/test_transformations/test_graph_rewrite.py
@@ -19,19 +19,6 @@ def test_graph_rewrite():
     assert count_ops(model, "Relu") == [2]
 
 
-def test_runtime_graph_rewrite():
-    import openvino.runtime.passes as rt
-    model = get_relu_model()
-
-    manager = rt.Manager()
-    # check that register pass returns pass instance
-    anchor = manager.register_pass(rt.GraphRewrite())
-    anchor.add_matcher(PatternReplacement())
-    manager.run_passes(model)
-
-    assert count_ops(model, "Relu") == [2]
-
-
 def test_register_new_node():
     class InsertExp(MatcherPass):
         def __init__(self):

--- a/src/bindings/python/tests/test_transformations/test_graph_rewrite.py
+++ b/src/bindings/python/tests/test_transformations/test_graph_rewrite.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from openvino.runtime import opset8
+from openvino import opset8
 from openvino.passes import Manager, GraphRewrite, MatcherPass, WrapType, Matcher
 
 from tests.test_transformations.utils.utils import count_ops, get_relu_model, PatternReplacement

--- a/src/bindings/python/tests/test_transformations/test_matcher_pass.py
+++ b/src/bindings/python/tests/test_transformations/test_matcher_pass.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from openvino.runtime import opset8
+from openvino import opset8
 from openvino.passes import Manager, Matcher, MatcherPass, WrapType
-from openvino.runtime.utils import replace_node
+from openvino.utils import replace_node
 
 from tests.test_transformations.utils.utils import count_ops, get_relu_model, PatternReplacement
 

--- a/src/bindings/python/tests/test_transformations/test_offline_api.py
+++ b/src/bindings/python/tests/test_transformations/test_offline_api.py
@@ -16,7 +16,7 @@ from openvino._offline_transformations import (
 )
 
 from openvino import Model, PartialShape, Core, serialize, save_model
-import openvino.runtime as ov
+import openvino as ov
 
 from tests.utils.helpers import create_filenames_for_ir, compare_models, _compare_models
 

--- a/src/bindings/python/tests/test_transformations/test_pattern_ops.py
+++ b/src/bindings/python/tests/test_transformations/test_pattern_ops.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from openvino import PartialShape
-from openvino.runtime import opset13 as ops
+from openvino import opset13 as ops
 from openvino.passes import Matcher, WrapType, Or, AnyInput, Optional
 from openvino.passes import (
     consumers_count,
@@ -16,7 +16,7 @@ from openvino.passes import (
     type_matches,
     type_matches_any,
 )
-from openvino.runtime.utils.types import get_element_type
+from openvino.utils.types import get_element_type
 
 from tests.test_transformations.utils.utils import expect_exception
 

--- a/src/bindings/python/tests/test_transformations/test_public_transformations.py
+++ b/src/bindings/python/tests/test_transformations/test_public_transformations.py
@@ -6,7 +6,7 @@ import pytest
 import numpy as np
 
 from openvino import Model, PartialShape, Shape, Core
-from openvino.runtime import opset13 as ops
+from openvino import opset13 as ops
 from openvino.passes import (
     Manager,
     ConstantFolding,

--- a/src/bindings/python/tests/test_transformations/test_replacement_api.py
+++ b/src/bindings/python/tests/test_transformations/test_replacement_api.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Model, PartialShape
-from openvino.runtime import opset13 as ops
-from openvino.runtime.utils import replace_node, replace_output_update_name
+from openvino import opset13 as ops
+from openvino.utils import replace_node, replace_output_update_name
 
 
 def get_relu_model():

--- a/src/bindings/python/tests/test_transformations/utils/utils.py
+++ b/src/bindings/python/tests/test_transformations/utils/utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from openvino import Model, PartialShape
-from openvino.runtime import opset13 as ops
+from openvino import opset13 as ops
 from openvino.passes import ModelPass, Matcher, MatcherPass, WrapType
 
 

--- a/src/bindings/python/tests/test_utils/test_data_dispatch.py
+++ b/src/bindings/python/tests/test_utils/test_data_dispatch.py
@@ -10,8 +10,8 @@ import numpy as np
 from tests.utils.helpers import generate_add_compiled_model, generate_relu_compiled_model
 
 from openvino import Core, Model, Type, Shape, Tensor, PartialShape
-import openvino.runtime.opset13 as ops
-from openvino.runtime.utils.data_helpers import _data_dispatch
+import openvino.opset13 as ops
+from openvino.utils.data_helpers import _data_dispatch
 
 is_myriad = os.environ.get("TEST_DEVICE") == "MYRIAD"
 

--- a/src/bindings/python/tests/utils/helpers.py
+++ b/src/bindings/python/tests/utils/helpers.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import openvino
 from openvino import Model, Core, Shape, Tensor, Type
-import openvino.runtime.opset13 as ops
+import openvino.opset13 as ops
 
 
 def _compare_models(model_one: Model, model_two: Model, compare_names: bool = True) -> Tuple[bool, str]:  # noqa: C901 the function is too complex


### PR DESCRIPTION
### Details:
 - Replace 'openvino.runtime' imports with 'openvino' in _openvino/src/bindings/python/tests_
 - Create a new test suite [test_deprecated_runtime.py](https://github.com/openvinotoolkit/openvino/pull/28353/files#diff-7d9fa0ff44c9ad25b02db3b6c802da86c24ac8356705496103ed9aa579b3014d) to test deprecated runtime functionality.

### Tickets:
 - [CVS-159527](https://jira.devtools.intel.com/browse/CVS-159527)
