### PR TITLE
[GPU] Define to_type in jitter for reorder to support INT4

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1483,6 +1483,7 @@ JitConstants MakeTypeJitConstants(Datatype dataType, const std::string& macroNam
             break;
         case Datatype::INT4:
             type = "char";
+            to_type = "convert_char(v)";
             type_size = "0.5f";
             is_fp = false;
             break;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/reorder/reorder_kernel.cpp
@@ -12,6 +12,7 @@ ParamsKey ReorderKernelRef::GetSupportedKey() const {
     k.EnableInputDataType(Datatype::UINT8);
     k.EnableInputDataType(Datatype::UINT16);
     k.EnableInputDataType(Datatype::UINT32);
+    k.EnableInputDataType(Datatype::INT4);
     k.EnableInputDataType(Datatype::INT8);
     k.EnableInputDataType(Datatype::INT16);
     k.EnableInputDataType(Datatype::INT32);


### PR DESCRIPTION
### Details:
 - Define to_type in Jitter for reorder to support the case input INT4 and output FP16.

### Tickets:
 - 100911
