### PR TITLE
[CPU] Remove errorPrefix usage for error reporting

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -54,9 +54,7 @@ bool AdaptivePooling::isSupportedOperation(const std::shared_ptr<const ov::Node>
 AdaptivePooling::AdaptivePooling(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     : Node(op, context, AdaptivePoolingShapeInferFactory(op)) {
     std::string errorMessage;
-    if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "Adaptive Pooling layer with name '" + getName() + "' ";
-    } else {
+    if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     if (one_of(op->get_type_info(), ov::op::v8::AdaptiveAvgPool::get_type_info_static())) {
@@ -70,21 +68,21 @@ AdaptivePooling::AdaptivePooling(const std::shared_ptr<ov::Node>& op, const Grap
 
 void AdaptivePooling::getSupportedDescriptors() {
     if (getParentEdges().size() != 2)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (getChildEdges().size() < (algorithm == Algorithm::AdaptivePoolingMax ? 2 : 1))
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 
     auto srcRank = getInputShapeAtPort(0).getRank();
     if (!one_of(spatialDimsCount, 1, 2, 3)) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 0th input with rank: ", srcRank);
+        THROW_CPU_NODE_ERR("doesn't support 0th input with rank: ", srcRank);
     }
 
     if (getInputShapeAtPort(1).getRank() != 1) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
     }
 
     if (getOutputShapeAtPort(0).getRank() != getInputShapeAtPort(0).getRank()) {
-        OPENVINO_THROW(errorPrefix, "must keep data rank");
+        THROW_CPU_NODE_ERR("must keep data rank");
     }
 }
 
@@ -136,7 +134,7 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     auto inputPrec = getParentEdgeAt(0)->getMemory().getDataType();
     auto outputPrec = getChildEdgeAt(0)->getMemory().getDataType();
     if (!(inputPrec == dnnl_f32 && outputPrec == dnnl_f32))
-        OPENVINO_THROW(errorPrefix, "doesn't support demanded precisions");
+        THROW_CPU_NODE_ERR("doesn't support demanded precisions");
 
     auto& srcMemory0 = getParentEdgeAt(0)->getMemory();
     auto& srcMemory1 = getParentEdgeAt(1)->getMemory();
@@ -159,12 +157,11 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     auto* dst = getDstDataAtPortAs<float>(0);
 
     if (static_cast<int>(srcMemory1.getShape().getElementsCount()) != spatialDimsCount)
-        OPENVINO_THROW(errorPrefix,
-                       "has input spatial dimension (",
-                       srcMemory1.getShape().getElementsCount(),
-                       ") inconsistent with pooling vector size (",
-                       spatialDimsCount,
-                       ")");
+        THROW_CPU_NODE_ERR("has input spatial dimension (",
+                           srcMemory1.getShape().getElementsCount(),
+                           ") inconsistent with pooling vector size (",
+                           spatialDimsCount,
+                           ")");
 
     auto inputDimVector = srcMemory0.getStaticDims();
     const int N = static_cast<int>(inputDimVector[0]);
@@ -185,7 +182,7 @@ void AdaptivePooling::execute(dnnl::stream strm) {
     const int blockCount = (isTailCFmt ? 1 : chPadding / blockSize);
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor)
-        OPENVINO_THROW(errorPrefix, "doesn't have primitive descriptors.");
+        THROW_CPU_NODE_ERR("doesn't have primitive descriptors.");
     auto config = selectedPrimitiveDescriptor->getConfig();
     auto srcStrides = srcBlockDesc->getStrides();
     auto dstStrides = getChildEdgeAt(0)->getMemory().getDescWithType<BlockedMemoryDesc>()->getStrides();
@@ -231,7 +228,7 @@ void AdaptivePooling::execute(dnnl::stream strm) {
         setBinBorders(&wStart, &wEnd, ow, IW, OW);
         auto binSize = (dEnd - dStart) * (hEnd - hStart) * (wEnd - wStart);
         if (binSize == 0)
-            OPENVINO_THROW(errorPrefix, "has empty bin");
+            THROW_CPU_NODE_ERR("has empty bin");
         float sum = 0;
         for (size_t pixD = dStart; pixD < dEnd; pixD++) {
             for (size_t pixH = hStart; pixH < hEnd; pixH++) {

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.h
@@ -33,8 +33,6 @@ private:
     ov::element::Type precision = ov::element::f32;
     inline void setBinBorders(size_t* startPtr, size_t* endPtr, size_t idx, size_t inputLength, size_t outputLength);
 
-    std::string errorPrefix;
-
 protected:
     bool needShapeInfer() const override;
     bool needPrepareParams() const override {

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.h
@@ -42,8 +42,6 @@ private:
 private:
     std::vector<size_t> blockShapeIn;
     std::vector<size_t> cropsBeginIn;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -940,7 +940,6 @@ BinaryConvolution::BinaryConvolution(const std::shared_ptr<ov::Node>& op, const 
     : Node(op, context, NgraphShapeInferFactory(op)) {
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "BinaryConvolution node with name '" + getName() + "' ";
         const auto binConv = ov::as_type_ptr<const ov::opset1::BinaryConvolution>(op);
 
         pad_value = binConv->get_pad_value();
@@ -980,21 +979,21 @@ void BinaryConvolution::getSupportedDescriptors() {
     }
 
     if (getParentEdges().size() != expectedInputEdgesNum)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges");
 
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges");
 
     if (getInputShapeAtPort(0).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 0th input with rank: ", getInputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 0th input with rank: ", getInputShapeAtPort(0).getRank());
     }
 
     if (getInputShapeAtPort(1).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
     }
 
     if (getOutputShapeAtPort(0).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support output with rank: ", getOutputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("doesn't support output with rank: ", getOutputShapeAtPort(0).getRank());
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.h
@@ -129,8 +129,6 @@ private:
                           const std::vector<size_t>& s_str,
                           const std::vector<size_t>& w_str,
                           const std::vector<size_t>& d_str);
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -57,21 +57,20 @@ Broadcast::Broadcast(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "Broadcast node with name '" + op->get_friendly_name() + "' ";
     if (op->get_input_size() != 2 && op->get_input_size() != 3)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (op->get_output_size() == 0)
-        OPENVINO_THROW(errorPrefix, "has no output edges.");
+        THROW_CPU_NODE_ERR("has no output edges.");
 
     auto broadcastOp = ov::as_type_ptr<const ov::op::v1::Broadcast>(op);
     if (broadcastOp->get_broadcast_spec().m_type == ov::op::AutoBroadcastType::NUMPY) {
         broadcastType = NUMPY;
     } else if (broadcastOp->get_broadcast_spec().m_type == ov::op::AutoBroadcastType::EXPLICIT) {
         if (op->get_input_size() <= AXES_MAPPING_IDX)
-            OPENVINO_THROW(errorPrefix, " and EXPLICIT mode must have tree input edges: ", getParentEdges().size());
+            THROW_CPU_NODE_ERR("and EXPLICIT mode must have tree input edges: ", getParentEdges().size());
         broadcastType = EXPLICIT;
     } else {
-        OPENVINO_THROW(errorPrefix, "has unexpected broadcast type: ", broadcastOp->get_broadcast_spec().m_type);
+        THROW_CPU_NODE_ERR("has unexpected broadcast type: ", broadcastOp->get_broadcast_spec().m_type);
     }
 
     if (ov::is_type<ov::op::v0::Constant>(op->get_input_node_ptr(TARGET_SHAPE_IDX))) {

--- a/src/plugins/intel_cpu/src/nodes/broadcast.h
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.h
@@ -44,8 +44,6 @@ private:
 
     std::vector<int32_t> targetShape;
     std::vector<int32_t> axesMapping;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -36,7 +36,6 @@ Bucketize::Bucketize(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "Bucketize layer with name '" + op->get_friendly_name() + "' ";
     const auto bucketsize = ov::as_type_ptr<const ov::opset3::Bucketize>(op);
     if (bucketsize == nullptr)
         OPENVINO_THROW("Operation with name '",
@@ -44,7 +43,7 @@ Bucketize::Bucketize(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
                        "' is not an instance of Bucketize from opset3.");
 
     if (getOriginalInputsNumber() != 2 || getOriginalOutputsNumber() != 1) {
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
     }
 
     // check one attribute
@@ -181,7 +180,7 @@ void Bucketize::execute(dnnl::stream strm) {
                   element_type_traits<ov::element::i64>::value_type>();
         break;
     default:
-        OPENVINO_THROW(errorPrefix, " has unsupported precision: ", precision_mask);
+        THROW_CPU_NODE_ERR("has unsupported precision: ", precision_mask);
     }
 }
 
@@ -201,11 +200,11 @@ void Bucketize::prepareParams() {
     // update with_bins/num_values/num_bin_values
     auto input_tensor_dims = inputTensorMemPtr->getStaticDims();
     if (input_tensor_dims.size() < 1) {
-        OPENVINO_THROW(errorPrefix, " has incorrect dimensions of the input.");
+        THROW_CPU_NODE_ERR("has incorrect dimensions of the input.");
     }
     auto input_bin_dims = inputBinsMemPtr->getStaticDims();
     if (input_bin_dims.size() != 1) {
-        OPENVINO_THROW(errorPrefix, " has incorrect dimensions of the boundaries tensor.");
+        THROW_CPU_NODE_ERR("has incorrect dimensions of the boundaries tensor.");
     }
     if (input_bin_dims[0] != 0) {
         with_bins = true;

--- a/src/plugins/intel_cpu/src/nodes/bucketize.h
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.h
@@ -43,7 +43,6 @@ private:
     ov::element::Type input_precision;
     ov::element::Type boundaries_precision;
     ov::element::Type output_precision;
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/convert.cpp
@@ -39,9 +39,7 @@ bool Convert::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, st
 Convert::Convert(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     : Node(op, context, PassThroughShapeInferFactory()) {
     std::string errorMessage;
-    if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "Convert node with name '" + getName() + "'";
-    } else {
+    if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
@@ -61,8 +59,6 @@ Convert::Convert(const Shape& shape,
     if (isDynamicNode()) {
         shapeInference = std::make_shared<ShapeInferPassThrough>();
     }
-
-    errorPrefix = "Convert node with name '" + getName() + "'";
 }
 
 void Convert::getSupportedDescriptors() {
@@ -73,9 +69,9 @@ void Convert::getSupportedDescriptors() {
     if (inputShapes.empty())
         inputShapes.push_back(input->getShape());
     if (getParentEdges().size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input edges");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges");
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, " has incorrect number of output edges");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges");
 }
 
 bool Convert::isSupportedDesc(const MemoryDesc& desc) {
@@ -157,7 +153,7 @@ void Convert::initSupportedPrimitiveDescriptors() {
             supportedPrimitiveDescriptorsBuilder(config);
         }
     } else {
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges");
     }
 }
 
@@ -185,7 +181,7 @@ void Convert::execute(dnnl::stream strm) {
     const auto childPaddElemCount = childMem.getDescWithType<BlockedMemoryDesc>()->getPaddedElementsCount();
 
     if (parentPaddElemCount != childPaddElemCount)
-        OPENVINO_THROW(errorPrefix, " has different elements number in input and output buffers");
+        THROW_CPU_NODE_ERR("has different elements number in input and output buffers");
 
     MemoryCPtr srcMemory = getSrcMemoryAtPort(0);
     MemoryPtr dstMemory = getDstMemoryAtPort(0);

--- a/src/plugins/intel_cpu/src/nodes/convert.h
+++ b/src/plugins/intel_cpu/src/nodes/convert.h
@@ -60,8 +60,6 @@ private:
     ConvertParams convertParams;
     std::shared_ptr<ConvertExecutor> execPtr = nullptr;
     NodeConfig config;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
@@ -35,17 +35,16 @@ CTCGreedyDecoder::CTCGreedyDecoder(const std::shared_ptr<ov::Node>& op, const Gr
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "CTCGreedyDecoder layer with name '" + op->get_friendly_name() + "' ";
     if (getOriginalInputsNumber() != 2)
-        OPENVINO_THROW(errorPrefix, "has invalid number of input edges: ", getOriginalInputsNumber());
+        THROW_CPU_NODE_ERR("has invalid number of input edges: ", getOriginalInputsNumber());
     if (getOriginalOutputsNumber() != 1)
-        OPENVINO_THROW(errorPrefix, "has invalid number of outputs edges: ", getOriginalOutputsNumber());
+        THROW_CPU_NODE_ERR("has invalid number of outputs edges: ", getOriginalOutputsNumber());
 
     const auto& dataDims = getInputShapeAtPort(DATA_INDEX).getDims();
     const auto& seqDims = getInputShapeAtPort(SEQUENCE_LENGTH_INDEX).getDims();
 
     if (!dimsEqualWeak(dataDims[0], seqDims[0]) || !dimsEqualWeak(dataDims[1], seqDims[1]))
-        OPENVINO_THROW(errorPrefix, "has invalid input shapes.");
+        THROW_CPU_NODE_ERR("has invalid input shapes.");
 
     auto greedyDecOp = ov::as_type_ptr<const ov::op::v0::CTCGreedyDecoder>(op);
     mergeRepeated = greedyDecOp->get_ctc_merge_repeated();
@@ -57,11 +56,11 @@ void CTCGreedyDecoder::initSupportedPrimitiveDescriptors() {
 
     ov::element::Type inDataPrecision = getOriginalInputPrecisionAtPort(DATA_INDEX);
     if (!one_of(inDataPrecision, ov::element::f32, ov::element::bf16, ov::element::f16))
-        OPENVINO_THROW(errorPrefix, "has unsupported 'data' input precision: ", inDataPrecision);
+        THROW_CPU_NODE_ERR("has unsupported 'data' input precision: ", inDataPrecision);
 
     ov::element::Type seqLenPrecision = getOriginalInputPrecisionAtPort(SEQUENCE_LENGTH_INDEX);
     if (!one_of(seqLenPrecision, ov::element::f32, ov::element::bf16, ov::element::f16))
-        OPENVINO_THROW(errorPrefix, "has unsupported 'sequence_length' input precision: ", seqLenPrecision);
+        THROW_CPU_NODE_ERR("has unsupported 'sequence_length' input precision: ", seqLenPrecision);
 
     addSupportedPrimDesc({{LayoutType::ncsp, ov::element::f32}, {LayoutType::ncsp, ov::element::f32}},
                          {{LayoutType::ncsp, ov::element::f32}},

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.h
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.h
@@ -27,8 +27,6 @@ private:
     const size_t DATA_INDEX = 0lu;
     const size_t SEQUENCE_LENGTH_INDEX = 1lu;
     bool mergeRepeated;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.h
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.h
@@ -30,8 +30,6 @@ private:
     const size_t DECODED_CLASSES_INDEX = 0lu;
     const size_t DECODED_CLASSES_LENGTH_INDEX = 1lu;
     bool mergeRepeated;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -33,10 +33,8 @@ CTCLoss::CTCLoss(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = std::string("CTCLoss layer with name '") + op->get_friendly_name() + "'";
-
     if (getOriginalInputsNumber() != 4 && getOriginalInputsNumber() != 5)
-        OPENVINO_THROW(errorPrefix, " has invalid inputs number.");
+        THROW_CPU_NODE_ERR("has invalid inputs number.");
 
     auto ctcLossOp = ov::as_type_ptr<const ov::op::v4::CTCLoss>(op);
     ctcMergeRepeated = ctcLossOp->get_ctc_merge_repeated();
@@ -95,7 +93,7 @@ void CTCLoss::execute(dnnl::stream strm) {
         for (size_t b = start; b < end; b++) {
             if (logitsLength[b] < 0 || labelsLength[b] < 0 || logitsLength[b] > static_cast<int>(maxTime) ||
                 labelsLength[b] > logitsLength[b]) {
-                errorMsgB[ithr] = errorPrefix + ". Logit length cannot be greater than max sequence length. " +
+                errorMsgB[ithr] = std::string("Logit length cannot be greater than max sequence length. ") +
                                   "Label length cannot be greater than a logit length" +
                                   " and both cannot be negative.\nMaxSeqLen: " + std::to_string(maxTime) +
                                   "; Logit len: " + std::to_string(logitsLength[b]) +
@@ -160,7 +158,7 @@ void CTCLoss::execute(dnnl::stream strm) {
             if (!err.empty())
                 resErr += err + "\n";
         }
-        OPENVINO_THROW(resErr);
+        THROW_CPU_NODE_ERR(resErr);
     }
 
     const size_t TC = maxTime * classesNum;

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.h
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.h
@@ -30,8 +30,6 @@ private:
     bool ctcMergeRepeated;
     bool preprocessCollapseRepeated;
     bool unique;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
@@ -37,16 +37,14 @@ CumSum::CumSum(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "CumSum layer with name '" + op->get_friendly_name() + "' ";
-
     if ((getOriginalInputsNumber() != numOfInputs && getOriginalInputsNumber() != (numOfInputs - 1)) ||
         getOriginalOutputsNumber() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     const auto& dataShape = getInputShapeAtPort(CUM_SUM_DATA);
     numOfDims = dataShape.getRank();
     if (numOfDims < 1) {
-        OPENVINO_THROW(errorPrefix, " doesn't support 'data' input tensor with rank: ", numOfDims);
+        THROW_CPU_NODE_ERR("doesn't support 'data' input tensor with rank: ", numOfDims);
     }
 
     const auto cumsum = ov::as_type_ptr<const ov::opset3::CumSum>(op);
@@ -59,11 +57,11 @@ CumSum::CumSum(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
     if (getOriginalInputsNumber() == numOfInputs) {
         const auto axis_shape = cumsum->get_input_partial_shape(AXIS);
         if (axis_shape.is_dynamic() || !ov::is_scalar(axis_shape.to_shape()))
-            OPENVINO_THROW(errorPrefix, " doesn't support 'axis' input tensor with non scalar rank");
+            THROW_CPU_NODE_ERR("doesn't support 'axis' input tensor with non scalar rank");
     }
 
     if (dataShape != getOutputShapeAtPort(0))
-        OPENVINO_THROW(errorPrefix, " has different 'data' input and output dimensions");
+        THROW_CPU_NODE_ERR("has different 'data' input and output dimensions");
 }
 
 void CumSum::initSupportedPrimitiveDescriptors() {
@@ -81,12 +79,12 @@ void CumSum::initSupportedPrimitiveDescriptors() {
                 ov::element::bf16,
                 ov::element::f16,
                 ov::element::f32))
-        OPENVINO_THROW(errorPrefix, " has unsupported 'data' input precision: ", dataPrecision.get_type_name());
+        THROW_CPU_NODE_ERR("has unsupported 'data' input precision: ", dataPrecision.get_type_name());
 
     if (inputShapes.size() == numOfInputs) {
         const auto& axisTensorPrec = getOriginalInputPrecisionAtPort(AXIS);
         if (axisTensorPrec != ov::element::i32 && axisTensorPrec != ov::element::i64)
-            OPENVINO_THROW(errorPrefix, " has unsupported 'axis' input precision: ", axisTensorPrec.get_type_name());
+            THROW_CPU_NODE_ERR("has unsupported 'axis' input precision: ", axisTensorPrec.get_type_name());
     }
 
     std::vector<PortConfigurator> inDataConf;
@@ -255,11 +253,11 @@ size_t CumSum::getAxis(const IMemory& _axis, const IMemory& _data) const {
         break;
     }
     default: {
-        OPENVINO_THROW(errorPrefix, "  doesn't support 'axis' input with precision: ", axisPrecision.get_type_name());
+        THROW_CPU_NODE_ERR("doesn't support 'axis' input with precision: ", axisPrecision.get_type_name());
     }
     }
     if (axisValueFromBlob < -dataShapeSize || axisValueFromBlob > dataShapeSize - 1)
-        OPENVINO_THROW(errorPrefix, "  has axis with a value out of range: ", axisValueFromBlob);
+        THROW_CPU_NODE_ERR("has axis with a value out of range: ", axisValueFromBlob);
     return axisValueFromBlob >= 0 ? axisValueFromBlob : (axisValueFromBlob + dataShapeSize);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.h
@@ -46,7 +46,6 @@ private:
     size_t axis = 0;
 
     ov::element::Type dataPrecision;
-    std::string errorPrefix;
 
     template <typename T>
     struct CumSumExecute {

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -167,9 +167,8 @@ bool Deconvolution::isSupportedOperation(const std::shared_ptr<const ov::Node>& 
 Deconvolution::Deconvolution(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     : Node(op, context, DeconfolutionShapeInferFactory(op)) {
     std::string errorMessage;
-    errorPrefix = "Deconvolution node with name '" + getName() + "' ";
     if (!isSupportedOperation(op, errorMessage))
-        OPENVINO_THROW_NOT_IMPLEMENTED(errorPrefix + errorMessage);
+        OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
 
     const auto& weightDims = getWeightDims();
 
@@ -233,9 +232,7 @@ Deconvolution::Deconvolution(const std::shared_ptr<ov::Node>& op, const GraphCon
         const auto spDimsNum = getInputShapeAtPort(0).getRank() - 2;
         if (getInputShapeAtPort(2).getStaticDims()[0] != spDimsNum ||
             (isConstOutShape && lastOutputSpatialDims.size() != spDimsNum)) {
-            OPENVINO_THROW(errorPrefix,
-                           "'output_shape' input has incorrect number of elements. Expected = ",
-                           spDimsNum);
+            THROW_CPU_NODE_ERR("'output_shape' input has incorrect number of elements. Expected = ", spDimsNum);
         }
     }
 
@@ -408,7 +405,7 @@ std::pair<VectorDims, VectorDims> Deconvolution::makeDummyInOutShape() {
                             auto upper_bound =
                                 deconvAttrs.stride[i] * static_cast<int32_t>(origInMaxDims[i + 2] - 1) - c1;
                             if (upper_bound < 0) {
-                                OPENVINO_THROW(errorPrefix, ": paddings for dummy shapes can't be computed");
+                                THROW_CPU_NODE_ERR("paddings for dummy shapes can't be computed");
                             }
                         }
 
@@ -506,10 +503,10 @@ void Deconvolution::getSupportedDescriptors() {
             fusedWith[fusedWith.size() - 1]->getOriginalOutputPrecisionAtPort(0));
     }
     if (getParentEdges().size() != (withBiases ? (biasPort + 1) : biasPort)) {
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input edges");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges");
     }
     if (getChildEdges().empty()) {
-        OPENVINO_THROW(errorPrefix, " has incorrect number of output edges");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges");
     }
     VectorDims inDims, outDims;
     std::tie(inDims, outDims) = makeDummyInOutShape();

--- a/src/plugins/intel_cpu/src/nodes/deconv.h
+++ b/src/plugins/intel_cpu/src/nodes/deconv.h
@@ -106,8 +106,6 @@ private:
     bool withBiases = false;
     size_t biasPort;
 
-    std::string errorPrefix;
-
     void createDnnlCompatibleWeights();
     bool weightIsConst = false;
     bool asymmetricPaddingAnd1x1 = false;

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -774,10 +774,9 @@ DeformableConvolution::DeformableConvolution(const std::shared_ptr<ov::Node>& op
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
-    errorPrefix = "Deformable convolution with name '" + op->get_friendly_name() + "'";
     auto defConvNodeBase = ov::as_type_ptr<ov::op::util::DeformableConvolutionBase>(op);
     if (defConvNodeBase == nullptr)
-        OPENVINO_THROW(errorPrefix, " is not an instance of DeformableConvolutionBase.");
+        THROW_CPU_NODE_ERR("is not an instance of DeformableConvolutionBase.");
 
     defConvAttr.group = defConvNodeBase->get_group();
     defConvAttr.deformable_group = defConvNodeBase->get_deformable_group();
@@ -798,7 +797,7 @@ DeformableConvolution::DeformableConvolution(const std::shared_ptr<ov::Node>& op
     if (op->get_type_info() == ov::op::v8::DeformableConvolution::get_type_info_static()) {
         auto defConvNode = ov::as_type_ptr<ov::op::v8::DeformableConvolution>(op);
         if (defConvNode == nullptr)
-            OPENVINO_THROW(errorPrefix, " is not an instance of DeformableConvolution from opset8.");
+            THROW_CPU_NODE_ERR("is not an instance of DeformableConvolution from opset8.");
         defConvAttr.with_bilinear_pad = defConvNode->get_bilinear_interpolation_pad();
     } else {
         defConvAttr.with_bilinear_pad = false;
@@ -807,20 +806,20 @@ DeformableConvolution::DeformableConvolution(const std::shared_ptr<ov::Node>& op
 
 void DeformableConvolution::getSupportedDescriptors() {
     if (getParentEdges().size() != 3 && getParentEdges().size() != 4)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input edges");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges");
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, " has incorrect number of output edges");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges");
     if (getInputShapeAtPort(DATA_ID).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, " has unsupported mode. Only 4D blobs are supported as input.");
+        THROW_CPU_NODE_ERR("has unsupported mode. Only 4D blobs are supported as input.");
     }
     if (getInputShapeAtPort(OFF_ID).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, " doesn't support 1st input with rank: ", getInputShapeAtPort(OFF_ID).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 1st input with rank: ", getInputShapeAtPort(OFF_ID).getRank());
     }
     if (getInputShapeAtPort(WEI_ID).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, " doesn't support 2nd input with rank: ", getInputShapeAtPort(WEI_ID).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 2nd input with rank: ", getInputShapeAtPort(WEI_ID).getRank());
     }
     if (getOutputShapeAtPort(DATA_ID).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, " doesn't support output with rank: ", getOutputShapeAtPort(DATA_ID).getRank());
+        THROW_CPU_NODE_ERR("doesn't support output with rank: ", getOutputShapeAtPort(DATA_ID).getRank());
     }
 }
 
@@ -1225,23 +1224,23 @@ void DeformableConvolution::prepareParams() {
     auto weiMemPtr = getSrcMemoryAtPort(WEI_ID);
 
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined destination memory");
+        THROW_CPU_NODE_ERR("has undefined destination memory");
     if (!srcMemPtr || !srcMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory");
+        THROW_CPU_NODE_ERR("has undefined input memory");
     if (!offMemPtr || !offMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined offsets shape memory");
+        THROW_CPU_NODE_ERR("has undefined offsets shape memory");
     if (!weiMemPtr || !weiMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined weights memory");
+        THROW_CPU_NODE_ERR("has undefined weights memory");
 
     if (getOriginalInputsNumber() > 3) {
         auto modMemPtr = getSrcMemoryAtPort(MOD_ID);
         if (!modMemPtr || !modMemPtr->isDefined())
-            OPENVINO_THROW(errorPrefix, " has undefined modulations memory");
+            THROW_CPU_NODE_ERR("has undefined modulations memory");
     }
 
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor)
-        OPENVINO_THROW(errorPrefix, "' doesn't have primitive descriptors.");
+        THROW_CPU_NODE_ERR("doesn't have primitive descriptors.");
     auto config = selectedPrimitiveDescriptor->getConfig();
 
     bool withModulation = getParentEdges().size() > 3;

--- a/src/plugins/intel_cpu/src/nodes/def_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.h
@@ -108,7 +108,6 @@ private:
     static constexpr size_t OFF_ID = 1;
     static constexpr size_t WEI_ID = 2;
     static constexpr size_t MOD_ID = 3;
-    std::string errorPrefix;
     class DefConvExecutor {
     public:
         DefConvExecutor(const DefConvAttr& defConvAttr,

--- a/src/plugins/intel_cpu/src/nodes/detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.cpp
@@ -55,13 +55,11 @@ DetectionOutput::DetectionOutput(const std::shared_ptr<ov::Node>& op, const Grap
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "DetectionOutput node with name '" + getName() + "' ";
-
     if (getOriginalInputsNumber() != 3 && getOriginalInputsNumber() != 5)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges.");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges.");
 
     if (getOriginalOutputsNumber() != 1)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges.");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges.");
 
     auto doOp = ov::as_type_ptr<const ov::op::v8::DetectionOutput>(op);
     auto attributes = doOp->get_attrs();
@@ -101,19 +99,17 @@ void DetectionOutput::prepareParams() {
 
     const auto& idLocDims = getParentEdgeAt(ID_LOC)->getMemory().getShape().getStaticDims();
     if (priorsNum * locNumForClasses * 4 != static_cast<int>(idLocDims[1]))
-        OPENVINO_THROW(errorPrefix,
-                       "has incorrect number of priors, which must match number of location predictions (",
-                       priorsNum * locNumForClasses * 4,
-                       " vs ",
-                       idLocDims[1],
-                       ")");
+        THROW_CPU_NODE_ERR("has incorrect number of priors, which must match number of location predictions (",
+                           priorsNum * locNumForClasses * 4,
+                           " vs ",
+                           idLocDims[1],
+                           ")");
 
     if (priorsNum * classesNum != static_cast<int>(idConfDims.back()))
-        OPENVINO_THROW(errorPrefix,
-                       "has incorrect number of priors, which must match number of confidence predictions.");
+        THROW_CPU_NODE_ERR("has incorrect number of priors, which must match number of confidence predictions.");
 
     if (decreaseClassId && backgroundClassId != 0)
-        OPENVINO_THROW(errorPrefix, "cannot use decrease_label_id and background_label_id parameter simultaneously.");
+        THROW_CPU_NODE_ERR("cannot use decrease_label_id and background_label_id parameter simultaneously.");
 
     imgNum = static_cast<int>(idConfDims[0]);
 
@@ -923,7 +919,7 @@ inline void DetectionOutput::generateOutput(float* reorderedConfData,
     const int numResults = outDims[2];
     const int DETECTION_SIZE = outDims[3];
     if (DETECTION_SIZE != 7) {
-        OPENVINO_THROW_NOT_IMPLEMENTED(errorPrefix);
+        THROW_CPU_NODE_ERR("has unsupported output layout.");
     }
 
     int dstDataSize = 0;
@@ -935,7 +931,7 @@ inline void DetectionOutput::generateOutput(float* reorderedConfData,
         dstDataSize = imgNum * classesNum * priorsNum * DETECTION_SIZE * sizeof(float);
 
     if (static_cast<size_t>(dstDataSize) > getChildEdgeAt(0)->getMemory().getSize()) {
-        OPENVINO_THROW(errorPrefix, ": OUT_OF_BOUNDS");
+        THROW_CPU_NODE_ERR("has insufficient output buffer size.");
     }
     memset(dstData, 0, dstDataSize);
 

--- a/src/plugins/intel_cpu/src/nodes/detection_output.h
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.h
@@ -130,8 +130,6 @@ private:
     std::vector<float> bboxSizes;
     std::vector<int> numPriorsActual;
     std::vector<int> confInfoForPrior;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -49,29 +49,28 @@ DFT::DFT(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    layerErrorPrefix = "DFT layer with name '" + op->get_name() + "'";
     const size_t inputsNumber = getOriginalInputsNumber();
     if (inputsNumber != 2 && inputsNumber != 3) {
-        OPENVINO_THROW(layerErrorPrefix, " has invalid number of input/output edges: ", inputsNumber);
+        THROW_CPU_NODE_ERR("has invalid number of input/output edges: ", inputsNumber);
     }
 
     /* Data */
     inputShape = inputShapes[DATA_INDEX].getStaticDims();
     if (inputShape.size() < 2) {
-        OPENVINO_THROW(layerErrorPrefix, " has invalid 'data' input tensor with rank: ", inputShape.size());
+        THROW_CPU_NODE_ERR("has invalid 'data' input tensor with rank: ", inputShape.size());
     }
 
     /* Axes */
     const auto axesRank = inputShapes[AXES_INDEX].getRank();
     if (axesRank != 1) {
-        OPENVINO_THROW(layerErrorPrefix, " has invalid 'axes' input tensor with rank: ", axesRank);
+        THROW_CPU_NODE_ERR("has invalid 'axes' input tensor with rank: ", axesRank);
     }
 
     /* Signal size */
     if (inputsNumber > SIGNAL_SIZE_INDEX) {
         const auto signalSizeRank = inputShapes[SIGNAL_SIZE_INDEX].getRank();
         if (signalSizeRank != 1) {
-            OPENVINO_THROW(layerErrorPrefix, " has invalid 'signal_size' input tensor with rank: ", signalSizeRank);
+            THROW_CPU_NODE_ERR("has invalid 'signal_size' input tensor with rank: ", signalSizeRank);
         }
     }
 
@@ -87,20 +86,18 @@ void DFT::initSupportedPrimitiveDescriptors() {
 
     const auto& dataPrecision = getOriginalInputPrecisionAtPort(DATA_INDEX);
     if (!dataPrecision.is_real()) {
-        OPENVINO_THROW(layerErrorPrefix, " has unsupported 'data' input precision: ", dataPrecision.get_type_name());
+        THROW_CPU_NODE_ERR("has unsupported 'data' input precision: ", dataPrecision.get_type_name());
     }
 
     const auto& axesPrecision = getOriginalInputPrecisionAtPort(AXES_INDEX);
     if (axesPrecision != ov::element::i32 && axesPrecision != ov::element::i64) {
-        OPENVINO_THROW(layerErrorPrefix, " has unsupported 'axes' input precision: ", axesPrecision.get_type_name());
+        THROW_CPU_NODE_ERR("has unsupported 'axes' input precision: ", axesPrecision.get_type_name());
     }
 
     if (inputShapes.size() > SIGNAL_SIZE_INDEX) {
         const auto& signalSizeTensorPrec = getOriginalInputPrecisionAtPort(SIGNAL_SIZE_INDEX);
         if (signalSizeTensorPrec != ov::element::i32 && signalSizeTensorPrec != ov::element::i64) {
-            OPENVINO_THROW(layerErrorPrefix,
-                           " has unsupported 'signal_size' input precision: ",
-                           signalSizeTensorPrec.get_type_name());
+            THROW_CPU_NODE_ERR("has unsupported 'signal_size' input precision: ", signalSizeTensorPrec.get_type_name());
         }
     }
 

--- a/src/plugins/intel_cpu/src/nodes/dft.h
+++ b/src/plugins/intel_cpu/src/nodes/dft.h
@@ -53,7 +53,7 @@ private:
 
     std::vector<int32_t> axes;
     std::vector<size_t> inputShape;
-    std::string layerErrorPrefix;
+    std::string layer;
     const size_t DATA_INDEX = 0;
     const size_t AXES_INDEX = 1;
     const size_t SIGNAL_SIZE_INDEX = 2;

--- a/src/plugins/intel_cpu/src/nodes/dft.h
+++ b/src/plugins/intel_cpu/src/nodes/dft.h
@@ -53,7 +53,6 @@ private:
 
     std::vector<int32_t> axes;
     std::vector<size_t> inputShape;
-    std::string layer;
     const size_t DATA_INDEX = 0;
     const size_t AXES_INDEX = 1;
     const size_t SIGNAL_SIZE_INDEX = 2;

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -3117,7 +3117,9 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
             if (scales.size() == 1) {
                 depthwiseData.resize(channelSize, depthwiseData.back());
             } else if (scales.size() != channelSize) {
-                THROW_CPU_NODE_ERR("failed due to scales data size inconsistency");
+                OPENVINO_THROW("Appending Eltwise node with name '",
+                               getName(),
+                               "' failed due to scales data size inconsistency");
             }
             depthwiseData.insert(depthwiseData.end(), shifts.begin(), shifts.end());
             if (shifts.empty()) {
@@ -3126,7 +3128,9 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
             } else if (shifts.size() == 1) {
                 depthwiseData.resize(2 * channelSize, depthwiseData.back());
             } else if (shifts.size() != channelSize) {
-                THROW_CPU_NODE_ERR("failed due to shifts data size inconsistency");
+                OPENVINO_THROW("Appending Eltwise node with name '",
+                               getName(),
+                               "' failed due to shifts data size inconsistency");
             }
             depthwiseDataSize = 2 * channelSize;
 

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -3065,8 +3065,6 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
                                 const VectorDims& postOpDims,
                                 std::vector<T>& postOpsMem,
                                 const int channelAxis) {
-    const std::string errorPrefix = "Appending Eltwise node with name '" + getName() + "' ";
-
     if (getOneDnnAlgorithm() != dnnl::algorithm::undef) {
         switch (getOneDnnAlgorithm()) {
         case dnnl::algorithm::eltwise_relu:
@@ -3091,7 +3089,7 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
             ops.append_eltwise(getOneDnnAlgorithm(), getAlpha(), getBeta());
             break;
         default:
-            OPENVINO_THROW(errorPrefix, "as post operation is not supported");
+            THROW_CPU_NODE_ERR("Appending Eltwise node with name '", getName(), "' as post operation is not supported");
         }
     } else {
         // per-tensor EltwisePowerStatic can be implemented with more well-supported eltwise postOps
@@ -3119,7 +3117,7 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
             if (scales.size() == 1) {
                 depthwiseData.resize(channelSize, depthwiseData.back());
             } else if (scales.size() != channelSize) {
-                OPENVINO_THROW(errorPrefix, "failed due to scales data size inconsistency");
+                THROW_CPU_NODE_ERR("failed due to scales data size inconsistency");
             }
             depthwiseData.insert(depthwiseData.end(), shifts.begin(), shifts.end());
             if (shifts.empty()) {
@@ -3128,7 +3126,7 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
             } else if (shifts.size() == 1) {
                 depthwiseData.resize(2 * channelSize, depthwiseData.back());
             } else if (shifts.size() != channelSize) {
-                OPENVINO_THROW(errorPrefix, "failed due to shifts data size inconsistency");
+                THROW_CPU_NODE_ERR("failed due to shifts data size inconsistency");
             }
             depthwiseDataSize = 2 * channelSize;
 
@@ -3139,7 +3137,7 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
         }
 
         if (depthwiseData.empty())
-            OPENVINO_THROW(errorPrefix, "cannot be performed since buffers are not allocated");
+            THROW_CPU_NODE_ERR("cannot be performed since buffers are not allocated");
 
         std::array<size_t, 2> offsets = {0};
         offsets[1] = offsets[0] + channelSize;
@@ -3160,7 +3158,7 @@ void Eltwise::appendPostOpsImpl(dnnl::post_ops& ops,
             ops.append_depthwise(dnnl::algorithm::depthwise_prelu, offsets);
             break;
         default:
-            OPENVINO_THROW(errorPrefix, "as post operation is not supported");
+            THROW_CPU_NODE_ERR("as post operation is not supported");
         }
 
         appendMemory(depthwiseData, depthwiseMemory, postOpsMem);
@@ -3192,8 +3190,6 @@ bool Eltwise::appendAttrPostOps(DnnlPostOpsComposerLegacy& dnnlpoc,
                                 bool isLastPostOp,
                                 dnnl::memory::data_type outDataType,
                                 bool allowBinary) {
-    const std::string errorPrefix = "Appending Eltwise node with name '" + getName() + "' as binary post op ";
-
     if (getOneDnnAlgorithm() != dnnl::algorithm::undef) {
         switch (getOneDnnAlgorithm()) {
         case dnnl::algorithm::eltwise_relu:
@@ -3221,7 +3217,7 @@ bool Eltwise::appendAttrPostOps(DnnlPostOpsComposerLegacy& dnnlpoc,
             dnnlpoc.appendLinear({getAlpha()}, {getBeta()}, isLastPostOp);
             break;
         default:
-            OPENVINO_THROW(errorPrefix, "as post operation is not supported");
+            THROW_CPU_NODE_ERR("as post operation is not supported");
         }
     } else {
         switch (getAlgorithm()) {
@@ -3248,7 +3244,7 @@ bool Eltwise::appendAttrPostOps(DnnlPostOpsComposerLegacy& dnnlpoc,
             dnnlpoc.appendBinary(dnnl::algorithm::binary_prelu, scales);
             break;
         default:
-            OPENVINO_THROW(errorPrefix, "as post operation is not supported");
+            THROW_CPU_NODE_ERR("as post operation is not supported");
         }
     }
     return true;

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -131,7 +131,7 @@ float ov::intel_cpu::InterpolateExecutor::coordTransToInput(int outCoord,
         break;
     }
     default: {
-        OPENVINO_THROW("does not support specified coordinate transformation mode");
+        OPENVINO_THROW("Interpolate executor does not support specified coordinate transformation mode");
         break;
     }
     }
@@ -167,7 +167,7 @@ int ov::intel_cpu::InterpolateExecutor::nearestRound(float originCoord,
             return static_cast<int>(originCoord);
     }
     default: {
-        OPENVINO_THROW("does not support specified nearest round mode");
+        OPENVINO_THROW("Interpolate executor does not support specified nearest round mode");
         break;
     }
     }
@@ -547,7 +547,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
             srcPadded.resize(eltsTotal * srcDataSize, 0x0);
             uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
             if ((srcDim5d[0] != srcDimPad5d[0]) || (srcDim5d[1] != srcDimPad5d[1])) {
-                OPENVINO_THROW("Interpolate layer with name does not support padding on batch and channel dimensions");
+                OPENVINO_THROW("Interpolate executor does not support padding on batch and channel dimensions");
             }
             parallel_for5d(
                 srcDim5d[0],

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -131,7 +131,7 @@ float ov::intel_cpu::InterpolateExecutor::coordTransToInput(int outCoord,
         break;
     }
     default: {
-        OPENVINO_THROW("errorPrefix", " does not support specified coordinate transformation mode");
+        OPENVINO_THROW("does not support specified coordinate transformation mode");
         break;
     }
     }
@@ -167,7 +167,7 @@ int ov::intel_cpu::InterpolateExecutor::nearestRound(float originCoord,
             return static_cast<int>(originCoord);
     }
     default: {
-        OPENVINO_THROW("errorPrefix", " does not support specified nearest round mode");
+        OPENVINO_THROW("does not support specified nearest round mode");
         break;
     }
     }

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
@@ -35,10 +35,9 @@ ExperimentalDetectronPriorGridGenerator::ExperimentalDetectronPriorGridGenerator
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "ExperimentalDetectronPriorGridGenerator layer with name '" + op->get_friendly_name() + "'";
     const auto priorGridGen = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronPriorGridGenerator>(op);
     if (getOriginalInputsNumber() != 3 || getOriginalOutputsNumber() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     const auto& attr = priorGridGen->get_attrs();
     grid_w_ = attr.w;

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.h
@@ -43,8 +43,6 @@ private:
     int grid_h_;
     float stride_w_;
     float stride_h_;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
@@ -38,7 +38,6 @@ ExperimentalDetectronTopKROIs::ExperimentalDetectronTopKROIs(const std::shared_p
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "ExperimentalDetectronTopKROIs layer with name '" + op->get_friendly_name() + "'";
     const auto topKROI = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronTopKROIs>(op);
     if (topKROI == nullptr)
         OPENVINO_THROW("Operation with name '",
@@ -46,10 +45,10 @@ ExperimentalDetectronTopKROIs::ExperimentalDetectronTopKROIs(const std::shared_p
                        "' is not an instance of ExperimentalDetectronTopKROIs from opset6.");
 
     if (inputShapes.size() != 2 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     if (getInputShapeAtPort(INPUT_ROIS).getRank() != 2 || getInputShapeAtPort(INPUT_PROBS).getRank() != 1)
-        OPENVINO_THROW(errorPrefix, " has unsupported input shape");
+        THROW_CPU_NODE_ERR("has unsupported input shape");
 
     max_rois_num_ = topKROI->get_max_rois();
 }

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.h
@@ -43,8 +43,6 @@ private:
 
     const int OUTPUT_ROIS{0};
     int max_rois_num_;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -364,22 +364,20 @@ ExtractImagePatches::ExtractImagePatches(const std::shared_ptr<ov::Node>& op, co
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "ExtractImagePatches layer with name '" + op->get_friendly_name() + "' ";
     auto extImgPatcher = ov::as_type_ptr<const ov::opset3::ExtractImagePatches>(op);
 
     if (inputShapes.size() != 1 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix,
-                       "has incorrect number of input or output edges!",
-                       " Input: ",
-                       inputShapes.size(),
-                       "); Output: ",
-                       outputShapes.size());
+        THROW_CPU_NODE_ERR("has incorrect number of input or output edges!",
+                           " Input: ",
+                           inputShapes.size(),
+                           "); Output: ",
+                           outputShapes.size());
 
     if (getInputShapeAtPort(0).getRank() != 4)
-        OPENVINO_THROW(errorPrefix, "must have 4D input tensor. Actual: ", getInputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("must have 4D input tensor. Actual: ", getInputShapeAtPort(0).getRank());
 
     if (getOutputShapeAtPort(0).getRank() != 4)
-        OPENVINO_THROW(errorPrefix, "must have 4D output tensor. Actual: ", getOutputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("must have 4D output tensor. Actual: ", getOutputShapeAtPort(0).getRank());
 
     if (extImgPatcher->get_auto_pad() == ov::op::PadType::VALID) {
         _auto_pad = ExtImgPatcherPadType::VALID;
@@ -388,7 +386,7 @@ ExtractImagePatches::ExtractImagePatches(const std::shared_ptr<ov::Node>& op, co
     } else if (extImgPatcher->get_auto_pad() == ov::op::PadType::SAME_UPPER) {
         _auto_pad = ExtImgPatcherPadType::SAME_UPPER;
     } else {
-        OPENVINO_THROW(errorPrefix, "has unsupported pad type: ", extImgPatcher->get_auto_pad());
+        THROW_CPU_NODE_ERR("has unsupported pad type: ", extImgPatcher->get_auto_pad());
     }
 
     _ksizes = extImgPatcher->get_sizes();
@@ -396,7 +394,7 @@ ExtractImagePatches::ExtractImagePatches(const std::shared_ptr<ov::Node>& op, co
     _strides = extImgPatcher->get_strides();
     _rates = extImgPatcher->get_rates();
     if (_ksizes.size() != 2 || _strides.size() != 2 || _rates.size() != 2)
-        OPENVINO_THROW(errorPrefix, "must have the following attributes with shape {2}: sizes, strides, rates.");
+        THROW_CPU_NODE_ERR("must have the following attributes with shape {2}: sizes, strides, rates.");
 }
 
 void ExtractImagePatches::prepareParams() {
@@ -444,7 +442,7 @@ void ExtractImagePatches::initSupportedPrimitiveDescriptors() {
 
     const auto precision = getOriginalInputPrecisionAtPort(0);
     if (_supported_precisions_sizes.find(precision.size()) == _supported_precisions_sizes.end())
-        OPENVINO_THROW(errorPrefix, "has unsupported precision: ", precision.get_type_name());
+        THROW_CPU_NODE_ERR("has unsupported precision: ", precision.get_type_name());
 
     addSupportedPrimDesc({{LayoutType::ncsp, precision}}, {{LayoutType::ncsp, precision}}, impl_desc_type::ref_any);
 }

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
@@ -63,8 +63,6 @@ private:
     static const std::set<size_t> _supported_precisions_sizes;
     ExtImgPatcherPadType _auto_pad;
 
-    std::string errorPrefix;
-
     struct ExtractImagePatchesExecutor {
         ExtractImagePatchesExecutor() = default;
         virtual void exec(void* src, void* dst, const VectorDims& istrides, const VectorDims& ostrides) = 0;

--- a/src/plugins/intel_cpu/src/nodes/eye.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eye.cpp
@@ -53,15 +53,15 @@ Eye::Eye(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     outType = op->get_output_element_type(0);
     withBatchShape = (op->get_input_size() == 4);
     if (!one_of(outType, ov::element::f32, ov::element::bf16, ov::element::i32, ov::element::i8, ov::element::u8)) {
-        THROW_ERROR(errorPrefix, "doesn't support demanded output precision");
+        THROW_CPU_NODE_ERR("doesn't support demanded output precision");
     }
 }
 
 void Eye::getSupportedDescriptors() {
     if (!one_of(getParentEdges().size(), 3u, 4u))
-        THROW_ERROR(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (getChildEdges().empty())
-        THROW_ERROR(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 }
 
 template <typename T>
@@ -106,7 +106,7 @@ void Eye::executeSpecified() {
     const int64_t shift = getDiagIndex();
     auto outPtr = getDstMemoryAtPort(0);
     if (!outPtr || !outPtr->isDefined())
-        THROW_ERROR(errorPrefix, "Destination memory is undefined.");
+        THROW_CPU_NODE_ERR("Destination memory is undefined.");
     T* dst = outPtr->getDataAs<T>();
 
     const size_t batchVolume = getBatchVolume(getBatchShape());

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -43,7 +43,6 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
-    std::string errorPrefix = "";
     ov::element::Type outType = ov::element::Type_t::undefined;
     template <typename inputType>
     void executeSpecified();
@@ -52,7 +51,7 @@ private:
     inline const size_t getRowNum() const {
         auto rowMem = getSrcMemoryAtPort(ROWS_NUM);
         if (rowMem == nullptr)
-            OPENVINO_THROW(errorPrefix, " doesn't contain row_count data");
+            THROW_CPU_NODE_ERR("doesn't contain row_count data");
         const int* rowPtr = rowMem->getDataAs<const int>();
 
         return rowPtr[0];
@@ -60,7 +59,7 @@ private:
     inline const size_t getColNum() const {
         auto colMem = getSrcMemoryAtPort(COLS_NUM);
         if (colMem == nullptr)
-            OPENVINO_THROW(errorPrefix, " doesn't contain col_count data");
+            THROW_CPU_NODE_ERR("doesn't contain col_count data");
         const int* colPtr = colMem->getDataAs<const int>();
 
         return colPtr[0];
@@ -68,7 +67,7 @@ private:
     inline const int getDiagIndex() const {
         auto diagIndMem = getSrcMemoryAtPort(DIAGONAL_INDEX);
         if (diagIndMem == nullptr)
-            OPENVINO_THROW(errorPrefix, " doesn't contain diag_index data");
+            THROW_CPU_NODE_ERR("doesn't contain diag_index data");
         const int* diagIndexPtr = diagIndMem->getDataAs<const int>();
 
         return diagIndexPtr[0];

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1063,15 +1063,14 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
         algorithm = Algorithm::FQCommon;
         const auto fq = ov::as_type_ptr<const ov::opset1::FakeQuantize>(op);
 
-        errorPrefix = "FakeQuantize node with name '" + getName() + "' ";
         levels = fq->get_levels();
         if (levels <= 1)
-            OPENVINO_THROW(errorPrefix, "supports 'levels' attribute greater than or equal to 2");
+            THROW_CPU_NODE_ERR("supports 'levels' attribute greater than or equal to 2");
 
         if (inputShapes.size() != 5)
-            OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", inputShapes.size());
+            THROW_CPU_NODE_ERR("has incorrect number of input edges: ", inputShapes.size());
         if (outputShapes.size() != 1)
-            OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", outputShapes.size());
+            THROW_CPU_NODE_ERR("has incorrect number of output edges: ", outputShapes.size());
 
         auto initAxisIdx = [&](const VectorDims& inputDims) {
             size_t axisIdx = 0;
@@ -1126,7 +1125,7 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
         auto outputHighAxisSize = ov::is_scalar(ohShape) ? 1 : ohShape[outputHighAxis];
 
         if (axisSize != -1 && !dimsEqualWeak(axisSize, getInputShapeAtPort(0).getDims()[axis])) {
-            OPENVINO_THROW(errorPrefix, "has different quantization axis size on 'data' and 'range' inputs");
+            THROW_CPU_NODE_ERR("has different quantization axis size on 'data' and 'range' inputs");
         }
 
         const auto inputLowNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(1));
@@ -1411,25 +1410,25 @@ void FakeQuantize::init() {
 
 void FakeQuantize::getSupportedDescriptors() {
     if (getParentEdges().size() != 5)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 
     if (getInputShapeAtPort(0).getRank() != getOutputShapeAtPort(0).getRank()) {
-        OPENVINO_THROW(errorPrefix, "has different ranks for input and output tensors");
+        THROW_CPU_NODE_ERR("has different ranks for input and output tensors");
     }
 
     if (isBinarization()) {
         if (getInputShapeAtPort(0).getRank() != 4ul) {
-            OPENVINO_THROW(errorPrefix, "doesn't support input/output rank != 4");
+            THROW_CPU_NODE_ERR("doesn't support input/output rank != 4");
         }
     }
 
     if (getAxis() != 1) {
         if (isBinarization())
-            OPENVINO_THROW(errorPrefix, "doesn't support non per-tensor binarization for axis: ", getAxis());
+            THROW_CPU_NODE_ERR("doesn't support non per-tensor binarization for axis: ", getAxis());
         if (getAxis() != 0)
-            OPENVINO_THROW(errorPrefix, "doesn't support non per-tensor quantization for axis: ", getAxis());
+            THROW_CPU_NODE_ERR("doesn't support non per-tensor quantization for axis: ", getAxis());
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -320,8 +320,6 @@ private:
     ov::element::Type inputPrecision = ov::element::f32;
     ov::element::Type outputPrecision = ov::element::f32;
 
-    std::string errorPrefix;
-
     BroadcastingPolicy broadcastingPolicy;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -168,8 +168,7 @@ void FullyConnected::initTensorParallelConfig(const GraphContext::CPtr context) 
 }
 
 FullyConnected::FullyConnected(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
-    : Node(op, context, FCShapeInferFactory(op)),
-      errorPrefix("FullyConnected node with name '" + getName() + "'") {
+    : Node(op, context, FCShapeInferFactory(op)) {
     std::string errorMessage;
     initTensorParallelConfig(context);
     if (!isSupportedOperation(op, errorMessage))

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -123,7 +123,6 @@ private:
     MemoryArgs memory;
     ExecutorFactoryPtr<FCAttrs> factory;
     ExecutorPtr executor = nullptr;
-    std::string errorPrefix;
 
     FCTensorParallelConfig tp_cfg;
 };

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
@@ -37,22 +37,20 @@ GatherElements::GatherElements(const std::shared_ptr<ov::Node>& op, const GraphC
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
-    errorPrefix_ = std::string("Layer GatherElements with name '") + op->get_friendly_name() + "'";
-
     if (inputShapes.size() != 2 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix_, " has invalid number of input/output edges.");
+        THROW_CPU_NODE_ERR(" has invalid number of input/output edges.");
 
     const auto dataRank = getInputShapeAtPort(dataIndex_).getRank();
     const auto indicesRank = getInputShapeAtPort(indicesIndex_).getRank();
     if (dataRank != indicesRank)
-        OPENVINO_THROW(errorPrefix_, " has invalid input shapes. Inputs 'Data' and 'Indices' must have equal ranks.");
+        THROW_CPU_NODE_ERR(" has invalid input shapes. Inputs 'Data' and 'Indices' must have equal ranks.");
 
     auto gatherElementsOp = ov::as_type_ptr<ov::op::v6::GatherElements>(op);
     auto axis = gatherElementsOp->get_axis();
     if (axis < 0)
         axis += dataRank;
     if (axis < 0 || axis >= static_cast<int>(dataRank))
-        OPENVINO_THROW(errorPrefix_, " has invalid axis attribute: ", axis);
+        THROW_CPU_NODE_ERR(" has invalid axis attribute: ", axis);
     axis_ = axis;
 }
 
@@ -80,12 +78,12 @@ void GatherElements::initSupportedPrimitiveDescriptors() {
                 sizeof(element_type_traits<ov::element::i32>::value_type),
                 sizeof(element_type_traits<ov::element::i16>::value_type),
                 sizeof(element_type_traits<ov::element::i8>::value_type))) {
-        OPENVINO_THROW(errorPrefix_, " has unsupported 'inputData' input precision: ", inDataPrecision);
+        THROW_CPU_NODE_ERR(" has unsupported 'inputData' input precision: ", inDataPrecision);
     }
 
     ov::element::Type indicesPrecision = getOriginalInputPrecisionAtPort(indicesIndex_);
     if (!one_of(indicesPrecision, ov::element::i32, ov::element::i64)) {
-        OPENVINO_THROW(errorPrefix_, " has unsupported 'indices' input precision: ", indicesPrecision);
+        THROW_CPU_NODE_ERR(" has unsupported 'indices' input precision: ", indicesPrecision);
     }
 
     dataTypeSize_ = inDataPrecision.size();

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.h
@@ -34,7 +34,6 @@ private:
     int strideAxDst_ = 0;
     int dstAxDim_ = 0;
     int strideAx1Diff_ = 0;
-    std::string errorPrefix_;
 
     template <typename dataType>
     void directExecution();

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
@@ -36,20 +36,19 @@ GatherTree::GatherTree(const std::shared_ptr<ov::Node>& op, const GraphContext::
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = std::string("Node GatherTree with name '") + op->get_friendly_name() + "'";
     if (inputShapes.size() != 4)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input edges.");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges.");
     if (outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of output edges.");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges.");
 
     if (getInputShapeAtPort(GATHER_TREE_STEP_IDX).getRank() != 3)
-        OPENVINO_THROW(errorPrefix, " step_idx vector should be 3 dimension");
+        THROW_CPU_NODE_ERR("step_idx vector should be 3 dimension");
     if (getInputShapeAtPort(GATHER_TREE_PARENT_IDX).getRank() != 3)
-        OPENVINO_THROW(errorPrefix, " parent_idx vector should be 3 dimension");
+        THROW_CPU_NODE_ERR("parent_idx vector should be 3 dimension");
     if (getInputShapeAtPort(GATHER_TREE_MAX_SEQ_LEN).getRank() != 1)
-        OPENVINO_THROW(errorPrefix, " max_seq_len vector should be 1 dimension");
+        THROW_CPU_NODE_ERR("max_seq_len vector should be 1 dimension");
     if (!is_scalar(op->get_input_partial_shape(GATHER_TREE_END_TOKEN)))
-        OPENVINO_THROW(errorPrefix, " end_token should be scalar");
+        THROW_CPU_NODE_ERR("end_token should be scalar");
 }
 
 void GatherTree::initSupportedPrimitiveDescriptors() {
@@ -64,7 +63,7 @@ void GatherTree::initSupportedPrimitiveDescriptors() {
         getOriginalInputPrecisionAtPort(GATHER_TREE_MAX_SEQ_LEN) != precision ||
         getOriginalInputPrecisionAtPort(GATHER_TREE_END_TOKEN) != precision ||
         getOriginalOutputPrecisionAtPort(0) != precision) {
-        OPENVINO_THROW(errorPrefix, " has incorrect input/output data precision. Must be the same.");
+        THROW_CPU_NODE_ERR("has incorrect input/output data precision. Must be the same.");
     }
 
     addSupportedPrimDesc({{LayoutType::ncsp, precision},
@@ -77,7 +76,7 @@ void GatherTree::initSupportedPrimitiveDescriptors() {
 
 void GatherTree::execute(dnnl::stream strm) {
     if (!execPtr)
-        OPENVINO_THROW(errorPrefix, " has not compiled executor.");
+        THROW_CPU_NODE_ERR("has not compiled executor.");
 
     if (precision == ov::element::f32)
         execPtr->exec<float>(getSrcMemoryAtPort(GATHER_TREE_STEP_IDX),
@@ -100,15 +99,15 @@ void GatherTree::prepareParams() {
     const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!stepIdxMemPtr || !stepIdxMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory of 'step_ids'.");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'step_ids'.");
     if (!parentIdxMemPtr || !parentIdxMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory of 'parent_ids'.");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'parent_ids'.");
     if (!maxSeqLenMemPtr || !maxSeqLenMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory of 'max_seq_len'.");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'max_seq_len'.");
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined output memory.");
+        THROW_CPU_NODE_ERR("has undefined output memory.");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        OPENVINO_THROW(errorPrefix, " has unidentified preferable primitive descriptor.");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor.");
 
     const VectorDims& stepIdxDims = stepIdxMemPtr->getStaticDims();
     const VectorDims& parentIdxDims = parentIdxMemPtr->getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.h
@@ -56,8 +56,6 @@ private:
     static const size_t GATHER_TREE_END_TOKEN = 3;
 
     ov::element::Type precision;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -33,18 +33,17 @@ GRN::GRN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "GRN layer with name '" + op->get_friendly_name() + "'";
     const auto grn = ov::as_type_ptr<const ov::opset1::GRN>(op);
     if (grn == nullptr)
-        OPENVINO_THROW("Operation with name '", op->get_friendly_name(), "' is not an instance of GRN from opset1.");
+        THROW_CPU_NODE_ERR("is not an instance of GRN from opset1.");
 
     if (inputShapes.size() != 1 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     const auto dataRank = getInputShapeAtPort(0).getRank();
 
     if (dataRank != getOutputShapeAtPort(0).getRank())
-        OPENVINO_THROW(errorPrefix, " has input/output rank mismatch");
+        THROW_CPU_NODE_ERR("has input/output rank mismatch");
 
     bias = grn->get_bias();
 }
@@ -63,18 +62,18 @@ void GRN::prepareParams() {
     const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!dataMemPtr || !dataMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory");
+        THROW_CPU_NODE_ERR("has undefined input memory");
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined output memory");
+        THROW_CPU_NODE_ERR("has undefined output memory");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        OPENVINO_THROW(errorPrefix, " has unidentified preferable primitive descriptor");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor");
 
     const VectorDims& dataDims = dataMemPtr->getStaticDims();
     const VectorDims& dstDims = dstMemPtr->getStaticDims();
 
     for (size_t i = 0; i < dataDims.size(); ++i) {
         if (dataDims[i] != dstDims[i])
-            OPENVINO_THROW(errorPrefix, " hsd input/output tensors dimensions mismatch");
+            THROW_CPU_NODE_ERR("hsd input/output tensors dimensions mismatch");
     }
 
     if (dataDims.size() > 0)

--- a/src/plugins/intel_cpu/src/nodes/grn.h
+++ b/src/plugins/intel_cpu/src/nodes/grn.h
@@ -30,8 +30,6 @@ private:
     int C = 1;
     int H = 1;
     int W = 1;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -187,7 +187,6 @@ Interaction::Interaction(const std::shared_ptr<ov::Node>& op, const GraphContext
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
-    errorPrefix = "Interaction node with name '" + getName() + "'";
     const auto interaction = ov::as_type_ptr<const InteractionNode>(op);
     const std::vector<float>& scales = interaction->get_output_scales();
     if (!scales.empty()) {

--- a/src/plugins/intel_cpu/src/nodes/interaction.h
+++ b/src/plugins/intel_cpu/src/nodes/interaction.h
@@ -62,7 +62,6 @@ private:
     size_t inputSizes = 0;
     size_t outputFeaturesLen = 0;
     size_t interactFeatureSize = 0;
-    std::string errorPrefix;
     MemoryPtr inputMemPtr;
     MemoryPtr flatMemPtr;
     MemoryPtr outputMemPtr;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.h
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.h
@@ -347,8 +347,6 @@ private:
 
     VectorDims lastOutputDims;
 
-    std::string errorPrefix;
-
     bool canUseAclExecutor = false;
     std::shared_ptr<InterpolateExecutor> aclExecPtr = nullptr;
 };

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -33,7 +33,6 @@ LogSoftmax::LogSoftmax(const std::shared_ptr<ov::Node>& op, const GraphContext::
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "LogSoftmax layer with name '" + op->get_friendly_name() + "'";
     const auto logSoftMax = ov::as_type_ptr<const ov::opset5::LogSoftmax>(op);
     if (logSoftMax == nullptr)
         OPENVINO_THROW("Operation with name '",
@@ -41,7 +40,7 @@ LogSoftmax::LogSoftmax(const std::shared_ptr<ov::Node>& op, const GraphContext::
                        "' is not an instance of LogSoftmax from opset5.");
 
     if (inputShapes.size() != 1 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     auto dimsSize = getInputShapeAtPort(0).getDims().size();
     if (dimsSize == 0)
@@ -51,7 +50,7 @@ LogSoftmax::LogSoftmax(const std::shared_ptr<ov::Node>& op, const GraphContext::
         axis += dimsSize;
 
     if (dimsSize < static_cast<size_t>((size_t)(1) + axis))
-        OPENVINO_THROW(errorPrefix, " has incorrect input parameters dimensions and axis number!");
+        THROW_CPU_NODE_ERR("has incorrect input parameters dimensions and axis number!");
 }
 
 void LogSoftmax::initSupportedPrimitiveDescriptors() {

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.h
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.h
@@ -30,8 +30,6 @@ private:
     size_t reducedAxisStride = 1;
     size_t axisStep = 1;
     bool isLastDim = false;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -113,8 +113,6 @@ Lrn::Lrn(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     : Node(op, context, PassThroughShapeInferFactory()) {
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "LRN node with name '" + getName() + "'";
-
         auto lrn = ov::as_type_ptr<const ov::opset1::LRN>(op);
         auto axes =
             ov::as_type_ptr<const ov::opset1::Constant>(lrn->get_input_node_shared_ptr(1))->cast_vector<int64_t>();
@@ -134,9 +132,9 @@ void Lrn::getSupportedDescriptors() {
         return;
 
     if (getParentEdges().size() != 2)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input edges");
+        THROW_CPU_NODE_ERR("has incorrect number of input edges");
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, " has incorrect number of output edges");
+        THROW_CPU_NODE_ERR("has incorrect number of output edges");
 
     ov::element::Type precision = getOriginalOutputPrecisionAtPort(0);
     if (precision != ov::element::f32 && precision != ov::element::bf16)
@@ -166,13 +164,13 @@ void Lrn::prepareParams() {
     auto srcMemPtr = getSrcMemoryAtPort(0);
     auto dstMemPtr = getDstMemoryAtPort(0);
     if (!srcMemPtr || !srcMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " input memory is undefined");
+        THROW_CPU_NODE_ERR("input memory is undefined");
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, "destination memory is undefined");
+        THROW_CPU_NODE_ERR("destination memory is undefined");
 
     const NodeDesc* selected_pd = getSelectedPrimitiveDescriptor();
     if (selected_pd == nullptr)
-        OPENVINO_THROW(errorPrefix, "preferable primitive descriptor did not set");
+        THROW_CPU_NODE_ERR("preferable primitive descriptor did not set");
 
     auto inpDesc = getParentEdgeAt(0)->getMemory().getDescWithType<DnnlMemoryDesc>();
 
@@ -246,7 +244,7 @@ void Lrn::execute(dnnl::stream strm) {
     if (execPtr) {
         execPtr->exec(primArgs, strm);
     } else {
-        OPENVINO_THROW(errorPrefix, " doesn't have an initialized executor");
+        THROW_CPU_NODE_ERR("doesn't have an initialized executor");
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/lrn.h
+++ b/src/plugins/intel_cpu/src/nodes/lrn.h
@@ -41,8 +41,6 @@ private:
     int k = 1;
     float alpha = 1.0f;
     float beta = 1.0f;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/mathematics.h
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.h
@@ -33,8 +33,6 @@ private:
     float alpha = 0.0f;
     float beta = 0.0f;
     float gamma = 0.0f;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -59,8 +59,6 @@ private:
 
     void setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims, bool initWeights);
 
-    std::string errorPrefix;
-
     /* whether to transpose input */
     std::array<bool, 2> transposeIn;
 

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -54,16 +54,14 @@ MatrixNms::MatrixNms(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    m_errorPrefix = "MatrixNMS layer with name '" + getName() + "' ";
-
     if (one_of(op->get_type_info(), ov::op::internal::NmsStaticShapeIE<ov::op::v8::MatrixNms>::get_type_info_static()))
         m_outStaticShape = true;
 
     if (getOriginalInputsNumber() != 2)
-        OPENVINO_THROW(m_errorPrefix, "has incorrect number of input edges: ", getOriginalInputsNumber());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getOriginalInputsNumber());
 
     if (getOriginalOutputsNumber() != 3)
-        OPENVINO_THROW(m_errorPrefix, "has incorrect number of output edges: ", getOriginalOutputsNumber());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getOriginalOutputsNumber());
 
     const auto matrix_nms = ov::as_type_ptr<const ov::op::v8::MatrixNms>(op);
 
@@ -101,12 +99,12 @@ MatrixNms::MatrixNms(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
 
     const auto& boxes_dims = getInputShapeAtPort(NMS_BOXES).getDims();
     if (boxes_dims.size() != 3)
-        OPENVINO_THROW(m_errorPrefix, "has unsupported 'boxes' input rank: ", boxes_dims.size());
+        THROW_CPU_NODE_ERR("has unsupported 'boxes' input rank: ", boxes_dims.size());
     if (boxes_dims[2] != 4)
-        OPENVINO_THROW(m_errorPrefix, "has unsupported 'boxes' input 3rd dimension size: ", boxes_dims[2]);
+        THROW_CPU_NODE_ERR("has unsupported 'boxes' input 3rd dimension size: ", boxes_dims[2]);
     const auto& scores_dims = getInputShapeAtPort(NMS_SCORES).getDims();
     if (scores_dims.size() != 3)
-        OPENVINO_THROW(m_errorPrefix, "has unsupported 'scores' input rank: ", scores_dims.size());
+        THROW_CPU_NODE_ERR("has unsupported 'scores' input rank: ", scores_dims.size());
 }
 
 void MatrixNms::initSupportedPrimitiveDescriptors() {
@@ -265,7 +263,7 @@ void MatrixNms::prepareParams() {
     const auto& boxes_dims = getParentEdgeAt(NMS_BOXES)->getMemory().getStaticDims();
     const auto& scores_dims = getParentEdgeAt(NMS_SCORES)->getMemory().getStaticDims();
     if (!(boxes_dims[0] == scores_dims[0] && boxes_dims[1] == scores_dims[2])) {
-        OPENVINO_THROW(m_errorPrefix, "has incompatible 'boxes' and 'scores' input dmensions");
+        THROW_CPU_NODE_ERR("has incompatible 'boxes' and 'scores' input dmensions");
     }
 
     m_numBatches = boxes_dims[0];
@@ -450,7 +448,7 @@ void MatrixNms::checkPrecision(const ov::element::Type prec,
                                const std::string name,
                                const std::string type) {
     if (std::find(precList.begin(), precList.end(), prec) == precList.end())
-        OPENVINO_THROW(m_errorPrefix, "has unsupported '", name, "' ", type, " precision: ", prec);
+        THROW_CPU_NODE_ERR("has unsupported '", name, "' ", type, " precision: ", prec);
 }
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.h
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.h
@@ -96,7 +96,6 @@ private:
         int64_t classIndex = -1;
         float score = 0.0f;
     };
-    std::string m_errorPrefix;
     const std::string m_inType = "input", m_outType = "output";
     std::vector<int64_t> m_numPerBatch;
     std::vector<std::vector<int64_t>> m_numPerBatchClass;

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -66,8 +66,6 @@ private:
 
     bool m_outStaticShape = false;
 
-    std::string m_errorPrefix;
-
     std::vector<std::vector<size_t>> m_numFiltBox;  // number of rois after nms for each class in each image
     std::vector<size_t> m_numBoxOffset;
     const std::string m_inType = "input", m_outType = "output";

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -34,21 +34,19 @@ bool NonZero::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, st
 NonZero::NonZero(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     : Node(op, context, InternalDynShapeInferFactory()) {
     std::string errorMessage;
-    if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "NonZero layer with name '" + getName() + "' ";
-    } else {
+    if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     if (op->get_output_element_type(0) != ov::element::i32) {
-        OPENVINO_THROW(errorPrefix, "doesn't support demanded output precision");
+        THROW_CPU_NODE_ERR("doesn't support demanded output precision");
     }
 }
 
 void NonZero::getSupportedDescriptors() {
     if (getParentEdges().size() != 1)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (!getChildEdges().size())
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 }
 
 void NonZero::initSupportedPrimitiveDescriptors() {

--- a/src/plugins/intel_cpu/src/nodes/non_zero.h
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.h
@@ -40,7 +40,6 @@ public:
 
 private:
     int threadsCount = 1;
-    std::string errorPrefix;
     template <typename inputType>
     void executeSpecified();
     template <typename T>

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -48,7 +48,6 @@ OneHot::OneHot(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "OneHot layer with name '" + op->get_friendly_name() + "'";
     const auto oneHot = ov::as_type_ptr<const ov::opset1::OneHot>(op);
     const auto depthNode = ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(DEPTH_ID));
     if (depthNode) {
@@ -70,12 +69,12 @@ OneHot::OneHot(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
         axis += output_dims_size;
     }
     if (axis < 0 || axis >= output_dims_size) {
-        OPENVINO_THROW(errorPrefix, " has unsupported 'axis' attribute: ", oneHot->get_axis());
+        THROW_CPU_NODE_ERR("has unsupported 'axis' attribute: ", oneHot->get_axis());
     }
 
     if (!(((1 + srcDims.size()) == dstDims.size()) ||
           (depthNode && (srcDims.size() == 1 && dstDims.size() == 1 && dstDims[0] == depth && srcDims[0] == 1))))
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output dimensions!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output dimensions!");
 }
 
 bool OneHot::needShapeInfer() const {
@@ -95,7 +94,7 @@ void OneHot::initSupportedPrimitiveDescriptors() {
     // check a precision of the input tensor
     auto input_precision = getOriginalInputPrecisionAtPort(INDICES_ID);
     if (input_precision != ov::element::i32) {
-        OPENVINO_THROW(errorPrefix, " has incorrect input precision for the input. Only I32 is supported!");
+        THROW_CPU_NODE_ERR("has incorrect input precision for the input. Only I32 is supported!");
     }
     output_precision = getOriginalOutputPrecisionAtPort(0);
 

--- a/src/plugins/intel_cpu/src/nodes/one_hot.h
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.h
@@ -49,8 +49,6 @@ private:
 
     ov::element::Type output_precision;
 
-    std::string errorPrefix;
-
     static const size_t INDICES_ID = 0;
     static const size_t DEPTH_ID = 1;
     static const size_t ON_VALUE_ID = 2;

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -222,9 +222,9 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
     auto& srcMemPtr = srcMemory[DATA_ID];
     auto& dstMemPtr = dstMemory[DATA_ID];
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW("has undefined source memory.");
+        OPENVINO_THROW("Pad executor has undefined source memory.");
     if (!srcMemPtr || !srcMemPtr->isDefined())
-        OPENVINO_THROW("has undefined destination memory.");
+        OPENVINO_THROW("Pad executor has undefined destination memory.");
     const auto srcBlockMemDesc = srcMemPtr->getDescWithType<BlockedMemoryDesc>();
     const auto dstBlockMemDesc = dstMemPtr->getDescWithType<BlockedMemoryDesc>();
     const auto& srcDims = srcBlockMemDesc->getBlockDims();

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -48,8 +48,7 @@ private:
     struct PadExecutor {
         PadExecutor(const PadAttrs& attrs,
                     const std::vector<MemoryCPtr>& srcMemory,
-                    const std::vector<MemoryCPtr>& dstMemory,
-                    const std::string& errorPrefix);
+                    const std::vector<MemoryCPtr>& dstMemory);
         void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
         ~PadExecutor() = default;
 
@@ -106,7 +105,6 @@ private:
             size_t innerEndPadCount = 0lu;
             PadMode padMode;
         } params;
-        const std::string errorPrefix;
     };
 
     static constexpr size_t DATA_ID = 0lu;
@@ -120,7 +118,6 @@ private:
     executorPtr execPtr = nullptr;
     std::vector<MemoryCPtr> srcMemory;
     std::vector<MemoryCPtr> dstMemory;
-    std::string errorPrefix;
     bool shapeHasDataDependency = false;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -71,11 +71,11 @@ PSROIPooling::PSROIPooling(const std::shared_ptr<ov::Node>& op, const GraphConte
 
     noTrans = op->get_input_size() == 2;
     if (op->get_input_shape(0).size() != 4)
-        THROW_CPU_NODE_ERR(" has first input with incorrect rank: " + std::to_string(op->get_input_shape(0).size()));
+        THROW_CPU_NODE_ERR("has first input with incorrect rank: " + std::to_string(op->get_input_shape(0).size()));
     if (op->get_input_shape(1).size() != 2)
-        THROW_CPU_NODE_ERR(" has second input with incorrect rank: " + std::to_string(op->get_input_shape(1).size()));
+        THROW_CPU_NODE_ERR("has second input with incorrect rank: " + std::to_string(op->get_input_shape(1).size()));
     if (!noTrans && op->get_input_shape(2).size() != 4)
-        THROW_CPU_NODE_ERR(" has third input with incorrect rank: " + std::to_string(op->get_input_shape(2).size()));
+        THROW_CPU_NODE_ERR("has third input with incorrect rank: " + std::to_string(op->get_input_shape(2).size()));
 
     if (psroi) {
         if (psroi->get_input_size() != 2)
@@ -206,13 +206,13 @@ void PSROIPooling::unpackParams(const BlockedMemoryDesc& srcDesc,
     auto inBlkDims = srcDesc.getBlockDims();
     auto outBlkDims = dstDesc.getBlockDims();
     if (inBlkDims.size() != expectedInBlockDimsSize)
-        THROW_CPU_NODE_ERR(" has unexpected size of blocking dims in input (given ",
+        THROW_CPU_NODE_ERR("has unexpected size of blocking dims in input (given ",
                            inBlkDims.size(),
                            ", expected ",
                            expectedInBlockDimsSize,
                            ")");
     if (outBlkDims.size() != expectedOutBlockDimsSize)
-        THROW_CPU_NODE_ERR(" has unexpected size of blocking dims in output (given ",
+        THROW_CPU_NODE_ERR("has unexpected size of blocking dims in output (given ",
                            outBlkDims.size(),
                            ", expected ",
                            expectedOutBlockDimsSize,

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.h
@@ -46,8 +46,6 @@ private:
     int partSize = 1;
     float transStd = 1.f;
 
-    std::string errorPrefix;
-
     void unpackParams(const BlockedMemoryDesc& srcDesc,
                       const BlockedMemoryDesc& dstDesc,
                       int& hInputStride,

--- a/src/plugins/intel_cpu/src/nodes/range.cpp
+++ b/src/plugins/intel_cpu/src/nodes/range.cpp
@@ -36,26 +36,24 @@ Range::Range(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr conte
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "Range layer with name '" + op->get_friendly_name() + "'";
-
     if (getOriginalInputsNumber() != 3 || getOriginalOutputsNumber() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     auto start_dims = op->get_input_shape(RANGE_START);
     if (ov::shape_size(start_dims) != 1)
-        OPENVINO_THROW(errorPrefix, " has start scalar with more than 1 value");
+        THROW_CPU_NODE_ERR("has start scalar with more than 1 value");
 
     auto limit_dims = op->get_input_shape(RANGE_LIMIT);
     if (ov::shape_size(limit_dims) != 1)
-        OPENVINO_THROW(errorPrefix, " has limit scalar with more than 1 value");
+        THROW_CPU_NODE_ERR("has limit scalar with more than 1 value");
 
     auto delta_dims = op->get_input_shape(RANGE_DELTA);
     if (ov::shape_size(delta_dims) != 1)
-        OPENVINO_THROW(errorPrefix, " has delta scalar with more than 1 value");
+        THROW_CPU_NODE_ERR("has delta scalar with more than 1 value");
 
     size_t dstRank = op->get_output_partial_shape(0).size();
     if (dstRank > 1)
-        OPENVINO_THROW(errorPrefix, " has unsupported rank for output: ", dstRank);
+        THROW_CPU_NODE_ERR("has unsupported rank for output: ", dstRank);
 }
 
 void Range::initSupportedPrimitiveDescriptors() {

--- a/src/plugins/intel_cpu/src/nodes/range.h
+++ b/src/plugins/intel_cpu/src/nodes/range.h
@@ -41,8 +41,6 @@ private:
     static const size_t RANGE_START = 0;
     static const size_t RANGE_LIMIT = 1;
     static const size_t RANGE_DELTA = 2;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -197,8 +197,6 @@ private:
                           std::function<void(const std::shared_ptr<ov::Node>& op, Reduce& node)>>&
     getInitializers();
 
-    std::string errorPrefix;
-
 #if defined(OV_CPU_WITH_ACL)
     ReduceAttrs reduceAttrs;
     bool canUseAclExecutor = false;

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -265,9 +265,8 @@ RegionYolo::RegionYolo(const std::shared_ptr<ov::Node>& op, const GraphContext::
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = std::string(op->get_type_name()) + " node with name '" + op->get_friendly_name() + "'";
     if (op->get_input_size() != 1 || op->get_output_size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     const auto regionYolo = ov::as_type_ptr<const ov::opset1::RegionYolo>(op);
     classes = regionYolo->get_num_classes();

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.h
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.h
@@ -64,8 +64,6 @@ private:
     std::vector<int64_t> mask;
     ov::element::Type input_prec, output_prec;
 
-    std::string errorPrefix;
-
     int block_size;
     std::shared_ptr<jit_uni_logistic_kernel> logistic_kernel = nullptr;
     std::shared_ptr<SoftmaxGeneric> softmax_kernel;

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
@@ -33,14 +33,13 @@ ReorgYolo::ReorgYolo(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = std::string(op->get_type_name()) + " node with name '" + op->get_friendly_name() + "'";
     if (getOriginalInputsNumber() != 1 || getOriginalOutputsNumber() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     const auto reorgYolo = ov::as_type_ptr<const ov::opset2::ReorgYolo>(op);
     const auto strides = reorgYolo->get_strides();
     if (strides.empty())
-        OPENVINO_THROW(errorPrefix, " has empty strides");
+        THROW_CPU_NODE_ERR("has empty strides");
     stride = strides[0];
 }
 

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.h
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.h
@@ -27,8 +27,6 @@ public:
 
 private:
     int stride;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -37,8 +37,6 @@ Reshape::Reshape(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = std::string(op->get_type_name()) + " node with name '" + getName() + "'";
-
     if (isDynamicNode()) {
         auto checkSecondInput = [](const std::shared_ptr<ov::Node>& op, const std::string opType) {
             if (op->get_input_partial_shape(1).is_dynamic()) {

--- a/src/plugins/intel_cpu/src/nodes/reshape.h
+++ b/src/plugins/intel_cpu/src/nodes/reshape.h
@@ -31,8 +31,6 @@ public:
 
 private:
     mutable std::vector<int> lastSecondInputValues;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
@@ -35,36 +35,33 @@ ReverseSequence::ReverseSequence(const std::shared_ptr<ov::Node>& op, const Grap
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "ReverseSequence layer with name '" + op->get_friendly_name() + "'";
     const auto revSeq = ov::as_type_ptr<const ov::opset1::ReverseSequence>(op);
     if (revSeq == nullptr)
-        OPENVINO_THROW("Operation with name '",
-                       op->get_friendly_name(),
-                       "' is not an instance of ReverseSequence from opset1.");
+        THROW_CPU_NODE_ERR("is not an instance of ReverseSequence from opset1.");
 
     if (inputShapes.size() != 2 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     const auto dataRank = getInputShapeAtPort(REVERSESEQUENCE_DATA).getRank();
 
     if (dataRank < 2)
-        OPENVINO_THROW(errorPrefix, " 'data' rank should be greater than or equal to 2");
+        THROW_CPU_NODE_ERR("'data' rank should be greater than or equal to 2");
 
     if (getInputShapeAtPort(REVERSESEQUENCE_LENGTHS).getRank() != 1)
-        OPENVINO_THROW(errorPrefix, " 'seq_lengths' should be 1D tensor");
+        THROW_CPU_NODE_ERR("'seq_lengths' should be 1D tensor");
 
     if (dataRank != getOutputShapeAtPort(0).getRank())
-        OPENVINO_THROW(errorPrefix, " has input/output rank mismatch");
+        THROW_CPU_NODE_ERR("has input/output rank mismatch");
 
     seq_axis = revSeq->get_sequence_axis();
 
     if (seq_axis < 0 || seq_axis >= static_cast<int>(dataRank))
-        OPENVINO_THROW(errorPrefix, " has incorrect 'seq_axis' parameters dimensions and axis number!");
+        THROW_CPU_NODE_ERR("has incorrect 'seq_axis' parameters dimensions and axis number!");
 
     batch_axis = revSeq->get_batch_axis();
 
     if (batch_axis < 0 || batch_axis >= static_cast<int>(dataRank))
-        OPENVINO_THROW(errorPrefix, " has incorrect 'batch_axis' parameters dimensions and axis number!");
+        THROW_CPU_NODE_ERR("has incorrect 'batch_axis' parameters dimensions and axis number!");
 }
 
 void ReverseSequence::initSupportedPrimitiveDescriptors() {
@@ -86,13 +83,13 @@ void ReverseSequence::prepareParams() {
     const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!dataMemPtr || !dataMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory of 'data'");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'data'");
     if (!seqLengthsMemPtr || !seqLengthsMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory of 'seq_lengths'");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'seq_lengths'");
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined output memory");
+        THROW_CPU_NODE_ERR("has undefined output memory");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        OPENVINO_THROW(errorPrefix, " has unidentified preferable primitive descriptor");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor");
 
     const VectorDims& dataDims = dataMemPtr->getStaticDims();
     const VectorDims& seqLengthsDims = seqLengthsMemPtr->getStaticDims();
@@ -174,7 +171,7 @@ void ReverseSequence::ReverseSequenceExecutor::exec(const MemoryPtr& dataMemPtr,
 
 void ReverseSequence::execute(dnnl::stream strm) {
     if (!execPtr)
-        OPENVINO_THROW(errorPrefix, " has no compiled executor");
+        THROW_CPU_NODE_ERR("has no compiled executor");
 
     const auto precision = getParentEdgeAt(REVERSESEQUENCE_LENGTHS)->getMemory().getDesc().getPrecision();
     if (!one_of(precision, ov::element::f32, ov::element::i32))

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.h
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.h
@@ -53,7 +53,6 @@ private:
     int batch_axis;
 
     ov::element::Type lengthsPrecision;
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -698,8 +698,6 @@ ROIAlign::ROIAlign(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
     : Node(op, context, NgraphShapeInferFactory(op)) {
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "ROIPooling layer with name '" + getName() + "' ";
-
         auto roiAlign = ov::as_type_ptr<const ov::opset9::ROIAlign>(op);
         pooledH = roiAlign->get_pooled_h();
         pooledW = roiAlign->get_pooled_w();
@@ -726,39 +724,38 @@ ROIAlign::ROIAlign(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
 
 void ROIAlign::getSupportedDescriptors() {
     if (getParentEdges().size() != 3)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 
     if (getInputShapeAtPort(0).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 0th input with rank: ", getInputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 0th input with rank: ", getInputShapeAtPort(0).getRank());
     }
 
     if (getInputShapeAtPort(1).getRank() != 2) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
     }
 
     if (getInputShapeAtPort(2).getRank() != 1) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 2nd input with rank: ", getInputShapeAtPort(2).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 2nd input with rank: ", getInputShapeAtPort(2).getRank());
     }
 
     if (getOutputShapeAtPort(0).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support output with rank: ", getOutputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("doesn't support output with rank: ", getOutputShapeAtPort(0).getRank());
     }
 
     const auto& proposalsDims = getInputShapeAtPort(1).getDims();
     if (proposalsDims[1] != 4) {
-        OPENVINO_THROW(errorPrefix, "has invalid shape on 1st input: [", proposalsDims[0], ",", proposalsDims[1], "]");
+        THROW_CPU_NODE_ERR("has invalid shape on 1st input: [", proposalsDims[0], ",", proposalsDims[1], "]");
     }
 
     const auto& indexesDims = getInputShapeAtPort(2).getDims();
     if (!dimsEqualWeak(proposalsDims[0], indexesDims[0])) {
-        OPENVINO_THROW(errorPrefix,
-                       "has different sizes of inputs for proposals (",
-                       proposalsDims[0],
-                       ") and indexes (",
-                       indexesDims[0],
-                       ")");
+        THROW_CPU_NODE_ERR("has different sizes of inputs for proposals (",
+                           proposalsDims[0],
+                           ") and indexes (",
+                           indexesDims[0],
+                           ")");
     }
 }
 
@@ -835,9 +832,9 @@ void ROIAlign::createPrimitive() {
     auto srcMemPtr = getSrcMemoryAtPort(0);
     auto dstMemPtr = getDstMemoryAtPort(0);
     if (!srcMemPtr)
-        OPENVINO_THROW(errorPrefix, " has null input memory");
+        THROW_CPU_NODE_ERR("has null input memory");
     if (!dstMemPtr)
-        OPENVINO_THROW(errorPrefix, " has null destination memory");
+        THROW_CPU_NODE_ERR("has null destination memory");
 
     if (!roi_align_kernel) {
         ROIAlignLayoutType selectedLayout = ROIAlignLayoutType::nspc;

--- a/src/plugins/intel_cpu/src/nodes/roi_align.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.h
@@ -81,8 +81,6 @@ private:
 
     void createJitKernel(const ov::element::Type& dataPrec, const ROIAlignLayoutType& selectLayout);
     std::shared_ptr<jit_uni_roi_align_kernel> roi_align_kernel = nullptr;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -408,8 +408,6 @@ ROIPooling::ROIPooling(const std::shared_ptr<ov::Node>& op, const GraphContext::
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    std::string errorPrefix = "ROIPooling layer with name '" + getName() + "' ";
-
     auto roiPooling = ov::as_type_ptr<const ov::opset2::ROIPooling>(op);
     refParams.pooled_h = roiPooling->get_output_roi()[0];
     refParams.pooled_w = roiPooling->get_output_roi()[1];
@@ -424,25 +422,25 @@ ROIPooling::ROIPooling(const std::shared_ptr<ov::Node>& op, const GraphContext::
 
 void ROIPooling::getSupportedDescriptors() {
     if (getParentEdges().size() != 2)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 
     if (getInputShapeAtPort(0).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 0th input with rank: ", getInputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 0th input with rank: ", getInputShapeAtPort(0).getRank());
     }
 
     if (getInputShapeAtPort(1).getRank() != 2) {
-        OPENVINO_THROW(errorPrefix, "doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
+        THROW_CPU_NODE_ERR("doesn't support 1st input with rank: ", getInputShapeAtPort(1).getRank());
     }
 
     if (getOutputShapeAtPort(0).getRank() != 4) {
-        OPENVINO_THROW(errorPrefix, "doesn't support output with rank: ", getOutputShapeAtPort(0).getRank());
+        THROW_CPU_NODE_ERR("doesn't support output with rank: ", getOutputShapeAtPort(0).getRank());
     }
 
     const auto& dims = getInputShapeAtPort(1).getDims();
     if (dims[1] != 5) {
-        OPENVINO_THROW(errorPrefix, "has invalid shape on 1st input: [", dims[0], ",", dims[1], "]");
+        THROW_CPU_NODE_ERR("has invalid shape on 1st input: [", dims[0], ",", dims[1], "]");
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.h
@@ -84,8 +84,6 @@ private:
 
     jit_roi_pooling_params refParams = {};
 
-    std::string errorPrefix;
-
     class ROIPoolingExecutor {
     public:
         ROIPoolingExecutor() = default;

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -70,7 +70,7 @@ Roll::Roll(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
         /* Shift */
         const auto& shiftTensorPrec = getOriginalInputPrecisionAtPort(SHIFT_INDEX);
         if (shiftTensorPrec != ov::element::i32 && shiftTensorPrec != ov::element::i64) {
-            THROW_CPU_NODE_ERR(" has unsupported 'shift' input precision: ", shiftTensorPrec.get_type_name());
+            THROW_CPU_NODE_ERR("has unsupported 'shift' input precision: ", shiftTensorPrec.get_type_name());
         }
 
         const auto shiftTensorRank = getInputShapeAtPort(SHIFT_INDEX).getRank();

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -38,49 +38,44 @@ Roll::Roll(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
     : Node(op, context, NgraphShapeInferFactory(op)) {
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
-        layerErrorPrefix = "Roll layer with name '" + getName() + "'";
         if (inputShapes.size() != 3 || outputShapes.size() != 1) {
-            OPENVINO_THROW(layerErrorPrefix, " has incorrect number of input/output edges!");
+            THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
         }
 
         const auto& dataPrecision = getOriginalInputPrecisionAtPort(DATA_INDEX);
 
         if (std::find(supportedPrecisionSizes.begin(), supportedPrecisionSizes.end(), dataPrecision.size()) ==
             supportedPrecisionSizes.end())
-            OPENVINO_THROW(layerErrorPrefix, "has unsupported precision: ", dataPrecision.get_type_name());
+            THROW_CPU_NODE_ERR("as unsupported precision: ", dataPrecision.get_type_name());
 
         const auto dataRank = getInputShapeAtPort(DATA_INDEX).getRank();
         if (dataRank < 1) {
-            OPENVINO_THROW(layerErrorPrefix, " doesn't support 'data' input tensor with rank: ", dataRank);
+            THROW_CPU_NODE_ERR("doesn't support 'data' input tensor with rank: ", dataRank);
         }
 
         if (dataRank != getOutputShapeAtPort(0).getRank())
-            OPENVINO_THROW(layerErrorPrefix, " has input/output rank mismatch");
+            THROW_CPU_NODE_ERR("has input/output rank mismatch");
 
         /* Axes */
         const auto& axesTensorPrec = getOriginalInputPrecisionAtPort(AXES_INDEX);
         if (axesTensorPrec != ov::element::i32 && axesTensorPrec != ov::element::i64) {
-            OPENVINO_THROW(layerErrorPrefix,
-                           " has unsupported 'axes' input precision: ",
-                           axesTensorPrec.get_type_name());
+            THROW_CPU_NODE_ERR("has unsupported 'axes' input precision: ", axesTensorPrec.get_type_name());
         }
 
         const auto axesTensorRank = getInputShapeAtPort(AXES_INDEX).getRank();
         if (axesTensorRank > 1) {
-            OPENVINO_THROW(layerErrorPrefix, " doesn't support 'axes' input tensor with rank: ", axesTensorRank);
+            THROW_CPU_NODE_ERR("doesn't support 'axes' input tensor with rank: ", axesTensorRank);
         }
 
         /* Shift */
         const auto& shiftTensorPrec = getOriginalInputPrecisionAtPort(SHIFT_INDEX);
         if (shiftTensorPrec != ov::element::i32 && shiftTensorPrec != ov::element::i64) {
-            OPENVINO_THROW(layerErrorPrefix,
-                           " has unsupported 'shift' input precision: ",
-                           shiftTensorPrec.get_type_name());
+            THROW_CPU_NODE_ERR(" has unsupported 'shift' input precision: ", shiftTensorPrec.get_type_name());
         }
 
         const auto shiftTensorRank = getInputShapeAtPort(SHIFT_INDEX).getRank();
         if (shiftTensorRank > 1) {
-            OPENVINO_THROW(layerErrorPrefix, " doesn't support 'shift' input tensor with rank: ", shiftTensorRank);
+            THROW_CPU_NODE_ERR("doesn't support 'shift' input tensor with rank: ", shiftTensorRank);
         }
     } else {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
@@ -108,15 +103,15 @@ void Roll::prepareParams() {
     const auto& dstMemPtr = getDstMemoryAtPort(0);
 
     if (!dataMemPtr || !dataMemPtr->isDefined())
-        OPENVINO_THROW(layerErrorPrefix, " has undefined input memory of 'data'");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'data'");
     if (!shiftMemPtr || !shiftMemPtr->isDefined())
-        OPENVINO_THROW(layerErrorPrefix, " has undefined input memory of 'shift'");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'shift'");
     if (!axesMemPtr || !axesMemPtr->isDefined())
-        OPENVINO_THROW(layerErrorPrefix, " has undefined input memory of 'axes'");
+        THROW_CPU_NODE_ERR("has undefined input memory of 'axes'");
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(layerErrorPrefix, " has undefined output memory");
+        THROW_CPU_NODE_ERR("has undefined output memory");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        OPENVINO_THROW(layerErrorPrefix, " has unidentified preferable primitive descriptor");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor");
 
     const VectorDims& dataDims = dataMemPtr->getStaticDims();
     const VectorDims& shiftDims = shiftMemPtr->getStaticDims();
@@ -132,7 +127,7 @@ void Roll::executeDynamicImpl(dnnl::stream strm) {
 
 void Roll::execute(dnnl::stream strm) {
     if (!execPtr)
-        OPENVINO_THROW(layerErrorPrefix, " has no compiled executor");
+        THROW_CPU_NODE_ERR("has no compiled executor");
 
     const auto dataPrecision = getParentEdgeAt(DATA_INDEX)->getMemory().getDesc().getPrecision();
     const auto& dataTypeSize = dataPrecision.size();
@@ -159,7 +154,7 @@ void Roll::execute(dnnl::stream strm) {
         break;
     }
     default:
-        OPENVINO_THROW(layerErrorPrefix, "has unsupported 'data' input precision: ", dataPrecision.get_type_name());
+        THROW_CPU_NODE_ERR("as unsupported 'data' input precision: ", dataPrecision.get_type_name());
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/roll.h
+++ b/src/plugins/intel_cpu/src/nodes/roll.h
@@ -48,8 +48,6 @@ private:
     using ExecutorPtr = std::shared_ptr<RollExecutor>;
     ExecutorPtr execPtr = nullptr;
 
-    std::string layerErrorPrefix;
-
     static constexpr std::array<size_t, 3> supportedPrecisionSizes{1, 2, 4};
     static constexpr size_t DATA_INDEX = 0ul;
     static constexpr size_t SHIFT_INDEX = 1ul;

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.h
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.h
@@ -137,8 +137,6 @@ private:
     // In ov::PartialShape with rank 0 (scalars) is converted to ov::intel_cpu::Shape with rank 1.
     // Add flag set in constructor for workaround for ScatterNDUpdates
     bool isUpdateScalar = false;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -29,9 +29,8 @@ ShapeOf::ShapeOf(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
     : Node(op, context, ShapeOfShapeInferFactory()) {
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "ShapeOf layer with name '" + getName() + "' ";
         if (op->get_input_partial_shape(0).size() == 0)
-            OPENVINO_THROW(errorPrefix, "gets unsupported input 0D tensor (scalar)");
+            THROW_CPU_NODE_ERR("gets unsupported input 0D tensor (scalar)");
     } else {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
@@ -39,9 +38,9 @@ ShapeOf::ShapeOf(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
 
 void ShapeOf::getSupportedDescriptors() {
     if (getParentEdges().size() != 1)
-        OPENVINO_THROW(errorPrefix, "has incorrect number of input edges: ", getParentEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, "has incorrect number of output edges: ", getChildEdges().size());
+        THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
 }
 
 void ShapeOf::initSupportedPrimitiveDescriptors() {
@@ -89,7 +88,7 @@ void ShapeOf::execute(dnnl::stream strm) {
     auto&& inDims = inPtr->getStaticDims();
     size_t dimsCount = inDims.size();
     if (outPtr->getStaticDims().size() != 1 || dimsCount != outPtr->getStaticDims()[0])
-        OPENVINO_THROW(errorPrefix, "has inconsistent input shape and output size");
+        THROW_CPU_NODE_ERR("has inconsistent input shape and output size");
 
     auto* dst = outPtr->getDataAs<int>();
 

--- a/src/plugins/intel_cpu/src/nodes/shapeof.h
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.h
@@ -35,9 +35,6 @@ public:
     bool isExecutable() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
-
-private:
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
@@ -32,17 +32,15 @@ SpaceToBatch::SpaceToBatch(const std::shared_ptr<ov::Node>& op, const GraphConte
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "BatchToSpace layer with name '" + op->get_friendly_name() + "'";
-
     if (inputShapes.size() != 4 || outputShapes.size() != 1)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input or output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input or output edges!");
 
     const size_t srcRank = getInputShapeAtPort(0).getRank();
     const size_t dstRank = getOutputShapeAtPort(0).getRank();
     if (srcRank < 4 || srcRank > 5)
-        OPENVINO_THROW(errorPrefix, " has unsupported 'data' input rank: ", srcRank);
+        THROW_CPU_NODE_ERR("has unsupported 'data' input rank: ", srcRank);
     if (srcRank != dstRank)
-        OPENVINO_THROW(errorPrefix, " has incorrect number of input/output dimensions");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output dimensions");
 }
 
 void SpaceToBatch::initSupportedPrimitiveDescriptors() {
@@ -53,7 +51,7 @@ void SpaceToBatch::initSupportedPrimitiveDescriptors() {
     const auto precision = getOriginalInputPrecisionAtPort(0);
     const std::set<size_t> supported_precision_sizes = {1, 2, 4, 8};
     if (supported_precision_sizes.find(precision.size()) == supported_precision_sizes.end())
-        OPENVINO_THROW(errorPrefix, " has unsupported precision: ", precision.get_type_name());
+        THROW_CPU_NODE_ERR("has unsupported precision: ", precision.get_type_name());
 
     addSupportedPrimDesc({{LayoutType::nspc, precision},
                           {LayoutType::ncsp, ov::element::i32},

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.h
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.h
@@ -37,8 +37,6 @@ private:
     std::vector<size_t> blockShapeIn;
     std::vector<size_t> padsBeginIn;
 
-    std::string errorPrefix;
-
     template <typename T>
     void SpaceToBatchKernel();
 };

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -440,11 +440,11 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     params.attrs.beginDims = srcMemory[attrs.BEGIN_ID]->getShape().getStaticDims();
     params.attrs.endDims = srcMemory[attrs.END_ID]->getShape().getStaticDims();
     if (params.attrs.beginDims.size() != 1)
-        OPENVINO_THROW("should have begin vector with 1 dimension");
+        OPENVINO_THROW("Strided slice common executor should have begin vector with 1 dimension");
     if (params.attrs.endDims.size() != 1)
-        OPENVINO_THROW("should have end vector with 1 dimension");
+        OPENVINO_THROW("Strided slice common executor should have end vector with 1 dimension");
     if (params.attrs.beginDims[0] != params.attrs.endDims[0])
-        OPENVINO_THROW("should have begin vector with size equal to end vector size");
+        OPENVINO_THROW("Strided slice common executor should have begin vector with size equal to end vector size");
 
     if (params.attrs.begin.empty())
         fillingInParameters(params.attrs.begin, attrs.BEGIN_ID, params.attrs.beginDims[0], 0);
@@ -454,9 +454,10 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     if (srcMemory.size() > attrs.STRIDE_ID) {
         params.attrs.strideDims = srcMemory[attrs.STRIDE_ID]->getShape().getStaticDims();
         if (params.attrs.strideDims.size() > 1)
-            OPENVINO_THROW("should have stride vector with 1 dimension");
+            OPENVINO_THROW("Strided slice common executor should have stride vector with 1 dimension");
         if (params.attrs.beginDims[0] != params.attrs.strideDims[0])
-            OPENVINO_THROW("should have stride vector with size equal to begin vector size");
+            OPENVINO_THROW(
+                "Strided slice common executor should have stride vector with size equal to begin vector size");
 
         if (params.attrs.stride.empty())
             fillingInParameters(params.attrs.stride, attrs.STRIDE_ID, params.attrs.strideDims[0], 1);
@@ -465,9 +466,10 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     if (srcMemory.size() > attrs.AXES_ID) {
         params.attrs.axesDims = srcMemory[attrs.AXES_ID]->getShape().getStaticDims();
         if (params.attrs.axesDims.size() != 1)
-            OPENVINO_THROW("should have axes vector with 1 dimension.");
+            OPENVINO_THROW("Strided slice common executor should have axes vector with 1 dimension.");
         if (params.attrs.beginDims[0] != params.attrs.axesDims[0])
-            OPENVINO_THROW("should have axes vector with size equal to begin vector size.");
+            OPENVINO_THROW(
+                "Strided slice common executor should have axes vector with size equal to begin vector size.");
 
         if (params.attrs.axes.empty())
             fillingInParameters(params.attrs.axes, attrs.AXES_ID, params.attrs.axesDims[0], 0);

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -72,22 +72,16 @@ private:
     public:
         StridedSliceExecutor(const StridedSliceAttributes& attrs,
                              const std::vector<MemoryCPtr>& srcMemory,
-                             const std::vector<MemoryCPtr>& dstMemory,
-                             const std::string& errorPrefix)
-            : errorPrefix(errorPrefix) {}
+                             const std::vector<MemoryCPtr>& dstMemory) {}
         virtual void exec(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory) = 0;
         virtual ~StridedSliceExecutor() = default;
-
-    protected:
-        const std::string errorPrefix;
     };
 
     class StridedSliceCommonExecutor : public StridedSliceExecutor {
     public:
         StridedSliceCommonExecutor(const StridedSliceAttributes& attrs,
                                    const std::vector<MemoryCPtr>& srcMemory,
-                                   const std::vector<MemoryCPtr>& dstMemory,
-                                   const std::string& errorPrefix);
+                                   const std::vector<MemoryCPtr>& dstMemory);
         void exec(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory) override;
         void execSliceScatter(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory);
         void execStridedSlice(const std::vector<MemoryCPtr>& srcMemory, const std::vector<MemoryCPtr>& dstMemory);
@@ -134,8 +128,6 @@ private:
 
     std::vector<MemoryCPtr> srcMemory;
     std::vector<MemoryCPtr> dstMemory;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/tile.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tile.cpp
@@ -40,8 +40,6 @@ Tile::Tile(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    errorPrefix = "Tile node with name '" + getName() + "'";
-
     if (ov::is_type<ov::op::v0::Constant>(op->get_input_node_ptr(TILE_REPEATS))) {
         constMap[TILE_REPEATS] = true;
         repeats = originRepeats =
@@ -63,38 +61,34 @@ void Tile::getSupportedDescriptors() {
         return result;
     };
     if (getParentEdges().size() != 2)
-        OPENVINO_THROW(errorPrefix,
-                       " has incorrect number of input edges. "
-                       "Expected: 2, Actual: ",
-                       getParentEdges().size());
+        THROW_CPU_NODE_ERR(" has incorrect number of input edges. "
+                           "Expected: 2, Actual: ",
+                           getParentEdges().size());
     if (getChildEdges().empty())
-        OPENVINO_THROW(errorPrefix, " has no output edges.");
+        THROW_CPU_NODE_ERR("has no output edges.");
     const auto& dstDims0 = getOutputShapeAtPort(0).getDims();
     for (size_t i = 1lu; i < outputShapes.size(); i++) {
         const auto& dstDims = getOutputShapeAtPort(i).getDims();
         if (dstDims.size() != dstDims0.size())
-            OPENVINO_THROW(errorPrefix,
-                           " has output edges 0 and ",
-                           i,
-                           " with different ranks: ",
-                           dstDims0.size(),
-                           " and ",
-                           dstDims.size());
+            THROW_CPU_NODE_ERR(" has output edges 0 and ",
+                               i,
+                               " with different ranks: ",
+                               dstDims0.size(),
+                               " and ",
+                               dstDims.size());
         for (size_t j = 0; j < dstDims0.size(); j++) {
             if (dstDims0[j] != dstDims[j]) {
-                OPENVINO_THROW(errorPrefix,
-                               " has output edges 0 and ",
-                               i,
-                               " with different dims: ",
-                               vec_to_string(dstDims0),
-                               " and ",
-                               vec_to_string(dstDims));
+                THROW_CPU_NODE_ERR(" has output edges 0 and ",
+                                   i,
+                                   " with different dims: ",
+                                   vec_to_string(dstDims0),
+                                   " and ",
+                                   vec_to_string(dstDims));
             }
         }
     }
     if (constMap[TILE_REPEATS] && getInputShapeAtPort(TILE_INPUT).getRank() > getOutputShapeAtPort(0).getRank())
-        OPENVINO_THROW(
-            errorPrefix,
+        THROW_CPU_NODE_ERR(
             " has incorrect input/output data shape rank. Input shape rank cannot be more than output shape rank. "
             "Actual input shape size: ",
             getInputShapeAtPort(TILE_INPUT).getRank(),

--- a/src/plugins/intel_cpu/src/nodes/tile.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tile.cpp
@@ -61,7 +61,7 @@ void Tile::getSupportedDescriptors() {
         return result;
     };
     if (getParentEdges().size() != 2)
-        THROW_CPU_NODE_ERR(" has incorrect number of input edges. "
+        THROW_CPU_NODE_ERR("has incorrect number of input edges. "
                            "Expected: 2, Actual: ",
                            getParentEdges().size());
     if (getChildEdges().empty())
@@ -70,7 +70,7 @@ void Tile::getSupportedDescriptors() {
     for (size_t i = 1lu; i < outputShapes.size(); i++) {
         const auto& dstDims = getOutputShapeAtPort(i).getDims();
         if (dstDims.size() != dstDims0.size())
-            THROW_CPU_NODE_ERR(" has output edges 0 and ",
+            THROW_CPU_NODE_ERR("has output edges 0 and ",
                                i,
                                " with different ranks: ",
                                dstDims0.size(),
@@ -78,7 +78,7 @@ void Tile::getSupportedDescriptors() {
                                dstDims.size());
         for (size_t j = 0; j < dstDims0.size(); j++) {
             if (dstDims0[j] != dstDims[j]) {
-                THROW_CPU_NODE_ERR(" has output edges 0 and ",
+                THROW_CPU_NODE_ERR("has output edges 0 and ",
                                    i,
                                    " with different dims: ",
                                    vec_to_string(dstDims0),

--- a/src/plugins/intel_cpu/src/nodes/tile.h
+++ b/src/plugins/intel_cpu/src/nodes/tile.h
@@ -39,8 +39,6 @@ private:
     int tiles = 0;
     bool noTiling = false;
     VectorDims originRepeats;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1891,8 +1891,6 @@ TopK::TopK(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
     : Node(op, context, NgraphShapeInferFactory(op)) {
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
-        errorPrefix = "TopK layer with name '" + getName() + "'";
-
         auto topKOp = ov::as_type_ptr<const ov::op::util::TopKBase>(op);
 
         auto in_dims = topKOp->get_input_partial_shape(TOPK_DATA);
@@ -1903,7 +1901,7 @@ TopK::TopK(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
         if (!isDynamicNgraphNode(op)) {
             auto topKConst = ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
             if (!topKConst) {
-                OPENVINO_THROW(errorPrefix, "gets non-constant second tensor in static shape mode!");
+                THROW_CPU_NODE_ERR("gets non-constant second tensor in static shape mode!");
             }
         }
 
@@ -1925,21 +1923,21 @@ TopK::TopK(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
         vec_idx_block.clear();
 
         if (inputShapes.size() != 2 || outputShapes.size() < 2)
-            OPENVINO_THROW(errorPrefix, " gets incorrect number of input/output edges!");
+            THROW_CPU_NODE_ERR("gets incorrect number of input/output edges!");
 
         if (getInputShapeAtPort(TOPK_DATA).getRank() != getOutputShapeAtPort(TOPK_DATA).getRank())
-            OPENVINO_THROW(errorPrefix, " gets incorrect number of input/output dimensions!");
+            THROW_CPU_NODE_ERR("gets incorrect number of input/output dimensions!");
 
         if (getInputShapeAtPort(TOPK_K).getRank() != 1)
-            OPENVINO_THROW(errorPrefix, " gets incorrect index vector dimension! Index vector should be 1 dimension.");
+            THROW_CPU_NODE_ERR("gets incorrect index vector dimension! Index vector should be 1 dimension.");
 
         if (out_dims != out_idx_dims)
-            OPENVINO_THROW(errorPrefix, " gets incorrect output tensor dimension sizes!");
+            THROW_CPU_NODE_ERR("gets incorrect output tensor dimension sizes!");
 
         if (axis < 0)
             axis += in_dims_size;
         if (axis < 0 || axis >= static_cast<int>(in_dims_size))
-            OPENVINO_THROW(errorPrefix, " gets incorrect input parameters dimensions and axis number!");
+            THROW_CPU_NODE_ERR("gets incorrect input parameters dimensions and axis number!");
     } else {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
@@ -1976,7 +1974,7 @@ void TopK::initSupportedPrimitiveDescriptors() {
 
     ov::element::Type dataPrecision = getOriginalOutputPrecisionAtPort(TOPK_DATA);
     if (dataPrecision == ov::element::bf16 && !mayiuse(avx512_core))
-        OPENVINO_THROW(errorPrefix, " gets incorrect isa for BF16! AVX512 must be supported!");
+        THROW_CPU_NODE_ERR("gets incorrect isa for BF16! AVX512 must be supported!");
     bool precisionSupported = std::find(std::begin(supportedPrecision), std::end(supportedPrecision), dataPrecision) !=
                               std::end(supportedPrecision);
     if (!precisionSupported) {
@@ -2046,11 +2044,11 @@ void TopK::prepareParams() {
     auto dstMemPtr = getDstMemoryAtPort(TOPK_DATA);
     auto srcMemPtr = getSrcMemoryAtPort(TOPK_DATA);
     if (!dstMemPtr || !dstMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined destination memory.");
+        THROW_CPU_NODE_ERR("has undefined destination memory.");
     if (!srcMemPtr || !srcMemPtr->isDefined())
-        OPENVINO_THROW(errorPrefix, " has undefined input memory.");
+        THROW_CPU_NODE_ERR("has undefined input memory.");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        OPENVINO_THROW(errorPrefix, " has nullable preferable primitive descriptor");
+        THROW_CPU_NODE_ERR("has nullable preferable primitive descriptor");
 
     src_dims = srcMemPtr->getDesc().getShape().getDims();
     dst_dims = dstMemPtr->getDesc().getShape().getDims();
@@ -2058,7 +2056,7 @@ void TopK::prepareParams() {
     if (isDynamicNode()) {
         const int src_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
         if (static_cast<size_t>(src_k) > src_dims[axis])
-            OPENVINO_THROW(errorPrefix, " gets top_k out of range!");
+            THROW_CPU_NODE_ERR("gets top_k out of range!");
         if (top_k != src_k) {
             top_k = src_k;
         }
@@ -2219,7 +2217,7 @@ void TopK::execute(dnnl::stream strm) {
             auto out_idx_ptr = reinterpret_cast<int32_t*>(dst_idx);
             topk_ref(in_ptr, out_ptr, out_idx_ptr);
         } else {
-            OPENVINO_THROW(errorPrefix, "only support plain layout on machine w/o sse42.");
+            THROW_CPU_NODE_ERR("only support plain layout on machine w/o sse42.");
         }
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/topk.h
+++ b/src/plugins/intel_cpu/src/nodes/topk.h
@@ -146,8 +146,6 @@ private:
     std::vector<uint8_t> vec_process_idx_ptr;
 
     std::shared_ptr<jit_uni_topk_kernel> topk_kernel = nullptr;
-
-    std::string errorPrefix;
 };
 
 }  // namespace node


### PR DESCRIPTION
### Details:
Take a first step of unifying error handling infrastructure in CPU plugin: get rid of `OPENVINO_THROW` and `errorPrefix` class field usage in favor of `THROW_CPU_NODE_ERR` approach

### Tickets:
 - 160275
