### PR TITLE
[CPU][DEBUG_CAPS] Bring back an execution of all nodes for debug caps

### DIFF
--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -181,6 +181,8 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
 
 #    define CREATE_DEBUG_TIMER(x) PrintableTimer x
 
+#    define CPU_DEBUG_CAPS_ALWAYS_TRUE(x) true
+
 /*
  * important debugging tools for accuracy issues
  *   OV_CPU_INFER_PRC_POS_PATTERN : positive regex pattern to filter node type & orgname.
@@ -285,6 +287,8 @@ bool getEnvBool(const char* name);
 #    define DEBUG_LOG_EXT(name, ...)
 
 #    define CREATE_DEBUG_TIMER(x)
+
+#    define CPU_DEBUG_CAPS_ALWAYS_TRUE(x) x
 
 #endif  // CPU_DEBUG_CAPS
 


### PR DESCRIPTION
The logic was reverted due to the issues with making all the nodes
executable in some scenarious.
The problem is that without this functionality debug capabilities became
less usable.
So bring back the logic and try to cover problematic scenarios,
i.e. static nodes with empty shapes, which should never be executed
even with debug caps.