### PR TITLE
[REFERENCE] Fix Interpolate reference implementation

### DIFF
--- a/src/core/reference/include/openvino/reference/interpolate.hpp
+++ b/src/core/reference/include/openvino/reference/interpolate.hpp
@@ -711,9 +711,13 @@ inline PartialShape get_padded_input_shape(const PartialShape& input_shape,
 
     PartialShape padded_input_shape = input_shape;
 
+    auto pads_begin = attrs.pads_begin;
+    auto pads_end = attrs.pads_end;
+    pads_begin.resize(input_rank);
+    pads_end.resize(input_rank);
     for (int64_t i = 0; i < input_rank; ++i) {
         if (input_shape[i].is_static()) {
-            auto new_length = attrs.pads_begin[i] + attrs.pads_end[i] + input_shape[i].get_length();
+            auto new_length = pads_begin[i] + pads_end[i] + input_shape[i].get_length();
             padded_input_shape[i] = Dimension(new_length);
         }
     }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -185,8 +185,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(^smoke_Multinomial(?:Static|Dynamic)+(?:Log)*.*seed_g=0_seed_o=0.*device=CPU.*)",
         // Issue: 129025
         R"(.*smoke_CpuExecNetworkCheck.*StreamsHasHigherPriorityThanLatencyHint.*)",
-        // Issue: 119648
-        R"(.*smoke_LPT/InterpolateTransformation.*)",
         // Issue: 129931
         R"(smoke_LPT/ConvolutionTransformation.CompareWithRefImpl/f32_\[.*,3,16,16\]_CPU_f32_rank=4D_fq_on_data=\{level=256_shape=\[1\]_input_low=\{ 0 \}_input_high=\{ 255 \}_output_low=\{ .*18.7 \}_output_high\{ 18.8 \}_precision=\}_fq_on_weights=\{_255_\[6,1,1,1\]_\{ .*1.52806e.*39, .*0.2, .*0.3, .*0.3, .*0.2, .*0.1 \}_\{ 1.52806e.*39, 0.2, 0.3, 0.3, 0.2, 0.1 \}\})",
         // TODO: 141068

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -58,8 +58,6 @@ std::vector<std::string> disabledTestPatterns() {
             R"(smoke_MemoryTestV3.*)",
             // Issue: 90539
             R"(.*CachingSupportCase.*LoadNetworkCacheTestBase.*CompareWithRefImpl.*)",
-            // Issue: 119648
-            R"(.*smoke_LPT/InterpolateTransformation.*)",
             R"(.*CachingSupportCase.*GPU.*CompileModelCacheTestBase.*CompareWithRefImpl.*)",
             // Issue: 111437
             R"(.*smoke_Deconv_2D_Dynamic_.*FP32/DeconvolutionLayerGPUTest.Inference.*)",


### PR DESCRIPTION
### Details:
 - This PR fixes Interpolate reference implementation: missed padding resizing is added. This logic was transferred from [interpolate shape inference implemetation](https://github.com/openvinotoolkit/openvino/blob/master/src/core/shape_inference/include/interpolate_shape_inference.hpp) (for the details, please see `interpolate::resize_padding` implementation and usage).
 - [The specification](https://github.com/openvinotoolkit/openvino/blob/master/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/image/interpolate-4.rst) have no hard limitation that paddings size must be equal to input shape rank
 - LPT tests, that were affected by the issue, are reenabled

### Tickets:
 - *CVS-119648*
