### PR TITLE
Backport to 2025.0 - More strict dependencies for PyTorch in torchvision preprocess

### DIFF
--- a/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
+++ b/src/bindings/python/src/openvino/preprocess/torchvision/requirements.txt
@@ -1,5 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.13
-torchvision; platform_machine == 'arm64' and python_version >= '3.9'
-torchvision; platform_machine != 'arm64'
+networkx<=3.2.1; python_version <= '3.9'
+torch<=2.5.1; python_version <= '3.9'
+torch>=1.13; python_version > '3.9'
+torchvision<=0.20.1; python_version <= '3.9'
+torchvision; python_version > '3.9'
 pillow>=9.0


### PR DESCRIPTION
### Details:
Backport of https://github.com/openvinotoolkit/openvino/pull/28722