### PR TITLE
More strict dependencies for PyTorch in torchvision preprocess

### DIFF
--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,4 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
+networkx<=3.2.1; python_version <= '3.9'
 torch<=2.5.1; python_version <= '3.9'
 torch>=1.13; python_version > '3.9'
 torchvision<=0.20.1; python_version <= '3.9'

--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch<=2.5.1; python_version <= '3.9'
 torch>=1.13; python_version > '3.9'
-torchvision; platform_machine == 'arm64' and python_version >= '3.9'
+torchvision; platform_machine == 'arm64' and python_version > '3.9'
+torchvision<=0.20.1; python_version <= '3.9'
 torchvision; platform_machine != 'arm64'
 pillow>=9.0

--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,7 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch<=2.5.1; python_version <= '3.9'
 torch>=1.13; python_version > '3.9'
-torchvision; platform_machine == 'arm64' and python_version > '3.9'
 torchvision<=0.20.1; python_version <= '3.9'
-torchvision; platform_machine != 'arm64'
+torchvision; python_version > '3.9'
 pillow>=9.0

--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.13
+torch<=2.5.1; python_version <= '3.9'
+torch>=1.13; python_version > '3.9'
 torchvision; platform_machine == 'arm64' and python_version >= '3.9'
 torchvision; platform_machine != 'arm64'
 pillow>=9.0


### PR DESCRIPTION
### Details:
Old dependencies started to cause issues after Torch 2.6.0 got released
