### PR TITLE
[RTTI] Replace std::dynamic_(pointer)?_casts with ov::as_type_(ptr)? - CPU

### DIFF
--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -33,10 +33,10 @@ namespace {
             return "INT8";
         }
         for (auto & node : model->get_ordered_ops()) {
-            if (std::dynamic_pointer_cast<ov::op::v1::Convolution>(node) ||
-                std::dynamic_pointer_cast<ov::op::v1::GroupConvolution>(node) ||
-                std::dynamic_pointer_cast<ov::op::v1::GroupConvolutionBackpropData>(node) ||
-                std::dynamic_pointer_cast<ov::op::v1::ConvolutionBackpropData>(node)) {
+            if (ov::as_type_ptr<ov::op::v1::Convolution>(node) ||
+                ov::as_type_ptr<ov::op::v1::GroupConvolution>(node) ||
+                ov::as_type_ptr<ov::op::v1::GroupConvolutionBackpropData>(node) ||
+                ov::as_type_ptr<ov::op::v1::ConvolutionBackpropData>(node)) {
                 auto layer_type = node->input(1).get_element_type().get_type_name();
                 if (layer_type == "f32")
                     return "FP32";
@@ -827,8 +827,8 @@ std::vector<DeviceInformation> Plugin::filter_device_by_model(const std::vector<
 
     std::vector<std::string> stateful_node_names;
     for (auto& op : model->get_ops()) {
-        if (std::dynamic_pointer_cast<ov::op::util::AssignBase>(op) ||
-            std::dynamic_pointer_cast<ov::op::util::ReadValueBase>(op)) {
+        if (ov::as_type_ptr<ov::op::util::AssignBase>(op) ||
+            ov::as_type_ptr<ov::op::util::ReadValueBase>(op)) {
             stateful_node_names.push_back(op->get_friendly_name());
         }
     }

--- a/src/plugins/hetero/src/subgraph_collector.cpp
+++ b/src/plugins/hetero/src/subgraph_collector.cpp
@@ -556,7 +556,7 @@ std::pair<ov::hetero::SubgraphsVector, ov::hetero::SubgraphsMappingInfo> ov::het
                         "supported by any plugin");
                 }
                 if (dump_dot_files) {
-                    if (auto multi_subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node)) {
+                    if (auto multi_subgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
                         for (size_t i = 0; i < multi_subgraph_op->get_internal_subgraphs_size(); ++i) {
                             if (const auto& sub_graph = multi_subgraph_op->get_function(i)) {
                                 collect_affinities(sub_graph, debug_supported_ops.at(node->get_friendly_name()));
@@ -589,7 +589,7 @@ std::pair<ov::hetero::SubgraphsVector, ov::hetero::SubgraphsMappingInfo> ov::het
                         subgraph_id = default_id;
                     }
                     map_id.emplace(node->get_friendly_name(), subgraph_id);
-                    if (auto multi_subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(node)) {
+                    if (auto multi_subgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(node)) {
                         for (size_t i = 0; i < multi_subgraph_op->get_internal_subgraphs_size(); ++i) {
                             if (const auto& sub_graph = multi_subgraph_op->get_function(i)) {
                                 collect_map_id(sub_graph, subgraph_id);

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
@@ -118,7 +118,7 @@ jit_clamp_emitter::jit_clamp_emitter(dnnl::impl::cpu::aarch64::jit_generator* ho
                                      dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
                                      const std::shared_ptr<ov::Node>& node)
     : jit_emitter(host, host_isa, node, get_arithmetic_binary_exec_precision(node)) {
-    const auto clamp = std::dynamic_pointer_cast<ov::op::v0::Clamp>(node);
+    const auto clamp = ov::as_type_ptr<ov::op::v0::Clamp>(node);
     if (clamp == nullptr) {
         OV_CPU_JIT_EMITTER_THROW("Can't cast to ov::op::v0::Clamp");
     }
@@ -294,7 +294,7 @@ jit_elu_emitter::jit_elu_emitter(dnnl::impl::cpu::aarch64::jit_generator* host,
                                  dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
                                  const std::shared_ptr<ov::Node>& node)
     : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {
-    const auto elu = std::dynamic_pointer_cast<ov::op::v0::Elu>(node);
+    const auto elu = ov::as_type_ptr<ov::op::v0::Elu>(node);
     if (elu == nullptr) {
         OV_CPU_JIT_EMITTER_THROW("Can't cast to ov::op::v0::Clamp");
     }
@@ -2633,7 +2633,7 @@ jit_swish_emitter::jit_swish_emitter(dnnl::impl::cpu::aarch64::jit_generator* ho
                                      dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
                                      const std::shared_ptr<ov::Node>& node)
     : jit_emitter(host, host_isa, node, get_arithmetic_binary_exec_precision(node)) {
-    const auto swish = std::dynamic_pointer_cast<SwishNode>(node);
+    const auto swish = ov::as_type_ptr<SwishNode>(node);
     if (swish == nullptr) {
         OV_CPU_JIT_EMITTER_THROW("Can't cast to SwishNode");
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -64,7 +64,7 @@ namespace ov {
             }                                                                                        \
         },                                                                                           \
             [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> {         \
-                const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                   \
+                const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                             \
                 if (gelu == nullptr) {                                                               \
                     OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                \
                 }                                                                                    \
@@ -97,7 +97,7 @@ namespace ov {
             }                                                                                        \
         },                                                                                           \
             [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> {         \
-                const auto& round = ov::as_type_ptr<ov::op::v5::Round>(n);                 \
+                const auto& round = ov::as_type_ptr<ov::op::v5::Round>(n);                           \
                 if (round == nullptr) {                                                              \
                     OPENVINO_THROW("Can't cast to ov::op::v5::Round");                               \
                 }                                                                                    \

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -64,7 +64,7 @@ namespace ov {
             }                                                                                        \
         },                                                                                           \
             [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> {         \
-                const auto& gelu = std::dynamic_pointer_cast<ov::op::v7::Gelu>(n);                   \
+                const auto& gelu = ov::as_type_ptr<ov::op::v7::Gelu>(n);                   \
                 if (gelu == nullptr) {                                                               \
                     OPENVINO_THROW("Can't cast to ov::op::v7::Gelu");                                \
                 }                                                                                    \
@@ -97,7 +97,7 @@ namespace ov {
             }                                                                                        \
         },                                                                                           \
             [](const std::shared_ptr<ov::Node>& n) -> std::set<std::vector<element::Type>> {         \
-                const auto& round = std::dynamic_pointer_cast<ov::op::v5::Round>(n);                 \
+                const auto& round = ov::as_type_ptr<ov::op::v5::Round>(n);                 \
                 if (round == nullptr) {                                                              \
                     OPENVINO_THROW("Can't cast to ov::op::v5::Round");                               \
                 }                                                                                    \
@@ -264,7 +264,7 @@ std::shared_ptr<snippets::Generator> CPUGenerator::clone() const {
 
 ov::snippets::RegType CPUGenerator::get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const {
     const auto op = out.get_node_shared_ptr();
-    if (std::dynamic_pointer_cast<intel_cpu::FusedMulAdd>(op) || std::dynamic_pointer_cast<intel_cpu::SwishNode>(op))
+    if (ov::as_type_ptr<intel_cpu::FusedMulAdd>(op) || ov::as_type_ptr<intel_cpu::SwishNode>(op))
         return ov::snippets::RegType::vec;
     else
         return ov::snippets::RegType::undefined;

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
@@ -30,7 +30,7 @@ jit_load_memory_emitter::jit_load_memory_emitter(jit_generator* h, cpu_isa_t isa
         src_prc == dst_prc;
     OV_CPU_JIT_EMITTER_ASSERT(is_supported_precision, "Unsupported precision pair.");
 
-    const auto load = std::dynamic_pointer_cast<snippets::op::Load>(expr->get_node());
+    const auto load = ov::as_type_ptr<snippets::op::Load>(expr->get_node());
     OV_CPU_JIT_EMITTER_ASSERT(load != nullptr, "Expects Load expression");
     count = load->get_count();
     byte_offset = load->get_offset();
@@ -66,7 +66,7 @@ jit_load_broadcast_emitter::jit_load_broadcast_emitter(jit_generator* h, cpu_isa
                               dst_prc.get_type_name());
     OV_CPU_JIT_EMITTER_ASSERT(src_prc == ov::element::f32, "Only supports FP32 precision.");
 
-    const auto broadcast_load = std::dynamic_pointer_cast<snippets::op::BroadcastLoad>(expr->get_node());
+    const auto broadcast_load = ov::as_type_ptr<snippets::op::BroadcastLoad>(expr->get_node());
     OV_CPU_JIT_EMITTER_ASSERT(broadcast_load != nullptr, "Expects BroadcastLoad expression");
     byte_offset = broadcast_load->get_offset();
     in_out_type_ = emitter_in_out_map::gpr_to_vec;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -390,15 +390,14 @@ std::shared_ptr<snippets::Generator> intel_cpu::CPUGenerator::clone() const {
 
 ov::snippets::RegType intel_cpu::CPUGenerator::get_specific_op_out_reg_type(const ov::Output<ov::Node>& out) const {
     const auto op = out.get_node_shared_ptr();
-    if (std::dynamic_pointer_cast<intel_cpu::BrgemmCPU>(op) ||
+    if (ov::as_type_ptr<intel_cpu::BrgemmCPU>(op) ||
 #ifdef SNIPPETS_LIBXSMM_TPP
         std::dynamic_pointer_cast<intel_cpu::tpp::modifier::TensorProcessingPrimitive>(op) ||
-        std::dynamic_pointer_cast<intel_cpu::tpp::op::Scalar>(op) ||
+        ov::as_type_ptr<intel_cpu::tpp::op::Scalar>(op) ||
 #endif
-        std::dynamic_pointer_cast<intel_cpu::BrgemmCopyB>(op))
+        ov::as_type_ptr<intel_cpu::BrgemmCopyB>(op))
         return ov::snippets::RegType::gpr;
-    else if (std::dynamic_pointer_cast<intel_cpu::FusedMulAdd>(op) ||
-             std::dynamic_pointer_cast<intel_cpu::SwishNode>(op))
+    else if (ov::as_type_ptr<intel_cpu::FusedMulAdd>(op) || ov::as_type_ptr<intel_cpu::SwishNode>(op))
         return ov::snippets::RegType::vec;
     else
         return ov::snippets::RegType::undefined;

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -131,7 +131,7 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model>& model,
     auto createNode = [&](std::shared_ptr<ov::Node> op) -> NodePtr {
         // special handling for Parameters and Results
         if (op->get_type_info() == op::v0::Parameter::get_type_info_static()) {
-            auto input_index = model->get_parameter_index(std::dynamic_pointer_cast<op::v0::Parameter>(op));
+            auto input_index = model->get_parameter_index(ov::as_type_ptr<op::v0::Parameter>(op));
             OPENVINO_ASSERT(input_index >= 0,
                             "CPU plugin cannot find op: ",
                             op->get_friendly_name(),
@@ -150,7 +150,7 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model>& model,
         }
 
         if (op->get_type_info() == op::v0::Result::get_type_info_static()) {
-            auto output_index = model->get_result_index(std::dynamic_pointer_cast<op::v0::Result>(op));
+            auto output_index = model->get_result_index(ov::as_type_ptr<op::v0::Result>(op));
             OPENVINO_ASSERT(output_index >= 0,
                             "CPU plugin cannot find op: ",
                             op->get_friendly_name(),

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -30,13 +30,13 @@ bool AdaptivePooling::isSupportedOperation(const std::shared_ptr<const ov::Node>
                                            std::string& errorMessage) noexcept {
     try {
         if (one_of(op->get_type_info(), ov::op::v8::AdaptiveAvgPool::get_type_info_static())) {
-            auto adaPool = std::dynamic_pointer_cast<const ov::opset8::AdaptiveAvgPool>(op);
+            auto adaPool = ov::as_type_ptr<const ov::opset8::AdaptiveAvgPool>(op);
             if (!adaPool) {
                 errorMessage = "Only opset8 AdaptiveAvgPooling operation is supported";
                 return false;
             }
         } else if (one_of(op->get_type_info(), ov::op::v8::AdaptiveMaxPool::get_type_info_static())) {
-            auto adaPool = std::dynamic_pointer_cast<const ov::opset8::AdaptiveMaxPool>(op);
+            auto adaPool = ov::as_type_ptr<const ov::opset8::AdaptiveMaxPool>(op);
             if (!adaPool) {
                 errorMessage = "Only opset8 AdaptiveMaxPooling operation is supported";
                 return false;

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.cpp
@@ -19,7 +19,7 @@ namespace node {
 
 bool BatchToSpace::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto batchToSpace = std::dynamic_pointer_cast<const ov::opset2::BatchToSpace>(op);
+        const auto batchToSpace = ov::as_type_ptr<const ov::opset2::BatchToSpace>(op);
         if (!batchToSpace) {
             errorMessage = "Only opset2 BatchToSpace operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -921,7 +921,7 @@ bool BinaryConvolution::isSupportedOperation(const std::shared_ptr<const ov::Nod
             return false;
         }
 
-        const auto binConv = std::dynamic_pointer_cast<const ov::opset1::BinaryConvolution>(op);
+        const auto binConv = ov::as_type_ptr<const ov::opset1::BinaryConvolution>(op);
         if (!binConv) {
             errorMessage = "Only opset1 BinaryConvolution operation is supported";
             return false;
@@ -941,7 +941,7 @@ BinaryConvolution::BinaryConvolution(const std::shared_ptr<ov::Node>& op, const 
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
         errorPrefix = "BinaryConvolution node with name '" + getName() + "' ";
-        const auto binConv = std::dynamic_pointer_cast<const ov::opset1::BinaryConvolution>(op);
+        const auto binConv = ov::as_type_ptr<const ov::opset1::BinaryConvolution>(op);
 
         pad_value = binConv->get_pad_value();
         for (size_t i = 0; i < binConv->get_strides().size(); i++) {

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -18,7 +18,7 @@ namespace node {
 
 bool Bucketize::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto bucketsize = std::dynamic_pointer_cast<const ov::opset3::Bucketize>(op);
+        const auto bucketsize = ov::as_type_ptr<const ov::opset3::Bucketize>(op);
         if (!bucketsize) {
             errorMessage = "Only opset3 Bucketize operation is supported";
             return false;
@@ -37,7 +37,7 @@ Bucketize::Bucketize(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
     }
 
     errorPrefix = "Bucketize layer with name '" + op->get_friendly_name() + "' ";
-    const auto bucketsize = std::dynamic_pointer_cast<const ov::opset3::Bucketize>(op);
+    const auto bucketsize = ov::as_type_ptr<const ov::opset3::Bucketize>(op);
     if (bucketsize == nullptr)
         OPENVINO_THROW("Operation with name '",
                        op->get_friendly_name(),

--- a/src/plugins/intel_cpu/src/nodes/causal_mask_preprocess.cpp
+++ b/src/plugins/intel_cpu/src/nodes/causal_mask_preprocess.cpp
@@ -106,14 +106,14 @@ CausalMaskPreprocess::CausalMaskPreprocess(const std::shared_ptr<ov::Node>& op, 
         OPENVINO_THROW("CPU: " + errorMessage);
     }
 
-    const auto node = std::dynamic_pointer_cast<const intel_cpu::CausalMaskPreprocessNode>(op);
+    const auto node = ov::as_type_ptr<const intel_cpu::CausalMaskPreprocessNode>(op);
     m_config = node->get_config();
 }
 
 bool CausalMaskPreprocess::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                                 std::string& errorMessage) noexcept {
     try {
-        const auto node = std::dynamic_pointer_cast<const intel_cpu::CausalMaskPreprocessNode>(op);
+        const auto node = ov::as_type_ptr<const intel_cpu::CausalMaskPreprocessNode>(op);
         if (!node) {
             errorMessage = "Only CausalMaskPreprocessNode operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/convert.cpp
@@ -17,7 +17,7 @@ namespace node {
 
 bool Convert::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto convert = std::dynamic_pointer_cast<const ov::opset1::Convert>(op);
+        const auto convert = ov::as_type_ptr<const ov::opset1::Convert>(op);
         if (!convert) {
             errorMessage = "Only opset1 Convert operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
@@ -19,7 +19,7 @@ namespace node {
 
 bool CumSum::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto cumsum = std::dynamic_pointer_cast<const ov::opset3::CumSum>(op);
+        const auto cumsum = ov::as_type_ptr<const ov::opset3::CumSum>(op);
         if (!cumsum) {
             errorMessage = "Only opset3 CumSum operation is supported";
             return false;
@@ -49,7 +49,7 @@ CumSum::CumSum(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
         OPENVINO_THROW(errorPrefix, " doesn't support 'data' input tensor with rank: ", numOfDims);
     }
 
-    const auto cumsum = std::dynamic_pointer_cast<const ov::opset3::CumSum>(op);
+    const auto cumsum = ov::as_type_ptr<const ov::opset3::CumSum>(op);
     if (cumsum == nullptr)
         OPENVINO_THROW("Operation with name '", op->get_friendly_name(), "' is not an instance of CumSum from opset3.");
 

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -142,8 +142,8 @@ private:
 bool Deconvolution::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                          std::string& errorMessage) noexcept {
     try {
-        if (std::dynamic_pointer_cast<const ov::op::v1::ConvolutionBackpropData>(op) == nullptr &&
-            std::dynamic_pointer_cast<const ov::op::v1::GroupConvolutionBackpropData>(op) == nullptr) {
+        if (ov::as_type_ptr<const ov::op::v1::ConvolutionBackpropData>(op) == nullptr &&
+            ov::as_type_ptr<const ov::op::v1::GroupConvolutionBackpropData>(op) == nullptr) {
             errorMessage =
                 "Only opset1 ConvolutionBackpropData and GroupConvolutionBackpropData operations are supported";
             return false;
@@ -173,7 +173,7 @@ Deconvolution::Deconvolution(const std::shared_ptr<ov::Node>& op, const GraphCon
 
     const auto& weightDims = getWeightDims();
 
-    if (auto convBackprop = std::dynamic_pointer_cast<const ov::op::v1::ConvolutionBackpropData>(op)) {
+    if (auto convBackprop = ov::as_type_ptr<const ov::op::v1::ConvolutionBackpropData>(op)) {
         algorithm = Algorithm::DeconvolutionCommon;
 
         IC = weightDims[0];
@@ -195,7 +195,7 @@ Deconvolution::Deconvolution(const std::shared_ptr<ov::Node>& op, const GraphCon
         deconvAttrs.outputPadding = convBackprop->get_output_padding();
 
         autoPad = one_of(convBackprop->get_auto_pad(), ov::op::PadType::SAME_LOWER, ov::op::PadType::SAME_UPPER);
-    } else if (auto groupConvBackprop = std::dynamic_pointer_cast<const ov::op::v1::GroupConvolutionBackpropData>(op)) {
+    } else if (auto groupConvBackprop = ov::as_type_ptr<const ov::op::v1::GroupConvolutionBackpropData>(op)) {
         algorithm = Algorithm::DeconvolutionGrouped;
 
         groupNum = weightDims[0];

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -775,7 +775,7 @@ DeformableConvolution::DeformableConvolution(const std::shared_ptr<ov::Node>& op
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     errorPrefix = "Deformable convolution with name '" + op->get_friendly_name() + "'";
-    auto defConvNodeBase = std::dynamic_pointer_cast<ov::op::util::DeformableConvolutionBase>(op);
+    auto defConvNodeBase = ov::as_type_ptr<ov::op::util::DeformableConvolutionBase>(op);
     if (defConvNodeBase == nullptr)
         OPENVINO_THROW(errorPrefix, " is not an instance of DeformableConvolutionBase.");
 
@@ -796,7 +796,7 @@ DeformableConvolution::DeformableConvolution(const std::shared_ptr<ov::Node>& op
     autoPadding = one_of(defConvNodeBase->get_auto_pad(), ov::op::PadType::SAME_UPPER, ov::op::PadType::SAME_LOWER);
 
     if (op->get_type_info() == ov::op::v8::DeformableConvolution::get_type_info_static()) {
-        auto defConvNode = std::dynamic_pointer_cast<ov::op::v8::DeformableConvolution>(op);
+        auto defConvNode = ov::as_type_ptr<ov::op::v8::DeformableConvolution>(op);
         if (defConvNode == nullptr)
             OPENVINO_THROW(errorPrefix, " is not an instance of DeformableConvolution from opset8.");
         defConvAttr.with_bilinear_pad = defConvNode->get_bilinear_interpolation_pad();

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
@@ -16,8 +16,7 @@ namespace node {
 bool ExperimentalDetectronPriorGridGenerator::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                                                    std::string& errorMessage) noexcept {
     try {
-        const auto priorGridGen =
-            std::dynamic_pointer_cast<const ov::opset6::ExperimentalDetectronPriorGridGenerator>(op);
+        const auto priorGridGen = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronPriorGridGenerator>(op);
         if (!priorGridGen) {
             errorMessage = "Only opset6 ExperimentalDetectronPriorGridGenerator operation is supported";
             return false;
@@ -37,7 +36,7 @@ ExperimentalDetectronPriorGridGenerator::ExperimentalDetectronPriorGridGenerator
     }
 
     errorPrefix = "ExperimentalDetectronPriorGridGenerator layer with name '" + op->get_friendly_name() + "'";
-    const auto priorGridGen = std::dynamic_pointer_cast<const ov::opset6::ExperimentalDetectronPriorGridGenerator>(op);
+    const auto priorGridGen = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronPriorGridGenerator>(op);
     if (getOriginalInputsNumber() != 3 || getOriginalOutputsNumber() != 1)
         OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
@@ -271,7 +271,7 @@ bool ExperimentalDetectronROIFeatureExtractor::isSupportedOperation(const std::s
                                                                     std::string& errorMessage) noexcept {
     try {
         const auto roiFeatureExtractor =
-            std::dynamic_pointer_cast<const ov::opset6::ExperimentalDetectronROIFeatureExtractor>(op);
+            ov::as_type_ptr<const ov::opset6::ExperimentalDetectronROIFeatureExtractor>(op);
         if (!roiFeatureExtractor) {
             errorMessage = "Only opset6 ExperimentalDetectronROIFeatureExtractor operation is supported";
             return false;
@@ -290,8 +290,7 @@ ExperimentalDetectronROIFeatureExtractor::ExperimentalDetectronROIFeatureExtract
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    const auto roiFeatureExtractor =
-        std::dynamic_pointer_cast<const ov::opset6::ExperimentalDetectronROIFeatureExtractor>(op);
+    const auto roiFeatureExtractor = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronROIFeatureExtractor>(op);
     const auto& attr = roiFeatureExtractor->get_attrs();
     output_dim_ = attr.output_size;
     pyramid_scales_ = attr.pyramid_scales;

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.cpp
@@ -19,7 +19,7 @@ namespace node {
 bool ExperimentalDetectronTopKROIs::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                                          std::string& errorMessage) noexcept {
     try {
-        const auto topKROI = std::dynamic_pointer_cast<const ov::opset6::ExperimentalDetectronTopKROIs>(op);
+        const auto topKROI = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronTopKROIs>(op);
         if (!topKROI) {
             errorMessage = "Only opset6 ExperimentalDetectronTopKROIs operation is supported";
             return false;
@@ -39,7 +39,7 @@ ExperimentalDetectronTopKROIs::ExperimentalDetectronTopKROIs(const std::shared_p
     }
 
     errorPrefix = "ExperimentalDetectronTopKROIs layer with name '" + op->get_friendly_name() + "'";
-    const auto topKROI = std::dynamic_pointer_cast<const ov::opset6::ExperimentalDetectronTopKROIs>(op);
+    const auto topKROI = ov::as_type_ptr<const ov::opset6::ExperimentalDetectronTopKROIs>(op);
     if (topKROI == nullptr)
         OPENVINO_THROW("Operation with name '",
                        op->get_friendly_name(),

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -961,7 +961,7 @@ private:
 #endif
 bool FakeQuantize::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto fq = std::dynamic_pointer_cast<const ov::opset1::FakeQuantize>(op);
+        const auto fq = ov::as_type_ptr<const ov::opset1::FakeQuantize>(op);
         if (!fq) {
             errorMessage = "Only opset1 FakeQuantize operation is supported";
             return false;
@@ -979,7 +979,7 @@ bool FakeQuantize::isSupportedOperation(const std::shared_ptr<const ov::Node>& o
             }
         }
         for (size_t i = 1; i < fq->get_input_size(); i++) {
-            if (!std::dynamic_pointer_cast<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(i))) {
+            if (!ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(i))) {
                 errorMessage = "Has non const 'range' input on " + std::to_string(i) + " port";
                 return false;
             }
@@ -1061,7 +1061,7 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
         algorithm = Algorithm::FQCommon;
-        const auto fq = std::dynamic_pointer_cast<const ov::opset1::FakeQuantize>(op);
+        const auto fq = ov::as_type_ptr<const ov::opset1::FakeQuantize>(op);
 
         errorPrefix = "FakeQuantize node with name '" + getName() + "' ";
         levels = fq->get_levels();
@@ -1129,20 +1129,16 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
             OPENVINO_THROW(errorPrefix, "has different quantization axis size on 'data' and 'range' inputs");
         }
 
-        const auto inputLowNode =
-            std::dynamic_pointer_cast<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(1));
+        const auto inputLowNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(1));
         auto inputLowData = inputLowNode->cast_vector<float>();
 
-        const auto inputHighNode =
-            std::dynamic_pointer_cast<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(2));
+        const auto inputHighNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(2));
         auto inputHighData = inputHighNode->cast_vector<float>();
 
-        const auto outputLowNode =
-            std::dynamic_pointer_cast<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(3));
+        const auto outputLowNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(3));
         auto outputLowData = outputLowNode->cast_vector<float>();
 
-        const auto outputHighNode =
-            std::dynamic_pointer_cast<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(4));
+        const auto outputHighNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(4));
         auto outputHighData = outputHighNode->cast_vector<float>();
 
         binarization = levels == 2;

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -32,7 +32,7 @@ namespace node {
 
 bool Gather::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto gather_compression = std::dynamic_pointer_cast<const ov::op::internal::GatherCompressed>(op);
+        const auto gather_compression = ov::as_type_ptr<const ov::op::internal::GatherCompressed>(op);
         if (gather_compression) {
             return true;
         }

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -15,7 +15,7 @@ namespace node {
 
 bool GRN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto grn = std::dynamic_pointer_cast<const ov::opset1::GRN>(op);
+        const auto grn = ov::as_type_ptr<const ov::opset1::GRN>(op);
         if (!grn) {
             errorMessage = "Only opset1 GRN operation is supported";
             return false;
@@ -34,7 +34,7 @@ GRN::GRN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
     }
 
     errorPrefix = "GRN layer with name '" + op->get_friendly_name() + "'";
-    const auto grn = std::dynamic_pointer_cast<const ov::opset1::GRN>(op);
+    const auto grn = ov::as_type_ptr<const ov::opset1::GRN>(op);
     if (grn == nullptr)
         OPENVINO_THROW("Operation with name '", op->get_friendly_name(), "' is not an instance of GRN from opset1.");
 

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -188,7 +188,7 @@ Interaction::Interaction(const std::shared_ptr<ov::Node>& op, const GraphContext
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     errorPrefix = "Interaction node with name '" + getName() + "'";
-    const auto interaction = std::dynamic_pointer_cast<const InteractionNode>(op);
+    const auto interaction = ov::as_type_ptr<const InteractionNode>(op);
     const std::vector<float>& scales = interaction->get_output_scales();
     if (!scales.empty()) {
         fqScales = scales;
@@ -367,7 +367,7 @@ bool Interaction::isExecutable() const {
 
 bool Interaction::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto interaction = std::dynamic_pointer_cast<const InteractionNode>(op);
+        const auto interaction = ov::as_type_ptr<const InteractionNode>(op);
         if (!interaction) {
             errorMessage = "Only Interaction operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -1734,7 +1734,7 @@ using ngInterpShapeCalcMode = ov::op::v4::Interpolate::ShapeCalcMode;
 
 bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (const auto interp = std::dynamic_pointer_cast<const ov::op::v4::Interpolate>(op)) {
+        if (const auto interp = ov::as_type_ptr<const ov::op::v4::Interpolate>(op)) {
             const auto& interpAttr = interp->get_attrs();
             const auto& interpMode = interpAttr.mode;
             if (!one_of(interpMode,
@@ -1797,12 +1797,12 @@ bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
                 return false;
             }
 
-            if (interp->get_input_size() > 3 && std::dynamic_pointer_cast<const ov::op::v0::Constant>(
-                                                    interp->get_input_node_shared_ptr(AXES_ID)) == nullptr) {
+            if (interp->get_input_size() > 3 &&
+                ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID)) == nullptr) {
                 errorMessage = "Only const 'axes' input is supported in Interpolate-4";
                 return false;
             }
-        } else if (const auto interp = std::dynamic_pointer_cast<const ov::op::v11::Interpolate>(op)) {
+        } else if (const auto interp = ov::as_type_ptr<const ov::op::v11::Interpolate>(op)) {
             const auto& interpAttr = interp->get_attrs();
             const auto& interpMode = interpAttr.mode;
             if (!one_of(interpMode, ngInterpMode::BILINEAR_PILLOW, ngInterpMode::BICUBIC_PILLOW)) {
@@ -1826,7 +1826,7 @@ bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
                 errorMessage = "Only const 'scales_or_sizes' input is supported for static shapes in Interpolate-11";
                 return false;
             }
-            if (interp->get_input_size() > 2 && std::dynamic_pointer_cast<const ov::op::v0::Constant>(
+            if (interp->get_input_size() > 2 && ov::as_type_ptr<const ov::op::v0::Constant>(
                                                     interp->get_input_node_shared_ptr(AXES_ID_V11)) == nullptr) {
                 errorMessage = "Only const 'axes' input is supported in Interpolate-11";
                 return false;
@@ -1878,7 +1878,7 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
     if (isSupportedOperation(op, errorMessage)) {
         errorPrefix = "Interpolate node with name '" + getName() + "'";
         dataRank = getInputShapeAtPort(DATA_ID).getRank();
-        if (const auto interp = std::dynamic_pointer_cast<const ov::opset4::Interpolate>(op)) {
+        if (const auto interp = ov::as_type_ptr<const ov::opset4::Interpolate>(op)) {
             is_version11 = false;
             const auto numInputs = inputShapes.size();
             if (numInputs != 3 && numInputs != 4)
@@ -1967,14 +1967,14 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             }
 
             const auto scalesNode =
-                std::dynamic_pointer_cast<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(SCALES_ID));
+                ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(SCALES_ID));
             if (scalesNode) {
                 scales = scalesNode->cast_vector<float>();
                 isScaleConstant = true;
             }
 
             if (isAxesSpecified) {
-                axes = std::dynamic_pointer_cast<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID))
+                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID))
                            ->cast_vector<int>();
             } else {
                 axes.resize(dataRank);
@@ -1982,7 +1982,7 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
                     axes[i] = i;
                 }
             }
-        } else if (const auto interp = std::dynamic_pointer_cast<const ov::op::v11::Interpolate>(op)) {
+        } else if (const auto interp = ov::as_type_ptr<const ov::op::v11::Interpolate>(op)) {
             is_version11 = true;
             const auto numInputs = inputShapes.size();
             if (numInputs != 2 && numInputs != 3)
@@ -2009,7 +2009,7 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             const auto& interpShapeCalcMode = interpAttr.shape_calculation_mode;
             if (interpShapeCalcMode == ngInterpShapeCalcMode::SCALES) {
                 interpAttrs.shapeCalcMode = InterpolateShapeCalcMode::scales;
-                const auto scalesNode = std::dynamic_pointer_cast<const ov::op::v0::Constant>(
+                const auto scalesNode = ov::as_type_ptr<const ov::op::v0::Constant>(
                     interp->get_input_node_shared_ptr(SIZE_OR_SCALE_ID_V11));
                 if (scalesNode) {
                     scales = scalesNode->cast_vector<float>();
@@ -2038,8 +2038,7 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             }
 
             if (isAxesSpecified) {
-                axes = std::dynamic_pointer_cast<const ov::op::v0::Constant>(
-                           interp->get_input_node_shared_ptr(AXES_ID_V11))
+                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID_V11))
                            ->cast_vector<int>();
                 if (dataRank == 4 && axes.size() == 2 && axes[0] == 1 && axes[1] == 2 && mayiuse(cpu::x64::sse41)) {
                     NCHWAsNHWC = true;

--- a/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
+++ b/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
@@ -503,7 +503,7 @@ LLMMLP::LLMMLP(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
     if (!isSupportedOperation(op, errorMessage, config.fcDynamicQuantizationGroupSize)) {
         OPENVINO_THROW("CPU: " + errorMessage);
     }
-    const auto node_mlp = std::dynamic_pointer_cast<const LLMMLPNode>(op);
+    const auto node_mlp = ov::as_type_ptr<const LLMMLPNode>(op);
     m_mlp_config = node_mlp->get_config();
 }
 
@@ -599,7 +599,7 @@ bool LLMMLP::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                   uint64_t fcDynamicQuantizationGroupSize) noexcept {
 #if defined(OPENVINO_ARCH_X86_64)
     try {
-        const auto node_mlp = std::dynamic_pointer_cast<const LLMMLPNode>(op);
+        const auto node_mlp = ov::as_type_ptr<const LLMMLPNode>(op);
         if (node_mlp) {
             auto down_proj_w_pshape = op->input_value(1).get_partial_shape();
             if (!down_proj_w_pshape.is_static()) {

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -15,7 +15,7 @@ namespace node {
 
 bool LogSoftmax::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto logSoftMax = std::dynamic_pointer_cast<const ov::opset5::LogSoftmax>(op);
+        const auto logSoftMax = ov::as_type_ptr<const ov::opset5::LogSoftmax>(op);
         if (!logSoftMax) {
             errorMessage = "Only opset5 LogSoftmax operation is supported";
             return false;
@@ -34,7 +34,7 @@ LogSoftmax::LogSoftmax(const std::shared_ptr<ov::Node>& op, const GraphContext::
     }
 
     errorPrefix = "LogSoftmax layer with name '" + op->get_friendly_name() + "'";
-    const auto logSoftMax = std::dynamic_pointer_cast<const ov::opset5::LogSoftmax>(op);
+    const auto logSoftMax = ov::as_type_ptr<const ov::opset5::LogSoftmax>(op);
     if (logSoftMax == nullptr)
         OPENVINO_THROW("Operation with name '",
                        op->get_friendly_name(),

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -86,7 +86,7 @@ bool MatMul::canBeExecutedInInt8() const {
 
 bool MatMul::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto matMul = std::dynamic_pointer_cast<const ov::opset1::MatMul>(op);
+        const auto matMul = ov::as_type_ptr<const ov::opset1::MatMul>(op);
         if (!matMul) {
             errorMessage = "Only opset1 MatMul operation is supported";
             return false;
@@ -121,7 +121,7 @@ MatMul::MatMul(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
     if (!isSupportedOperation(op, errorMessage))
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
 
-    const auto matMul = std::dynamic_pointer_cast<const ov::opset1::MatMul>(op);
+    const auto matMul = ov::as_type_ptr<const ov::opset1::MatMul>(op);
 
     if (!matMul) {
         OPENVINO_THROW_NOT_IMPLEMENTED("Operation with name ",

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -25,7 +25,7 @@ using ngNmseDcayFunction = ov::op::v8::MatrixNms::DecayFunction;
 
 bool MatrixNms::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto nms = std::dynamic_pointer_cast<const ov::op::v8::MatrixNms>(op);
+        const auto nms = ov::as_type_ptr<const ov::op::v8::MatrixNms>(op);
         if (!nms) {
             errorMessage = "Only MatrixNms operation is supported";
             return false;
@@ -65,7 +65,7 @@ MatrixNms::MatrixNms(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
     if (getOriginalOutputsNumber() != 3)
         OPENVINO_THROW(m_errorPrefix, "has incorrect number of output edges: ", getOriginalOutputsNumber());
 
-    const auto matrix_nms = std::dynamic_pointer_cast<const ov::op::v8::MatrixNms>(op);
+    const auto matrix_nms = ov::as_type_ptr<const ov::op::v8::MatrixNms>(op);
 
     auto& attrs = matrix_nms->get_attrs();
     if (attrs.sort_result_type == ov::op::v8::MatrixNms::SortResultType::CLASSID)

--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -728,7 +728,7 @@ private:
 
 bool MHA::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto mha = std::dynamic_pointer_cast<const MHANode>(op);
+        const auto mha = ov::as_type_ptr<const MHANode>(op);
         if (!mha) {
             errorMessage = "Only MHA from CPU internal opset is supported";
             return false;
@@ -808,7 +808,7 @@ MHA::MHA(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    const auto mha = std::dynamic_pointer_cast<const MHANode>(op);
+    const auto mha = ov::as_type_ptr<const MHANode>(op);
     mulScales = mha->get_mul_scales();
     isMulFirst = mha->get_is_mul_first();
     fqScales0 = mha->get_fq_scales0();

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -59,7 +59,7 @@ MultiClassNms::MultiClassNms(const std::shared_ptr<ov::Node>& op, const GraphCon
     if (getOriginalOutputsNumber() != 3)
         OPENVINO_THROW(m_errorPrefix, "has incorrect number of output edges: ", getOriginalOutputsNumber());
 
-    auto nmsBase = std::dynamic_pointer_cast<ov::op::util::MulticlassNmsBase>(op);
+    auto nmsBase = ov::as_type_ptr<ov::op::util::MulticlassNmsBase>(op);
     if (nmsBase == nullptr)
         OPENVINO_THROW(m_errorPrefix, " is not an instance of MulticlassNmsBase.");
     auto& atrri = nmsBase->get_attrs();

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -21,18 +21,17 @@ namespace node {
 
 bool OneHot::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto oneHot = std::dynamic_pointer_cast<const ov::opset1::OneHot>(op);
+        const auto oneHot = ov::as_type_ptr<const ov::opset1::OneHot>(op);
         if (!oneHot) {
             errorMessage = "Only opset1 OneHot operation is supported";
             return false;
         }
-        if (std::dynamic_pointer_cast<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(ON_VALUE_ID)) ==
-            nullptr) {
+        if (ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(ON_VALUE_ID)) == nullptr) {
             errorMessage = "Only const 'on_value' input is supported";
             return false;
         }
-        if (std::dynamic_pointer_cast<const ov::opset1::Constant>(
-                oneHot->get_input_node_shared_ptr(OFF_VALUEAXES_ID)) == nullptr) {
+        if (ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(OFF_VALUEAXES_ID)) ==
+            nullptr) {
             errorMessage = "Only const 'off_value' input is supported";
             return false;
         }
@@ -50,9 +49,8 @@ OneHot::OneHot(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
     }
 
     errorPrefix = "OneHot layer with name '" + op->get_friendly_name() + "'";
-    const auto oneHot = std::dynamic_pointer_cast<const ov::opset1::OneHot>(op);
-    const auto depthNode =
-        std::dynamic_pointer_cast<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(DEPTH_ID));
+    const auto oneHot = ov::as_type_ptr<const ov::opset1::OneHot>(op);
+    const auto depthNode = ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(DEPTH_ID));
     if (depthNode) {
         depth = depthNode->cast_vector<uint32_t>()[0];
     }

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -32,7 +32,7 @@ float clip_less(float x, float threshold) {
 
 bool PriorBox::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto priorBox = std::dynamic_pointer_cast<const ov::opset1::PriorBox>(op);
+        const auto priorBox = ov::as_type_ptr<const ov::opset1::PriorBox>(op);
         if (!priorBox) {
             errorMessage = "Only opset1 PriorBox operation is supported";
             return false;
@@ -50,7 +50,7 @@ PriorBox::PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    const auto priorBox = std::dynamic_pointer_cast<const ov::opset1::PriorBox>(op);
+    const auto priorBox = ov::as_type_ptr<const ov::opset1::PriorBox>(op);
     const ov::opset1::PriorBox::Attributes& attrs = priorBox->get_attrs();
     offset = attrs.offset;
     step = attrs.step;

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -20,7 +20,7 @@ namespace node {
 bool PriorBoxClustered::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                              std::string& errorMessage) noexcept {
     try {
-        const auto priorBox = std::dynamic_pointer_cast<const ov::opset1::PriorBoxClustered>(op);
+        const auto priorBox = ov::as_type_ptr<const ov::opset1::PriorBoxClustered>(op);
         if (!priorBox) {
             errorMessage = "Only opset1 PriorBoxClustered operation is supported";
             return false;
@@ -38,7 +38,7 @@ PriorBoxClustered::PriorBoxClustered(const std::shared_ptr<ov::Node>& op, const 
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    const auto priorBox = std::dynamic_pointer_cast<const ov::opset1::PriorBoxClustered>(op);
+    const auto priorBox = ov::as_type_ptr<const ov::opset1::PriorBoxClustered>(op);
     const ov::opset1::PriorBoxClustered::Attributes& attrs = priorBox->get_attrs();
 
     widths = attrs.widths;

--- a/src/plugins/intel_cpu/src/nodes/proposal.cpp
+++ b/src/plugins/intel_cpu/src/nodes/proposal.cpp
@@ -81,7 +81,7 @@ bool Proposal::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, s
             errorMessage = "Node is not an instance of the Proposal from the operations set v0 or v4.";
             return false;
         }
-        auto proposalOp = std::dynamic_pointer_cast<const ov::op::v0::Proposal>(op);
+        auto proposalOp = ov::as_type_ptr<const ov::op::v0::Proposal>(op);
         if (proposalOp->get_attrs().framework != "tensorflow" && !proposalOp->get_attrs().framework.empty()) {
             errorMessage = "Unsupported framework attribute: " + proposalOp->get_attrs().framework;
             return false;
@@ -99,7 +99,7 @@ Proposal::Proposal(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
 
-    auto proposalOp = std::dynamic_pointer_cast<const ov::op::v0::Proposal>(op);
+    auto proposalOp = ov::as_type_ptr<const ov::op::v0::Proposal>(op);
     auto proposalAttrs = proposalOp->get_attrs();
 
     conf.feat_stride_ = proposalAttrs.feat_stride;

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -32,8 +32,8 @@ bool PSROIPooling::isSupportedOperation(const std::shared_ptr<const ov::Node>& o
             errorMessage = "Doesn't support op with dynamic shapes";
             return false;
         }
-        const auto psroi = std::dynamic_pointer_cast<const ov::opset1::PSROIPooling>(op);
-        const auto defPsroi = std::dynamic_pointer_cast<const ov::opset1::DeformablePSROIPooling>(op);
+        const auto psroi = ov::as_type_ptr<const ov::opset1::PSROIPooling>(op);
+        const auto defPsroi = ov::as_type_ptr<const ov::opset1::DeformablePSROIPooling>(op);
         if (!psroi && !defPsroi) {
             errorMessage = "Only opset1 PSROIPooling and DeformablePSROIPooling operations are supported";
             return false;
@@ -68,8 +68,8 @@ PSROIPooling::PSROIPooling(const std::shared_ptr<ov::Node>& op, const GraphConte
 
     errorPrefix = std::string(op->get_type_name()) + " node with name '" + op->get_friendly_name() + "'";
 
-    const auto psroi = std::dynamic_pointer_cast<const ov::opset1::PSROIPooling>(op);
-    const auto defPsroi = std::dynamic_pointer_cast<const ov::opset1::DeformablePSROIPooling>(op);
+    const auto psroi = ov::as_type_ptr<const ov::opset1::PSROIPooling>(op);
+    const auto defPsroi = ov::as_type_ptr<const ov::opset1::DeformablePSROIPooling>(op);
 
     noTrans = op->get_input_size() == 2;
     if (op->get_input_shape(0).size() != 4)

--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -346,7 +346,7 @@ QKVProjection::QKVProjection(const std::shared_ptr<ov::Node>& op, const GraphCon
     if (!isSupportedOperation(op, errorMessage, concurrency, config.fcDynamicQuantizationGroupSize)) {
         OPENVINO_THROW("CPU: " + errorMessage);
     }
-    const auto node = std::dynamic_pointer_cast<const QKVProjectionNode>(op);
+    const auto node = ov::as_type_ptr<const QKVProjectionNode>(op);
     m_config = node->get_config();
 }
 
@@ -424,7 +424,7 @@ bool QKVProjection::isSupportedOperation(const std::shared_ptr<const ov::Node>& 
                                          uint64_t fcDynamicQuantizationGroupSize) noexcept {
 #if defined(OPENVINO_ARCH_X86_64)
     try {
-        const auto node_qkv = std::dynamic_pointer_cast<const QKVProjectionNode>(op);
+        const auto node_qkv = ov::as_type_ptr<const QKVProjectionNode>(op);
         if (node_qkv) {
             if (concurrency > 0) {
                 if (concurrency < 3) {

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1923,23 +1923,23 @@ Reduce::getInitializers() {
 
 bool Reduce::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (std::dynamic_pointer_cast<const ov::op::util::ArithmeticReductionKeepDims>(op) == nullptr &&
-            std::dynamic_pointer_cast<const ov::op::util::LogicalReductionKeepDims>(op) == nullptr) {
+        if (ov::as_type_ptr<const ov::op::util::ArithmeticReductionKeepDims>(op) == nullptr &&
+            ov::as_type_ptr<const ov::op::util::LogicalReductionKeepDims>(op) == nullptr) {
             errorMessage = "Reduce node with name " + op->get_friendly_name() +
                            " is not derived from ArithmeticReductionKeepDims or LogicalReductionKeepDims";
             return false;
         }
-        if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::ArithmeticReductionKeepDims>(op)) {
-            auto reduceConst = std::dynamic_pointer_cast<const ov::opset1::Constant>(
-                reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+        if (const auto reduce = ov::as_type_ptr<const ov::op::util::ArithmeticReductionKeepDims>(op)) {
+            auto reduceConst =
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
             if (!reduceConst) {
                 errorMessage = "Second tensor is not constant";
                 return false;
             }
         }
-        if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::LogicalReductionKeepDims>(op)) {
-            auto reduceConst = std::dynamic_pointer_cast<const ov::opset1::Constant>(
-                reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+        if (const auto reduce = ov::as_type_ptr<const ov::op::util::LogicalReductionKeepDims>(op)) {
+            auto reduceConst =
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
             if (!reduceConst) {
                 errorMessage = "Second tensor is not constant";
                 return false;
@@ -1949,7 +1949,7 @@ bool Reduce::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
             errorMessage = "Doesn't support Reduce algorithm: " + std::string(op->get_type_info().name);
             return false;
         }
-        if (std::dynamic_pointer_cast<ov::opset1::Constant>(op->get_input_node_shared_ptr(REDUCE_INDEXES)) == nullptr) {
+        if (ov::as_type_ptr<ov::opset1::Constant>(op->get_input_node_shared_ptr(REDUCE_INDEXES)) == nullptr) {
             errorMessage = "Only const 'reduce_indexes' input is supported";
             return false;
         }
@@ -1965,17 +1965,17 @@ Reduce::Reduce(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr con
     if (isSupportedOperation(op, errorMessage)) {
         errorPrefix = "Reduce node with name '" + getName() + "'";
         getInitializers().at(op->get_type_info())(op, *this);
-        if (const auto reduce = std::dynamic_pointer_cast<ov::op::util::ArithmeticReductionKeepDims>(op)) {
+        if (const auto reduce = ov::as_type_ptr<ov::op::util::ArithmeticReductionKeepDims>(op)) {
             keep_dims = reduce->get_keep_dims();
-            auto reduceConst = std::dynamic_pointer_cast<const ov::opset1::Constant>(
-                reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+            auto reduceConst =
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
             if (!reduceConst)
                 OPENVINO_THROW(errorPrefix, " second tensor is not constant!");
             raw_axes = reduceConst->cast_vector<int>();
-        } else if (const auto reduce = std::dynamic_pointer_cast<ov::op::util::LogicalReductionKeepDims>(op)) {
+        } else if (const auto reduce = ov::as_type_ptr<ov::op::util::LogicalReductionKeepDims>(op)) {
             keep_dims = reduce->get_keep_dims();
-            auto reduceConst = std::dynamic_pointer_cast<const ov::opset1::Constant>(
-                reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+            auto reduceConst =
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
             if (!reduceConst)
                 OPENVINO_THROW(errorPrefix, " second tensor is not constant!");
             raw_axes = reduceConst->cast_vector<int>();

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -243,7 +243,7 @@ private:
 
 bool RegionYolo::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto regionYolo = std::dynamic_pointer_cast<const ov::opset1::RegionYolo>(op);
+        const auto regionYolo = ov::as_type_ptr<const ov::opset1::RegionYolo>(op);
         if (!regionYolo) {
             errorMessage = "Only opset1 RegionYolo operation is supported";
             return false;
@@ -269,7 +269,7 @@ RegionYolo::RegionYolo(const std::shared_ptr<ov::Node>& op, const GraphContext::
     if (op->get_input_size() != 1 || op->get_output_size() != 1)
         OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
 
-    const auto regionYolo = std::dynamic_pointer_cast<const ov::opset1::RegionYolo>(op);
+    const auto regionYolo = ov::as_type_ptr<const ov::opset1::RegionYolo>(op);
     classes = regionYolo->get_num_classes();
     coords = regionYolo->get_num_coords();
     num = regionYolo->get_num_regions();

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
@@ -15,7 +15,7 @@ namespace node {
 
 bool ReorgYolo::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto reorgYolo = std::dynamic_pointer_cast<const ov::opset2::ReorgYolo>(op);
+        const auto reorgYolo = ov::as_type_ptr<const ov::opset2::ReorgYolo>(op);
         if (!reorgYolo) {
             errorMessage = "Only opset2 ReorgYolo operation is supported";
             return false;
@@ -37,7 +37,7 @@ ReorgYolo::ReorgYolo(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
     if (getOriginalInputsNumber() != 1 || getOriginalOutputsNumber() != 1)
         OPENVINO_THROW(errorPrefix, " has incorrect number of input/output edges!");
 
-    const auto reorgYolo = std::dynamic_pointer_cast<const ov::opset2::ReorgYolo>(op);
+    const auto reorgYolo = ov::as_type_ptr<const ov::opset2::ReorgYolo>(op);
     const auto strides = reorgYolo->get_strides();
     if (strides.empty())
         OPENVINO_THROW(errorPrefix, " has empty strides");

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -19,9 +19,8 @@ namespace node {
 
 bool Reshape::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (!std::dynamic_pointer_cast<const ov::opset1::Reshape>(op) &&
-            !std::dynamic_pointer_cast<const ov::opset1::Squeeze>(op) &&
-            !std::dynamic_pointer_cast<const ov::opset1::Unsqueeze>(op)) {
+        if (!ov::as_type_ptr<const ov::opset1::Reshape>(op) && !ov::as_type_ptr<const ov::opset1::Squeeze>(op) &&
+            !ov::as_type_ptr<const ov::opset1::Unsqueeze>(op)) {
             errorMessage = "Only opset1 Reshape, Squeeze, Unsqueeze operations are supported";
             return false;
         }
@@ -47,13 +46,13 @@ Reshape::Reshape(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
             }
         };
 
-        if (std::dynamic_pointer_cast<const ov::opset1::Reshape>(op)) {
+        if (ov::as_type_ptr<const ov::opset1::Reshape>(op)) {
             checkSecondInput(op, "Reshape");
-        } else if (std::dynamic_pointer_cast<const ov::opset1::Squeeze>(op)) {
+        } else if (ov::as_type_ptr<const ov::opset1::Squeeze>(op)) {
             if (op->get_input_size() == 1)
                 OPENVINO_THROW("CPU plug-in doesn't support Squeeze node with inputs num equal 1");
             checkSecondInput(op, "Squeeze");
-        } else if (std::dynamic_pointer_cast<const ov::opset1::Unsqueeze>(op)) {
+        } else if (ov::as_type_ptr<const ov::opset1::Unsqueeze>(op)) {
             checkSecondInput(op, "Unsqueeze");
         } else {
             OPENVINO_THROW("Unsupported operation type via reshape node");

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.cpp
@@ -17,7 +17,7 @@ namespace node {
 bool ReverseSequence::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                            std::string& errorMessage) noexcept {
     try {
-        const auto revSeq = std::dynamic_pointer_cast<const ov::opset1::ReverseSequence>(op);
+        const auto revSeq = ov::as_type_ptr<const ov::opset1::ReverseSequence>(op);
         if (!revSeq) {
             errorMessage = "Only opset1 ReverseSequence operation is supported";
             return false;
@@ -36,7 +36,7 @@ ReverseSequence::ReverseSequence(const std::shared_ptr<ov::Node>& op, const Grap
     }
 
     errorPrefix = "ReverseSequence layer with name '" + op->get_friendly_name() + "'";
-    const auto revSeq = std::dynamic_pointer_cast<const ov::opset1::ReverseSequence>(op);
+    const auto revSeq = ov::as_type_ptr<const ov::opset1::ReverseSequence>(op);
     if (revSeq == nullptr)
         OPENVINO_THROW("Operation with name '",
                        op->get_friendly_name(),

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
@@ -123,7 +123,7 @@ RMSNorm::RMSNorm(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr c
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW("CPU: " + errorMessage);
     }
-    const auto rms = std::dynamic_pointer_cast<const ov::op::internal::RMS>(op);
+    const auto rms = ov::as_type_ptr<const ov::op::internal::RMS>(op);
     m_eps = static_cast<float>(rms->get_epsilon());
 }
 
@@ -185,7 +185,7 @@ void RMSNorm::execute(dnnl::stream strm) {
 
 bool RMSNorm::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto rms = std::dynamic_pointer_cast<const ov::op::internal::RMS>(op);
+        const auto rms = ov::as_type_ptr<const ov::op::internal::RMS>(op);
         if (rms) {
             if (!dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2)) {
                 errorMessage = "RMSNorm needs avx2+.";

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -480,7 +480,7 @@ RNN::RNN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context)
         coIdx = 2;
     }
 
-    auto rnnCellBase = std::dynamic_pointer_cast<ov::op::util::RNNCellBase>(op);
+    auto rnnCellBase = ov::as_type_ptr<ov::op::util::RNNCellBase>(op);
     if (!rnnCellBase)
         THROW_CPU_NODE_ERR("does not have original layer for RNNCell.");
 

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -23,7 +23,7 @@ namespace node {
 
 bool Roll::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto interp = std::dynamic_pointer_cast<const ov::opset7::Roll>(op);
+        const auto interp = ov::as_type_ptr<const ov::opset7::Roll>(op);
         if (!interp) {
             errorMessage = "Only opset7 Roll operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -28,7 +28,7 @@ RoPE::RoPE(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
         OPENVINO_THROW("CPU: " + errorMessage);
     }
 
-    const auto node = std::dynamic_pointer_cast<const op::internal::RoPE>(op);
+    const auto node = ov::as_type_ptr<const op::internal::RoPE>(op);
     m_config = node->get_config();
 }
 
@@ -457,7 +457,7 @@ void RoPE::execute(dnnl::stream strm) {
 
 bool RoPE::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto node = std::dynamic_pointer_cast<const op::internal::RoPE>(op);
+        const auto node = ov::as_type_ptr<const op::internal::RoPE>(op);
         if (!node) {
             errorMessage = "Only RoPE operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -1082,11 +1082,11 @@ ScaledDotProductAttention::ScaledDotProductAttention(const std::shared_ptr<ov::N
                                         : cpuConfig.valueCacheGroupSize;
     m_key_quant_param.precision = valueCachePrecision;
 
-    if (const auto node = std::dynamic_pointer_cast<const ov::op::v13::ScaledDotProductAttention>(op)) {
+    if (const auto node = ov::as_type_ptr<const ov::op::v13::ScaledDotProductAttention>(op)) {
         m_config.config.is_causal = node->get_causal();
-    } else if (const auto node = std::dynamic_pointer_cast<const ScaledDotProductAttentionWithKVCache>(op)) {
+    } else if (const auto node = ov::as_type_ptr<const ScaledDotProductAttentionWithKVCache>(op)) {
         m_config.config = node->get_config();
-    } else if (const auto node = std::dynamic_pointer_cast<const SDPAWithTransposeReshape>(op)) {
+    } else if (const auto node = ov::as_type_ptr<const SDPAWithTransposeReshape>(op)) {
         m_config.config = node->get_config();
     }
 }
@@ -1247,9 +1247,9 @@ void ScaledDotProductAttention::execute(dnnl::stream strm) {
 bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                                      std::string& errorMessage) noexcept {
     try {
-        auto sdpaWithTransposeReshapeOp = std::dynamic_pointer_cast<const SDPAWithTransposeReshape>(op);
-        if (!std::dynamic_pointer_cast<const ov::op::v13::ScaledDotProductAttention>(op) &&
-            !std::dynamic_pointer_cast<const ScaledDotProductAttentionWithKVCache>(op) && !sdpaWithTransposeReshapeOp) {
+        auto sdpaWithTransposeReshapeOp = ov::as_type_ptr<const SDPAWithTransposeReshape>(op);
+        if (!ov::as_type_ptr<const ov::op::v13::ScaledDotProductAttention>(op) &&
+            !ov::as_type_ptr<const ScaledDotProductAttentionWithKVCache>(op) && !sdpaWithTransposeReshapeOp) {
             errorMessage = "Only ScaledDotProductAttention, ScaledDotProductAttentionWithKVCache or "
                            "SDPAWithTransposeReshape operation are supported";
             return false;
@@ -1270,7 +1270,7 @@ bool ScaledDotProductAttention::isSupportedOperation(const std::shared_ptr<const
         }
 
         int orgSDPAInput = static_cast<int>(op->get_input_size());
-        const auto node = std::dynamic_pointer_cast<const ScaledDotProductAttentionWithKVCache>(op);
+        const auto node = ov::as_type_ptr<const ScaledDotProductAttentionWithKVCache>(op);
         if (node) {
             if (node->get_config().fuse_concat) {
                 orgSDPAInput -= 3;

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -58,7 +58,7 @@ bool SoftmaxKey::operator==(const SoftmaxKey& rhs) const {
 
 bool SoftMax::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (!std::dynamic_pointer_cast<const ov::opset1::Softmax>(op)) {
+        if (!ov::as_type_ptr<const ov::opset1::Softmax>(op)) {
             errorMessage = "Only opset1 Softmax operation is supported";
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.cpp
@@ -14,7 +14,7 @@ namespace node {
 
 bool SpaceToBatch::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        const auto spaceToBatch = std::dynamic_pointer_cast<const ov::op::v1::SpaceToBatch>(op);
+        const auto spaceToBatch = ov::as_type_ptr<const ov::op::v1::SpaceToBatch>(op);
         if (!spaceToBatch) {
             errorMessage = "Only opset2 SpaceToBatch operation is supported";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1863,8 +1863,7 @@ bool TopK::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::
 
         auto topKOp = ov::as_type_ptr<const ov::op::util::TopKBase>(op);
         if (!isDynamicNgraphNode(op)) {
-            auto topKConst =
-                std::dynamic_pointer_cast<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
+            auto topKConst = ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
             if (!topKConst) {
                 errorMessage = "Second tensor is not constant in static shape mode";
                 return false;
@@ -1902,8 +1901,7 @@ TopK::TopK(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr context
         auto in_dims_size = in_dims.size();
 
         if (!isDynamicNgraphNode(op)) {
-            auto topKConst =
-                std::dynamic_pointer_cast<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
+            auto topKConst = ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
             if (!topKConst) {
                 OPENVINO_THROW(errorPrefix, "gets non-constant second tensor in static shape mode!");
             }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
@@ -71,7 +71,7 @@ private:
 };
 
 ShapeInferPtr SDPAShapeInferFactory::makeShapeInfer() const {
-    if (auto sdpa = std::dynamic_pointer_cast<const ScaledDotProductAttentionWithKVCache>(m_op)) {
+    if (auto sdpa = ov::as_type_ptr<const ScaledDotProductAttentionWithKVCache>(m_op)) {
         const auto& config = sdpa->get_config();
         if (config.output_BLHxS == false)
             return std::make_shared<SDPAShapeInfer>(config);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
@@ -14,7 +14,7 @@ ov::intel_cpu::ConvertGroupConvolution::ConvertGroupConvolution() {
 
     ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
         enum Inputs { Data, Weights };
-        auto gconv = std::dynamic_pointer_cast<opset8::GroupConvolution>(m.get_match_root());
+        auto gconv = ov::as_type_ptr<opset8::GroupConvolution>(m.get_match_root());
         if (!gconv) {
             return false;
         }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.cpp
@@ -18,7 +18,7 @@ ov::matcher_pass_callback ov::intel_cpu::ConvertReduceMultiAxisBase::convert_red
         const auto& input0 = reduce->input_value(0);
         const auto& input1 = reduce->input_value(1);
         const auto& data_shape0 = input0.get_partial_shape();
-        auto reduction_axes = std::dynamic_pointer_cast<ov::opset8::Constant>(input1.get_node_shared_ptr());
+        auto reduction_axes = ov::as_type_ptr<ov::opset8::Constant>(input1.get_node_shared_ptr());
         if (!reduction_axes) {
             return false;
         }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/mish_decomposition.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/mish_decomposition.cpp
@@ -10,7 +10,7 @@ ov::intel_cpu::MishDecomposition::MishDecomposition() {
     auto mish = ov::pass::pattern::wrap_type<opset4::Mish>();
 
     ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
-        auto mish = std::dynamic_pointer_cast<opset4::Mish>(m.get_match_root());
+        auto mish = ov::as_type_ptr<opset4::Mish>(m.get_match_root());
         if (!mish) {
             return false;
         }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/align_matmul_input_ranks.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/align_matmul_input_ranks.cpp
@@ -22,7 +22,7 @@ ov::intel_cpu::AlignMatMulInputRanks::AlignMatMulInputRanks() {
     auto matmulPattern = ov::pass::pattern::wrap_type<ov::op::v0::MatMul>(twoInputs);
 
     ov::matcher_pass_callback callback = [this](ov::pass::pattern::Matcher& m) {
-        auto matmul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(m.get_match_root());
+        auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(m.get_match_root());
 
         if (!matmul || transformation_callback(matmul))
             return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.cpp
@@ -207,8 +207,7 @@ CausalMaskPreprocess::CausalMaskPreprocess() {
         ov::intel_cpu::CausalMaskPreprocessNode::Config config;
         config.type = "CausalMaskPreprocess";
 
-        auto triu =
-            std::dynamic_pointer_cast<ov::opset1::Constant>(pattern_map.find(const_triu)->second.get_node_shared_ptr());
+        auto triu = ov::as_type_ptr<ov::opset1::Constant>(pattern_map.find(const_triu)->second.get_node_shared_ptr());
 
         auto triu_shape = triu->get_output_shape(0);
         if (triu_shape.size() != 4)

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_broadcast_to_tiles.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_broadcast_to_tiles.cpp
@@ -14,7 +14,7 @@ ov::intel_cpu::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
     auto broadcast = ov::pass::pattern::wrap_type<ov::opset1::Broadcast>();
 
     ov::matcher_pass_callback callback = [this](ov::pass::pattern::Matcher& m) {
-        auto broadcast = std::dynamic_pointer_cast<ov::opset1::Broadcast>(m.get_match_root());
+        auto broadcast = ov::as_type_ptr<ov::opset1::Broadcast>(m.get_match_root());
         if (!broadcast) {
             return false;
         }
@@ -24,10 +24,8 @@ ov::intel_cpu::ConvertBroadcastToTiles::ConvertBroadcastToTiles() {
             return false;
         }
 
-        auto shape_node =
-            std::dynamic_pointer_cast<ov::opset1::Constant>(broadcast->input_value(1).get_node_shared_ptr());
-        auto axes_node =
-            std::dynamic_pointer_cast<ov::opset1::Constant>(broadcast->input_value(2).get_node_shared_ptr());
+        auto shape_node = ov::as_type_ptr<ov::opset1::Constant>(broadcast->input_value(1).get_node_shared_ptr());
+        auto axes_node = ov::as_type_ptr<ov::opset1::Constant>(broadcast->input_value(2).get_node_shared_ptr());
         if (!shape_node || !axes_node)
             return false;
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
@@ -170,10 +170,9 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
         const auto& input_scale_output = pattern_map.at(input_scale_X);
         const auto& weights_scale_output = pattern_map.at(weights_scale_W);
         // extract constant values
-        const auto input_scale_constant =
-            std::dynamic_pointer_cast<op::v0::Constant>(input_scale_output.get_node_shared_ptr());
+        const auto input_scale_constant = ov::as_type_ptr<op::v0::Constant>(input_scale_output.get_node_shared_ptr());
         const auto weights_scale_constant =
-            std::dynamic_pointer_cast<op::v0::Constant>(weights_scale_output.get_node_shared_ptr());
+            ov::as_type_ptr<op::v0::Constant>(weights_scale_output.get_node_shared_ptr());
 
         if (!input_scale_constant || !weights_scale_constant)
             return false;
@@ -201,7 +200,7 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
 
         if (input_shift_it != pattern_map.end()) {
             const auto input_shift_constant =
-                std::dynamic_pointer_cast<op::v0::Constant>(input_shift_it->second.get_node_shared_ptr());
+                ov::as_type_ptr<op::v0::Constant>(input_shift_it->second.get_node_shared_ptr());
             const float* input_shift_ptr = input_shift_constant->get_data_ptr<float>();
             runtime_info["inputShift"] = *input_shift_ptr;
         }
@@ -225,8 +224,7 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
             std::shared_ptr<Node> multiply_input = new_convert;
             // dequantize with subtract
             if (subtract_it != pattern_map.end()) {
-                const auto subtract =
-                    std::dynamic_pointer_cast<op::v1::Subtract>(subtract_it->second.get_node_shared_ptr());
+                const auto subtract = ov::as_type_ptr<op::v1::Subtract>(subtract_it->second.get_node_shared_ptr());
                 multiply_input = subtract->clone_with_new_inputs({multiply_input, subtract->input_value(1)});
             }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_matmul_to_fc.cpp
@@ -27,7 +27,7 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
 
-        auto matmul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(pattern_map.at(matmul_m).get_node_shared_ptr());
+        auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(pattern_map.at(matmul_m).get_node_shared_ptr());
         if (!matmul || transformation_callback(matmul)) {
             return false;
         }
@@ -37,7 +37,7 @@ ov::intel_cpu::ConvertMatMulToFC::ConvertMatMulToFC() {
         auto fc_input_a = pattern_map.at(activations_m);
         auto fc_input_b = pattern_map.at(weights_m);
         bool is_convert = false;
-        if (auto convert_node = std::dynamic_pointer_cast<ov::op::v0::Convert>(fc_input_b.get_node_shared_ptr())) {
+        if (auto convert_node = ov::as_type_ptr<ov::op::v0::Convert>(fc_input_b.get_node_shared_ptr())) {
             if (is_decompression(convert_node)) {
                 is_convert = true;
                 fc_input_b = convert_node->get_input_node_shared_ptr(0);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_tile_to_seq_tiles.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_tile_to_seq_tiles.cpp
@@ -19,12 +19,12 @@ ov::intel_cpu::ConvertTileToSeqTiles::ConvertTileToSeqTiles() {
          ov::pass::pattern::wrap_type<ov::opset1::Constant>()});
 
     ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
-        auto tile = std::dynamic_pointer_cast<ov::opset1::Tile>(m.get_match_root());
+        auto tile = ov::as_type_ptr<ov::opset1::Tile>(m.get_match_root());
         if (!tile) {
             return false;
         }
 
-        auto tiles_node = std::dynamic_pointer_cast<ov::opset1::Constant>(tile->input_value(1).get_node_shared_ptr());
+        auto tiles_node = ov::as_type_ptr<ov::opset1::Constant>(tile->input_value(1).get_node_shared_ptr());
         if (!tiles_node)
             return false;
 
@@ -48,7 +48,7 @@ ov::intel_cpu::ConvertTileToSeqTiles::ConvertTileToSeqTiles() {
         if (num_of_tile_dims == 0) {
             auto outputs = tile->get_output_target_inputs(0);
             for (const auto& out : outputs) {
-                if (std::dynamic_pointer_cast<ov::opset1::Result>(out.get_node()->shared_from_this())) {
+                if (ov::as_type_ptr<ov::opset1::Result>(out.get_node()->shared_from_this())) {
                     return false;
                 }
             }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_leaky_relu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_leaky_relu.cpp
@@ -17,11 +17,11 @@ ov::intel_cpu::ConvertToLeakyRelu::ConvertToLeakyRelu() {
     auto prelu = ov::pass::pattern::wrap_type<ov::opset1::PRelu>({input, slope_constant});
 
     ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
-        auto prelu = std::dynamic_pointer_cast<ov::opset1::PRelu>(m.get_match_root());
+        auto prelu = ov::as_type_ptr<ov::opset1::PRelu>(m.get_match_root());
         if (!prelu) {
             return false;
         }
-        auto slopeNode = std::dynamic_pointer_cast<ov::opset1::Constant>(prelu->get_input_node_shared_ptr(1));
+        auto slopeNode = ov::as_type_ptr<ov::opset1::Constant>(prelu->get_input_node_shared_ptr(1));
         if (slopeNode != nullptr && ov::shape_size(slopeNode->get_shape()) == 1) {
             const float slope = slopeNode->cast_vector<float>()[0];
             const auto leakyRelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(prelu->input(0).get_source_output(),

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_power_static.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_power_static.cpp
@@ -20,8 +20,8 @@
 namespace {
 
 int getConstPort(const std::shared_ptr<ov::Node>& node) {
-    const auto const1 = std::dynamic_pointer_cast<ov::opset1::Constant>(node->get_input_node_shared_ptr(0));
-    const auto const2 = std::dynamic_pointer_cast<ov::opset1::Constant>(node->get_input_node_shared_ptr(1));
+    const auto const1 = ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(0));
+    const auto const2 = ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(1));
     int constPort = -1;
     if (const2) {
         constPort = 1;
@@ -63,7 +63,7 @@ bool isConvertableToPowerStatic(const std::shared_ptr<ov::opset1::Power>& node) 
     auto input_rank = node->get_input_partial_shape(0).rank();
     if (input_rank.is_dynamic())
         return false;
-    auto const_node = std::dynamic_pointer_cast<ov::opset1::Constant>(node->get_input_node_shared_ptr(1));
+    auto const_node = ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(1));
     return const_node &&
            input_rank.get_length() >= static_cast<ov::Dimension::value_type>(const_node->get_shape().size()) &&
            ov::shape_size(const_node->get_shape()) == 1;
@@ -74,7 +74,7 @@ std::shared_ptr<ov::Node> convert(const std::shared_ptr<BaseOp>& node) {
     const int constPort = getConstPort(node);
     const int nonConstPort = 1 - constPort;
     std::shared_ptr<ov::opset1::Constant> powerNode =
-        std::dynamic_pointer_cast<ov::opset1::Constant>(node->get_input_node_shared_ptr(constPort));
+        ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(constPort));
     const float value = powerNode->cast_vector<float>()[0];
     if (std::is_same<BaseOp, ov::opset1::Power>::value) {
         return std::make_shared<ov::intel_cpu::PowerStaticNode>(node->input(nonConstPort).get_source_output(),
@@ -134,19 +134,19 @@ ov::intel_cpu::ConvertToPowerStatic::ConvertToPowerStatic() {
         auto node = m.get_match_root();
 
         std::shared_ptr<ov::Node> toReplace = node;
-        if (auto power = std::dynamic_pointer_cast<ov::opset1::Power>(node)) {
+        if (auto power = ov::as_type_ptr<ov::opset1::Power>(node)) {
             if (!isConvertableToPowerStatic(power))
                 return false;
             toReplace = convert(power);
-        } else if (auto add = std::dynamic_pointer_cast<ov::opset1::Add>(node)) {
+        } else if (auto add = ov::as_type_ptr<ov::opset1::Add>(node)) {
             if (!isConvertableToPowerStatic(add))
                 return false;
             toReplace = convert(add);
-        } else if (auto sub = std::dynamic_pointer_cast<ov::opset1::Subtract>(node)) {
+        } else if (auto sub = ov::as_type_ptr<ov::opset1::Subtract>(node)) {
             if (!isConvertableToPowerStatic(sub))
                 return false;
             toReplace = convert(sub);
-        } else if (auto mult = std::dynamic_pointer_cast<ov::opset1::Multiply>(node)) {
+        } else if (auto mult = ov::as_type_ptr<ov::opset1::Multiply>(node)) {
             if (!isConvertableToPowerStatic(mult))
                 return false;
             toReplace = convert(mult);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_swish_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_swish_cpu.cpp
@@ -15,13 +15,13 @@ ov::intel_cpu::ConvertToSwishCPU::ConvertToSwishCPU() {
     auto swish = ov::pass::pattern::wrap_type<ov::opset4::Swish>();
 
     ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
-        auto swish = std::dynamic_pointer_cast<ov::opset4::Swish>(m.get_match_root());
+        auto swish = ov::as_type_ptr<ov::opset4::Swish>(m.get_match_root());
         if (!swish) {
             return false;
         }
         float beta_value = 1.0;
         if (swish->input_values().size() == 2) {
-            auto beta = std::dynamic_pointer_cast<ov::opset4::Constant>(swish->get_input_node_shared_ptr(1));
+            auto beta = ov::as_type_ptr<ov::opset4::Constant>(swish->get_input_node_shared_ptr(1));
 
             if (!beta || ov::shape_size(swish->get_input_shape(1)) != 1) {
                 return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_integer_divide.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_integer_divide.cpp
@@ -13,7 +13,7 @@ DecomposeIntegerDivide::DecomposeIntegerDivide() {
     register_matcher(std::make_shared<ov::pass::pattern::Matcher>(ov::pass::pattern::wrap_type<ov::opset1::Divide>(),
                                                                   "DecomposeIntegerDivide"),
                      [](ov::pass::pattern::Matcher& m) {
-                         auto divide = std::dynamic_pointer_cast<ov::opset1::Divide>(m.get_match_root());
+                         auto divide = ov::as_type_ptr<ov::opset1::Divide>(m.get_match_root());
                          if (!divide) {
                              return false;
                          }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_rms_norm.cpp
@@ -19,8 +19,7 @@ DecomposeRMSNorm::DecomposeRMSNorm() {
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
-        auto node =
-            std::dynamic_pointer_cast<ov::op::internal::RMS>(pattern_to_output.at(pattern_node).get_node_shared_ptr());
+        auto node = ov::as_type_ptr<ov::op::internal::RMS>(pattern_to_output.at(pattern_node).get_node_shared_ptr());
 
         if (node == nullptr || transformation_callback(node)) {
             return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -68,7 +68,7 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
         auto unsqueeze_kv = makePattern<opset1::Unsqueeze>({kv, any_input()});
 
         auto check_one = [](Output<Node> output) -> bool {
-            auto node = std::dynamic_pointer_cast<opset1::Constant>(output.get_node_shared_ptr());
+            auto node = ov::as_type_ptr<opset1::Constant>(output.get_node_shared_ptr());
             const auto& bcst_arg = node->cast_vector<float>();
             return std::all_of(bcst_arg.begin(), bcst_arg.end(), [](float i) {
                 return i == 1.0f;
@@ -128,14 +128,14 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
             auto present_to = out.get_target_inputs();
             for (auto& to : present_to) {
                 auto to_node = to.get_node();
-                if (auto convert = dynamic_cast<opset1::Convert*>(to_node)) {
+                if (auto convert = ov::as_type<opset1::Convert>(to_node)) {
                     auto cvt_targets = convert->get_output_target_inputs(0);
                     if (cvt_targets.size() == 1) {
                         to_node = cvt_targets.begin()->get_node();
                         cvt = convert;
                     }
                 }
-                assign = dynamic_cast<opset6::Assign*>(to_node);
+                assign = ov::as_type<opset6::Assign>(to_node);
                 if (assign)
                     return true;
             }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
@@ -72,7 +72,7 @@ ov::intel_cpu::QKVProjFusion::QKVProjFusion() {
         size_t hidden_size = 0;
         std::vector<int> proj_size;
         for (auto& child : children) {
-            auto mm = dynamic_cast<opset1::MatMul*>(child.get_node());
+            auto mm = ov::as_type<opset1::MatMul>(child.get_node());
             if (!mm) {
                 // maybe a ShapeOf
                 continue;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.cpp
@@ -486,11 +486,11 @@ bool SnippetsMarkSkipped::run_on_model(const std::shared_ptr<ov::Model>& m) {
             SetNodeFusingType(node, NodeFusingType::FusedWithBinaryConvolution);
             channelAxis = DEFAULT_AXIS;
         } else if (isSuitableReduceParent(node)) {
-            const auto reduce = std::dynamic_pointer_cast<const ov::op::util::ArithmeticReductionKeepDims>(node);
+            const auto reduce = ov::as_type_ptr<const ov::op::util::ArithmeticReductionKeepDims>(node);
             channelAxis = getChannelAxis(reduce->get_reduction_axes(), reduce->get_keep_dims());
             SetNodeFusingType(node, NodeFusingType::FusedWithReduce);
         } else if (isSuitableMiscParent(node)) {
-            if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::ArithmeticReductionKeepDims>(node)) {
+            if (const auto reduce = ov::as_type_ptr<const ov::op::util::ArithmeticReductionKeepDims>(node)) {
                 channelAxis = getChannelAxis(reduce->get_reduction_axes(), reduce->get_keep_dims());
             } else {
                 channelAxis = DEFAULT_AXIS;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -526,7 +526,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_SET_CALLBACK_COMMON(
         manager,
         [](const_node_ptr& node) -> bool {
-            const auto maxpool = std::dynamic_pointer_cast<const ov::op::v14::MaxPool>(node);
+            const auto maxpool = ov::as_type_ptr<const ov::op::v14::MaxPool>(node);
             return !maxpool || maxpool->get_rounding_type() == ov::op::RoundingType::CEIL_TORCH;
         },
         ov::pass::ConvertMaxPool14ToMaxPool8);
@@ -534,7 +534,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_SET_CALLBACK_COMMON(
         manager,
         [](const_node_ptr& node) -> bool {
-            const auto avgpool = std::dynamic_pointer_cast<const ov::op::v14::AvgPool>(node);
+            const auto avgpool = ov::as_type_ptr<const ov::op::v14::AvgPool>(node);
             return !avgpool || avgpool->get_rounding_type() == ov::op::RoundingType::CEIL_TORCH;
         },
         ov::pass::ConvertAvgPool14ToAvgPool1);

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
@@ -512,7 +512,7 @@ std::ostream& operator<<(std::ostream& os, const PrintableModel& model) {
             sep = ",";
         }
 
-        if (auto constop = std::dynamic_pointer_cast<op::v0::Constant>(op)) {
+        if (auto constop = ov::as_type_ptr<op::v0::Constant>(op)) {
             if (constop->get_element_type() == element::Type_t::f32) {
                 os << printable(constop->get_vector<float>());
             } else if (constop->get_element_type() == element::Type_t::i8) {
@@ -538,7 +538,7 @@ std::ostream& operator<<(std::ostream& os, const PrintableModel& model) {
         os << std::endl;
 
         // recursively output subgraphs
-        if (auto msubgraph = std::dynamic_pointer_cast<op::util::MultiSubGraphOp>(op)) {
+        if (auto msubgraph = ov::as_type_ptr<op::util::MultiSubGraphOp>(op)) {
             auto cnt = msubgraph->get_internal_subgraphs_size();
             for (size_t i = 0; i < cnt; i++) {
                 os << "\t\t MultiSubGraphOp " << tag << msubgraph->get_friendly_name() << "[" << i << "]" << std::endl;
@@ -549,7 +549,7 @@ std::ostream& operator<<(std::ostream& os, const PrintableModel& model) {
     os << prefix << "}\n";
     os << prefix << "fp16_compress disabled Ngraph nodes:\n";
     for (const auto& op : f.get_ordered_ops()) {
-        if (ov::fp16_compression_is_disabled(op) && !std::dynamic_pointer_cast<op::v0::Constant>(op))
+        if (ov::fp16_compression_is_disabled(op) && !ov::as_type_ptr<op::v0::Constant>(op))
             os << "\t" << tag << op->get_friendly_name() << "\n";
     }
     return os;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
@@ -123,7 +123,7 @@ std::shared_ptr<ov::Node> ConvolutionLayerCPUTest::modifyGraph(const ov::element
                 }
 
                 std::vector<ov::Shape> secondParameterShapes;
-                if (auto parameter = dynamic_cast<ov::op::v0::Parameter*>(opToShapeInfer->get_input_node_ptr(0))) {
+                if (auto parameter = ov::as_type<ov::op::v0::Parameter>(opToShapeInfer->get_input_node_ptr(0))) {
                     parameter->set_partial_shape(targetShapes.front());
                     parameter->validate_and_infer_types();
                 }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets.cpp
@@ -79,7 +79,7 @@ public:
         auto emb_table_node = std::make_shared<ov::op::v0::Parameter>(inType, inputShapes.first);
         ov::ParameterVector params = {emb_table_node};
 
-        auto embBag = std::dynamic_pointer_cast<ov::op::v15::EmbeddingBagOffsets>(
+        auto embBag = ov::as_type_ptr<ov::op::v15::EmbeddingBagOffsets>(
             ov::test::utils::make_embedding_bag_offsets(inType,
                                                         indPrecision,
                                                         emb_table_node,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -74,7 +74,7 @@ public:
         auto emb_table_node = std::make_shared<ov::op::v0::Parameter>(inType, inputShapes.first);
         ov::ParameterVector params = {emb_table_node};
 
-        auto embBag = std::dynamic_pointer_cast<ov::op::v3::EmbeddingBagOffsetsSum>(
+        auto embBag = ov::as_type_ptr<ov::op::v3::EmbeddingBagOffsetsSum>(
             ov::test::utils::make_embedding_bag_offsets_sum(inType,
                                                             indPrecision,
                                                             emb_table_node,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed.cpp
@@ -73,7 +73,7 @@ protected:
         auto emb_table_node = std::make_shared<ov::op::v0::Parameter>(inType, inputShapes.first);
         ov::ParameterVector params = {emb_table_node};
 
-        auto embBag = std::dynamic_pointer_cast<ov::op::v15::EmbeddingBagPacked>(
+        auto embBag = ov::as_type_ptr<ov::op::v15::EmbeddingBagPacked>(
             ov::test::utils::make_embedding_bag_packed(inType,
                                                        indPrecision,
                                                        emb_table_node,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed_sum.cpp
@@ -67,7 +67,7 @@ protected:
         auto emb_table_node = std::make_shared<ov::op::v0::Parameter>(inType, inputShapes.first);
         ov::ParameterVector params = {emb_table_node};
 
-        auto embBag = std::dynamic_pointer_cast<ov::op::v3::EmbeddingBagPackedSum>(
+        auto embBag = ov::as_type_ptr<ov::op::v3::EmbeddingBagPackedSum>(
             ov::test::utils::make_embedding_bag_packed_sum(inType, indPrecision, emb_table_node, indices, withWeights));
         ov::ResultVector results{std::make_shared<ov::op::v0::Result>(embBag)};
         function = std::make_shared<ov::Model>(results, params, "embeddingBagPackedSum");

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_segments_sum.cpp
@@ -77,7 +77,7 @@ protected:
         auto emb_table_node = std::make_shared<ov::op::v0::Parameter>(inType, inputShapes.first);
         ov::ParameterVector params = {emb_table_node};
 
-        auto embBag = std::dynamic_pointer_cast<ov::op::v3::EmbeddingSegmentsSum>(
+        auto embBag = ov::as_type_ptr<ov::op::v3::EmbeddingSegmentsSum>(
             ov::test::utils::make_embedding_segments_sum(inType,
                                                          indPrecision,
                                                          emb_table_node,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
@@ -142,7 +142,7 @@ protected:
                     }
 
                     std::vector<ov::Shape> secondParameterShapes;
-                    if (auto parameter = dynamic_cast<ov::op::v0::Parameter*>(opToShapeInfer->get_input_node_ptr(0))) {
+                    if (auto parameter = ov::as_type<ov::op::v0::Parameter>(opToShapeInfer->get_input_node_ptr(0))) {
                         parameter->set_partial_shape(targetShapes.front());
                         parameter->validate_and_infer_types();
                     }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice.cpp
@@ -121,14 +121,14 @@ protected:
             auto stepNode =
                 std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.step.size()});
 
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(startNode));
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(stopdNode));
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(stepNode));
+            params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(startNode));
+            params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(stopdNode));
+            params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(stepNode));
             if (!sliceParams.axes.empty()) {
                 // With axes parameter
                 auto axesNode =
                     std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.axes.size()});
-                params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(axesNode));
+                params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(axesNode));
                 sliceNode = std::make_shared<ov::op::v8::Slice>(params[0], startNode, stopdNode, stepNode, axesNode);
             } else {
                 // without axes parameter

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice_scatter.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice_scatter.cpp
@@ -123,14 +123,14 @@ protected:
             auto stepNode =
                 std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.step.size()});
 
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(startNode));
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(stopdNode));
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(stepNode));
+            params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(startNode));
+            params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(stopdNode));
+            params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(stepNode));
             if (!sliceParams.axes.empty()) {
                 // With axes parameter
                 auto axesNode =
                     std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{sliceParams.axes.size()});
-                params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(axesNode));
+                params.push_back(ov::as_type_ptr<ov::op::v0::Parameter>(axesNode));
                 sliceNode = std::make_shared<ov::op::v15::SliceScatter>(params[0],
                                                                         params[1],
                                                                         startNode,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/topk.cpp
@@ -120,12 +120,12 @@ protected:
         std::shared_ptr<ov::op::v11::TopK> topk;
         if (staticShape) {
             auto k = std::make_shared<ov::op::v0::Constant>(ElementType::i64, ov::Shape{}, &keepK);
-            topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(
+            topk = ov::as_type_ptr<ov::op::v11::TopK>(
                 std::make_shared<ov::op::v11::TopK>(params[0], k, axis, mode, sort, ElementType::i32, stable));
         } else {
             auto k = std::make_shared<ov::op::v0::Parameter>(ElementType::i64, inputDynamicShapes[1]);
             params.push_back(k);
-            topk = std::dynamic_pointer_cast<ov::op::v11::TopK>(
+            topk = ov::as_type_ptr<ov::op::v11::TopK>(
                 std::make_shared<ov::op::v11::TopK>(params[0], k, axis, mode, sort, ElementType::i32, stable));
         }
 

--- a/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.hpp
@@ -113,11 +113,11 @@ static int getChannelAxis(const ov::AxisSet &axes, bool keep_dims) {
 }
 
 static int getFusingAxis(const std::shared_ptr<ov::Node>& node) {
-    if (std::dynamic_pointer_cast<const ov::op::v0::MatMul>(node)) {
+    if (ov::as_type_ptr<const ov::op::v0::MatMul>(node)) {
         return node->get_output_partial_shape(0).size() - 1; // last dimension
-    } else if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::ArithmeticReductionKeepDims>(node)) {
+    } else if (const auto reduce = ov::as_type_ptr<const ov::op::util::ArithmeticReductionKeepDims>(node)) {
         return getChannelAxis(reduce->get_reduction_axes(), reduce->get_keep_dims());
-    } else if (const auto reduce = std::dynamic_pointer_cast<const ov::op::util::LogicalReductionKeepDims>(node)) {
+    } else if (const auto reduce = ov::as_type_ptr<const ov::op::util::LogicalReductionKeepDims>(node)) {
         return getChannelAxis(reduce->get_reduction_axes(), reduce->get_keep_dims());
     } else {
         return 1; // second dimension

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/fake_quantize_tokenization_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/fake_quantize_tokenization_test.cpp
@@ -33,10 +33,10 @@ public:
         TransformationTestsF::TearDown();
 
         auto subgraph = FunctionHelper::getSubgraph(model);
-        auto body = subgraph == nullptr ? nullptr : std::dynamic_pointer_cast<ov::snippets::op::Subgraph>(subgraph)->body_ptr();
+        auto body = subgraph == nullptr ? nullptr : ov::as_type_ptr<ov::snippets::op::Subgraph>(subgraph)->body_ptr();
 
         auto subgraph_ref = FunctionHelper::getSubgraph(model_ref);
-        auto body_ref = subgraph_ref == nullptr ? nullptr : std::dynamic_pointer_cast<ov::snippets::op::Subgraph>(subgraph_ref)->body_ptr();
+        auto body_ref = subgraph_ref == nullptr ? nullptr : ov::as_type_ptr<ov::snippets::op::Subgraph>(subgraph_ref)->body_ptr();
 
         if ((body != nullptr) && (body_ref != nullptr)) {
             auto res = comparator.compare(body, body_ref);

--- a/src/plugins/template/backend/int_executable.cpp
+++ b/src/plugins/template/backend/int_executable.cpp
@@ -56,7 +56,7 @@ void ov::runtime::interpreter::INTExecutable::cancel() {
 
 void collect_variables(const ov::NodeVector& nodes, ov::op::util::VariableContext& variable_context) {
     for (const auto& op : nodes) {
-        if (auto multi_subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(op)) {
+        if (auto multi_subgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(op)) {
             for (const auto& sub_graph : multi_subgraph_op->get_functions()) {
                 collect_variables(sub_graph->get_ordered_ops(), variable_context);
             }
@@ -118,7 +118,7 @@ bool ov::runtime::interpreter::INTExecutable::call(std::vector<ov::Tensor>& outp
     // for each ordered op in the graph
     for (const auto& op : m_nodes) {
         CHECK_TERMINATE()
-        if (std::dynamic_pointer_cast<ov::op::v0::Parameter>(op)) {
+        if (ov::as_type_ptr<ov::op::v0::Parameter>(op)) {
             continue;
         }
         // get op inputs from map

--- a/src/plugins/template/backend/ops/string_tensor_pack.cpp
+++ b/src/plugins/template/backend/ops/string_tensor_pack.cpp
@@ -11,7 +11,7 @@ template <>
 bool evaluate_node<ov::op::v15::StringTensorPack>(std::shared_ptr<ov::Node> node,
                                                   ov::TensorVector& outputs,
                                                   const ov::TensorVector& inputs) {
-    auto string_tensor_pack = std::dynamic_pointer_cast<ov::op::v15::StringTensorPack>(node);
+    auto string_tensor_pack = ov::as_type_ptr<ov::op::v15::StringTensorPack>(node);
     OPENVINO_ASSERT(string_tensor_pack, "Node passed to StringTensorPack evaluate function is invalid.");
     ov::Shape output_shape;
     output_shape = ov::op::v15::shape_infer(string_tensor_pack.get(),

--- a/src/plugins/template/backend/ops/string_tensor_unpack.cpp
+++ b/src/plugins/template/backend/ops/string_tensor_unpack.cpp
@@ -12,7 +12,7 @@ bool evaluate_node<ov::op::v15::StringTensorUnpack>(std::shared_ptr<ov::Node> no
                                                     ov::TensorVector& outputs,
                                                     const ov::TensorVector& inputs) {
     if (node->get_input_element_type(0) == ov::element::string) {
-        auto string_tensor_unpack = std::dynamic_pointer_cast<ov::op::v15::StringTensorUnpack>(node);
+        auto string_tensor_unpack = ov::as_type_ptr<ov::op::v15::StringTensorUnpack>(node);
         OPENVINO_ASSERT(string_tensor_unpack, "Node passed to StringTensorUnpack evaluate function is invalid.");
         std::vector<ov::PartialShape> output_shapes;
         output_shapes = ov::op::v15::shape_infer(string_tensor_unpack.get(),

--- a/src/plugins/template/backend/ops/unique.cpp
+++ b/src/plugins/template/backend/ops/unique.cpp
@@ -13,8 +13,7 @@ void execute_unique(ov::TensorVector& outputs,
     const auto maybe_extract_axis = [&op]() {
         std::unique_ptr<int64_t> axis;
         if (op->get_input_size() == 2 && ov::op::util::is_constant(op->input_value(1).get_node())) {
-            const auto axis_constant =
-                std::dynamic_pointer_cast<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
+            const auto axis_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
             const auto axis_vec = axis_constant->cast_vector<int64_t>();
             axis = std::unique_ptr<int64_t>(new int64_t{axis_vec.at(0)});
         }

--- a/src/plugins/template/src/sync_infer_request.cpp
+++ b/src/plugins/template/src/sync_infer_request.cpp
@@ -44,7 +44,7 @@ void collect_variables(const std::shared_ptr<ov::Model>& ov_model,
                        ov::op::util::VariableContext& variable_context,
                        std::vector<ov::SoPtr<ov::IVariableState>>& list_of_variables) {
     for (const auto& op : ov_model->get_ordered_ops()) {
-        if (auto multi_subgraph_op = std::dynamic_pointer_cast<ov::op::util::MultiSubGraphOp>(op)) {
+        if (auto multi_subgraph_op = ov::as_type_ptr<ov::op::util::MultiSubGraphOp>(op)) {
             for (const auto& sub_graph : multi_subgraph_op->get_functions()) {
                 collect_variables(sub_graph, variable_context, list_of_variables);
             }


### PR DESCRIPTION
### Details:
 - Replaced `std::dynamic_cast` and `std::dynamic_pointed_cast` with `ov::as_type` or `ov::as_type_ptr` respectively in src/plugins (CPU, Template, Auto, Hetero)

### Tickets:
 - CVS-160243
