### PR TITLE
[CPU] Fixed FC dynamic quantization accuracy issue

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
@@ -211,6 +211,11 @@ const std::vector<MatMulDecompressionShapeParams> input_shapes_basic_dyn_quant =
 };
 
 const std::vector<ov::test::ElementType> weights_precisions_dyn_quant = {ov::element::u8, ov::element::u4};
+const std::vector<fusingSpecificParams> fusing_params_dyn_quant{
+    emptyFusingSpec,
+    fusingBias, // bias is hanlded in separate code-path with post-ops
+    fusingSwish // max amount of post-op regs (which reduces available accum regs)
+};
 
 std::vector<ov::AnyMap> filter_additional_config_dyn_quant() {
     std::vector<ov::AnyMap> additional_config = {
@@ -232,7 +237,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_non_default_dyn_quant_gro
                                             ::testing::ValuesIn(decompression_subtract_type),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_dyn_quant()),
-                                            ::testing::ValuesIn(fusing_params),
+                                            ::testing::ValuesIn(fusing_params_dyn_quant),
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 
@@ -249,7 +254,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_sym_non_default_dyn_quant
                                             ::testing::Values(DecompressionType::empty),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_dyn_quant()),
-                                            ::testing::ValuesIn(fusing_params),
+                                            ::testing::ValuesIn(fusing_params_dyn_quant),
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 
@@ -265,7 +270,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_mxfp4,
                                             // todo: zero points converted to fp32 for reshape == true case
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_basic()),
-                                            ::testing::ValuesIn(fusing_params),
+                                            ::testing::ValuesIn(fusing_params_dyn_quant),
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);
 


### PR DESCRIPTION
### Details:
 - This PR fixes registers allocation for InnerProduct with dynamic quantization.
 - Regressions was introduced with oneDNN 3.6 migration. These changes is needed to restore DQ IP behavior prior the migration.
 - oneDNN PR: https://github.com/openvinotoolkit/oneDNN/pull/271

### Tickets:
 - [CVS-160384](https://jira.devtools.intel.com/browse/CVS-160384)
 - [CVS-160733](https://jira.devtools.intel.com/browse/CVS-160733)
