### PR TITLE
[CI] [GHA] Remove `pip cache info` from `setup_python` action

### DIFF
--- a/.github/actions/setup_python/action.yml
+++ b/.github/actions/setup_python/action.yml
@@ -75,8 +75,3 @@ runs:
         $pipVersion = python3 -c "import pip; print(pip.__version__)"
         Write-Host "Using pip version: $pipVersion"
         "PIP_CACHE_DIR=${{ inputs.pip-cache-path }}/$pipVersion" >> $env:GITHUB_ENV
-
-    - if: ${{ inputs.show-cache-info == 'true' }}
-      name: Get pip cache info
-      shell: bash
-      run: python3 -m pip cache info

--- a/.github/actions/setup_python/action.yml
+++ b/.github/actions/setup_python/action.yml
@@ -15,10 +15,6 @@ inputs:
     description: 'If the runner is self-hosted'
     required: false
     default: 'true'
-  show-cache-info:
-    description: 'If the action should show the share space occupied by cache'
-    required: false
-    default: 'false'
 runs:
   using: 'composite'
   steps:

--- a/.github/workflows/job_build_windows.yml
+++ b/.github/workflows/job_build_windows.yml
@@ -80,7 +80,6 @@ jobs:
           pip-cache-path: ${{ env.PIP_CACHE_PATH }}
           should-setup-pip-paths: 'true'
           self-hosted-runner: 'true'
-          show-cache-info: 'true'
 
       - name: Generate product manifest and set CI_BUILD_NUMBER & CI_BUILD_DEV_TAG
         id: create_manifest

--- a/docs/dev/ci/github_actions/custom_actions.md
+++ b/docs/dev/ci/github_actions/custom_actions.md
@@ -29,14 +29,12 @@ Since `actions/setup-python` does not work on the Linux ARM64 machines,
       pip-cache-path: ${{ env.PIP_CACHE_PATH }}
       should-setup-pip-paths: 'true'
       self-hosted-runner: 'true'
-      show-cache-info: 'true'
 ```
 where:
 * `version` - the Python version to install in the `MAJOR.MINOR` format
 * `pip-cache-path` - the path to the `pip` cache on the mounted share. Read more in the [shares and caches](./caches.md) documentation
 * `should-setup-pip-paths` - indicates whether the action should set up the `PIP_CACHE_DIR` and `PIP_INSTALL_PATH` environment variables for later usage
 * `self-hosted-runner` - indicates whether the runner is self-hosted. Learn more about [available runners](./runners.md)
-* `show-cache-info` - indicates whether the action should show the share space occupied by the `pip` cache
 
 ## System Info Print
 


### PR DESCRIPTION
### Details:
 - Port of #28557
