### PR TITLE
[CPU] Enable Debian 10 ARM tests

### DIFF
--- a/.github/workflows/debian_10_arm.yml
+++ b/.github/workflows/debian_10_arm.yml
@@ -113,8 +113,7 @@ jobs:
 
   CPU_Functional_Tests:
     name: CPU functional tests
-    if: ${{ 'false' }} # Ticket: 153289
-    # if: fromJSON(needs.smart_ci.outputs.affected_components).CPU.test
+    if: fromJSON(needs.smart_ci.outputs.affected_components).CPU.test
     needs: [ Docker, Build, Smart_CI ]
     uses: ./.github/workflows/job_cpu_functional_tests.yml
     with:

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/custom_op_insert_convert_i64.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/custom_op_insert_convert_i64.cpp
@@ -116,6 +116,7 @@ public:
 
 protected:
     void SetUp() override {
+        SKIP_IF_CURRENT_TEST_IS_DISABLED();
         targetDevice = test::utils::DEVICE_CPU;
 
         const auto& params = this->GetParam();

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -519,6 +519,46 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*EltwiseLayerCPUTest.*IS=\(\[1\.\.10\.2\.5\.6\]_\).*eltwiseOpType=SqDiff.*_configItem=INFERENCE_PRECISION_HINT=f16.*)");
     }
 #endif
+#if defined(OPENVINO_ARCH_ARM)
+    retVector.emplace_back(R"(.*ActivationLayerTest.*Inference.*)");
+    retVector.emplace_back(R"(.*AddConvertToReorderTest.*smoke_TestAddReorder_CPU.*)");
+    retVector.emplace_back(R"(.*AddOutputsTest.*smoke_CheckOutputExist.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheRuntimePropertiesTestBase.*CanLoadFromFileWithoutException.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*2InputSubtract_f.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*ConvPoolRelu_f.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*MatMulBias_f.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*SimpleFunctionRelu_f.*)");
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl/MatMulBias_f32_batch1_CPU)");
+    retVector.emplace_back(R"(.*CompileModelLoadFromCacheTest.*CanGetCorrectLoadedFromCacheProperty.*)");
+    retVector.emplace_back(R"(.*CompileModelLoadFromFileTestBase.*CanCreateCacheDirAndDumpBinariesUnicodePath.*)");
+    retVector.emplace_back(R"(.*CompileModelLoadFromFileTestBase.*CanLoadFromFileWithoutException.*)");
+    retVector.emplace_back(R"(.*CompileModelLoadFromMemoryTestBase.*CanLoadFromMemoryWithoutExecption.*)");
+    retVector.emplace_back(R"(.*CompileModelLoadFromMemoryTestBase.*CanLoadFromMemoryWithoutWeightsANdExecption.*)");
+    retVector.emplace_back(R"(.*CompileModelWithCacheEncryptionTest.*CanImportModelWithoutException.*)");
+    retVector.emplace_back(R"(.*ConcatMultiQuerySDPTest.*f16.*)");
+    retVector.emplace_back(R"(.*ConcatSDPTest.*f16.*)");
+    retVector.emplace_back(R"(.*CoreThreadingTestsWithCacheEnabled.*smoke_compiled_model_cache_enabled.*)");
+    retVector.emplace_back(R"(.*CoreThreadingTestsWithIter.*smoke_CompileModel.*)");
+    retVector.emplace_back(R"(.*CustomOpConvertI64CPUTest.*CompareWithRefs.*)");
+    retVector.emplace_back(R"(.*EltwiseLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
+    retVector.emplace_back(R"(.*EltwiseLayerTest.*Inference.*)");
+    retVector.emplace_back(R"(.*ExecGraphDuplicateInputsOutputsNames.*CheckOutputsMatch.*)");
+    retVector.emplace_back(R"(.*ExecGraphKeepAssignNode.*KeepAssignNode.*)");
+    retVector.emplace_back(R"(.*ExecGraphRemoveParameterNode.*RemoveParameterNode.*)");
+    retVector.emplace_back(R"(.*IndexAddTest.*CompareWithRefs.*)");
+    retVector.emplace_back(R"(.*InterpolateLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
+    retVector.emplace_back(R"(.*MatMulLayerCPUTest.*CompareWithRefs.*)");
+    retVector.emplace_back(R"(.*MatmulWeightsDecompression.*CompareWithRefs.*)");
+    retVector.emplace_back(R"(.*MvnLayerCPUTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
+    retVector.emplace_back(R"(.*NonInputInPlaceTest.*CompareWithRefs.*)");
+    retVector.emplace_back(R"(.*OVClassCompiledModelGetPropertyTest_EXEC_DEVICES.*CanGetExecutionDeviceInfo.*)");
+    retVector.emplace_back(R"(.*OVClassConfigTestCPU.*smoke_.*)");
+    retVector.emplace_back(R"(.*OVClassConfigTestCPU.*smoke_CpuExecNetwork.*)");
+    retVector.emplace_back(R"(.*OVInferenceChaining.*StaticOutputToDynamicInput.*)");
+    retVector.emplace_back(R"(.*OVInferenceChaining.*StaticOutputToStaticInput.*)");
+    retVector.emplace_back(R"(.*OVInferenceChainingStatic.*StaticOutputToStaticInput.*)");
+    retVector.emplace_back(R"(.*ReduceCPULayerTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
+#endif
     if (!ov::with_cpu_x86_avx512_core_vnni() &&
         !ov::with_cpu_x86_avx2_vnni() &&
         !ov::with_cpu_x86_avx512_core_amx_int8()) {

--- a/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_plugin/caching_tests.cpp
@@ -297,6 +297,7 @@ std::string CompileModelLoadFromFileTestBase::getTestCaseName(testing::TestParam
 }
 
 void CompileModelLoadFromFileTestBase::SetUp() {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     ovModelWithName funcPair;
     std::tie(targetDevice, configuration) = GetParam();
     target_device = targetDevice;


### PR DESCRIPTION
### Details:
 - Enable running CPU unit tests on Debian ARM 32 bit
 - Disable all failing tests
 - Fix tests that ignore test skip mechanism

### Tickets:
 - 153289
