### PR TITLE
[HETERO] Add CPU and GPU plugins to tests dependencies if exists

### DIFF
--- a/src/plugins/hetero/tests/functional/CMakeLists.txt
+++ b/src/plugins/hetero/tests/functional/CMakeLists.txt
@@ -26,6 +26,9 @@ ov_add_test_target(
 if(ENABLE_INTEL_CPU)
     add_dependencies(${TARGET_NAME} openvino_intel_cpu_plugin)
 endif()
+if(ENABLE_INTEL_GPU)
+    add_dependencies(${TARGET_NAME} openvino_intel_gpu_plugin)
+endif()
 
 target_compile_definitions(${TARGET_NAME} PRIVATE CI_BUILD_NUMBER=\"mock_version\")
 

--- a/src/plugins/hetero/tests/functional/CMakeLists.txt
+++ b/src/plugins/hetero/tests/functional/CMakeLists.txt
@@ -23,6 +23,10 @@ ov_add_test_target(
             OV HETERO
 )
 
+if(ENABLE_INTEL_CPU)
+    add_dependencies(${TARGET_NAME} openvino_intel_cpu_plugin)
+endif()
+
 target_compile_definitions(${TARGET_NAME} PRIVATE CI_BUILD_NUMBER=\"mock_version\")
 
 if(ENABLE_OV_IR_FRONTEND)


### PR DESCRIPTION
### Details:
Fix dependencies issue when hetero tests dependent on CPU and GPU plugins fail if ov_hetero_func_tests are built as the only target:
```bash
$ cmake -S . -B build -DENABLE_TESTS=ON
$ make -j$(nproc) ov_hetero_func_tests
```

### Tickets:
 - N/A
