### PR TITLE
[IE-MDK] Cleanup debug error logs

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -11,7 +11,7 @@
 
 using namespace ov::test::behavior;
 
-const std::vector<ov::AnyMap> configsInferRequestRunTests = {{ov::log::level(ov::log::Level::INFO)}};
+const std::vector<ov::AnyMap> configsInferRequestRunTests = {{ov::log::level(ov::log::Level::ERR)}};
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          InferRequestRunTests,

--- a/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/remote_tensor_tests/remote_run.cpp
@@ -10,7 +10,7 @@
 
 using namespace ov::test::behavior;
 
-const std::vector<ov::AnyMap> remoteConfigs = {{ov::log::level(ov::log::Level::INFO)}};
+const std::vector<ov::AnyMap> remoteConfigs = {{ov::log::level(ov::log::Level::ERR)}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          RemoteRunTests,

--- a/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/work_with_devices.cpp
@@ -10,7 +10,7 @@
 namespace {
 
 const std::vector<ov::AnyMap> configs = {
-    {{ov::log::level(ov::log::Level::DEBUG)}},
+    {{ov::log::level(ov::log::Level::ERR)}},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compiled_model/property.cpp
@@ -116,7 +116,7 @@ std::vector<std::pair<std::string, ov::Any>> plugin_public_mutable_properties = 
     {ov::compilation_num_threads.name(), ov::Any(1)},
     {ov::hint::performance_mode.name(), ov::Any(ov::hint::PerformanceMode::THROUGHPUT)},
     {ov::hint::enable_cpu_pinning.name(), ov::Any(true)},
-    {ov::log::level.name(), ov::Any(ov::log::Level::DEBUG)},
+    {ov::log::level.name(), ov::Any(ov::log::Level::ERR)},
     {ov::device::id.name(), ov::Any(ov::test::utils::getDeviceNameID(ov::test::utils::getDeviceName()))},
 };
 

--- a/src/plugins/intel_npu/tests/functional/internal/overload/ov_plugin/core_integration.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/ov_plugin/core_integration.hpp
@@ -231,7 +231,7 @@ TEST_P(OVClassGetMetricAndPrintNoThrow, VpuDeviceAllocMemSizeLesserAfterModelIsL
 
     SKIP_IF_CURRENT_TEST_IS_DISABLED() {
         auto model = ov::test::utils::make_conv_pool_relu();
-        OV_ASSERT_NO_THROW(ie.compile_model(model, target_device, ov::AnyMap{ov::log::level(ov::log::Level::DEBUG)}));
+        OV_ASSERT_NO_THROW(ie.compile_model(model, target_device, ov::AnyMap{ov::log::level(ov::log::Level::ERR)}));
     }
 
     OV_ASSERT_NO_THROW(p = ie.get_property(target_device, ov::intel_npu::device_alloc_mem_size.name()));

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_test_tool.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_test_tool.cpp
@@ -14,7 +14,7 @@ namespace ov::test::utils {
 NpuTestTool::NpuTestTool(const NpuTestEnvConfig& envCfg)
         : envConfig(envCfg),
           DEVICE_NAME(envConfig.IE_NPU_TESTS_DEVICE_NAME.empty() ? "NPU" : envConfig.IE_NPU_TESTS_DEVICE_NAME),
-          _log("NpuTestTool", ov::log::Level::INFO) {
+          _log("NpuTestTool", ov::log::Level::ERR) {
 }
 
 std::string NpuTestTool::getDeviceMetric(std::string name) {


### PR DESCRIPTION
### Details:
 - Functional tests logs will now only print Error logs instead of Debug and Info

### Tickets:
 - CVS-160452 [IE-MDK] Cleanup debug error logs
