### PR TITLE
[CPU] Replace custom THROW_ERROR macros usage with THROW_CPU_NODE_ERR

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -14,8 +14,6 @@
 #include "openvino/opsets/opset1.hpp"
 #include "utils/general_utils.h"
 
-#define THROW_ERROR(...) OPENVINO_THROW("DepthToSpace layer with name '", getName(), "' ", __VA_ARGS__)
-
 using namespace dnnl::impl;
 
 namespace ov {
@@ -73,11 +71,11 @@ DepthToSpace::DepthToSpace(const std::shared_ptr<ov::Node>& op, const GraphConte
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     if (inputShapes.size() != 1 || outputShapes.size() != 1)
-        THROW_ERROR("has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     auto depthToSpace = ov::as_type_ptr<const ov::opset1::DepthToSpace>(op);
     if (!depthToSpace)
-        THROW_ERROR("supports only opset1");
+        THROW_CPU_NODE_ERR("supports only opset1");
 
     const auto modeNgraph = depthToSpace->get_mode();
     if (modeNgraph == ov::op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST) {
@@ -85,22 +83,22 @@ DepthToSpace::DepthToSpace(const std::shared_ptr<ov::Node>& op, const GraphConte
     } else if (modeNgraph == ov::op::v0::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST) {
         attrs.mode = Mode::DEPTH_FIRST;
     } else {
-        THROW_ERROR("doesn't support mode: ", ov::as_string(modeNgraph));
+        THROW_CPU_NODE_ERR("doesn't support mode: ", ov::as_string(modeNgraph));
     }
 
     attrs.blockSize = depthToSpace->get_block_size();
     if (attrs.blockSize == 0)
-        THROW_ERROR("has incorrect block_size parameter is zero!");
+        THROW_CPU_NODE_ERR("has incorrect block_size parameter is zero!");
 
     const size_t srcRank = getInputShapeAtPort(0).getRank();
     const size_t dstRank = getOutputShapeAtPort(0).getRank();
 
     if (srcRank < 3)
-        THROW_ERROR("has incorrect number of input dimensions");
+        THROW_CPU_NODE_ERR("has incorrect number of input dimensions");
     if (srcRank > 5)
-        THROW_ERROR("doesn't support dimensions with rank greater than 5");
+        THROW_CPU_NODE_ERR("doesn't support dimensions with rank greater than 5");
     if (srcRank != dstRank)
-        THROW_ERROR("has incorrect number of input/output dimensions");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output dimensions");
 
     const size_t nSpatialDims = srcRank - 2;
     attrs.blockStep = static_cast<size_t>(std::pow(attrs.blockSize, nSpatialDims));
@@ -164,11 +162,11 @@ void DepthToSpace::createPrimitive() {
     auto dstMemPtr = getDstMemoryAtPort(0);
     auto srcMemPtr = getSrcMemoryAtPort(0);
     if (!dstMemPtr)
-        THROW_ERROR("has null destination memory");
+        THROW_CPU_NODE_ERR("has null destination memory");
     if (!srcMemPtr)
-        THROW_ERROR("has null input memory");
+        THROW_CPU_NODE_ERR("has null input memory");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        THROW_ERROR("has unidentified preferable primitive descriptor");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor");
 
     const auto& memoryDesc = srcMemPtr->getDesc();
     attrs.dataSize = memoryDesc.getPrecision().size();
@@ -305,7 +303,7 @@ void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const 
 
 void DepthToSpace::execute(const dnnl::stream& strm) {
     if (!execPtr) {
-        THROW_ERROR("doesn't have a compiled executor.");
+        THROW_CPU_NODE_ERR("doesn't have a compiled executor.");
     }
 
     int MB = getSrcMemoryAtPort(0)->getStaticDims()[0];

--- a/src/plugins/intel_cpu/src/nodes/eye.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eye.cpp
@@ -12,8 +12,6 @@
 #include "shape_inference/shape_inference.hpp"
 #include "utils/bfloat16.hpp"
 
-#define THROW_ERROR(...) OPENVINO_THROW(NameFromType(getType()), " node with name '", getName(), "' ", __VA_ARGS__)
-
 namespace ov {
 namespace intel_cpu {
 namespace node {

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -24,8 +24,6 @@
 
 using namespace dnnl::impl::cpu;
 
-#define THROW_ERROR(...) OPENVINO_THROW(getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
-
 namespace ov {
 namespace intel_cpu {
 namespace node {
@@ -69,7 +67,7 @@ Gather::Gather(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
     if (one_of(op->get_input_size(), 4u, 5u) && op->get_output_size() == 1u) {
         compressed = true;
     } else if (op->get_input_size() != 3 || op->get_output_size() != 1) {
-        THROW_ERROR("has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
     }
 
     const auto& dataShape = getInputShapeAtPort(GATHER_DATA);
@@ -80,7 +78,7 @@ Gather::Gather(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
     isIdxShapeStat = idxShape.isStatic();
     const auto indicesRank = idxShape.getRank();
     if (dataSrcRank == 0lu || indicesRank == 0lu)
-        THROW_ERROR("has incorrect input parameters ranks.");
+        THROW_CPU_NODE_ERR("has incorrect input parameters ranks.");
 
     if (ov::is_type<ov::op::v8::Gather>(op)) {
         batchDims = static_cast<int>(ov::as_type_ptr<ov::op::v8::Gather>(op)->get_batch_dims());
@@ -104,7 +102,7 @@ Gather::Gather(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
     if (batchDims < 0)
         batchDims += indicesRank;
     if (batchDims < 0 || batchDims > std::min(static_cast<int>(dataSrcRank), static_cast<int>(indicesRank)))
-        THROW_ERROR("has incorrect batch_dims ", batchDims, "!");
+        THROW_CPU_NODE_ERR("has incorrect batch_dims ", batchDims, "!");
 
     if (ov::is_type<ov::op::v0::Constant>(op->get_input_node_ptr(GATHER_AXIS))) {
         isAxisInputConst = true;
@@ -112,7 +110,7 @@ Gather::Gather(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
         if (axis < 0)
             axis += dataSrcRank;
         if (axis < 0 || axis >= dataSrcRank || batchDims > axis)
-            THROW_ERROR("has incorrect input parameter axis value: ", axis);
+            THROW_CPU_NODE_ERR("has incorrect input parameter axis value: ", axis);
     }
 
     if (auto indices = ov::as_type<ov::op::v0::Constant>(op->get_input_node_ptr(GATHER_INDICES))) {
@@ -339,12 +337,12 @@ bool Gather::needPrepareParams() const {
 void Gather::prepareParams() {
     auto dataMemPtr = getSrcMemoryAtPort(GATHER_DATA);
     if (!dataMemPtr || !dataMemPtr->isDefined())
-        THROW_ERROR(" has undefined input data memory.");
+        THROW_CPU_NODE_ERR("has undefined input data memory.");
     auto idxMemPtr = getSrcMemoryAtPort(GATHER_INDICES);
     if (!idxMemPtr || !idxMemPtr->isDefined())
-        THROW_ERROR(" has undefined input indices memory.");
+        THROW_CPU_NODE_ERR("has undefined input indices memory.");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        THROW_ERROR(" has unidentified preferable primitive descriptor.");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor.");
 
     // short 1D vector fast execution impl (typical in shape infer subgraph)
     canOptimize1DCase = false;
@@ -363,7 +361,7 @@ void Gather::prepareParams() {
         if (axis < 0)
             axis += dataSrcRank;
         if (axis < 0 || axis >= dataSrcRank || batchDims > axis)
-            THROW_ERROR("has incorrect input parameter axis value: ", axis);
+            THROW_CPU_NODE_ERR("has incorrect input parameter axis value: ", axis);
     }
 
     if (!isDataShapeStat || !isAxisInputConst) {
@@ -553,7 +551,7 @@ void Gather::executeDynamicImpl(const dnnl::stream& strm) {
 
 void Gather::initShortParams(threadExecParams& p, const uint64_t start) {
     if (!jitKernel)
-        THROW_ERROR("has uninitialized kernel in function initShortParams.");
+        THROW_CPU_NODE_ERR("has uninitialized kernel in function initShortParams.");
     const uint64_t idxElPerVec = jitKernel->getIdxElPerVec();
 
     if (afterAxisSize == 1) {  // Elementwise gather.

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.cpp
@@ -38,19 +38,19 @@ GatherElements::GatherElements(const std::shared_ptr<ov::Node>& op, const GraphC
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     if (inputShapes.size() != 2 || outputShapes.size() != 1)
-        THROW_CPU_NODE_ERR(" has invalid number of input/output edges.");
+        THROW_CPU_NODE_ERR("has invalid number of input/output edges.");
 
     const auto dataRank = getInputShapeAtPort(dataIndex_).getRank();
     const auto indicesRank = getInputShapeAtPort(indicesIndex_).getRank();
     if (dataRank != indicesRank)
-        THROW_CPU_NODE_ERR(" has invalid input shapes. Inputs 'Data' and 'Indices' must have equal ranks.");
+        THROW_CPU_NODE_ERR("has invalid input shapes. Inputs 'Data' and 'Indices' must have equal ranks.");
 
     auto gatherElementsOp = ov::as_type_ptr<ov::op::v6::GatherElements>(op);
     auto axis = gatherElementsOp->get_axis();
     if (axis < 0)
         axis += dataRank;
     if (axis < 0 || axis >= static_cast<int>(dataRank))
-        THROW_CPU_NODE_ERR(" has invalid axis attribute: ", axis);
+        THROW_CPU_NODE_ERR("has invalid axis attribute: ", axis);
     axis_ = axis;
 }
 
@@ -78,12 +78,12 @@ void GatherElements::initSupportedPrimitiveDescriptors() {
                 sizeof(element_type_traits<ov::element::i32>::value_type),
                 sizeof(element_type_traits<ov::element::i16>::value_type),
                 sizeof(element_type_traits<ov::element::i8>::value_type))) {
-        THROW_CPU_NODE_ERR(" has unsupported 'inputData' input precision: ", inDataPrecision);
+        THROW_CPU_NODE_ERR("has unsupported 'inputData' input precision: ", inDataPrecision);
     }
 
     ov::element::Type indicesPrecision = getOriginalInputPrecisionAtPort(indicesIndex_);
     if (!one_of(indicesPrecision, ov::element::i32, ov::element::i64)) {
-        THROW_CPU_NODE_ERR(" has unsupported 'indices' input precision: ", indicesPrecision);
+        THROW_CPU_NODE_ERR("has unsupported 'indices' input precision: ", indicesPrecision);
     }
 
     dataTypeSize_ = inDataPrecision.size();

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.cpp
@@ -14,8 +14,6 @@ using namespace ov::intel_cpu::node;
 using namespace dnnl::impl::cpu;
 #endif  // OPENVINO_ARCH_X86_64
 
-#define THROW_ERROR(...) OPENVINO_THROW(getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
-
 bool GridSample::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
         if (!ov::is_type<op::v9::GridSample>(op)) {

--- a/src/plugins/intel_cpu/src/nodes/interaction.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interaction.cpp
@@ -28,8 +28,6 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
-#define THROW_ERROR(...) OPENVINO_THROW(getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
-
 #if defined(OPENVINO_ARCH_X86_64)
 
 template <cpu_isa_t isa>
@@ -346,7 +344,7 @@ void Interaction::prepareParams() {
         moveFeatureKernel->create_ker();
         moveInteractKernel->create_ker();
     } else {
-        THROW_ERROR("cannot create jit eltwise kernel");
+        THROW_CPU_NODE_ERR("cannot create jit eltwise kernel");
     }
 #ifdef CPU_DEBUG_CAPS
     if (prim) {

--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -25,8 +25,6 @@ using namespace dnnl::impl::cpu::x64;
 using namespace dnnl::impl::cpu::x64::matmul;
 using namespace Xbyak;
 
-#define THROW_ERROR(...) OPENVINO_THROW(getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
-
 namespace ov {
 namespace intel_cpu {
 namespace node {
@@ -879,7 +877,7 @@ void MHA::init_brgemm(brgemmCtx& ctx, std::unique_ptr<brgemm_kernel_t>& brgKerne
                                    ctx.K,
                                    &strides);
     if (status != dnnl_success) {
-        THROW_ERROR("cannot be executed due to invalid brgconv params");
+        THROW_CPU_NODE_ERR("cannot be executed due to invalid brgconv params");
     }
 
     ctx.is_with_amx = use_amx;
@@ -893,11 +891,11 @@ void MHA::init_brgemm(brgemmCtx& ctx, std::unique_ptr<brgemm_kernel_t>& brgKerne
     brgemm_kernel_t* brgKernel_ = nullptr;
     status = brgemm_kernel_create(&brgKernel_, brgDesc);
     if (status != dnnl_success) {
-        THROW_ERROR("cannot be executed due to invalid brgconv params");
+        THROW_CPU_NODE_ERR("cannot be executed due to invalid brgconv params");
     }
     brgKernel.reset(brgKernel_);
 #else
-    THROW_ERROR("is not supported on non-x86_64");
+    THROW_CPU_NODE_ERR("is not supported on non-x86_64");
 #endif  // OPENVINO_ARCH_X86_64
 }
 
@@ -972,7 +970,7 @@ void MHA::init_brgemm_copy_b(std::unique_ptr<jit_brgemm_matmul_copy_b_t>& brgCop
 #if defined(OPENVINO_ARCH_X86_64)
     auto ret = create_brgemm_matmul_copy_b(brgCopyKernel, &brgCopyKernelConf);
     if (ret != dnnl::impl::status_t::dnnl_success)
-        THROW_ERROR("cannot create_brgemm_matmul_copy_b kernel, dnnl_status: ", ret);
+        THROW_CPU_NODE_ERR("cannot create_brgemm_matmul_copy_b kernel, dnnl_status: ", ret);
 #endif  // OPENVINO_ARCH_X86_64
 }
 
@@ -1204,7 +1202,7 @@ void MHA::prepareParams() {
         }
 #endif  // OPENVINO_ARCH_X86_64
         if (!mulAddSoftmaxKernel) {
-            THROW_ERROR("cannot create jit eltwise kernel");
+            THROW_CPU_NODE_ERR("cannot create jit eltwise kernel");
         }
     }
 
@@ -1228,7 +1226,7 @@ void MHA::prepareParams() {
         }
 #endif  // OPENVINO_ARCH_X86_64
         if (!convertReorderKernel) {
-            THROW_ERROR("cannot create jit eltwise kernel");
+            THROW_CPU_NODE_ERR("cannot create jit eltwise kernel");
         }
     }
 
@@ -1255,7 +1253,7 @@ void MHA::prepareParams() {
 #endif  // OPENVINO_ARCH_X86_64
 
         if (!convertTransposeKernel) {
-            THROW_ERROR("cannot create jit eltwise kernel");
+            THROW_CPU_NODE_ERR("cannot create jit eltwise kernel");
         }
     }
 
@@ -1312,7 +1310,7 @@ void MHA::callBrgemm(brgemmCtx& ctx,
         brgemm_kernel_execute(brgKernel.get(), 1, pin0, pin1, nullptr, pout, wsp);
     }
 #else
-    THROW_ERROR("is not supported on non-x64 platforms");
+    THROW_CPU_NODE_ERR("is not supported on non-x64 platforms");
 #endif  // OPENVINO_ARCH_X86_64
 }
 
@@ -1547,7 +1545,7 @@ void MHA::execute(const dnnl::stream& strm) {
     } else if (inputPrecisions[1] == ov::element::i8) {
         mhaImpl<int8_t>();
     } else {
-        THROW_ERROR("doesn't support provided input precisions");
+        THROW_CPU_NODE_ERR("doesn't support provided input precisions");
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -14,8 +14,6 @@
 #include "openvino/opsets/opset1.hpp"
 #include "shape_inference/custom/priorbox.hpp"
 
-#define THROW_ERROR(...) OPENVINO_THROW("PriorBox layer with name '", getName(), "': ", __VA_ARGS__)
-
 namespace ov {
 namespace intel_cpu {
 namespace node {
@@ -69,7 +67,7 @@ PriorBox::PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
         exist = false;
 
         if (std::fabs(aspect_ratio_item) < std::numeric_limits<float>::epsilon()) {
-            THROW_ERROR("Aspect_ratio param can't be equal to zero");
+            THROW_CPU_NODE_ERR("has aspect_ratio param can't be equal to zero");
         }
 
         for (float _aspect_ratio : aspect_ratio) {
@@ -94,7 +92,7 @@ PriorBox::PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
     if (attrs.variance.size() == 1 || attrs.variance.size() == 4) {
         for (float i : attrs.variance) {
             if (i < 0) {
-                THROW_ERROR("Variance must be > 0.");
+                THROW_CPU_NODE_ERR("variance must be > 0.");
             }
 
             variance.push_back(i);
@@ -102,7 +100,7 @@ PriorBox::PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
     } else if (attrs.variance.empty()) {
         variance.push_back(0.1f);
     } else {
-        THROW_ERROR("Wrong number of variance values. Not less than 1 and more than 4 variance values.");
+        THROW_CPU_NODE_ERR("has wrong number of variance values. Not less than 1 and more than 4 variance values.");
     }
 }
 

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -15,8 +15,6 @@
 #include "openvino/util/pp.hpp"
 #include "utils/general_utils.h"
 
-#define THROW_ERROR(...) OPENVINO_THROW("SpaceToDepth layer with name '", getName(), "' ", __VA_ARGS__)
-
 using namespace dnnl;
 using namespace dnnl::impl;
 
@@ -76,11 +74,11 @@ SpaceToDepth::SpaceToDepth(const std::shared_ptr<ov::Node>& op, const GraphConte
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     if (inputShapes.size() != 1 || outputShapes.size() != 1)
-        THROW_ERROR("has incorrect number of input/output edges!");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output edges!");
 
     auto spaceToDepth = ov::as_type_ptr<const ov::opset1::SpaceToDepth>(op);
     if (!spaceToDepth)
-        THROW_ERROR("supports only opset1");
+        THROW_CPU_NODE_ERR("supports only opset1");
 
     const auto modeNgraph = spaceToDepth->get_mode();
     if (modeNgraph == ov::op::v0::SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST) {
@@ -88,21 +86,21 @@ SpaceToDepth::SpaceToDepth(const std::shared_ptr<ov::Node>& op, const GraphConte
     } else if (modeNgraph == ov::op::v0::SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST) {
         attrs.mode = Mode::DEPTH_FIRST;
     } else {
-        THROW_ERROR("doesn't support mode: ", ov::as_string(modeNgraph));
+        THROW_CPU_NODE_ERR("doesn't support mode: ", ov::as_string(modeNgraph));
     }
 
     attrs.blockSize = spaceToDepth->get_block_size();
     if (attrs.blockSize == 0)
-        THROW_ERROR("has incorrect block_size parameter is zero!");
+        THROW_CPU_NODE_ERR("has incorrect block_size parameter is zero!");
 
     const size_t srcRank = getInputShapeAtPort(0).getRank();
     const size_t dstRank = getOutputShapeAtPort(0).getRank();
     if (srcRank < 3)
-        THROW_ERROR("has incorrect number of input dimensions");
+        THROW_CPU_NODE_ERR("has incorrect number of input dimensions");
     if (srcRank > 5)
-        THROW_ERROR("doesn't support dimensions with rank greater than 5");
+        THROW_CPU_NODE_ERR("doesn't support dimensions with rank greater than 5");
     if (srcRank != dstRank)
-        THROW_ERROR("has incorrect number of input/output dimensions");
+        THROW_CPU_NODE_ERR("has incorrect number of input/output dimensions");
     attrs.nSpatialDims = srcRank - 2;
     attrs.blockStep = static_cast<size_t>(std::pow(attrs.blockSize, attrs.nSpatialDims));
 }
@@ -164,11 +162,11 @@ void SpaceToDepth::createPrimitive() {
     auto dstMemPtr = getDstMemoryAtPort(0);
     auto srcMemPtr = getSrcMemoryAtPort(0);
     if (!dstMemPtr)
-        THROW_ERROR("has null destination memory");
+        THROW_CPU_NODE_ERR("has null destination memory");
     if (!srcMemPtr)
-        THROW_ERROR("has null input memory");
+        THROW_CPU_NODE_ERR("has null input memory");
     if (getSelectedPrimitiveDescriptor() == nullptr)
-        THROW_ERROR("has unidentified preferable primitive descriptor");
+        THROW_CPU_NODE_ERR("has unidentified preferable primitive descriptor");
 
     const auto& memoryDesc = srcMemPtr->getDesc();
     attrs.dataSize = memoryDesc.getPrecision().size();
@@ -301,7 +299,7 @@ void SpaceToDepth::SpaceToDepthExecutor::exec(const uint8_t* srcData, uint8_t* d
 
 void SpaceToDepth::execute(const dnnl::stream& strm) {
     if (!execPtr) {
-        THROW_ERROR("doesn't have a compiled executor.");
+        THROW_CPU_NODE_ERR("doesn't have a compiled executor.");
     }
     const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(0);
     uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -25,8 +25,6 @@ namespace ov {
 namespace intel_cpu {
 namespace node {
 
-#define THROW_ERROR(...) OPENVINO_THROW(getTypeStr(), " layer with name '", getName(), "' ", __VA_ARGS__)
-
 static NodeConfig make_plain_config(const std::shared_ptr<ov::Node>& op) {
     NodeConfig config;
 
@@ -435,7 +433,7 @@ TensorIterator::TensorIterator(const std::shared_ptr<ov::Node>& op, const GraphC
 void TensorIterator::getSupportedDescriptors() {
     auto tiOp = ov::as_type_ptr<const ov::op::util::SubGraphOp>(ngraphOp);
     if (!tiOp) {
-        THROW_ERROR("cannot be cast to ov::op::util::SubGraphOp");
+        THROW_CPU_NODE_ERR("cannot be cast to ov::op::util::SubGraphOp");
     }
     const std::shared_ptr<const ov::Model> body = tiOp->get_function();
     sub_graph.CreateGraph(body, context);
@@ -519,7 +517,7 @@ void TensorIterator::getSupportedDescriptors() {
                                               -1,
                                               1});
         } else {
-            THROW_ERROR("has incorrect type of the input description.");
+            THROW_CPU_NODE_ERR("has incorrect type of the input description.");
         }
     }
 
@@ -537,7 +535,7 @@ void TensorIterator::getSupportedDescriptors() {
     } else if (auto ti = ov::as_type_ptr<const ov::op::v0::TensorIterator>(ngraphOp)) {
         algorithm = Algorithm::TensorIteratorCommon;
     } else {
-        THROW_ERROR("isn't supported!");
+        THROW_CPU_NODE_ERR("isn't supported!");
     }
 }
 
@@ -894,11 +892,11 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
     const auto getNumIterations = [this](const PortMap& rule, const std::vector<size_t>& dimensions) -> int {
         const auto axis = rule.axis;
         if (axis < 0 || static_cast<std::size_t>(axis) >= dimensions.size()) {
-            THROW_ERROR(": Invalid \"axis\" value in an iteration component: ",
-                        rule.axis,
-                        ", dimensions number = ",
-                        dimensions.size(),
-                        " (out of range)");
+            THROW_CPU_NODE_ERR(": Invalid \"axis\" value in an iteration component: ",
+                               rule.axis,
+                               ", dimensions number = ",
+                               dimensions.size(),
+                               " (out of range)");
         }
         const auto space = dimensions[axis];
         const int start = static_cast<int>((rule.start < 0 ? (space + 1) : 0) + rule.start);
@@ -906,7 +904,9 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
 
         const auto stride = rule.stride;
         if (stride == 0) {
-            THROW_ERROR(": Invalid \"stride\" value in an iteration component: ", rule.stride, " (infinite loop)");
+            THROW_CPU_NODE_ERR(": Invalid \"stride\" value in an iteration component: ",
+                               rule.stride,
+                               " (infinite loop)");
         }
         const auto step = std::abs(stride);
 
@@ -914,21 +914,21 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
         const auto dst = stride < 0 ? start : end;
         const auto length = dst - src;
         if (src < 0 || src >= dst || dst > static_cast<int64_t>(space) || length < step) {
-            THROW_ERROR(": Invalid \"start\",\"stride\",\"end\" values in an iteration component",
-                        ": \"start\" = ",
-                        rule.start,
-                        ", \"stride\" = ",
-                        rule.stride,
-                        ", \"end\" = ",
-                        rule.end);
+            THROW_CPU_NODE_ERR(": Invalid \"start\",\"stride\",\"end\" values in an iteration component",
+                               ": \"start\" = ",
+                               rule.start,
+                               ", \"stride\" = ",
+                               rule.stride,
+                               ", \"end\" = ",
+                               rule.end);
         }
 
         if (length % step != 0) {
-            THROW_ERROR(": Each iteration must be the same size: length (",
-                        length,
-                        ") is not divisible by step (",
-                        step,
-                        ")");
+            THROW_CPU_NODE_ERR(": Each iteration must be the same size: length (",
+                               length,
+                               ") is not divisible by step (",
+                               step,
+                               ")");
         }
 
         return static_cast<int>(length / step);
@@ -943,11 +943,11 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
         }
 
         if (rule.from < 0 || rule.from >= static_cast<int64_t>(inputShapes.size())) {
-            THROW_ERROR(": Invalid \"from\" value: \"from\" = ",
-                        rule.from,
-                        " inputs number = ",
-                        inputShapes.size(),
-                        " (out of range)");
+            THROW_CPU_NODE_ERR(": Invalid \"from\" value: \"from\" = ",
+                               rule.from,
+                               " inputs number = ",
+                               inputShapes.size(),
+                               " (out of range)");
         }
 
         const auto currentNumIterations = getNumIterations(rule, dims);
@@ -955,10 +955,10 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
             isDefault = false;
             numIterations = currentNumIterations;
         } else if (numIterations != currentNumIterations) {
-            THROW_ERROR(": There are at least two different iterations numbers: ",
-                        numIterations,
-                        " and ",
-                        currentNumIterations);
+            THROW_CPU_NODE_ERR(": There are at least two different iterations numbers: ",
+                               numIterations,
+                               " and ",
+                               currentNumIterations);
         }
     }
 
@@ -972,11 +972,11 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
             continue;
 
         if (rule.from < 0 || rule.from >= static_cast<int64_t>(outputShapes.size())) {
-            THROW_ERROR(": Invalid \"from\" value: \"from\" = ",
-                        rule.from,
-                        " inputs number = ",
-                        outputShapes.size(),
-                        " (out of range)");
+            THROW_CPU_NODE_ERR(": Invalid \"from\" value: \"from\" = ",
+                               rule.from,
+                               " inputs number = ",
+                               outputShapes.size(),
+                               " (out of range)");
         }
 
         const auto currentNumIterations = getNumIterations(rule, dims);
@@ -984,10 +984,10 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
             isDefault = false;
             numIterations = currentNumIterations;
         } else if (numIterations != currentNumIterations) {
-            THROW_ERROR(": There are at least two different iterations numbers: ",
-                        numIterations,
-                        " and ",
-                        currentNumIterations);
+            THROW_CPU_NODE_ERR(": There are at least two different iterations numbers: ",
+                               numIterations,
+                               " and ",
+                               currentNumIterations);
         }
     }
 


### PR DESCRIPTION
### Details:
Replace custom THROW_ERROR macros usage for error reporting in nodes implementation with THROW_CPU_NODE_ERR to unify error handling infrastructure in CPU plugin

### Tickets:
 - 160275
