### PR TITLE
Update links to genai samples to 2024.6 branch

### DIFF
--- a/docs/articles_en/learn-openvino/llm_inference_guide/genai-guide.rst
+++ b/docs/articles_en/learn-openvino/llm_inference_guide/genai-guide.rst
@@ -123,7 +123,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
 
 
          For more information, refer to the
-         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/python/image_generation>`__
+         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/image_generation>`__
 
       .. tab-item:: C++
          :sync: cpp
@@ -225,7 +225,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
                   }
 
          For more information, refer to the
-         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/image_generation/>`__
+         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/image_generation/>`__
 
 
 .. dropdown:: Speech Recognition
@@ -271,7 +271,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
 
 
          For more information, refer to the
-         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/python/whisper_speech_recognition/>`__.
+         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/whisper_speech_recognition/>`__.
 
       .. tab-item:: C++
          :sync: cpp
@@ -323,7 +323,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
             }
 
          For more information, refer to the
-         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/whisper_speech_recognition/>`__.
+         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/whisper_speech_recognition/>`__.
 
 
 .. dropdown:: Using GenAI in Chat Scenario
@@ -367,7 +367,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
 
 
          For more information, refer to the
-         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/python/chat_sample/>`__.
+         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/chat_sample/>`__.
 
       .. tab-item:: C++
          :sync: cpp
@@ -415,7 +415,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
 
 
          For more information, refer to the
-         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/chat_sample/>`__
+         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/chat_sample/>`__
 
 
 .. dropdown:: Using GenAI with Vision Language Models
@@ -483,7 +483,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
 
 
          For more information, refer to the
-         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/python/visual_language_chat>`__.
+         `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/visual_language_chat>`__.
 
       .. tab-item:: C++
          :sync: cpp
@@ -549,7 +549,7 @@ make sure to :doc:`install OpenVINO with GenAI <../../get-started/install-openvi
 
 
          For more information, refer to the
-         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/visual_language_chat/>`__
+         `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/visual_language_chat/>`__
 
 
 |
@@ -803,7 +803,7 @@ runs prediction of the next K tokens, thus repeating the cycle.
 
 
       For more information, refer to the
-      `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/python/speculative_decoding_lm/>`__.
+      `Python sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/speculative_decoding_lm/>`__.
 
 
    .. tab-item:: C++
@@ -859,7 +859,7 @@ runs prediction of the next K tokens, thus repeating the cycle.
 
 
       For more information, refer to the
-      `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/speculative_decoding_lm/>`__
+      `C++ sample <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/speculative_decoding_lm/>`__
 
 
 

--- a/docs/articles_en/learn-openvino/llm_inference_guide/ov-tokenizers.rst
+++ b/docs/articles_en/learn-openvino/llm_inference_guide/ov-tokenizers.rst
@@ -336,7 +336,7 @@ Additional Resources
 
 * `OpenVINO Tokenizers repo <https://github.com/openvinotoolkit/openvino_tokenizers>`__
 * `OpenVINO Tokenizers Notebook <https://github.com/openvinotoolkit/openvino_notebooks/tree/latest/notebooks/openvino-tokenizers>`__
-* `Text generation C++ samples that support most popular models like LLaMA 3 <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/greedy_causal_lm>`__
+* `Text generation C++ samples that support most popular models like LLaMA 3 <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/greedy_causal_lm>`__
 * `OpenVINO GenAI Repo <https://github.com/openvinotoolkit/openvino.genai>`__
 
 

--- a/docs/articles_en/openvino-workflow/running-inference/string-tensors.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/string-tensors.rst
@@ -12,7 +12,7 @@ Such a tensor is called a string tensor and can be passed as input or retrieved 
 
 While this section describes basic API to handle string tensors, more practical examples that leverage both
 string tensors and OpenVINO tokenizer can be found in
-`GenAI Samples <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/greedy_causal_lm>`__.
+`GenAI Samples <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/greedy_causal_lm>`__.
 
 
 Representation
@@ -203,4 +203,4 @@ Additional Resources
 
 * Use `OpenVINO tokenizers <https://github.com/openvinotoolkit/openvino_contrib/tree/releases/2024/0/modules/custom_operations/user_ie_extensions/tokenizer/python>`__ to produce models that use string tensors to work with textual information as pre- and post-processing for the large language models.
 
-* Check out `GenAI Samples <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/greedy_causal_lm>`__ to see how string tensors are used in real-life applications.
+* Check out `GenAI Samples <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/greedy_causal_lm>`__ to see how string tensors are used in real-life applications.

--- a/docs/notebooks/openvino-tokenizers-with-output.rst
+++ b/docs/notebooks/openvino-tokenizers-with-output.rst
@@ -548,6 +548,6 @@ Links
    Types <https://github.com/openvinotoolkit/openvino_tokenizers?tab=readme-ov-file#supported-tokenizer-types>`__
 -  `OpenVINO.GenAI repository with the C++ example of OpenVINO
    Tokenizers
-   usage <https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/cpp/greedy_causal_lm>`__
+   usage <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/cpp/greedy_causal_lm>`__
 -  `HuggingFace Tokenizers Comparison
    Table <https://github.com/openvinotoolkit/openvino_tokenizers?tab=readme-ov-file#output-match-by-model>`__

--- a/docs/notebooks/whisper-asr-genai-with-output.rst
+++ b/docs/notebooks/whisper-asr-genai-with-output.rst
@@ -30,7 +30,7 @@ converts the models to OpenVINO™ IR format. To simplify the user
 experience, we will use `OpenVINO Generate
 API <https://github.com/openvinotoolkit/openvino.genai>`__ for `Whisper
 automatic speech recognition
-scenarios <https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/python/whisper_speech_recognition/README.md>`__.
+scenarios <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/whisper_speech_recognition/README.md>`__.
 
 Installation Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -406,7 +406,7 @@ Run inference OpenVINO model with WhisperPipeline
 
 
 To simplify user experience we will use `OpenVINO Generate
-API <https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/python/whisper_speech_recognition/README.md>`__.
+API <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/whisper_speech_recognition/README.md>`__.
 Firstly we will create pipeline with ``WhisperPipeline``. You can
 construct it straight away from the folder with the converted model. It
 will automatically load the ``model``, ``tokenizer``, ``detokenizer``

--- a/docs/notebooks/whisper-subtitles-generation-with-output.rst
+++ b/docs/notebooks/whisper-subtitles-generation-with-output.rst
@@ -21,7 +21,7 @@ GitHub `repository <https://github.com/openai/whisper>`__.
 In this notebook, we will use Whisper model with `OpenVINO Generate
 API <https://github.com/openvinotoolkit/openvino.genai>`__ for `Whisper
 automatic speech recognition
-scenarios <https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/python/whisper_speech_recognition/README.md>`__
+scenarios <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/whisper_speech_recognition/README.md>`__
 to generate subtitles in a sample video. Additionally, we will use
 `NNCF <https://github.com/openvinotoolkit/nncf>`__ improving model
 performance by INT8 quantization. Notebook contains the following steps:
@@ -228,7 +228,7 @@ Whisper model.
    whisper_pipeline.png
 
 To simplify user experience we will use `OpenVINO Generate
-API <https://github.com/openvinotoolkit/openvino.genai/blob/master/samples/python/whisper_speech_recognition/README.md>`__.
+API <https://github.com/openvinotoolkit/openvino.genai/tree/releases/2024/6/samples/python/whisper_speech_recognition/README.md>`__.
 Firstly we will create pipeline with ``WhisperPipeline``. You can
 construct it straight away from the folder with the converted model. It
 will automatically load the ``model``, ``tokenizer``, ``detokenizer``


### PR DESCRIPTION
### Details:
 - Update links to genai samples to 2024.6 branch
 - related to https://github.com/openvinotoolkit/openvino.genai/pull/1411

### Tickets:
 - *ticket-id*
