### PR TITLE
[intel-npu]  Quickfix for core.get_available_devices exception on hosts with no NPU compiler

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -585,10 +585,17 @@ void Plugin::reset_supported_properties() const {
 }
 
 void Plugin::reset_compiler_dependent_properties() const {
+    uint32_t active_compiler_version = 0;
     // get active compiler version
-    CompilerAdapterFactory compilerAdapterFactory;
-    auto dummyCompiler = compilerAdapterFactory.getCompiler(_backends->getIEngineBackend(), _globalConfig);
-    uint32_t active_compiler_version = dummyCompiler->get_version();
+    try {
+        CompilerAdapterFactory compilerAdapterFactory;
+        auto dummyCompiler = compilerAdapterFactory.getCompiler(_backends->getIEngineBackend(), _globalConfig);
+        active_compiler_version = dummyCompiler->get_version();
+    } catch (...) {
+        _logger.warning(
+            "No available compiler. Can not determine version > compiler dependent properties remain hidden");
+        return;
+    }
 
     // NPU_COMPILER_DYNAMIC_QUANTIZATION
     // unpublish if compiler version requirement is not met


### PR DESCRIPTION
### Details:
 - Quickfix for core.get_available_devices exception on hosts with no NPU compiler
 - get_available_devices calls get_property(supported_properties), which throws exception if there is no compiler. catching that exception.

### Tickets:
 - [*CVS-160690*](https://jira.devtools.intel.com/browse/CVS-160690)
