### PR TITLE
fix openvino panic when run CPU inference on XEON HBM platform

### DIFF
--- a/src/inference/src/os/lin/lin_system_conf.cpp
+++ b/src/inference/src/os/lin/lin_system_conf.cpp
@@ -140,7 +140,9 @@ CPU::CPU() {
             }
             std::string cache_info;
             std::getline(cache_file, cache_info);
-            node_info_table.emplace_back(std::move(cache_info));
+            if (cache_info.size() > 0) {
+                node_info_table.emplace_back(std::move(cache_info));
+            }
             node_index++;
         }
     };


### PR DESCRIPTION
### Details:
 - *skip HBM numa node on XEON HBM platform*

### Tickets:
 - *[issues-28335](https://github.com/openvinotoolkit/openvino/issues/28335)*
