### PR TITLE
[Py OV] Update samples to use __version__ instead of get_version()

### DIFF
--- a/samples/python/benchmark/bert_benchmark/README.md
+++ b/samples/python/benchmark/bert_benchmark/README.md
@@ -12,7 +12,7 @@ The following Python API is used in the application:
 
 | Feature                  | API                                             | Description                                  |
 | -------------------------| ------------------------------------------------|----------------------------------------------|
-| OpenVINO API Version     | [openvino.__version__]                          | Get Openvino API version.                    |
+| OpenVINO API Version     | [openvino.\_\_version__]                          | Get Openvino API version.                    |
 | Basic Infer Flow         | [openvino.runtime.Core],                        | Common API to do inference: compile a model. |
 |                          | [openvino.runtime.Core.compile_model]           |                                              |
 | Asynchronous Infer       | [openvino.runtime.AsyncInferQueue],             | Do asynchronous inference.                   |

--- a/samples/python/benchmark/bert_benchmark/README.md
+++ b/samples/python/benchmark/bert_benchmark/README.md
@@ -12,7 +12,7 @@ The following Python API is used in the application:
 
 | Feature                  | API                                             | Description                                  |
 | -------------------------| ------------------------------------------------|----------------------------------------------|
-| OpenVINO Runtime Version | [openvino.runtime.get_version]                  | Get Openvino API version.                    |
+| OpenVINO API Version     | [openvino.__version__]                          | Get Openvino API version.                    |
 | Basic Infer Flow         | [openvino.runtime.Core],                        | Common API to do inference: compile a model. |
 |                          | [openvino.runtime.Core.compile_model]           |                                              |
 | Asynchronous Infer       | [openvino.runtime.AsyncInferQueue],             | Do asynchronous inference.                   |

--- a/samples/python/benchmark/bert_benchmark/bert_benchmark.py
+++ b/samples/python/benchmark/bert_benchmark/bert_benchmark.py
@@ -11,7 +11,6 @@ from time import perf_counter
 
 import openvino as ov
 import datasets
-from openvino import get_version
 from transformers import AutoTokenizer
 from transformers.onnx import export
 from transformers.onnx.features import FeaturesManager
@@ -20,7 +19,7 @@ from transformers.onnx.features import FeaturesManager
 def main():
     log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
     log.info('OpenVINO:')
-    log.info(f"{'Build ':.<39} {get_version()}")
+    log.info(f"{'Build ':.<39} {ov.__version__}")
     model_name = 'bert-base-uncased'
     # Download the model
     transformers_model = FeaturesManager.get_model_from_feature('default', model_name)

--- a/samples/python/benchmark/sync_benchmark/README.md
+++ b/samples/python/benchmark/sync_benchmark/README.md
@@ -19,7 +19,7 @@ The following Python API is used in the application:
 
 | Feature                   | API                                             | Description                                  |
 | --------------------------| ------------------------------------------------|----------------------------------------------|
-| OpenVINO API Version      | [openvino.__version__]                          | Get Openvino API version.                    |
+| OpenVINO API Version      | [openvino.\_\_version__]                          | Get Openvino API version.                    |
 | Basic Infer Flow          | [openvino.runtime.Core],                        | Common API to do inference: compile a model, |
 |                           | [openvino.runtime.Core.compile_model],          | configure input tensors.                     |
 |                           | [openvino.runtime.InferRequest.get_tensor]      |                                              |

--- a/samples/python/benchmark/sync_benchmark/README.md
+++ b/samples/python/benchmark/sync_benchmark/README.md
@@ -19,7 +19,7 @@ The following Python API is used in the application:
 
 | Feature                   | API                                             | Description                                  |
 | --------------------------| ------------------------------------------------|----------------------------------------------|
-| OpenVINO Runtime Version  | [openvino.runtime.get_version]                  | Get Openvino API version.                    |
+| OpenVINO API Version      | [openvino.__version__]                          | Get Openvino API version.                    |
 | Basic Infer Flow          | [openvino.runtime.Core],                        | Common API to do inference: compile a model, |
 |                           | [openvino.runtime.Core.compile_model],          | configure input tensors.                     |
 |                           | [openvino.runtime.InferRequest.get_tensor]      |                                              |

--- a/samples/python/benchmark/sync_benchmark/sync_benchmark.py
+++ b/samples/python/benchmark/sync_benchmark/sync_benchmark.py
@@ -10,7 +10,6 @@ from time import perf_counter
 
 import numpy as np
 import openvino as ov
-from openvino import get_version
 from openvino.utils.types import get_dtype
 
 
@@ -29,7 +28,7 @@ def fill_tensor_random(tensor):
 def main():
     log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
     log.info('OpenVINO:')
-    log.info(f"{'Build ':.<39} {get_version()}")
+    log.info(f"{'Build ':.<39} {ov.__version__}")
     device_name = 'CPU'
     if len(sys.argv) == 3:
         device_name = sys.argv[2]

--- a/samples/python/benchmark/throughput_benchmark/README.md
+++ b/samples/python/benchmark/throughput_benchmark/README.md
@@ -21,7 +21,7 @@ The following Python API is used in the application:
 
 | Feature                   | API                                             | Description                                  |
 | --------------------------| ------------------------------------------------|----------------------------------------------|
-| OpenVINO API Version      | [openvino.__version__]                          | Get Openvino API version.                    |
+| OpenVINO API Version      | [openvino.\_\_version__]                          | Get Openvino API version.                    |
 | Basic Infer Flow          | [openvino.runtime.Core],                        | Common API to do inference: compile a model, |
 |                           | [openvino.runtime.Core.compile_model]           | configure input tensors.                     |
 |                           | [openvino.runtime.InferRequest.get_tensor]      |                                              |

--- a/samples/python/benchmark/throughput_benchmark/README.md
+++ b/samples/python/benchmark/throughput_benchmark/README.md
@@ -21,7 +21,7 @@ The following Python API is used in the application:
 
 | Feature                   | API                                             | Description                                  |
 | --------------------------| ------------------------------------------------|----------------------------------------------|
-| OpenVINO Runtime Version  | [openvino.runtime.get_version]                  | Get Openvino API version.                    |
+| OpenVINO API Version      | [openvino.__version__]                          | Get Openvino API version.                    |
 | Basic Infer Flow          | [openvino.runtime.Core],                        | Common API to do inference: compile a model, |
 |                           | [openvino.runtime.Core.compile_model]           | configure input tensors.                     |
 |                           | [openvino.runtime.InferRequest.get_tensor]      |                                              |

--- a/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
+++ b/samples/python/benchmark/throughput_benchmark/throughput_benchmark.py
@@ -10,7 +10,6 @@ from time import perf_counter
 
 import numpy as np
 import openvino as ov
-from openvino import get_version
 from openvino.utils.types import get_dtype
 
 
@@ -29,7 +28,7 @@ def fill_tensor_random(tensor):
 def main():
     log.basicConfig(format='[ %(levelname)s ] %(message)s', level=log.INFO, stream=sys.stdout)
     log.info('OpenVINO:')
-    log.info(f"{'Build ':.<39} {get_version()}")
+    log.info(f"{'Build ':.<39} {ov.__version__}")
     device_name = 'CPU'
     if len(sys.argv) == 3:
         device_name = sys.argv[2]


### PR DESCRIPTION
### Details:
 - Change `get_version()` to `__version__`
 - Discussed [here](https://github.com/openvinotoolkit/openvino/pull/28341#discussion_r1908609241)


### Tickets:
 - [CVS-160332](https://jira.devtools.intel.com/browse/CVS-160332)
