### PR TITLE
Update reqs: remove fastjsonschema, networkx and new version of flake8-pytest-style

### DIFF
--- a/src/bindings/python/requirements_test.txt
+++ b/src/bindings/python/requirements_test.txt
@@ -14,7 +14,7 @@ flake8-eradicate<=1.5.0
 flake8-executable<=2.1.3
 flake8-expression-complexity<=0.0.11
 flake8-print<=5.0.0
-flake8-pytest-style<=2.0.0
+flake8-pytest-style<=2.1.0
 flake8-rst-docstrings<=0.3.0
 pygments
 flake8-string-format<=0.3.0

--- a/src/bindings/python/tests/test_graph/test_create_op.py
+++ b/src/bindings/python/tests/test_graph/test_create_op.py
@@ -583,7 +583,7 @@ def test_roi_pooling_deprecation():
         _ = ov.roi_pooling(inputs, coords=coords, output_roi=[6, 6])
     assert "The following arguments must be defined: `spatial_scale`!" in str(e.value)
 
-    with pytest.warns(DeprecationWarning) as w:
+    with pytest.warns(DeprecationWarning, match="`output_size` is deprecated and will be removed in future") as w:
         node = ov.roi_pooling(inputs, coords=coords, output_size=[6, 6], spatial_scale=0.0625, method="Max")
     assert issubclass(w[0].category, DeprecationWarning)
     assert "`output_size` is deprecated and will be removed in future" in str(w[0].message)

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -10,7 +10,6 @@ scipy>=1.11.1; python_version >= "3.9"
 sympy>=1.10
 wheel>=0.38.1
 defusedxml>=0.7.1
-fastjsonschema~=2.17.1
 tensorflow>=2.5,<2.19.0
 requests>=2.25.1
 opencv-python>=4.5

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -21,7 +21,6 @@ pytest-dependency==0.5.1
 pytest-html==4.1.1
 pytest-timeout==2.3.1
 kornia==0.7.0
-networkx<=3.3
 
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch~=2.5.1; platform_system != "Darwin" or platform_machine != "x86_64"

--- a/tests/stress_tests/scripts/requirements.txt
+++ b/tests/stress_tests/scripts/requirements.txt
@@ -2,7 +2,6 @@
 pymongo
 Jinja2
 PyYAML
-fastjsonschema
 pandas
 h5py
 scipy

--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -4,7 +4,6 @@
 # tensorflow, numpy
 h5py>=3.1.0,<3.11.0
 onnx>=1.8.1,<=1.17.0
-networkx<=3.1.0
 pytest>=5.0,<8.4
 protobuf>=3.18.1,<4.0.0
 defusedxml>=0.7.1

--- a/tools/constraints.txt
+++ b/tools/constraints.txt
@@ -9,7 +9,6 @@ pytest>=5.0,<8.4
 protobuf>=3.18.1,<4.0.0
 defusedxml>=0.7.1
 requests>=2.25.1
-fastjsonschema>=2.15.1,<2.18
 coverage>=4.4.2,<=7.0.5
 astroid>=2.9.0
 pylint>=2.7.0


### PR DESCRIPTION
### Details:
 - Update of `flake8-pytest-style` breaks linters job [here](https://github.com/openvinotoolkit/openvino/pull/28400), so required separate PR

### Tickets:
 - *ticket-id*
