### PR TITLE
[GPU] allow to read activations scale factor from rt_info for non-LLMs

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
@@ -140,7 +140,9 @@ public:
 
     // Note that RT info property value has lower priority than values set by user via core.set_property or passed to compile_model call
     // So this method should be called after setting all user properties, but before apply_user_properties() call.
-    void apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info);
+    void apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info, const bool is_llm);
+
+    bool is_model_llm(std::shared_ptr<ov::Model>& model);
 
     std::string to_string() const;
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
@@ -142,8 +142,6 @@ public:
     // So this method should be called after setting all user properties, but before apply_user_properties() call.
     void apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info, const bool is_llm);
 
-    bool is_model_llm(std::shared_ptr<ov::Model>& model);
-
     std::string to_string() const;
 
 protected:

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -40,6 +40,7 @@
 #include "transformations/init_node_info.hpp"
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/utils/utils.hpp"
+#include "openvino/op/paged_attention.hpp"
 
 // Undef DEVICE_TYPE macro which can be defined somewhere in windows headers as DWORD and conflict with our metric
 #ifdef DEVICE_TYPE
@@ -64,7 +65,8 @@ namespace intel_gpu {
 
 const auto is_llm = [](const std::shared_ptr<const ov::Model>& model) -> bool {
     for (auto& op : model->get_ordered_ops()) {
-        if (ov::is_type<ov::op::v6::ReadValue>(op))
+        if (ov::is_type<ov::op::v6::ReadValue>(op) ||
+            ov::is_type<ov::op::PagedAttentionExtension>(op))
             return true;
     }
     return false;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -41,6 +41,7 @@
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/utils/utils.hpp"
 #include "openvino/op/paged_attention.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
 
 // Undef DEVICE_TYPE macro which can be defined somewhere in windows headers as DWORD and conflict with our metric
 #ifdef DEVICE_TYPE
@@ -64,11 +65,9 @@ namespace intel_gpu {
 #undef REGISTER_FACTORY
 
 const auto is_llm = [](const std::shared_ptr<const ov::Model>& model) -> bool {
-    for (auto& op : model->get_ordered_ops()) {
-        if (ov::is_type<ov::op::v6::ReadValue>(op) ||
-            ov::is_type<ov::op::PagedAttentionExtension>(op))
-            return true;
-    }
+    if ((op::util::has_op_with_type<op::v13::ScaledDotProductAttention>(model) && model->get_variables().size() > 0) ||
+        op::util::has_op_with_type<ov::op::PagedAttentionExtension>(model))
+        return true;
     return false;
 };
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -272,11 +272,12 @@ void ExecutionConfig::apply_user_properties(const cldnn::device_info& info) {
     user_properties.clear();
 }
 
-void ExecutionConfig::apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info) {
+void ExecutionConfig::apply_rt_info(const cldnn::device_info& info, const ov::RTMap& rt_info, const bool is_llm) {
     if (!info.supports_immad) {
         apply_rt_info_property(ov::hint::kv_cache_precision, rt_info);
-        apply_rt_info_property(ov::hint::activations_scale_factor, rt_info);
     }
+    if (!info.supports_immad || !is_llm)
+        apply_rt_info_property(ov::hint::activations_scale_factor, rt_info);
     apply_rt_info_property(ov::hint::dynamic_quantization_group_size, rt_info);
 }
 


### PR DESCRIPTION
### Details:
 - allows to read `ACTIVATIONS_SCALE_FACTOR` from rt_info for non-LLMs, such as FLUX.1 and SDXL.
 - assumes that LLMs have `ReadValue` layers and non-LLMs does not.
