### PR TITLE
[GPU] False mark shapeof subgraph when shapeof has multiple user

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/mark_shape_of_subgraphs.cpp
@@ -90,7 +90,7 @@ bool mark_shape_of_subgraphs::can_mark_node(const program_node& node) {
     // skip mark_node for broadcast node if dependency nodes are data and shape_of
     auto& dependencies = node.get_dependencies();
     if (node.is_type<broadcast>() && dependencies.size() == 2) {
-        if (dependencies[0].first->is_type<data>() && dependencies[1].first->is_type<shape_of>())
+        if (dependencies[0].first->is_type<data>() && dependencies[1].first->is_type<shape_of>() && (dependencies[1].first->get_users().size() == 1))
             return false;
     }
 


### PR DESCRIPTION
### Details:
 - False mark shapeof subgraph when shapeof has multiple user
 - This is workaround for regression from https://github.com/openvinotoolkit/openvino/pull/27786.
 - Partial revert of https://github.com/openvinotoolkit/openvino/pull/27786 for multiple user shapeof case.

### Tickets:
 - 159953
