### PR TITLE
[CPU] Fixed accuracy of compressed matmul with scalar scale

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/matmul_weights_decompression.cpp
@@ -46,7 +46,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights,
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::ValuesIn(fusing_params),
@@ -61,9 +62,9 @@ const std::vector<MatMulDecompressionShapeParams> input_shapes_corner_cases = {
 };
 
 const std::vector<bool> transpose_weights = {true, false};
-const std::vector<DecompressionSubtractType> decompression_subtract_type = {DecompressionSubtractType::full,
-                                                                            DecompressionSubtractType::scalar,
-                                                                            DecompressionSubtractType::empty};
+const std::vector<DecompressionType> decompression_subtract_type = {DecompressionType::full,
+                                                                            DecompressionType::scalar,
+                                                                            DecompressionType::empty};
 const std::vector<bool> reshape_on_decompression = {true, false};
 const std::vector<ov::test::ElementType> decompression_precisions_corner_cases = {ov::element::f16, ov::element::f32};
 
@@ -74,6 +75,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases,
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::ValuesIn(transpose_weights),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::ValuesIn(filter_additional_config_basic()),

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.cpp
@@ -16,7 +16,8 @@ std::string MatmulWeightsDecompression::getTestCaseName(testing::TestParamInfo<M
     ov::test::ElementType decompression_precision;
     ov::test::ElementType scale_precision;
     bool transpose;
-    DecompressionSubtractType decompression_subtract_type;
+    DecompressionType decompression_multiply_type;
+    DecompressionType decompression_subtract_type;
     bool reshape_on_decompression;
     ov::AnyMap additional_config;
     fusingSpecificParams fusing_params;
@@ -27,6 +28,7 @@ std::string MatmulWeightsDecompression::getTestCaseName(testing::TestParamInfo<M
              decompression_precision,
              scale_precision,
              transpose,
+             decompression_multiply_type,
              decompression_subtract_type,
              reshape_on_decompression,
              additional_config,
@@ -39,6 +41,7 @@ std::string MatmulWeightsDecompression::getTestCaseName(testing::TestParamInfo<M
     result << "decompression_precision=" << decompression_precision << "_";
     result << "scale_precision=" << scale_precision << "_";
     result << "transpose_weights=" << transpose << "_";
+    result << "decompression_multiply=" << decompression_multiply_type << "_";
     result << "decompression_subtract=" << decompression_subtract_type << "_";
     result << "reshape_on_decompression=" << reshape_on_decompression << "_";
 
@@ -60,7 +63,8 @@ std::shared_ptr<ov::Model> MatmulWeightsDecompression::initSubgraph(const ov::Pa
                                                                     const ov::element::Type decompression_precision,
                                                                     const ov::element::Type scale_precision,
                                                                     const bool transpose_weights,
-                                                                    const DecompressionSubtractType decompression_subtract_type,
+                                                                    const DecompressionType decompression_multiply_type,
+                                                                    const DecompressionType decompression_subtract_type,
                                                                     const bool reshape_on_decompression) {
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(data_precision, data_shape)};
     const auto weights_subgraph = initMatMulDecompressionSubgraph(weights_shape,
@@ -70,6 +74,7 @@ std::shared_ptr<ov::Model> MatmulWeightsDecompression::initSubgraph(const ov::Pa
                                                                     decompression_precision,
                                                                     scale_precision,
                                                                     transpose_weights,
+                                                                    decompression_multiply_type,
                                                                     decompression_subtract_type,
                                                                     reshape_on_decompression);
     auto matMul = std::make_shared<ov::op::v0::MatMul>(params[0], weights_subgraph);
@@ -84,7 +89,8 @@ void MatmulWeightsDecompression::SetUp() {
     ov::test::ElementType decompression_precision;
     ov::test::ElementType scale_precision;
     bool transpose_weights;
-    DecompressionSubtractType decompression_subtract_type;
+    DecompressionType decompression_multiply_type;
+    DecompressionType decompression_subtract_type;
     bool reshape_on_decompression;
     ov::AnyMap additional_config;
     fusingSpecificParams fusing_params;
@@ -95,6 +101,7 @@ void MatmulWeightsDecompression::SetUp() {
                 decompression_precision,
                 scale_precision,
                 transpose_weights,
+                decompression_multiply_type,
                 decompression_subtract_type,
                 reshape_on_decompression,
                 additional_config,
@@ -131,6 +138,7 @@ void MatmulWeightsDecompression::SetUp() {
                             decompression_precision,
                             scale_precision,
                             transpose_weights,
+                            decompression_multiply_type,
                             decompression_subtract_type,
                             reshape_on_decompression);
 }
@@ -138,7 +146,7 @@ void MatmulWeightsDecompression::SetUp() {
 void MatmulWeightsDecompression::check_results() {
     const auto& test_param = GetParam();
     const ov::element::Type compressed_weights_precision = std::get<1>(test_param);
-    const bool use_matmul_decompression_impl = std::get<9>(test_param);
+    const bool use_matmul_decompression_impl = std::get<10>(test_param);
 
     const auto runtime_model = compiledModel.get_runtime_model();
     const auto result = runtime_model->get_result();

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.hpp
@@ -45,7 +45,8 @@ typedef std::tuple<MatMulDecompressionShapeParams,
                    ov::test::ElementType,      // decompression precision
                    ov::test::ElementType,      // scale precision
                    bool,                       // transpose on weights
-                   DecompressionSubtractType,  // decompression subtract type
+                   DecompressionType,          // decompression multiply type
+                   DecompressionType,          // decompression subtract type
                    bool,                       // reshape on decompression constants
                    ov::AnyMap,                 // additional config
                    fusingSpecificParams,
@@ -67,7 +68,8 @@ protected:
                                             const ov::element::Type decompression_precision,
                                             const ov::element::Type scale_precision,
                                             const bool transpose_weights,
-                                            const DecompressionSubtractType decompression_subtract_type,
+                                            const DecompressionType decompression_multiply_type,
+                                            const DecompressionType decompression_subtract_type,
                                             const bool reshape_on_decompression);
 
     void SetUp() override;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
@@ -56,7 +56,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_basic,
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::full),
                                             // todo: zero points converted to fp32 for reshape == true case
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
@@ -71,7 +72,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_amx,
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::full),
                                             // todo: zero points converted to fp32 for reshape == true case
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_amx()),
@@ -89,7 +91,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_sym,
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::empty),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::empty),
                                             // todo: zero points converted to fp32 for reshape == true case
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
@@ -104,7 +107,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_sym_amx,
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::empty),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::empty),
                                             // todo: zero points converted to fp32 for reshape == true case
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_amx()),
@@ -124,9 +128,9 @@ const std::vector<MatMulDecompressionShapeParams> input_shapes_corner_cases_amx 
 };
 
 const std::vector<bool> transpose_weights = {true, false};
-const std::vector<DecompressionSubtractType> decompression_subtract_type = {DecompressionSubtractType::full,
-                                                                            DecompressionSubtractType::scalar,
-                                                                            DecompressionSubtractType::empty};
+const std::vector<DecompressionType> decompression_subtract_type = {DecompressionType::full,
+                                                                    DecompressionType::scalar,
+                                                                    DecompressionType::empty};
 const std::vector<bool> reshape_on_decompression = {true, false};
 const std::vector<ov::test::ElementType> decompression_precisions_corner_cases = {ov::element::f16, ov::element::f32};
 
@@ -137,6 +141,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_basic,
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::ValuesIn(transpose_weights),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
@@ -156,7 +161,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_f32_decompression_f16_sca
                                             ::testing::Values(ov::element::f32),
                                             ::testing::Values(ov::element::f16),
                                             ::testing::ValuesIn(transpose_weights),
-                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::Values(emptyFusingSpec),
@@ -174,7 +180,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_negative,
                                             ::testing::Values(ov::element::f32),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::empty),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::empty),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::Values(emptyFusingSpec),
@@ -188,6 +195,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_corner_cases_amx,
                                             ::testing::ValuesIn(decompression_precisions_corner_cases),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::ValuesIn(transpose_weights),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::ValuesIn(reshape_on_decompression),
                                             ::testing::ValuesIn(filter_additional_config_amx()),
@@ -220,6 +228,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_non_default_dyn_quant_gro
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_dyn_quant()),
@@ -236,7 +245,8 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_sym_non_default_dyn_quant
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::empty),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::empty),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_dyn_quant()),
                                             ::testing::ValuesIn(fusing_params),
@@ -250,11 +260,43 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_mxfp4,
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::f8e8m0),
                                             ::testing::Values(true),
-                                            ::testing::Values(DecompressionSubtractType::empty),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::empty),
                                             // todo: zero points converted to fp32 for reshape == true case
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
                                             ::testing::ValuesIn(fusing_params),
+                                            ::testing::Values(true)),
+                         MatmulWeightsDecompression::getTestCaseName);
+
+const std::vector<MatMulDecompressionShapeParams> input_shapes_scalar_scale = {
+    {{{}, {{1, 1, 128}}}, {128, 32}},
+    {{{}, {{1, 3, 256}}}, {256, 64}, 16lu},
+    {{{}, {{1, 10, 128}}}, {128, 32}},
+};
+
+const std::vector<ov::test::ElementType> weights_precisions_scalar_scale = {ov::element::u8};
+
+std::vector<ov::AnyMap> filter_additional_config_scalar_scale() {
+    std::vector<ov::AnyMap> additional_config = {
+        {{ov::hint::dynamic_quantization_group_size(0)}},
+        {{ov::hint::dynamic_quantization_group_size(16)}}
+    };
+    return additional_config;
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_scalar_scale,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_scalar_scale),
+                                            ::testing::ValuesIn(weights_precisions_scalar_scale),
+                                            ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::element::undefined),
+                                            ::testing::Values(false),
+                                            ::testing::Values(DecompressionType::scalar),
+                                            ::testing::Values(DecompressionType::scalar),
+                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(filter_additional_config_scalar_scale()),
+                                            ::testing::Values(emptyFusingSpec),
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_weights_decompression.cpp
@@ -29,7 +29,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulSharedCompressedWeights,
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::ValuesIn(transpose_weights),
-                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::Values(true)),
                          SharedMatmulWeightsDecompression::getTestCaseName);
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/shared_matmul_weights_decompression.cpp
@@ -39,7 +39,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulSharedCompressedWeights,
                                             ::testing::ValuesIn(weights_precisions),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::ValuesIn(transpose_weights),
-                                            ::testing::Values(DecompressionSubtractType::full),
+                                            ::testing::Values(DecompressionType::full),
                                             ::testing::Values(true)),
                          SharedMatmulWeightsDecompression::getTestCaseName);
 

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/shared_matmul_weights_decompression.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/shared_matmul_weights_decompression.hpp
@@ -37,7 +37,7 @@ using MatmulSharedWeightsDecompressionParams = std::tuple<std::string,          
                                                           ElementType,                 // weights precision
                                                           ElementType,                 // decompression precision
                                                           bool,                        // transpose on weights
-                                                          DecompressionSubtractType,   // decompression subtract type
+                                                          DecompressionType,           // decompression subtract type
                                                           bool>;                       // use matmul decompression implementation
 
 class SharedMatmulWeightsDecompression : public testing::WithParamInterface<MatmulSharedWeightsDecompressionParams>,
@@ -53,7 +53,7 @@ protected:
                                             const ov::element::Type weights_precision,
                                             const ov::element::Type decompression_precision,
                                             const bool transpose_weights,
-                                            const DecompressionSubtractType decompression_subtract_type);
+                                            const DecompressionType decompression_subtract_type);
     void SetUp() override;
     void check_results();
 };

--- a/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/weights_decompression_builders.hpp
+++ b/src/tests/functional/shared_test_classes/include/shared_test_classes/subgraph/weights_decompression_builders.hpp
@@ -49,13 +49,13 @@ struct GatherDecompressionShapeParams {
 
 std::ostream& operator<<(std::ostream& os, GatherDecompressionShapeParams type);
 
-enum class DecompressionSubtractType {
-    empty,  // no decompression subtract
-    scalar, // decompression subtract with scalar shape
-    full    // decompression subtract with per-channel or grouped shape
+enum class DecompressionType {
+    empty,  // no decompression
+    scalar, // decompression with scalar shape
+    full    // decompression with per-channel or grouped shape
 };
 
-std::ostream& operator<<(std::ostream& os, DecompressionSubtractType type);
+std::ostream& operator<<(std::ostream& os, DecompressionType type);
 
 std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
     const ov::Shape& weights_shape,
@@ -65,7 +65,8 @@ std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
     const ov::element::Type decompression_precision,
     const ov::element::Type scale_precision,
     const bool transpose_weights,
-    const DecompressionSubtractType decompression_subtract_type,
+    const DecompressionType decompression_multiply_type,
+    const DecompressionType decompression_subtract_type,
     const bool reshape_on_decompression_constant);
 
 std::shared_ptr<ov::Node> initGatherDecompressionSubgraph(const ov::Shape& data_shape,

--- a/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_weights_decompression.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_weights_decompression.cpp
@@ -16,7 +16,7 @@ std::string SharedMatmulWeightsDecompression::getTestCaseName(testing::TestParam
     ov::test::ElementType weights_precision;
     ov::test::ElementType decompression_precision;
     bool transpose;
-    DecompressionSubtractType decompression_subtract_type;
+    DecompressionType decompression_subtract_type;
     bool use_decompression_impl;
 
     std::tie(target_device,
@@ -46,7 +46,7 @@ std::shared_ptr<ov::Model> SharedMatmulWeightsDecompression::initSubgraph(
     const ov::element::Type weights_precision,
     const ov::element::Type decompression_precision,
     const bool transpose_weights,
-    const DecompressionSubtractType decompression_subtract_type) {
+    const DecompressionType decompression_subtract_type) {
     const auto weights_subgraph = initMatMulDecompressionSubgraph(weights_shape,
                                                                   group_size,
                                                                   data_precision,
@@ -54,6 +54,7 @@ std::shared_ptr<ov::Model> SharedMatmulWeightsDecompression::initSubgraph(
                                                                   decompression_precision,
                                                                   ov::element::undefined,
                                                                   transpose_weights,
+                                                                  DecompressionType::full,
                                                                   decompression_subtract_type,
                                                                   false);
     ov::ParameterVector params;
@@ -85,7 +86,7 @@ void SharedMatmulWeightsDecompression::SetUp() {
     ov::test::ElementType weights_precision;
     ov::test::ElementType decompression_precision;
     bool transpose_weights;
-    DecompressionSubtractType decompression_subtract_type;
+    DecompressionType decompression_subtract_type;
     bool use_decompression_impl;
 
     std::tie(targetDevice,

--- a/src/tests/functional/shared_test_classes/src/subgraph/weights_decompression_builders.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/weights_decompression_builders.cpp
@@ -25,19 +25,19 @@ std::ostream& operator<<(std::ostream& os, GatherDecompressionShapeParams shape_
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, DecompressionSubtractType type) {
+std::ostream& operator<<(std::ostream& os, DecompressionType type) {
     switch (type) {
-    case DecompressionSubtractType::empty:
+    case DecompressionType::empty:
         os << "empty";
         break;
-    case DecompressionSubtractType::scalar:
+    case DecompressionType::scalar:
         os << "scalar";
         break;
-    case DecompressionSubtractType::full:
+    case DecompressionType::full:
         os << "full";
         break;
     default:
-        OPENVINO_THROW("Not supported DecompressionSubtractType");
+        OPENVINO_THROW("Not supported DecompressionType");
     }
     return os;
 }
@@ -50,7 +50,8 @@ std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
     const ov::element::Type decompression_precision,
     const ov::element::Type scale_precision,
     const bool transpose_weights,
-    const DecompressionSubtractType decompression_subtract_type,
+    const DecompressionType decompression_multiply_type,
+    const DecompressionType decompression_subtract_type,
     const bool reshape_on_decompression_constant) {
     auto transpose_if_necessary = [&](const ov::Shape& shape) {
         auto result_shape = shape;
@@ -107,9 +108,9 @@ std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
     if (reshape_on_decompression_constant)
         scaleshift_const_shape.erase(std::remove(scaleshift_const_shape.begin(), scaleshift_const_shape.end(), 1),
                                         scaleshift_const_shape.end());
-    if (decompression_subtract_type != DecompressionSubtractType::empty) {
+    if (decompression_subtract_type != DecompressionType::empty) {
         auto subtract_shape =
-            decompression_subtract_type == DecompressionSubtractType::full ? scaleshift_const_shape : ov::Shape({});
+            decompression_subtract_type == DecompressionType::full ? scaleshift_const_shape : ov::Shape({});
         auto shift_const_tensor = ov::test::utils::create_and_fill_tensor(weights_precision,
                                                                           subtract_shape,
                                                                           ov::test::utils::InputGenerateData(1, up_to));
@@ -118,7 +119,7 @@ std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
         std::shared_ptr<ov::Node> shift_convert =
             std::make_shared<ov::op::v0::Convert>(shift_const, decompression_precision);
         if (reshape_on_decompression_constant) {
-            auto subtract_target_shape = decompression_subtract_type == DecompressionSubtractType::full
+            auto subtract_target_shape = decompression_subtract_type == DecompressionType::full
                                                 ? scaleshift_target_shape
                                                 : ov::Shape(scaleshift_const_shape.size(), 1);
             auto shift_reshape_const = ov::opset10::Constant::create(ov::element::i32,
@@ -130,27 +131,34 @@ std::shared_ptr<ov::Node> initMatMulDecompressionSubgraph(
         mul_parent = std::make_shared<ov::opset10::Subtract>(weights_convert, shift_convert);
     }
 
+    std::shared_ptr<ov::Node> last_node = mul_parent;
     const auto& scale_prc = scale_precision == ov::element::undefined ? decompression_precision : scale_precision;
-    auto scale_const_tensor = ov::test::utils::create_and_fill_tensor_real_distribution(scale_prc,
-                                                                                        scaleshift_const_shape,
-                                                                                        0.001f,
-                                                                                        0.01f,
-                                                                                        1);
+    if (decompression_multiply_type != DecompressionType::empty) {
+        auto multiply_shape =
+            decompression_multiply_type == DecompressionType::full ? scaleshift_const_shape : ov::Shape({});
+        auto scale_const_tensor = ov::test::utils::create_and_fill_tensor_real_distribution(scale_prc,
+                                                                                            multiply_shape,
+                                                                                            0.001f,
+                                                                                            0.01f,
+                                                                                            1);
+        std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_const_tensor);
 
-    std::shared_ptr<ov::Node> scale_const = std::make_shared<ov::op::v0::Constant>(scale_const_tensor);
+        if (scale_prc != decompression_precision) {
+            const auto scale_convert = std::make_shared<ov::op::v0::Convert>(scale_const, decompression_precision);
+            ov::mark_as_decompression(scale_convert);
+            scale_const = scale_convert;
+        }
 
-    if (scale_prc != decompression_precision) {
-        const auto scale_convert = std::make_shared<ov::op::v0::Convert>(scale_const, decompression_precision);
-        ov::mark_as_decompression(scale_convert);
-        scale_const = scale_convert;
+        if (reshape_on_decompression_constant) {
+            auto multiply_target_shape = decompression_multiply_type == DecompressionType::full
+                                    ? scaleshift_target_shape
+                                    : ov::Shape(scaleshift_const_shape.size(), 1);
+            auto reshape_const = ov::opset10::Constant::create(ov::element::i32, {multiply_target_shape.size()}, multiply_target_shape);
+            auto scale_reshape = std::make_shared<ov::opset10::Reshape>(scale_const, reshape_const, false);
+            scale_const = scale_reshape;
+        }
+        last_node = std::make_shared<ov::opset10::Multiply>(mul_parent, scale_const);
     }
-
-    if (reshape_on_decompression_constant) {
-        auto reshape_const = ov::opset10::Constant::create(ov::element::i32, {scaleshift_target_shape.size()}, scaleshift_target_shape);
-        auto scale_reshape = std::make_shared<ov::opset10::Reshape>(scale_const, reshape_const, false);
-        scale_const = scale_reshape;
-    }
-    std::shared_ptr<ov::Node> last_node = std::make_shared<ov::opset10::Multiply>(mul_parent, scale_const);
 
     if (group_decompression) {
         auto reshape_target_shape = transpose_weights ? std::vector<int>{-1, static_cast<int>(weights_shape[0])}


### PR DESCRIPTION
### Details:
 - This PR fixes accuracy of compressed Matmuls with scalar scale
 - The issue was on micro-kernel level: incorrect offset during scales load

oneDNN PR: https://github.com/openvinotoolkit/oneDNN/pull/270

### Tickets:
 - [CVS-143420](https://jira.devtools.intel.com/browse/CVS-143420)
