### PR TITLE
[TRANSFORMATIONS] SDPAToPagedAttention transformation: support decompression case in the Qwen-7b-Chat pattern

### DIFF
--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/position_ids_replacer.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/position_ids_replacer.cpp
@@ -72,8 +72,15 @@ ov::pass::PositionIDsReplacerQwen::PositionIDsReplacerQwen(const Output<Node>& p
 
     auto p_neg_const = wrap_type<v0::Constant>();
     auto p_neg_mul = wrap_type<v1::Multiply>({p_current_len, p_neg_const});
+
+    // For now, it has always been a constant, but this may change in the future.
+    // In case of model being in FP16, there will be a decompressing subgraph:
+    // i.e. Constant -> Convert -> Slice
+    //
+    // Also, it hasn't been observed yet, but, theoretically, there can also be a
+    // dequantizing subgraph, so it's going to be any_input() here.
+    auto p_rotary_emb_sincos = pattern::any_input();
     // the rotary_emb_cos/rotary_emb_sin are sliced by the total length [1,..4096,1,128]
-    auto p_rotary_emb_sincos = wrap_type<v0::Constant>();
     auto p_slice_1 = wrap_type<v8::Slice>({p_rotary_emb_sincos, _const(), p_opt_reshape, _const(), _const()});
     auto p_slice_2 = wrap_type<v8::Slice>({p_slice_1, p_neg_mul, _const(), _const(), _const()});
 


### PR DESCRIPTION
Qwen-7b-Chat has a decompression if the model is executed in lower
precision resulting into the model having additional Converts (i.e. FP16
to FP32).

Handle this case of optional Convert in PositionIDsReplacerQwen

Added a unit test for it.

### Tickets:
 - *[CVS-157308](https://jira.devtools.intel.com/browse/CVS-157308)*

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
Signed-off-by: Ivan Tikhonov <ivan.tikhonov@intel.com>