### PR TITLE
[NPU] Get remote tensors info from methods and not through properties to avoid CPU overhead

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_remote_tensor.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_remote_tensor.hpp
@@ -26,6 +26,7 @@ public:
                      void* mem = nullptr);
 
     void* get_original_memory() const;
+    ze_context_handle_t get_zero_context_handle() const;
 
     ~ZeroRemoteTensor() override;
 

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -65,7 +65,7 @@ Pipeline::Pipeline(const Config& config,
                 if (remote_tensor == nullptr) {
                     data = input_tensors.at(io_index).at(i)->data();
                 } else {
-                    data = zeroUtils::extract_object(remote_tensor->get_properties(), ov::intel_npu::mem_handle);
+                    data = remote_tensor->get_original_memory();
                 }
 
                 graph->set_argument_value(desc.idx, data);
@@ -79,7 +79,7 @@ Pipeline::Pipeline(const Config& config,
             if (remote_tensor == nullptr) {
                 data = input_tensors.at(io_index).at(0)->data();
             } else {
-                data = zeroUtils::extract_object(remote_tensor->get_properties(), ov::intel_npu::mem_handle);
+                data = remote_tensor->get_original_memory();
             }
 
             graph->set_argument_value(
@@ -97,7 +97,7 @@ Pipeline::Pipeline(const Config& config,
             if (remote_tensor == nullptr) {
                 data = output_tensors.at(io_index)->data();
             } else {
-                data = zeroUtils::extract_object(remote_tensor->get_properties(), ov::intel_npu::mem_handle);
+                data = remote_tensor->get_original_memory();
             }
 
             graph->set_argument_value(

--- a/src/plugins/intel_npu/src/backend/src/zero_remote_tensor.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_remote_tensor.cpp
@@ -172,4 +172,8 @@ void* ZeroRemoteTensor::get_original_memory() const {
     return _data;
 }
 
+ze_context_handle_t ZeroRemoteTensor::get_zero_context_handle() const {
+    return _init_structs->getContext();
+}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_variable_state.cpp
@@ -46,9 +46,7 @@ void ZeroVariableState::set_state(const ov::SoPtr<ov::ITensor>& new_state) {
 void ZeroVariableState::reset() {
     auto remoteTensor = std::dynamic_pointer_cast<ZeroRemoteTensor>(m_state._ptr);
 
-    void* userBuffer = !remoteTensor
-                           ? m_state->data()
-                           : zeroUtils::extract_object(remoteTensor->get_properties(), ov::intel_npu::mem_handle);
+    void* userBuffer = !remoteTensor ? m_state->data() : remoteTensor->get_original_memory();
 
     std::memset(userBuffer, 0, m_state->get_byte_size());
 }

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -277,17 +277,6 @@ static inline std::string getLatestBuildError(ze_graph_dditable_ext_curr_t& _gra
     }
 }
 
-template <typename Type>
-static inline Type extract_object(const ov::AnyMap& params, const ov::Property<Type>& p) {
-    auto itrHandle = params.find(p.name());
-    ov::Any res = nullptr;
-    if (itrHandle == params.end()) {
-        OPENVINO_THROW("No parameter ", p.name(), " found in parameters map");
-    }
-    res = itrHandle->second;
-    return res.as<Type>();
-}
-
 static inline bool memory_was_allocated_in_the_same_l0_context(ze_context_handle_t hContext, const void* ptr) {
     ze_memory_allocation_properties_t desc = {};
     desc.stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;


### PR DESCRIPTION
### Details:
 - *Get remote tensors info from methods and not through properties to avoid CPU overhead*

### Tickets:
 - *CVS-160977*
