### PR TITLE
Pin triton version

### DIFF
--- a/tests/requirements_pytorch
+++ b/tests/requirements_pytorch
@@ -21,6 +21,8 @@ pytest-xdist[psutil]==3.6.1
 defusedxml==0.7.1
 
 autoawq==0.2.7; platform_system == "Linux" and platform_machine == "x86_64"
+# triton is a dependency of autoawq, newer versions lead to TorchFX test failures
+triton==3.1.0; platform_system == "Linux" and platform_machine == "x86_64"
 auto-gptq==0.7.1; platform_system == "Linux" and platform_machine == "x86_64" and python_version < "3.12"
 av==13.0.0
 basicsr==1.4.2; python_version < "3.12"


### PR DESCRIPTION
### Details:
 - Ported https://github.com/openvinotoolkit/openvino/pull/28627
 - We can see here https://github.com/openvinotoolkit/openvino/pull/28630, that releases/2025/0 is affected as well.
