### PR TITLE
[CORE] Try to correct 'undefined' and 'dynamic' type serialization

### DIFF
--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -731,8 +731,9 @@ std::string get_opset_name(const ov::Node* n) {
 std::string get_precision_name(const ov::element::Type& elem_type) {
     switch (elem_type) {
     case ::ov::element::Type_t::undefined:
+        return "undefined";
     case ::ov::element::Type_t::dynamic:
-        return "UNSPECIFIED";
+        return "dynamic";
     case ::ov::element::Type_t::f16:
         return "FP16";
     case ::ov::element::Type_t::f32:


### PR DESCRIPTION
### Details:
 - There is misalignment between ov::element::type string serialization / de-serialization methods
   and the ir serializer itself.
   After introduction of internal opset FullyConnected operation the 'undefined' element type basically
   became valid and serializable
 - Try to update the serializer and see which tests are going to fail
 - There are potential issues with IR backward compatibility which should be addressed carefully