### PR TITLE
[CI] [GHA] Simplify cache info display for `setup-python` action

### DIFF
--- a/.github/actions/setup_python/action.yml
+++ b/.github/actions/setup_python/action.yml
@@ -79,9 +79,4 @@ runs:
     - if: ${{ inputs.show-cache-info == 'true' }}
       name: Get pip cache info
       shell: bash
-      run: |
-        echo "Cache size: "
-        du -h -d2 ${{ env.PIP_CACHE_DIR }}
-        echo "Cache info: "
-        python3 -m pip cache info
-      continue-on-error: true
+      run: python3 -m pip cache info


### PR DESCRIPTION
Should eliminate:
![image](https://github.com/user-attachments/assets/ab1ea38c-d6cc-414e-8145-235379457067)

The `pip cache info` command should display the cache size, no need to use `du`.

### Tickets:
 - *160388*
