### PR TITLE
Fixed C++ RTTI for Core base classes

### DIFF
--- a/src/common/low_precision_transformations/include/low_precision/cleanup_transformation.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/cleanup_transformation.hpp
@@ -17,7 +17,6 @@ namespace low_precision {
 class LP_TRANSFORMATIONS_API CleanupTransformation : public LayerTransformation {
 public:
     CleanupTransformation(const Params& params);
-    virtual ~CleanupTransformation() = default;
 
     bool canBeTransformed(const std::shared_ptr<Node>& layer) const override;
     static bool canBeTransformedStatic(

--- a/src/common/low_precision_transformations/include/low_precision/fuse_elementwise_to_fake_quantize.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/fuse_elementwise_to_fake_quantize.hpp
@@ -19,7 +19,6 @@ namespace low_precision {
 class LP_TRANSFORMATIONS_API FuseElementwiseToFakeQuantizeTransformation : public CleanupTransformation {
 public:
     FuseElementwiseToFakeQuantizeTransformation(const Params& params);
-    virtual ~FuseElementwiseToFakeQuantizeTransformation() = default;
 
     bool canBeTransformed(const std::shared_ptr<Node>& layer) const override;
 };

--- a/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/layer_transformation.hpp
@@ -288,7 +288,6 @@ public:
     };
 
     LayerTransformation(const Params& params);
-    virtual ~LayerTransformation() = default;
     virtual bool transform(ov::pass::pattern::Matcher &m) = 0;
 
     virtual bool canBeTransformed(const std::shared_ptr<Node>& layer) const;

--- a/src/common/low_precision_transformations/include/low_precision/rt_info/shared_value_attribute.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/rt_info/shared_value_attribute.hpp
@@ -15,8 +15,6 @@
 template <class T>
 class LP_TRANSFORMATIONS_API SharedAttribute : public ov::RuntimeAttribute {
 public:
-    virtual ~SharedAttribute() = default;
-
     /**
      * @ingroup ov_transformation_common_api
      * @brief SharedValueAttribute type for shared value attributes.

--- a/src/core/include/openvino/core/any.hpp
+++ b/src/core/include/openvino/core/any.hpp
@@ -536,7 +536,7 @@ class OPENVINO_API Any {
         template <class U, class T, class... Others>
         U convert_impl() const;
 
-        virtual ~Base() = default;
+        virtual ~Base();
     };
 
     template <class T, typename = void>
@@ -610,8 +610,6 @@ class OPENVINO_API Any {
 
         template <typename... Args>
         Impl(Args&&... args) : value(std::forward<Args>(args)...) {}
-
-        virtual ~Impl(){};
 
         const std::type_info& type_info() const override {
             return typeid(T);

--- a/src/core/include/openvino/core/attribute_adapter.hpp
+++ b/src/core/include/openvino/core/attribute_adapter.hpp
@@ -34,7 +34,7 @@ public:
     /// \brief type info enables identification of the value accessor, as well as is_type and
     /// as_type.
     virtual const DiscreteTypeInfo& get_type_info() const = 0;
-    virtual ~ValueAccessor() = default;
+    virtual ~ValueAccessor();
     virtual void set_as_any(const ov::Any& x) {
         OPENVINO_NOT_IMPLEMENTED;
     }

--- a/src/core/include/openvino/core/attribute_visitor.hpp
+++ b/src/core/include/openvino/core/attribute_visitor.hpp
@@ -56,7 +56,7 @@ class VisitorAdapter;
 /// deserialization.
 class OPENVINO_API AttributeVisitor {
 public:
-    virtual ~AttributeVisitor() = default;
+    virtual ~AttributeVisitor();
     // Must implement these methods
     /// \brief handles all specialized on_adapter methods implemented by the visitor.
     ///

--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -107,7 +107,7 @@ public:
     /// based on traversing the graph from the results and the sinks.
     Model(const ov::OutputVector& results, const ov::SinkVector& sinks, const std::string& name = "");
 
-    virtual ~Model() = default;
+    virtual ~Model();
     /// Return the number of outputs for this Model.
     size_t get_output_size() const;
 

--- a/src/core/include/openvino/core/runtime_attribute.hpp
+++ b/src/core/include/openvino/core/runtime_attribute.hpp
@@ -28,7 +28,7 @@ public:
     }
     using Ptr = std::shared_ptr<RuntimeAttribute>;
     using Base = std::tuple<::ov::RuntimeAttribute>;
-    virtual ~RuntimeAttribute() = default;
+    virtual ~RuntimeAttribute();
     virtual bool is_copyable() const;
     virtual bool is_copyable(const std::shared_ptr<Node>& to) const;
     virtual Any init(const std::shared_ptr<Node>& node) const;

--- a/src/core/include/openvino/op/util/multi_subgraph_base.hpp
+++ b/src/core/include/openvino/op/util/multi_subgraph_base.hpp
@@ -20,7 +20,7 @@ public:
     OPENVINO_OP("MultiSubGraphOp", "util", ov::op::Sink);
     /// \brief Abstract class describes a connection between a MultiSubGraphOp input and
     /// the body.
-    class InputDescription {
+    class OPENVINO_API InputDescription {
     protected:
         ///
         /// \brief      Constructs a new instance.
@@ -34,7 +34,7 @@ public:
     public:
         using Ptr = std::shared_ptr<InputDescription>;
         using type_info_t = DiscreteTypeInfo;
-        virtual ~InputDescription() = default;
+        virtual ~InputDescription();
         virtual std::shared_ptr<InputDescription> copy() const = 0;
 
         virtual const type_info_t& get_type_info() const = 0;
@@ -45,7 +45,7 @@ public:
 
     /// \brief Abstract class describes how a MultiSubGraphOp output is produced from
     /// the body.
-    class OutputDescription {
+    class OPENVINO_API OutputDescription {
     protected:
         ///
         /// \brief      Constructs a new instance.
@@ -59,7 +59,7 @@ public:
     public:
         using Ptr = std::shared_ptr<OutputDescription>;
         using type_info_t = DiscreteTypeInfo;
-        virtual ~OutputDescription() = default;
+        virtual ~OutputDescription();
         virtual std::shared_ptr<OutputDescription> copy() const = 0;
         virtual const type_info_t& get_type_info() const = 0;
 

--- a/src/core/include/openvino/op/util/variable_extension.hpp
+++ b/src/core/include/openvino/op/util/variable_extension.hpp
@@ -39,7 +39,7 @@ public:
     virtual std::string get_variable_id() const = 0;
 
 protected:
-    virtual ~VariableExtension(){};
+    virtual ~VariableExtension();
 
 protected:
     std::shared_ptr<Variable> m_variable;

--- a/src/core/include/openvino/pass/pass.hpp
+++ b/src/core/include/openvino/pass/pass.hpp
@@ -44,7 +44,7 @@ class OPENVINO_API PassBase {
 
 public:
     PassBase();
-    virtual ~PassBase() = default;
+    virtual ~PassBase();
     /// Check if this pass has all the pass properties.
     bool get_property(const PassPropertyMask& prop_mask) const;
 

--- a/src/core/include/openvino/pass/pattern/matcher.hpp
+++ b/src/core/include/openvino/pass/pattern/matcher.hpp
@@ -108,7 +108,8 @@ public:
     Matcher(std::shared_ptr<Node> pattern_node, const std::string& name);
     Matcher(std::shared_ptr<Node> pattern_node, const std::string& name, bool strict_mode);
 
-    virtual ~Matcher() = default;
+    virtual ~Matcher();
+
     /// \brief Matches a pattern to \p graph_node
     ///
     /// \param graph_value is an input graph to be matched against
@@ -176,7 +177,7 @@ public:
 
     size_t add_node(Output<Node> node);
 
-    bool virtual match_value(const ov::Output<Node>& pattern_value, const ov::Output<Node>& graph_value);
+    virtual bool match_value(const ov::Output<Node>& pattern_value, const ov::Output<Node>& graph_value);
 
     bool is_strict_mode() {
         return m_strict_mode;

--- a/src/core/include/openvino/runtime/allocator.hpp
+++ b/src/core/include/openvino/runtime/allocator.hpp
@@ -37,7 +37,7 @@ class OPENVINO_API Allocator {
 
     friend class ov::Tensor;
 
-    struct Base : public std::enable_shared_from_this<Base> {
+    struct OPENVINO_API Base : public std::enable_shared_from_this<Base> {
         virtual void* addressof() = 0;
         const void* addressof() const {
             return const_cast<Base*>(this)->addressof();
@@ -48,7 +48,7 @@ class OPENVINO_API Allocator {
         virtual bool is_equal(const Base& other) const = 0;
 
     protected:
-        virtual ~Base() = default;
+        virtual ~Base();
     };
 
     template <typename A>

--- a/src/core/reference/include/openvino/reference/utils/philox_converter.hpp
+++ b/src/core/reference/include/openvino/reference/utils/philox_converter.hpp
@@ -19,7 +19,7 @@ class PhiloxConverter {
 public:
     PhiloxConverter() = delete;
 
-    virtual ~PhiloxConverter(){};
+    virtual ~PhiloxConverter() = default;
 
     /// \brief Returns the number of generated elements per execution
     /// based on the requested data type.

--- a/src/core/reference/include/openvino/reference/utils/philox_generator.hpp
+++ b/src/core/reference/include/openvino/reference/utils/philox_generator.hpp
@@ -30,7 +30,7 @@ class PhiloxGenerator {
 public:
     PhiloxGenerator() = delete;
 
-    virtual ~PhiloxGenerator(){};
+    virtual ~PhiloxGenerator() = default;
 
     /// @brief Get a set of 4 random 32-bit unsigned integers based on the seed(s).
     /// @return A vector with a random set of 4 32-bit unsigned integers.

--- a/src/core/src/any.cpp
+++ b/src/core/src/any.cpp
@@ -30,6 +30,8 @@ bool util::equal(std::type_index lhs, std::type_index rhs) {
     return result;
 }
 
+Any::Base::~Base() = default;
+
 bool Any::Base::is(const std::type_info& other) const {
     return util::equal(type_info(), other);
 }

--- a/src/core/src/attribute_visitor.cpp
+++ b/src/core/src/attribute_visitor.cpp
@@ -10,6 +10,10 @@
 
 using namespace std;
 
+ov::ValueAccessor<void>::~ValueAccessor() = default;
+
+ov::AttributeVisitor::~AttributeVisitor() = default;
+
 void ov::AttributeVisitor::start_structure(const string& name) {
     m_context.push_back(name);
 }

--- a/src/core/src/model.cpp
+++ b/src/core/src/model.cpp
@@ -221,6 +221,8 @@ ov::Model::Model(const ov::OutputVector& results, const ov::SinkVector& sinks, c
 
 ov::Model::Model(const OutputVector& results, const string& name) : Model(results, ov::SinkVector{}, name) {}
 
+ov::Model::~Model() = default;
+
 void ov::Model::prerequirements(bool detect_variables, bool detect_parameters) {
     OV_ITT_SCOPED_TASK(ov::itt::domains::core, "Model::prerequirements");
 

--- a/src/core/src/op/util/multi_subgraph_base.cpp
+++ b/src/core/src/op/util/multi_subgraph_base.cpp
@@ -8,9 +8,13 @@ ov::op::util::MultiSubGraphOp::InputDescription::InputDescription(uint64_t input
     : m_input_index(input_index),
       m_body_parameter_index(body_parameter_index) {}
 
+ov::op::util::MultiSubGraphOp::InputDescription::~InputDescription() = default;
+
 ov::op::util::MultiSubGraphOp::OutputDescription::OutputDescription(uint64_t body_value_index, uint64_t output_index)
     : m_body_value_index(body_value_index),
       m_output_index(output_index) {}
+
+ov::op::util::MultiSubGraphOp::OutputDescription::~OutputDescription() = default;
 
 ov::op::util::MultiSubGraphOp::SliceInputDescription::SliceInputDescription(uint64_t input_index,
                                                                             uint64_t body_parameter_index,

--- a/src/core/src/op/util/variable_extension.cpp
+++ b/src/core/src/op/util/variable_extension.cpp
@@ -1,0 +1,9 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/util/variable_extension.hpp"
+
+using namespace ov::op::util;
+
+VariableExtension::~VariableExtension() = default;

--- a/src/core/src/pass/pass.cpp
+++ b/src/core/src/pass/pass.cpp
@@ -16,6 +16,8 @@ using namespace std;
 
 ov::pass::PassBase::PassBase() : m_property(), m_name(), m_pass_config(std::make_shared<PassConfig>()) {}
 
+ov::pass::PassBase::~PassBase() = default;
+
 bool ov::pass::PassBase::get_property(const PassPropertyMask& prop) const {
     return m_property.is_set(prop);
 }

--- a/src/core/src/pattern/matcher.cpp
+++ b/src/core/src/pattern/matcher.cpp
@@ -37,6 +37,8 @@ Matcher::Matcher(std::shared_ptr<Node> pattern_node, const std::string& name)
 Matcher::Matcher(std::shared_ptr<Node> pattern_node, const std::string& name, bool strict_mode)
     : Matcher(make_node_output(pattern_node), name, strict_mode) {}
 
+Matcher::~Matcher() = default;
+
 MatcherState::~MatcherState() {
     if (m_restore) {
         if (!m_matcher->m_matched_list.empty()) {

--- a/src/core/src/runtime/allocator.cpp
+++ b/src/core/src/runtime/allocator.cpp
@@ -45,6 +45,8 @@ struct DefaultAllocator {
     }
 };
 
+Allocator::Base::~Base() = default;
+
 Allocator::Allocator() : Allocator{DefaultAllocator{}} {}
 
 Allocator::~Allocator() {

--- a/src/core/src/runtime_attribute.cpp
+++ b/src/core/src/runtime_attribute.cpp
@@ -9,6 +9,8 @@
 
 namespace ov {
 
+RuntimeAttribute::~RuntimeAttribute() = default;
+
 std::string RuntimeAttribute::to_string() const {
     return {};
 }

--- a/src/frontends/common/include/openvino/frontend/decoder.hpp
+++ b/src/frontends/common/include/openvino/frontend/decoder.hpp
@@ -49,9 +49,9 @@ struct Union;
 }  // namespace type
 
 /// Plays a role of node, block and module decoder
-class IDecoder {
+class FRONTEND_API IDecoder {
 public:
-    virtual ~IDecoder() = default;
+    virtual ~IDecoder();
 };
 
 class FRONTEND_API DecoderBase : public IDecoder {
@@ -82,9 +82,6 @@ public:
 
     /// \brief Get node name
     virtual const std::string& get_op_name() const = 0;
-
-    /// \brief Destructor
-    virtual ~DecoderBase();
 };
 
 }  // namespace frontend

--- a/src/frontends/common/include/openvino/frontend/graph_iterator.hpp
+++ b/src/frontends/common/include/openvino/frontend/graph_iterator.hpp
@@ -34,9 +34,6 @@ public:
     /// \brief Return a pointer to a decoder of the current node
     virtual std::shared_ptr<DecoderBase> get_decoder() const = 0;
 
-    /// \brief Destructor
-    virtual ~GraphIterator() = default;
-
     /// \brief Checks if the main model graph contains a function of the requested name in the library
     /// Returns GraphIterator to this function and nullptr, if it does not exist
     virtual std::shared_ptr<GraphIterator> get_body_graph_iterator(const std::string& func_name) const = 0;

--- a/src/frontends/common/include/openvino/frontend/input_model.hpp
+++ b/src/frontends/common/include/openvino/frontend/input_model.hpp
@@ -51,7 +51,7 @@ public:
     InputModel& operator=(const InputModel&) = delete;
     InputModel& operator=(InputModel&&) = delete;
 
-    virtual ~InputModel() = default;
+    virtual ~InputModel();
 
     /////  Searching for places  /////
 

--- a/src/frontends/common/include/openvino/frontend/node_context.hpp
+++ b/src/frontends/common/include/openvino/frontend/node_context.hpp
@@ -18,7 +18,7 @@ class FRONTEND_API NodeContext {
 public:
     // TODO: Why this ctor is explicit when get_op_type is virtual so m_op_type looks to be a custom implementation
     explicit NodeContext(const std::string& op_type) : m_op_type(op_type) {}
-    virtual ~NodeContext() = default;
+    virtual ~NodeContext();
 
     /// \brief  Returns a number of inputs
     virtual size_t get_input_size() const {

--- a/src/frontends/common/include/openvino/frontend/place.hpp
+++ b/src/frontends/common/include/openvino/frontend/place.hpp
@@ -61,7 +61,7 @@ class FRONTEND_API Place {
 public:
     typedef std::shared_ptr<Place> Ptr;
 
-    virtual ~Place() = 0;
+    virtual ~Place();
 
     /// \brief All associated names (synonyms) that identify this place in the graph in a
     /// framework specific way

--- a/src/frontends/common/src/decoder.cpp
+++ b/src/frontends/common/src/decoder.cpp
@@ -6,4 +6,4 @@
 
 using namespace ov::frontend;
 
-DecoderBase::~DecoderBase() = default;
+IDecoder::~IDecoder() = default;

--- a/src/frontends/common/src/input_model.cpp
+++ b/src/frontends/common/src/input_model.cpp
@@ -12,6 +12,8 @@
 using namespace ov;
 using namespace ov::frontend;
 
+InputModel::~InputModel() = default;
+
 std::vector<Place::Ptr> InputModel::get_inputs() const {
     if (!m_actual) {
         return {};

--- a/src/frontends/common/src/node_context.cpp
+++ b/src/frontends/common/src/node_context.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "openvino/frontend/variable.hpp"
+#include "openvino/frontend/node_context.hpp"
 
 using namespace ov::frontend;
 
-Variable::~Variable() = default;
+NodeContext::~NodeContext() = default;


### PR DESCRIPTION
### Details:
Android support:

<img width="200" alt="{ABD03686-78FD-4F33-A2E8-C3BE1C030D5C}" src="https://github.com/user-attachments/assets/55bb0600-4f14-448c-b4be-e1e97e354859" />

in header files threated as an inline definition, which typically results in a "weak" symbol
"weak"  symbols are not exported from dll/so libs. 

To make these symbols "strong", we moved the definitions to ".cpp" files.
