### PR TITLE
Check for 'dot' tool presence in PATH before calling in VisualizeTree pass and make it debug only

### DIFF
--- a/src/common/transformations/tests/offline_transformations/pruning_test.cpp
+++ b/src/common/transformations/tests/offline_transformations/pruning_test.cpp
@@ -4738,9 +4738,11 @@ TEST_F(TransformationTestsF, MaskPropagationComplexReshape) {
         };
 
         manager.register_pass<ov::pass::ShrinkWeights>();
-        manager.register_pass<pass::VisualizeTree>(
-            std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationComplexReshapeWithMasks.svg",
-            modifier);
+        if (VISUALIZE_TESTS_TREE) {
+            manager.register_pass<pass::VisualizeTree>(
+                std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationComplexReshapeWithMasks.svg",
+                modifier);
+        }
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
@@ -4929,10 +4931,12 @@ TEST_P(TransformationTestsBoolParamF, MaskPropagationReshapedPassThroughP) {
     };
 
     manager.register_pass<ov::pass::ShrinkWeights>();
-    auto postfix = (add_shape_of) ? "True" : "False";
-    manager.register_pass<pass::VisualizeTree>(
-        std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReverseFlattenWithMasks" + postfix + ".svg",
-        modifier);
+    if (VISUALIZE_TESTS_TREE) {
+        auto postfix = (add_shape_of) ? "True" : "False";
+        manager.register_pass<pass::VisualizeTree>(
+            std::string(VISUALIZE_TREE_ROOT) + "MaskPropagationReverseFlattenWithMasks" + postfix + ".svg",
+            modifier);
+    }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 

--- a/src/core/src/pass/visualize_tree.cpp
+++ b/src/core/src/pass/visualize_tree.cpp
@@ -692,6 +692,9 @@ void ov::pass::VisualizeTree::render() const {
         if (!m_dot_only && ov::util::to_lower(ext) != ".dot") {
 #ifndef _WIN32
             std::stringstream ss;
+            if (system("command -v dot > /dev/null 2>&1") != 0) {
+                OPENVINO_THROW("Graphviz 'dot' command not found in PATH");
+            }
             ss << "dot -T" << output_format << " " << dot_file << " -o" << m_name;
             auto cmd = ss.str();
             auto stream = popen(cmd.c_str(), "r");

--- a/src/core/src/pass/visualize_tree.cpp
+++ b/src/core/src/pass/visualize_tree.cpp
@@ -690,7 +690,7 @@ void ov::pass::VisualizeTree::render() const {
         out.close();
 
         if (!m_dot_only && ov::util::to_lower(ext) != ".dot") {
-#if defined(ENABLE_DEBUG_CAPS) && !defined(_WIN32)
+#if defined(ENABLE_OPENVINO_DEBUG) && !defined(_WIN32)
             std::stringstream ss;
             if (system("command -v dot > /dev/null 2>&1") != 0) {
                 OPENVINO_THROW("Graphviz 'dot' command not found in PATH");

--- a/src/core/src/pass/visualize_tree.cpp
+++ b/src/core/src/pass/visualize_tree.cpp
@@ -690,7 +690,7 @@ void ov::pass::VisualizeTree::render() const {
         out.close();
 
         if (!m_dot_only && ov::util::to_lower(ext) != ".dot") {
-#ifndef _WIN32
+#if defined(ENABLE_DEBUG_CAPS) && !defined(_WIN32)
             std::stringstream ss;
             if (system("command -v dot > /dev/null 2>&1") != 0) {
                 OPENVINO_THROW("Graphviz 'dot' command not found in PATH");


### PR DESCRIPTION
### Details:
Check for dot tool availability in PATH before execution:
- Ensure the Graphviz `dot` tool is installed and accessible in the system PATH before attempting to execute it
- If the dot tool is not found, fail gracefully with a clear error message instead of producing the uninformative output: `sh: 1: dot: not found`
- Make external 'dot' process call only when `ENABLE_OPENVINO_DEBUG` define is on
- Add missing `if (VISUALIZE_TESTS_TREE)` in tests where `VisualizeTree` pass is invoked

### Tickets:
 - N/A
