### PR TITLE
[CPU] Fix medium coverity issues

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -37,7 +37,7 @@ DnnlPostOpsComposer::DnnlPostOpsComposer(const PostOps& postOps,
       isINT8(isInt8),
       weightScaleMaskPerChannel(weiScaleMaskPerChannel),
       outDataType(outDataType) {
-    OPENVINO_ASSERT(idxOC >= 0 && static_cast<size_t>(idxOC) < outputDims.size());
+    OPENVINO_ASSERT(idxOC < outputDims.size());
     OC = outputDims[idxOC];
     dimsPerOC = dimsPerTensor = VectorDims(outputDims.size(), 1);
     dimsPerOC[idxOC] = OC;

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -83,7 +83,7 @@ private:
     Dim OC;
     int wei_scale_mask = -1;
     std::vector<float> wei_scale_values;
-    float dst_scale_val;
+    float dst_scale_val = 0.0f;
     dnnl::post_ops ops;
 
     void updateWeiScales();

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -26,8 +26,8 @@ GraphContext::GraphContext(Config config,
       m_numNumaNodes(1),
       m_memoryStatesRegister(std::make_shared<node::MemoryStatesRegister>()),
       m_networkMemoryControl(std::make_shared<NetworkMemoryControl>()) {
-    if (streamExecutor) {
-        m_cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(streamExecutor);
+    if (m_streamExecutor) {
+        m_cpuStreamExecutor = std::dynamic_pointer_cast<ov::threading::CPUStreamsExecutor>(m_streamExecutor);
         m_numaNodeId = m_cpuStreamExecutor ? m_cpuStreamExecutor->get_numa_node_id() : 0;
         auto nNumaNodes = get_num_numa_nodes();
         if (m_numNumaNodes < nNumaNodes)

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -407,9 +407,11 @@ const std::tuple<U, U>& Range<T, U>::fit(const ov::element::Type& prec) {
         case ov::element::f8e4m3:
             lbound = static_cast<double>(std::numeric_limits<ov::float8_e4m3>::lowest());
             ubound = static_cast<double>(std::numeric_limits<ov::float8_e4m3>::max());
+            break;
         case ov::element::f8e5m2:
             lbound = static_cast<double>(std::numeric_limits<ov::float8_e5m2>::lowest());
             ubound = static_cast<double>(std::numeric_limits<ov::float8_e5m2>::max());
+            break;
         case ov::element::bf16:
             lbound = static_cast<double>(std::numeric_limits<ov::intel_cpu::bfloat16_t>::lowest());
             ubound = static_cast<double>(std::numeric_limits<ov::intel_cpu::bfloat16_t>::max());

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -103,6 +103,7 @@ MlasGemmExecutor::MlasGemmExecutor(const FCAttrs& attrs,
     : m_attrs(attrs),
       m_memoryArgs(memory),
       packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context, !attrs.weightsNonTransposed)),
+      M(0),
       N(batchDim(memory.at(ARG_WEI)->getStaticDims())),
       K(memory.at(ARG_WEI)->getStaticDims().back()) {}
 

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -733,7 +733,7 @@ void RandomUniform::computeMersenneTwister(void* out, size_t output_elements_cou
     const auto elements_consumed_per_one_output = m_mersenne_twister_optimization_enabled ? 1 : 2;
     const auto state_regenerations_required =
         static_cast<uint64_t>(std::ceil(static_cast<double>(output_elements_count) /
-                                        static_cast<double>(MERSENNE_STATE_N / elements_consumed_per_one_output)));
+                                        (static_cast<double>(MERSENNE_STATE_N) / elements_consumed_per_one_output)));
     const auto byte_offset = MERSENNE_STATE_N * m_output_prc.size();
 
     uint32_t mersenne_state_ptr[MERSENNE_STATE_N];

--- a/src/plugins/intel_cpu/src/nodes/rnn.h
+++ b/src/plugins/intel_cpu/src/nodes/rnn.h
@@ -149,7 +149,7 @@ private:
     float inputShift = 0.f;
     std::vector<float> weightsScales;
 
-    const uint64_t* m_gate_map;
+    const uint64_t* m_gate_map = nullptr;
     // Need to reorder from the initial memory descs due to limited Reorders set.
     MemoryPtr m_initial_weights[3] = {nullptr, nullptr, nullptr};
     // Need to keep cache objects. Otherwise, they will be erased from the global cache.

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -172,7 +172,7 @@ private:
         for (int i = 0; i < c_blocks; i++) {
             Vmm vmm_max = get_acc_reg(i);
 
-            load_emitter->emit_code({static_cast<size_t>(reg_input.getIdx()), static_cast<size_t>(i * src_c_off)},
+            load_emitter->emit_code({static_cast<size_t>(reg_input.getIdx()), static_cast<size_t>(i) * src_c_off},
                                     {static_cast<size_t>(vmm_max.getIdx())},
                                     {},
                                     load_pool_gpr_idxs);
@@ -190,7 +190,7 @@ private:
                     Vmm vmm_src = get_src_reg(i);
 
                     load_emitter->emit_code(
-                        {static_cast<size_t>(aux_reg_input1.getIdx()), static_cast<size_t>(i * src_c_off)},
+                        {static_cast<size_t>(aux_reg_input1.getIdx()), static_cast<size_t>(i) * src_c_off},
                         {static_cast<size_t>(vmm_src.getIdx())},
                         {},
                         load_pool_gpr_idxs);
@@ -227,7 +227,7 @@ private:
             Vmm vmm_dst = get_acc_reg(i);
 
             store_emitter->emit_code({static_cast<size_t>(vmm_dst.getIdx())},
-                                     {static_cast<size_t>(reg_output.getIdx()), static_cast<size_t>(i * dst_c_off)},
+                                     {static_cast<size_t>(reg_output.getIdx()), static_cast<size_t>(i) * dst_c_off},
                                      get_local_store_pool_vec_idxs(vmm_dst),
                                      store_pool_gpr_idxs);
         }
@@ -297,7 +297,7 @@ private:
         for (int i = 0; i < c_blocks; i++) {
             store_empty_roi_emitter->emit_code(
                 {static_cast<size_t>(vmm_zero.getIdx())},
-                {static_cast<size_t>(reg_output.getIdx()), static_cast<size_t>(i * dst_c_off)},
+                {static_cast<size_t>(reg_output.getIdx()), static_cast<size_t>(i) * dst_c_off},
                 store_pool_vec_idxs,
                 store_pool_gpr_idxs);
         }


### PR DESCRIPTION
### Details:
Fix medium severity issues in CPU plugin reported by coverity tool
- Logically dead code: 1590308
- Uninitialized pointer field: 1590284
- Uninitialized scalar field: 1567790, 1590248
- Missing break in switch: 1568687, 1568688
- Result is not floating-point: 1568461
- Unintentional integer overflow: 1568371, 1568372, 1568374
- Macro compares unsigned to 0: 1567805

### Tickets:
 - 160879
