### PR TITLE
Use graph properties from ZeroInitStruct in compiler adapter

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/include/driver_compiler_adapter.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/driver_compiler_adapter.hpp
@@ -55,7 +55,7 @@ private:
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
     std::shared_ptr<ZeGraphExtWrappers> _zeGraphExt;
 
-    ze_device_graph_properties_t _deviceGraphProperties = {};
+    ze_device_graph_properties_t _compilerProperties = {};
 
     Logger _logger;
 };

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -145,7 +145,7 @@ DriverCompilerAdapter::DriverCompilerAdapter(const std::shared_ptr<ZeroInitStruc
 
     uint32_t graphExtVersion = _zeroInitStruct->getGraphDdiTable().version();
 
-    _deviceGraphProperties = _zeroInitStruct->getCompilerProperties();
+    _compilerProperties = _zeroInitStruct->getCompilerProperties();
 
     _logger.info("DriverCompilerAdapter creating adapter using graphExtVersion");
 
@@ -160,8 +160,8 @@ std::shared_ptr<IGraph> DriverCompilerAdapter::compile(const std::shared_ptr<con
                                                        const Config& config) const {
     OV_ITT_TASK_CHAIN(COMPILE_BLOB, itt::domains::NPUPlugin, "DriverCompilerAdapter", "compile");
 
-    const ze_graph_compiler_version_info_t& compilerVersion = _deviceGraphProperties.compilerVersion;
-    const auto maxOpsetVersion = _deviceGraphProperties.maxOVOpsetVersionSupported;
+    const ze_graph_compiler_version_info_t& compilerVersion = _compilerProperties.compilerVersion;
+    const auto maxOpsetVersion = _compilerProperties.maxOVOpsetVersionSupported;
     _logger.info("getSupportedOpsetVersion Max supported version of opset in CiD: %d", maxOpsetVersion);
 
     _logger.debug("serialize IR");
@@ -222,8 +222,8 @@ ov::SupportedOpsMap DriverCompilerAdapter::query(const std::shared_ptr<const ov:
                                                  const Config& config) const {
     OV_ITT_TASK_CHAIN(query_BLOB, itt::domains::NPUPlugin, "DriverCompilerAdapter", "query");
 
-    const ze_graph_compiler_version_info_t& compilerVersion = _deviceGraphProperties.compilerVersion;
-    const auto maxOpsetVersion = _deviceGraphProperties.maxOVOpsetVersionSupported;
+    const ze_graph_compiler_version_info_t& compilerVersion = _compilerProperties.compilerVersion;
+    const auto maxOpsetVersion = _compilerProperties.maxOVOpsetVersionSupported;
     _logger.info("getSupportedOpsetVersion Max supported version of opset in CiD: %d", maxOpsetVersion);
 
     _logger.debug("serialize IR");

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -145,10 +145,7 @@ DriverCompilerAdapter::DriverCompilerAdapter(const std::shared_ptr<ZeroInitStruc
 
     uint32_t graphExtVersion = _zeroInitStruct->getGraphDdiTable().version();
 
-    _deviceGraphProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
-    auto result = _zeroInitStruct->getGraphDdiTable().pfnDeviceGetGraphProperties(_zeroInitStruct->getDevice(),
-                                                                                  &_deviceGraphProperties);
-    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnDeviceGetGraphProperties", result, _zeroInitStruct->getGraphDdiTable());
+    _deviceGraphProperties = _zeroInitStruct->getCompilerProperties();
 
     _logger.info("DriverCompilerAdapter creating adapter using graphExtVersion");
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -183,6 +183,7 @@ Plugin::Plugin()
 
     // parse env_variables to get LOG_LEVEL if needed
     _globalConfig.parseEnvVars();
+    Logger::global().setLevel(_globalConfig.get<LOG_LEVEL>());
 
     // TODO: generation of available backends list can be done during execution of CMake scripts
     std::vector<AvailableBackends> backendRegistry;

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -50,7 +50,10 @@ public:
         return driver_properties.driverVersion;
     }
     inline uint32_t getCompilerVersion() const {
-        return compiler_version;
+        return ZE_MAKE_VERSION(graph_properties.compilerVersion.major, graph_properties.compilerVersion.minor);
+    }
+    inline ze_device_graph_properties_t getCompilerProperties() const {
+        return graph_properties;
     }
     inline uint32_t getMutableCommandListVersion() const {
         return mutable_command_list_version;
@@ -89,7 +92,7 @@ private:
 
     ze_api_version_t ze_drv_api_version = {};
 
-    uint32_t compiler_version = 0;
+    ze_device_graph_properties_t graph_properties = {};
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -50,10 +50,10 @@ public:
         return driver_properties.driverVersion;
     }
     inline uint32_t getCompilerVersion() const {
-        return ZE_MAKE_VERSION(graph_properties.compilerVersion.major, graph_properties.compilerVersion.minor);
+        return ZE_MAKE_VERSION(compiler_properties.compilerVersion.major, compiler_properties.compilerVersion.minor);
     }
     inline ze_device_graph_properties_t getCompilerProperties() const {
-        return graph_properties;
+        return compiler_properties;
     }
     inline uint32_t getMutableCommandListVersion() const {
         return mutable_command_list_version;
@@ -92,7 +92,7 @@ private:
 
     ze_api_version_t ze_drv_api_version = {};
 
-    ze_device_graph_properties_t graph_properties = {};
+    ze_device_graph_properties_t compiler_properties = {};
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -313,7 +313,7 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     log.debug("ZeroInitStructsHolder initialize complete");
 
-    // Obtain compiler-in-driver (vcl) properties
+    // Obtain compiler-in-driver properties
     compiler_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
     auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &compiler_properties);
     THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -314,8 +314,8 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     log.debug("ZeroInitStructsHolder initialize complete");
 
     // Obtain compiler-in-driver (vcl) properties
-    graph_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
-    auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &graph_properties);
+    compiler_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
+    auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &compiler_properties);
     THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
 }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -313,12 +313,10 @@ ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder",
     THROW_ON_FAIL_FOR_LEVELZERO("zeContextCreate", zeContextCreate(driver_handle, &context_desc, &context));
     log.debug("ZeroInitStructsHolder initialize complete");
 
-    // Obtain compiler-in-driver (vcl) version
-    ze_device_graph_properties_t graph_props;
-    graph_props.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
-    auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &graph_props);
+    // Obtain compiler-in-driver (vcl) properties
+    graph_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES;
+    auto result = graph_dditable_ext_decorator->pfnDeviceGetGraphProperties(device_handle, &graph_properties);
     THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
-    compiler_version = ZE_MAKE_VERSION(graph_props.compilerVersion.major, graph_props.compilerVersion.minor);
 }
 
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {


### PR DESCRIPTION
### Details:
 - *FEIL/FIL was increased with https://github.com/openvinotoolkit/openvino/pull/28314. Querying compiler properties forces UMD to load the compiler DLL. To optimize the memory consumption UMD will also unload the the compiler DLL.*
 - *By reusing graph properties in the compiler adapter we remove one (load + read + unload) cycle from FEIL/FIL*
 -  *Rename private member names to _compiler_properties_: even if we use a common graph ext API to query graph properties we only store ZE_STRUCTURE_TYPE_DEVICE_GRAPH_PROPERTIES - which are compiler properties.*

### Tickets:
 - *CVS-161294*
