### PR TITLE
[NPU] fix segfault in compile_tool

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/include/compiler_adapter_factory.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/compiler_adapter_factory.hpp
@@ -19,14 +19,14 @@ public:
         auto compilerType = config.get<COMPILER_TYPE>();
         switch (compilerType) {
         case ov::intel_npu::CompilerType::MLIR: {
-            if (engineBackend->getName() != "LEVEL0") {
+            if (engineBackend == nullptr || engineBackend->getName() == "IMD") {
                 return std::make_unique<PluginCompilerAdapter>(nullptr);
             }
-
             return std::make_unique<PluginCompilerAdapter>(engineBackend->getInitStructs());
         }
         case ov::intel_npu::CompilerType::DRIVER: {
-            if (engineBackend->getName() != "LEVEL0") {
+            if (engineBackend == nullptr || engineBackend->getName() != "LEVEL0") {
+                //TODO: need add a log here?
                 OPENVINO_THROW("NPU Compiler Adapter must be used with LEVEL0 backend");
             }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/compiler_adapter_factory.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/compiler_adapter_factory.hpp
@@ -26,7 +26,6 @@ public:
         }
         case ov::intel_npu::CompilerType::DRIVER: {
             if (engineBackend == nullptr || engineBackend->getName() != "LEVEL0") {
-                //TODO: need add a log here?
                 OPENVINO_THROW("NPU Compiler Adapter must be used with LEVEL0 backend");
             }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/compiler_adapter_factory.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/compiler_adapter_factory.hpp
@@ -19,7 +19,7 @@ public:
         auto compilerType = config.get<COMPILER_TYPE>();
         switch (compilerType) {
         case ov::intel_npu::CompilerType::MLIR: {
-            if (engineBackend == nullptr || engineBackend->getName() == "IMD") {
+            if (engineBackend == nullptr || engineBackend->getName() != "LEVEL0") {
                 return std::make_unique<PluginCompilerAdapter>(nullptr);
             }
             return std::make_unique<PluginCompilerAdapter>(engineBackend->getInitStructs());


### PR DESCRIPTION
### Details:
 - Fix `Segmentation fault (core dumped)`  issue when running `compile_tool` without a device.
 
### Tickets:
 - *E151581*
