### PR TITLE
[RTTI] Replace std::dynamic_(pointer)?_casts with ov::as_type_(ptr)? - Core, IE

### DIFF
--- a/src/common/low_precision_transformations/src/assign_and_read_value.cpp
+++ b/src/common/low_precision_transformations/src/assign_and_read_value.cpp
@@ -109,7 +109,7 @@ bool AssignAndReadValueTransformation::canBeTransformed(const TransformationCont
         return false;
     }
 
-    const auto readValue = std::dynamic_pointer_cast<op::util::ReadValueBase>(op->get_control_dependencies()[0]);
+    const auto readValue = ov::as_type_ptr<op::util::ReadValueBase>(op->get_control_dependencies()[0]);
     if (!readValue) {
         return false;
     }

--- a/src/common/low_precision_transformations/src/low_precision.cpp
+++ b/src/common/low_precision_transformations/src/low_precision.cpp
@@ -112,7 +112,7 @@ void make_matcher_type_relaxed(ov::pass::GraphRewrite* transformation) {
     auto p_node = std::make_shared<pass::pattern::op::Label>(element::f32, Shape{}, is_op_type);
 
     ov::graph_rewrite_callback callback = [](ov::pass::pattern::Matcher& m) {
-        auto l_node = std::dynamic_pointer_cast<BaseOp>(m.get_match_root());
+        auto l_node = ov::as_type_ptr<BaseOp>(m.get_match_root());
         if (!l_node) {
             THROW_TRANSFORMATION_EXCEPTION << "unexpected operation type for type relaxed conversion";
         }

--- a/src/common/low_precision_transformations/src/markup_can_be_quantized.cpp
+++ b/src/common/low_precision_transformations/src/markup_can_be_quantized.cpp
@@ -36,25 +36,25 @@ bool ov::pass::low_precision::MarkupCanBeQuantized::run_on_model(const std::shar
             continue;
         }
 
-        if (const auto convolution = std::dynamic_pointer_cast<ov::opset1::Convolution>(node)) {
+        if (const auto convolution = ov::as_type_ptr<ov::opset1::Convolution>(node)) {
             if (!ConvolutionTransformation::isQuantizedStatic(convolution, defaultPrecisions)) {
                 setEmptyPrecisions(convolution);
             }
             continue;
         }
-        if (const auto convolutionBackpropData = std::dynamic_pointer_cast<ov::opset1::ConvolutionBackpropData>(node)) {
+        if (const auto convolutionBackpropData = ov::as_type_ptr<ov::opset1::ConvolutionBackpropData>(node)) {
             if (!ConvolutionBackpropDataTransformation::isQuantizedStatic(convolutionBackpropData, defaultPrecisions)) {
                 setEmptyPrecisions(convolutionBackpropData);
             }
             continue;
         }
-        if (const auto groupConvolution = std::dynamic_pointer_cast<ov::opset1::GroupConvolution>(node)) {
+        if (const auto groupConvolution = ov::as_type_ptr<ov::opset1::GroupConvolution>(node)) {
             if (!GroupConvolutionTransformation::isQuantizedStatic(groupConvolution, defaultPrecisions)) {
                 setEmptyPrecisions(groupConvolution);
             }
             continue;
         }
-        if (const auto concat = std::dynamic_pointer_cast<ov::opset1::Concat>(node)) {
+        if (const auto concat = ov::as_type_ptr<ov::opset1::Concat>(node)) {
             if (!ConcatTransformation::isQuantizedStatic(concat)) {
                 setEmptyPrecisions(concat);
             }

--- a/src/common/offline_transformations/src/compress_quantize_weigths.cpp
+++ b/src/common/offline_transformations/src/compress_quantize_weigths.cpp
@@ -89,7 +89,7 @@ ov::pass::CompressWeightsWithFakeQuantize::CompressWeightsWithFakeQuantize() {
         {weights_pattern, input_low_pattern, input_high_pattern, output_low_pattern, output_high_pattern});
 
     ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto fq = std::dynamic_pointer_cast<op::v0::FakeQuantize>(m.get_match_root());
+        auto fq = ov::as_type_ptr<op::v0::FakeQuantize>(m.get_match_root());
         if (!fq)
             return false;
         const auto& high_precision_type = fq->get_element_type();

--- a/src/common/offline_transformations/src/pruning/init_const_mask.cpp
+++ b/src/common/offline_transformations/src/pruning/init_const_mask.cpp
@@ -18,7 +18,7 @@ ov::pass::InitConstMask::InitConstMask(const ov::AxisSet& dims,
         pattern::type_matches_any({element::i8, element::u8, element::f16, element::f32, element::f64}));
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto const_node = std::dynamic_pointer_cast<opset6::Constant>(m.get_match_root());
+        auto const_node = ov::as_type_ptr<opset6::Constant>(m.get_match_root());
         if (!const_node)
             return false;
 

--- a/src/common/offline_transformations/src/pruning/init_masks.cpp
+++ b/src/common/offline_transformations/src/pruning/init_masks.cpp
@@ -68,8 +68,7 @@ public:
 
         ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
             const auto& pattern_map = m.get_pattern_value_map();
-            const auto& matmul =
-                std::dynamic_pointer_cast<opset6::MatMul>(pattern_map.at(matmul_pattern).get_node_shared_ptr());
+            const auto& matmul = ov::as_type_ptr<opset6::MatMul>(pattern_map.at(matmul_pattern).get_node_shared_ptr());
             if (!matmul)
                 return false;
 
@@ -117,7 +116,7 @@ public:
                 return false;
             }
             // 2. Get constant rank to set mask on last dimension
-            const auto const_op = std::dynamic_pointer_cast<opset6::Constant>(cur_node);
+            const auto const_op = ov::as_type_ptr<opset6::Constant>(cur_node);
             const auto shape_rank = const_op->get_shape().size();
             const size_t shift = (matmul->get_transpose_b()) ? 2 : 1;
             if (shape_rank < shift) {

--- a/src/common/offline_transformations/src/pruning/propagate_masks.cpp
+++ b/src/common/offline_transformations/src/pruning/propagate_masks.cpp
@@ -100,7 +100,7 @@ public:
                 a_mask_row = a_mask.get();
             auto b_mask_row = b_mask.get();
 
-            const auto matmul_op = std::dynamic_pointer_cast<opset10::MatMul>(m_matmul.get_node_shared_ptr());
+            const auto matmul_op = ov::as_type_ptr<opset10::MatMul>(m_matmul.get_node_shared_ptr());
             const auto transpose_a = matmul_op->get_transpose_a();
             const auto transpose_b = matmul_op->get_transpose_b();
 
@@ -717,13 +717,13 @@ public:
                                        m_input_high.get_node_shared_ptr(),
                                        m_output_low.get_node_shared_ptr(),
                                        m_output_high.get_node_shared_ptr()};
-            auto fq_node = std::dynamic_pointer_cast<opset10::FakeQuantize>(m_output.get_node_shared_ptr());
+            auto fq_node = ov::as_type_ptr<opset10::FakeQuantize>(m_output.get_node_shared_ptr());
             if (!fq_node)
                 return false;
             size_t idx = 0;
             if (fq_node->get_auto_broadcast() != ov::op::AutoBroadcastType::NONE) {
                 for (const auto& node : fq_params_nodes) {
-                    auto const_node = std::dynamic_pointer_cast<op::v0::Constant>(node);
+                    auto const_node = ov::as_type_ptr<op::v0::Constant>(node);
                     if (!const_node)
                         OPENVINO_THROW("Unexpected operation type.");
                     auto new_shape = broadcast_shape_to_rank(const_node->get_shape(),
@@ -771,7 +771,7 @@ public:
         ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
             const auto& pattern_map = m.get_pattern_value_map();
             const auto& m_output = pattern_map.at(concat);
-            auto concat_ptr = std::dynamic_pointer_cast<opset10::Concat>(m_output.get_node_shared_ptr());
+            auto concat_ptr = ov::as_type_ptr<opset10::Concat>(m_output.get_node_shared_ptr());
             if (!concat_ptr) {
                 return false;
             }
@@ -930,7 +930,7 @@ public:
             // Check reduce operation reduces only dimension without masks
             if (auto input_mask = getMask(m_input)) {
                 auto output_mask = std::make_shared<ov::Mask>(m_output.get_partial_shape().rank().get_length());
-                const auto constant = std::dynamic_pointer_cast<opset10::Constant>(m_weights.get_node_shared_ptr());
+                const auto constant = ov::as_type_ptr<opset10::Constant>(m_weights.get_node_shared_ptr());
                 OPENVINO_ASSERT(!!constant, "Dynamic cast returned a nullptr");
                 const auto reduce_dims = constant->cast_vector<int64_t>();
 
@@ -1144,7 +1144,7 @@ public:
                 if (is_type<opset10::GroupConvolution>(inp.get_node()))
                     return true;
 
-            auto constant = std::dynamic_pointer_cast<opset10::Constant>(m_weights.get_node_shared_ptr());
+            auto constant = ov::as_type_ptr<opset10::Constant>(m_weights.get_node_shared_ptr());
             if (!constant) {
                 constant = ov::util::get_constant_from_source(m_weights.get_node_shared_ptr());
                 if (!constant) {

--- a/src/common/offline_transformations/src/pruning/shrink_weights.cpp
+++ b/src/common/offline_transformations/src/pruning/shrink_weights.cpp
@@ -28,7 +28,7 @@ static bool not_empty_mask(ov::Mask::Ptr mask) {
 }
 
 static bool is_static_reshape_op(std::shared_ptr<ov::Node> node) {
-    auto reshape_node = std::dynamic_pointer_cast<ov::opset6::Reshape>(node);
+    auto reshape_node = ov::as_type_ptr<ov::opset6::Reshape>(node);
     if (!reshape_node)
         return false;
 
@@ -224,7 +224,7 @@ bool ov::pass::ShrinkWeights::run_on_model(const std::shared_ptr<ov::Model>& f) 
             continue;
 
         // TODO: constant can be shared across functions so we need to avoid consumers from other function
-        auto const_node = std::dynamic_pointer_cast<opset6::Constant>(node);
+        auto const_node = ov::as_type_ptr<opset6::Constant>(node);
         if (!const_node)
             continue;
 

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -71,22 +71,22 @@ RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
     const auto op = out.get_node_shared_ptr();
     if (ov::as_type_ptr<ov::op::v0::Parameter>(op) ||
         ov::as_type_ptr<ov::op::v0::Result>(op) ||
-        std::dynamic_pointer_cast<op::LoopBegin>(op) ||
-        std::dynamic_pointer_cast<op::LoopEnd>(op) ||
-        std::dynamic_pointer_cast<op::Brgemm>(op) ||
-        std::dynamic_pointer_cast<op::Buffer>(op) ||
-        std::dynamic_pointer_cast<op::RankNormalization>(op) ||
+        ov::as_type_ptr<op::LoopBegin>(op) ||
+        ov::as_type_ptr<op::LoopEnd>(op) ||
+        ov::as_type_ptr<op::Brgemm>(op) ||
+        ov::as_type_ptr<op::Buffer>(op) ||
+        ov::as_type_ptr<op::RankNormalization>(op) ||
         ov::as_type_ptr<op::Reshape>(op) ||
-        std::dynamic_pointer_cast<op::Reorder>(op) ||
-        std::dynamic_pointer_cast<snippets::op::Store>(op)
+        ov::as_type_ptr<op::Reorder>(op) ||
+        ov::as_type_ptr<snippets::op::Store>(op)
 #ifdef SNIPPETS_DEBUG_CAPS
-        || std::dynamic_pointer_cast<op::PerfCountBeginBase>(op)
-        || std::dynamic_pointer_cast<op::PerfCountEndBase>(op)
+        || ov::as_type_ptr<op::PerfCountBeginBase>(op)
+        || ov::as_type_ptr<op::PerfCountEndBase>(op)
 #endif
         )
         return RegType::gpr;
-    else if (std::dynamic_pointer_cast<snippets::op::Load>(op) ||
-             std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(op) ||
+    else if (ov::as_type_ptr<snippets::op::Load>(op) ||
+             ov::as_type_ptr<snippets::op::BroadcastLoad>(op) ||
              ov::op::util::is_unary_elementwise_arithmetic(op) ||
              ov::op::util::is_binary_elementwise_arithmetic(op) ||
              ov::op::util::is_binary_elementwise_comparison(op) ||
@@ -95,12 +95,12 @@ RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
              ov::as_type_ptr<ov::op::v0::PRelu>(op) ||
              ov::as_type_ptr<ov::op::v0::Convert>(op) ||
              ov::as_type_ptr<ov::op::v1::Select>(op) ||
-             std::dynamic_pointer_cast<op::VectorBuffer>(op) ||
-             std::dynamic_pointer_cast<op::BroadcastMove>(op) ||
+             ov::as_type_ptr<op::VectorBuffer>(op) ||
+             ov::as_type_ptr<op::BroadcastMove>(op) ||
              ov::as_type_ptr<op::Scalar>(op) ||
-             std::dynamic_pointer_cast<op::HorizonMax>(op) ||
-             std::dynamic_pointer_cast<op::HorizonSum>(op) ||
-             std::dynamic_pointer_cast<op::Fill>(op))
+             ov::as_type_ptr<op::HorizonMax>(op) ||
+             ov::as_type_ptr<op::HorizonSum>(op) ||
+             ov::as_type_ptr<op::Fill>(op))
         return RegType::vec;
     else
         OPENVINO_THROW("Register type of the operation " + std::string(op->get_type_name()) + " isn't determined!");

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -69,14 +69,14 @@ RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
     if (reg_type != RegType::undefined)
         return reg_type;
     const auto op = out.get_node_shared_ptr();
-    if (std::dynamic_pointer_cast<ov::op::v0::Parameter>(op) ||
-        std::dynamic_pointer_cast<ov::op::v0::Result>(op) ||
+    if (ov::as_type_ptr<ov::op::v0::Parameter>(op) ||
+        ov::as_type_ptr<ov::op::v0::Result>(op) ||
         std::dynamic_pointer_cast<op::LoopBegin>(op) ||
         std::dynamic_pointer_cast<op::LoopEnd>(op) ||
         std::dynamic_pointer_cast<op::Brgemm>(op) ||
         std::dynamic_pointer_cast<op::Buffer>(op) ||
         std::dynamic_pointer_cast<op::RankNormalization>(op) ||
-        std::dynamic_pointer_cast<op::Reshape>(op) ||
+        ov::as_type_ptr<op::Reshape>(op) ||
         std::dynamic_pointer_cast<op::Reorder>(op) ||
         std::dynamic_pointer_cast<snippets::op::Store>(op)
 #ifdef SNIPPETS_DEBUG_CAPS
@@ -91,13 +91,13 @@ RegType Generator::get_op_out_reg_type(const ov::Output<Node>& out) const {
              ov::op::util::is_binary_elementwise_arithmetic(op) ||
              ov::op::util::is_binary_elementwise_comparison(op) ||
              ov::op::util::is_binary_elementwise_logical(op) ||
-             std::dynamic_pointer_cast<ov::op::v1::LogicalNot>(op) ||
-             std::dynamic_pointer_cast<ov::op::v0::PRelu>(op) ||
-             std::dynamic_pointer_cast<ov::op::v0::Convert>(op) ||
-             std::dynamic_pointer_cast<ov::op::v1::Select>(op) ||
+             ov::as_type_ptr<ov::op::v1::LogicalNot>(op) ||
+             ov::as_type_ptr<ov::op::v0::PRelu>(op) ||
+             ov::as_type_ptr<ov::op::v0::Convert>(op) ||
+             ov::as_type_ptr<ov::op::v1::Select>(op) ||
              std::dynamic_pointer_cast<op::VectorBuffer>(op) ||
              std::dynamic_pointer_cast<op::BroadcastMove>(op) ||
-             std::dynamic_pointer_cast<op::Scalar>(op) ||
+             ov::as_type_ptr<op::Scalar>(op) ||
              std::dynamic_pointer_cast<op::HorizonMax>(op) ||
              std::dynamic_pointer_cast<op::HorizonSum>(op) ||
              std::dynamic_pointer_cast<op::Fill>(op))

--- a/src/common/snippets/src/lowered/pass/pass.cpp
+++ b/src/common/snippets/src/lowered/pass/pass.cpp
@@ -35,7 +35,7 @@ void PassPipeline::run(const lowered::LinearIR& linear_ir) const {
         if (m_pass_config->is_disabled(pass->get_type_info())) {
             continue;
         }
-        const auto const_pass = std::dynamic_pointer_cast<ConstPass>(pass);
+        const auto const_pass = ov::as_type_ptr<ConstPass>(pass);
         OPENVINO_ASSERT(const_pass != nullptr,
                         "Unexpected pass (",
                         pass->get_type_info(),
@@ -58,9 +58,9 @@ void PassPipeline::run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearI
         }
         if (auto lir_pass = std::dynamic_pointer_cast<Pass>(pass)) {
             lir_pass->run(linear_ir);
-        } else if (auto const_pass = std::dynamic_pointer_cast<ConstPass>(pass)) {
+        } else if (auto const_pass = ov::as_type_ptr<ConstPass>(pass)) {
             const_pass->run(linear_ir);
-        } else if (auto ranged_pass = std::dynamic_pointer_cast<RangedPass>(pass)) {
+        } else if (auto ranged_pass = ov::as_type_ptr<RangedPass>(pass)) {
             ranged_pass->run(linear_ir, begin, end);
         } else {
             OPENVINO_THROW("Unexpected pass (", pass->get_type_info(), ") is registered in PassPipeline");

--- a/src/common/snippets/src/lowered/pass/pass.cpp
+++ b/src/common/snippets/src/lowered/pass/pass.cpp
@@ -56,7 +56,7 @@ void PassPipeline::run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearI
         if (m_pass_config->is_disabled(pass->get_type_info())) {
             continue;
         }
-        if (auto lir_pass = std::dynamic_pointer_cast<Pass>(pass)) {
+        if (auto lir_pass = ov::as_type_ptr<Pass>(pass)) {
             lir_pass->run(linear_ir);
         } else if (auto const_pass = ov::as_type_ptr<ConstPass>(pass)) {
             const_pass->run(linear_ir);

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -290,7 +290,7 @@ auto Subgraph::constant_input_should_be_inside_body(const std::shared_ptr<ov::No
 }
 
 bool Subgraph::check_broadcast(const std::shared_ptr<const ov::Node>& node) noexcept {
-    const auto elementwise = std::dynamic_pointer_cast<const ov::op::util::BinaryElementwiseArithmetic>(node);
+    const auto elementwise = ov::as_type_ptr<const ov::op::util::BinaryElementwiseArithmetic>(node);
     return
         (elementwise == nullptr) ||
         (elementwise->get_input_partial_shape(0).size() == elementwise->get_input_partial_shape(1).size()) ||

--- a/src/common/snippets/src/pass/fq_decomposition.cpp
+++ b/src/common/snippets/src/pass/fq_decomposition.cpp
@@ -35,7 +35,7 @@ ov::snippets::pass::FakeQuantizeDecomposition::FakeQuantizeDecomposition() {
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::FakeQuantizeDecomposition")
         auto& pattern_to_output = m.get_pattern_value_map();
-        const auto fake_quantize_node = std::dynamic_pointer_cast<ov::op::v0::FakeQuantize>(
+        const auto fake_quantize_node = ov::as_type_ptr<ov::op::v0::FakeQuantize>(
             pattern_to_output.at(fake_quantize).get_node_shared_ptr());
 
         if (!fake_quantize_node || transformation_callback(fake_quantize_node)) {
@@ -358,7 +358,7 @@ bool ov::snippets::pass::CommonFakeQuantizeDecomposition::is_supported_fq(const 
         if (!greater_equal->constant_fold(result, greater_equal->input_values()))
             return false;
 
-        const auto res_node = std::dynamic_pointer_cast<const ov::op::v0::Constant>(result[0].get_node_shared_ptr());
+        const auto res_node = ov::as_type_ptr<const ov::op::v0::Constant>(result[0].get_node_shared_ptr());
         const auto comp_result = res_node->cast_vector<bool>();
         return !std::any_of(comp_result.begin(), comp_result.end(), [](const bool value) {
             return value;

--- a/src/common/snippets/tests/src/pass/fake_quantize_decomposition_test.cpp
+++ b/src/common/snippets/tests/src/pass/fake_quantize_decomposition_test.cpp
@@ -26,10 +26,10 @@ public:
         TransformationTestsF::TearDown();
 
         auto subgraph = FunctionHelper::getSubgraph(model);
-        auto body = subgraph == nullptr ? nullptr : std::dynamic_pointer_cast<ov::snippets::op::Subgraph>(subgraph)->body_ptr();
+        auto body = subgraph == nullptr ? nullptr : ov::as_type_ptr<ov::snippets::op::Subgraph>(subgraph)->body_ptr();
 
         auto subgraph_ref = FunctionHelper::getSubgraph(model_ref);
-        auto body_ref = subgraph_ref == nullptr ? nullptr : std::dynamic_pointer_cast<ov::snippets::op::Subgraph>(subgraph_ref)->body_ptr();
+        auto body_ref = subgraph_ref == nullptr ? nullptr : ov::as_type_ptr<ov::snippets::op::Subgraph>(subgraph_ref)->body_ptr();
 
         auto res = comparator.compare(body, body_ref);
         ASSERT_TRUE(res.valid) << res.message;

--- a/src/common/transformations/include/transformations/common_optimizations/depth_to_space_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/depth_to_space_fusion.hpp
@@ -31,7 +31,7 @@ class TRANSFORMATIONS_API DepthToSpaceFusion;
  *
  *     // This callback enables DepthToSpaceFusion transformation
  *     auto callback = [](const std::shared_ptr<const ov::Node> & node) -> bool {
- *         return std::dynamic_pointer_cast<const ov::opset3::DepthToSpace>(node) != nullptr;
+ *         return ov::as_type_ptr<const ov::opset3::DepthToSpace>(node) != nullptr;
  *     };
  *
  *     auto p = ov::pass::DepthToSpaceFusion();

--- a/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_pooling.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_pooling.hpp
@@ -72,7 +72,7 @@ public:
 template <class T>
 ov::matcher_pass_callback ConvertReduceBase::convert_reduce_to_pooling() {
     return [&](ov::pass::pattern::Matcher& m) {
-        auto reduce = std::dynamic_pointer_cast<T>(m.get_match_root());
+        auto reduce = ov::as_type_ptr<T>(m.get_match_root());
 
         if (!reduce || transformation_callback(reduce) || ov::shape_size(reduce->input_value(0).get_shape()) == 0) {
             return false;

--- a/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_pooling.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_pooling.hpp
@@ -80,7 +80,7 @@ ov::matcher_pass_callback ConvertReduceBase::convert_reduce_to_pooling() {
 
         auto input = reduce->input_value(0);
 
-        auto axes_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(reduce->input_value(1).get_node_shared_ptr());
+        auto axes_node = ov::as_type_ptr<ov::op::v0::Constant>(reduce->input_value(1).get_node_shared_ptr());
         if (!axes_node) {
             return false;
         }

--- a/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_reshape.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/convert_reduce_to_reshape.hpp
@@ -101,7 +101,7 @@ public:
 template <class T>
 ov::matcher_pass_callback CvtReduceBase::convert_reduce_to_reshape() {
     return [&](ov::pass::pattern::Matcher& m) {
-        auto reduce = std::dynamic_pointer_cast<T>(m.get_match_root());
+        auto reduce = ov::as_type_ptr<T>(m.get_match_root());
         if (!reduce)
             return false;
 

--- a/src/common/transformations/include/transformations/utils/gen_pattern.hpp
+++ b/src/common/transformations/include/transformations/utils/gen_pattern.hpp
@@ -1262,7 +1262,7 @@ public:
                 if (rt_info.count("symbolic_const_value")) {
                     // symbolic constant node, a symbol reference is observed
                     auto& symbols = rt_info["symbolic_const_value"].as<std::vector<Symbol>>();
-                    auto constop = std::dynamic_pointer_cast<op::v0::Constant>(value_node);
+                    auto constop = ov::as_type_ptr<op::v0::Constant>(value_node);
                     if (!constop) {
                         _VERBOSE_LOG("symbolic_const_value unexpected OP: ", value_node->get_friendly_name());
                         return false;
@@ -1292,9 +1292,9 @@ public:
                 }
                 continue;
             }
-            if (auto pconst_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(pnode)) {
+            if (auto pconst_node = ov::as_type_ptr<ov::op::v0::Constant>(pnode)) {
                 // const_node needs to match type/shape/value
-                auto vconst_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(value_node);
+                auto vconst_node = ov::as_type_ptr<ov::op::v0::Constant>(value_node);
                 if (!vconst_node) {
                     _VERBOSE_LOG("expecting Constant op, but got ", value_node);
                     return false;

--- a/src/common/transformations/include/transformations/utils/print_model.hpp
+++ b/src/common/transformations/include/transformations/utils/print_model.hpp
@@ -262,7 +262,7 @@ void dump_cpp_style(std::ostream& os, const std::shared_ptr<ov::Model>& model) {
     // collect all scalar & short 1D vectors for literal-style display
     std::map<std::shared_ptr<ov::Node>, std::string> literal_consts;
     for (auto op : f.get_ordered_ops()) {
-        if (auto constop = std::dynamic_pointer_cast<op::v0::Constant>(op)) {
+        if (auto constop = ov::as_type_ptr<op::v0::Constant>(op)) {
             // only i32/f32 type const literal can be parsed by C++ compiler
             if (constop->get_output_element_type(0) != ov::element::i32 &&
                 constop->get_output_element_type(0) != ov::element::i64 &&
@@ -328,7 +328,7 @@ void dump_cpp_style(std::ostream& os, const std::shared_ptr<ov::Model>& model) {
         auto name = opname[op.get()];
         os << prefix << "    ";
 
-        if (auto constop = std::dynamic_pointer_cast<op::v0::Constant>(op)) {
+        if (auto constop = ov::as_type_ptr<op::v0::Constant>(op)) {
             os << "auto " << name << " = makeConst(" << to_code(op->get_output_element_type(0)) << ", "
                << to_code(op->get_output_shape(0)) << ", " << to_code(constop, true) << ");" << std::endl;
         } else {
@@ -376,7 +376,7 @@ void dump_cpp_style(std::ostream& os, const std::shared_ptr<ov::Model>& model) {
         }
 
         // recursively output subgraphs
-        if (auto msubgraph = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(op)) {
+        if (auto msubgraph = ov::as_type_ptr<op::util::MultiSubGraphOp>(op)) {
             auto cnt = msubgraph->get_internal_subgraphs_size();
             for (size_t i = 0; i < cnt; i++) {
                 os << "    MultiSubGraphOp " << tag << msubgraph->get_friendly_name() << "[" << i << "]" << std::endl;

--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -45,7 +45,7 @@ bool normalize_single_value(std::vector<T> vec, float& value, bool check_value_r
 template <class T>
 bool has_op_with_type(const std::shared_ptr<const ov::Model>& function) {
     for (const auto& op : function->get_ops()) {
-        if (std::dynamic_pointer_cast<T>(op)) {
+        if (ov::as_type_ptr<T>(op)) {
             return true;
         }
     }

--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -54,7 +54,7 @@ bool has_op_with_type(const std::shared_ptr<const ov::Model>& function) {
 
 inline bool has_decompression_converts(const std::shared_ptr<const ov::Model>& function) {
     for (const auto& op : function->get_ops()) {
-        if (std::dynamic_pointer_cast<ov::op::v0::Convert>(op)) {
+        if (ov::as_type_ptr<ov::op::v0::Convert>(op)) {
             if (ov::is_decompression(op))
                 return true;
         }
@@ -125,7 +125,7 @@ bool has_constant_value(const std::shared_ptr<Node>& node,
         return false;
     }
 
-    auto constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+    auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
     if (!constant) {
         return false;
     }
@@ -159,7 +159,7 @@ bool has_constant_value(const std::shared_ptr<Node>& node,
         return false;
     }
 
-    auto constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+    auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
     if (!constant) {
         return false;
     }

--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
@@ -16,7 +16,7 @@ namespace {
 bool can_eliminate_broadcast(const ov::Output<ov::Node>& eltwise,
                              const ov::Output<ov::Node>& eltwise_input,
                              const ov::Output<ov::Node>& broadcast) {
-    auto b = std::dynamic_pointer_cast<ov::op::util::BinaryElementwiseArithmetic>(eltwise.get_node_shared_ptr());
+    auto b = ov::as_type_ptr<ov::op::util::BinaryElementwiseArithmetic>(eltwise.get_node_shared_ptr());
     if (!b || b->get_autob() == ov::op::AutoBroadcastType::NONE) {
         return false;
     }

--- a/src/common/transformations/src/transformations/common_optimizations/convert_nms_gather_path_to_unsigned.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_nms_gather_path_to_unsigned.cpp
@@ -130,7 +130,7 @@ public:
                 return false;
             gather->get_rt_info()["dontReverseIndices"] = true;
             auto out_type = (indices.get_element_type() == element::i64 ? element::u64 : element::u32);
-            auto existing_convert = dynamic_pointer_cast<ov::op::v0::Convert>(indices.get_node_shared_ptr());
+            auto existing_convert = ov::as_type_ptr<ov::op::v0::Convert>(indices.get_node_shared_ptr());
             if (existing_convert && indices.get_target_inputs().size() == 1) {
                 existing_convert->set_convert_element_type(out_type);
                 existing_convert->validate_and_infer_types();

--- a/src/common/transformations/src/transformations/common_optimizations/eliminate_duplicate_ti_inputs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/eliminate_duplicate_ti_inputs.cpp
@@ -31,14 +31,14 @@ ov::pass::EliminateDuplicateTIInputs::EliminateDuplicateTIInputs() {
         for (auto& key : input_descs) {
             auto is_equal = [&](const std::shared_ptr<SubGraphOp::InputDescription>& input) -> bool {
                 if (ti->input_value(input->m_input_index) == ti->input_value(key->m_input_index)) {
-                    auto invariant_l = std::dynamic_pointer_cast<SubGraphOp::InvariantInputDescription>(input);
-                    auto invariant_r = std::dynamic_pointer_cast<SubGraphOp::InvariantInputDescription>(key);
+                    auto invariant_l = ov::as_type_ptr<SubGraphOp::InvariantInputDescription>(input);
+                    auto invariant_r = ov::as_type_ptr<SubGraphOp::InvariantInputDescription>(key);
                     if (invariant_l && invariant_r) {
                         return true;
                     }
 
-                    auto slice_l = std::dynamic_pointer_cast<SubGraphOp::SliceInputDescription>(input);
-                    auto slice_r = std::dynamic_pointer_cast<SubGraphOp::SliceInputDescription>(key);
+                    auto slice_l = ov::as_type_ptr<SubGraphOp::SliceInputDescription>(input);
+                    auto slice_r = ov::as_type_ptr<SubGraphOp::SliceInputDescription>(key);
 
                     if (slice_l && slice_r) {
                         return slice_l->m_axis == slice_r->m_axis && slice_l->m_start == slice_r->m_start &&
@@ -46,8 +46,8 @@ ov::pass::EliminateDuplicateTIInputs::EliminateDuplicateTIInputs() {
                                slice_l->m_stride == slice_r->m_stride;
                     }
 
-                    auto merged_l = std::dynamic_pointer_cast<SubGraphOp::MergedInputDescription>(input);
-                    auto merged_r = std::dynamic_pointer_cast<SubGraphOp::MergedInputDescription>(key);
+                    auto merged_l = ov::as_type_ptr<SubGraphOp::MergedInputDescription>(input);
+                    auto merged_r = ov::as_type_ptr<SubGraphOp::MergedInputDescription>(key);
 
                     if (merged_l && merged_r) {
                         return merged_l->m_body_value_index == merged_r->m_body_value_index;
@@ -91,12 +91,12 @@ ov::pass::EliminateDuplicateTIInputs::EliminateDuplicateTIInputs() {
         for (const auto& remain : should_stay) {
             auto par = body->get_parameters()[remain->m_body_parameter_index];
             auto in = ti->input_value(remain->m_input_index);
-            if (auto invariant = std::dynamic_pointer_cast<SubGraphOp::InvariantInputDescription>(remain)) {
+            if (auto invariant = ov::as_type_ptr<SubGraphOp::InvariantInputDescription>(remain)) {
                 new_ti->set_invariant_input(par, in);
-            } else if (auto merged = std::dynamic_pointer_cast<SubGraphOp::MergedInputDescription>(remain)) {
+            } else if (auto merged = ov::as_type_ptr<SubGraphOp::MergedInputDescription>(remain)) {
                 auto results = body->get_results();
                 new_ti->set_merged_input(par, in, results[merged->m_body_value_index]);
-            } else if (auto slice = std::dynamic_pointer_cast<SubGraphOp::SliceInputDescription>(remain)) {
+            } else if (auto slice = ov::as_type_ptr<SubGraphOp::SliceInputDescription>(remain)) {
                 new_ti->set_sliced_input(par,
                                          in,
                                          slice->m_start,

--- a/src/common/transformations/src/transformations/common_optimizations/fold_subgraph_empty_inputs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fold_subgraph_empty_inputs.cpp
@@ -19,7 +19,7 @@ ov::pass::FoldSubgraphEmptyInputs::FoldSubgraphEmptyInputs() {
     MATCHER_SCOPE(FoldSubgraphEmptyInputs);
     auto multi_subgraph_op_pattern = pattern::wrap_type<op::util::MultiSubGraphOp>();
     ov::matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto multi_subgraph_op = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(m.get_match_root());
+        auto multi_subgraph_op = ov::as_type_ptr<op::util::MultiSubGraphOp>(m.get_match_root());
         if (multi_subgraph_op == nullptr) {
             return false;
         }

--- a/src/common/transformations/src/transformations/common_optimizations/glu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/glu_fusion.cpp
@@ -53,7 +53,7 @@ GLUFusion::GLUFusion() {
         OPENVINO_ASSERT(pattern_map.count(variadic_split_m));
         OPENVINO_ASSERT(pattern_map.count(split_lengths_const_m));
         OPENVINO_ASSERT(pattern_map.count(axis_const_m));
-        auto mul = std::dynamic_pointer_cast<ov::op::v1::Multiply>(pattern_map.at(mul_m).get_node_shared_ptr());
+        auto mul = ov::as_type_ptr<ov::op::v1::Multiply>(pattern_map.at(mul_m).get_node_shared_ptr());
         if (!mul || transformation_callback(mul))
             return false;
 
@@ -63,7 +63,7 @@ GLUFusion::GLUFusion() {
         ov::op::internal::GLU::GluType glu_type = ov::op::internal::GLU::GluType::Swish;
 
         if (isSwiGLU) {
-            auto swish = std::dynamic_pointer_cast<ov::op::v4::Swish>(pattern_map.at(swish_m).get_node_shared_ptr());
+            auto swish = ov::as_type_ptr<ov::op::v4::Swish>(pattern_map.at(swish_m).get_node_shared_ptr());
             glu_type = ov::op::internal::GLU::GluType::Swish;
             split_to_glu_idx = swish->input_value(0).get_index();
 
@@ -71,7 +71,7 @@ GLUFusion::GLUFusion() {
             if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
                 return false;
         } else if (isGeGLU) {
-            auto gelu = std::dynamic_pointer_cast<ov::op::v7::Gelu>(pattern_map.at(gelu_m).get_node_shared_ptr());
+            auto gelu = ov::as_type_ptr<ov::op::v7::Gelu>(pattern_map.at(gelu_m).get_node_shared_ptr());
             glu_type = (gelu->get_approximation_mode() == ov::op::GeluApproximationMode::ERF)
                            ? ov::op::internal::GLU::GluType::Gelu
                            : ov::op::internal::GLU::GluType::Gelu_Tanh;
@@ -84,20 +84,20 @@ GLUFusion::GLUFusion() {
             OPENVINO_THROW("'glu_type' not initialized");
         }
 
-        auto variadic_split = std::dynamic_pointer_cast<ov::op::v1::VariadicSplit>(
-            pattern_map.at(variadic_split_m).get_node_shared_ptr());
+        auto variadic_split =
+            ov::as_type_ptr<ov::op::v1::VariadicSplit>(pattern_map.at(variadic_split_m).get_node_shared_ptr());
         auto variadic_split_in_ps = variadic_split->get_input_partial_shape(0);
         auto last_dim = variadic_split_in_ps.rank().get_length() - 1;
 
-        auto axis = std::dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(axis_const_m).get_node_shared_ptr());
+        auto axis = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(axis_const_m).get_node_shared_ptr());
         bool valid_axis_const_values = ov::op::util::has_constant_value<int64_t>(axis, -1) ||
                                        ov::op::util::has_constant_value<int64_t>(axis, last_dim);
         if (!valid_axis_const_values)
             return false;
         auto axis_value = axis->cast_vector<int64_t>()[0];
 
-        auto split_lengths = std::dynamic_pointer_cast<ov::op::v0::Constant>(
-            pattern_map.at(split_lengths_const_m).get_node_shared_ptr());
+        auto split_lengths =
+            ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(split_lengths_const_m).get_node_shared_ptr());
         auto split_lengths_value = split_lengths->cast_vector<int64_t>()[0];
         // Allow only case that exactly splits in half along the last dimension
         auto split_length = variadic_split_in_ps[last_dim].get_length() / 2;

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -463,7 +463,7 @@ pass::EliminateConvert::EliminateConvert() {
     auto convert_pattern = pattern::wrap_type<ov::op::v0::Convert>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto convert = dynamic_pointer_cast<ov::op::v0::Convert>(m.get_match_root());
+        auto convert = ov::as_type_ptr<ov::op::v0::Convert>(m.get_match_root());
         if (!convert) {
             return false;
         }
@@ -517,7 +517,7 @@ pass::EliminateSplit::EliminateSplit() {
     auto convert_pattern = pattern::wrap_type<ov::op::v1::Split>();
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto split = dynamic_pointer_cast<ov::op::v1::Split>(m.get_match_root());
+        auto split = ov::as_type_ptr<ov::op::v1::Split>(m.get_match_root());
         if (!split || split->get_num_splits() != 1) {
             return false;
         }
@@ -632,9 +632,9 @@ int64_t make_positive(int64_t value, const Output<Node>& node) {
 };
 
 bool check_squeeze(const shared_ptr<Node>& node) {
-    auto squeeze = dynamic_pointer_cast<ov::op::v0::Squeeze>(node);
+    auto squeeze = ov::as_type_ptr<ov::op::v0::Squeeze>(node);
     if (squeeze) {
-        auto axis = dynamic_pointer_cast<ov::op::v0::Constant>(squeeze->input_value(1).get_node_shared_ptr());
+        auto axis = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->input_value(1).get_node_shared_ptr());
         if (axis) {
             auto axis_val = axis->cast_vector<int64_t>();
             if (axis_val.size() == 1 && make_positive(axis_val[0], squeeze->input_value(0)) == 1) {
@@ -648,9 +648,9 @@ bool check_squeeze(const shared_ptr<Node>& node) {
 // Checks that Reshape actually equals to Squeeze op
 // 0, -1 values in the shape pattern are not allowed.
 bool check_reshape(const shared_ptr<Node>& node) {
-    auto reshape = dynamic_pointer_cast<ov::op::v1::Reshape>(node);
+    auto reshape = ov::as_type_ptr<ov::op::v1::Reshape>(node);
     if (reshape) {
-        auto shape_pattern = dynamic_pointer_cast<ov::op::v0::Constant>(reshape->input_value(1).get_node_shared_ptr());
+        auto shape_pattern = ov::as_type_ptr<ov::op::v0::Constant>(reshape->input_value(1).get_node_shared_ptr());
         if (shape_pattern) {
             auto pattern_val = shape_pattern->cast_vector<int64_t>();
             bool is_valid_pattern = find(pattern_val.begin(), pattern_val.end(), 0) == pattern_val.end();
@@ -675,7 +675,7 @@ bool check_reshape(const shared_ptr<Node>& node) {
 bool check_axis(const shared_ptr<ov::op::v0::Concat>& concat,
                 const shared_ptr<Node>& split,
                 bool is_special_case = false) {
-    auto axis = dynamic_pointer_cast<ov::op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
+    auto axis = ov::as_type_ptr<ov::op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
     if (!axis) {
         return false;
     }
@@ -731,9 +731,9 @@ shared_ptr<T> check_all_inputs(const shared_ptr<ov::op::v0::Concat>& concat) {
 
             auto seq_node = seq_out.get_node_shared_ptr();
             if (!seq_node || seq_out.get_index() != 0 ||
-                !(dynamic_pointer_cast<ov::op::v5::RNNSequence>(seq_node) ||
-                  dynamic_pointer_cast<ov::op::v5::GRUSequence>(seq_node) ||
-                  dynamic_pointer_cast<ov::op::v5::LSTMSequence>(seq_node))) {
+                !(ov::as_type_ptr<ov::op::v5::RNNSequence>(seq_node) ||
+                  ov::as_type_ptr<ov::op::v5::GRUSequence>(seq_node) ||
+                  ov::as_type_ptr<ov::op::v5::LSTMSequence>(seq_node))) {
                 return {};
             }
 
@@ -787,7 +787,7 @@ ov::pass::EliminateSplitConcat::EliminateSplitConcat() {
     auto pattern_concat = pattern::wrap_type<ov::op::v0::Concat>();
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
-        const auto concat = dynamic_pointer_cast<ov::op::v0::Concat>(pattern_map.at(pattern_concat));
+        const auto concat = ov::as_type_ptr<ov::op::v0::Concat>(pattern_map.at(pattern_concat));
         if (!concat) {
             return false;
         }
@@ -814,7 +814,7 @@ pass::EliminateTranspose::EliminateTranspose() {
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_map();
-        auto order_const = dynamic_pointer_cast<ov::op::v0::Constant>(pattern_map.at(order));
+        auto order_const = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(order));
         if (!order_const) {
             return false;
         }

--- a/src/common/transformations/src/transformations/common_optimizations/pad_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/pad_fusion.cpp
@@ -105,7 +105,7 @@ pass::PadFusionAvgPool::PadFusionAvgPool() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map[data_pattern];
-        auto pad = std::dynamic_pointer_cast<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
+        auto pad = ov::as_type_ptr<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
         auto pad_value = pattern_map[pad_value_pattern].get_node_shared_ptr();
         auto pads_begin = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_begin_pattern].get_node_shared_ptr());
         auto pads_end = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_end_pattern].get_node_shared_ptr());
@@ -205,7 +205,7 @@ pass::PadFusionConvolution::PadFusionConvolution() {
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map[data_pattern];
         auto filter = pattern_map[filter_pattern];
-        auto pad = std::dynamic_pointer_cast<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
+        auto pad = ov::as_type_ptr<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
         auto pad_value = pattern_map[pad_value_pattern].get_node_shared_ptr();
         auto pads_begin = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_begin_pattern].get_node_shared_ptr());
         auto pads_end = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_end_pattern].get_node_shared_ptr());
@@ -250,7 +250,7 @@ pass::PadFusionConvolutionBackpropData::PadFusionConvolutionBackpropData() {
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map[data_pattern];
         auto filter = pattern_map[filter_pattern];
-        auto pad = std::dynamic_pointer_cast<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
+        auto pad = ov::as_type_ptr<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
         auto pad_value = pattern_map[pad_value_pattern].get_node_shared_ptr();
         auto pads_begin = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_begin_pattern].get_node_shared_ptr());
         auto pads_end = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_end_pattern].get_node_shared_ptr());
@@ -306,7 +306,7 @@ pass::PadFusionGroupConvolution::PadFusionGroupConvolution() {
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map[data_pattern];
         auto filter = pattern_map[filter_pattern];
-        auto pad = std::dynamic_pointer_cast<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
+        auto pad = ov::as_type_ptr<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
         auto pad_value = pattern_map[pad_value_pattern].get_node_shared_ptr();
         auto pads_begin = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_begin_pattern].get_node_shared_ptr());
         auto pads_end = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_end_pattern].get_node_shared_ptr());
@@ -352,7 +352,7 @@ pass::PadFusionGroupConvolutionBackpropData::PadFusionGroupConvolutionBackpropDa
         auto pattern_map = m.get_pattern_value_map();
         auto data = pattern_map[data_pattern];
         auto filter = pattern_map[filter_pattern];
-        auto pad = std::dynamic_pointer_cast<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
+        auto pad = ov::as_type_ptr<op::util::PadBase>(pattern_map[pad_node_pattern].get_node_shared_ptr());
         auto pad_value = pattern_map[pad_value_pattern].get_node_shared_ptr();
         auto pads_begin = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_begin_pattern].get_node_shared_ptr());
         auto pads_end = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map[pads_end_pattern].get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/prelu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/prelu_fusion.cpp
@@ -171,7 +171,7 @@ ov::pass::PReluFusionAbsSubMulMulAdd::PReluFusionAbsSubMulMulAdd() {
 
     const auto equals_half = [](const Output<Node>& node) {
         float v;
-        const auto constant = dynamic_pointer_cast<ov::op::v0::Constant>(node.get_node_shared_ptr());
+        const auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node.get_node_shared_ptr());
         return constant && op::util::get_single_value(constant, v) && v == 0.5f;
     };
 

--- a/src/common/transformations/src/transformations/common_optimizations/pull_through_reduce.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/pull_through_reduce.cpp
@@ -120,8 +120,7 @@ ov::pass::PullUnsqueezeThroughReduce::PullUnsqueezeThroughReduce() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pattern_map = m.get_pattern_value_map();
         const auto input_node = pattern_map.at(input);
-        const auto reduce_node =
-            std::dynamic_pointer_cast<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
+        const auto reduce_node = ov::as_type_ptr<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
         const auto unsqueeze_node = pattern_map.at(unsqueeze).get_node_shared_ptr();
         auto unsqueeze_axes_input =
             ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(unsqueeze_axes).get_node_shared_ptr());
@@ -193,8 +192,7 @@ ov::pass::PullReshapeThroughReduce::PullReshapeThroughReduce() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pattern_map = m.get_pattern_value_map();
         const auto input_node = pattern_map.at(input);
-        const auto reduce_node =
-            std::dynamic_pointer_cast<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
+        const auto reduce_node = ov::as_type_ptr<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
         if (!reduce_node) {
             return false;
         }

--- a/src/common/transformations/src/transformations/common_optimizations/push_constant_to_subgraph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/push_constant_to_subgraph.cpp
@@ -15,7 +15,7 @@ static std::shared_ptr<ov::op::v0::Constant> try_constantfold_input(
     const std::shared_ptr<MultiSubGraphOp>& op,
     const MultiSubGraphOp::InputDescription::Ptr& input_desc,
     std::map<ov::Output<ov::Node>, std::shared_ptr<ov::op::v0::Constant>>& cache) {
-    if (!std::dynamic_pointer_cast<MultiSubGraphOp::InvariantInputDescription>(input_desc)) {
+    if (!ov::as_type_ptr<MultiSubGraphOp::InvariantInputDescription>(input_desc)) {
         return nullptr;
     }
     const auto outer_input = op->input_value(input_desc->m_input_index);

--- a/src/common/transformations/src/transformations/common_optimizations/reduce_reshape_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reduce_reshape_fusion.cpp
@@ -31,8 +31,7 @@ ov::pass::ReduceReshapeFusion::ReduceReshapeFusion() {
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
         auto& pattern_map = m.get_pattern_value_map();
         auto reshape_node = pattern_map.at(reshape).get_node_shared_ptr();
-        const auto reduce_node =
-            std::dynamic_pointer_cast<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
+        const auto reduce_node = ov::as_type_ptr<op::util::ReductionBase>(pattern_map.at(reduce).get_node_shared_ptr());
         if (!reduce_node) {
             return false;
         }
@@ -57,11 +56,9 @@ ov::pass::ReduceReshapeFusion::ReduceReshapeFusion() {
             return false;
         }
 
-        if (auto arithmetic_reduce_node =
-                std::dynamic_pointer_cast<op::util::ArithmeticReductionKeepDims>(reduce_node)) {
+        if (auto arithmetic_reduce_node = ov::as_type_ptr<op::util::ArithmeticReductionKeepDims>(reduce_node)) {
             arithmetic_reduce_node->set_keep_dims(true);
-        } else if (auto logical_reduce_node =
-                       std::dynamic_pointer_cast<op::util::LogicalReductionKeepDims>(reduce_node)) {
+        } else if (auto logical_reduce_node = ov::as_type_ptr<op::util::LogicalReductionKeepDims>(reduce_node)) {
             logical_reduce_node->set_keep_dims(true);
         }
         reduce_node->validate_and_infer_types();

--- a/src/common/transformations/src/transformations/common_optimizations/remove_multi_subgraph_op_dangling_params.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/remove_multi_subgraph_op_dangling_params.cpp
@@ -41,7 +41,7 @@ bool ov::pass::RemoveMultiSubGraphOpDanglingParamsResults::run_on_model(const st
     auto ops = m->get_ordered_ops();
     // Going in reverse order
     for (auto it = ops.rbegin(); it != ops.rend(); ++it) {
-        auto multi_subgraph_op = std::dynamic_pointer_cast<MultiSubGraphOp>(*it);
+        auto multi_subgraph_op = ov::as_type_ptr<MultiSubGraphOp>(*it);
         if (!multi_subgraph_op)
             continue;
         auto if_op = ov::as_type_ptr<ov::op::v8::If>(multi_subgraph_op);

--- a/src/common/transformations/src/transformations/common_optimizations/reverse_shape_and_type_infer.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reverse_shape_and_type_infer.cpp
@@ -154,7 +154,7 @@ bool ov::pass::ReverseShapeAndTypeInfer::run_on_model(const std::shared_ptr<ov::
         } else if (ov::as_type_ptr<ov::op::v8::DeformableConvolution>(op)) {
             is_changed |= inherit_output_rank(op, {0, 1, 2, 3});
             is_changed |= inherit_output_type(op, {0, 1, 2, 3});
-        } else if (std::dynamic_pointer_cast<ov::op::util::PadBase>(op)) {
+        } else if (ov::as_type_ptr<ov::op::util::PadBase>(op)) {
             // Shape of pads_begin and pads_end must match rank of input
             if (op->get_input_partial_shape(0).rank().is_dynamic()) {
                 auto pads_begin_shape = op->get_input_partial_shape(1);
@@ -168,10 +168,10 @@ bool ov::pass::ReverseShapeAndTypeInfer::run_on_model(const std::shared_ptr<ov::
                 }
             }
             is_changed |= inherit_output_type(op, {0});
-        } else if (std::dynamic_pointer_cast<op::util::UnaryElementwiseArithmetic>(op)) {
+        } else if (ov::as_type_ptr<op::util::UnaryElementwiseArithmetic>(op)) {
             is_changed |= inherit_output_shape(op, {0});
             is_changed |= inherit_output_type(op, {0});
-        } else if (const auto& eltwise = std::dynamic_pointer_cast<op::util::BinaryElementwiseArithmetic>(op)) {
+        } else if (const auto& eltwise = ov::as_type_ptr<op::util::BinaryElementwiseArithmetic>(op)) {
             if (output_shape.rank().is_static()) {
                 auto in0_rank = op->get_input_partial_shape(0).rank();
                 auto in1_rank = op->get_input_partial_shape(1).rank();

--- a/src/common/transformations/src/transformations/common_optimizations/ric_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/ric_fusion.cpp
@@ -823,7 +823,7 @@ public:
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
         RUN_ON_FUNCTION_SCOPE(Constant);
         for (const auto& node : model->get_ordered_ops()) {
-            if ((std::dynamic_pointer_cast<op::util::BinaryElementwiseArithmetic>(node) ||
+            if ((ov::as_type_ptr<op::util::BinaryElementwiseArithmetic>(node) ||
                  ov::as_type_ptr<ov::op::v0::FakeQuantize>(node) || ov::as_type_ptr<ov::op::v0::Convert>(node)) &&
                 node->get_output_partial_shape(0).rank().is_static()) {
                 continue;

--- a/src/common/transformations/src/transformations/common_optimizations/sdpa_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sdpa_fusion.cpp
@@ -31,8 +31,7 @@ SDPAFusion::SDPAFusion() {
     auto mask = makePattern();
 
     auto k_transpose_order = pattern::wrap_type<ov::op::v0::Constant>([](const Output<Node>& node) {
-        auto axis_order =
-            std::dynamic_pointer_cast<ov::op::v0::Constant>(node.get_node_shared_ptr())->cast_vector<int64_t>();
+        auto axis_order = ov::as_type_ptr<ov::op::v0::Constant>(node.get_node_shared_ptr())->cast_vector<int64_t>();
         return axis_order == std::vector<int64_t>{0, 1, 3, 2};
     });
 

--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -102,7 +102,7 @@ bool check_lstm_cell(const shared_ptr<RNNCellBase>& prev_cell, const shared_ptr<
         const auto& target_inputs = prev_cell->get_output_target_inputs(1);
         bool valid = target_inputs.empty() ||
                      (target_inputs.size() == 1 &&
-                      dynamic_cast<RNNCellBase*>(target_inputs.begin()->get_node()) == current_cell.get() &&
+                      ov::as_type<RNNCellBase>(target_inputs.begin()->get_node()) == current_cell.get() &&
                       target_inputs.begin()->get_index() == 2);
 
         // if intermediate C output is connected to other node, except ov::op::v4::LSTMCell,

--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -33,8 +33,8 @@ using namespace ov::op::util;
 
 namespace {
 bool is_equal_consts(const shared_ptr<ov::Node>& l, const shared_ptr<ov::Node>& r) {
-    auto l_const = dynamic_pointer_cast<ov::op::v0::Constant>(l);
-    auto r_const = dynamic_pointer_cast<ov::op::v0::Constant>(r);
+    auto l_const = ov::as_type_ptr<ov::op::v0::Constant>(l);
+    auto r_const = ov::as_type_ptr<ov::op::v0::Constant>(r);
     if (l_const && r_const) {
         auto l_ptr = l_const->get_data_ptr();
         auto r_ptr = r_const->get_data_ptr();
@@ -52,14 +52,14 @@ bool check_WRB(const shared_ptr<RNNCellBase>& cell_1, const shared_ptr<RNNCellBa
         ++idx_R;
         ++idx_W;
     };
-    auto lstm_cell_v4_1 = dynamic_pointer_cast<ov::op::v4::LSTMCell>(cell_1);
-    auto lstm_cell_v4_2 = dynamic_pointer_cast<ov::op::v4::LSTMCell>(cell_2);
+    auto lstm_cell_v4_1 = ov::as_type_ptr<ov::op::v4::LSTMCell>(cell_1);
+    auto lstm_cell_v4_2 = ov::as_type_ptr<ov::op::v4::LSTMCell>(cell_2);
     // 2nd input is Cell State
     if (lstm_cell_v4_1 && lstm_cell_v4_2) {
         increase_indexes();
     }
-    auto lstm_cell_v0_1 = dynamic_pointer_cast<ov::op::v0::LSTMCell>(cell_1);
-    auto lstm_cell_v0_2 = dynamic_pointer_cast<ov::op::v0::LSTMCell>(cell_2);
+    auto lstm_cell_v0_1 = ov::as_type_ptr<ov::op::v0::LSTMCell>(cell_1);
+    auto lstm_cell_v0_2 = ov::as_type_ptr<ov::op::v0::LSTMCell>(cell_2);
     if (lstm_cell_v0_1 && lstm_cell_v0_2) {
         if (lstm_cell_v0_1->get_weights_format() != lstm_cell_v0_2->get_weights_format() ||
             lstm_cell_v0_1->get_input_forget() != lstm_cell_v0_2->get_input_forget()) {
@@ -81,8 +81,8 @@ bool check_WRB(const shared_ptr<RNNCellBase>& cell_1, const shared_ptr<RNNCellBa
 
 bool is_equal_cells(const shared_ptr<RNNCellBase>& cell_1, const shared_ptr<RNNCellBase>& cell_2) {
     bool is_equal = true;
-    auto gru_cell_1 = dynamic_pointer_cast<ov::op::v3::GRUCell>(cell_1);
-    auto gru_cell_2 = dynamic_pointer_cast<ov::op::v3::GRUCell>(cell_2);
+    auto gru_cell_1 = ov::as_type_ptr<ov::op::v3::GRUCell>(cell_1);
+    auto gru_cell_2 = ov::as_type_ptr<ov::op::v3::GRUCell>(cell_2);
     if (gru_cell_1 && gru_cell_2) {
         is_equal = gru_cell_1->get_linear_before_reset() == gru_cell_2->get_linear_before_reset();
     }
@@ -98,8 +98,7 @@ bool is_equal_cells(const shared_ptr<RNNCellBase>& cell_1, const shared_ptr<RNNC
 bool check_lstm_cell(const shared_ptr<RNNCellBase>& prev_cell, const shared_ptr<RNNCellBase>& current_cell) {
     // check intermediate C outputs in case of LSTMCell
     // LSTMCell - C -> LSTMCell
-    if ((dynamic_pointer_cast<ov::op::v4::LSTMCell>(prev_cell) ||
-         dynamic_pointer_cast<ov::op::v0::LSTMCell>(prev_cell))) {
+    if ((ov::as_type_ptr<ov::op::v4::LSTMCell>(prev_cell) || ov::as_type_ptr<ov::op::v0::LSTMCell>(prev_cell))) {
         const auto& target_inputs = prev_cell->get_output_target_inputs(1);
         bool valid = target_inputs.empty() ||
                      (target_inputs.size() == 1 &&
@@ -127,7 +126,7 @@ shared_ptr<RNNCellBase> find_cell_chain(ov::pass::NodeRegistry& cp_from,
         cp_from.add(current);
         // check the source node of HiddenState input
         auto prev = current->input_value(1).get_node_shared_ptr();
-        auto prev_cell = dynamic_pointer_cast<RNNCellBase>(prev);
+        auto prev_cell = ov::as_type_ptr<RNNCellBase>(prev);
 
         auto in_X = current->input(0);
         x_to_concat.push_back(cp_to.make<ov::op::v0::Unsqueeze>(in_X.get_source_output(), axis_1));
@@ -162,8 +161,7 @@ bool create_sequence(ov::pass::NodeRegistry& cp_to,
     int64_t idx_W = 2, idx_R = 3, idx_B = 4;
     // 2nd input is Cell State
     bool is_lstm = false;
-    if (dynamic_pointer_cast<ov::op::v4::LSTMCell>(last_cell) ||
-        dynamic_pointer_cast<ov::op::v0::LSTMCell>(last_cell)) {
+    if (ov::as_type_ptr<ov::op::v4::LSTMCell>(last_cell) || ov::as_type_ptr<ov::op::v0::LSTMCell>(last_cell)) {
         is_lstm = true;
         idx_B++;
         idx_R++;
@@ -184,7 +182,7 @@ bool create_sequence(ov::pass::NodeRegistry& cp_to,
         cp_to.add(ov::op::util::make_try_fold<ov::op::v3::Broadcast>(seq_lengths_scalar, batch_dimension));
     shared_ptr<ov::Node> sequence;
     ov::OutputVector outputs(1);
-    if (dynamic_pointer_cast<ov::op::v4::LSTMCell>(first_cell)) {
+    if (ov::as_type_ptr<ov::op::v4::LSTMCell>(first_cell)) {
         const auto Ct_in = cp_to.make<ov::op::v0::Unsqueeze>(first_cell->input_value(2), axis_1);
         sequence = cp_to.make<ov::op::v5::LSTMSequence>(X_in,
                                                         Ht_in,
@@ -201,7 +199,7 @@ bool create_sequence(ov::pass::NodeRegistry& cp_to,
                                                         first_cell->get_clip());
         outputs.resize(2);
         outputs[1] = cp_to.make<ov::op::v0::Squeeze>(sequence->output(2), axis_1);
-    } else if (auto lstm_cell_v0 = dynamic_pointer_cast<ov::op::v0::LSTMCell>(first_cell)) {
+    } else if (auto lstm_cell_v0 = ov::as_type_ptr<ov::op::v0::LSTMCell>(first_cell)) {
         // input_forget modification is not supported
         if (lstm_cell_v0->get_input_forget()) {
             return false;
@@ -229,7 +227,7 @@ bool create_sequence(ov::pass::NodeRegistry& cp_to,
                                                         first_cell->get_clip());
         outputs.resize(2);
         outputs[1] = cp_to.make<ov::op::v0::Squeeze>(sequence->output(2), axis_1);
-    } else if (auto gru_cell = dynamic_pointer_cast<ov::op::v3::GRUCell>(first_cell)) {
+    } else if (auto gru_cell = ov::as_type_ptr<ov::op::v3::GRUCell>(first_cell)) {
         sequence = cp_to.make<ov::op::v5::GRUSequence>(X_in,
                                                        Ht_in,
                                                        sequence_lengths_in,
@@ -243,7 +241,7 @@ bool create_sequence(ov::pass::NodeRegistry& cp_to,
                                                        first_cell->get_activations_beta(),
                                                        first_cell->get_clip(),
                                                        gru_cell->get_linear_before_reset());
-    } else if (dynamic_pointer_cast<ov::op::v0::RNNCell>(first_cell)) {
+    } else if (ov::as_type_ptr<ov::op::v0::RNNCell>(first_cell)) {
         sequence = cp_to.make<ov::op::v5::RNNSequence>(X_in,
                                                        Ht_in,
                                                        sequence_lengths_in,
@@ -307,7 +305,7 @@ ov::pass::SequenceFusion::SequenceFusion() {
         NodeRegistry copy_from;
         NodeRegistry copy_to;
         auto cell = m.get_match_root();
-        shared_ptr<RNNCellBase> current_cell = dynamic_pointer_cast<RNNCellBase>(cell);
+        shared_ptr<RNNCellBase> current_cell = ov::as_type_ptr<RNNCellBase>(cell);
         if (!current_cell) {
             return false;
         }
@@ -315,7 +313,7 @@ ov::pass::SequenceFusion::SequenceFusion() {
         // GRUCell -> GRUCell (the last cell) -> OtherNode
         // GRUCell (hidden_size = 128) -> GRUCell (hs = 128, the last) -> GRUCell (hs = 64)
         for (const auto& target : cell->get_output_target_inputs(0)) {
-            auto cell_1 = dynamic_pointer_cast<RNNCellBase>(target.get_node()->shared_from_this());
+            auto cell_1 = ov::as_type_ptr<RNNCellBase>(target.get_node()->shared_from_this());
             if (cell_1 && is_equal_cells(cell_1, current_cell)) {
                 return false;
             }

--- a/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sequence_fusion.cpp
@@ -132,7 +132,7 @@ shared_ptr<RNNCellBase> find_cell_chain(ov::pass::NodeRegistry& cp_from,
         x_to_concat.push_back(cp_to.make<ov::op::v0::Unsqueeze>(in_X.get_source_output(), axis_1));
         h_outputs_to_redirect[cells_cnt] = current->output(0);
 
-        if (auto augru = dynamic_pointer_cast<ov::op::internal::AUGRUCell>(current)) {
+        if (auto augru = ov::as_type_ptr<ov::op::internal::AUGRUCell>(current)) {
             attention_to_concat.push_back(cp_to.make<ov::op::v0::Unsqueeze>(augru->input_value(5), axis_1));
         }
 
@@ -254,7 +254,7 @@ bool create_sequence(ov::pass::NodeRegistry& cp_to,
                                                        first_cell->get_activations_alpha(),
                                                        first_cell->get_activations_beta(),
                                                        first_cell->get_clip());
-    } else if (dynamic_pointer_cast<ov::op::internal::AUGRUCell>(first_cell)) {
+    } else if (ov::as_type_ptr<ov::op::internal::AUGRUCell>(first_cell)) {
         const auto A_in = cp_to.make<ov::op::v0::Concat>(attention_to_concat, 1);
         sequence = cp_to.make<ov::op::internal::AUGRUSequence>(X_in,
                                                                Ht_in,

--- a/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
@@ -109,7 +109,7 @@ bool shared_node_optimization(const shared_ptr<Model>& model) {
         index_map[order[i]] = i;
     for (const auto& op : order) {
         // Recursively apply transformation for sub-graph based operations
-        if (auto multi_subgraph_op = dynamic_pointer_cast<op::util::MultiSubGraphOp>(op)) {
+        if (auto multi_subgraph_op = ov::as_type_ptr<op::util::MultiSubGraphOp>(op)) {
             for (const auto& sub_graph : multi_subgraph_op->get_functions()) {
                 if (sub_graph)
                     rewritten = shared_node_optimization(sub_graph) || rewritten;
@@ -168,7 +168,7 @@ bool shape_of_upgrade(const shared_ptr<Model>& model) {
     bool rewritten = false;
     for (const auto& op : model->get_ordered_ops()) {
         // Recursively apply transformation for sub-graph based operations
-        if (auto multi_subgraph_op = dynamic_pointer_cast<op::util::MultiSubGraphOp>(op)) {
+        if (auto multi_subgraph_op = ov::as_type_ptr<op::util::MultiSubGraphOp>(op)) {
             for (const auto& sub_graph : multi_subgraph_op->get_functions()) {
                 if (sub_graph)
                     rewritten = shape_of_upgrade(sub_graph) || rewritten;

--- a/src/common/transformations/src/transformations/common_optimizations/space_to_batch_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/space_to_batch_fusion.cpp
@@ -93,7 +93,7 @@ ov::pass::SpaceToBatchFusion::SpaceToBatchFusion() {
         if (!check_input_output_shape(reshape_or_trans_after))
             return false;
 
-        auto pad = std::dynamic_pointer_cast<op::util::PadBase>(pattern_map.at(pad_pattern).get_node_shared_ptr());
+        auto pad = ov::as_type_ptr<op::util::PadBase>(pattern_map.at(pad_pattern).get_node_shared_ptr());
         if (!pad || pad->get_pad_mode() != op::PadMode::CONSTANT)
             return false;
         auto pad_value_const = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(pad_value).get_node_shared_ptr());

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -164,8 +164,8 @@ ov::pass::TransposeReduction::TransposeReduction() {
 
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
         auto reduction = pattern_to_output.at(reduce_or_squeeze_label).get_node_shared_ptr();
-        auto arithmetic_reduce = std::dynamic_pointer_cast<op::util::ArithmeticReductionKeepDims>(reduction);
-        auto logical_reduce = std::dynamic_pointer_cast<op::util::LogicalReductionKeepDims>(reduction);
+        auto arithmetic_reduce = ov::as_type_ptr<op::util::ArithmeticReductionKeepDims>(reduction);
+        auto logical_reduce = ov::as_type_ptr<op::util::LogicalReductionKeepDims>(reduction);
         auto squeeze = ov::as_type_ptr<ov::op::v0::Squeeze>(reduction);
         if (!transpose || !(arithmetic_reduce || logical_reduce || squeeze))
             return false;

--- a/src/common/transformations/src/transformations/control_flow/unroll_if.cpp
+++ b/src/common/transformations/src/transformations/control_flow/unroll_if.cpp
@@ -20,7 +20,7 @@ bool ov::pass::UnrollIf::run_on_model(const std::shared_ptr<ov::Model>& f) {
     RUN_ON_FUNCTION_SCOPE(UnrollIf);
     bool is_applicable = false;
     for (const auto& op : f->get_ordered_ops()) {
-        auto multisubgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(op);
+        auto multisubgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(op);
         if (multisubgraph_op) {
             for (size_t i = 0; i < multisubgraph_op->get_internal_subgraphs_size(); ++i) {
                 run_on_model(multisubgraph_op->get_function(static_cast<int>(i)));

--- a/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
@@ -25,7 +25,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
     for (const auto& op : f->get_ops()) {
         ov::op::util::process_subgraph(*this, op);
 
-        auto sub_graph_op = std::dynamic_pointer_cast<op::util::SubGraphOp>(op);
+        auto sub_graph_op = ov::as_type_ptr<op::util::SubGraphOp>(op);
         if (!sub_graph_op || transformation_callback(sub_graph_op)) {
             continue;
         }
@@ -52,8 +52,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
 
         // Port map : inputs and back edges
         for (const auto& desc : sub_graph_op->get_input_descriptions()) {
-            if (const auto& input_desc =
-                    std::dynamic_pointer_cast<ov::op::v0::TensorIterator::SliceInputDescription>(desc)) {
+            if (const auto& input_desc = ov::as_type_ptr<ov::op::v0::TensorIterator::SliceInputDescription>(desc)) {
                 // Connect the sliced input (layer before the input) to the Split layer and connect
                 // the corresponding Split output to the corresponding copy of the body.
                 // If the number of iterations is 1, then the Split is not needed.
@@ -81,7 +80,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
                     }
                 }
             } else if (const auto& merged_desc =
-                           std::dynamic_pointer_cast<ov::op::v0::TensorIterator::MergedInputDescription>(desc)) {
+                           ov::as_type_ptr<ov::op::v0::TensorIterator::MergedInputDescription>(desc)) {
                 // Connect the input to the corresponding copy of the body.
                 auto in_data = sub_graph_op->input_values()[merged_desc->m_input_index];
                 const auto& param = body_functions[0]->get_parameters()[merged_desc->m_body_parameter_index];
@@ -98,7 +97,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
                     }
                 }
             } else if (const auto& invariant_desc =
-                           std::dynamic_pointer_cast<ov::op::v0::TensorIterator::InvariantInputDescription>(desc)) {
+                           ov::as_type_ptr<ov::op::v0::TensorIterator::InvariantInputDescription>(desc)) {
                 // Connect the input to the corresponding copy of the body.
                 auto in_data = sub_graph_op->input_values()[invariant_desc->m_input_index];
                 for (int64_t j = 0; j < num_iter; j++) {
@@ -155,7 +154,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
                     }
                 }
             } else if (const auto& output_desc =
-                           std::dynamic_pointer_cast<ov::op::v0::TensorIterator::BodyOutputDescription>(desc)) {
+                           ov::as_type_ptr<ov::op::v0::TensorIterator::BodyOutputDescription>(desc)) {
                 // Connect outputs of the bodies to the corresponding TI outputs
                 auto iter = output_desc->m_iteration;
                 iter = iter >= 0 ? iter : num_iter - 1;

--- a/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
@@ -114,8 +114,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
 
         // Port map: outputs
         for (const auto& desc : sub_graph_op->get_output_descriptions()) {
-            if (const auto& concat_desc =
-                    ov::as_type_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>(desc)) {
+            if (const auto& concat_desc = ov::as_type_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>(desc)) {
                 if (!concat_desc) {
                     return false;
                 }

--- a/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
+++ b/src/common/transformations/src/transformations/control_flow/unroll_tensor_iterator.cpp
@@ -115,7 +115,7 @@ bool ov::pass::UnrollTensorIterator::run_on_model(const std::shared_ptr<ov::Mode
         // Port map: outputs
         for (const auto& desc : sub_graph_op->get_output_descriptions()) {
             if (const auto& concat_desc =
-                    std::dynamic_pointer_cast<ov::op::v0::TensorIterator::ConcatOutputDescription>(desc)) {
+                    ov::as_type_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>(desc)) {
                 if (!concat_desc) {
                     return false;
                 }

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -274,7 +274,7 @@ bool convert_function_precision(ov::pass::PassBase& pass,
         if (skip_precision_sensitive && fp16_compression_is_disabled(node) && has_fp16_compression)
             continue;
         // Recursively apply transformation for sub-graph based operations
-        if (auto sub_graph_node = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(node)) {
+        if (auto sub_graph_node = ov::as_type_ptr<op::util::MultiSubGraphOp>(node)) {
             size_t sub_graphs_num = sub_graph_node->get_internal_subgraphs_size();
             for (size_t sub_graph_ind = 0; sub_graph_ind < sub_graphs_num; ++sub_graph_ind) {
                 is_changed = convert_function_precision(pass,
@@ -400,7 +400,7 @@ precisions_set_t find_all_used_precisions(const std::shared_ptr<ov::Model>& fn) 
         for (const auto& output : node->outputs()) {
             used_precisions.emplace(output.get_element_type());
         }
-        if (auto sub_graph_node = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node)) {
+        if (auto sub_graph_node = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
             size_t sub_graphs_num = sub_graph_node->get_internal_subgraphs_size();
             for (size_t sub_graph_ind = 0; sub_graph_ind < sub_graphs_num; ++sub_graph_ind) {
                 auto sub_graph_precisions =
@@ -1050,7 +1050,7 @@ bool extend_select_type(const std::shared_ptr<ov::Node>& node, const precisions_
 }
 
 bool extend_reverse_type(const std::shared_ptr<ov::Node>& node, const precisions_map& precisions) {
-    if (const auto casted = std::dynamic_pointer_cast<ov::op::v1::Reverse>(node)) {
+    if (const auto casted = ov::as_type_ptr<ov::op::v1::Reverse>(node)) {
         if (casted->get_mode() == ov::op::v1::Reverse::Mode::MASK) {
             auto relaxed_op = std::make_shared<op::TypeRelaxed<ov::op::v1::Reverse>>(
                 *casted,

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -79,7 +79,7 @@ bool fuse_type_to_binary_comparision(const std::shared_ptr<ov::Node>& node, cons
     if (auto type_relaxed = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(node)) {
         type_relaxed->set_overridden_output_type(to);
         return true;
-    } else if (auto casted = std::dynamic_pointer_cast<T>(node)) {
+    } else if (auto casted = ov::as_type_ptr<T>(node)) {
         auto relaxed_op =
             std::make_shared<ov::op::TypeRelaxed<T>>(*casted, ov::element::TypeVector{}, ov::element::TypeVector{to});
         replace_node(node, relaxed_op);
@@ -99,7 +99,7 @@ bool fuse_type_to_logical(const std::shared_ptr<ov::Node>& node, const precision
         for (size_t i = 0; i < node->get_input_size(); ++i)
             type_relaxed->set_origin_input_type(ov::element::boolean, i);
         return true;
-    } else if (auto casted = std::dynamic_pointer_cast<T>(node)) {
+    } else if (auto casted = ov::as_type_ptr<T>(node)) {
         ov::element::TypeVector input_types(node->get_input_size(), ov::element::boolean);
         auto relaxed_op = std::make_shared<ov::op::TypeRelaxed<T>>(*casted, input_types, ov::element::TypeVector{to});
         replace_node(node, relaxed_op);
@@ -118,7 +118,7 @@ bool fuse_type_to_reduce_logical(const std::shared_ptr<ov::Node>& node, const pr
         type_relaxed->set_overridden_output_type(to);
         type_relaxed->set_origin_input_type(ov::element::boolean, 0);
         return true;
-    } else if (auto casted = std::dynamic_pointer_cast<T>(node)) {
+    } else if (auto casted = ov::as_type_ptr<T>(node)) {
         auto relaxed_op = std::make_shared<ov::op::TypeRelaxed<T>>(*casted,
                                                                    ov::element::TypeVector{ov::element::boolean},
                                                                    ov::element::TypeVector{to});
@@ -139,7 +139,7 @@ bool fuse_type_to_prior_box(const std::shared_ptr<ov::Node>& node, const precisi
     if (auto type_relaxed = std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(node)) {
         type_relaxed->set_overridden_output_type(to);
         return true;
-    } else if (const auto casted = std::dynamic_pointer_cast<T>(node)) {
+    } else if (const auto casted = ov::as_type_ptr<T>(node)) {
         auto relaxed_op = std::make_shared<op::TypeRelaxed<T>>(
             *casted,
             ov::element::TypeVector{casted->get_input_element_type(0), casted->get_input_element_type(1)},

--- a/src/common/transformations/src/transformations/flush_fp32_subnormals_to_zero.cpp
+++ b/src/common/transformations/src/transformations/flush_fp32_subnormals_to_zero.cpp
@@ -22,7 +22,7 @@ ov::pass::FlushFP32SubnormalsToZero::FlushFP32SubnormalsToZero() {
     auto node_pattern = pattern::wrap_type<ov::op::v0::Constant>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto node = dynamic_pointer_cast<ov::op::v0::Constant>(m.get_match_root());
+        auto node = ov::as_type_ptr<ov::op::v0::Constant>(m.get_match_root());
 
         if (!node)
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/batch_norm_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/batch_norm_decomposition.cpp
@@ -44,14 +44,14 @@ ov::pass::BatchNormDecomposition::BatchNormDecomposition() {
         auto m_bn = m.get_match_root();
         Output<Node> m_input, m_gamma, m_beta, m_mean, m_var;
         double eps;
-        if (auto m_bn_v1 = dynamic_pointer_cast<ov::op::v0::BatchNormInference>(m_bn)) {
+        if (auto m_bn_v1 = ov::as_type_ptr<ov::op::v0::BatchNormInference>(m_bn)) {
             m_gamma = m_bn_v1->input_value(0);
             m_beta = m_bn_v1->input_value(1);
             m_input = m_bn_v1->input_value(2);
             m_mean = m_bn_v1->input_value(3);
             m_var = m_bn_v1->input_value(4);
             eps = m_bn_v1->get_eps_value();
-        } else if (auto m_bn_v5 = dynamic_pointer_cast<ov::op::v5::BatchNormInference>(m_bn)) {
+        } else if (auto m_bn_v5 = ov::as_type_ptr<ov::op::v5::BatchNormInference>(m_bn)) {
             m_input = m_bn_v5->input_value(0);
             m_gamma = m_bn_v5->input_value(1);
             m_beta = m_bn_v5->input_value(2);

--- a/src/common/transformations/src/transformations/op_conversions/convert_batch_to_space.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_batch_to_space.cpp
@@ -33,7 +33,7 @@ void ov::pass::ConvertBatchToSpace::convert_batch_to_space() {
     MATCHER_SCOPE(ConvertBatchToSpace_convert_batch_to_space);
     const auto batch_to_space = pattern::wrap_type<ov::op::v1::BatchToSpace>();
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        const auto batch_to_space = dynamic_pointer_cast<ov::op::v1::BatchToSpace>(m.get_match_root());
+        const auto batch_to_space = ov::as_type_ptr<ov::op::v1::BatchToSpace>(m.get_match_root());
         if (!batch_to_space || transformation_callback(batch_to_space)) {
             return false;
         }
@@ -120,7 +120,7 @@ void ov::pass::ConvertBatchToSpace::convert_batch_to_space_by_elements() {
     MATCHER_SCOPE(ConvertBatchToSpace_convert_batch_to_space_by_elements);
     const auto batch_to_space = pattern::wrap_type<ov::op::v1::BatchToSpace>();
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        const auto batch_to_space = dynamic_pointer_cast<ov::op::v1::BatchToSpace>(m.get_match_root());
+        const auto batch_to_space = ov::as_type_ptr<ov::op::v1::BatchToSpace>(m.get_match_root());
         if (!batch_to_space || transformation_callback(batch_to_space)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
@@ -71,8 +71,8 @@ ov::pass::ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnected
         OPENVINO_ASSERT(pattern_map.count(weights_m));
         OPENVINO_ASSERT(pattern_map.count(bias_m));
         OPENVINO_ASSERT(pattern_map.count(convert_m));
-        auto fc = ov::as_type_ptr<ov::op::internal::FullyConnected>(
-            pattern_map.at(fully_connected_m).get_node_shared_ptr());
+        auto fc =
+            ov::as_type_ptr<ov::op::internal::FullyConnected>(pattern_map.at(fully_connected_m).get_node_shared_ptr());
         if (!fc || transformation_callback(fc)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
@@ -93,7 +93,7 @@ ov::pass::ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnected
             return false;
 
         auto reshape_const_to_2d = [has_transpose, grouped](std::shared_ptr<ov::Node> node) {
-            auto constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
             OPENVINO_ASSERT(constant != nullptr);
             ov::Shape current_shape = constant->get_shape();
             if (current_shape.size() <= 2)
@@ -109,7 +109,7 @@ ov::pass::ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnected
         };
 
         auto convert_u4const_to_u8 = [convert_u4zp_to_u8](std::shared_ptr<ov::Node> node) -> std::shared_ptr<ov::Node> {
-            auto constant = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(node);
             if (constant->get_element_type() != ov::element::u4 || !convert_u4zp_to_u8)
                 return std::dynamic_pointer_cast<ov::Node>(constant);
             return std::make_shared<ov::op::v0::Convert>(node, ov::element::u8);

--- a/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_fc_to_compressed.cpp
@@ -71,7 +71,7 @@ ov::pass::ConvertFullyConnectedToFullyConnectedCompressed::ConvertFullyConnected
         OPENVINO_ASSERT(pattern_map.count(weights_m));
         OPENVINO_ASSERT(pattern_map.count(bias_m));
         OPENVINO_ASSERT(pattern_map.count(convert_m));
-        auto fc = std::dynamic_pointer_cast<ov::op::internal::FullyConnected>(
+        auto fc = ov::as_type_ptr<ov::op::internal::FullyConnected>(
             pattern_map.at(fully_connected_m).get_node_shared_ptr());
         if (!fc || transformation_callback(fc)) {
             return false;

--- a/src/common/transformations/src/transformations/op_conversions/convert_fc_to_quantized_legacy.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_fc_to_quantized_legacy.cpp
@@ -48,8 +48,8 @@ ov::pass::ConvertFCToFCQuantizedLegacy::ConvertFCToFCQuantizedLegacy() {
             return false;
         }
 
-        auto fc_node = ov::as_type_ptr<ov::op::internal::FullyConnected>(
-            pattern_map.at(fully_connected_m).get_node_shared_ptr());
+        auto fc_node =
+            ov::as_type_ptr<ov::op::internal::FullyConnected>(pattern_map.at(fully_connected_m).get_node_shared_ptr());
 
         ov::NodeVector new_ops;
         auto zp = std::make_shared<ov::op::v0::Constant>(element::undefined, Shape{0});

--- a/src/common/transformations/src/transformations/op_conversions/convert_fc_to_quantized_legacy.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_fc_to_quantized_legacy.cpp
@@ -48,7 +48,7 @@ ov::pass::ConvertFCToFCQuantizedLegacy::ConvertFCToFCQuantizedLegacy() {
             return false;
         }
 
-        auto fc_node = std::dynamic_pointer_cast<ov::op::internal::FullyConnected>(
+        auto fc_node = ov::as_type_ptr<ov::op::internal::FullyConnected>(
             pattern_map.at(fully_connected_m).get_node_shared_ptr());
 
         ov::NodeVector new_ops;

--- a/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie.cpp
@@ -21,7 +21,7 @@ pass::ConvertMulticlassNmsToMulticlassNmsIE::ConvertMulticlassNmsToMulticlassNms
     auto nms = pattern::wrap_type<op::util::MulticlassNmsBase>();
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](pattern::Matcher& m) {
-        auto nms = std::dynamic_pointer_cast<op::util::MulticlassNmsBase>(m.get_match_root());
+        auto nms = ov::as_type_ptr<op::util::MulticlassNmsBase>(m.get_match_root());
         if (!nms || transformation_callback(nms)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_pad_to_group_conv.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_pad_to_group_conv.cpp
@@ -20,7 +20,7 @@ ov::pass::ConvertPadToGroupConvolution::ConvertPadToGroupConvolution() {
     auto neg = ov::pass::pattern::wrap_type<op::util::PadBase>(pattern::has_static_dim(1));
 
     matcher_pass_callback callback = [](pattern::Matcher& m) {
-        auto pad = std::dynamic_pointer_cast<ov::op::util::PadBase>(m.get_match_root());
+        auto pad = ov::as_type_ptr<ov::op::util::PadBase>(m.get_match_root());
         if (!pad) {
             return false;
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_space_to_batch.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_space_to_batch.cpp
@@ -31,7 +31,7 @@ void ov::pass::ConvertSpaceToBatch::convert_space_to_batch() {
     MATCHER_SCOPE(ConvertSpaceToBatch_convert_space_to_batch);
     const auto space_to_batch = pattern::wrap_type<ov::op::v1::SpaceToBatch>();
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        const auto space_to_batch = dynamic_pointer_cast<ov::op::v1::SpaceToBatch>(m.get_match_root());
+        const auto space_to_batch = ov::as_type_ptr<ov::op::v1::SpaceToBatch>(m.get_match_root());
         if (!space_to_batch || transformation_callback(space_to_batch)) {
             return false;
         }
@@ -128,7 +128,7 @@ void ov::pass::ConvertSpaceToBatch::convert_space_to_batch_by_elements() {
     MATCHER_SCOPE(ConvertSpaceToBatch_convert_space_to_batch_by_elements);
     const auto space_to_batch = pattern::wrap_type<ov::op::v1::SpaceToBatch>();
     matcher_pass_callback callback = [this](pattern::Matcher& m) {
-        const auto space_to_batch = dynamic_pointer_cast<ov::op::v1::SpaceToBatch>(m.get_match_root());
+        const auto space_to_batch = ov::as_type_ptr<ov::op::v1::SpaceToBatch>(m.get_match_root());
         if (!space_to_batch || transformation_callback(space_to_batch)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -98,7 +98,7 @@ bool convertTensorIteratorToSequence(const std::shared_ptr<ov::op::v0::TensorIte
         std::shared_ptr<ov::op::v0::Result> res = results[output_desc->m_body_value_index];
         if (res->input_value(0) == unsqueeze_after_cell) {
             auto concat_output =
-                std::dynamic_pointer_cast<ov::op::v0::TensorIterator::ConcatOutputDescription>(output_desc);
+                ov::as_type_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>(output_desc);
             if (!concat_output)
                 return false;
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -97,8 +97,7 @@ bool convertTensorIteratorToSequence(const std::shared_ptr<ov::op::v0::TensorIte
     for (const auto& output_desc : ti->get_output_descriptions()) {
         std::shared_ptr<ov::op::v0::Result> res = results[output_desc->m_body_value_index];
         if (res->input_value(0) == unsqueeze_after_cell) {
-            auto concat_output =
-                ov::as_type_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>(output_desc);
+            auto concat_output = ov::as_type_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>(output_desc);
             if (!concat_output)
                 return false;
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -70,7 +70,7 @@ bool convertTensorIteratorToSequence(const std::shared_ptr<ov::op::v0::TensorIte
     for (const auto& input_desc : ti->get_input_descriptions()) {
         auto param = params[input_desc->m_body_parameter_index];
         if (param == data.get_node_shared_ptr()) {
-            auto slice_input = std::dynamic_pointer_cast<ov::op::v0::TensorIterator::SliceInputDescription>(input_desc);
+            auto slice_input = ov::as_type_ptr<ov::op::v0::TensorIterator::SliceInputDescription>(input_desc);
             if (!slice_input)
                 return false;
 
@@ -568,7 +568,7 @@ ov::pass::ConvertTensorIteratorToLSTMSequence::ConvertTensorIteratorToLSTMSequen
 
         const auto& pattern_map = matcher.get_pattern_value_map();
         std::shared_ptr<Node> found_cell = pattern_map.at(cell).get_node_shared_ptr();
-        const auto lstm_cell = std::dynamic_pointer_cast<ov::op::util::RNNCellBase>(found_cell);
+        const auto lstm_cell = ov::as_type_ptr<ov::op::util::RNNCellBase>(found_cell);
         if (lstm_cell == nullptr)
             return false;
 
@@ -859,7 +859,7 @@ ov::pass::ConvertLoopWithScatterUpdateToLSTMSequence::ConvertLoopWithScatterUpda
         if (output_descs.size() != 1)
             return false;
         const auto body_output_desc =
-            std::dynamic_pointer_cast<op::util::MultiSubGraphOp::BodyOutputDescription>(output_descs[0]);
+            ov::as_type_ptr<op::util::MultiSubGraphOp::BodyOutputDescription>(output_descs[0]);
         if (!body_output_desc || body_output_desc->m_iteration != -1)
             return false;
 
@@ -932,7 +932,7 @@ ov::pass::ConvertLoopWithScatterUpdateToLSTMSequence::ConvertLoopWithScatterUpda
         const auto& input_descs = loop->get_input_descriptions();
         for (const auto& desc : input_descs) {
             if (body_parameters[desc->m_body_parameter_index] == X_body) {
-                if (!std::dynamic_pointer_cast<op::util::MultiSubGraphOp::InvariantInputDescription>(desc)) {
+                if (!ov::as_type_ptr<op::util::MultiSubGraphOp::InvariantInputDescription>(desc)) {
                     return false;
                 }
                 if (loop->input_value(desc->m_input_index) != pattern_map.at(scatter_label)) {
@@ -940,7 +940,7 @@ ov::pass::ConvertLoopWithScatterUpdateToLSTMSequence::ConvertLoopWithScatterUpda
                 }
             }
             if (body_parameters[desc->m_body_parameter_index] == H_body) {
-                auto merged_desc = std::dynamic_pointer_cast<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
+                auto merged_desc = ov::as_type_ptr<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
                 if (!merged_desc) {
                     return false;
                 }
@@ -951,7 +951,7 @@ ov::pass::ConvertLoopWithScatterUpdateToLSTMSequence::ConvertLoopWithScatterUpda
                 }
             }
             if (body_parameters[desc->m_body_parameter_index] == C_body) {
-                auto merged_desc = std::dynamic_pointer_cast<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
+                auto merged_desc = ov::as_type_ptr<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
                 if (!merged_desc) {
                     return false;
                 }
@@ -962,13 +962,13 @@ ov::pass::ConvertLoopWithScatterUpdateToLSTMSequence::ConvertLoopWithScatterUpda
                 }
             }
             if (body_parameters[desc->m_body_parameter_index] == sequence_index) {
-                auto merged_desc = std::dynamic_pointer_cast<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
+                auto merged_desc = ov::as_type_ptr<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
                 if (!merged_desc) {
                     return false;
                 }
             }
             if (body_parameters[desc->m_body_parameter_index] == iteration_counter) {
-                auto merged_desc = std::dynamic_pointer_cast<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
+                auto merged_desc = ov::as_type_ptr<op::util::MultiSubGraphOp::MergedInputDescription>(desc);
                 if (!merged_desc) {
                     return false;
                 }

--- a/src/common/transformations/src/transformations/op_conversions/convert_xor_to_logical_xor.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_xor_to_logical_xor.cpp
@@ -16,7 +16,7 @@ ov::pass::ConvertXorToLogicalXor::ConvertXorToLogicalXor() {
     auto xor_v1 = pattern::wrap_type<ov::op::v0::Xor>();
 
     matcher_pass_callback callback = [=](pattern::Matcher& m) {
-        auto xor_v1_node = std::dynamic_pointer_cast<ov::op::v0::Xor>(m.get_match_root());
+        auto xor_v1_node = ov::as_type_ptr<ov::op::v0::Xor>(m.get_match_root());
         if (!xor_v1_node)
             return false;
 

--- a/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/lstm_cell_decomposition.cpp
@@ -24,7 +24,7 @@ ov::pass::LSTMCellDecomposition::LSTMCellDecomposition() {
     auto any_lstm = pattern::wrap_type<ov::op::v0::LSTMCell, ov::op::v4::LSTMCell>();
 
     matcher_pass_callback callback = [this](ov::pass::pattern::Matcher& m) {
-        auto lstm_cell = std::dynamic_pointer_cast<op::util::RNNCellBase>(m.get_match_root());
+        auto lstm_cell = ov::as_type_ptr<op::util::RNNCellBase>(m.get_match_root());
         if (!lstm_cell || transformation_callback(lstm_cell)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
@@ -104,7 +104,7 @@ shared_ptr<ov::Node> deduce_outer_source_of_batch_for_inner_lstm_cell(
 }
 
 bool broadcast_state_by_batch(ov::Input<ov::Node> input, const shared_ptr<ov::Node>& batch_delivering_node) {
-    auto constant_state = dynamic_pointer_cast<ov::op::v0::Constant>(input.get_source_output().get_node_shared_ptr());
+    auto constant_state = ov::as_type_ptr<ov::op::v0::Constant>(input.get_source_output().get_node_shared_ptr());
     if (constant_state == nullptr)
         return false;
     const auto& constant_shape = constant_state->get_shape();
@@ -132,11 +132,11 @@ bool relax_batch_for_initial_states_of_lstm_in_ti(const shared_ptr<ov::op::v0::T
     auto batch_delivering_node = deduce_outer_source_of_batch_for_inner_lstm_cell(ti, lstm_cell);
     if (batch_delivering_node == nullptr)
         return rewritten;
-    if (auto init_hidden_state = dynamic_pointer_cast<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
+    if (auto init_hidden_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
         auto outer_init_hidden_state_input = get_outer_input_of_ti_by_parameter(init_hidden_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_hidden_state_input, batch_delivering_node) || rewritten;
     }
-    if (auto init_cell_state = dynamic_pointer_cast<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
+    if (auto init_cell_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
         auto outer_init_cell_state_input = get_outer_input_of_ti_by_parameter(init_cell_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_cell_state_input, batch_delivering_node) || rewritten;
     }
@@ -165,16 +165,16 @@ bool ov::pass::LSTMStatesBroadcast::run_on_model(const shared_ptr<ov::Model>& f)
         rewritten = ov::op::util::process_subgraph(*this, node) || rewritten;
 
         // Case without TI (LSTMCell and Constant are in the same ov::Model)
-        if (const auto& lstm_cell = dynamic_pointer_cast<ov::op::v4::LSTMCell>(node))
+        if (const auto& lstm_cell = ov::as_type_ptr<ov::op::v4::LSTMCell>(node))
             rewritten = relax_batch_for_initial_states_of_lstm(lstm_cell) || rewritten;
 
         // Case with TI (LSTMCell and Constant are in different ov::Model objects)
-        if (auto ti = dynamic_pointer_cast<ov::op::v0::TensorIterator>(node)) {
+        if (auto ti = ov::as_type_ptr<ov::op::v0::TensorIterator>(node)) {
             auto body = ti->get_body();
             if (body == nullptr)
                 continue;
             for (const auto& body_node : body->get_ordered_ops())
-                if (const auto& lstm_cell = dynamic_pointer_cast<ov::op::v4::LSTMCell>(body_node))
+                if (const auto& lstm_cell = ov::as_type_ptr<ov::op::v4::LSTMCell>(body_node))
                     rewritten = relax_batch_for_initial_states_of_lstm_in_ti(ti, lstm_cell) || rewritten;
         }
     }

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
@@ -52,7 +52,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check first Reshape eligibility: has a constant output pattern in a form of [-1, K]
         auto reshape = pattern_to_node.at(reshape_label);
         int64_t K = -1;
-        if (const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1))) {
+        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1))) {
             auto output_pattern_vector = constant->cast_vector<int64_t>();
             if (output_pattern_vector.size() != 2 || output_pattern_vector[0] != -1)
                 return false;
@@ -70,11 +70,11 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
             return false;
 
         // check matmul eligibility: has constant second input in a form of [O, K]
-        auto matmul = dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_to_node.at(matmul_label));
+        auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(pattern_to_node.at(matmul_label));
         if (!matmul || matmul->get_transpose_a())
             return false;
         int64_t O = -1;
-        if (const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(matmul->get_input_node_shared_ptr(1))) {
+        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(matmul->get_input_node_shared_ptr(1))) {
             const auto& constant_shape = constant->get_shape();
             if (constant_shape.size() != 2)
                 return false;
@@ -90,10 +90,10 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check add eligibility if present: has constant second input that has a form of [1, 1, ..., O] (doesn't
         // broadcast first input)
         if (pattern_to_node.count(add_label)) {
-            auto add = dynamic_pointer_cast<ov::op::v1::Add>(pattern_to_node.at(add_label));
+            auto add = ov::as_type_ptr<ov::op::v1::Add>(pattern_to_node.at(add_label));
             if (!add || add->get_autob() != ov::op::AutoBroadcastType::NUMPY)
                 return false;
-            const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
+            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
             if (!constant)
                 return false;
             const auto& constant_shape = constant->get_shape();
@@ -110,7 +110,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // input_shape of the pattern except for the batch and last dimension
         auto reshape_1 = m.get_match_root();
 
-        const auto& constant = dynamic_pointer_cast<ov::op::v0::Constant>(reshape_1->get_input_node_shared_ptr(1));
+        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->get_input_node_shared_ptr(1));
         if (constant == nullptr)
             return false;
         auto output_pattern = constant->cast_vector<int64_t>();
@@ -131,8 +131,8 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
                 return false;
         }
 
-        auto first_reshape = dynamic_pointer_cast<ov::op::v1::Reshape>(reshape);
-        auto second_reshape = dynamic_pointer_cast<ov::op::v1::Reshape>(reshape_1);
+        auto first_reshape = ov::as_type_ptr<ov::op::v1::Reshape>(reshape);
+        auto second_reshape = ov::as_type_ptr<ov::op::v1::Reshape>(reshape_1);
         if (!first_reshape || !second_reshape)
             return false;
 

--- a/src/common/transformations/src/transformations/symbolic_transformations/symbol_optimization.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/symbol_optimization.cpp
@@ -29,7 +29,7 @@ void update_symbol(std::shared_ptr<ov::Symbol>& symbol) {
 void apply_table_of_equivalence_on_model(const std::shared_ptr<ov::Model>& m) {
     for (const auto& op : m->get_ordered_ops()) {
         // handle inner sub-graphs
-        if (auto multi_subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(op))
+        if (auto multi_subgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(op))
             for (const auto& sub_graph : multi_subgraph_op->get_functions())
                 if (sub_graph)
                     apply_table_of_equivalence_on_model(sub_graph);

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -484,7 +484,7 @@ bool is_on_constant_path(const ov::Output<ov::Node>& output) {
 bool process_subgraph(ov::pass::ModelPass& model_pass, const std::shared_ptr<Node>& node) {
     bool changed = false;
 
-    if (const auto& multi_subgraph_op = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(node)) {
+    if (const auto& multi_subgraph_op = ov::as_type_ptr<op::util::MultiSubGraphOp>(node)) {
         for (const auto& sub_graph : multi_subgraph_op->get_functions()) {
             if (sub_graph) {
                 changed = model_pass.run_on_model(sub_graph) || changed;

--- a/src/common/transformations/tests/common_optimizations/eliminate_duplicate_ti_inputs.cpp
+++ b/src/common/transformations/tests/common_optimizations/eliminate_duplicate_ti_inputs.cpp
@@ -69,7 +69,7 @@ TEST(TransformationTests, EliminateDuplicateTIInputs) {
 
     shared_ptr<TensorIterator> ti_after_transformation;
     for (const auto& op : model->get_ordered_ops()) {
-        if ((ti_after_transformation = dynamic_pointer_cast<TensorIterator>(op))) {
+        if ((ti_after_transformation = ov::as_type_ptr<TensorIterator>(op))) {
             break;
         }
     }

--- a/src/common/transformations/tests/common_optimizations/gru_cell_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/gru_cell_fusion.cpp
@@ -99,12 +99,12 @@ shared_ptr<Model> gen_reference(WeightsFormat format,
     shared_ptr<Node> B = make_shared<Constant>(f32, Shape{1, 2 * hidden_size}, 0);
     if (use_bias_add_1) {
         B = make_shared<Parameter>(f32, Shape{1, 2 * hidden_size});
-        params.push_back(dynamic_pointer_cast<Parameter>(B));
+        params.push_back(ov::as_type_ptr<Parameter>(B));
     }
     shared_ptr<Node> Bh = make_shared<Constant>(f32, Shape{1, hidden_size}, 0);
     if (use_bias_add_2) {
         Bh = make_shared<Parameter>(f32, Shape{1, hidden_size});
-        params.push_back(dynamic_pointer_cast<Parameter>(Bh));
+        params.push_back(ov::as_type_ptr<Parameter>(Bh));
     }
 
     auto axis_0 = make_shared<Constant>(i64, Shape{}, 0);

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -209,9 +209,9 @@ private:
                         " version: ",
                         reduction_type_info.version_id);
 
-        if (auto arithmetic_reduce = std::dynamic_pointer_cast<op::util::ArithmeticReductionKeepDims>(reduction))
+        if (auto arithmetic_reduce = ov::as_type_ptr<op::util::ArithmeticReductionKeepDims>(reduction))
             arithmetic_reduce->set_keep_dims(keep_dims);
-        else if (auto logical_reduce = std::dynamic_pointer_cast<op::util::LogicalReductionKeepDims>(reduction))
+        else if (auto logical_reduce = ov::as_type_ptr<op::util::LogicalReductionKeepDims>(reduction))
             logical_reduce->set_keep_dims(keep_dims);
         reduction->validate_and_infer_types();
         return reduction;

--- a/src/common/transformations/tests/transpose_sinking/ts_test_utils.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_test_utils.cpp
@@ -30,7 +30,7 @@ ParameterVector filter_parameters(const OutputVector& out_vec) {
     ParameterVector parameters;
     for (const auto& out : out_vec) {
         auto node = out.get_node_shared_ptr();
-        if (auto param = dynamic_pointer_cast<Parameter>(node)) {
+        if (auto param = ov::as_type_ptr<Parameter>(node)) {
             parameters.push_back(param);
         }
     }

--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -739,7 +739,7 @@ class OPENVINO_API Any {
                     OPENVINO_THROW("Any does not contains pointer to runtime_attribute. It contains ",
                                    _impl->type_info().name());
                 }
-                auto vptr = std::dynamic_pointer_cast<typename T::element_type>(runtime_attribute);
+                auto vptr = ov::as_type_ptr<typename T::element_type>(runtime_attribute);
                 if (vptr == nullptr && T::element_type::get_type_info_static() != runtime_attribute->get_type_info() &&
                     T::element_type::get_type_info_static() != RuntimeAttribute::get_type_info_static()) {
                     OPENVINO_THROW("Could not as Any runtime_attribute to ",

--- a/src/core/reference/src/op/loop.cpp
+++ b/src/core/reference/src/op/loop.cpp
@@ -62,7 +62,7 @@ void loop(const std::shared_ptr<Model>& func,
     std::vector<BackEdge> back_edges;
     for (const auto& desc : input_descs) {
         inputs_to_body[desc->m_body_parameter_index] = args[desc->m_input_index];
-        if (const auto& merged_desc = std::dynamic_pointer_cast<op::v5::Loop::MergedInputDescription>(desc)) {
+        if (const auto& merged_desc = ov::as_type_ptr<op::v5::Loop::MergedInputDescription>(desc)) {
             back_edges.push_back({merged_desc->m_body_parameter_index, merged_desc->m_body_value_index});
             cur_iter_back_edge_exist |= merged_desc->m_body_parameter_index == static_cast<uint64_t>(cur_iter_idx);
         }
@@ -87,7 +87,7 @@ void loop(const std::shared_ptr<Model>& func,
         // Find all ConcatOutputDescription
         std::vector<std::shared_ptr<op::v5::Loop::ConcatOutputDescription>> concat_outputs;
         for (const auto& desc : out_descs) {
-            if (const auto& concat_desc = std::dynamic_pointer_cast<op::v5::Loop::ConcatOutputDescription>(desc)) {
+            if (const auto& concat_desc = ov::as_type_ptr<op::v5::Loop::ConcatOutputDescription>(desc)) {
                 concat_outputs.push_back(concat_desc);
             }
         }
@@ -97,8 +97,7 @@ void loop(const std::shared_ptr<Model>& func,
         std::vector<ov::TensorVector> sliced_values;
         int slice_in_idx = 0;
         for (const auto& desc : input_descs) {
-            if (const auto& slice_desc =
-                    std::dynamic_pointer_cast<op::v0::TensorIterator::SliceInputDescription>(desc)) {
+            if (const auto& slice_desc = ov::as_type_ptr<op::v0::TensorIterator::SliceInputDescription>(desc)) {
                 const auto el_size = args[slice_desc->m_input_index].get_element_type().size();
                 slice_inputs.push_back(slice_desc);
                 auto shape = args[slice_desc->m_input_index].get_shape();
@@ -196,7 +195,7 @@ void loop(const std::shared_ptr<Model>& func,
         }
 
         for (const auto& desc : out_descs) {
-            if (const auto& body_desc = std::dynamic_pointer_cast<op::v5::Loop::BodyOutputDescription>(desc)) {
+            if (const auto& body_desc = ov::as_type_ptr<op::v5::Loop::BodyOutputDescription>(desc)) {
                 const auto& res = body_outputs[body_desc->m_body_value_index];
                 res.copy_to(out[body_desc->m_output_index]);
             }

--- a/src/core/reference/src/op/tensor_iterator.cpp
+++ b/src/core/reference/src/op/tensor_iterator.cpp
@@ -32,15 +32,14 @@ void tensor_iterator(uint64_t num_iterations,
     std::vector<BackEdge> back_edges;
     for (const auto& desc : input_descs) {
         inputs_to_body[desc->m_body_parameter_index] = args[desc->m_input_index];
-        if (const auto& merged_desc = std::dynamic_pointer_cast<ov::op::v5::Loop::MergedInputDescription>(desc)) {
+        if (const auto& merged_desc = ov::as_type_ptr<ov::op::v5::Loop::MergedInputDescription>(desc)) {
             back_edges.push_back({merged_desc->m_body_parameter_index, merged_desc->m_body_value_index});
         }
     }
     // Find all ConcatOutputDescription
     std::vector<std::shared_ptr<ov::op::v0::TensorIterator::ConcatOutputDescription>> concat_outputs;
     for (const auto& desc : out_descs) {
-        if (const auto& concat_desc =
-                std::dynamic_pointer_cast<op::v0::TensorIterator::ConcatOutputDescription>(desc)) {
+        if (const auto& concat_desc = ov::as_type_ptr<op::v0::TensorIterator::ConcatOutputDescription>(desc)) {
             concat_outputs.push_back(concat_desc);
         }
     }
@@ -50,7 +49,7 @@ void tensor_iterator(uint64_t num_iterations,
     std::vector<ov::TensorVector> sliced_values;
     int slice_in_idx = 0;
     for (const auto& desc : input_descs) {
-        if (const auto& slice_desc = std::dynamic_pointer_cast<op::v0::TensorIterator::SliceInputDescription>(desc)) {
+        if (const auto& slice_desc = ov::as_type_ptr<op::v0::TensorIterator::SliceInputDescription>(desc)) {
             const auto el_size = args[slice_desc->m_input_index].get_element_type().size();
             slice_inputs.push_back(slice_desc);
             auto shape = args[slice_desc->m_input_index].get_shape();
@@ -106,7 +105,7 @@ void tensor_iterator(uint64_t num_iterations,
     }
 
     for (const auto& desc : out_descs) {
-        if (const auto& body_desc = std::dynamic_pointer_cast<op::v0::TensorIterator::BodyOutputDescription>(desc)) {
+        if (const auto& body_desc = ov::as_type_ptr<op::v0::TensorIterator::BodyOutputDescription>(desc)) {
             // Copy output values from the last iteration
             const auto& res = body_outputs[body_desc->m_body_value_index];
             res.copy_to(out[body_desc->m_output_index]);

--- a/src/core/src/bound_evaluate.cpp
+++ b/src/core/src/bound_evaluate.cpp
@@ -590,7 +590,7 @@ bool ov::tensor_has_max_value(const Tensor& bound) {
     folded = std::make_shared<op::v1::ReduceLogicalOr>(equal[0], axes)->constant_fold(all, {equal[0], axes});
     OPENVINO_ASSERT(folded && ov::is_type<op::v0::Constant>(all[0].get_node_shared_ptr()));
     OPENVINO_ASSERT(all[0].get_shape() == Shape{});
-    return std::dynamic_pointer_cast<op::v0::Constant>(all[0].get_node_shared_ptr())->cast_vector<bool>()[0];
+    return ov::as_type_ptr<op::v0::Constant>(all[0].get_node_shared_ptr())->cast_vector<bool>()[0];
 }
 
 bool ov::tensor_has_zero_value(const Tensor& bound) {
@@ -611,7 +611,7 @@ bool ov::tensor_has_zero_value(const Tensor& bound) {
     folded = std::make_shared<op::v1::ReduceLogicalOr>(equal[0], axes)->constant_fold(all, {equal[0], axes});
     OPENVINO_ASSERT(folded && ov::is_type<op::v0::Constant>(all[0].get_node_shared_ptr()));
     OPENVINO_ASSERT(all[0].get_shape() == Shape{});
-    return std::dynamic_pointer_cast<op::v0::Constant>(all[0].get_node_shared_ptr())->cast_vector<bool>()[0];
+    return ov::as_type_ptr<op::v0::Constant>(all[0].get_node_shared_ptr())->cast_vector<bool>()[0];
 }
 
 bool ov::has_and_set_equal_bounds(const Output<Node>& source) {

--- a/src/core/src/layout.cpp
+++ b/src/core/src/layout.cpp
@@ -604,7 +604,7 @@ ov::Layout get_layout(const ov::Output<ov::Node>& output) {
 
 void set_layout(ov::Output<ov::Node> output, const ov::Layout& layout) {
     OPENVINO_ASSERT(
-        dynamic_cast<ov::op::v0::Parameter*>(output.get_node()) || dynamic_cast<ov::op::v0::Result*>(output.get_node()),
+        ov::as_type<ov::op::v0::Parameter>(output.get_node()) || ov::as_type<ov::op::v0::Result>(output.get_node()),
         "Layout can be set only for Parameter and Result operations.");
     if (layout.empty()) {
         output.get_rt_info().erase(ov::LayoutAttribute::get_type_info_static());

--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -75,7 +75,7 @@ ov::ParameterVector auto_detect_parameters(const std::vector<std::shared_ptr<ov:
     OV_ITT_SCOPED_TASK(ov::itt::domains::core, "Model::auto_detect_parameters");
     ov::ParameterVector parameter_vector;
     for (const auto& op : ordered_ops) {
-        if (const auto& param = dynamic_pointer_cast<ov::op::v0::Parameter>(op)) {
+        if (const auto& param = ov::as_type_ptr<ov::op::v0::Parameter>(op)) {
             parameter_vector.push_back(param);
         }
     }

--- a/src/core/src/op/convert_like.cpp
+++ b/src/core/src/op/convert_like.cpp
@@ -39,7 +39,7 @@ bool ConvertLike::constant_fold(OutputVector& output_values, const OutputVector&
         return false;
     }
 
-    if (auto data_const = std::dynamic_pointer_cast<op::v0::Constant>(input_values[0].get_node_shared_ptr())) {
+    if (auto data_const = ov::as_type_ptr<op::v0::Constant>(input_values[0].get_node_shared_ptr())) {
         auto convert = std::make_shared<ov::op::v0::Convert>(input_values[0], input_values[1].get_element_type());
         return convert->constant_fold(output_values, OutputVector{data_const});
     }

--- a/src/core/src/op/loop.cpp
+++ b/src/core/src/op/loop.cpp
@@ -90,7 +90,7 @@ void Loop::validate_and_infer_types() {
             m_num_iterations = 1;  // condition_always_false, do_while mode
         }
     } else if (const auto& cond_param =
-                   std::dynamic_pointer_cast<const op::v0::Parameter>(body_execution_condition.get_node_shared_ptr())) {
+                   ov::as_type_ptr<const op::v0::Parameter>(body_execution_condition.get_node_shared_ptr())) {
         // Const(true or false) -> Loop (body: Parameter -> execution_condition output)
         for (const auto& desc : get_input_descriptions()) {
             if (m_bodies[0]->get_parameters().at(desc->m_body_parameter_index) == cond_param) {

--- a/src/core/src/op/reshape.cpp
+++ b/src/core/src/op/reshape.cpp
@@ -101,7 +101,7 @@ bool Reshape::constant_fold(OutputVector& output_values, const OutputVector& inp
         return false;
     }
 
-    if (auto data_const = std::dynamic_pointer_cast<v0::Constant>(inputs_values[0].get_node_shared_ptr())) {
+    if (auto data_const = ov::as_type_ptr<v0::Constant>(inputs_values[0].get_node_shared_ptr())) {
         output_values[0] = std::make_shared<v0::Constant>(*data_const, get_output_shape(0));
         return true;
     } else {

--- a/src/core/src/op/unique.cpp
+++ b/src/core/src/op/unique.cpp
@@ -34,8 +34,7 @@ std::tuple<Shape, Shape, Shape> calculate_static_output_shapes(const Tensor& inp
     const auto maybe_extract_axis = [&op]() {
         std::unique_ptr<int64_t> axis;
         if (op.get_input_size() == 2 && ov::op::util::is_constant(op.input_value(1).get_node())) {
-            const auto axis_constant =
-                std::dynamic_pointer_cast<op::v0::Constant>(op.input_value(1).get_node_shared_ptr());
+            const auto axis_constant = ov::as_type_ptr<op::v0::Constant>(op.input_value(1).get_node_shared_ptr());
             axis = std::unique_ptr<int64_t>(new int64_t{extract_axis(axis_constant)});
         }
         return axis;
@@ -112,7 +111,7 @@ void op::v10::Unique::validate_and_infer_types() {
     output_shapes[3] = output_shapes[1];
 
     if (ov::op::util::is_constant(input_value(0).get_node())) {
-        const auto input_const = std::dynamic_pointer_cast<op::v0::Constant>(input_value(0).get_node_shared_ptr());
+        const auto input_const = ov::as_type_ptr<op::v0::Constant>(input_value(0).get_node_shared_ptr());
         ov::Tensor input_data = ov::Tensor(input_const->get_element_type(), input_const->get_shape());
         memcpy(input_data.data(), input_const->get_data_ptr(), input_data.get_byte_size());
         const auto tensor_shapes = calculate_static_output_shapes(input_data, *this);
@@ -137,8 +136,7 @@ void op::v10::Unique::validate_and_infer_types() {
                 get_input_partial_shape(1) == PartialShape{} || get_input_partial_shape(1) == PartialShape{1},
                 "The 'axis' input tensor of the Unique operator must be a scalar or 1D tensor with 1 element.");
 
-            const int64_t axis =
-                extract_axis(std::dynamic_pointer_cast<op::v0::Constant>(input_value(1).get_node_shared_ptr()));
+            const int64_t axis = extract_axis(ov::as_type_ptr<op::v0::Constant>(input_value(1).get_node_shared_ptr()));
 
             if (input_shape.rank().is_static()) {
                 const auto normalized_axis = ov::util::try_normalize_axis(axis, input_shape.rank(), *this);

--- a/src/core/src/op/unsqueeze.cpp
+++ b/src/core/src/op/unsqueeze.cpp
@@ -88,7 +88,7 @@ bool ov::op::v0::Unsqueeze::constant_fold(OutputVector& output_values, const Out
 
     const auto& shape = get_output_shape(0);
 
-    if (auto data_const = std::dynamic_pointer_cast<op::v0::Constant>(inputs_values[0].get_node_shared_ptr())) {
+    if (auto data_const = ov::as_type_ptr<op::v0::Constant>(inputs_values[0].get_node_shared_ptr())) {
         output_values[0] = std::make_shared<op::v0::Constant>(*data_const, shape);
         return true;
     }

--- a/src/core/src/op/util/gather_base.cpp
+++ b/src/core/src/op/util/gather_base.cpp
@@ -32,9 +32,9 @@ Shape out_shape_infer(const Shape& data_shape, const Shape& indices_shape, int64
 bool cf_gather_with_subgraph(OutputVector& output_values,
                              const OutputVector& input_values,
                              const PartialShape& gather_ps) {
-    const auto concat = std::dynamic_pointer_cast<v0::Concat>(input_values[0].get_node_shared_ptr());
-    const auto indices = std::dynamic_pointer_cast<v0::Constant>(input_values[1].get_node_shared_ptr());
-    const auto axis = std::dynamic_pointer_cast<v0::Constant>(input_values[2].get_node_shared_ptr());
+    const auto concat = ov::as_type_ptr<v0::Concat>(input_values[0].get_node_shared_ptr());
+    const auto indices = ov::as_type_ptr<v0::Constant>(input_values[1].get_node_shared_ptr());
+    const auto axis = ov::as_type_ptr<v0::Constant>(input_values[2].get_node_shared_ptr());
 
     if (!concat || !indices || !axis) {
         return false;

--- a/src/core/src/op/util/op_types.cpp
+++ b/src/core/src/op/util/op_types.cpp
@@ -26,60 +26,60 @@
 #include "openvino/op/xor.hpp"
 
 bool ov::op::util::is_unary_elementwise_arithmetic(const ov::Node* node) {
-    return dynamic_cast<const ov::op::util::UnaryElementwiseArithmetic*>(node) != nullptr;
+    return ov::as_type<const ov::op::util::UnaryElementwiseArithmetic>(node) != nullptr;
 }
 
 bool ov::op::util::is_binary_elementwise_arithmetic(const ov::Node* node) {
-    return dynamic_cast<const ov::op::util::BinaryElementwiseArithmetic*>(node) != nullptr;
+    return ov::as_type<const ov::op::util::BinaryElementwiseArithmetic>(node) != nullptr;
 }
 
 bool ov::op::util::is_binary_elementwise_comparison(const ov::Node* node) {
-    return dynamic_cast<const ov::op::util::BinaryElementwiseComparison*>(node) != nullptr;
+    return ov::as_type<const ov::op::util::BinaryElementwiseComparison>(node) != nullptr;
 }
 
 bool ov::op::util::is_binary_elementwise_logical(const ov::Node* node) {
-    return dynamic_cast<const ov::op::util::BinaryElementwiseLogical*>(node) != nullptr;
+    return ov::as_type<const ov::op::util::BinaryElementwiseLogical>(node) != nullptr;
 }
 
 bool ov::op::util::supports_auto_broadcast(const ov::Node* node) {
-    return dynamic_cast<const ov::op::v1::Select*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v0::SquaredDifference*>(node) != nullptr ||
-           dynamic_cast<const ov::op::util::BinaryElementwiseComparison*>(node) != nullptr ||
-           dynamic_cast<const ov::op::util::BinaryElementwiseLogical*>(node) != nullptr ||
-           dynamic_cast<const ov::op::util::BinaryElementwiseArithmetic*>(node) != nullptr;
+    return ov::as_type<const ov::op::v1::Select>(node) != nullptr ||
+           ov::as_type<const ov::op::v0::SquaredDifference>(node) != nullptr ||
+           ov::as_type<const ov::op::util::BinaryElementwiseComparison>(node) != nullptr ||
+           ov::as_type<const ov::op::util::BinaryElementwiseLogical>(node) != nullptr ||
+           ov::as_type<const ov::op::util::BinaryElementwiseArithmetic>(node) != nullptr;
 }
 
 bool ov::op::util::is_op(const ov::Node* node) {
-    return dynamic_cast<const ov::op::Op*>(node) != nullptr;
+    return ov::as_type<const ov::op::Op>(node) != nullptr;
 }
 
 bool ov::op::util::is_parameter(const ov::Node* node) {
-    return dynamic_cast<const ov::op::v0::Parameter*>(node) != nullptr;
+    return ov::as_type<const ov::op::v0::Parameter>(node) != nullptr;
 }
 
 bool ov::op::util::is_output(const ov::Node* node) {
-    return dynamic_cast<const ov::op::v0::Result*>(node) != nullptr;
+    return ov::as_type<const ov::op::v0::Result>(node) != nullptr;
 }
 
 bool ov::op::util::is_sink(const ov::Node* node) {
-    return dynamic_cast<const ov::op::Sink*>(node) != nullptr;
+    return ov::as_type<const ov::op::Sink>(node) != nullptr;
 }
 
 bool ov::op::util::is_constant(const ov::Node* node) {
-    return dynamic_cast<const ov::op::v0::Constant*>(node) != nullptr;
+    return ov::as_type<const ov::op::v0::Constant>(node) != nullptr;
 }
 
 bool ov::op::util::is_commutative(const ov::Node* node) {
-    return dynamic_cast<const ov::op::v1::Add*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::Maximum*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::Equal*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::NotEqual*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::LogicalAnd*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v0::Xor*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::LogicalXor*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::Minimum*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::Multiply*>(node) != nullptr ||
-           dynamic_cast<const ov::op::v1::LogicalOr*>(node) != nullptr;
+    return ov::as_type<const ov::op::v1::Add>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::Maximum>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::Equal>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::NotEqual>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::LogicalAnd>(node) != nullptr ||
+           ov::as_type<const ov::op::v0::Xor>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::LogicalXor>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::Minimum>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::Multiply>(node) != nullptr ||
+           ov::as_type<const ov::op::v1::LogicalOr>(node) != nullptr;
 }
 
 bool ov::op::util::is_unary_elementwise_arithmetic(const std::shared_ptr<ov::Node>& node) {

--- a/src/core/src/op/util/squeeze_base.cpp
+++ b/src/core/src/op/util/squeeze_base.cpp
@@ -73,7 +73,7 @@ bool SqueezeBase::constant_fold(OutputVector& output_values, const OutputVector&
         return false;
     }
 
-    if (auto data_const = std::dynamic_pointer_cast<ov::op::v0::Constant>(inputs_values[0].get_node_shared_ptr())) {
+    if (auto data_const = ov::as_type_ptr<ov::op::v0::Constant>(inputs_values[0].get_node_shared_ptr())) {
         const auto& shape = get_output_shape(0);
         output_values[0] = std::make_shared<ov::op::v0::Constant>(*data_const, shape);
         return true;

--- a/src/core/src/op/util/symbolic_info.cpp
+++ b/src/core/src/op/util/symbolic_info.cpp
@@ -35,7 +35,7 @@ void ov::populate_tensor_with_missing_symbols(ov::descriptor::Tensor& tensor) {
 void ov::remove_skip_invalidation_rti(const std::shared_ptr<ov::Model>& model, bool outermost_model) {
     const auto& type = ov::SkipInvalidation::get_type_info_static();
     for (const auto& op : model->get_ops()) {
-        if (auto multi_subgraph_op = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(op))
+        if (auto multi_subgraph_op = ov::as_type_ptr<op::util::MultiSubGraphOp>(op))
             for (const auto& sub_graph : multi_subgraph_op->get_functions())
                 if (sub_graph)
                     remove_skip_invalidation_rti(sub_graph, false);

--- a/src/core/src/pass/constant_folding.cpp
+++ b/src/core/src/pass/constant_folding.cpp
@@ -106,7 +106,7 @@ bool ov::pass::ConstantFolding::run_on_model(const std::shared_ptr<ov::Model>& m
     for (const auto& original_node : model->get_ordered_ops()) {
         auto node = original_node;
         if (!original_node->can_constant_fold(original_node->input_values())) {
-            if (auto sub_graph_node = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node)) {
+            if (auto sub_graph_node = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
                 // recursively constant fold operators containing subgraphs (ie: TensorIterator, Loop)
                 size_t sub_graphs_num = sub_graph_node->get_internal_subgraphs_size();
                 for (size_t sub_graph_ind = 0; sub_graph_ind < sub_graphs_num; ++sub_graph_ind) {

--- a/src/core/src/pass/graph_rewrite.cpp
+++ b/src/core/src/pass/graph_rewrite.cpp
@@ -117,7 +117,7 @@ bool ov::pass::GraphRewrite::apply_matcher_passes(std::shared_ptr<Model> f,
         auto root = matcher->get_pattern_value().get_node_shared_ptr();
         // pattern::op::AnyOutput operation automatically appends for multi output operations inside
         // Matcher and to gen actual root node we need to take it's parent.
-        if (auto any_type = std::dynamic_pointer_cast<pattern::op::AnyOutput>(root)) {
+        if (auto any_type = ov::as_type_ptr<pattern::op::AnyOutput>(root)) {
             root = any_type->input_value(0).get_node_shared_ptr();
         }
 
@@ -126,7 +126,7 @@ bool ov::pass::GraphRewrite::apply_matcher_passes(std::shared_ptr<Model> f,
         // and use it in unordered_map as key for fast MatcherPass search. Otherwise type is unknown
         // and default algorithm is used.
         if (auto p = std::dynamic_pointer_cast<pattern::op::Pattern>(root)) {
-            if (auto any_type = std::dynamic_pointer_cast<ov::pass::pattern::op::WrapType>(p)) {
+            if (auto any_type = ov::as_type_ptr<ov::pass::pattern::op::WrapType>(p)) {
                 for (const auto& root_type_info : any_type->get_wrapped_types()) {
                     type_to_matcher[root_type_info].push_back(matcher_index);
                 }
@@ -186,7 +186,7 @@ bool ov::pass::GraphRewrite::apply_matcher_passes(std::shared_ptr<Model> f,
             continue;
 
         // Recursive apply Matchers for sub-graph based nodes
-        if (auto sub_graph_node = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node)) {
+        if (auto sub_graph_node = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
             if (sub_graph_node->get_transformations_allowed()) {
                 size_t sub_graphs_num = sub_graph_node->get_internal_subgraphs_size();
                 for (size_t sub_graph_ind = 0; sub_graph_ind < sub_graphs_num; ++sub_graph_ind) {

--- a/src/core/src/pass/low_latency.cpp
+++ b/src/core/src/pass/low_latency.cpp
@@ -158,7 +158,7 @@ std::vector<std::shared_ptr<ov::opset9::Assign>> process_sequence(const std::sha
     std::shared_ptr<ov::Node> cell;
     std::vector<std::shared_ptr<ov::opset9::Assign>> new_assigns;
     bool unroll = false;
-    if (auto lstm_seq_v5 = std::dynamic_pointer_cast<LSTMSequence>(op)) {
+    if (auto lstm_seq_v5 = ov::as_type_ptr<LSTMSequence>(op)) {
         unroll = need_unroll(op);
         new_assigns = replace_with_memory(op, {1, 2}, m_use_const_initializer, to);
         if (unroll) {
@@ -175,7 +175,7 @@ std::vector<std::shared_ptr<ov::opset9::Assign>> process_sequence(const std::sha
                                      lstm_seq_v5->get_activations_beta(),
                                      lstm_seq_v5->get_clip());
         }
-    } else if (auto gru_seq = std::dynamic_pointer_cast<GRUSequence>(op)) {
+    } else if (auto gru_seq = ov::as_type_ptr<GRUSequence>(op)) {
         unroll = need_unroll(op);
         new_assigns = replace_with_memory(op, {1}, m_use_const_initializer, to);
         if (unroll) {
@@ -192,7 +192,7 @@ std::vector<std::shared_ptr<ov::opset9::Assign>> process_sequence(const std::sha
                                     gru_seq->get_clip(),
                                     gru_seq->get_linear_before_reset());
         }
-    } else if (auto rnn_seq = std::dynamic_pointer_cast<RNNSequence>(op)) {
+    } else if (auto rnn_seq = ov::as_type_ptr<RNNSequence>(op)) {
         unroll = need_unroll(op);
         new_assigns = replace_with_memory(op, {1}, m_use_const_initializer, to);
         if (unroll) {
@@ -245,21 +245,20 @@ bool ov::pass::LowLatency2::run_on_model(const std::shared_ptr<Model>& f) {
     for (const auto& op : f->get_ordered_ops()) {
         ov::op::util::process_subgraph(*this, op);
 
-        if (const auto& sub_graph_op = std::dynamic_pointer_cast<SubGraphOp>(op)) {
+        if (const auto& sub_graph_op = ov::as_type_ptr<SubGraphOp>(op)) {
             int64_t variable_id = 0;
             const auto& func = sub_graph_op->get_function();
             const auto& params = func->get_parameters();
             for (const auto& in : sub_graph_op->get_input_descriptions()) {
                 // Process all back edges
-                if (const auto& merged_in = std::dynamic_pointer_cast<SubGraphOp::MergedInputDescription>(in)) {
+                if (const auto& merged_in = ov::as_type_ptr<SubGraphOp::MergedInputDescription>(in)) {
                     // create new Variable
                     const std::string& param_name = params.at(merged_in->m_body_parameter_index)->get_friendly_name();
                     const std::string& var_name =
                         generate_variable_name(sub_graph_op->get_friendly_name(), param_name, variable_id);
 
                     const auto& input = sub_graph_op->input(merged_in->m_input_index);
-                    if (std::dynamic_pointer_cast<ReadValueBase>(input.get_source_output().get_node_shared_ptr()) !=
-                        nullptr) {
+                    if (ov::as_type_ptr<ReadValueBase>(input.get_source_output().get_node_shared_ptr()) != nullptr) {
                         OPENVINO_DEBUG(msg_low_latency_2_already_applied);
                         return false;
                     }

--- a/src/core/src/pass/low_latency.cpp
+++ b/src/core/src/pass/low_latency.cpp
@@ -266,7 +266,7 @@ bool ov::pass::LowLatency2::run_on_model(const std::shared_ptr<Model>& f) {
                     const auto& param =
                         sub_graph_op->get_function()->get_parameters().at(merged_in->m_body_parameter_index);
                     for (const auto& in_to : param->output(0).get_target_inputs()) {
-                        if (dynamic_cast<ReadValueBase*>(in_to.get_node()) != nullptr) {
+                        if (ov::as_type<ReadValueBase>(in_to.get_node()) != nullptr) {
                             OPENVINO_DEBUG(msg_low_latency_already_applied);
                             return false;
                         }

--- a/src/core/src/pass/make_stateful.cpp
+++ b/src/core/src/pass/make_stateful.cpp
@@ -70,7 +70,7 @@ std::tuple<ov::pass::MakeStateful::ParamResPairs, std::vector<std::string>> find
                         " are already involved in the transformation.");
         uniq_res.insert(unused_res);
 
-        if (auto casted = std::dynamic_pointer_cast<ov::op::v0::Result>(unused_res->shared_from_this()))
+        if (auto casted = ov::as_type_ptr<ov::op::v0::Result>(unused_res->shared_from_this()))
             pairs_to_replace.emplace_back(*param, casted);
         variable_names.push_back(param_name + res_name);
     }

--- a/src/core/src/pass/manager.cpp
+++ b/src/core/src/pass/manager.cpp
@@ -385,11 +385,11 @@ bool ov::pass::Manager::run_pass(const std::shared_ptr<PassBase>& pass,
 
     OV_ITT_SCOPE(FIRST_INFERENCE, ov::itt::domains::ov_pass, ov::pass::perf_counters()[pass->get_type_info()]);
 
-    if (auto matcher_pass = std::dynamic_pointer_cast<MatcherPass>(pass)) {
+    if (auto matcher_pass = ov::as_type_ptr<MatcherPass>(pass)) {
         // GraphRewrite is a temporary container for MatcherPass to make execution on entire ov::Model
         return GraphRewrite(matcher_pass).run_on_model(model);
-    } else if (auto model_pass = std::dynamic_pointer_cast<ModelPass>(pass)) {
-        if (std::dynamic_pointer_cast<ov::pass::Validate>(model_pass) && !needs_validate) {
+    } else if (auto model_pass = ov::as_type_ptr<ModelPass>(pass)) {
+        if (ov::as_type_ptr<ov::pass::Validate>(model_pass) && !needs_validate) {
             return false;
         }
         return model_pass->run_on_model(model);

--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -112,7 +112,7 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
         position_ids = setName(std::make_shared<v0::Parameter>(element::i64, PartialShape{-1}), "position_ids");
         model->add_parameters({position_ids});
     } else {
-        position_ids = std::dynamic_pointer_cast<v0::Parameter>(model->input("position_ids").get_node_shared_ptr());
+        position_ids = ov::as_type_ptr<v0::Parameter>(model->input("position_ids").get_node_shared_ptr());
         position_ids->set_partial_shape(PartialShape{-1});
         position_ids->validate_and_infer_types();
     }

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -842,7 +842,7 @@ private:
                 std::make_shared<ov::opset1::Parameter>(input.get_element_type(), input.get_partial_shape()));
         }
         m_cloned_node = op->clone_with_new_inputs(m_parameters);
-        auto typed_cloned_node = std::dynamic_pointer_cast<T>(m_cloned_node);
+        auto typed_cloned_node = ov::as_type_ptr<T>(m_cloned_node);
         OPENVINO_ASSERT(typed_cloned_node);
         typed_cloned_node->set_pads_begin(P(op->get_pads_begin().size(), 0));
         typed_cloned_node->set_pads_end(P(op->get_pads_end().size(), 0));

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1045,7 +1045,7 @@ void ngfunction_2_ir(pugi::xml_node& netXml,
             pugi::xml_node input = layer.append_child("input");
             for (auto& i : node->inputs()) {
                 // WA for LSTMCellv0, peephole input shall not be serialized
-                if (i.get_index() == 6 && dynamic_cast<ov::opset1::LSTMCell*>(node)) {
+                if (i.get_index() == 6 && ov::as_type<ov::opset1::LSTMCell>(node)) {
                     port_id++;
                     continue;
                 }

--- a/src/core/src/pass/stateful_to_stateless.cpp
+++ b/src/core/src/pass/stateful_to_stateless.cpp
@@ -96,9 +96,8 @@ bool ov::pass::StatefulToStateless::run_on_model(const std::shared_ptr<ov::Model
         future_params;  // to collect nodes, each with a single output that will be replaced by new parameters
     if (beam_idx) {
         for (const ov::Input<ov::Node>& input : beam_idx->get_output_target_inputs(0)) {
-            if (auto gather = std::dynamic_pointer_cast<op::util::GatherBase>(input.get_node()->shared_from_this())) {
-                auto read_value =
-                    std::dynamic_pointer_cast<op::util::ReadValueBase>(gather->get_input_node_shared_ptr(0));
+            if (auto gather = ov::as_type_ptr<op::util::GatherBase>(input.get_node()->shared_from_this())) {
+                auto read_value = ov::as_type_ptr<op::util::ReadValueBase>(gather->get_input_node_shared_ptr(0));
                 OPENVINO_ASSERT(read_value,
                                 "Unexpected model topology in StatefulToStateless: no ReadValue is found at the first "
                                 "input of Gather by `beam_idx` parameter");
@@ -118,7 +117,7 @@ bool ov::pass::StatefulToStateless::run_on_model(const std::shared_ptr<ov::Model
     std::unordered_map<std::string, size_t> assign_index_by_var_id;
     const auto& sinks = model->get_sinks();
     for (size_t i = 0; i < sinks.size(); ++i) {
-        if (auto assign = std::dynamic_pointer_cast<op::util::AssignBase>(sinks[i])) {
+        if (auto assign = ov::as_type_ptr<op::util::AssignBase>(sinks[i])) {
             const auto& var_id = assign->get_variable_id();
             assigns_by_var_id[var_id] = std::move(assign);
             assign_index_by_var_id[var_id] = i;

--- a/src/core/src/pass/visualize_tree.cpp
+++ b/src/core/src/pass/visualize_tree.cpp
@@ -185,7 +185,7 @@ static void collect_symbol_print_values(const std::shared_ptr<ov::Model>& m,
                                         std::unordered_map<std::shared_ptr<ov::Symbol>, size_t>& symbol_to_number) {
     size_t n = symbol_to_number.size() + 1;
     for (const auto& node : m->get_ops()) {
-        if (auto multi_subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node))
+        if (auto multi_subgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node))
             for (size_t i = 0; i < multi_subgraph_op->get_internal_subgraphs_size(); ++i)
                 if (const auto& sub_graph = multi_subgraph_op->get_function(i))
                     collect_symbol_print_values(sub_graph, symbol_to_number);
@@ -241,7 +241,7 @@ bool ov::pass::VisualizeTree::run_on_model(const std::shared_ptr<ov::Model>& f) 
 
     for (auto it = nodes.rbegin(); it != nodes.rend(); ++it) {
         auto& node = *it;
-        if (auto multi_subgraph_op = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(node)) {
+        if (auto multi_subgraph_op = ov::as_type_ptr<op::util::MultiSubGraphOp>(node)) {
             for (size_t i = 0; i < multi_subgraph_op->get_internal_subgraphs_size(); ++i)
                 if (const auto& sub_graph = multi_subgraph_op->get_function(i))
                     ov::pass::VisualizeTree(name_of_subgraph_file(multi_subgraph_op, m_name, i),

--- a/src/core/src/preprocess/preprocess_impls.cpp
+++ b/src/core/src/preprocess/preprocess_impls.cpp
@@ -415,7 +415,7 @@ void OutputInfo::OutputInfoImpl::dump(std::ostream& str) const {
     std::shared_ptr<opset8::Result> result;
     auto node = m_output_node;
     const auto& start_out_node_names = node.get_tensor().get_names();
-    result = std::dynamic_pointer_cast<opset8::Result>(node.get_node_shared_ptr());
+    result = ov::as_type_ptr<opset8::Result>(node.get_node_shared_ptr());
     auto model_layout = get_model_data()->is_layout_set() ? get_model_data()->get_layout() : result->get_layout();
     PostprocessingContext context(model_layout);
     if (get_tensor_data()->is_layout_set()) {

--- a/src/core/src/preprocess/preprocess_impls.cpp
+++ b/src/core/src/preprocess/preprocess_impls.cpp
@@ -211,7 +211,7 @@ bool InputInfo::InputInfoImpl::build(const std::shared_ptr<Model>& model,
 
     // Replace parameter
     for (auto consumer : consumers) {
-        if (dynamic_cast<ov::opset8::Result*>(consumer.get_node())) {
+        if (ov::as_type<ov::opset8::Result>(consumer.get_node())) {
             // Some result points to old parameter (Param->Result case), need to trigger revalidation
             need_validate = true;
         }

--- a/src/core/src/runtime/itensor.cpp
+++ b/src/core/src/runtime/itensor.cpp
@@ -68,8 +68,7 @@ void ITensor::copy_to(const std::shared_ptr<ov::ITensor>& dst) const {
         dst->set_shape(shape);
     }
 
-    if (std::dynamic_pointer_cast<ov::IRemoteTensor>(dst)) {
-        auto remote_tensor_dst = std::dynamic_pointer_cast<ov::IRemoteTensor>(dst);
+    if (auto remote_tensor_dst = std::dynamic_pointer_cast<ov::IRemoteTensor>(dst)) {
         remote_tensor_dst->copy_from(shared_from_this());
         return;
     }

--- a/src/core/tests/copy.cpp
+++ b/src/core/tests/copy.cpp
@@ -422,7 +422,7 @@ TEST(copy, loop) {
     OutputVector new_args = {trip_count, exec_condition, X_new, Y_new, M_new};
     auto loop_copy = loop->clone_with_new_inputs(new_args);
 
-    auto node_cast = std::dynamic_pointer_cast<op::v5::Loop>(loop_copy);
+    auto node_cast = ov::as_type_ptr<op::v5::Loop>(loop_copy);
     ASSERT_NE(node_cast, nullptr);
     ASSERT_TRUE(nullptr != loop_copy);
     EXPECT_EQ(loop->get_num_iterations(), node_cast->get_num_iterations());

--- a/src/core/tests/graph_rewrite.cpp
+++ b/src/core/tests/graph_rewrite.cpp
@@ -71,7 +71,7 @@ inline std::shared_ptr<Model> get_model() {
 
 inline ov::pass::param_callback get_callback() {
     return [](const std::shared_ptr<const Node>& node) -> bool {
-        if (std::dynamic_pointer_cast<const op::v1::Divide>(node)) {
+        if (ov::as_type_ptr<const op::v1::Divide>(node)) {
             return true;
         } else {
             return false;

--- a/src/core/tests/pass/constant_folding.cpp
+++ b/src/core/tests/pass/constant_folding.cpp
@@ -2584,8 +2584,8 @@ TEST(constant_folding, const_reshape_no_data_copy) {
 
     run_constant_folding(f);
 
-    auto const1 = std::dynamic_pointer_cast<ov::op::v0::Constant>(consumer1->input_value(0).get_node_shared_ptr());
-    auto const2 = std::dynamic_pointer_cast<ov::op::v0::Constant>(consumer2->input_value(0).get_node_shared_ptr());
+    auto const1 = ov::as_type_ptr<ov::op::v0::Constant>(consumer1->input_value(0).get_node_shared_ptr());
+    auto const2 = ov::as_type_ptr<ov::op::v0::Constant>(consumer2->input_value(0).get_node_shared_ptr());
 
     ASSERT_TRUE(const1);
     ASSERT_TRUE(const2);
@@ -2604,8 +2604,8 @@ TEST(constant_folding, const_squeeze_no_data_copy) {
 
     run_constant_folding(f);
 
-    auto const1 = std::dynamic_pointer_cast<ov::op::v0::Constant>(consumer1->input_value(0).get_node_shared_ptr());
-    auto const2 = std::dynamic_pointer_cast<ov::op::v0::Constant>(consumer2->input_value(0).get_node_shared_ptr());
+    auto const1 = ov::as_type_ptr<ov::op::v0::Constant>(consumer1->input_value(0).get_node_shared_ptr());
+    auto const2 = ov::as_type_ptr<ov::op::v0::Constant>(consumer2->input_value(0).get_node_shared_ptr());
 
     ASSERT_TRUE(const1);
     ASSERT_TRUE(const2);
@@ -2624,8 +2624,8 @@ TEST(constant_folding, const_unsqueeze_no_data_copy) {
 
     run_constant_folding(f);
 
-    auto const1 = std::dynamic_pointer_cast<ov::op::v0::Constant>(consumer1->input_value(0).get_node_shared_ptr());
-    auto const2 = std::dynamic_pointer_cast<ov::op::v0::Constant>(consumer2->input_value(0).get_node_shared_ptr());
+    auto const1 = ov::as_type_ptr<ov::op::v0::Constant>(consumer1->input_value(0).get_node_shared_ptr());
+    auto const2 = ov::as_type_ptr<ov::op::v0::Constant>(consumer2->input_value(0).get_node_shared_ptr());
 
     ASSERT_TRUE(const1);
     ASSERT_TRUE(const2);
@@ -3914,7 +3914,7 @@ TEST(constant_folding, gather_with_dynamic_shapes_in_data_input) {
     ASSERT_EQ(count_ops_of_type<ov::op::v8::Gather>(model), 0);
     ASSERT_EQ(count_ops_of_type<ov::op::v1::StridedSlice>(model), 1);
 
-    auto new_const = dynamic_pointer_cast<ov::op::v0::Constant>(strided_slice->input_value(1).get_node_shared_ptr());
+    auto new_const = ov::as_type_ptr<ov::op::v0::Constant>(strided_slice->input_value(1).get_node_shared_ptr());
     EXPECT_NE(new_const, nullptr);
 
     check_names(new_const, {"shape_of", "indices", "axis", "test"});
@@ -3943,9 +3943,9 @@ TEST(constant_folding, sq_diff) {
     ops = model->get_ordered_ops();
     // constant + result
     ASSERT_EQ(ops.size(), 2);
-    auto const_node = std::dynamic_pointer_cast<ov::op::v0::Constant>(ops.front());
+    auto const_node = ov::as_type_ptr<ov::op::v0::Constant>(ops.front());
     ASSERT_NE(const_node, nullptr);
-    auto res_node = std::dynamic_pointer_cast<ov::op::v0::Result>(ops.back());
+    auto res_node = ov::as_type_ptr<ov::op::v0::Result>(ops.back());
     ASSERT_NE(res_node, nullptr);
 }
 

--- a/src/core/tests/pass/serialization/from_model.cpp
+++ b/src/core/tests/pass/serialization/from_model.cpp
@@ -191,7 +191,7 @@ TEST_P(SerializationFromModelTest_large, DISABLED_Model_very_large) {
     auto actual = ov::test::readModel(m_out_xml_path, m_out_bin_path);
     bool found = false;
     for (const auto& op : actual->get_ordered_ops()) {
-        if (auto const1 = std::dynamic_pointer_cast<op::v0::Constant>(op)) {
+        if (auto const1 = ov::as_type_ptr<op::v0::Constant>(op)) {
             auto ptr = const1->get_data_ptr<uint8_t>();
             for (size_t i = 0; i < s; i++) {
                 EXPECT_EQ(ptr[i], uint8_t(i + 42)) << "Index " << i << " has value " << static_cast<int>(ptr[i]);

--- a/src/core/tests/pass_config.cpp
+++ b/src/core/tests/pass_config.cpp
@@ -265,11 +265,11 @@ public:
         ov::matcher_pass_callback callback = [this](pattern::Matcher& m) {
             auto root = m.get_match_root();
             auto pass_config = this->get_pass_config();
-            if (std::dynamic_pointer_cast<op::v0::Relu>(root) && !pass_config->is_disabled<RenameReLU>()) {
+            if (ov::as_type_ptr<op::v0::Relu>(root) && !pass_config->is_disabled<RenameReLU>()) {
                 auto pass = std::make_shared<RenameReLU>();
                 pass->set_pass_config(pass_config);
                 pass->apply(root);
-            } else if (std::dynamic_pointer_cast<op::v0::Sigmoid>(root) && !pass_config->is_disabled<RenameSigmoid>()) {
+            } else if (ov::as_type_ptr<op::v0::Sigmoid>(root) && !pass_config->is_disabled<RenameSigmoid>()) {
                 auto pass = std::make_shared<RenameSigmoid>();
                 pass->set_pass_config(pass_config);
                 pass->apply(root);

--- a/src/core/tests/preprocess.cpp
+++ b/src/core/tests/preprocess.cpp
@@ -1547,7 +1547,7 @@ TEST(pre_post_process, postprocess_convert_element_type_explicit) {
     EXPECT_EQ(f->output().get_tensor().get_names(), old_names);
     auto ops = f->get_ordered_ops();
     auto res_count = std::count_if(ops.begin(), ops.end(), [](const std::shared_ptr<ov::Node>& n) {
-        return std::dynamic_pointer_cast<ov::op::v0::Result>(n) != nullptr;
+        return ov::as_type_ptr<ov::op::v0::Result>(n) != nullptr;
     });
     EXPECT_EQ(res_count, 1);
     auto names_count = std::count_if(ops.begin(), ops.end(), [](std::shared_ptr<ov::Node> n) {
@@ -1575,7 +1575,7 @@ TEST(pre_post_process, trivial_model_convert_element_type_explicit) {
     EXPECT_THAT(f->output().get_tensor().get_names(), old_names);
     const auto ops = f->get_ordered_ops();
     const auto res_count = std::count_if(ops.begin(), ops.end(), [](const std::shared_ptr<ov::Node>& n) {
-        return std::dynamic_pointer_cast<ov::op::v0::Result>(n) != nullptr;
+        return ov::as_type_ptr<ov::op::v0::Result>(n) != nullptr;
     });
     EXPECT_EQ(res_count, 1);
     const auto names_count = std::count_if(ops.begin(), ops.end(), [](std::shared_ptr<ov::Node> n) {

--- a/src/core/tests/threading.cpp
+++ b/src/core/tests/threading.cpp
@@ -158,7 +158,7 @@ TEST(threading, clone_with_new_inputs) {
 
             const auto inSize = op->get_input_size();
             for (size_t i = 0; i < inSize; i++) {
-                if (dynamic_cast<ov::opset8::Constant*>(op->get_input_node_ptr(i))) {
+                if (ov::as_type<ov::opset8::Constant>(op->get_input_node_ptr(i))) {
                     inputsForShapeInfer.push_back(op->get_input_node_ptr(i)->clone_with_new_inputs(ov::OutputVector{}));
                 } else {
                     inputsForShapeInfer.push_back(

--- a/src/core/tests/type_prop/if.cpp
+++ b/src/core/tests/type_prop/if.cpp
@@ -118,7 +118,7 @@ TEST(type_prop, if_clone_test) {
     if_op->set_input(X, Xt, Xe);
     if_op->set_input(Y, Yt, Ye);
     auto res = if_op->set_output(then_body_res, else_body_res);
-    auto new_if = std::dynamic_pointer_cast<op::v8::If>(if_op->clone_with_new_inputs(OutputVector{cond, Xnew, Ynew}));
+    auto new_if = ov::as_type_ptr<op::v8::If>(if_op->clone_with_new_inputs(OutputVector{cond, Xnew, Ynew}));
     EXPECT_EQ(true, true);
 }
 

--- a/src/inference/src/check_network_batchable.cpp
+++ b/src/inference/src/check_network_batchable.cpp
@@ -19,7 +19,7 @@ bool model_has_suitable_do(const std::shared_ptr<const ov::Model>& model) {
             convert_node = do_node;
             do_node = convert_node->get_input_node_shared_ptr(0);
         }
-        auto detectionOutputBase = std::dynamic_pointer_cast<ov::op::util::DetectionOutputBase>(do_node);
+        auto detectionOutputBase = ov::as_type_ptr<ov::op::util::DetectionOutputBase>(do_node);
         if (detectionOutputBase) {
             bDetectionOutput = true;
         }
@@ -83,7 +83,7 @@ std::shared_ptr<const ov::Model> apply_batch_affinity(const std::shared_ptr<cons
         }
         // the code below doesn't need to separate the versions (opsets) of the DetectionOutput
         // so base class  check is enough
-        auto detectionOutputBase = std::dynamic_pointer_cast<ov::op::util::DetectionOutputBase>(do_node);
+        auto detectionOutputBase = ov::as_type_ptr<ov::op::util::DetectionOutputBase>(do_node);
         if (detectionOutputBase) {
             result_node->get_rt_info()["affinity"] = deviceNameWithoutBatch;
             do_node->get_rt_info()["affinity"] = deviceNameWithoutBatch;

--- a/src/inference/src/dev/icompiled_model.cpp
+++ b/src/inference/src/dev/icompiled_model.cpp
@@ -101,7 +101,7 @@ ov::ICompiledModel::ICompiledModel(const std::shared_ptr<const ov::Model>& model
                 result->output(0).get_tensor().add_names({res_name});
                 new_result->output(0).get_tensor().add_names({res_name});
             }
-            auto r = std::dynamic_pointer_cast<ov::op::v0::Result>(new_result);
+            auto r = ov::as_type_ptr<ov::op::v0::Result>(new_result);
             r->set_layout(result->get_layout());
             new_result->output(0).get_rt_info() = result->output(0).get_rt_info();
             auto old_tensor = result->output(0).get_tensor_ptr();

--- a/src/inference/tests/functional/local_test.cpp
+++ b/src/inference/tests/functional/local_test.cpp
@@ -235,7 +235,7 @@ protected:
         for (const auto& op : model->get_ops()) {
             if (!isLSTM) {
                 if (op->get_friendly_name() == "output") {
-                    const auto roi = std::dynamic_pointer_cast<ov::op::v3::ROIAlign>(op);
+                    const auto roi = ov::as_type_ptr<ov::op::v3::ROIAlign>(op);
                     ASSERT_TRUE(roi);
                     ASSERT_EQ(roi->get_pooled_h(), 7);
                     ASSERT_EQ(roi->get_pooled_w(), 7);
@@ -244,7 +244,7 @@ protected:
                 }
             } else {
                 if (op->get_friendly_name() == "LSTMCell") {
-                    const auto lstm_seq = std::dynamic_pointer_cast<ov::op::util::RNNCellBase>(op);
+                    const auto lstm_seq = ov::as_type_ptr<ov::op::util::RNNCellBase>(op);
                     ASSERT_TRUE(lstm_seq);
                     ASSERT_EQ(lstm_seq->get_clip(), 0.0f);
                     ASSERT_EQ(lstm_seq->get_hidden_size(), 256);


### PR DESCRIPTION
### Details:
 - Replaced `std::dynamic_cast` and `std::dynamic_pointed_cast` with `ov::as_type` or `ov::as_type_ptr` respectively in src/common, src/core and src/inference directories, where applicable.

### Tickets:
 - CVS-160238
