### PR TITLE
[JAX FE]:Support jax.lax.scatter operation for JAX

### DIFF
--- a/src/frontends/jax/src/op/scatter.cpp
+++ b/src/frontends/jax/src/op/scatter.cpp
@@ -1,0 +1,199 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/scatter_elements_update.hpp"
+
+#include <cstdint>
+#include <vector>
+
+#include "openvino/core/node.hpp"
+#include "openvino/core/node_output.hpp"
+#include "openvino/frontend/jax/node_context.hpp"
+#include "utils.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/convert.hpp"
+
+
+namespace ov {
+namespace frontend {
+namespace jax {
+namespace op {
+
+using namespace ov::op;
+
+std::vector<int64_t> find_missing_dimensions(const int64_t total_dims, const std::vector<int64_t>& present_dims) {
+    std::vector<bool> is_present(total_dims, false);
+    
+    for (int64_t dim : present_dims) {
+        if (dim >= 0 && dim < total_dims) {
+            is_present[dim] = true;
+        }
+    }
+    
+    std::vector<int64_t> missing_dims;
+    for (int64_t i = 0; i < total_dims; ++i) {
+        if (!is_present[i]) {
+            missing_dims.push_back(i);
+        }
+    }
+
+    return missing_dims;
+}
+
+
+// Computes the flat indices for scatter dimensions using stride-based indexing
+// - total_prod_dims: Total product of dimensions in the tensor
+// - scatter_dims_list: List of scatter dimensions
+// - cumulative_prod_dims: Cumulative product of dimensions used to calculate strides
+std::vector<int64_t> compute_scatter_flat_indices(size_t total_prod_dims, const std::vector<int64_t>& scatter_dims_list, 
+                                                  const std::vector<size_t>& cumulative_prod_dims) {
+    std::vector<int64_t> flat_indices;
+    // Iteratively compute flat indices based on scatter dimensions
+    for (int64_t scatter_dim : scatter_dims_list) {
+        int64_t end = scatter_dim == 0 ? total_prod_dims : cumulative_prod_dims[scatter_dim - 1];
+        int64_t step = cumulative_prod_dims[scatter_dim];
+
+        std::vector<int64_t> temp_indices = std::move(flat_indices);
+        flat_indices.clear();
+
+        if (!temp_indices.empty()) {
+            // Expand indices for each scatter dimension
+            for (int64_t base_index : temp_indices) {
+                for (int64_t i = 0; i < end; i += step) {
+                    flat_indices.push_back(base_index + i);
+                }
+            }
+        } else {
+            // Initialize flat indices if this is the first dimension
+            for (int64_t i = 0; i < end; i += step) {
+                flat_indices.push_back(i);
+            }
+        }
+    }
+    return flat_indices;
+}
+
+OutputVector translate_scatter(const NodeContext& context){
+    num_inputs_check(context, 3, 3);
+    Output<Node> input = context.get_input(0);
+    Output<Node> scatter_indices = context.get_input(1);
+    Output<Node> updates = context.get_input(2);
+    
+    auto dimension_numbers = context.const_named_param<std::vector<std::vector<int64_t>>>("dimension_numbers");
+    
+    JAX_OP_CONVERSION_CHECK(dimension_numbers.size() == 3,
+                            "Internal error: dimension_numbers must have 3 vectors but actually got ",
+                            dimension_numbers.size());
+
+    auto update_window_dimensions = dimension_numbers[0];
+    auto inserted_window_dimensions = dimension_numbers[1];
+    auto scatter_dims_to_operand_dims = dimension_numbers[2];
+
+    int64_t num_update_window_dims = update_window_dimensions.size();
+    int64_t num_inserted_window_dims = inserted_window_dimensions.size();
+    int64_t num_scatter_operand_dims = scatter_dims_to_operand_dims.size();
+
+    Shape input_shape = input.get_shape();
+    std::vector<int64_t> input_dims(input_shape.begin(), input_shape.end());
+    int64_t num_input_dims = input_dims.size();
+    
+    JAX_OP_CONVERSION_CHECK(num_update_window_dims + num_inserted_window_dims == num_input_dims, 
+                            "Dimension Error : operand.rank: ", num_input_dims, 
+                            " must equal the sum of update_window_dims.size: ", num_update_window_dims, 
+                            " and inserted_window_dims.size: ", num_inserted_window_dims);
+
+    Shape scatter_indices_shape = scatter_indices.get_shape();
+    std::vector<int64_t> scatter_indices_dims(scatter_indices_shape.begin(), scatter_indices_shape.end());
+    int64_t num_scatter_indices_dims = scatter_indices_dims.size();
+
+    Shape updates_shape = updates.get_shape();
+    std::vector<int64_t> updates_dims(updates_shape.begin(), updates_shape.end());
+    int64_t num_updates_dims = updates_dims.size();
+
+    JAX_OP_CONVERSION_CHECK(num_update_window_dims + num_scatter_indices_dims - 1 == num_updates_dims, "Dimension Error : updates array must be of rank update_window_dims.size + scatter_indices.rank - 1 but got update rank ",
+                            num_updates_dims, " instead of ", num_update_window_dims + num_scatter_indices_dims - 1);
+    JAX_OP_CONVERSION_CHECK(std::is_sorted(update_window_dimensions.begin(), update_window_dimensions.end()), "Internal Error : update_window_dims must be sorted");
+    JAX_OP_CONVERSION_CHECK(std::is_sorted(inserted_window_dimensions.begin(), inserted_window_dimensions.end()), "Internal Error : inserted_window_dims must be sorted");
+    JAX_OP_CONVERSION_CHECK(num_updates_dims > *std::max_element(update_window_dimensions.begin(), update_window_dimensions.end()), "Internal Error : update_window_dims values must be in the range [0, updates.rank), but got ",
+                            *std::max_element(update_window_dimensions.begin(), update_window_dimensions.end()));
+    JAX_OP_CONVERSION_CHECK(num_input_dims > *std::max_element(inserted_window_dimensions.begin(), inserted_window_dimensions.end()), "Internal Error : inserted_window_dims values must be in the range [0, operand.rank), but got ",
+                            *std::max_element(inserted_window_dimensions.begin(), inserted_window_dimensions.end()));
+    JAX_OP_CONVERSION_CHECK(num_input_dims > *std::max_element(scatter_dims_to_operand_dims.begin(), scatter_dims_to_operand_dims.end()), "Internal Error : scatter_dims_to_operand_dims values must be in the range [0, operand.rank), but got ",
+                             *std::max_element(scatter_dims_to_operand_dims.begin(), scatter_dims_to_operand_dims.end()));
+    
+    // Precompute cumulative products for input dimensions for stride calculation
+    std::vector<size_t> cumulative_prod_dims;
+    size_t total_prod = std::accumulate(input_dims.begin(), input_dims.end(), 1, std::multiplies<size_t>());
+    size_t cumulative_prod = total_prod;
+
+    for(int64_t i=0; i<num_input_dims; i++){
+        cumulative_prod /= input_dims[i];
+        cumulative_prod_dims.push_back(cumulative_prod);
+    }
+
+    std::vector<size_t> scatter_indices_stride(num_scatter_operand_dims);
+    for(int64_t i=0; i<num_scatter_operand_dims; i++)
+        scatter_indices_stride[i] = cumulative_prod_dims[scatter_dims_to_operand_dims[i]];
+
+    auto strides_tensor = std::make_shared<v0::Constant>(ov::element::i64, Shape{scatter_indices_stride.size(), 1}, scatter_indices_stride);
+    
+    if (scatter_indices.get_element_type() != ov::element::i64) 
+        scatter_indices = std::make_shared<ov::op::v0::Convert>(scatter_indices, ov::element::i64);
+    
+    // Flatten scatter indices
+    auto flattened_scatter_indices = std::make_shared<v0::MatMul>(scatter_indices, strides_tensor);
+
+    // Handles the case where scatter dimensions match input dimensions
+    if(num_scatter_operand_dims == num_input_dims){
+        auto flatten_shape = std::make_shared<v0::Constant>(ov::element::i32, Shape{1}, -1);
+        auto flattened_updates = std::make_shared<v1::Reshape>(updates, flatten_shape, false);
+        auto flattened_input = std::make_shared<v1::Reshape>(input, flatten_shape, false);
+
+        auto scatter_elements_update = std::make_shared<v3::ScatterElementsUpdate>(flattened_input, flattened_scatter_indices, flattened_updates, flatten_shape);
+        auto res_shape = std::make_shared<v0::Constant>(ov::element::i32, Shape{input_dims.size()}, input_dims);
+        return {std::make_shared<v1::Reshape>(scatter_elements_update, res_shape, false)};
+    }
+
+    // Handles cases with extra missing scatter dimensions
+    std::vector<int64_t> scatter_missing_dims = find_missing_dimensions(num_input_dims, scatter_dims_to_operand_dims);
+    std::vector<int64_t> scatter_flat_indices = compute_scatter_flat_indices(total_prod, scatter_missing_dims, cumulative_prod_dims);
+
+    // Extend scatter indices shape to include missing dimensions
+    scatter_indices_dims.back() = scatter_flat_indices.size();
+    auto broadcast_shape_tensor = std::make_shared<v0::Constant>(ov::element::i64, Shape{scatter_indices_dims.size()}, scatter_indices_dims);
+    
+    // Broadcast indices for both scatter and missing scatter dimensions
+    auto broadcasted_flattened_indices = std::make_shared<v3::Broadcast>(flattened_scatter_indices, broadcast_shape_tensor, BroadcastType::NUMPY);  
+    auto scatter_flat_indices_tensor = std::make_shared<v0::Constant>(ov::element::i64, Shape{scatter_flat_indices.size()}, scatter_flat_indices); 
+    auto broadcasted_flat_scatter_indices = std::make_shared<v3::Broadcast>(scatter_flat_indices_tensor, broadcast_shape_tensor, BroadcastType::NUMPY);
+    
+    // Combine broadcasted indices
+    auto combined_scatter_indices = std::make_shared<v1::Add>(broadcasted_flattened_indices, broadcasted_flat_scatter_indices);
+    
+    // Flatten input, updates and scatter indices tensors for scatter operation
+    auto flatten_shape = std::make_shared<v0::Constant>(ov::element::i32, Shape{1}, -1);
+    auto flattened_updates = std::make_shared<v1::Reshape>(updates, flatten_shape, false);
+    auto flattened_input = std::make_shared<v1::Reshape>(input, flatten_shape, false);
+    auto flattened_combined_indices = std::make_shared<v1::Reshape>(combined_scatter_indices, flatten_shape, false);
+
+    auto scatter_elements_update = std::make_shared<v3::ScatterElementsUpdate>(flattened_input, flattened_combined_indices, flattened_updates, flatten_shape);
+    
+    // Reshape the result back to original input dimensions
+    auto res_shape = std::make_shared<v0::Constant>(ov::element::i32, Shape{input_dims.size()}, input_dims);
+    Output<Node> res = std::make_shared<v1::Reshape>(scatter_elements_update, res_shape, false);
+    return {res};
+
+};
+
+}
+}
+}
+}
+
+
+

--- a/src/frontends/jax/src/op_table.cpp
+++ b/src/frontends/jax/src/op_table.cpp
@@ -53,6 +53,7 @@ OP_CONVERTER(translate_reduce_window_max);
 OP_CONVERTER(translate_reduce_window_sum);
 OP_CONVERTER(translate_reshape);
 OP_CONVERTER(translate_rsqrt);
+OP_CONVERTER(translate_scatter);
 OP_CONVERTER(translate_select_n);
 OP_CONVERTER(translate_slice);
 OP_CONVERTER(translate_square);
@@ -94,6 +95,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops_jaxpr() {
             {"transpose", op::translate_transpose},
             {"rsqrt", op::translate_rsqrt},
             {"reshape", op::translate_reshape},
+            {"scatter", op::translate_scatter},
             {"select_n", op::translate_select_n},
             {"logistic", op::translate_1to1_match_1_input<v0::Sigmoid>},
             {"slice", op::translate_slice},

--- a/tests/layer_tests/jax_tests/test_scatter.py
+++ b/tests/layer_tests/jax_tests/test_scatter.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+from jax import lax
+from jax import numpy as jnp
+
+from jax_layer_test_class import JaxLayerTest
+
+class TestScatter(JaxLayerTest):
+    def _prepare_input(self):
+        operand = jnp.array(np.random.rand(*self.operand_shape).astype(np.float32))
+        scatter_indices = jnp.array(np.random.randint([self.operand_shape[scatter_indices_dim] 
+                                                    for scatter_indices_dim in self.scatter_dims_to_operand_dims], 
+                                                    size=self.scatter_indices_shape))
+        if len(scatter_indices.shape) == 1:
+                scatter_indices = scatter_indices[:, None]
+        updates = jnp.array(np.random.rand(*self.updates_shape).astype(np.float32))
+        return (operand, scatter_indices, updates)
+    
+
+    def create_model(self, operand_shape, scatter_indices_shape, updates_shape, update_window_dims, 
+                     inserted_window_dims, scatter_dims_to_operand_dims):
+        self.operand_shape = operand_shape
+        self.scatter_indices_shape = scatter_indices_shape
+        self.scatter_dims_to_operand_dims = scatter_dims_to_operand_dims
+        self.updates_shape = updates_shape
+
+        def jax_scatter(operand, scatter_indices, updates):
+            out = lax.scatter(operand=operand, scatter_indices=scatter_indices, updates=updates, 
+                              dimension_numbers=lax.ScatterDimensionNumbers(
+                                                update_window_dims=update_window_dims,
+                                                inserted_window_dims=inserted_window_dims,
+                                                scatter_dims_to_operand_dims=scatter_dims_to_operand_dims,
+                                ),
+            )
+            return out
+        
+        return jax_scatter, None, 'scatter'
+
+    
+    test_data_basic = [
+        dict(operand_shape=[64], scatter_indices_shape=[32], updates_shape=[32], 
+            update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,)),
+        dict(operand_shape=[128, 64], scatter_indices_shape=[128, 2], updates_shape=[128], 
+            update_window_dims=(), inserted_window_dims=(0,1,), scatter_dims_to_operand_dims=(0,1,)),
+        dict(operand_shape=[128, 64], scatter_indices_shape=[32], updates_shape=[32, 128], 
+            update_window_dims=(1,), inserted_window_dims=(1,), scatter_dims_to_operand_dims=(1,)),
+        dict(operand_shape=[128, 64], scatter_indices_shape=[32], updates_shape=[32, 64], 
+            update_window_dims=(1,), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,)),
+        dict(operand_shape=[128, 64, 32], scatter_indices_shape=[87], updates_shape=[87, 64, 32], 
+            update_window_dims=(1,2,), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,)),
+        dict(operand_shape=[128, 64, 32], scatter_indices_shape=[55,2], updates_shape=[55, 64], 
+            update_window_dims=(1,), inserted_window_dims=(0,2,), scatter_dims_to_operand_dims=(0,2)),
+        dict(operand_shape=[64, 128, 32, 16], scatter_indices_shape=[440, 2], updates_shape=[440, 128, 16], 
+            update_window_dims=(1,2,), inserted_window_dims=(0,2,), scatter_dims_to_operand_dims=(0,2,)),
+    ]
+
+    @pytest.mark.parametrize("params", test_data_basic)
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_jax_fe
+    def test_scatter(self, ie_device, precision, ir_version, params):
+        self._test(*self.create_model(**params), ie_device, precision,
+                   ir_version)


### PR DESCRIPTION
**Overview:**
This pull request fixes #26573 

**Issues/Problems:**

1) Jaxpr Decoder is unable to deal with `jax.lax.ScatterDimensionNumbers`. I was expecting dimension_numbers parameter to be a 2D vector but got a single integer value. This is not allowing me too access `update_window_dims`, `inserted_window_dims` and `scatter_dims_to_operand_dims` values.

``` c++

auto dimension_numbers = context.const_named_param<std::vector<std::vector<int64_t>>>("dimension_numbers");
    
JAX_OP_CONVERSION_CHECK(dimension_numbers.size() == 3,
"Internal error: dimension_numbers must have 3 vectors but actually got ",
dimension_numbers.size());

auto update_window_dimensions = dimension_numbers[0];
auto inserted_window_dimensions = dimension_numbers[1];
auto scatter_dims_to_operand_dims = dimension_numbers[2];

```

2) Jaxpr Decoder is also unable to deal with `update_window_dims` being an empty tuple. 
Below mentioned 2 testcases are failing because of it all other testcases are working as intended.
```python

dict(operand_shape=[64], scatter_indices_shape=[32], updates_shape=[32], 
update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,)),
dict(operand_shape=[128, 64], scatter_indices_shape=[128, 2], updates_shape=[128], 
update_window_dims=(), inserted_window_dims=(0,1,), scatter_dims_to_operand_dims=(0,1,)),

```

**Error Message:**

Segmentation fault error due to `update_window_dims` being empty

![Screenshot 2025-01-10 012215](https://github.com/user-attachments/assets/14c6e6e2-121b-4a22-a73e-84b3af19731a)

**Dependencies:**

- No dependencies on other pull requests.

**CC:**

- @rkazants 

