### PR TITLE
Enable GIT_TRACE for clone step in Fedora 29 workflow

### DIFF
--- a/.github/workflows/job_build_linux.yml
+++ b/.github/workflows/job_build_linux.yml
@@ -91,7 +91,7 @@ jobs:
       PRODUCT_TYPE: public_linux_${{ inputs.os }}_${{ inputs.arch }}_release
     steps:
       - name: Clone OpenVINO (with trace)
-        if: {{ inputs.os == 'fedora_29' }} # to debug ticket 160901
+        if: ${{ inputs.os == 'fedora_29' }} # to debug ticket 160901
         env:
           GIT_TRACE: 1
           GIT_TRACE_PERFORMANCE: 1
@@ -103,7 +103,7 @@ jobs:
           submodules: 'true'
 
       - name: Clone OpenVINO
-        if: {{ inputs.os != 'fedora_29' }}
+        if: ${{ inputs.os != 'fedora_29' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 15
         with:

--- a/.github/workflows/job_build_linux.yml
+++ b/.github/workflows/job_build_linux.yml
@@ -90,7 +90,20 @@ jobs:
       MANIFEST_PATH: '/__w/openvino/openvino/manifest.yml'
       PRODUCT_TYPE: public_linux_${{ inputs.os }}_${{ inputs.arch }}_release
     steps:
+      - name: Clone OpenVINO (with trace)
+        if: {{ inputs.os == 'fedora_29' }} # to debug ticket 160901
+        env:
+          GIT_TRACE: 1
+          GIT_TRACE_PERFORMANCE: 1
+          GIT_CURL_VERBOSE: 1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        timeout-minutes: 15
+        with:
+          path: ${{ env.OPENVINO_REPO }}
+          submodules: 'true'
+
       - name: Clone OpenVINO
+        if: {{ inputs.os != 'fedora_29' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         timeout-minutes: 15
         with:
@@ -182,23 +195,23 @@ jobs:
           cmake --install . --config ${{ env.CMAKE_BUILD_TYPE }} --prefix ${INSTALL_TEST_DIR} --component tests
           cmake --install . --config ${{ env.CMAKE_BUILD_TYPE }} --prefix ${DEVELOPER_PACKAGE_DIR} --component developer_package
         working-directory: ${{ env.BUILD_DIR }}
-          
+
       - name: Pack openvino_package
         run: tar -cvf - * | pigz > ${BUILD_DIR}/openvino_package.tar.gz
         working-directory: ${{ env.INSTALL_DIR }}
-        
+
       - name: Pack openvino_developer_package
         run: tar -cvf - * | pigz > ${BUILD_DIR}/openvino_developer_package.tar.gz
         working-directory: ${{ env.DEVELOPER_PACKAGE_DIR }}
-        
+
       - name: Pack openvino_tests
         run: tar -cvf - * | pigz > ${BUILD_DIR}/openvino_tests.tar.gz
         working-directory: ${{ env.INSTALL_TEST_DIR }}
-      
+
       - name: Build Debian packages
         if: ${{ inputs.build-debian-packages }}
         run: |
-          # Ubuntu 24 does not allow using the system Python directly so 
+          # Ubuntu 24 does not allow using the system Python directly so
           # we have to use Python from the virtual environment created in Docker
           [[ ${{ inputs.os }} == "ubuntu_24_04" ]] && python_exec=/venv/bin/python3 || python_exec=/usr/bin/python3
           $python_exec -m pip install -U pip
@@ -234,7 +247,7 @@ jobs:
                 -DENABLE_WHEEL=OFF
           cmake --build ${BUILD_DIR} --parallel $(nproc)
           cmake --install ${BUILD_DIR} --prefix ${INSTALL_DIR_JS}
-      
+
       - name: Pack openvino_js_package
         if: ${{ fromJSON(inputs.affected-components).JS_API && inputs.build-js }}
         run: tar -cvf - * | pigz > ${BUILD_DIR}/openvino_js_package.tar.gz
@@ -270,7 +283,7 @@ jobs:
           name: openvino_package
           path: ${{ env.BUILD_DIR }}/openvino_package.tar.gz
           if-no-files-found: 'error'
-          
+
       - name: Upload openvino wheels
         if: ${{ inputs.os != 'debian_10' && inputs.arch != 'arm' }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
@@ -278,7 +291,7 @@ jobs:
           name: openvino_wheels
           path: ${{ env.INSTALL_WHEELS_DIR }}/wheels/*.whl
           if-no-files-found: 'error'
-        
+
       - name: Upload openvino js package
         if: ${{ fromJSON(inputs.affected-components).JS_API && inputs.build-js }}
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,6 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch<=2.5.1; python_version <= '3.9'
-torch>=1.13; python_version > '3.9'
+torch>=1.13
 torchvision; platform_machine == 'arm64' and python_version >= '3.9'
 torchvision; platform_machine != 'arm64'
 pillow>=9.0

--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.13
+torch<=2.5.1; python_version <= '3.9'
+torch>=1.13; python_version > '3.9'
 torchvision; platform_machine == 'arm64' and python_version >= '3.9'
 torchvision; platform_machine != 'arm64'
 pillow>=9.0


### PR DESCRIPTION
### Details:
Trying to get more information about git clone hangs in Fedora 29 workflow

### Tickets:
 - *160901*
