### PR TITLE
Add CodeQL scans to GitHub Actions Workflows

### DIFF
--- a/.github/workflows/merge_queue_stub.yml
+++ b/.github/workflows/merge_queue_stub.yml
@@ -1,6 +1,8 @@
 on:
   merge_group:
 
+permissions: read-all
+
 jobs:
   merge_group_stub_check:
     name: ci/jenkins

--- a/.github/workflows/windows_vs2019_release.yml
+++ b/.github/workflows/windows_vs2019_release.yml
@@ -45,7 +45,7 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           skip_when_only_listed_labels_set: 'docs'
           skip_when_only_listed_files_changed: '*.md,*.rst,*.png,*.jpg,*.svg,*/layer_tests_summary/*,*/conformance/*'
-          
+
       - name: Get target branch
         id: set_target_branch
         run: |
@@ -192,7 +192,7 @@ jobs:
           sparse-checkout: |
             src/bindings/js
           path: 'openvino'
-        
+
       - name: Download OpenVINO artifacts (JS)
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
@@ -223,7 +223,7 @@ jobs:
         run: call npm test
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
       - name: E2E of openvino-node package
         working-directory: ${{ env.OPENVINO_JS_DIR }}/node

--- a/.github/workflows/workflows_scans.yml
+++ b/.github/workflows/workflows_scans.yml
@@ -18,6 +18,37 @@ concurrency:
 permissions: read-all
 
 jobs:
+  codeql:
+    name: github_actions_workflows_scan/codeql
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners
+    # Consider using larger runners for possible analysis time improvements.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        timeout-minutes: 15
+        with:
+          submodules: 'false'
+          sparse-checkout: .github/workflows
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
+        with:
+          languages: "actions"
+          build-mode: "none"
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
+        with:
+          category: "/language:actions"
+
   semgrep:
     name: github_actions_workflows_scan/semgrep
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Details:
This PR adds an additional job to `workflow_scans` workflow to scan GitHub Actions Workflows themselves using CodeQL