### PR TITLE
[CPU][TESTS] Remove sse4 instances from oneDNN related tests

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
@@ -190,16 +190,6 @@ void ConvolutionLayerCPUTest::SetUp() {
 }
 
 TEST_P(ConvolutionLayerCPUTest, CompareWithRefs) {
-    // Skip tests for sse41 convolution where ic or oc cannot be exactly divided by the block size,
-    // since tails processing for sse41 nspc layout is not supported yet (see 52736).
-    if (!inFmts.empty() && (inFmts.front() == nwc || inFmts.front() == nhwc || inFmts.front() == ndhwc) && selectedType.find("jit_sse") != std::string::npos) {
-        auto inpChannels = function->get_parameters().front()->get_partial_shape()[1].get_length();
-        auto outChannels = function->get_output_partial_shape(0)[1].get_length();
-        if ((inpChannels % 8) || (outChannels % 8)) {
-            GTEST_SKIP() << "Disabled test due to the sse41 convolution kernel does not support tails for nspc layout." << std::endl;
-        }
-    }
-
     if (!priority.empty()) {
         // Skip tests for brgconv convolution where kernel size = 1x1
         if (one_of(priority[0], "brgconv_avx512", "brgconv_avx512_amx", "brgconv_avx2")) {
@@ -340,10 +330,7 @@ const std::vector<InputShape>& inShapesGemm2D_cache() {
 
 const std::vector<CPUSpecificParams>& CPUParams_2D() {
     static const std::vector<CPUSpecificParams> CPUParams_2D = {
-        conv_sse42_2D,
-        conv_avx2_2D,
         conv_avx512_2D,
-        conv_sse42_2D_nspc,
         conv_avx2_2D_nspc,
         conv_avx2_2D_nspc_brgconv,
         conv_avx512_2D_nspc,
@@ -354,7 +341,6 @@ const std::vector<CPUSpecificParams>& CPUParams_2D() {
 
 const std::vector<CPUSpecificParams>& CPUParams_3D() {
     static const std::vector<CPUSpecificParams> CPUParams_3D = {
-        //conv_sse42_3D, // not supported jit_sse42 for 3d
         conv_avx2_3D,
         conv_avx512_3D,
         conv_avx2_3D_nspc,
@@ -479,10 +465,8 @@ const std::vector<InputShape>& inputShapes2d_dynBatch() {
 
 const std::vector<CPUSpecificParams>& CPUParams_1x1_1D() {
     static const std::vector<CPUSpecificParams> CPUParams_1x1_1D = {
-            conv_sse42_1D_1x1,
             conv_avx2_1D_1x1,
             conv_avx512_1D_1x1,
-            conv_sse42_1D_1x1_nspc,
             conv_avx2_1D_1x1_nspc,
             conv_avx2_1D_1x1_nspc_brgconv,
             conv_avx512_1D_1x1_nspc,
@@ -567,10 +551,8 @@ const std::vector<CPUSpecificParams>& CPUParams_GEMM_3D() {
 
 const std::vector<CPUSpecificParams>& CPUParams_1x1_2D() {
     static const std::vector<CPUSpecificParams> CPUParams_1x1_2D = {
-            conv_sse42_2D_1x1,
             conv_avx2_2D_1x1,
             conv_avx512_2D_1x1,
-            conv_sse42_2D_1x1_nspc,
             conv_avx2_2D_1x1_nspc,
             conv_avx2_2D_1x1_nspc_brgconv,
             conv_avx512_2D_1x1_nspc,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/pooling.cpp
@@ -787,12 +787,11 @@ const CPUSpecificParams& expectedCpuConfigAnyLayout() {
 }
 
 const std::vector<CPUSpecificParams>& vecCpuConfigsFusing_4D() {
-    const auto sse42_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42"}, "jit_sse42"};
     const auto avx2_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2"}, "jit_avx2"};
     const auto avx512_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx512"}, "jit_avx512"};
     const auto acl_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {"acl"}, "acl"};
 
-    static const std::vector<CPUSpecificParams> vecCpuConfigsFusing_4D = {sse42_nhwc, avx2_nhwc, avx512_nhwc, acl_nhwc, expectedCpuConfigAnyLayout()};
+    static const std::vector<CPUSpecificParams> vecCpuConfigsFusing_4D = {avx2_nhwc, avx512_nhwc, acl_nhwc, expectedCpuConfigAnyLayout()};
     return vecCpuConfigsFusing_4D;
 }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
@@ -1043,7 +1043,7 @@ const auto groupConvParams_ExplicitPadding_1D = ::testing::Combine(::testing::Va
                                                                    ::testing::Values(ov::op::PadType::EXPLICIT));
 
 const std::vector<CPUSpecificParams> CPUParams_1D =
-    {conv_sse42_1D, conv_avx2_1D, conv_avx512_1D, conv_sse42_1D_nspc, conv_avx2_1D_nspc, conv_avx512_1D_nspc};
+    {conv_avx2_1D, conv_avx512_1D, conv_avx2_1D_nspc, conv_avx512_1D_nspc};
 
 std::vector<InputShape> inputShapes1d = {{{}, {{2, 64, 7}}},
                                          {// dynamic shapes
@@ -1108,7 +1108,7 @@ const auto groupConvParams_ExplicitPadding_2D = ::testing::Combine(::testing::Va
                                                                    ::testing::Values(ov::op::PadType::EXPLICIT));
 
 const std::vector<CPUSpecificParams> CPUParams_2D =
-    {conv_sse42_2D, conv_avx2_2D, conv_avx512_2D, conv_sse42_2D_nspc, conv_avx2_2D_nspc, conv_avx512_2D_nspc};
+    {conv_avx2_2D, conv_avx512_2D, conv_avx2_2D_nspc, conv_avx512_2D_nspc};
 
 std::vector<InputShape> inputShapes2d = {{{}, {{1, 64, 7, 7}}},
                                          {// dynamic shapes
@@ -1197,7 +1197,6 @@ const auto groupConvParams_ExplicitPadding_3D = ::testing::Combine(::testing::Va
                                                                    ::testing::Values(ov::op::PadType::EXPLICIT));
 
 const std::vector<CPUSpecificParams> CPUParams_3D = {
-    //        conv_sse42_3D, // not supported jit_sse42 for 3d
     conv_avx2_3D,
     conv_avx512_3D,
     conv_avx2_3D_nspc,
@@ -1247,10 +1246,8 @@ const auto groupConvParams_ExplicitPadding_DW_1D = ::testing::Combine(::testing:
                                                                       ::testing::ValuesIn(numGroups_DW),
                                                                       ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_DW_1D = {conv_sse42_dw_1D,
-                                                        conv_avx2_dw_1D,
+const std::vector<CPUSpecificParams> CPUParams_DW_1D = {conv_avx2_dw_1D,
                                                         conv_avx512_dw_1D,
-                                                        conv_sse42_dw_1D_nspc,
                                                         conv_avx2_dw_1D_nspc,
                                                         conv_avx512_dw_1D_nspc};
 
@@ -1272,8 +1269,7 @@ INSTANTIATE_TEST_SUITE_P(
                            ::testing::ValuesIn(inputShapes1dDW),
                            ::testing::Values(ov::test::utils::DEVICE_CPU)),
         ::testing::ValuesIn(filterCPUInfoForDevice(
-            {conv_sse42_dw_1D, conv_avx2_dw_1D, conv_avx512_dw_1D})),  // todo: [AV] what about conv_sse42_dw_1D_nspc,
-                                                                       //  conv_avx2_dw_1D_nspc, conv_avx512_dw_1D_nspc?
+            {conv_avx2_dw_1D, conv_avx512_dw_1D})),  // todo: [AV] what about conv_avx2_dw_1D_nspc, conv_avx512_dw_1D_nspc?
         ::testing::ValuesIn(fusingParamsSet),
         ::testing::Values(empty_plugin_config)),
     GroupConvolutionLayerCPUTest::getTestCaseName);
@@ -1302,10 +1298,8 @@ const auto groupConvParams_ExplicitPadding_DW_2D = ::testing::Combine(::testing:
                                                                       ::testing::ValuesIn(numGroups_DW),
                                                                       ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_DW_2D = {conv_sse42_dw_2D,
-                                                        conv_avx2_dw_2D,
+const std::vector<CPUSpecificParams> CPUParams_DW_2D = {conv_avx2_dw_2D,
                                                         conv_avx512_dw_2D,
-                                                        conv_sse42_dw_2D_nspc,
                                                         conv_avx2_dw_2D_nspc,
                                                         conv_avx512_dw_2D_nspc};
 
@@ -1411,10 +1405,8 @@ const auto groupConvParams_ExplicitPadding_DW_3D = ::testing::Combine(::testing:
                                                                       ::testing::ValuesIn(numGroups_DW),
                                                                       ::testing::Values(ov::op::PadType::EXPLICIT));
 
-const std::vector<CPUSpecificParams> CPUParams_DW_3D = {conv_sse42_dw_3D,
-                                                        conv_avx2_dw_3D,
+const std::vector<CPUSpecificParams> CPUParams_DW_3D = {conv_avx2_dw_3D,
                                                         conv_avx512_dw_3D,
-                                                        conv_sse42_dw_3D_nspc,
                                                         conv_avx2_dw_3D_nspc,
                                                         conv_avx512_dw_3D_nspc};
 
@@ -1671,171 +1663,6 @@ const std::vector<groupConvLayerCPUTestParamsSet> gemmGroupConvTestCases = gener
 INSTANTIATE_TEST_SUITE_P(smoke_GEMM_GroupConv,
                          GroupConvolutionLayerCPUTest,
                          ::testing::ValuesIn(filterParamsSetForDevice(gemmGroupConvTestCases)),
-                         GroupConvolutionLayerCPUTest::getTestCaseName);
-
-/* ============= JIT SSE42 GroupConvolution ============= */
-const std::vector<CPUSpecificParams> sse42_GroupConv = {conv_sse42_2D, conv_sse42_2D_nspc};
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-    //  1. jcp.ur_w (=3,<3)
-    //  2. jcp.ur_w_tail (=0,>0)
-    //  3. jcp.kw (>7,<=7)
-    //  4. jcp.nb_oc = jcp.oc / jcp.oc_block;
-    //  5. jcp.nb_ic = jcp.ic / jcp.ic_block;
-    //  6. ocb_work
-
-    //  jcp.ur_w == 3, jcp.ur_w_tail == 2
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 10},
-                                    8,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.ur_w < 3 (jcp.ur_w == jcp.ow)
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 4},
-                                    8,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.ur_w == 3, jcp.ur_w_tail == 0
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 11},
-                                    8,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.kw > 7
-    makeSingleGroupConvCPUTestCases({3, 8},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 10},
-                                    8,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.nb_oc == 2
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 5},
-                                    8,
-                                    16,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.nb_ic == 2
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 5},
-                                    16,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  ocb_work > 1 (ocb_work == 2)
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 5},
-                                    8,
-                                    40,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.nb_ic == 2, ocb_work == 2
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    2,
-                                    1,
-                                    {5, 5},
-                                    16,
-                                    40,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32),
-
-    //  "hard" cases
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {2, 2},
-                                    {1, 1},
-                                    {1, 1},
-                                    {1, 1},
-                                    ov::op::PadType::EXPLICIT,
-                                    3,
-                                    2,
-                                    {129, 129},
-                                    8,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32Default),
-    makeSingleGroupConvCPUTestCases({2, 4},
-                                    {1, 2},
-                                    {3, 2},
-                                    {2, 1},
-                                    {1, 0},
-                                    ov::op::PadType::EXPLICIT,
-                                    2,
-                                    1,
-                                    {10, 10},
-                                    8,
-                                    8,
-                                    sse42_GroupConv,
-                                    vecPrcConnectParamsFP32Default)
-
-    //  not supported jit_sse42 for 3d
-    //  makeSingleGroupConvCPUTestCases({3, 3, 3}, {2, 2, 2}, {1, 1, 1}, {1, 1, 1}, {1, 1, 1},
-    //  ov::op::PadType::EXPLICIT,
-    //                              3, 2, {33, 33, 33}, 8, 8, cpuParams_sse42_3D),
-    //  makeSingleGroupConvCPUTestCases({2, 3, 4}, {1, 2, 2}, {3, 1, 2}, {2, 2, 1}, {1, 1, 0},
-    //  ov::op::PadType::EXPLICIT,
-    //                              2, 1, {10, 10, 10}, 8, 8, cpuParams_sse42_3D),
-);
-
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_SSE42_GroupConv,
-                         GroupConvolutionLayerCPUTest,
-                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_GroupConvTestCases)),
                          GroupConvolutionLayerCPUTest::getTestCaseName);
 
 /* ============= JIT AVX2 GroupConvolution ============= */
@@ -2130,120 +1957,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX512_GroupConv,
                          ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_GroupConvTestCases)),
                          GroupConvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= JIT SSE42 DW GroupConvolution ============= */
-const std::vector<CPUSpecificParams> sse42_DW_2D = {conv_sse42_dw_2D, conv_sse42_dw_2D_nspc};
-const std::vector<CPUSpecificParams> sse42_DW_3D = {conv_sse42_dw_3D, conv_sse42_dw_3D_nspc};
-const std::vector<groupConvLayerCPUTestParamsSet> JIT_SSE42_DW_GroupConvTestCases = generateSingleGroupConvCPUTestCases(
-    //  1. jcp.ngroups % simd_w (=0,!=0)
-    //  2. jcp.nb_ch
-    //  3. jcp.nb_ch_blocking (=2,<2)
-    //  4. jcp.ur_w == 3
-
-    //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 1, jcp.nb_ch_blocking == 1 (jcp.ngroups == 8)
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    8,
-                                    1,
-                                    {5, 5},
-                                    1,
-                                    1,
-                                    sse42_DW_2D,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.ngroups % simd_w == 0, jcp.nb_ch == 2, jcp.nb_ch_blocking == 2 (jcp.ngroups == 16)
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    16,
-                                    1,
-                                    {5, 5},
-                                    1,
-                                    1,
-                                    sse42_DW_2D,
-                                    vecPrcConnectParamsFP32),
-    //  jcp.ngroups % simd_w != 0, jcp.nb_ch == 3, jcp.nb_ch_blocking == 2 (jcp.ngroups == 17) TODO: pad channels not
-    //  supported for SSE42 makeSingleGroupConvCPUTestCases({3, 3}, {1, 1}, {1, 1}, {0, 0}, {0, 0},
-    //  ov::op::PadType::VALID, 17, 1, {5, 5}, 1, 1, conv_sse42_DW_2D, vecPrcConnectParamsFP32only), jcp.ow > jcp.ur_w
-    //  (jcp.ow == 7)
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {1, 1},
-                                    {1, 1},
-                                    {0, 0},
-                                    {0, 0},
-                                    ov::op::PadType::VALID,
-                                    8,
-                                    1,
-                                    {5, 9},
-                                    1,
-                                    1,
-                                    sse42_DW_2D,
-                                    vecPrcConnectParamsFP32),
-
-    //  "hard" cases
-    makeSingleGroupConvCPUTestCases({3, 3},
-                                    {2, 2},
-                                    {1, 1},
-                                    {1, 1},
-                                    {1, 1},
-                                    ov::op::PadType::EXPLICIT,
-                                    8,
-                                    2,
-                                    {129, 129},
-                                    1,
-                                    1,
-                                    sse42_DW_2D,
-                                    vecPrcConnectParamsFP32),
-    makeSingleGroupConvCPUTestCases({2, 4},
-                                    {1, 2},
-                                    {3, 2},
-                                    {2, 1},
-                                    {1, 0},
-                                    ov::op::PadType::EXPLICIT,
-                                    8,
-                                    1,
-                                    {10, 10},
-                                    1,
-                                    1,
-                                    sse42_DW_2D,
-                                    vecPrcConnectParamsFP32Default),
-    makeSingleGroupConvCPUTestCases({3, 3, 3},
-                                    {2, 2, 2},
-                                    {1, 1, 1},
-                                    {1, 1, 1},
-                                    {1, 1, 1},
-                                    ov::op::PadType::EXPLICIT,
-                                    8,
-                                    2,
-                                    {33, 33, 33},
-                                    1,
-                                    1,
-                                    sse42_DW_3D,
-                                    vecPrcConnectParamsFP32Default),
-    makeSingleGroupConvCPUTestCases({2, 3, 4},
-                                    {1, 2, 2},
-                                    {3, 1, 2},
-                                    {2, 2, 1},
-                                    {1, 1, 0},
-                                    ov::op::PadType::EXPLICIT,
-                                    8,
-                                    1,
-                                    {10, 10, 10},
-                                    1,
-                                    1,
-                                    sse42_DW_3D,
-                                    vecPrcConnectParamsFP32));
-
-INSTANTIATE_TEST_SUITE_P(smoke_JIT_SSE42_DW_GroupConv,
-                         GroupConvolutionLayerCPUTest,
-                         ::testing::ValuesIn(filterParamsSetForDevice(JIT_SSE42_DW_GroupConvTestCases)),
-                         GroupConvolutionLayerCPUTest::getTestCaseName);
-
 /* ============= JIT AVX2 DW GroupConvolution ============= */
 const std::vector<CPUSpecificParams> avx2_DW_2D = {conv_avx2_dw_2D, conv_avx2_dw_2D_nspc};
 const std::vector<CPUSpecificParams> avx2_DW_3D = {conv_avx2_dw_3D, conv_avx2_dw_3D_nspc};
@@ -2494,7 +2207,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_JIT_AVX512_DW_GroupConv,
                          ::testing::ValuesIn(filterParamsSetForDevice(JIT_AVX512_DW_GroupConvTestCases)),
                          GroupConvolutionLayerCPUTest::getTestCaseName);
 
-/* ============= JIT SSE42 1x1 Convolution (not supported with groups) ============= */
 /* ============= JIT AVX2 1x1 Convolution (not supported with groups) ============= */
 /* ============= JIT AVX512 1x1 Convolution (not supported with groups) ============= */
 /* ============= JIT AVX2 PLANAR Convolution (not supported with groups) ============= */

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/convolution.cpp
@@ -106,7 +106,6 @@ INSTANTIATE_TEST_SUITE_P(Conv_2D_FP32_dilated_empty_fusing, ConvolutionLayerCPUT
                          ConvolutionLayerCPUTest::getTestCaseName);
 
 const std::vector<CPUSpecificParams> CPUParams_2D_plain_to_blocked = {
-        conv_sse42_plain_to_blocked_2D,
         conv_avx2_plain_to_blocked_2D,
         conv_avx512_plain_to_blocked_2D,
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/convolution.cpp
@@ -344,10 +344,8 @@ const auto convParams_ExplicitPadding_1D = ::testing::Combine(
 );
 
 const std::vector<CPUSpecificParams> CPUParams_1D_f32 = {
-        conv_sse42_1D,
         conv_avx2_1D,
         conv_avx512_1D,
-        conv_sse42_1D_nspc,
         conv_avx2_1D_nspc,
         conv_avx2_1D_nspc_brgconv,
         conv_avx512_1D_nspc,
@@ -356,10 +354,8 @@ const std::vector<CPUSpecificParams> CPUParams_1D_f32 = {
 
 //Current avx2 I8 fall back on JIT avx2 implement when having src zero point.Not enabling conv_avx2_1D_nspc_brgconv for I8 precision.
 const std::vector<CPUSpecificParams> CPUParams_1D_I8 = {
-        conv_sse42_1D,
         conv_avx2_1D,
         conv_avx512_1D,
-        conv_sse42_1D_nspc,
         conv_avx2_1D_nspc,
         conv_avx512_1D_nspc,
         conv_avx512_1D_nspc_brgconv
@@ -424,7 +420,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_1D_I8, ConvolutionLayerCPUTest,
                          ConvolutionLayerCPUTest::getTestCaseName);
 
 const std::vector<CPUSpecificParams> CPUParams_1D_plain_to_blocked = {
-        conv_sse42_plain_to_blocked_1D,
         conv_avx2_plain_to_blocked_1D,
         conv_avx512_plain_to_blocked_1D,
 };
@@ -630,7 +625,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_Conv_2D_1x1_FP16, ConvolutionLayerCPUTest,
 /* ============= Jit Planar ============= */
 /* ============= Convolution planar params (2D) ============= */
 const std::vector<CPUSpecificParams> CPUParams_Jit_Planar_2D = {
-        // sse42 is not supported
         conv_avx2_planar_2D,
         conv_avx512_planar_2D,
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/pooling.cpp
@@ -17,9 +17,8 @@ namespace {
 const auto ref = CPUSpecificParams{{}, {}, {"ref_any"}, "ref_any"};
 const auto avx512 = CPUSpecificParams{{}, {}, {"jit_avx512"}, "jit_avx512"};
 const auto avx = CPUSpecificParams{{}, {}, {"jit_avx"}, "jit_avx"};
-const auto sse42 = CPUSpecificParams{{}, {}, {"jit_sse42"}, "jit_sse42"};
 
-const std::vector<CPUSpecificParams> vecCpuConfigs = {sse42, avx, avx512};
+const std::vector<CPUSpecificParams> vecCpuConfigs = {avx, avx512};
 
 const std::vector<maxPoolV8SpecificParams> paramsMaxV84D_ref = {
         maxPoolV8SpecificParams{ {2, 2}, {2, 2}, {2, 2}, {0, 0}, {0, 0},
@@ -50,13 +49,9 @@ const auto avx2_nwc = CPUSpecificParams{{nwc}, {nwc}, {"jit_avx2"}, "jit_avx2"};
 const auto avx2_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2"}, "jit_avx2"};
 const auto avx2_ndhwc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_avx2"}, "jit_avx2"};
 
-const auto sse42_nwc = CPUSpecificParams{{nwc}, {nwc}, {"jit_sse42"}, "jit_sse42"};
-const auto sse42_nhwc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42"}, "jit_sse42"};
-const auto sse42_ndhwc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42"}, "jit_sse42"};
-
-const std::vector<CPUSpecificParams> vecCpuConfigsFusing_3D = {sse42_nwc, avx2_nwc, avx512_nwc};
-const std::vector<CPUSpecificParams> vecCpuConfigsFusing_4D = {sse42_nhwc, avx2_nhwc, avx512_nhwc};
-const std::vector<CPUSpecificParams> vecCpuConfigsFusing_5D = {sse42_ndhwc, avx2_ndhwc, avx512_ndhwc};
+const std::vector<CPUSpecificParams> vecCpuConfigsFusing_3D = {avx2_nwc, avx512_nwc};
+const std::vector<CPUSpecificParams> vecCpuConfigsFusing_4D = {avx2_nhwc, avx512_nhwc};
+const std::vector<CPUSpecificParams> vecCpuConfigsFusing_5D = {avx2_ndhwc, avx512_ndhwc};
 
 std::vector<fusingSpecificParams> fusingParamsSet {
     emptyFusingSpec,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/softmax.cpp
@@ -17,8 +17,7 @@ namespace {
 const auto optimizedCPUSpec = []()-> std::vector<CPUSpecificParams>{
     const auto avx512 = CPUSpecificParams{{}, {}, {"jit"}, "jit_avx512"};
     const auto avx2 = CPUSpecificParams{{}, {}, {"jit"}, "jit_avx2"};
-    const auto sse42 = CPUSpecificParams{{}, {}, {"jit"}, "jit_sse42"};
-    const std::vector<CPUSpecificParams> vecCpuConfigs = {avx512, avx2, sse42};
+    const std::vector<CPUSpecificParams> vecCpuConfigs = {avx512, avx2};
     auto supportConfigure = CPUTestUtils::filterCPUInfoForDevice(vecCpuConfigs);
     // only the MAX ISA of vecCpuConfigs will be tested
     if (supportConfigure.size() > 0) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/conv_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/conv_concat.cpp
@@ -50,7 +50,6 @@ namespace ConvolutionConact {
 
 /* ============= Convolution (2D) ============= */
 const std::vector<CPUSpecificParams> CPUParams2D = {
-    conv_ref_2D_nspc,
     conv_gemm_2D
 };
 
@@ -66,7 +65,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_Convolution2D, ConvConcatSubgraphTest, params2D, 
 
 /* ============= Convolution (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
-    conv_ref_3D_nspc,
     conv_gemm_3D
 };
 
@@ -86,7 +84,6 @@ namespace GroupConvolutionConcat {
 
 /* ============= GroupConvolution (2D) ============= */
 const std::vector<CPUSpecificParams> CPUParams2D = {
-    conv_ref_2D_nspc,
     conv_gemm_2D
 };
 
@@ -102,7 +99,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupConvolution2D, ConvConcatSubgraphTest, param
 
 /* ============= GroupConvolution (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
-    conv_ref_3D_nspc,
     conv_gemm_3D
 };
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_concat.cpp
@@ -20,7 +20,6 @@ namespace Kernel_1x1 {
 
 /* ============= Kernel_1x1 (2D) ============= */
 const std::vector<CPUSpecificParams> CPUParams2DConv = {
-    conv_sse42_2D_1x1,
     conv_avx2_2D_1x1,
     conv_avx512_2D_1x1
 };
@@ -84,7 +83,6 @@ commonConvParams dwConvParams2D = commonConvParams{kernelSize2D(), strides2D(), 
                                                    numOutChannels(), paddingType(), numOutChannels()};
 const ov::Shape inputShapesDW2D{1, 32, 16, 16};
 const std::vector<CPUSpecificParams> CPUParams2D = {
-    conv_sse42_dw_2D,
     conv_avx2_dw_2D,
     conv_avx512_dw_2D
 };
@@ -104,7 +102,6 @@ commonConvParams dwConvParams3D = commonConvParams{kernelSize3D(), strides3D(), 
                                                    numOutChannels(), paddingType(), numOutChannels()};
 const ov::Shape inputShapesDW3D{1, 32, 8, 16, 16};
 const std::vector<CPUSpecificParams> CPUParams3D = {
-    conv_sse42_dw_3D,
     conv_avx2_dw_3D,
     conv_avx512_dw_3D
 };
@@ -158,8 +155,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionBackpropData3D, ConvConcatSubgraphTest
 namespace ConvolutionConcat {
 /* ============= Convolution (2D) ============= */
 const std::vector<CPUSpecificParams> CPUParams2D = {
-    conv_ref_2D,
-    conv_sse42_2D,
     conv_avx2_2D,
     conv_avx512_2D
 };
@@ -176,7 +171,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_Convolution2D, ConvConcatSubgraphTest, params2D, 
 
 /* ============= Convolution (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
-    conv_ref_3D,
     conv_avx2_3D,
     conv_avx512_3D
 };
@@ -195,8 +189,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_Convolution3D, ConvConcatSubgraphTest, params3D, 
 namespace GroupConvolutionConcat {
 /* ============= GroupConvolution (2D) ============= */
 const std::vector<CPUSpecificParams> CPUParams2D = {
-    conv_ref_2D,
-    conv_sse42_2D,
     conv_avx2_2D,
     conv_avx512_2D
 };
@@ -213,7 +205,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_GroupConvolution2D, ConvConcatSubgraphTest, param
 
 /* ============= GroupConvolution (3D) ============= */
 const std::vector<CPUSpecificParams> CPUParams3D = {
-    conv_ref_3D,
     conv_avx2_3D,
     conv_avx512_3D
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/memory_sharing_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/memory_sharing_test.cpp
@@ -33,8 +33,6 @@ TEST_F(EdgeWithSameNameInTwoModels, smoke_CompareWithRef) {
         std::tie(inFmts, outFmts, priority, selectedType) = conv_avx512_2D;
     } else if (ov::with_cpu_x86_avx2()) {
         std::tie(inFmts, outFmts, priority, selectedType) = conv_avx2_2D;
-    } else if (ov::with_cpu_x86_sse42()) {
-        std::tie(inFmts, outFmts, priority, selectedType) = conv_sse42_2D;
     }
 
     // first model

--- a/src/plugins/intel_cpu/tests/functional/utils/convolution_params.hpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/convolution_params.hpp
@@ -7,14 +7,6 @@
 #include "cpu_test_utils.hpp"
 
 namespace CPUTestUtils {
-    const auto conv_ref_1D = CPUSpecificParams{{ncw}, {ncw}, {"ref_any"}, "ref_any"};
-    const auto conv_ref_2D = CPUSpecificParams{{nchw}, {nchw}, {"ref_any"}, "ref_any"};
-    const auto conv_ref_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"ref_any"}, "ref_any"};
-
-    const auto conv_ref_1D_nspc = CPUSpecificParams{{nwc}, {nwc}, {"ref_any"}, "ref_any"};
-    const auto conv_ref_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"ref_any"}, "ref_any"};
-    const auto conv_ref_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"ref_any"}, "ref_any"};
-
     const auto conv_gemm_1D = CPUSpecificParams{{ncw}, {ncw}, {"jit_gemm"}, "jit_gemm"};
     const auto conv_gemm_2D = CPUSpecificParams{{nchw}, {nchw}, {"jit_gemm"}, "jit_gemm"};
     const auto conv_gemm_3D = CPUSpecificParams{{ncdhw}, {ncdhw}, {"jit_gemm"}, "jit_gemm"};
@@ -30,24 +22,6 @@ namespace CPUTestUtils {
     const auto conv_gemm_acl_1D_nspc = CPUSpecificParams{{nwc}, {nwc}, {"gemm_acl"}, "gemm_acl"};
     const auto conv_gemm_acl_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"gemm_acl"}, "gemm_acl"};
     const auto conv_gemm_acl_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"gemm_acl"}, "gemm_acl"};
-
-    const auto conv_sse42_1D = CPUSpecificParams{{nCw8c}, {nCw8c}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_dw_1D = CPUSpecificParams{{nCw8c}, {nCw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-    const auto conv_sse42_dw_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-    const auto conv_sse42_dw_3D = CPUSpecificParams{{nCdhw8c}, {nCdhw8c}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-
-    const auto conv_sse42_plain_to_blocked_1D = CPUSpecificParams{{ncw}, {nCw8c}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_plain_to_blocked_2D = CPUSpecificParams{{nchw}, {nChw8c}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_plain_to_blocked_3D = CPUSpecificParams{{ncdhw}, {nCdhw8c}, {"jit_sse42"}, "jit_sse42"};
-
-    const auto conv_sse42_1D_nspc = CPUSpecificParams{{nwc}, {nwc}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42"}, "jit_sse42"};
-    const auto conv_sse42_dw_1D_nspc = CPUSpecificParams{{nwc}, {nwc}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-    const auto conv_sse42_dw_2D_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42_dw"}, "jit_sse42_dw"};
-    const auto conv_sse42_dw_3D_nspc = CPUSpecificParams{{ndhwc}, {ndhwc}, {"jit_sse42_dw"}, "jit_sse42_dw"};
 
     const auto conv_avx2_1D = CPUSpecificParams{{nCw8c}, {nCw8c}, {"jit_avx2"}, "jit_avx2"};
     const auto conv_avx2_2D = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2"}, "jit_avx2"};
@@ -107,22 +81,18 @@ namespace CPUTestUtils {
     const auto conv_avx512_2D_nspc_brgconv_amx = CPUSpecificParams{{nhwc}, {nhwc}, {"brgconv_avx512_amx"}, "brgconv_avx512_amx"};
     const auto conv_avx512_3D_nspc_brgconv_amx = CPUSpecificParams{{ndhwc}, {ndhwc}, {"brgconv_avx512_amx"}, "brgconv_avx512_amx"};
 
-    const auto conv_sse42_1D_1x1 = CPUSpecificParams{{nCw8c}, {nCw8c}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
     const auto conv_avx2_1D_1x1 = CPUSpecificParams{{nCw8c}, {nCw8c}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx512_1D_1x1 = CPUSpecificParams{{nCw16c}, {nCw16c}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
 
-    const auto conv_sse42_1D_1x1_nspc = CPUSpecificParams{{nwc}, {nwc}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
     const auto conv_avx2_1D_1x1_nspc = CPUSpecificParams{{nwc}, {nwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx2_1D_1x1_nspc_brgconv = CPUSpecificParams{{nwc}, {nwc}, {"brgconv_avx2_1x1"}, "brgconv_avx2_1x1"};
     const auto conv_avx512_1D_1x1_nspc = CPUSpecificParams{{nwc}, {nwc}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
     const auto conv_avx512_1D_1x1_nspc_brgconv = CPUSpecificParams{{nwc}, {nwc}, {"brgconv_avx512_1x1"}, "brgconv_avx512_1x1"};
     const auto conv_avx512_1D_1x1_nspc_brgconv_amx = CPUSpecificParams{{nwc}, {nwc}, {"brgconv_avx512_amx_1x1"}, "brgconv_avx512_amx_1x1"};
 
-    const auto conv_sse42_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
     const auto conv_avx2_2D_1x1 = CPUSpecificParams{{nChw8c}, {nChw8c}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx512_2D_1x1 = CPUSpecificParams{{nChw16c}, {nChw16c}, {"jit_avx512_1x1"}, "jit_avx512_1x1"};
 
-    const auto conv_sse42_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_sse42_1x1"}, "jit_sse42_1x1"};
     const auto conv_avx2_2D_1x1_nspc = CPUSpecificParams{{nhwc}, {nhwc}, {"jit_avx2_1x1"}, "jit_avx2_1x1"};
     const auto conv_avx2_2D_1x1_nspc_brgconv = CPUSpecificParams{{nhwc}, {nhwc}, {"brgconv_avx2_1x1"}, "brgconv_avx2_1x1"};
     const auto conv_avx2_3D_1x1_nspc_brgconv = CPUSpecificParams{{ndhwc}, {ndhwc}, {"brgconv_avx2_1x1"}, "brgconv_avx2_1x1"};


### PR DESCRIPTION
Seems to not worth to verify them considering how slow they are