### PR TITLE
[CPU][ARM64] Enable FakeQuantize tokenization and decomposition

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1110,7 +1110,8 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v0::PRelu>(n) || ov::is_type<ov::op::v0::Relu>(n) ||
                 ov::is_type<ov::op::v5::Round>(n) || ov::is_type<ov::op::v0::Sigmoid>(n) ||
                 ov::is_type<ov::op::v0::Sqrt>(n) || ov::is_type<ov::op::v1::Subtract>(n) ||
-                ov::is_type<ov::op::v4::Swish>(n) || ov::is_type<ov::op::v0::Tanh>(n));
+                ov::is_type<ov::op::v4::Swish>(n) || ov::is_type<ov::op::v0::Tanh>(n) ||
+                ov::is_type<ov::op::v0::FakeQuantize>(n));
 #else
         // CPU Plugin support Swish in Subgraph via conversion to SwichCPU which assumes second input to be constant,
         // and CPU Plugin does not support Mish for x64

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1100,18 +1100,18 @@ void Transformations::MainSnippets(void) {
                 ov::is_type<ov::op::v0::Clamp>(n) || ov::is_type<ov::op::v0::Ceiling>(n) ||
                 ov::is_type<ov::op::v0::Convert>(n) || ov::is_type<ov::op::v1::Divide>(n) ||
                 ov::is_type<ov::op::v0::Elu>(n) || ov::is_type<ov::op::v0::Exp>(n) ||
-                ov::is_type<ov::op::v1::Equal>(n) || ov::is_type<ov::op::v0::Floor>(n) ||
-                ov::is_type<ov::op::v1::FloorMod>(n) || ov::is_type<ov::op::v0::Gelu>(n) ||
-                ov::is_type<ov::op::v7::Gelu>(n) || ov::is_type<ov::op::v1::Greater>(n) ||
-                ov::is_type<ov::op::v1::GreaterEqual>(n) || ov::is_type<ov::op::v4::HSwish>(n) ||
-                ov::is_type<ov::op::v1::LessEqual>(n) || ov::is_type<ov::op::v1::Maximum>(n) ||
-                ov::is_type<ov::op::v1::Minimum>(n) || ov::is_type<ov::op::v4::Mish>(n) ||
-                ov::is_type<ov::op::v1::Mod>(n) || ov::is_type<ov::op::v1::Multiply>(n) ||
-                ov::is_type<ov::op::v0::PRelu>(n) || ov::is_type<ov::op::v0::Relu>(n) ||
-                ov::is_type<ov::op::v5::Round>(n) || ov::is_type<ov::op::v0::Sigmoid>(n) ||
-                ov::is_type<ov::op::v0::Sqrt>(n) || ov::is_type<ov::op::v1::Subtract>(n) ||
-                ov::is_type<ov::op::v4::Swish>(n) || ov::is_type<ov::op::v0::Tanh>(n) ||
-                ov::is_type<ov::op::v0::FakeQuantize>(n));
+                ov::is_type<ov::op::v1::Equal>(n) || ov::is_type<ov::op::v0::FakeQuantize>(n) ||
+                ov::is_type<ov::op::v0::Floor>(n) || ov::is_type<ov::op::v1::FloorMod>(n) || 
+                ov::is_type<ov::op::v0::Gelu>(n) || ov::is_type<ov::op::v7::Gelu>(n) || 
+                ov::is_type<ov::op::v1::Greater>(n) || ov::is_type<ov::op::v1::GreaterEqual>(n) || 
+                ov::is_type<ov::op::v4::HSwish>(n) || ov::is_type<ov::op::v1::LessEqual>(n) || 
+                ov::is_type<ov::op::v1::Maximum>(n) || ov::is_type<ov::op::v1::Minimum>(n) || 
+                ov::is_type<ov::op::v4::Mish>(n) || ov::is_type<ov::op::v1::Mod>(n) || 
+                ov::is_type<ov::op::v1::Multiply>(n) || ov::is_type<ov::op::v0::PRelu>(n) || 
+                ov::is_type<ov::op::v0::Relu>(n) || ov::is_type<ov::op::v5::Round>(n) || 
+                ov::is_type<ov::op::v0::Sigmoid>(n) || ov::is_type<ov::op::v0::Sqrt>(n) || 
+                ov::is_type<ov::op::v1::Subtract>(n) || ov::is_type<ov::op::v4::Swish>(n) || 
+                ov::is_type<ov::op::v0::Tanh>(n));
 #else
         // CPU Plugin support Swish in Subgraph via conversion to SwichCPU which assumes second input to be constant,
         // and CPU Plugin does not support Mish for x64

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -460,7 +460,7 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(smoke_Snippets.*\[.*\?.*\].*)");
     retVector.emplace_back(R"(smoke_Snippets_Eltwise.*\[1.1..10.1..8.1..4\].*)");
     // smoke_Snippets test cases are not supported on arm64 platforms, except for smoke_Snippets_Eltwise
-    retVector.emplace_back(R"(smoke_Snippets(?!_Eltwise|_Convert).*)");
+    retVector.emplace_back(R"(smoke_Snippets(?!_Eltwise|_Convert|_FQDecomposition_).*)");
     // arm snippets doesn't support sve_128 that required by dnnl injector jit_uni_eltwise_injector_f32 yet
     retVector.emplace_back(R"(smoke_Snippets_Eltwise_TwoResults.*)");
     retVector.emplace_back(R"(smoke_Snippets_Eltwise/TwoInputsAndOutputs.*)");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fake_quantize_decomposition_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fake_quantize_decomposition_test.cpp
@@ -73,7 +73,6 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(testValuesDecompositionScalars),
         ::testing::ValuesIn(operations),
-        // reorder (nChw[16|8]c) + MaxPool + Subgraph + reorder(nchw)
         ::testing::Values(std::pair<size_t, size_t>{1, 1}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
@@ -84,7 +83,6 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(testValuesDecompositionPerChannel),
         ::testing::ValuesIn(operations),
-        // reorder (nChw[16|8]c) + MaxPool + reorder(nChw[16|8]c) x6 + Subgraph + reorder(nchw)
         ::testing::Values(std::pair<size_t, size_t>{1, 1}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
@@ -95,13 +93,12 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(testValuesDecompositionPerChannelInput),
         ::testing::ValuesIn(operations),
-        // reorder (nChw[16|8]c) + MaxPool + reorder(nChw[16|8]c) x4 + Subgraph + reorder(nchw)
         ::testing::Values(std::pair<size_t, size_t>{1, 1}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
 }  // namespace decompositionInSubgraph
 
-
+#ifdef OPENVINO_ARCH_X86_64
 namespace legacyFuse {
 const std::vector<TestValues> testValuesLegacyFuse = {
     {
@@ -138,7 +135,6 @@ std::vector<std::pair<std::shared_ptr<ov::Node>, std::pair<std::string, std::str
     {std::make_shared<ov::op::v1::Convolution>(), {"Convolution", "Convolution,fakeQuantize"}},
 };
 
-#ifdef OPENVINO_ARCH_X86_64
 INSTANTIATE_TEST_SUITE_P(
     smoke_Snippets,
     FakeQuantizeDecompositionTest,
@@ -149,7 +145,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(std::pair<size_t, size_t>{5, 0}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
-#endif
 }  // namespace legacyFuse
+#endif
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fake_quantize_decomposition_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fake_quantize_decomposition_test.cpp
@@ -74,7 +74,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(testValuesDecompositionScalars),
         ::testing::ValuesIn(operations),
         // reorder (nChw[16|8]c) + MaxPool + Subgraph + reorder(nchw)
-        ::testing::Values(std::pair<size_t, size_t>{4, 1}),
+        ::testing::Values(std::pair<size_t, size_t>{1, 1}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
 
@@ -85,7 +85,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(testValuesDecompositionPerChannel),
         ::testing::ValuesIn(operations),
         // reorder (nChw[16|8]c) + MaxPool + reorder(nChw[16|8]c) x6 + Subgraph + reorder(nchw)
-        ::testing::Values(std::pair<size_t, size_t>{10, 1}),
+        ::testing::Values(std::pair<size_t, size_t>{1, 1}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
 
@@ -96,7 +96,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::ValuesIn(testValuesDecompositionPerChannelInput),
         ::testing::ValuesIn(operations),
         // reorder (nChw[16|8]c) + MaxPool + reorder(nChw[16|8]c) x4 + Subgraph + reorder(nchw)
-        ::testing::Values(std::pair<size_t, size_t>{8, 1}),
+        ::testing::Values(std::pair<size_t, size_t>{1, 1}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
 }  // namespace decompositionInSubgraph
@@ -138,6 +138,7 @@ std::vector<std::pair<std::shared_ptr<ov::Node>, std::pair<std::string, std::str
     {std::make_shared<ov::op::v1::Convolution>(), {"Convolution", "Convolution,fakeQuantize"}},
 };
 
+#ifdef OPENVINO_ARCH_X86_64
 INSTANTIATE_TEST_SUITE_P(
     smoke_Snippets,
     FakeQuantizeDecompositionTest,
@@ -148,7 +149,7 @@ INSTANTIATE_TEST_SUITE_P(
         ::testing::Values(std::pair<size_t, size_t>{5, 0}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
-
+#endif
 }  // namespace legacyFuse
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fake_quantize_decomposition_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/fake_quantize_decomposition_test.cpp
@@ -141,8 +141,8 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Combine(
         ::testing::ValuesIn(testValuesLegacyFuse),
         ::testing::ValuesIn(operations),
-        // reorder (nChw[16|8]c) + MaxPool + reorder(nhwc) + Convolution(with internal weight reordering) + reorder(nchw)
-        ::testing::Values(std::pair<size_t, size_t>{5, 0}),
+        // reorder (nChw[16|8]c) + Convolution(with internal weight reordering) + reorder(nchw)
+        ::testing::Values(std::pair<size_t, size_t>{3, 0}),
         ::testing::Values(ov::test::utils::DEVICE_CPU)),
     FakeQuantizeDecompositionTest::getTestCaseName);
 }  // namespace legacyFuse

--- a/src/tests/functional/plugin/shared/src/snippets/fake_quantize_decomposition_test.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/fake_quantize_decomposition_test.cpp
@@ -61,7 +61,7 @@ void FakeQuantizeDecompositionTest::SetUp() {
         values.inputType,
         values.fakeQuantizeShapes,
         values.zeroPoint,
-        ov::test::snippets::FunctionHelper::makePrerequisitesOriginal(),
+        {},
         op);
 }
 


### PR DESCRIPTION
### Details:
 - **Enabled tests for FakeQuantizeDecomposition** in `src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp`
 - **Enabled FakeQuantize op tokenization** by adding it in `is_supported_op` in `transformation_pipeline.cpp`
 - Updated `FakeQuantizeDecompositionTest::SetUp()`, replaced MaxPool ops (`makePrerequisitesOriginal()`) with empty vector due to outdated limitations in Snippets, to support the operation in AArch64 platforms. 
 -  Adjusted expected node counts in tests since `reorder` ops are missed in AArch64 platforms and disabled `legacyFuse` tests for non-x64 platforms.
 
 ### Tests
 
<img width="873" alt="Screenshot 2025-01-27 at 4 53 59 PM" src="https://github.com/user-attachments/assets/8184923e-85bb-45c0-bbca-59db7e6a5381" />
Passed local tests


### Tickets:
 - Closes #28508 
