### PR TITLE
[CPU] Transpose insertion before FC in ConvertMatMulToFC

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -757,7 +757,8 @@ void GraphOptimizer::FuseFCAndConvertOnWeights(Graph& graph) {
 
         const auto weights = convert->getParentEdgeAt(0)->getParent();
         const auto weights_out_edge = weights->getChildEdges()[0].lock();
-        const auto fc_weights_path_edge = transpose ? transpose->getParentEdgeAt(0) : fullyConnected->getParentEdgeAt(1);
+        const auto fc_weights_path_edge =
+            transpose ? transpose->getParentEdgeAt(0) : fullyConnected->getParentEdgeAt(1);
         const auto inNum = weights_out_edge->getInputNum();
         const auto outNum = fc_weights_path_edge->getOutputNum();
         const auto originalPrecision = convert->getOriginalInputPrecisionAtPort(0);

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -713,10 +713,10 @@ void GraphOptimizer::FuseFCAndConvertOnWeights(Graph& graph) {
     // This optimization fuses Convert (fp16 -> bf16/fp32) on weights directly to FC input to allow precision conversion
     // handling based on internal logic (e.g. fuse conversion with weights reordering)
 
-    auto isSuitableTranspose = [](NodePtr node) {
+    auto isSuitableTranspose = [](const NodePtr& node) {
         return node->getType() == Type::Transpose && node->getChildEdges().size() == 1 && node->isConstant();
     };
-    auto isSuitableConvert = [&](NodePtr node) {
+    auto isSuitableConvert = [&](const NodePtr& node) {
         if (node->getType() != Type::Convert || !node->isConstant() ||
             !one_of(node->getOriginalInputPrecisionAtPort(0), ov::element::f16, ov::element::bf16) ||
             !one_of(node->getOriginalOutputPrecisionAtPort(0), ov::element::f32, ov::element::bf16))

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -717,22 +717,9 @@ void GraphOptimizer::FuseFCAndConvertOnWeights(Graph& graph) {
         return node->getType() == Type::Transpose && node->getChildEdges().size() == 1 && node->isConstant();
     };
     auto isSuitableConvert = [&](const NodePtr& node) {
-        if (node->getType() != Type::Convert || !node->isConstant() ||
-            !one_of(node->getOriginalInputPrecisionAtPort(0), ov::element::f16, ov::element::bf16) ||
-            !one_of(node->getOriginalOutputPrecisionAtPort(0), ov::element::f32, ov::element::bf16))
-            return false;
-
-        const auto childEdges = node->getChildEdgesAtPort(0);
-        for (auto childEdge : childEdges) {
-            if (childEdge->getChild()->getType() == Type::Transpose) {
-                if (!isSuitableTranspose(childEdge->getChild()))
-                    return false;
-                childEdge = childEdge->getChild()->getChildEdgeAt(0);
-            }
-            if (childEdge->getChild()->getType() != Type::FullyConnected || childEdge->getOutputNum() != 1)
-                return false;
-        }
-        return true;
+        return node->getType() == Type::Convert && node->isConstant() &&
+               one_of(node->getOriginalInputPrecisionAtPort(0), ov::element::f16, ov::element::bf16) &&
+               one_of(node->getOriginalOutputPrecisionAtPort(0), ov::element::f32, ov::element::bf16);
     };
 
     auto& graphNodes = graph.GetNodes();

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
@@ -36,12 +36,8 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
         // So in case of adding new operations that takes matmul inputs we need keep update fc_input_a and fc_input_b.
         auto fc_input_a = pattern_map.at(activations_m);
         auto fc_input_b = pattern_map.at(weights_m);
-        bool is_convert = false;
         if (auto convert_node = ov::as_type_ptr<ov::op::v0::Convert>(fc_input_b.get_node_shared_ptr())) {
-            if (is_decompression(convert_node)) {
-                is_convert = true;
-                fc_input_b = convert_node->get_input_node_shared_ptr(0);
-            } else {
+            if (!is_decompression(convert_node)) {
                 return false;
             }
         }
@@ -149,14 +145,6 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
         // Input normalization
         if (matmul->get_transpose_a()) {
             fc_input_a = create_transpose(fc_input_a, matmul->get_friendly_name() + "/transpose_a");
-        }
-
-        // Connect Convert to new input if needed
-        if (is_convert) {
-            auto convert = pattern_map.at(weights_m).get_node_shared_ptr();
-            convert->input(0).replace_source_output(fc_input_b);
-            convert->validate_and_infer_types();
-            fc_input_b = convert;
         }
 
         auto bias = std::make_shared<ov::op::v0::Constant>(element::undefined, Shape{0});

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -427,7 +427,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
         manager,
         [](const_node_ptr& node) -> bool {
             const auto consumers = node->get_output_target_inputs(0);
-            return std::all_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
+            return std::any_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
                 return !ov::is_type<ov::op::v0::MatMul>(consumer.get_node());
             });
         },

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -427,7 +427,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
         manager,
         [](const_node_ptr& node) -> bool {
             const auto consumers = node->get_output_target_inputs(0);
-            return std::any_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
+            return std::all_of(consumers.begin(), consumers.end(), [](const ov::Input<ov::Node>& consumer) {
                 return !ov::is_type<ov::op::v0::MatMul>(consumer.get_node());
             });
         },

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
@@ -461,13 +461,13 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_0) {
         auto input1 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 2});
 
         auto input2 = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 2, 2}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(input2, ov::element::f32);
         auto transpose_constant = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
-        auto transpose = std::make_shared<ov::opset1::Transpose>(input2, transpose_constant);
-        auto convert = std::make_shared<ov::opset1::Convert>(transpose, ov::element::f32);
+        auto transpose = std::make_shared<ov::opset1::Transpose>(convert, transpose_constant);
 
         auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
             input1,
-            convert,
+            transpose,
             std::make_shared<ov::op::v0::Constant>(ov::element::undefined, ov::Shape{0}));
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
@@ -491,13 +491,13 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
         auto transpose1 = std::make_shared<ov::opset1::Transpose>(input1, transpose_constant1);
 
         auto input2 = ov::opset1::Constant::create(ov::element::f16, ov::Shape{1, 2, 2}, {1});
+        auto convert = std::make_shared<ov::opset1::Convert>(input2, ov::element::f32);
         auto transpose_constant2 = ov::opset1::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 1});
-        auto transpose2 = std::make_shared<ov::opset1::Transpose>(input2, transpose_constant2);
-        auto convert = std::make_shared<ov::opset1::Convert>(transpose2, ov::element::f32);
+        auto transpose2 = std::make_shared<ov::opset1::Transpose>(convert, transpose_constant2);
 
         auto matmul = std::make_shared<ov::op::internal::FullyConnected>(
             transpose1,
-            convert,
+            transpose2,
             std::make_shared<ov::op::v0::Constant>(ov::element::undefined, ov::Shape{0}));
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});


### PR DESCRIPTION
### Details (Updated):
- *Previously, if `MatMul` has `transposed_b=false` and decompressed convert on weights, the pass `ConvertMatMulToFC` inserted `Transpose` before this `Convert`. It means that if `Convert` has another consumer (`Result` or even `MatMul` with `transposed=true`), the inserted `Transpose` could break the shapes of `Convert` consumers (please see details in the mentioned ticket).
The current PR inserts `Transpose` after existing `Convert` and updates CPUGraph-pass `FuseFCAndConvertOnWeights`.*

### Tickets:
 - *160215*
