### PR TITLE
[GPU] Added missing kv_cache_precision property to supported list

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -282,6 +282,7 @@ ov::Any CompiledModel::get_property(const std::string& name) const {
             ov::PropertyName{ov::hint::inference_precision.name(), PropertyMutability::RO},
             ov::PropertyName{ov::hint::dynamic_quantization_group_size.name(), PropertyMutability::RO},
             ov::PropertyName{ov::hint::activations_scale_factor.name(), PropertyMutability::RO},
+            ov::PropertyName{ov::hint::kv_cache_precision.name(), PropertyMutability::RO},
             ov::PropertyName{ov::device::id.name(), PropertyMutability::RO},
             ov::PropertyName{ov::execution_devices.name(), PropertyMutability::RO},
         };


### PR DESCRIPTION
### Details:
 - kv_cache_precision hint was missing in the list of supported_properties for compiled model impl while get_property call actually worked.

### Tickets:
 - *CVS-161323*
