### PR TITLE
[GPU] Remove unused PagedAttention inputs causing set_arg error in case of zero buffer

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/paged_attention.cpp
@@ -214,12 +214,6 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
                 if (desc->has_alibi) {
                     args.inputs.push_back(instance.alibi_memory_ptr());
                 }
-
-                if (desc->has_rotated_blocks) {
-                    args.inputs.push_back(instance.rotated_block_indices_memory_ptr());
-                    args.inputs.push_back(instance.rotation_deltas_memory_ptr());
-                    args.inputs.push_back(instance.rotation_trig_lut_memory_ptr());
-                }
             } else if (kernel_idx == 2 || kernel_idx == 3) {
                 // Finalization kernel or mixed stage finalization kernel
                 args.inputs = { instance.past_lens_memory_ptr() };
@@ -687,10 +681,6 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         if (has_alibi)
             inputs_number++;
 
-        const auto has_rotation = impl_param.input_layouts.size() == 16;
-        if (has_rotation)
-            inputs_number += 3;
-
         auto input_idx = 0;
         params.inputs.resize(inputs_number);
         params.inputs[input_idx++] = query_tensor;
@@ -708,12 +698,6 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
 
         if (has_alibi)
             params.inputs[input_idx++] = alibi_tensor;
-
-         if (has_rotation) {
-            params.inputs[input_idx++] = input_tensors[13];
-            params.inputs[input_idx++] = input_tensors[14];
-            params.inputs[input_idx++] = input_tensors[15];
-        }
 
         if (has_scores_output) {
             params.outputs.resize(2);
@@ -751,12 +735,6 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
 
         if (has_alibi)
             in_tensor_to_offset_map.insert({input_idx++, in_offsets_map.at(11)});
-
-        if (has_rotation) {
-            in_tensor_to_offset_map.insert({input_idx++, in_offsets_map.at(13)});
-            in_tensor_to_offset_map.insert({input_idx++, in_offsets_map.at(14)});
-            in_tensor_to_offset_map.insert({input_idx++, in_offsets_map.at(15)});
-        }
 
         if (has_scores_output)
             out_tensor_to_offset_map.insert({1, out_offsets_map.at(1)});

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
@@ -43,12 +43,6 @@ KERNEL(pa_sdpa_opt)(
 #if HAS_ALIBI
     const __global ALIBI_INPUT_TYPE* alibi_slopes,
 #endif
-
-#if HAS_ROTATED_BLOCKS
-    const __global INPUT7_TYPE* rotated_block_indices,
-    const __global INPUT8_TYPE* rotation_deltas,
-    const __global INPUT9_TYPE* rotation_trig_lut,
-#endif
     __global OUTPUT_TYPE* output,
 #if PAGED_ATTENTION_SCORES_OUTPUT
     __global SOFTMAX_ACCUMULATOR_TYPE* softmax_results,


### PR DESCRIPTION
### Details:
 - This change removes unused PagedAttention inputs that were accidentally added during the rebase of the original PR, which caused a set_arg error in the case of a zero buffer
- Added related test with a dummy activation function to simulate this behavior
- PR to master branch: https://github.com/openvinotoolkit/openvino/pull/28577 