### PR TITLE
NPUW: Fix BF16 tensor collision in weight bank in new LLM pipeline

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -14,8 +14,8 @@
 #include "openvino/pass/stateful_to_stateless.hpp"
 #include "openvino/pass/validate.hpp"
 #include "openvino/runtime/iasync_infer_request.hpp"
-#include "transformations/convert_precision.hpp"
 #include "serialization.hpp"
+#include "transformations/convert_precision.hpp"
 
 namespace opp = ov::pass::pattern;
 class TransposeValueTensors : public ov::pass::MatcherPass {

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -14,6 +14,7 @@
 #include "openvino/pass/stateful_to_stateless.hpp"
 #include "openvino/pass/validate.hpp"
 #include "openvino/runtime/iasync_infer_request.hpp"
+#include "transformations/convert_precision.hpp"
 #include "serialization.hpp"
 
 namespace opp = ov::pass::pattern;
@@ -457,6 +458,8 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
     auto kvcache_model = model->clone();
     LOG_DEBUG("2. Transform kvcache model from stateful to stateless.");
     ov::pass::StatefulToStateless().run_on_model(kvcache_model);
+    LOG_DEBUG("   ...also convert BF16 to FP16");
+    ov::pass::ConvertPrecision(ov::element::bf16, ov::element::f16).run_on_model(kvcache_model);
     LOG_DEBUG("3. Creating prefill model as clone of transformed kvcache one.");
     auto prefill_model = kvcache_model->clone();
     prefill_model->set_friendly_name(kvcache_model->get_friendly_name() + "_prefill");


### PR DESCRIPTION
### Details:
 - New LLM pipeline compile process happens in two stages, first for generate, second for the prompt parts
 - Each of these stages runs a convertBF16toFP16 pass which (on certain models) swaps the BF16 constants with FP16. That is, every stage gets its own personal set of new constants during its compilation
 - When generate model finishes its compilation, it routes its tensors to the bank, and after copying those to L0 memory, bank detaches the Constant nodes from the associated LazyTensors.
 - Since the newly-added FP16 constants are only referred to the model that is being compiled, they are destroyed immediately, freeing the CPU-side memory.
 - When the process is repeated for the 2nd model, it seems that the newly-allocated converted FP16 tensors sometimes get the same addresses as the previously freed once (it is perfectly ok). In this case, as the bank is shared among the stages, a bank detects these new tensors as already registered (match happened over the lazy tensor's hash which is based on meta and pointer address). It seems that some other (but still matching by dimensions) tensor can be returned from the bank on `get(uid)`, causing mess in the second model's function closure.
 - This fix essentially avoids this problem by lifting the conversion pass to a higher level. Now both models inherit the same constant tensor addresses from the beginning and those are held in memory till the very end of the compilation process.
 - Some long-term solution should be proposed to avoid these issues in the future (@smirnov-alexey )

### Tickets:
 - *ticket-id*
