### PR TITLE
Override the default `isExecutable()` method in `StringTensorPack-15`

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/string_tensor_pack.cpp
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_pack.cpp
@@ -88,9 +88,6 @@ bool StringTensorPack::isExecutable() const {
 void StringTensorPack::execute(dnnl::stream strm) {
     auto indicesPrecision = getParentEdgeAt(0)->getMemory().getDesc().getPrecision();
     StringTensorPackContext ctx = {*this};
-    std::cout << "Input 0 shape: " << getParentEdgeAt(0)->getMemory().getStaticDims() << std::endl;
-    std::cout << "Input 1 shape: " << getParentEdgeAt(1)->getMemory().getStaticDims() << std::endl;
-    std::cout << "Input 2 shape: " << getParentEdgeAt(2)->getMemory().getStaticDims() << std::endl;
     OV_SWITCH(intel_cpu,
               StringTensorPackExecute,
               ctx,

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_pack.cpp
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_pack.cpp
@@ -81,9 +81,16 @@ struct StringTensorPack::StringTensorPackExecute {
     }
 };
 
+bool StringTensorPack::isExecutable() const {
+    return !(isInputTensorAtPortEmpty(0) || isInputTensorAtPortEmpty(1));
+}
+
 void StringTensorPack::execute(dnnl::stream strm) {
     auto indicesPrecision = getParentEdgeAt(0)->getMemory().getDesc().getPrecision();
     StringTensorPackContext ctx = {*this};
+    std::cout << "Input 0 shape: " << getParentEdgeAt(0)->getMemory().getStaticDims() << std::endl;
+    std::cout << "Input 1 shape: " << getParentEdgeAt(1)->getMemory().getStaticDims() << std::endl;
+    std::cout << "Input 2 shape: " << getParentEdgeAt(2)->getMemory().getStaticDims() << std::endl;
     OV_SWITCH(intel_cpu,
               StringTensorPackExecute,
               ctx,

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_pack.h
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_pack.h
@@ -17,6 +17,7 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
+    bool isExecutable() const override;
     void execute(dnnl::stream strm) override;
     bool created() const override;
     bool needPrepareParams() const override;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/string_tensor_pack.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/string_tensor_pack.cpp
@@ -59,20 +59,23 @@ void StringTensorPackLayerCPUTest::generate_inputs(const std::vector<ov::Shape>&
             symbolsTensor = ov::Tensor(ov::element::u8, symbolsShape);
             beginsTensor = ov::Tensor(indicesType, indicesShape);
             endsTensor = ov::Tensor(indicesType, indicesShape);
-            std::fill(beginsTensor.data<int32_t>(), beginsTensor.data<int32_t>() + beginsTensor.get_byte_size(), 0);
-            std::fill(endsTensor.data<int32_t>(), endsTensor.data<int32_t>() + endsTensor.get_byte_size(), 0);
+            beginsTensor = ov::test::utils::create_and_fill_tensor_consistently(indicesType, indicesShape, 0, 0, 0);
+            endsTensor = ov::test::utils::create_and_fill_tensor_consistently(indicesType, indicesShape, 0, 0, 0);
         } else {
             ov::test::utils::InputGenerateData in_symbol_data;
             in_symbol_data.start_from = 0;
             in_symbol_data.range = 10;
             symbolsTensor = ov::test::utils::create_and_fill_tensor(ov::element::u8, symbolsShape, in_symbol_data);
-            beginsTensor = ov::test::utils::create_and_fill_tensor_consistently(indicesType, indicesShape, symbolsShape[0], 0, 3);
-            endsTensor = ov::test::utils::create_and_fill_tensor_consistently(indicesType, indicesShape, symbolsShape[0], 3, 3);
+            beginsTensor =
+                ov::test::utils::create_and_fill_tensor_consistently(indicesType, indicesShape, symbolsShape[0], 0, 3);
+            endsTensor =
+                ov::test::utils::create_and_fill_tensor_consistently(indicesType, indicesShape, symbolsShape[0], 3, 3);
         }
-        inputs.insert({ funcInputs[0].get_node_shared_ptr(), beginsTensor });
-        inputs.insert({ funcInputs[1].get_node_shared_ptr(), endsTensor });
-        inputs.insert({ funcInputs[2].get_node_shared_ptr(), symbolsTensor });
-    }
+
+        inputs.insert({funcInputs[0].get_node_shared_ptr(), beginsTensor});
+        inputs.insert({funcInputs[1].get_node_shared_ptr(), endsTensor});
+        inputs.insert({funcInputs[2].get_node_shared_ptr(), symbolsTensor});
+}
 
 void StringTensorPackLayerCPUTest::SetUp() {
         StringTensorPackLayerTestParams basicParamsSet;
@@ -128,9 +131,13 @@ const std::vector<StringTensorPackSpecificParams> StringTensorPackParamsVector =
         InputShape{{-1, {1, 4}, {1, 4}}, {{1, 1, 4}, {1, 4, 1}}},                   // begins/ends shape
         InputShape{{{50, 100}}, {{50}, {75}, {100}}},                               // utf-8 encoded symbols shape
     },
-    StringTensorPackSpecificParams {
-        InputShape{{}, {{1, 1, 4}}},                   // begins/ends shape
-        InputShape{{}, {{0}}},                                                    // utf-8 encoded symbols shape
+    StringTensorPackSpecificParams{
+        InputShape{{}, {{1, 1, 4}}},                                                // begins/ends shape
+        InputShape{{}, {{0}}},                                                      // utf-8 encoded symbols shape
+    },
+    StringTensorPackSpecificParams{
+        InputShape{{-1, -1, -1}, {{1, 1, 3}, {1, 1, 4}, {1, 3, 4}, {1, 3, 4}}},     // begins/ends shape
+        InputShape{{-1}, {{9}, {0}, {108}, {0}}},                                   // utf-8 encoded symbols shape
     },
 };
 

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/string_tensor_pack_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/string_tensor_pack_shape_inference_test.cpp
@@ -183,38 +183,6 @@ TEST_F(StringTensorPackStaticShapeInferenceWithTensorAccessorTest, data_from_ten
     EXPECT_EQ(output_shapes[0], StaticShape({2, 2}));
 }
 
-TEST_F(StringTensorPackStaticShapeInferenceWithTensorAccessorTest, empty_bytes) {
-    const auto begins_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());
-    const auto ends_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());
-    const auto symbols_param = std::make_shared<Parameter>(element::u8, ov::PartialShape::dynamic());
-    const auto op = make_op(begins_param, ends_param, symbols_param);
-    int32_t begins[] = {0};
-    int32_t ends[] = {5};
-    uint8_t symbols[] = {0x49, 0x6e, 0x74, 0x65, 0x6c};
-    const auto const_inputs = std::unordered_map<size_t, Tensor>{{0, {element::i32, ov::Shape{1}, begins}},
-                                                                 {1, {element::i32, ov::Shape{1}, ends}},
-                                                                 {2, {element::u8, ov::Shape{5}, symbols}}};
-
-    const auto input_shapes = StaticShapeVector{{1}, {1}, {5}};
-    auto shape_infer = make_shape_inference(op);
-    const auto input_shape_refs = make_static_shape_refs(input_shapes);
-    const auto output_shapes = *shape_infer->infer(input_shape_refs, make_tensor_accessor(const_inputs));
-    EXPECT_EQ(output_shapes.size(), 1);
-    EXPECT_EQ(output_shapes[0], StaticShape({1}));
-
-    // empty symbols tensor
-    uint8_t symbols_empty[] = {};
-    int32_t ends_symbols_empty[] = {0};
-    const auto const_inputs_empty_bytes = std::unordered_map<size_t, Tensor>{{0, {element::i32, ov::Shape{1}, begins}},
-                                                                 {1, {element::i32, ov::Shape{1}, ends_symbols_empty}},
-                                                                 {2, {element::u8, ov::Shape{0}, symbols_empty}}};
-    const auto input_shapes_empty_bytes = StaticShapeVector{{1}, {1}, {0}};
-    const auto input_shape_refs_empty_bytes = make_static_shape_refs(input_shapes_empty_bytes);
-    const auto output_shapes_empty_bytes = *shape_infer->infer(input_shape_refs_empty_bytes, make_tensor_accessor(const_inputs_empty_bytes));
-    EXPECT_EQ(output_shapes_empty_bytes.size(), 1);
-    EXPECT_EQ(output_shapes_empty_bytes[0], StaticShape({1}));
-}
-
 TEST_F(StringTensorPackStaticShapeInferenceWithTensorAccessorTest, indices_validation) {
     const auto begins_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());
     const auto ends_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/string_tensor_pack_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/string_tensor_pack_shape_inference_test.cpp
@@ -183,6 +183,38 @@ TEST_F(StringTensorPackStaticShapeInferenceWithTensorAccessorTest, data_from_ten
     EXPECT_EQ(output_shapes[0], StaticShape({2, 2}));
 }
 
+TEST_F(StringTensorPackStaticShapeInferenceWithTensorAccessorTest, empty_bytes) {
+    const auto begins_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());
+    const auto ends_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());
+    const auto symbols_param = std::make_shared<Parameter>(element::u8, ov::PartialShape::dynamic());
+    const auto op = make_op(begins_param, ends_param, symbols_param);
+    int32_t begins[] = {0};
+    int32_t ends[] = {5};
+    uint8_t symbols[] = {0x49, 0x6e, 0x74, 0x65, 0x6c};
+    const auto const_inputs = std::unordered_map<size_t, Tensor>{{0, {element::i32, ov::Shape{1}, begins}},
+                                                                 {1, {element::i32, ov::Shape{1}, ends}},
+                                                                 {2, {element::u8, ov::Shape{5}, symbols}}};
+
+    const auto input_shapes = StaticShapeVector{{1}, {1}, {5}};
+    auto shape_infer = make_shape_inference(op);
+    const auto input_shape_refs = make_static_shape_refs(input_shapes);
+    const auto output_shapes = *shape_infer->infer(input_shape_refs, make_tensor_accessor(const_inputs));
+    EXPECT_EQ(output_shapes.size(), 1);
+    EXPECT_EQ(output_shapes[0], StaticShape({1}));
+
+    // empty symbols tensor
+    uint8_t symbols_empty[] = {};
+    int32_t ends_symbols_empty[] = {0};
+    const auto const_inputs_empty_bytes = std::unordered_map<size_t, Tensor>{{0, {element::i32, ov::Shape{1}, begins}},
+                                                                 {1, {element::i32, ov::Shape{1}, ends_symbols_empty}},
+                                                                 {2, {element::u8, ov::Shape{0}, symbols_empty}}};
+    const auto input_shapes_empty_bytes = StaticShapeVector{{1}, {1}, {0}};
+    const auto input_shape_refs_empty_bytes = make_static_shape_refs(input_shapes_empty_bytes);
+    const auto output_shapes_empty_bytes = *shape_infer->infer(input_shape_refs_empty_bytes, make_tensor_accessor(const_inputs_empty_bytes));
+    EXPECT_EQ(output_shapes_empty_bytes.size(), 1);
+    EXPECT_EQ(output_shapes_empty_bytes[0], StaticShape({1}));
+}
+
 TEST_F(StringTensorPackStaticShapeInferenceWithTensorAccessorTest, indices_validation) {
     const auto begins_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());
     const auto ends_param = std::make_shared<Parameter>(element::i32, ov::PartialShape::dynamic());

--- a/src/plugins/template/tests/functional/op_reference/string_tensor_pack.cpp
+++ b/src/plugins/template/tests/functional/op_reference/string_tensor_pack.cpp
@@ -155,6 +155,11 @@ std::vector<StringTensorPackParams> generateStringTensorPackParams() {
                    ov::element::u8,
                    std::vector<uint8_t>{0x49, 0x6e, 0x74, 0x65, 0x6c, 0x4f, 0x70, 0x65, 0x6e, 0x56, 0x49, 0x4e, 0x4f}),
             Tensor({1, 3}, ov::element::string, std::vector<std::string>{"Intel", "OpenVINO", ""})),
+        // empty bytes input
+        StringTensorPackParams(Tensor({1, 3}, T_idx, std::vector<T_I>{0, 0, 0}),
+                               Tensor({1, 3}, T_idx, std::vector<T_I>{0, 0, 0}),
+                               Tensor({0}, ov::element::u8, std::vector<uint8_t>{}),
+                               Tensor({1, 3}, ov::element::string, std::vector<std::string>{"", "", ""})),
     };
     return StringTensorPackParamsList;
 }


### PR DESCRIPTION
### Details:
 - Override the default `isExecutable()` method in `StringTensorPack-15`
 - This fixes incorrect packing of empty strings (see reproducer in the ticket)

### Tickets:
 - CVS-159636
