### PR TITLE
Fix support of "inputs_embeds" input of VLMs in SDPAToPA transformation

### DIFF
--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6,6 +6,9 @@
 
 #include <gtest/gtest.h>
 
+// #include "openvino/cc/pass/itt.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
@@ -69,6 +72,16 @@ ov::ParameterVector nodes_to_params(const ov::NodeVector& node_vec) {
     }
     return params;
 }
+
+static std::shared_ptr<ov::Node> make_param(const PartialShape& pshape,
+                                            element::Type element_type,
+                                            const std::string& name) {
+    auto param = makeOP<v0::Parameter>({}, {{"shape", pshape}, {"element_type", element_type}});
+    param->set_friendly_name(name);
+    param->get_output_tensor(0).set_names({name});
+    return param;
+}
+
 
 enum QKV : int { Q = 0, K = 1, V = 2 };
 vector<int> MOCK_VALUE = {1};
@@ -446,10 +459,15 @@ TEST_P(SDPAToPATest, SDPAToPA_Qwen7bChat_General) {
     const auto model_precision = GetParam();
     {
         // Inputs to SDPA transformer:
-        auto beam_idx = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN}}, el_type_i64});
-        auto position_ids = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
-        auto attention_mask = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
-        auto input_ids = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
+        // auto beam_idx = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN}}, el_type_i64});
+        // auto position_ids = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
+        // auto attention_mask = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
+        // auto input_ids = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
+        
+        auto beam_idx = make_param(PartialShape{DYN}, element::i64, "beam_idx");
+        auto position_ids = make_param(PartialShape{DYN, DYN}, element::i64, "position_ids");
+        auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i64, "attention_mask");
+        auto input_ids = make_param(PartialShape{DYN, DYN}, element::i64, "input_ids");
         ParameterVector params = nodes_to_params({position_ids, input_ids, attention_mask, beam_idx});
 
         beam_idx->output(0).add_names({"beam_idx"});
@@ -638,15 +656,6 @@ TEST_P(SDPAToPATest, SDPAToPA_Qwen7bChat_TotalSequenceLengthPattern) {
     comparator.disable(FunctionsComparator::PRECISIONS);
     disable_result_friendly_names_check();
     disable_rt_info_check();
-}
-
-static std::shared_ptr<ov::Node> make_param(const PartialShape& pshape,
-                                            element::Type element_type,
-                                            const std::string& name) {
-    auto param = makeOP<v0::Parameter>({}, {{"shape", pshape}, {"element_type", element_type}});
-    param->set_friendly_name(name);
-    param->get_output_tensor(0).set_names({name});
-    return param;
 }
 
 // TODO: split the models in blocks the way it's done for Qwen and make the code not to be such a clutter
@@ -916,3 +925,37 @@ entire SDPAToPA transformation
 const std::vector<ov::element::Type> element_types = {element::f16, element::f32};
 
 INSTANTIATE_TEST_SUITE_P(SDPAToPATest_Conversion, SDPAToPATest, testing::ValuesIn(element_types));
+
+// class SampleMatcher : public ov::pass::MatcherPass {
+// public:
+//     OPENVINO_MATCHER_PASS_RTTI("SampleMatcher");
+//     explicit SampleMatcher() {
+//         const std::string matcher_name = "SampleMatcher";
+
+//         auto p_p1 = ov::pass::pattern::wrap_type<op::v0::Parameter>();
+//         auto p_mm = ov::pass::pattern::wrap_type<op::v0::Abs>({p_p1});
+//         auto p_conv = ov::pass::pattern::wrap_type<op::v0::Convert>({p_mm});
+
+//         ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+//             return true;
+//         };
+
+//         auto m = std::make_shared<ov::pass::pattern::Matcher>(p_conv, matcher_name);
+//         register_matcher(m, callback);
+//     }
+// };
+
+
+// TEST(TransformationsF, SampleTest) {
+//     auto input0 = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{2});
+//     auto matmul = std::make_shared<op::v0::Abs>(input0);
+//     auto conv = std::make_shared<op::v0::Convert>(matmul, element::i64);
+//     auto res = std::make_shared<op::v0::Result>(conv);
+
+//     auto model = std::make_shared<Model>(ResultVector{res}, ParameterVector{input0});
+
+//     ov::pass::Manager manager;
+//     manager.set_per_pass_validation(false);
+//     manager.register_pass<SampleMatcher>();
+//     manager.run_passes(model);
+// }

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -79,7 +79,6 @@ static std::shared_ptr<ov::Node> make_param(const PartialShape& pshape,
     return param;
 }
 
-
 enum QKV : int { Q = 0, K = 1, V = 2 };
 vector<int> MOCK_VALUE = {1};
 
@@ -898,6 +897,551 @@ TEST_P(SDPAToPATest, SDPAToPA_Baichuan2_13b_General) {
         model_ref = std::make_shared<ov::Model>(ResultVector{result}, params);
 
         // checks are also disabled temporarily
+        comparator.disable(FunctionsComparator::PRECISIONS);
+        disable_result_friendly_names_check();
+        disable_rt_info_check();
+    }
+}
+
+TEST_P(SDPAToPATest, SDPAToPA_nanoLLaVA_General) {
+    {
+        auto beam_idx = make_param(PartialShape{DYN}, element::i32, "beam_idx");
+        auto inputs_embeds = make_param(PartialShape{DYN, DYN, 8}, element::f32, "inputs_embeds");
+        auto position_ids = make_param(PartialShape{DYN, DYN}, element::i64, "position_ids");
+        auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i64, "attention_mask");
+
+        auto ShapeOf_19592 = makeOP<opset3::ShapeOf>({inputs_embeds}, {{"output_type", "i64"}});
+        auto Gather_19597 = makeOP<opset8::Gather>({ShapeOf_19592, {0}, 0}, {{"batch_dims", 0}});
+        auto Concat_19604 = makeOP<opset1::Concat>({Gather_19597, {2l}, {0l}, {2l}}, {{"axis", 0}});
+        auto Broadcast_19607 = makeOP<opset3::Broadcast>({0.000000f, Concat_19604}, {{"mode", "numpy"}});
+        auto ReadValue_19126 = makeOP<opset6::ReadValue>(
+            {Broadcast_19607},
+            {{"variable_id", "var1"}, {"variable_type", "f32"}, {"variable_shape", PartialShape{DYN, 2, DYN, 2}}});
+        auto Gather_18655 = makeOP<opset8::Gather>({ReadValue_19126, beam_idx, 0}, {{"batch_dims", 0}});
+        auto Constant_16156 =
+            makeConst(element::f32,
+                      ov::Shape({1, 1, 8}),
+                      {1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f});
+        auto Constant_16155 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1}),
+                                        {1.000000f});
+        auto Constant_16153 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1}),
+                                        {2.000000f});
+        auto __module_model_model_layers_0_input_layernorm_aten_pow_Power =
+            makeOP<opset1::Power>({inputs_embeds, Constant_16153}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_input_layernorm_aten_mean_ReduceMean =
+            makeOP<opset1::ReduceMean>({__module_model_model_layers_0_input_layernorm_aten_pow_Power, {-1}},
+                                       {{"keep_dims", true}});
+        auto Constant_16154 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1}),
+                                        {0.000001f});
+        auto __module_model_model_layers_0_input_layernorm_aten_add_Add =
+            makeOP<opset1::Add>({__module_model_model_layers_0_input_layernorm_aten_mean_ReduceMean, Constant_16154},
+                                {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_input_layernorm_aten_rsqrt_Sqrt =
+            makeOP<opset1::Sqrt>({__module_model_model_layers_0_input_layernorm_aten_add_Add});
+        auto __module_model_model_layers_0_input_layernorm_aten_rsqrt_Divide =
+            makeOP<opset1::Divide>({Constant_16155, __module_model_model_layers_0_input_layernorm_aten_rsqrt_Sqrt},
+                                   {{"auto_broadcast", "numpy"}, {"m_pythondiv", true}});
+        auto __module_model_model_layers_0_input_layernorm_aten_mul_Multiply =
+            makeOP<opset1::Multiply>({inputs_embeds, __module_model_model_layers_0_input_layernorm_aten_rsqrt_Divide},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1 =
+            makeOP<opset1::Multiply>({Constant_16156, __module_model_model_layers_0_input_layernorm_aten_mul_Multiply},
+                                     {{"auto_broadcast", "numpy"}});
+        auto self_model_model_layers_0_self_attn_q_proj_weight = makeConst(element::f32,
+                                                                           ov::Shape({8, 8}),
+                                                                           MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_q_proj_aten_linear_MatMul =
+            makeOP<opset1::MatMul>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1,
+                                    self_model_model_layers_0_self_attn_q_proj_weight},
+                                   {{"transpose_a", false}, {"transpose_b", true}});
+        auto __module_model_model_layers_0_self_attn_aten_view_Reshape =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_q_proj_aten_linear_MatMul, {0, 0, 4, 2}},
+                                    {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_transpose_Transpose =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_view_Reshape, {0, 2, 1, 3}});
+        auto self_model_model_layers_0_self_attn_rotary_emb_cos_cached = makeConst(element::f32,
+                                                                                   ov::Shape({32768, 2}),
+                                                                                   MOCK_VALUE);
+        auto ShapeOf_16753 =
+            makeOP<opset3::ShapeOf>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1},
+                                    {{"output_type", "i64"}});
+        auto Gather_16756 = makeOP<opset8::Gather>({ShapeOf_16753, 1, 0}, {{"batch_dims", 0}});
+        auto Reshape_16764 = makeOP<opset1::Reshape>({Gather_16756, {-1}}, {{"special_zero", false}});
+        auto ReadValue_19120 = makeOP<opset6::ReadValue>(
+            {Broadcast_19607},
+            {{"variable_id", "var2"}, {"variable_type", "f32"}, {"variable_shape", PartialShape{DYN, 2, DYN, 2}}});
+        auto Gather_18646 = makeOP<opset8::Gather>({ReadValue_19120, beam_idx, 0}, {{"batch_dims", 0}});
+        auto ShapeOf_16767 = makeOP<opset3::ShapeOf>({Gather_18646}, {{"output_type", "i64"}});
+        auto Gather_16770 = makeOP<opset8::Gather>({ShapeOf_16767, 2, 0}, {{"batch_dims", 0}});
+        auto Reshape_16772 = makeOP<opset1::Reshape>({Gather_16770, {-1}}, {{"special_zero", false}});
+        auto __module_model_model_layers_0_self_attn_aten_add__Add =
+            makeOP<opset1::Add>({Reshape_16764, Reshape_16772}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice =
+            makeOP<opset8::Slice>({self_model_model_layers_0_self_attn_rotary_emb_cos_cached,
+                                   {0},
+                                   __module_model_model_layers_0_self_attn_aten_add__Add,
+                                   {1},
+                                   {0}});
+        auto __module_model_model_aten_view_Reshape =
+            makeOP<opset1::Reshape>({position_ids, {0, 0}}, {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_index_Convert =
+            makeOP<opset1::Convert>({__module_model_model_aten_view_Reshape}, {{"destination_type", "i32"}});
+        auto __module_model_model_layers_0_self_attn_aten_index_Gather =
+            makeOP<opset8::Gather>({__module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice,
+                                    __module_model_model_layers_0_self_attn_aten_index_Convert,
+                                    0},
+                                   {{"batch_dims", 0}});
+        auto __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze =
+            makeOP<opset1::Unsqueeze>({__module_model_model_layers_0_self_attn_aten_index_Gather, 1});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_transpose_Transpose,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose, {1}, {LLONG_MAX}, {1}, {3}});
+        auto Constant_16157 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1, 1}),
+                                        {-1.000000f});
+        auto __module_model_model_layers_0_self_attn_aten_neg_Multiply =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_slice_Slice, Constant_16157},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice_1 = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose, {0}, {1}, {1}, {3}});
+        auto __module_model_model_layers_0_self_attn_aten_cat_Concat =
+            makeOP<opset1::Concat>({__module_model_model_layers_0_self_attn_aten_neg_Multiply,
+                                    __module_model_model_layers_0_self_attn_aten_slice_Slice_1},
+                                   {{"axis", -1}});
+        auto self_model_model_layers_0_self_attn_rotary_emb_sin_cached = makeConst(element::f32,
+                                                                                   ov::Shape({32768, 2}),
+                                                                                   MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice_1 =
+            makeOP<opset8::Slice>({self_model_model_layers_0_self_attn_rotary_emb_sin_cached,
+                                   {0},
+                                   __module_model_model_layers_0_self_attn_aten_add__Add,
+                                   {1},
+                                   {0}});
+        auto __module_model_model_layers_0_self_attn_aten_index_Gather_1 =
+            makeOP<opset8::Gather>({__module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice_1,
+                                    __module_model_model_layers_0_self_attn_aten_index_Convert,
+                                    0},
+                                   {{"batch_dims", 0}});
+        auto __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_1 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_layers_0_self_attn_aten_index_Gather_1, 1});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply_1 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_cat_Concat,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_1},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_add_Add =
+            makeOP<opset1::Add>({__module_model_model_layers_0_self_attn_aten_mul_Multiply,
+                                 __module_model_model_layers_0_self_attn_aten_mul_Multiply_1},
+                                {{"auto_broadcast", "numpy"}});
+        auto self_model_model_layers_0_self_attn_k_proj_weight = makeConst(element::f32,
+                                                                           ov::Shape({4, 8}),
+                                                                           MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_k_proj_aten_linear_MatMul =
+            makeOP<opset1::MatMul>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1,
+                                    self_model_model_layers_0_self_attn_k_proj_weight},
+                                   {{"transpose_a", false}, {"transpose_b", true}});
+        auto __module_model_model_layers_0_self_attn_aten_view_Reshape_1 =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_k_proj_aten_linear_MatMul, {0, 0, 2, 2}},
+                                    {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_transpose_Transpose_1 =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_view_Reshape_1, {0, 2, 1, 3}});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply_2 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_transpose_Transpose_1,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice_2 = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose_1, {1}, {LLONG_MAX}, {1}, {3}});
+        auto Constant_16158 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1, 1}),
+                                        {-1.000000f});
+        auto __module_model_model_layers_0_self_attn_aten_neg_Multiply_1 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_slice_Slice_2, Constant_16158},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice_3 = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose_1, {0}, {1}, {1}, {3}});
+        auto __module_model_model_layers_0_self_attn_aten_cat_Concat_1 =
+            makeOP<opset1::Concat>({__module_model_model_layers_0_self_attn_aten_neg_Multiply_1,
+                                    __module_model_model_layers_0_self_attn_aten_slice_Slice_3},
+                                   {{"axis", -1}});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply_3 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_cat_Concat_1,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_1},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_add_Add_1 =
+            makeOP<opset1::Add>({__module_model_model_layers_0_self_attn_aten_mul_Multiply_2,
+                                 __module_model_model_layers_0_self_attn_aten_mul_Multiply_3},
+                                {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_cat_Concat_2 =
+            makeOP<opset1::Concat>({Gather_18646, __module_model_model_layers_0_self_attn_aten_add_Add_1},
+                                   {{"axis", -2}});
+        auto __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_2 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_layers_0_self_attn_aten_cat_Concat_2, 2});
+        auto Gather_16778 = makeOP<opset8::Gather>({ShapeOf_16753, {0}, 0}, {{"batch_dims", 0}});
+        auto Add_16793 = makeOP<opset1::Add>({Reshape_16772, Reshape_16764}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_prim_ListConstruct_2 =
+            makeOP<opset1::Concat>({Gather_16778, {2l}, {2l}, Add_16793, {2l}}, {{"axis", 0}});
+        auto __module_model_model_layers_0_self_attn_aten_expand_Broadcast =
+            makeOP<opset3::Broadcast>({__module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_2,
+                                       __module_model_model_layers_0_self_attn_prim_ListConstruct_2},
+                                      {{"mode", "bidirectional"}});
+        auto __module_model_model_layers_0_self_attn_aten_reshape_Reshape =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_aten_expand_Broadcast, {0, 4, -1, 2}},
+                                    {{"special_zero", true}});
+        auto ReadValue_19122 = makeOP<opset6::ReadValue>(
+            {Broadcast_19607},
+            {{"variable_id", "var3"}, {"variable_type", "f32"}, {"variable_shape", PartialShape{DYN, 2, DYN, 2}}});
+        auto Gather_18649 = makeOP<opset8::Gather>({ReadValue_19122, beam_idx, 0}, {{"batch_dims", 0}});
+        auto self_model_model_layers_0_self_attn_v_proj_weight = makeConst(element::f32,
+                                                                           ov::Shape({4, 8}),
+                                                                           MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_v_proj_aten_linear_MatMul =
+            makeOP<opset1::MatMul>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1,
+                                    self_model_model_layers_0_self_attn_v_proj_weight},
+                                   {{"transpose_a", false}, {"transpose_b", true}});
+        auto __module_model_model_layers_0_self_attn_aten_view_Reshape_2 =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_v_proj_aten_linear_MatMul, {0, 0, 2, 2}},
+                                    {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_transpose_Transpose_2 =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_view_Reshape_2, {0, 2, 1, 3}});
+        auto __module_model_model_layers_0_self_attn_aten_cat_Concat_3 =
+            makeOP<opset1::Concat>({Gather_18649, __module_model_model_layers_0_self_attn_aten_transpose_Transpose_2},
+                                   {{"axis", -2}});
+        auto __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_3 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_layers_0_self_attn_aten_cat_Concat_3, 2});
+        auto __module_model_model_layers_0_self_attn_aten_expand_Broadcast_1 =
+            makeOP<opset3::Broadcast>({__module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_3,
+                                       __module_model_model_layers_0_self_attn_prim_ListConstruct_2},
+                                      {{"mode", "bidirectional"}});
+        auto __module_model_model_layers_0_self_attn_aten_reshape_Reshape_1 =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_aten_expand_Broadcast_1, {0, 4, -1, 2}},
+                                    {{"special_zero", true}});
+        auto Constant_16160 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1, 1}),
+                                        {1.000000f});
+        auto __module_model_model_aten_unsqueeze_Unsqueeze = makeOP<opset1::Unsqueeze>({attention_mask, 1});
+        auto __module_model_model_aten_unsqueeze_Unsqueeze_1 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_aten_unsqueeze_Unsqueeze, 2});
+        auto ShapeOf_16779 = makeOP<opset3::ShapeOf>({attention_mask}, {{"output_type", "i64"}});
+        auto Gather_16782 = makeOP<opset8::Gather>({ShapeOf_16779, {1}, 0}, {{"batch_dims", 0}});
+        auto __module_model_model_prim_ListConstruct_1 =
+            makeOP<opset1::Concat>({Gather_16778, {1l}, Reshape_16764, Gather_16782}, {{"axis", 0}});
+        auto __module_model_model_aten_expand_Broadcast = makeOP<opset3::Broadcast>(
+            {__module_model_model_aten_unsqueeze_Unsqueeze_1, __module_model_model_prim_ListConstruct_1},
+            {{"mode", "bidirectional"}});
+        auto __module_model_model_aten_to_Convert_1 =
+            makeOP<opset1::Convert>({__module_model_model_aten_expand_Broadcast}, {{"destination_type", "f32"}});
+        auto Constant_16159 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1, 1}),
+                                        {1.000000f});
+        auto __module_model_model_aten_rsub_Multiply =
+            makeOP<opset1::Multiply>({__module_model_model_aten_to_Convert_1, Constant_16159},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_aten_rsub_Subtract =
+            makeOP<opset1::Subtract>({Constant_16160, __module_model_model_aten_rsub_Multiply},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_aten_to_Convert_2 =
+            makeOP<opset1::Convert>({__module_model_model_aten_rsub_Subtract}, {{"destination_type", "boolean"}});
+        auto __module_model_model_aten_masked_fill_Select = makeOP<opset1::Select>(
+            {__module_model_model_aten_to_Convert_2, -FLT_MAX, __module_model_model_aten_rsub_Subtract},
+            {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_aten_to_Convert_4 =
+            makeOP<opset1::Convert>({__module_model_model_aten_masked_fill_Select}, {{"destination_type", "boolean"}});
+        auto __module_model_model_aten_add_Add =
+            makeOP<opset1::Add>({Gather_16756, Gather_16770}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_aten_sub_Subtract =
+            makeOP<opset1::Subtract>({__module_model_model_aten_add_Add, Gather_16756}, {{"auto_broadcast", "numpy"}});
+        auto Unsqueeze_124 = makeOP<opset1::Unsqueeze>({__module_model_model_aten_sub_Subtract, 0});
+        auto __module_model_model_prim_ListConstruct_2 =
+            makeOP<opset1::Concat>({Reshape_16764, Unsqueeze_124}, {{"axis", 0}});
+        auto __module_model_model_aten_zeros_Broadcast =
+            makeOP<opset3::Broadcast>({0.000000f, __module_model_model_prim_ListConstruct_2}, {{"mode", "numpy"}});
+        auto __module_model_model_aten_arange_Range =
+            makeOP<opset4::Range>({0, Gather_16756, 1}, {{"output_type", "f32"}});
+        auto __module_model_model_aten_arange_ConvertLike =
+            makeOP<opset1::Convert>({__module_model_model_aten_arange_Range}, {{"destination_type", "i64"}});
+        auto __module_model_model_aten_add_Add_1 =
+            makeOP<opset1::Add>({__module_model_model_aten_arange_ConvertLike, {1l}}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_aten_view_Reshape_1 =
+            makeOP<opset1::Reshape>({__module_model_model_aten_add_Add_1, {0, 1}}, {{"special_zero", true}});
+        auto __module_model_model_aten_lt_Less = makeOP<opset1::Less>(
+            {__module_model_model_aten_arange_ConvertLike, __module_model_model_aten_view_Reshape_1},
+            {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_prim_ListConstruct_3 =
+            makeOP<opset3::Broadcast>({Reshape_16764, {2}}, {{"mode", "numpy"}});
+        auto __module_model_model_aten_full_Broadcast =
+            makeOP<opset3::Broadcast>({-FLT_MAX, __module_model_model_prim_ListConstruct_3}, {{"mode", "numpy"}});
+        auto __module_model_model_aten_masked_fill__Select = makeOP<opset1::Select>(
+            {__module_model_model_aten_lt_Less, 0.000000f, __module_model_model_aten_full_Broadcast},
+            {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_aten_cat_Concat = makeOP<opset1::Concat>(
+            {__module_model_model_aten_zeros_Broadcast, __module_model_model_aten_masked_fill__Select},
+            {{"axis", -1}});
+        auto __module_model_model_aten_unsqueeze_Unsqueeze_2 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_aten_cat_Concat, 0});
+        auto __module_model_model_aten_unsqueeze_Unsqueeze_3 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_aten_unsqueeze_Unsqueeze_2, 1});
+        auto __module_model_model_aten_add_Add_2 =
+            makeOP<opset1::Add>({Reshape_16764, Unsqueeze_124}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_prim_ListConstruct_5 =
+            makeOP<opset1::Concat>({Gather_16778, {1l}, Reshape_16764, __module_model_model_aten_add_Add_2},
+                                   {{"axis", 0}});
+        auto __module_model_model_aten_expand_Broadcast_1 = makeOP<opset3::Broadcast>(
+            {__module_model_model_aten_unsqueeze_Unsqueeze_3, __module_model_model_prim_ListConstruct_5},
+            {{"mode", "bidirectional"}});
+        auto __module_model_model_aten_masked_fill_Select_1 = makeOP<opset1::Select>(
+            {__module_model_model_aten_to_Convert_4, -FLT_MAX, __module_model_model_aten_expand_Broadcast_1},
+            {{"auto_broadcast", "numpy"}});
+        auto sdpa =
+            makeOP<v13::ScaledDotProductAttention>({__module_model_model_layers_0_self_attn_aten_add_Add,
+                                                    __module_model_model_layers_0_self_attn_aten_reshape_Reshape,
+                                                    __module_model_model_layers_0_self_attn_aten_reshape_Reshape_1,
+                                                    __module_model_model_aten_masked_fill_Select_1},
+                                                   {{"causal", false}});
+
+        auto res = makeOP<v0::Result>({sdpa});
+
+        ParameterVector params = nodes_to_params({beam_idx, position_ids, attention_mask, inputs_embeds});
+        model = std::make_shared<ov::Model>(OutputVector{res}, params);
+
+        manager.register_pass<ov::pass::SDPAToPagedAttention>();
+    }
+
+    {
+        auto max_context_len = make_param(PartialShape{}, element::i32, "max_context_len");
+        auto block_indices_begins = make_param(PartialShape{DYN}, element::i32, "block_indices_begins");
+        auto block_indices = make_param(PartialShape{DYN}, element::i32, "block_indices");
+        auto subsequence_begins = make_param(PartialShape{DYN}, element::i32, "subsequence_begins");
+        auto past_lens = make_param(PartialShape{DYN}, element::i32, "past_lens");
+        auto value_cache_0 = make_param(PartialShape{DYN, 2, 2}, element::f32, "value_cache_0");
+        auto key_cache_0 = make_param(PartialShape{DYN, 2, 2}, element::f32, "key_cache_0");
+        auto inputs_embeds = make_param(PartialShape{DYN, DYN, 8}, element::f32, "inputs_embeds");
+        auto position_ids = make_param(PartialShape{DYN}, element::i64, "position_ids");
+
+        ParameterVector params = nodes_to_params({max_context_len,
+                                                  block_indices_begins,
+                                                  block_indices,
+                                                  subsequence_begins,
+                                                  past_lens,
+                                                  value_cache_0,
+                                                  key_cache_0,
+                                                  inputs_embeds,
+                                                  position_ids});
+
+        auto Constant_16156 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 8}),
+                                        {1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f, 1.000000f});
+        auto Constant_16155 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1}),
+                                        {1.000000f});
+        auto Constant_16153 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1}),
+                                        {2.000000f});
+        auto __module_model_model_layers_0_input_layernorm_aten_pow_Power =
+            makeOP<opset1::Power>({inputs_embeds, Constant_16153}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_input_layernorm_aten_mean_ReduceMean =
+            makeOP<opset1::ReduceMean>({__module_model_model_layers_0_input_layernorm_aten_pow_Power, {-1}},
+                                       {{"keep_dims", true}});
+        auto Constant_16154 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1}),
+                                        {0.000001f});
+        auto __module_model_model_layers_0_input_layernorm_aten_add_Add =
+            makeOP<opset1::Add>({__module_model_model_layers_0_input_layernorm_aten_mean_ReduceMean, Constant_16154},
+                                {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_input_layernorm_aten_rsqrt_Sqrt =
+            makeOP<opset1::Sqrt>({__module_model_model_layers_0_input_layernorm_aten_add_Add});
+        auto __module_model_model_layers_0_input_layernorm_aten_rsqrt_Divide =
+            makeOP<opset1::Divide>({Constant_16155, __module_model_model_layers_0_input_layernorm_aten_rsqrt_Sqrt},
+                                   {{"auto_broadcast", "numpy"}, {"m_pythondiv", true}});
+        auto __module_model_model_layers_0_input_layernorm_aten_mul_Multiply =
+            makeOP<opset1::Multiply>({inputs_embeds, __module_model_model_layers_0_input_layernorm_aten_rsqrt_Divide},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1 =
+            makeOP<opset1::Multiply>({Constant_16156, __module_model_model_layers_0_input_layernorm_aten_mul_Multiply},
+                                     {{"auto_broadcast", "numpy"}});
+        auto self_model_model_layers_0_self_attn_q_proj_weight = makeConst(element::f32,
+                                                                           ov::Shape({8, 8}),
+                                                                           MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_q_proj_aten_linear_MatMul =
+            makeOP<opset1::MatMul>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1,
+                                    self_model_model_layers_0_self_attn_q_proj_weight},
+                                   {{"transpose_a", false}, {"transpose_b", true}});
+        auto __module_model_model_layers_0_self_attn_aten_view_Reshape =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_q_proj_aten_linear_MatMul, {0, 0, 4, 2}},
+                                    {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_transpose_Transpose =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_view_Reshape, {0, 2, 1, 3}});
+        auto self_model_model_layers_0_self_attn_rotary_emb_cos_cached = makeConst(element::f32,
+                                                                                   ov::Shape({32768, 2}),
+                                                                                   MOCK_VALUE);
+        auto ShapeOf_16753 =
+            makeOP<opset3::ShapeOf>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1},
+                                    {{"output_type", "i64"}});
+        auto Gather_16756 = makeOP<opset8::Gather>({ShapeOf_16753, 1, 0}, {{"batch_dims", 0}});
+        auto Reshape_16764 = makeOP<opset1::Reshape>({Gather_16756, {-1}}, {{"special_zero", false}});
+        auto ShapeOf_52004 = makeOP<opset3::ShapeOf>({inputs_embeds}, {{"output_type", "i64"}});
+        auto Gather_52005 = makeOP<opset8::Gather>({ShapeOf_52004, 1, 0}, {{"batch_dims", 0}});
+        auto Convert_52006 = makeOP<opset1::Convert>({Gather_52005}, {{"destination_type", "i32"}});
+        auto Subtract_52007 = makeOP<opset1::Subtract>({max_context_len, Convert_52006}, {{"auto_broadcast", "numpy"}});
+        auto Convert_52008 = makeOP<opset1::Convert>({Subtract_52007}, {{"destination_type", "i64"}});
+        auto Reshape_16772 = makeOP<opset1::Reshape>({Convert_52008, {-1}}, {{"special_zero", false}});
+        auto __module_model_model_layers_0_self_attn_aten_add__Add =
+            makeOP<opset1::Add>({Reshape_16764, Reshape_16772}, {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice =
+            makeOP<opset8::Slice>({self_model_model_layers_0_self_attn_rotary_emb_cos_cached,
+                                   {0},
+                                   __module_model_model_layers_0_self_attn_aten_add__Add,
+                                   {1},
+                                   {0}});
+        auto Unsqueeze_51575 = makeOP<opset1::Unsqueeze>({position_ids, 1});
+        auto __module_model_model_aten_view_Reshape =
+            makeOP<opset1::Reshape>({Unsqueeze_51575, {0, 0}}, {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_index_Convert =
+            makeOP<opset1::Convert>({__module_model_model_aten_view_Reshape}, {{"destination_type", "i32"}});
+        auto __module_model_model_layers_0_self_attn_aten_index_Gather =
+            makeOP<opset8::Gather>({__module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice,
+                                    __module_model_model_layers_0_self_attn_aten_index_Convert,
+                                    0},
+                                   {{"batch_dims", 0}});
+        auto __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze =
+            makeOP<opset1::Unsqueeze>({__module_model_model_layers_0_self_attn_aten_index_Gather, 1});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_transpose_Transpose,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose, {1}, {LLONG_MAX}, {1}, {3}});
+        auto Constant_16157 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1, 1}),
+                                        {-1.000000f});
+        auto __module_model_model_layers_0_self_attn_aten_neg_Multiply =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_slice_Slice, Constant_16157},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice_1 = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose, {0}, {1}, {1}, {3}});
+        auto __module_model_model_layers_0_self_attn_aten_cat_Concat =
+            makeOP<opset1::Concat>({__module_model_model_layers_0_self_attn_aten_neg_Multiply,
+                                    __module_model_model_layers_0_self_attn_aten_slice_Slice_1},
+                                   {{"axis", -1}});
+        auto self_model_model_layers_0_self_attn_rotary_emb_sin_cached = makeConst(element::f32,
+                                                                                   ov::Shape({32768, 2}),
+                                                                                   MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice_1 =
+            makeOP<opset8::Slice>({self_model_model_layers_0_self_attn_rotary_emb_sin_cached,
+                                   {0},
+                                   __module_model_model_layers_0_self_attn_aten_add__Add,
+                                   {1},
+                                   {0}});
+        auto __module_model_model_layers_0_self_attn_aten_index_Gather_1 =
+            makeOP<opset8::Gather>({__module_model_model_layers_0_self_attn_rotary_emb_aten_slice_Slice_1,
+                                    __module_model_model_layers_0_self_attn_aten_index_Convert,
+                                    0},
+                                   {{"batch_dims", 0}});
+        auto __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_1 =
+            makeOP<opset1::Unsqueeze>({__module_model_model_layers_0_self_attn_aten_index_Gather_1, 1});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply_1 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_cat_Concat,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_1},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_add_Add =
+            makeOP<opset1::Add>({__module_model_model_layers_0_self_attn_aten_mul_Multiply,
+                                 __module_model_model_layers_0_self_attn_aten_mul_Multiply_1},
+                                {{"auto_broadcast", "numpy"}});
+        auto Transpose_51951 =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_add_Add, {0, 2, 1, 3}});
+        auto Reshape_51953 = makeOP<opset1::Reshape>({Transpose_51951, {0, -1}}, {{"special_zero", true}});
+        auto self_model_model_layers_0_self_attn_k_proj_weight = makeConst(element::f32,
+                                                                           ov::Shape({4, 8}),
+                                                                           MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_k_proj_aten_linear_MatMul =
+            makeOP<opset1::MatMul>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1,
+                                    self_model_model_layers_0_self_attn_k_proj_weight},
+                                   {{"transpose_a", false}, {"transpose_b", true}});
+        auto __module_model_model_layers_0_self_attn_aten_view_Reshape_1 =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_k_proj_aten_linear_MatMul, {0, 0, 2, 2}},
+                                    {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_transpose_Transpose_1 =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_view_Reshape_1, {0, 2, 1, 3}});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply_2 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_transpose_Transpose_1,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice_2 = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose_1, {1}, {LLONG_MAX}, {1}, {3}});
+        auto Constant_16158 = makeConst(element::f32,
+                                        ov::Shape({1, 1, 1, 1}),
+                                        {-1.000000f});
+        auto __module_model_model_layers_0_self_attn_aten_neg_Multiply_1 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_slice_Slice_2, Constant_16158},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_slice_Slice_3 = makeOP<opset8::Slice>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose_1, {0}, {1}, {1}, {3}});
+        auto __module_model_model_layers_0_self_attn_aten_cat_Concat_1 =
+            makeOP<opset1::Concat>({__module_model_model_layers_0_self_attn_aten_neg_Multiply_1,
+                                    __module_model_model_layers_0_self_attn_aten_slice_Slice_3},
+                                   {{"axis", -1}});
+        auto __module_model_model_layers_0_self_attn_aten_mul_Multiply_3 =
+            makeOP<opset1::Multiply>({__module_model_model_layers_0_self_attn_aten_cat_Concat_1,
+                                      __module_model_model_layers_0_self_attn_aten_unsqueeze_Unsqueeze_1},
+                                     {{"auto_broadcast", "numpy"}});
+        auto __module_model_model_layers_0_self_attn_aten_add_Add_1 =
+            makeOP<opset1::Add>({__module_model_model_layers_0_self_attn_aten_mul_Multiply_2,
+                                 __module_model_model_layers_0_self_attn_aten_mul_Multiply_3},
+                                {{"auto_broadcast", "numpy"}});
+        auto Transpose_51954 =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_add_Add_1, {0, 2, 1, 3}});
+        auto Reshape_51957 = makeOP<opset1::Reshape>({Transpose_51954, {0, -1}}, {{"special_zero", true}});
+        auto self_model_model_layers_0_self_attn_v_proj_weight = makeConst(element::f32,
+                                                                           ov::Shape({4, 8}),
+                                                                           MOCK_VALUE);
+        auto __module_model_model_layers_0_self_attn_v_proj_aten_linear_MatMul =
+            makeOP<opset1::MatMul>({__module_model_model_layers_0_input_layernorm_aten_mul_Multiply_1,
+                                    self_model_model_layers_0_self_attn_v_proj_weight},
+                                   {{"transpose_a", false}, {"transpose_b", true}});
+        auto __module_model_model_layers_0_self_attn_aten_view_Reshape_2 =
+            makeOP<opset1::Reshape>({__module_model_model_layers_0_self_attn_v_proj_aten_linear_MatMul, {0, 0, 2, 2}},
+                                    {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_transpose_Transpose_2 =
+            makeOP<opset1::Transpose>({__module_model_model_layers_0_self_attn_aten_view_Reshape_2, {0, 2, 1, 3}});
+        auto Transpose_51955 = makeOP<opset1::Transpose>(
+            {__module_model_model_layers_0_self_attn_aten_transpose_Transpose_2, {0, 2, 1, 3}});
+        auto Reshape_51959 = makeOP<opset1::Reshape>({Transpose_51955, {0, -1}}, {{"special_zero", true}});
+
+        auto c1 = makeConst(element::f32, {}, {0.707107f});
+        auto c2 = makeConst(element::i32, {}, {0});
+        // an empty Constant needs to be created in a usual way, not using makeConst()
+        auto c3 = v0::Constant::create(element::f32, {0}, {});
+        auto PagedAttentionExtension_51962 =
+            std::make_shared<ov::op::PagedAttentionExtension>(ov::OutputVector{Reshape_51953,
+                                                                               Reshape_51957,
+                                                                               Reshape_51959,
+                                                                               key_cache_0,
+                                                                               value_cache_0,
+                                                                               past_lens,
+                                                                               subsequence_begins,
+                                                                               block_indices,
+                                                                               block_indices_begins,
+                                                                               c1,
+                                                                               c2,
+                                                                               c3,
+                                                                               max_context_len});
+        auto ShapeOf_51965 = makeOP<opset3::ShapeOf>({Transpose_51955}, {{"output_type", "i64"}});
+        auto Gather_51966 = makeOP<opset8::Gather>({ShapeOf_51965, -1, 0}, {{"batch_dims", 0}});
+        auto Unsqueeze_51971 = makeOP<opset1::Unsqueeze>({Gather_51966, 0});
+        auto Concat_51972 = makeOP<opset1::Concat>({{0l}, {1l}, {-1l}, Unsqueeze_51971}, {{"axis", 0}});
+        auto Reshape_51973 =
+            makeOP<opset1::Reshape>({PagedAttentionExtension_51962->output(0), Concat_51972}, {{"special_zero", true}});
+        auto __module_model_model_layers_0_self_attn_aten_scaled_dot_product_attention_ScaledDotProductAttention =
+            makeOP<opset1::Transpose>({Reshape_51973, {0, 2, 1, 3}});
+
+        auto res = std::make_shared<v0::Result>(
+            __module_model_model_layers_0_self_attn_aten_scaled_dot_product_attention_ScaledDotProductAttention);
+        model_ref = std::make_shared<ov::Model>(ResultVector{res}, params);
+
         comparator.disable(FunctionsComparator::PRECISIONS);
         disable_result_friendly_names_check();
         disable_rt_info_check();

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -6,9 +6,6 @@
 
 #include <gtest/gtest.h>
 
-// #include "openvino/cc/pass/itt.hpp"
-#include "openvino/op/matmul.hpp"
-#include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
 #include "openvino/core/model.hpp"
 #include "openvino/op/add.hpp"
@@ -458,12 +455,6 @@ class SDPAToPATest : public TransformationTestsF, public ::testing::WithParamInt
 TEST_P(SDPAToPATest, SDPAToPA_Qwen7bChat_General) {
     const auto model_precision = GetParam();
     {
-        // Inputs to SDPA transformer:
-        // auto beam_idx = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN}}, el_type_i64});
-        // auto position_ids = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
-        // auto attention_mask = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
-        // auto input_ids = makeOP<v0::Parameter>({}, {{"shape", PartialShape{DYN, DYN}}, el_type_i64});
-        
         auto beam_idx = make_param(PartialShape{DYN}, element::i64, "beam_idx");
         auto position_ids = make_param(PartialShape{DYN, DYN}, element::i64, "position_ids");
         auto attention_mask = make_param(PartialShape{DYN, DYN}, element::i64, "attention_mask");
@@ -925,37 +916,3 @@ entire SDPAToPA transformation
 const std::vector<ov::element::Type> element_types = {element::f16, element::f32};
 
 INSTANTIATE_TEST_SUITE_P(SDPAToPATest_Conversion, SDPAToPATest, testing::ValuesIn(element_types));
-
-// class SampleMatcher : public ov::pass::MatcherPass {
-// public:
-//     OPENVINO_MATCHER_PASS_RTTI("SampleMatcher");
-//     explicit SampleMatcher() {
-//         const std::string matcher_name = "SampleMatcher";
-
-//         auto p_p1 = ov::pass::pattern::wrap_type<op::v0::Parameter>();
-//         auto p_mm = ov::pass::pattern::wrap_type<op::v0::Abs>({p_p1});
-//         auto p_conv = ov::pass::pattern::wrap_type<op::v0::Convert>({p_mm});
-
-//         ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
-//             return true;
-//         };
-
-//         auto m = std::make_shared<ov::pass::pattern::Matcher>(p_conv, matcher_name);
-//         register_matcher(m, callback);
-//     }
-// };
-
-
-// TEST(TransformationsF, SampleTest) {
-//     auto input0 = std::make_shared<op::v0::Parameter>(element::i32, PartialShape{2});
-//     auto matmul = std::make_shared<op::v0::Abs>(input0);
-//     auto conv = std::make_shared<op::v0::Convert>(matmul, element::i64);
-//     auto res = std::make_shared<op::v0::Result>(conv);
-
-//     auto model = std::make_shared<Model>(ResultVector{res}, ParameterVector{input0});
-
-//     ov::pass::Manager manager;
-//     manager.set_per_pass_validation(false);
-//     manager.register_pass<SampleMatcher>();
-//     manager.run_passes(model);
-// }

--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -18,8 +18,6 @@
 #include "transformations/sdpa_to_paged_attention/total_sequence_length_pattern.hpp"
 #include "transformations/utils/utils.hpp"
 
-#include "openvino/pass/visualize_tree.hpp"
-
 using namespace ov::op;
 
 ov::pass::SDPAToPagedAttention::SDPAToPagedAttention(bool use_per_layer_block_indices_inputs,
@@ -107,6 +105,8 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
         // for additional work on the input here as this is done
         // for "input_ids"
         processed_input_ids = input_ids_node;
+    } else {
+        OPENVINO_ASSERT(processed_input_ids, "Counln't process neither input_ids, nor inputs_embeds.");
     }
 
     ParameterVector kv_parameters;

--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -106,7 +106,7 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
         // for "input_ids"
         processed_input_ids = input_ids_node;
     } else {
-        OPENVINO_ASSERT(processed_input_ids, "Counln't process neither input_ids, nor inputs_embeds.");
+        OPENVINO_ASSERT(processed_input_ids, "Couldn't process neither input_ids, nor inputs_embeds.");
     }
 
     ParameterVector kv_parameters;

--- a/src/core/src/pass/sdpa_to_paged_attention.cpp
+++ b/src/core/src/pass/sdpa_to_paged_attention.cpp
@@ -18,6 +18,8 @@
 #include "transformations/sdpa_to_paged_attention/total_sequence_length_pattern.hpp"
 #include "transformations/utils/utils.hpp"
 
+#include "openvino/pass/visualize_tree.hpp"
+
 using namespace ov::op;
 
 ov::pass::SDPAToPagedAttention::SDPAToPagedAttention(bool use_per_layer_block_indices_inputs,
@@ -90,12 +92,21 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
 
     OPENVINO_ASSERT(input_ids_node, "The model doesn't contain input_ids or input_embeds input. Aborting.");
 
-    input_ids_node->set_partial_shape(PartialShape{-1});
-    auto input_ids_target_inputs = input_ids_node->get_output_target_inputs(0);
-    auto unsqueezed_input_ids =
-        std::make_shared<v0::Unsqueeze>(input_ids_node, v0::Constant::create(element::i32, Shape{}, {1}));
-    for (const auto& target : input_ids_target_inputs) {
-        target.replace_source_output(unsqueezed_input_ids);
+    std::shared_ptr<ov::Node> processed_input_ids;
+    if (input_ids_node->get_friendly_name() == "input_ids") {
+        auto input_ids_target_inputs = input_ids_node->get_output_target_inputs(0);
+        input_ids_node->set_partial_shape(PartialShape{-1});
+        processed_input_ids =
+            std::make_shared<v0::Unsqueeze>(input_ids_node, v0::Constant::create(element::i32, Shape{}, {1}));
+        for (const auto& target : input_ids_target_inputs) {
+            target.replace_source_output(processed_input_ids);
+        }
+    } else if (input_ids_node->get_friendly_name() == "inputs_embeds") {
+        // VLMs have the input_ids part + embeddings calculation
+        // served as "inputs_embeds" input, so there's no need
+        // for additional work on the input here as this is done
+        // for "input_ids"
+        processed_input_ids = input_ids_node;
     }
 
     ParameterVector kv_parameters;
@@ -141,7 +152,7 @@ bool ov::pass::SDPAToPagedAttention::run_on_model(const std::shared_ptr<ov::Mode
                                                   rotated_block_indices_inputs_for_each_layer,
                                                   rotation_deltas_inputs_for_each_layer,
                                                   model_rotation_trig_lut);
-    manager.register_pass<PrevSequenceLengthPattern>(unsqueezed_input_ids, max_context_len, position_ids);
+    manager.register_pass<PrevSequenceLengthPattern>(processed_input_ids, max_context_len, position_ids);
     manager.register_pass<TotalSequenceLengthPattern>(max_context_len);
     manager.register_pass<TotalSequenceLengthPatternQwen>(max_context_len);
     manager.register_pass<PositionIDsReplacer>(unsqueezed_position_ids);


### PR DESCRIPTION
VLMs have tokens and their generation already served as the "inputs_embeds" input, so there's no need to transform the input in the way this is done for "input_ids".

Tickets:
* [CVS-160598](https://github.com/CuriousPanCake/openvino/tree/CVS-160598)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
