### PR TITLE
[GPU] fix memory conflict for multi iteration in loop.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2391,6 +2391,9 @@ memory::ptr primitive_inst::allocate_output(engine& _engine,
     if (_node.is_in_shape_of_subgraph())
         reusable_across_network = false;
 
+    if (reusable_across_network && _node.get_program().is_body_program() && is_output_buffer && runtime_alloc)
+        reusable_across_network = false;
+
     // For outputs, cpu prim we want to have lockable alloc type
     // Also if the successor of a node is an cpu, then memory needs to be lockable.
     bool is_cpu = _node.get_selected_impl() ? _node.get_selected_impl()->is_cpu() :


### PR DESCRIPTION
Cause is shown in graph below.

The black, green, and dotted line donates the primitive dependency, memory buffer reuse, and memory conflict (at the second iteration) respectively.
The body of the loop is compiled as a separate model and is not aware the data reuse in backedge in multiple iteration.

Tickets:
[CVS-158017](https://jira.devtools.intel.com/browse/CVS-158017)