### PR TITLE
[Snippets][CPU] Mark serialized data flow graph as exec_graph

### DIFF
--- a/src/common/snippets/src/lowered/pass/serialize_data_flow.cpp
+++ b/src/common/snippets/src/lowered/pass/serialize_data_flow.cpp
@@ -34,6 +34,7 @@ bool SerializeDataFlow::run(const LinearIR& linear_ir) {
         }
         if (ov::is_type<ov::op::v0::Parameter>(node)) {
             const auto parameter = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{});
+            parameter->get_rt_info()["execTimeMcs"] = 0;
             ops_map[expr] = parameter;
             parameters.push_back(parameter);
         } else if (ov::is_type<ov::op::v0::Result>(node)) {


### PR DESCRIPTION
### Details:
Add property to serialized data flow graph to be treated as exec_graph in order to apply type substitution from runtime info

### Tickets:
 - 160593
