### PR TITLE
Revert "[GHA] Use upload-artifact with tag in Build Doc"

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -78,13 +78,13 @@ jobs:
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
       - name: 'Upload sphinx.log'
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: sphinx_build_log_${{ env.PR_NUMBER }}.log
           path: build/docs/sphinx.log
 
       - name: 'Upload docs html'
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: openvino_docs_html_${{ env.PR_NUMBER }}.zip
           path: build/docs/openvino_docs_html.zip
@@ -101,7 +101,7 @@ jobs:
 
       - name: 'Upload test results'
         if: failure()
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: openvino_docs_pytest
           path: build/docs/_artifacts/


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#28354

Original PR is not needed anymore. The culprit was `cache-apt-pkgs-action`, it used `upload-artifact@v3` action which caused the original workflow failure, but now it's fixed https://github.com/awalsh128/cache-apt-pkgs-action/pull/140 and `upload-artifact@v3` will be working till January 30 (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)