### PR TITLE
[CPU][LPT] Removed legacy PrecisionRestriction limitations for Multiply

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -770,10 +770,6 @@ void Transformations::Lpt(const std::vector<ov::element::Type>& defaultPrecision
 
             return PrecisionsRestriction::PrecisionsByPorts{{{0}, input0LowPrecisionList}, {{1}, {ov::element::i8}}};
         }),
-        PrecisionsRestriction::create<ov::opset1::Multiply>({
-            {{0}, {ov::element::u8}},
-            {{1}, {ov::element::i8}},
-        }),
         PrecisionsRestriction::create<ov::opset1::MatMul>(
             {{{0}, {ov::element::u8, ov::element::i8}}, {{1}, {ov::element::i8}}}),
         PrecisionsRestriction::create<ov::opset5::LSTMSequence>({{{0, 1}, {ov::element::u8}}}),
@@ -791,13 +787,6 @@ void Transformations::Lpt(const std::vector<ov::element::Type>& defaultPrecision
                              quantizationRestrictions,
                              LayerTransformation::Params(true, ov::element::f32, defaultPrecisions));
 
-    CPU_SET_CALLBACK_COMMON(
-        lptManager,
-        [](const_node_ptr& node) -> bool {
-            return ov::is_type<ov::opset1::Multiply>(node) &&
-                   !MultiplyToGroupConvolutionTransformation::canBeTransformedToGroupConvolution(node);
-        },
-        MarkupPrecisions);
     CPU_SET_CALLBACK_COMMON(
         lptManager,
         [&defaultPrecisions](const_node_ptr& node) -> bool {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/x64/fq_with_dq_not_optimal_transformation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/low_precision_transformations/x64/fq_with_dq_not_optimal_transformation.cpp
@@ -13,13 +13,11 @@ using namespace ov::pass::low_precision;
 
 namespace {
 const std::vector<ov::element::Type> netPrecisions = {
-        ov::element::f32,
-        ov::element::f16
+    ov::element::f32
 };
 
 const std::vector<LayerTransformation::Params> trasformationParamValues = {
     LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8AndI8(),
-    // LayerTestsUtils::LayerTransformationParamsFactory::createParamsU8I8AndI8().setUpdatePrecisions(false)
 };
 
 const std::vector<FakeQuantizeWithNotOptimalTransformationTestValues> fakeQuantizeOnDataValues = {
@@ -97,7 +95,7 @@ const std::vector<FakeQuantizeWithNotOptimalTransformationTestValues> fakeQuanti
             { {0.3f}, ov::element::f32, {}, false }
         },
         {},
-        "u8"
+        "i8"
     }
 };
 


### PR DESCRIPTION
### Tickets:
 - *CVS-161061*
