### PR TITLE
[CPU] Optimize DQ FC with stack allocated aux accum registers

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_weights_decompression.cpp
@@ -208,6 +208,8 @@ const std::vector<MatMulDecompressionShapeParams> input_shapes_basic_dyn_quant =
     {{{}, {{1, 1, 128}}}, {128, 32}},
     {{{}, {{1, 3, 144}}}, {144, 64}, 16lu},
     {{{}, {{1, 1, 1728}}}, {1728, 128}, 64lu},
+    // jit_brgemm_kernel corner cases: ic iters > 1 && has oc tail
+    {{{}, {{1, 1, 640}}}, {640, 90}},
 };
 
 const std::vector<ov::test::ElementType> weights_precisions_dyn_quant = {ov::element::u8, ov::element::u4};
@@ -280,8 +282,6 @@ const std::vector<MatMulDecompressionShapeParams> input_shapes_scalar_scale = {
     {{{}, {{1, 10, 128}}}, {128, 32}},
 };
 
-const std::vector<ov::test::ElementType> weights_precisions_scalar_scale = {ov::element::u8};
-
 std::vector<ov::AnyMap> filter_additional_config_scalar_scale() {
     std::vector<ov::AnyMap> additional_config = {
         {{ov::hint::dynamic_quantization_group_size(0)}},
@@ -293,7 +293,7 @@ std::vector<ov::AnyMap> filter_additional_config_scalar_scale() {
 INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_scalar_scale,
                          MatmulWeightsDecompression,
                          ::testing::Combine(::testing::ValuesIn(input_shapes_scalar_scale),
-                                            ::testing::ValuesIn(weights_precisions_scalar_scale),
+                                            ::testing::Values(ov::element::u8),
                                             ::testing::ValuesIn(decompression_precisions),
                                             ::testing::Values(ov::element::undefined),
                                             ::testing::Values(false),
@@ -301,6 +301,35 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_scalar_scale,
                                             ::testing::Values(DecompressionType::scalar),
                                             ::testing::Values(false),
                                             ::testing::ValuesIn(filter_additional_config_scalar_scale()),
+                                            ::testing::Values(emptyFusingSpec),
+                                            ::testing::Values(true)),
+                         MatmulWeightsDecompression::getTestCaseName);
+
+
+const std::vector<MatMulDecompressionShapeParams> input_shapes_non_multiples_groups = {
+    {{{}, {{1, 3, 192}}}, {192, 128}, 96lu},
+};
+
+std::vector<ov::AnyMap> filter_additional_config_non_multiples_groups() {
+    std::vector<ov::AnyMap> additional_config = {
+        {{ov::hint::dynamic_quantization_group_size(64)}}
+    };
+    return additional_config;
+}
+
+// Dynamic quantization requires weights compression group size to be divisible on dq group size
+// The test is intended to chech such case is correctly handled via non dq path
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_non_multiples_groups,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::ValuesIn(input_shapes_non_multiples_groups),
+                                            ::testing::Values(ov::element::u8),
+                                            ::testing::ValuesIn(decompression_precisions),
+                                            ::testing::Values(ov::element::undefined),
+                                            ::testing::ValuesIn(transpose_weights),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(DecompressionType::full),
+                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(filter_additional_config_non_multiples_groups()),
                                             ::testing::Values(emptyFusingSpec),
                                             ::testing::Values(true)),
                          MatmulWeightsDecompression::getTestCaseName);


### PR DESCRIPTION
### Details:
 - Enables FC dynamic quantization on systems with AVX2 ISA
 - Speed-ups for LLMs with asym compressions on LNL vs master: 2x in average for prompt processing and 1.5x in average for generation stage. 
 - OneDNN fork PR: https://github.com/openvinotoolkit/oneDNN/pull/272

### Tickets:
 - [CVS-146064](https://jira.devtools.intel.com/browse/CVS-146064) <- perf numbers
 - [CVS-134037](https://jira.devtools.intel.com/browse/CVS-134037)
 - [CVS-134034](https://jira.devtools.intel.com/browse/CVS-134034)
