### PR TITLE
[GPU] Reuse kv cache mem if it is not changed from previous infer

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/network.hpp
@@ -192,6 +192,8 @@ public:
     const ov::intel_gpu::VariableStateInfo& get_variable_info(const std::string &variable_id) const;
     const ov::intel_gpu::VariablesMap& get_variables() const;
     const ov::intel_gpu::VariablesInfoMap& get_variables_info() const;
+    void set_reuse_variable_mem(bool reuse = false);
+    bool is_reuse_variable_mem() { return _reuse_variable_mem; }
 
     const ExecutionConfig& get_config() const { return _config; }
 
@@ -215,6 +217,7 @@ private:
     bool _is_dynamic = false;
     bool _enable_profiling = false;
     bool _reset_arguments;
+    bool _reuse_variable_mem = false;
 
     std::unordered_map<primitive_id, std::shared_ptr<primitive_inst>> _primitives;
     std::vector<shared_mem_type> _in_out_shared_mem_types;

--- a/src/plugins/intel_gpu/src/graph/network.cpp
+++ b/src/plugins/intel_gpu/src/graph/network.cpp
@@ -997,5 +997,9 @@ void network::set_variables_state_info(const std::string& variable_id,
     _variables_state_info.at(variable_id).m_primitives.insert(p);
 }
 
+void network::set_reuse_variable_mem(bool reuse) {
+    _reuse_variable_mem = reuse;
+}
+
 
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -630,6 +630,7 @@ void primitive_inst::realloc_if_needed(bool prev_execution_skipped) {
                 if (!get_network().is_reuse_variable_mem()) {
                     GPU_DEBUG_TRACE_DETAIL << "Update output mem with new variable mem" << std::endl;
                     _outputs[0] = variable.get_memory();
+                    _max_output_layout_count[0] = variable.get_actual_mem_size() / dt_sizes_in_B[0];
 
                     if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
                         _outputs[2] = compressed_cache_variable->get_compression_scale_state()->get_memory();

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -624,16 +624,23 @@ void primitive_inst::realloc_if_needed(bool prev_execution_skipped) {
                     _max_output_layout_count[j] = 0;
                 }
             } else {
-                _outputs[0] = variable.get_memory();
+                GPU_DEBUG_TRACE_DETAIL
+                    << id() << " : realloc_if_needed: can_be_optimized = false and memories are not being shared"
+                    << std::endl;
+                if (!get_network().is_reuse_variable_mem()) {
+                    GPU_DEBUG_TRACE_DETAIL << "Update output mem with new variable mem" << std::endl;
+                    _outputs[0] = variable.get_memory();
 
-                if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
-                    _outputs[2] = compressed_cache_variable->get_compression_scale_state()->get_memory();
+                    if (auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable)) {
+                        _outputs[2] = compressed_cache_variable->get_compression_scale_state()->get_memory();
 
-                    if (compressed_cache_variable->has_zp_state()) {
-                        _outputs[3] = compressed_cache_variable->get_compression_zp_state()->get_memory();
+                        if (compressed_cache_variable->has_zp_state()) {
+                            _outputs[3] = compressed_cache_variable->get_compression_zp_state()->get_memory();
+                        }
                     }
+                } else {
+                    GPU_DEBUG_TRACE_DETAIL << "Can reuse variable mem of prev request" << std::endl;
                 }
-                GPU_DEBUG_TRACE_DETAIL << id() << " : realloc_if_needed: can_be_optimized = false and memories are not being shared" << std::endl;
             }
         } else {
             variable.set_layout(_impl_params->output_layouts[0]);

--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -300,7 +300,7 @@ void SyncInferRequest::enqueue() {
         const auto& name = it.first;
         const auto& variable = it.second;
         if (network->has_variable(name)) {
-            auto& prev_var = network->get_variable(name);
+            const auto& prev_var = network->get_variable(name);
             if (prev_var.get_memory() == variable->get_memory()) {
                 network->set_reuse_variable_mem(true);
                 continue;


### PR DESCRIPTION
### Details:
 - When kv cache variable is reset, it is allocating a new memory.
 - However, if the variable mem is not changed from previous iteration, we can reuse previsouly allocated memory

### Tickets:
 - *ticket-id*
