### PR TITLE
Use quotes include instead of brackets include

### DIFF
--- a/src/core/include/openvino/op/util/symbolic_info.hpp
+++ b/src/core/include/openvino/op/util/symbolic_info.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <openvino/core/descriptor/tensor.hpp>
-
+#include "openvino/core/descriptor/tensor.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/runtime_attribute.hpp"
 #include "openvino/core/visibility.hpp"


### PR DESCRIPTION
All othe headers files in `src/core/include/` all quotes include instead of brackets includes to include `openvino/op/util/symbolic_info.hpp`.

This commit changes the only brackets include to quotes include. This allows user not need to install headers into the system path or need to pollute their system include.