### PR TITLE
[CPU] Remove the limitation that requires to memset zero for KVCache of PagedAttention

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -1048,7 +1048,7 @@ static void pack_32xK_kernel(T* dst, T* src, size_t dst_stride, size_t src_strid
     static const uint64_t idx[8] = {0, 4, 1, 5, 2, 6, 3, 7};
     auto midx = _mm512_loadu_si512(idx);
     __mmask16 mask = (1 << K) - 1;
-    for (size_t i = 0; i < K; i++) {
+    for (size_t i = 0; i < 16; i++) {
         auto x = _mm256_maskz_loadu_epi16(mask, src);               // [a1  a2  a3 a4]   total 256-bits in 4 64bits unit
         auto y = _mm256_maskz_loadu_epi16(mask, src + src_stride);  // [b1  b2  b3 b4]   total 256-bits
         auto a = _mm512_castsi256_si512(x);
@@ -2343,6 +2343,27 @@ struct AttentionExecutor : public PagedAttentionExecutor {
                     block_indices.ptr<int32_t>()[block_number_start + block_offset / _helper._block_size];
                 _slot_mapping.ptr<int32_t>()[idx++] =
                     block_number * _helper._block_size + block_offset % _helper._block_size;
+            }
+            // To simplify tails of the kernels for Q*K and W*V:
+            // for first token kernels:
+            //    Q*K aka [m, k0] * [n0, k0]', there is already tails logic for m, k0, but no(always assume n0 is
+            //    block_size) for n0 which means the tail of k_cache need to be set to zero.
+            //    W*V aka [m, k1] * [n1, k1]', there is no tails handing for n1, so tails of v_cache need to be set to
+            //    zero.
+            // for second token, the kernels have tails handling logic
+            if (q_len != 1 && q_len % _helper._block_size != 0) {
+                // block no. which contains tails
+                auto block_number = block_indices.ptr<int32_t>()[block_number_start + kv_len / _helper._block_size];
+                // tails start position
+                auto block_offset = kv_len % _helper._block_size;
+                // tails number
+                auto zero_tokens = _helper._block_size - block_offset;
+                auto S = k_cache.m_dims[3];
+                auto SV = v_cache.m_dims[3];
+                parallel_for2d(k_cache.m_dims[2], zero_tokens, [&](size_t h, size_t l) {
+                    std::memset(k_cache.ptr_v(block_number, h, block_offset + l, 0), 0, S * k_cache.m_element_size);
+                    std::memset(v_cache.ptr_v(block_number, h, block_offset + l, 0), 0, SV * v_cache.m_element_size);
+                });
             }
         }
 


### PR DESCRIPTION
### Details:
 - *Remove the limitation that requires to memset zero for KVCache of PagedAttention*
 - *...*

### Tickets:
 - *[160731](https://jira.devtools.intel.com/browse/CVS-160731)*
