### PR TITLE
[Py OV] Replace openvino.runtime with openvino in benchmark tool

### DIFF
--- a/tools/benchmark_tool/openvino/tools/benchmark/benchmark.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/benchmark.py
@@ -5,7 +5,7 @@ import os
 import time
 from datetime import datetime
 from math import ceil
-from openvino.runtime import Core, get_version, AsyncInferQueue
+from openvino import Core, get_version, AsyncInferQueue
 
 from .utils.constants import GPU_DEVICE_NAME, XML_EXTENSION, BIN_EXTENSION
 from .utils.logging import logger

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -5,7 +5,7 @@ import os
 import sys
 from datetime import datetime
 
-from openvino.runtime import Dimension,properties
+from openvino import Dimension, properties
 
 from openvino.tools.benchmark.benchmark import Benchmark
 from openvino.tools.benchmark.parameters import parse_args

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/inputs_filling.py
@@ -10,8 +10,8 @@ from collections import defaultdict
 from pathlib import Path
 from importlib.util import find_spec
 
-from openvino.runtime import Tensor, PartialShape, Type
-from openvino.runtime.utils.types import get_dtype
+from openvino import Tensor, PartialShape, Type
+from openvino.utils.types import get_dtype
 
 from .constants import IMAGE_EXTENSIONS, NUMPY_EXTENSIONS, BINARY_EXTENSIONS
 from .logging import logger

--- a/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/utils/utils.py
@@ -4,7 +4,7 @@
 from collections import defaultdict
 from datetime import timedelta
 import enum
-from openvino.runtime import Core, Model, PartialShape, Dimension, Layout, Type, serialize, properties, OVAny
+from openvino import Core, Model, PartialShape, Dimension, Layout, Type, serialize, properties, OVAny
 from openvino.preprocess import PrePostProcessor
 
 from .constants import DEVICE_DURATION_IN_SECS, UNKNOWN_DEVICE_TYPE, \


### PR DESCRIPTION
### Details:
 - Replace openvino.runtime with openvino in benchmark tool
 

### Tickets:
 - [CVS-129450](https://jira.devtools.intel.com/browse/CVS-129450)
