### PR TITLE
[DO NOT MERGE] [NPU] Using global command queue

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -57,7 +57,6 @@ protected:
      */
     size_t _number_of_command_lists;
 
-    CommandQueueManager _command_queue_manager;
     std::shared_ptr<CommandQueue> _command_queue;
     std::vector<std::unique_ptr<CommandList>> _command_lists;
     std::vector<std::unique_ptr<Fence>> _fences;

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -27,7 +27,7 @@ public:
 
     Pipeline(const Pipeline&) = delete;
     Pipeline& operator=(const Pipeline&) = delete;
-    ~Pipeline();
+    virtual ~Pipeline() = default;
 
     void push();
     void pull();
@@ -66,11 +66,7 @@ protected:
     std::shared_ptr<zeroProfiling::NpuInferProfiling> _npu_profiling;
     Logger _logger;
 
-    uint32_t _group_ordinal;
     std::mutex _mutex;
-    bool _turbo = false;
-    ze_command_queue_priority_t _ze_queue_priority;
-    std::optional<ze_command_queue_workload_type_t> _ze_workload_type = std::nullopt;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -57,7 +57,7 @@ protected:
      */
     size_t _number_of_command_lists;
 
-    CommandQueueFactory _command_queue_factory;
+    CommandQueueManager _command_queue_manager;
     std::shared_ptr<CommandQueue> _command_queue;
     std::vector<std::unique_ptr<CommandList>> _command_lists;
     std::vector<std::unique_ptr<Fence>> _fences;
@@ -68,7 +68,6 @@ protected:
     Logger _logger;
 
     uint32_t _group_ordinal;
-    bool _fences_are_created = false;
     std::mutex _mutex;
     bool _turbo = false;
     ze_command_queue_priority_t _ze_queue_priority;

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -27,7 +27,7 @@ public:
 
     Pipeline(const Pipeline&) = delete;
     Pipeline& operator=(const Pipeline&) = delete;
-    virtual ~Pipeline() = default;
+    ~Pipeline();
 
     void push();
     void pull();
@@ -40,6 +40,9 @@ public:
     void closeCommandListIndex(size_t command_list_index);
 
 protected:
+    void getCommandQueue();
+
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
     std::shared_ptr<IGraph> _graph;
     const Config _config;
     const uint32_t _id;
@@ -54,14 +57,22 @@ protected:
      */
     size_t _number_of_command_lists;
 
+    CommandQueueFactory _command_queue_factory;
     std::shared_ptr<CommandQueue> _command_queue;
     std::vector<std::unique_ptr<CommandList>> _command_lists;
     std::vector<std::unique_ptr<Fence>> _fences;
     std::shared_ptr<EventPool> _event_pool;
     std::vector<std::shared_ptr<Event>> _events;
-    bool sync_output_with_fences_ = true;
+    bool _sync_output_with_fences = true;
     std::shared_ptr<zeroProfiling::NpuInferProfiling> _npu_profiling;
     Logger _logger;
+
+    uint32_t _group_ordinal;
+    bool _fences_are_created = false;
+    std::mutex _mutex;
+    bool _turbo = false;
+    ze_command_queue_priority_t _ze_queue_priority;
+    std::optional<ze_command_queue_workload_type_t> _ze_workload_type = std::nullopt;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -311,14 +311,16 @@ void Pipeline::closeCommandListIndex(size_t command_list_index) {
 
 Pipeline::~Pipeline() {
     // fences shall be destroyed before the command queue is destroyed
-    if (_sync_output_with_fences) {
-        for (size_t i = 0; i < _number_of_command_lists; i++) {
-            _fences[i].reset();
+    if (_command_queue) {
+        if (_sync_output_with_fences) {
+            for (size_t i = 0; i < _number_of_command_lists; i++) {
+                _fences[i].reset();
+            }
         }
-    }
 
-    _command_queue.reset();
-    _command_queue_factory.freeCommandQueue(_ze_queue_priority, _ze_workload_type, _turbo);
+        _command_queue.reset();
+        _command_queue_factory.freeCommandQueue(_ze_queue_priority, _ze_workload_type, _turbo);
+    }
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -42,9 +42,8 @@ public:
 
     const std::vector<ArgumentDescriptor>& get_input_descriptors() const;
     const std::vector<ArgumentDescriptor>& get_output_descriptors() const;
-    const std::shared_ptr<CommandQueue>& get_command_queue() const;
 
-    void set_workload_type(const ov::WorkloadType workloadType) const;
+    void set_workload_type(const ov::WorkloadType workloadType);
 
     std::mutex& get_mutex();
 
@@ -56,6 +55,7 @@ public:
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
+    const std::optional<ze_command_queue_workload_type_t> get_ze_workload_type() const;
 
 protected:
     /**
@@ -83,7 +83,6 @@ protected:
     std::vector<ArgumentDescriptor> _input_descriptors;
     std::vector<ArgumentDescriptor> _output_descriptors;
 
-    std::shared_ptr<CommandQueue> _command_queue;
     std::vector<std::shared_ptr<Event>> _last_submitted_event;
 
     // Used to protect zero pipeline creation in the graph. The pipeline should be created only once per graph when the
@@ -100,6 +99,8 @@ protected:
      * @details The attribute contains a value only if the plugin performs the batches splitting operation.
      */
     std::optional<std::size_t> _batch_size = std::nullopt;
+
+    std::optional<ze_command_queue_workload_type_t> _ze_workload_type = std::nullopt;
 
     Logger _logger;
 };

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -44,6 +44,7 @@ public:
     const std::vector<ArgumentDescriptor>& get_output_descriptors() const;
 
     void set_workload_type(const ov::WorkloadType workloadType);
+    const std::optional<ze_command_queue_workload_type_t> get_ze_workload_type() const;
 
     std::mutex& get_mutex();
 
@@ -55,7 +56,6 @@ public:
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
-    const std::optional<ze_command_queue_workload_type_t> get_ze_workload_type() const;
 
 protected:
     /**

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -45,7 +45,7 @@ public:
 
     const std::shared_ptr<CommandQueue>& get_command_queue() const;
 
-    void set_workload_type(const ov::WorkloadType workloadType);
+    virtual void set_workload_type(const ov::WorkloadType workloadType) = 0;
 
     std::mutex& get_mutex();
 
@@ -105,7 +105,7 @@ protected:
 
     std::shared_ptr<CommandQueue> _command_queue;
     uint32_t _group_ordinal;
-    std::optional<ze_command_queue_workload_type_t> _ze_workload_type = std::nullopt;
+    ze_command_queue_workload_type_t _ze_workload_type;
     bool _turbo = false;
     ze_command_queue_priority_t _ze_queue_priority;
 

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -21,11 +21,7 @@ IGraph::IGraph(ze_graph_handle_t handle,
     : _handle(handle),
       _metadata(std::move(metadata)),
       _blobPtr(std::move(blobPtr)),
-      _logger("IGraph", config.get<LOG_LEVEL>()) {
-    if (config.has<WORKLOAD_TYPE>()) {
-        set_workload_type(config.get<WORKLOAD_TYPE>());
-    }
-}
+      _logger("IGraph", config.get<LOG_LEVEL>()) {}
 
 const NetworkMetadata& IGraph::get_metadata() const {
     return _metadata;
@@ -47,8 +43,16 @@ const std::vector<ArgumentDescriptor>& IGraph::get_output_descriptors() const {
     return _output_descriptors;
 }
 
+const std::shared_ptr<CommandQueue>& IGraph::get_command_queue() const {
+    return _command_queue;
+}
+
 void IGraph::set_workload_type(const ov::WorkloadType workloadType) {
-    _ze_workload_type = zeroUtils::toZeQueueWorkloadType(workloadType);
+    if (_command_queue) {
+        _ze_workload_type = zeroUtils::toZeQueueWorkloadType(workloadType);
+
+        create_new_command_queue();
+    }
 }
 
 std::mutex& IGraph::get_mutex() {
@@ -135,10 +139,6 @@ std::optional<size_t> IGraph::get_batch_size(const NetworkMetadata& metadata) {
 
 const std::optional<std::size_t> IGraph::get_batch_size() const {
     return _batch_size;
-}
-
-const std::optional<ze_command_queue_workload_type_t> IGraph::get_ze_workload_type() const {
-    return _ze_workload_type;
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -47,14 +47,6 @@ const std::shared_ptr<CommandQueue>& IGraph::get_command_queue() const {
     return _command_queue;
 }
 
-void IGraph::set_workload_type(const ov::WorkloadType workloadType) {
-    if (_command_queue) {
-        _ze_workload_type = zeroUtils::toZeQueueWorkloadType(workloadType);
-
-        create_new_command_queue();
-    }
-}
-
 std::mutex& IGraph::get_mutex() {
     return _mutex;
 }

--- a/src/plugins/intel_npu/src/compiler_adapter/include/driver_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/driver_graph.hpp
@@ -32,6 +32,8 @@ public:
 
     void initialize(const Config& config) override;
 
+    void set_workload_type(const ov::WorkloadType workloadType) override;
+
     ~DriverGraph() override;
 
 private:

--- a/src/plugins/intel_npu/src/compiler_adapter/include/driver_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/driver_graph.hpp
@@ -37,6 +37,8 @@ public:
 private:
     bool release_blob(const Config& config);
 
+    void create_new_command_queue() override;
+
     std::shared_ptr<ZeGraphExtWrappers> _zeGraphExt;
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/plugin_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/plugin_graph.hpp
@@ -35,6 +35,8 @@ public:
 
     void initialize(const Config& config) override;
 
+    void set_workload_type(const ov::WorkloadType workloadType) override;
+
     ~PluginGraph() override;
 
 private:

--- a/src/plugins/intel_npu/src/compiler_adapter/include/plugin_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/plugin_graph.hpp
@@ -38,6 +38,8 @@ public:
     ~PluginGraph() override;
 
 private:
+    void create_new_command_queue() override;
+
     std::shared_ptr<ZeGraphExtWrappers> _zeGraphExt;
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/ze_graph_ext_wrappers.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/ze_graph_ext_wrappers.hpp
@@ -48,7 +48,7 @@ public:
 
     void setGraphArgumentValue(ze_graph_handle_t graphHandle, uint32_t argi_, const void* argv) const;
 
-    void initializeGraph(ze_graph_handle_t graphHandle, const Config& config) const;
+    void initializeGraph(ze_graph_handle_t graphHandle) const;
 
 private:
     std::unordered_set<std::string> getQueryResultFromSupportedLayers(
@@ -60,7 +60,7 @@ private:
                      std::vector<IODescriptor>& inputs,
                      std::vector<IODescriptor>& outputs) const;
 
-    void initialize_graph_through_command_list(ze_graph_handle_t graphHandle, const Config& config) const;
+    void initialize_graph_through_command_list(ze_graph_handle_t graphHandle) const;
 
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
     uint32_t _graphExtVersion;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_graph.cpp
@@ -103,23 +103,8 @@ void DriverGraph::initialize(const Config& config) {
     deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     THROW_ON_FAIL_FOR_LEVELZERO("zeDeviceGetProperties",
                                 zeDeviceGetProperties(_zeroInitStruct->getDevice(), &deviceProperties));
-    auto groupOrdinal = zeroUtils::findGroupOrdinal(_zeroInitStruct->getDevice(), deviceProperties);
 
-    bool turbo = false;
-    if (config.has<TURBO>()) {
-        turbo = config.get<TURBO>();
-    }
-
-    _command_queue = std::make_shared<CommandQueue>(_zeroInitStruct,
-                                                    zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
-                                                    groupOrdinal,
-                                                    turbo);
-
-    if (config.has<WORKLOAD_TYPE>()) {
-        set_workload_type(config.get<WORKLOAD_TYPE>());
-    }
-
-    _zeGraphExt->initializeGraph(_handle, config);
+    _zeGraphExt->initializeGraph(_handle);
 
     _logger.debug("Graph initialize finish");
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_graph.cpp
@@ -115,8 +115,12 @@ void PluginGraph::initialize(const Config& config) {
     }
 
     if (config.has<WORKLOAD_TYPE>()) {
-        _ze_workload_type = zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>());
+        if (!_zeroInitStruct->getCommandQueueDdiTable().version()) {
+            OPENVINO_THROW("The WorkloadType property is not supported by the current Driver Version!");
+        }
     }
+
+    _ze_workload_type = zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>());
 
     create_new_command_queue();
 
@@ -131,6 +135,18 @@ void PluginGraph::initialize(const Config& config) {
     }
 
     _logger.debug("Graph initialize finish");
+}
+
+void PluginGraph::set_workload_type(const ov::WorkloadType workloadType) {
+    if (!_zeroInitStruct->getCommandQueueDdiTable().version()) {
+        OPENVINO_THROW("The WorkloadType property is not supported by the current Driver Version!");
+    }
+
+    _ze_workload_type = zeroUtils::toZeQueueWorkloadType(workloadType);
+
+    if (_command_queue) {
+        create_new_command_queue();
+    }
 }
 
 void PluginGraph::create_new_command_queue() {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_graph.cpp
@@ -103,23 +103,8 @@ void PluginGraph::initialize(const Config& config) {
     deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     THROW_ON_FAIL_FOR_LEVELZERO("zeDeviceGetProperties",
                                 zeDeviceGetProperties(_zeroInitStruct->getDevice(), &deviceProperties));
-    auto groupOrdinal = zeroUtils::findGroupOrdinal(_zeroInitStruct->getDevice(), deviceProperties);
 
-    bool turbo = false;
-    if (config.has<TURBO>()) {
-        turbo = config.get<TURBO>();
-    }
-
-    _command_queue = std::make_shared<CommandQueue>(_zeroInitStruct,
-                                                    zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
-                                                    groupOrdinal,
-                                                    turbo);
-
-    if (config.has<WORKLOAD_TYPE>()) {
-        set_workload_type(config.get<WORKLOAD_TYPE>());
-    }
-
-    _zeGraphExt->initializeGraph(_handle, config);
+    _zeGraphExt->initializeGraph(_handle);
 
     if (config.get<BATCH_MODE>() != ov::intel_npu::BatchMode::COMPILER) {
         _batch_size = get_batch_size(_metadata);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -192,7 +192,8 @@ void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t
     _logger.debug("initialize_graph_through_command_list init start - create graph_command_list");
     CommandList graph_command_list(_zeroInitStruct, groupOrdinal);
     _logger.debug("initialize_graph_through_command_list - create graph_command_queue");
-    CommandQueue graph_command_queue(_zeroInitStruct, ZE_COMMAND_QUEUE_PRIORITY_NORMAL, groupOrdinal, false);
+    auto graph_command_queue =
+        std::make_shared<CommandQueue>(_zeroInitStruct, ZE_COMMAND_QUEUE_PRIORITY_NORMAL, groupOrdinal, false);
     _logger.debug("initialize_graph_through_command_list - create fence");
     Fence fence(graph_command_queue);
 
@@ -202,7 +203,7 @@ void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t
     graph_command_list.close();
 
     _logger.debug("initialize_graph_through_command_list - performing executeCommandList");
-    graph_command_queue.executeCommandList(graph_command_list, fence);
+    graph_command_queue->executeCommandList(graph_command_list, fence);
     _logger.debug("initialize_graph_through_command_list - performing hostSynchronize");
     fence.hostSynchronize();
     _logger.debug("initialize_graph_through_command_list - hostSynchronize completed");

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -192,8 +192,8 @@ void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t
     _logger.debug("initialize_graph_through_command_list init start - create graph_command_list");
     CommandList graph_command_list(_zeroInitStruct, groupOrdinal);
     _logger.debug("initialize_graph_through_command_list - create graph_command_queue");
-    auto graph_command_queue =
-        std::make_shared<CommandQueue>(_zeroInitStruct, ZE_COMMAND_QUEUE_PRIORITY_NORMAL, groupOrdinal, false);
+    CommandQueueDesc desc = {ZE_COMMAND_QUEUE_PRIORITY_NORMAL, ZE_WORKLOAD_TYPE_DEFAULT, false};
+    auto graph_command_queue = std::make_shared<CommandQueue>(_zeroInitStruct, desc, groupOrdinal);
     _logger.debug("initialize_graph_through_command_list - create fence");
     Fence fence(graph_command_queue);
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -160,10 +160,10 @@ void ZeGraphExtWrappers::setGraphArgumentValue(ze_graph_handle_t graphHandle, ui
     THROW_ON_FAIL_FOR_LEVELZERO_EXT("zeGraphSetArgumentValue", result, _zeroInitStruct->getGraphDdiTable());
 }
 
-void ZeGraphExtWrappers::initializeGraph(ze_graph_handle_t graphHandle, const Config& config) const {
+void ZeGraphExtWrappers::initializeGraph(ze_graph_handle_t graphHandle) const {
     if (_zeroInitStruct->getGraphDdiTable().version() < ZE_GRAPH_EXT_VERSION_1_8) {
         _logger.debug("Use initialize_graph_through_command_list for ext version smaller than 1.8");
-        initialize_graph_through_command_list(graphHandle, config);
+        initialize_graph_through_command_list(graphHandle);
     } else {
         _logger.debug("Initialize graph based on graph properties for ext version larger than 1.8");
         ze_graph_properties_2_t properties = {};
@@ -177,13 +177,12 @@ void ZeGraphExtWrappers::initializeGraph(ze_graph_handle_t graphHandle, const Co
         }
 
         if (properties.initStageRequired & ZE_GRAPH_STAGE_COMMAND_LIST_INITIALIZE) {
-            initialize_graph_through_command_list(graphHandle, config);
+            initialize_graph_through_command_list(graphHandle);
         }
     }
 }
 
-void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t graphHandle,
-                                                               const Config& config) const {
+void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t graphHandle) const {
     ze_device_properties_t deviceProperties = {};
     deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     THROW_ON_FAIL_FOR_LEVELZERO("zeDeviceGetProperties",

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -17,29 +17,6 @@
 
 namespace intel_npu {
 
-enum priority {
-    NORMAL,
-    LOW,
-    HIGH,
-
-    PRIORITY_COUNT
-};
-
-enum turbo {
-    DISABLED,
-    ENABLED,
-
-    TURBO_COUNT
-};
-
-enum workload {
-    NOT_SET,
-    DEFAULT,
-    EFFICIENT,
-
-    WORKLOAD_COUNT
-};
-
 struct ArgumentDescriptor {
     ze_graph_argument_properties_3_t info;
     uint32_t idx;
@@ -75,37 +52,29 @@ namespace zeroUtils {
                        ze_result_to_description(result)); \
     }
 
-static inline priority toPriorityEnum(const ze_command_queue_priority_t& val) {
+static inline size_t toPriorityVal(const ze_command_queue_priority_t& val) {
     switch (val) {
     case ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_LOW:
-        return priority::LOW;
+        return 0;
     case ZE_COMMAND_QUEUE_PRIORITY_NORMAL:
-        return priority::NORMAL;
+        return 1;
     case ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH:
-        return priority::HIGH;
+        return 2;
     default:
         OPENVINO_THROW("Incorrect queue priority.");
     }
 }
 
-static inline turbo toTurboEnum(bool val) {
-    if (val) {
-        return turbo::ENABLED;
-    }
-
-    return turbo::DISABLED;
-}
-
-static inline workload toWorkloadEnum(const std::optional<ze_command_queue_workload_type_t>& val) {
+static inline size_t toWorkloadVal(const std::optional<ze_command_queue_workload_type_t>& val) {
     if (!val.has_value()) {
-        return workload::NOT_SET;
+        return 0;
     }
 
     switch (*val) {
     case ZE_WORKLOAD_TYPE_DEFAULT:
-        return workload::DEFAULT;
+        return 1;
     case ZE_WORKLOAD_TYPE_BACKGROUND:
-        return workload::EFFICIENT;
+        return 2;
     default:
         OPENVINO_THROW("Incorrect workload type.");
     }

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -61,7 +61,7 @@ class CommandList {
 public:
     friend class CommandQueue;
     CommandList() = delete;
-    CommandList(const std::shared_ptr<ZeroInitStructsHolder>& initStructs,
+    CommandList(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                 const uint32_t& group_ordinal,
                 bool mtci_is_supported = false);
     CommandList(const CommandList&) = delete;
@@ -85,7 +85,7 @@ public:
     }
 
 private:
-    std::shared_ptr<ZeroInitStructsHolder> _initStructs;
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
 
     Logger _log;
 
@@ -147,23 +147,23 @@ static std::array<std::array<std::array<std::shared_ptr<CommandQueue>, workload:
                   priority::PRIORITY_COUNT>
     _gloabal_command_queues;
 
-class CommandQueueFactory {
+class CommandQueueManager {
 public:
-    CommandQueueFactory();
-    CommandQueueFactory(const CommandQueueFactory& other) = delete;
-    CommandQueueFactory(CommandQueueFactory&& other) = delete;
-    void operator=(const CommandQueueFactory&) = delete;
-    void operator=(CommandQueueFactory&&) = delete;
+    CommandQueueManager();
+    CommandQueueManager(const CommandQueueManager& other) = delete;
+    CommandQueueManager(CommandQueueManager&& other) = delete;
+    void operator=(const CommandQueueManager&) = delete;
+    void operator=(CommandQueueManager&&) = delete;
 
     const std::shared_ptr<CommandQueue>& getCommandQueue(
         const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
         const ze_command_queue_priority_t& priority,
-        const std::optional<ze_command_queue_workload_type_t>& workloadType,
+        const std::optional<ze_command_queue_workload_type_t>& workload_type,
         const uint32_t& group_ordinal,
         bool turbo);
 
     void freeCommandQueue(const ze_command_queue_priority_t& priority,
-                          const std::optional<ze_command_queue_workload_type_t>& workloadType,
+                          const std::optional<ze_command_queue_workload_type_t>& workload_type,
                           bool turbo);
 
 private:

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -155,11 +155,12 @@ public:
     void operator=(const CommandQueueFactory&) = delete;
     void operator=(CommandQueueFactory&&) = delete;
 
-    std::shared_ptr<CommandQueue>& getCommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-                                                   const ze_command_queue_priority_t& priority,
-                                                   const std::optional<ze_command_queue_workload_type_t>& workloadType,
-                                                   const uint32_t& group_ordinal,
-                                                   bool turbo);
+    const std::shared_ptr<CommandQueue>& getCommandQueue(
+        const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+        const ze_command_queue_priority_t& priority,
+        const std::optional<ze_command_queue_workload_type_t>& workloadType,
+        const uint32_t& group_ordinal,
+        bool turbo);
 
     void freeCommandQueue(const ze_command_queue_priority_t& priority,
                           const std::optional<ze_command_queue_workload_type_t>& workloadType,

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -145,10 +145,6 @@ private:
     ze_command_queue_handle_t _handle = nullptr;
 };
 
-static std::array<std::array<std::array<std::shared_ptr<CommandQueue>, workload::WORKLOAD_COUNT>, turbo::TURBO_COUNT>,
-                  priority::PRIORITY_COUNT>
-    _gloabal_command_queues;
-
 class CommandQueueManager {
 public:
     CommandQueueManager();
@@ -173,6 +169,10 @@ private:
     Logger _log;
 
     std::mutex _mutex;
+
+    std::array<std::array<std::array<std::shared_ptr<CommandQueue>, workload::WORKLOAD_COUNT>, turbo::TURBO_COUNT>,
+               priority::PRIORITY_COUNT>
+        _gloabal_command_queues;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -6,6 +6,8 @@
 
 #include <ze_api.h>
 
+#include <mutex>
+
 #include "intel_npu/utils/logger/logger.hpp"
 #include "intel_npu/utils/zero/zero_init.hpp"
 #include "intel_npu/utils/zero/zero_types.hpp"
@@ -155,6 +157,8 @@ public:
     void operator=(const CommandQueueManager&) = delete;
     void operator=(CommandQueueManager&&) = delete;
 
+    static CommandQueueManager& getInstance();
+
     const std::shared_ptr<CommandQueue>& getCommandQueue(
         const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
         const ze_command_queue_priority_t& priority,
@@ -168,6 +172,8 @@ public:
 
 private:
     Logger _log;
+
+    std::mutex _mutex;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -18,8 +18,8 @@ class CommandList;
 class CommandQueue;
 
 struct CommandQueueDesc {
-    size_t priority;
-    size_t workload;
+    ze_command_queue_priority_t priority;
+    ze_command_queue_workload_type_t workload;
     bool turbo;
 };
 
@@ -129,9 +129,8 @@ class CommandQueue {
 public:
     CommandQueue() = delete;
     CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-                 const ze_command_queue_priority_t& priority,
-                 const uint32_t& group_ordinal,
-                 bool turbo = false);
+                 const CommandQueueDesc desc,
+                 const uint32_t& group_ordinal);
     CommandQueue(const CommandQueue&) = delete;
     CommandQueue(CommandQueue&&) = delete;
     CommandQueue& operator=(const CommandQueue&) = delete;
@@ -165,7 +164,7 @@ public:
 
     std::shared_ptr<CommandQueue> getCommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                                                   const ze_command_queue_priority_t& priority,
-                                                  const std::optional<ze_command_queue_workload_type_t>& workload_type,
+                                                  const ze_command_queue_workload_type_t& workload_type,
                                                   const uint32_t& group_ordinal,
                                                   bool turbo);
 

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -159,12 +159,11 @@ public:
 
     static CommandQueueManager& getInstance();
 
-    const std::shared_ptr<CommandQueue>& getCommandQueue(
-        const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
-        const ze_command_queue_priority_t& priority,
-        const std::optional<ze_command_queue_workload_type_t>& workload_type,
-        const uint32_t& group_ordinal,
-        bool turbo);
+    std::shared_ptr<CommandQueue> getCommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+                                                  const ze_command_queue_priority_t& priority,
+                                                  const std::optional<ze_command_queue_workload_type_t>& workload_type,
+                                                  const uint32_t& group_ordinal,
+                                                  bool turbo);
 
     void freeCommandQueue(const ze_command_queue_priority_t& priority,
                           const std::optional<ze_command_queue_workload_type_t>& workload_type,

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_wrappers.hpp
@@ -118,7 +118,7 @@ private:
 class CommandQueue {
 public:
     CommandQueue() = delete;
-    CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& initStructs,
+    CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                  const ze_command_queue_priority_t& priority,
                  const uint32_t& group_ordinal,
                  bool turbo = false);
@@ -129,18 +129,44 @@ public:
 
     void executeCommandList(CommandList& command_list) const;
     void executeCommandList(CommandList& command_list, Fence& fence) const;
-    void setWorkloadType(ze_command_queue_workload_type_t workloadType) const;
+    void setWorkloadType(ze_command_queue_workload_type_t workload_type) const;
     ~CommandQueue();
     inline ze_command_queue_handle_t handle() const {
         return _handle;
     }
 
 private:
-    std::shared_ptr<ZeroInitStructsHolder> _initStructs;
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
 
     Logger _log;
 
     ze_command_queue_handle_t _handle = nullptr;
+};
+
+static std::array<std::array<std::array<std::shared_ptr<CommandQueue>, workload::WORKLOAD_COUNT>, turbo::TURBO_COUNT>,
+                  priority::PRIORITY_COUNT>
+    _gloabal_command_queues;
+
+class CommandQueueFactory {
+public:
+    CommandQueueFactory();
+    CommandQueueFactory(const CommandQueueFactory& other) = delete;
+    CommandQueueFactory(CommandQueueFactory&& other) = delete;
+    void operator=(const CommandQueueFactory&) = delete;
+    void operator=(CommandQueueFactory&&) = delete;
+
+    std::shared_ptr<CommandQueue>& getCommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+                                                   const ze_command_queue_priority_t& priority,
+                                                   const std::optional<ze_command_queue_workload_type_t>& workloadType,
+                                                   const uint32_t& group_ordinal,
+                                                   bool turbo);
+
+    void freeCommandQueue(const ze_command_queue_priority_t& priority,
+                          const std::optional<ze_command_queue_workload_type_t>& workloadType,
+                          bool turbo);
+
+private:
+    Logger _log;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -236,7 +236,7 @@ std::shared_ptr<CommandQueue> CommandQueueManager::getCommandQueue(
                                        [zeroUtils::toWorkloadEnum(workload_type)]
                                            ->setWorkloadType(*workload_type);
             } catch (const std::exception& ex) {
-                _log.debug("Destroy pipeline if workload type is not supported!");
+                _log.error("Destroy pipeline if workload type is not supported!");
                 _gloabal_command_queues[zeroUtils::toPriorityEnum(priority)][zeroUtils::toTurboEnum(turbo)]
                                        [zeroUtils::toWorkloadEnum(workload_type)]
                                            .reset();
@@ -255,7 +255,7 @@ void CommandQueueManager::freeCommandQueue(const ze_command_queue_priority_t& pr
 
     if (_gloabal_command_queues[zeroUtils::toPriorityEnum(priority)][zeroUtils::toTurboEnum(turbo)]
                                [zeroUtils::toWorkloadEnum(workload_type)]
-                                   .use_count() <= 1) {
+                                   .use_count() == 1) {
         _log.debug("Destroy command queue");
         _gloabal_command_queues[zeroUtils::toPriorityEnum(priority)][zeroUtils::toTurboEnum(turbo)]
                                [zeroUtils::toWorkloadEnum(workload_type)]

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -14,8 +14,8 @@ EventPool::EventPool(ze_device_handle_t device_handle, const ze_context_handle_t
                                             nullptr,
                                             ZE_EVENT_POOL_FLAG_HOST_VISIBLE,
                                             event_count};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventPoolCreate",
-                                zeEventPoolCreate(context, &event_pool_desc, 1, &device_handle, &_handle));
+    auto result = zeEventPoolCreate(context, &event_pool_desc, 1, &device_handle, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventPoolCreate", result);
 }
 EventPool::~EventPool() {
     auto result = zeEventPoolDestroy(_handle);
@@ -30,25 +30,28 @@ Event::Event(const std::shared_ptr<EventPool>& event_pool, uint32_t event_index)
     : _event_pool(event_pool),
       _log("Event", Logger::global().level()) {
     ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, event_index, 0, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventCreate", zeEventCreate(_event_pool->handle(), &event_desc, &_handle));
+    auto result = zeEventCreate(_event_pool->handle(), &event_desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventCreate", result);
 }
 void Event::AppendSignalEvent(CommandList& command_list) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendSignalEvent",
-                                zeCommandListAppendSignalEvent(command_list.handle(), _handle));
+    auto result = zeCommandListAppendSignalEvent(command_list.handle(), _handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendSignalEvent", result);
 }
 void Event::AppendWaitOnEvent(CommandList& command_list) {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWaitOnEvents",
-                                zeCommandListAppendWaitOnEvents(command_list.handle(), 1, &_handle));
+    auto result = zeCommandListAppendWaitOnEvents(command_list.handle(), 1, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWaitOnEvents", result);
 }
 void Event::AppendEventReset(CommandList& command_list) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendEventReset",
-                                zeCommandListAppendEventReset(command_list.handle(), _handle));
+    auto result = zeCommandListAppendEventReset(command_list.handle(), _handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendEventReset", result);
 }
 void Event::hostSynchronize() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostSynchronize", zeEventHostSynchronize(_handle, UINT64_MAX));
+    auto result = zeEventHostSynchronize(_handle, UINT64_MAX);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostSynchronize", result);
 }
 void Event::reset() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", zeEventHostReset(_handle));
+    auto result = zeEventHostReset(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", result);
 }
 Event::~Event() {
     auto result = zeEventDestroy(_handle);
@@ -66,24 +69,24 @@ CommandList::CommandList(const std::shared_ptr<ZeroInitStructsHolder>& init_stru
       _log("CommandList", Logger::global().level()) {
     ze_mutable_command_list_exp_desc_t mutable_desc = {ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_LIST_EXP_DESC, nullptr, 0};
     ze_command_list_desc_t desc = {ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC, &mutable_desc, group_ordinal, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO(
-        "zeCommandListCreate",
-        zeCommandListCreate(_init_structs->getContext(), _init_structs->getDevice(), &desc, &_handle));
+    auto result = zeCommandListCreate(_init_structs->getContext(), _init_structs->getDevice(), &desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListCreate", result);
 
     if (mtci_is_supported) {
         ze_mutable_command_id_exp_desc_t mutableCmdIdDesc = {ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_ID_EXP_DESC,
                                                              nullptr,
                                                              ZE_MUTABLE_COMMAND_EXP_FLAG_GRAPH_ARGUMENT};
-        THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListGetNextCommandIdExp",
-                                    zeCommandListGetNextCommandIdExp(_handle, &mutableCmdIdDesc, &_command_id));
+        result = zeCommandListGetNextCommandIdExp(_handle, &mutableCmdIdDesc, &_command_id);
+        THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListGetNextCommandIdExp", result);
     }
 }
 void CommandList::reset() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListReset", zeCommandListReset(_handle));
+    auto result = zeCommandListReset(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListReset", result);
 }
 void CommandList::appendMemoryCopy(void* dst, const void* src, const std::size_t size) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendMemoryCopy",
-                                zeCommandListAppendMemoryCopy(_handle, dst, src, size, nullptr, 0, nullptr));
+    auto result = zeCommandListAppendMemoryCopy(_handle, dst, src, size, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendMemoryCopy", result);
 }
 void CommandList::appendGraphInitialize(const ze_graph_handle_t& graph_handle) const {
     ze_result_t result =
@@ -97,14 +100,16 @@ void CommandList::appendGraphExecute(const ze_graph_handle_t& graph_handle,
     THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnAppendGraphExecute", result, _init_structs->getGraphDdiTable());
 }
 void CommandList::appendNpuTimestamp(uint64_t* timestamp_buff) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWriteGlobalTimestamp",
-                                zeCommandListAppendWriteGlobalTimestamp(_handle, timestamp_buff, nullptr, 0, nullptr));
+    auto result = zeCommandListAppendWriteGlobalTimestamp(_handle, timestamp_buff, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWriteGlobalTimestamp", result);
 }
 void CommandList::appendBarrier() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendBarrier", zeCommandListAppendBarrier(_handle, nullptr, 0, nullptr));
+    auto result = zeCommandListAppendBarrier(_handle, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendBarrier", result);
 }
 void CommandList::close() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListClose", zeCommandListClose(_handle));
+    auto result = zeCommandListClose(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListClose", result);
 }
 CommandList::~CommandList() {
     auto result = zeCommandListDestroy(_handle);
@@ -130,8 +135,8 @@ void CommandList::updateMutableCommandList(uint32_t arg_index, const void* arg_v
                                                                   &desc,
                                                                   0};
 
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListUpdateMutableCommandsExp",
-                                zeCommandListUpdateMutableCommandsExp(_handle, &mutable_commands_exp_desc_t));
+    auto result = zeCommandListUpdateMutableCommandsExp(_handle, &mutable_commands_exp_desc_t);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListUpdateMutableCommandsExp", result);
 }
 
 CommandQueue::CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
@@ -152,24 +157,22 @@ CommandQueue::CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_st
         }
     }
 
-    THROW_ON_FAIL_FOR_LEVELZERO(
-        "zeCommandQueueCreate",
-        zeCommandQueueCreate(_init_structs->getContext(), _init_structs->getDevice(), &queue_desc, &_handle));
+    auto result = zeCommandQueueCreate(_init_structs->getContext(), _init_structs->getDevice(), &queue_desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueCreate", result);
 }
 void CommandQueue::executeCommandList(CommandList& command_list) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists",
-                                zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, nullptr));
+    auto result = zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists", result);
 }
 void CommandQueue::executeCommandList(CommandList& command_list, Fence& fence) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists",
-                                zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, fence.handle()));
+    auto result = zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, fence.handle());
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists", result);
 }
 
 void CommandQueue::setWorkloadType(ze_command_queue_workload_type_t workload_type) const {
     if (_init_structs->getCommandQueueDdiTable().version()) {
-        THROW_ON_FAIL_FOR_LEVELZERO(
-            "zeSetWorkloadType",
-            _init_structs->getCommandQueueDdiTable().pfnSetWorkloadType(_handle, workload_type));
+        auto result = _init_structs->getCommandQueueDdiTable().pfnSetWorkloadType(_handle, workload_type);
+        THROW_ON_FAIL_FOR_LEVELZERO("zeSetWorkloadType", result);
     } else {
         OPENVINO_THROW("The WorkloadType property is not supported by the current Driver Version!");
     }
@@ -186,13 +189,16 @@ CommandQueue::~CommandQueue() {
 
 Fence::Fence(const CommandQueue& command_queue) : _log("Fence", Logger::global().level()) {
     ze_fence_desc_t fence_desc = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceCreate", zeFenceCreate(command_queue.handle(), &fence_desc, &_handle));
+    auto result = zeFenceCreate(command_queue.handle(), &fence_desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceCreate", result);
 }
 void Fence::reset() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceReset", zeFenceReset(_handle));
+    auto result = zeFenceReset(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceReset", result);
 }
 void Fence::hostSynchronize() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", zeFenceHostSynchronize(_handle, UINT64_MAX));
+    auto result = zeFenceHostSynchronize(_handle, UINT64_MAX);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", result);
 }
 Fence::~Fence() {
     auto result = zeFenceDestroy(_handle);

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -214,7 +214,7 @@ CommandQueueManager& CommandQueueManager::getInstance() {
     static CommandQueueManager instance;
     return instance;
 }
-const std::shared_ptr<CommandQueue>& CommandQueueManager::getCommandQueue(
+std::shared_ptr<CommandQueue> CommandQueueManager::getCommandQueue(
     const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
     const ze_command_queue_priority_t& priority,
     const std::optional<ze_command_queue_workload_type_t>& workload_type,
@@ -255,7 +255,7 @@ void CommandQueueManager::freeCommandQueue(const ze_command_queue_priority_t& pr
 
     if (_gloabal_command_queues[zeroUtils::toPriorityEnum(priority)][zeroUtils::toTurboEnum(turbo)]
                                [zeroUtils::toWorkloadEnum(workload_type)]
-                                   .use_count() == 1) {
+                                   .use_count() <= 1) {
         _log.debug("Destroy command queue");
         _gloabal_command_queues[zeroUtils::toPriorityEnum(priority)][zeroUtils::toTurboEnum(turbo)]
                                [zeroUtils::toWorkloadEnum(workload_type)]

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -252,20 +252,8 @@ std::shared_ptr<CommandQueue> CommandQueuePool::getCommandQueue(
         }
     }  // otherwise create a new object
 
-    // Create shared_ptr with a deleter
     _log.debug("Create Command Queue");
-    auto new_obj = std::shared_ptr<CommandQueue>(
-        new CommandQueue(init_structs, desc, group_ordinal),
-        [this, hash](CommandQueue* ptr) {
-            std::lock_guard<std::mutex> lock(_mutex);
-            if (_pool.at(hash).lock()) {
-                _log.debug("Don't destroy the command queue in case the shared ptr is in use!");
-                return;
-            }
-            _pool.erase(hash);
-            _log.debug("Destroy Command Queue");
-            delete ptr;
-        });
+    auto new_obj = std::make_shared<CommandQueue>(init_structs, desc, group_ordinal);
 
     auto pair = std::make_pair(hash, new_obj);
     _pool.emplace(pair);

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -37,6 +37,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(configsInferRequestRunTests)),
                          InferRequestRunTests::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         InferRunTestsOnNewerDrivers,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configsInferRequestRunTests)),
+                         InferRequestRunTests::getTestCaseName);
+
 const std::vector<ov::AnyMap> batchingConfigs = {
     {ov::log::level(ov::log::Level::WARNING), ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)},
     {ov::log::level(ov::log::Level::WARNING), ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER)},

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -170,6 +170,36 @@ TEST_P(InferRequestRunTests, MultipleExecutorStreamsTestsSyncInfers) {
     }
 }
 
+TEST_P(InferRequestRunTests, MultipleCompiledModelsTestsSyncInfers) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    // Load CNNNetwork to target plugins
+    const int no_of_iterations = 256;
+    std::array<ov::CompiledModel, no_of_iterations> compiled_models;
+
+    for (int i = 0; i < no_of_iterations; ++i) {
+        OV_ASSERT_NO_THROW(compiled_models[i] = core->compile_model(ov_model, target_device, configuration));
+    }
+
+    // Create InferRequests
+    std::array<ov::InferRequest, no_of_iterations> infer_reqs;
+    std::array<std::thread, no_of_iterations> infer_reqs_threads;
+    for (int i = 0; i < no_of_iterations; ++i) {
+        OV_ASSERT_NO_THROW(infer_reqs[i] = compiled_models[i].create_infer_request());
+    }
+
+    for (int i = 0; i < no_of_iterations; ++i) {
+        infer_reqs_threads[i] = std::thread([&infer_reqs, i]() -> void {
+            OV_ASSERT_NO_THROW(infer_reqs[i].infer());
+            infer_reqs[i] = {};
+        });
+    }
+
+    for (int i = 0; i < no_of_iterations; ++i) {
+        infer_reqs_threads[i].join();
+    }
+}
+
 TEST_P(InferRequestRunTests, MultipleExecutorStreamsTestsAsyncInfers) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -170,36 +170,6 @@ TEST_P(InferRequestRunTests, MultipleExecutorStreamsTestsSyncInfers) {
     }
 }
 
-TEST_P(InferRequestRunTests, MultipleCompiledModelsTestsSyncInfers) {
-    // Skip test according to plugin specific disabledTestPatterns() (if any)
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    // Load CNNNetwork to target plugins
-    const int no_of_iterations = 256;
-    std::array<ov::CompiledModel, no_of_iterations> compiled_models;
-
-    for (int i = 0; i < no_of_iterations; ++i) {
-        OV_ASSERT_NO_THROW(compiled_models[i] = core->compile_model(ov_model, target_device, configuration));
-    }
-
-    // Create InferRequests
-    std::array<ov::InferRequest, no_of_iterations> infer_reqs;
-    std::array<std::thread, no_of_iterations> infer_reqs_threads;
-    for (int i = 0; i < no_of_iterations; ++i) {
-        OV_ASSERT_NO_THROW(infer_reqs[i] = compiled_models[i].create_infer_request());
-    }
-
-    for (int i = 0; i < no_of_iterations; ++i) {
-        infer_reqs_threads[i] = std::thread([&infer_reqs, i]() -> void {
-            OV_ASSERT_NO_THROW(infer_reqs[i].infer());
-            infer_reqs[i] = {};
-        });
-    }
-
-    for (int i = 0; i < no_of_iterations; ++i) {
-        infer_reqs_threads[i].join();
-    }
-}
-
 TEST_P(InferRequestRunTests, MultipleExecutorStreamsTestsAsyncInfers) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
@@ -1088,6 +1058,38 @@ TEST_P(SetShapeInferRunTests, checkResultsAfterStateTensorsReallocation) {
         for (size_t i = 0; i < last_state_size; ++i) {
             EXPECT_NEAR(input_data[i], last_state_data[i], 1e-5);
         }
+    }
+}
+
+using InferRunTestsOnNewerDrivers = InferRequestRunTests;
+
+TEST_P(InferRunTestsOnNewerDrivers, MultipleCompiledModelsTestsSyncInfers) {
+    // Skip test according to plugin specific disabledTestPatterns() (if any)
+    SKIP_IF_CURRENT_TEST_IS_DISABLED()
+    // Load CNNNetwork to target plugins
+    const int no_of_iterations = 256;
+    std::array<ov::CompiledModel, no_of_iterations> compiled_models;
+
+    for (int i = 0; i < no_of_iterations; ++i) {
+        OV_ASSERT_NO_THROW(compiled_models[i] = core->compile_model(ov_model, target_device, configuration));
+    }
+
+    // Create InferRequests
+    std::array<ov::InferRequest, no_of_iterations> infer_reqs;
+    std::array<std::thread, no_of_iterations> infer_reqs_threads;
+    for (int i = 0; i < no_of_iterations; ++i) {
+        OV_ASSERT_NO_THROW(infer_reqs[i] = compiled_models[i].create_infer_request());
+    }
+
+    for (int i = 0; i < no_of_iterations; ++i) {
+        infer_reqs_threads[i] = std::thread([&infer_reqs, i]() -> void {
+            OV_ASSERT_NO_THROW(infer_reqs[i].infer());
+            infer_reqs[i] = {};
+        });
+    }
+
+    for (int i = 0; i < no_of_iterations; ++i) {
+        infer_reqs_threads[i].join();
     }
 }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -1080,9 +1080,10 @@ TEST_P(InferRunTestsOnNewerDrivers, MultipleCompiledModelsTestsSyncInfers) {
     }
 
     for (int i = 0; i < no_of_iterations; ++i) {
-        infer_reqs_threads[i] = std::thread([&infer_reqs, i]() -> void {
+        infer_reqs_threads[i] = std::thread([&compiled_models, &infer_reqs, i]() -> void {
             OV_ASSERT_NO_THROW(infer_reqs[i].infer());
             infer_reqs[i] = {};
+            compiled_models[i] = {};
         });
     }
 

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -1066,7 +1066,6 @@ using InferRunTestsOnNewerDrivers = InferRequestRunTests;
 TEST_P(InferRunTestsOnNewerDrivers, MultipleCompiledModelsTestsSyncInfers) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-    // Load CNNNetwork to target plugins
     const int no_of_iterations = 256;
     std::array<ov::CompiledModel, no_of_iterations> compiled_models;
 
@@ -1074,7 +1073,6 @@ TEST_P(InferRunTestsOnNewerDrivers, MultipleCompiledModelsTestsSyncInfers) {
         OV_ASSERT_NO_THROW(compiled_models[i] = core->compile_model(ov_model, target_device, configuration));
     }
 
-    // Create InferRequests
     std::array<ov::InferRequest, no_of_iterations> infer_reqs;
     std::array<std::thread, no_of_iterations> infer_reqs_threads;
     for (int i = 0; i < no_of_iterations; ++i) {

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/compile_and_infer.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/compile_and_infer.cpp
@@ -31,4 +31,11 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                                                 {ov::intel_npu::defer_weights_load(false)}})),
                          ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequestTurbo>);
 
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
+                         OVCompileAndInferRequesOnNewerDrivers,
+                         ::testing::Combine(::testing::Values(getConstantGraph(ov::element::f32)),
+                                            ::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configs)),
+                         ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequest>);
+
 }  // namespace

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compile_and_infer.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compile_and_infer.hpp
@@ -250,6 +250,18 @@ TEST_P(OVCompileAndInferRequest, CompiledModelWorkloadTypeUpdateAfterCompilation
         OV_ASSERT_NO_THROW(req2.start_async());
         OV_ASSERT_NO_THROW(req2.wait());
         ASSERT_TRUE(isCalled);
+
+        req1 = {};
+        req2 = {};
+        req3 = {};
+
+        OV_ASSERT_NO_THROW(req1 = execNet.create_infer_request());
+        OV_ASSERT_NO_THROW(req2 = secondCompiledModel.create_infer_request());
+        OV_ASSERT_NO_THROW(req1.infer());
+        OV_ASSERT_NO_THROW(req3 = execNet.create_infer_request());
+        OV_ASSERT_NO_THROW(req2.infer());
+        OV_ASSERT_NO_THROW(req3.infer());
+        OV_ASSERT_NO_THROW(req3.infer());
     }
 }
 

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compile_and_infer.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compile_and_infer.hpp
@@ -208,6 +208,60 @@ TEST_P(OVCompileAndInferRequest, CompiledModelWorkloadTypeUpdateAfterCompilation
     }
 }
 
+TEST_P(OVCompileAndInferRequest, CompiledModelWorkloadTypeUpdateAfterCompilationWithMultipleInfers) {
+    if (isCommandQueueExtSupported()) {
+        OV_ASSERT_NO_THROW(execNet = core->compile_model(function, target_device, configuration));
+
+        auto secondCompiledModel = core->compile_model(function, target_device, configuration);
+
+        ov::InferRequest req1, req2, req3;
+        OV_ASSERT_NO_THROW(req1 = execNet.create_infer_request());
+        OV_ASSERT_NO_THROW(req3 = secondCompiledModel.create_infer_request());
+        bool isCalled = false;
+        OV_ASSERT_NO_THROW(req1.set_callback([&](std::exception_ptr exception_ptr) {
+            ASSERT_EQ(exception_ptr, nullptr);
+            isCalled = true;
+        }));
+        OV_ASSERT_NO_THROW(req1.start_async());
+        OV_ASSERT_NO_THROW(req1.wait());
+        ASSERT_TRUE(isCalled);
+
+        OV_ASSERT_NO_THROW(req3.infer());
+
+        req1 = {};
+
+        ov::AnyMap modelConfiguration;
+        modelConfiguration[workload_type.name()] = WorkloadType::EFFICIENT;
+        OV_ASSERT_NO_THROW(execNet.set_property(modelConfiguration));
+        ASSERT_EQ(execNet.get_property(workload_type.name()).as<WorkloadType>(), WorkloadType::EFFICIENT);
+        OV_ASSERT_NO_THROW(req2 = execNet.create_infer_request())
+        OV_ASSERT_NO_THROW(req2.infer());
+
+        modelConfiguration[workload_type.name()] = WorkloadType::DEFAULT;
+        OV_ASSERT_NO_THROW(execNet.set_property(modelConfiguration));
+        ASSERT_EQ(execNet.get_property(workload_type.name()).as<WorkloadType>(), WorkloadType::DEFAULT);
+        isCalled = false;
+        OV_ASSERT_NO_THROW(req2.set_callback([&](std::exception_ptr exception_ptr) {
+            ASSERT_EQ(exception_ptr, nullptr);
+            isCalled = true;
+        }));
+        OV_ASSERT_NO_THROW(req2.start_async());
+        OV_ASSERT_NO_THROW(req2.wait());
+        ASSERT_TRUE(isCalled);
+
+        req2 = {};
+        req3 = {};
+
+        OV_ASSERT_NO_THROW(req1 = execNet.create_infer_request());
+        OV_ASSERT_NO_THROW(req2 = secondCompiledModel.create_infer_request());
+        OV_ASSERT_NO_THROW(req1.infer());
+        OV_ASSERT_NO_THROW(req3 = execNet.create_infer_request());
+        OV_ASSERT_NO_THROW(req2.infer());
+        OV_ASSERT_NO_THROW(req3.infer());
+        OV_ASSERT_NO_THROW(req3.infer());
+    }
+}
+
 using OVCompileAndInferRequestTurbo = OVCompileAndInferRequest;
 
 TEST_P(OVCompileAndInferRequestTurbo, CompiledModelTurbo) {

--- a/src/plugins/intel_npu/tests/functional/internal/overload/compile_and_infer.hpp
+++ b/src/plugins/intel_npu/tests/functional/internal/overload/compile_and_infer.hpp
@@ -235,11 +235,13 @@ TEST_P(OVCompileAndInferRequest, CompiledModelWorkloadTypeUpdateAfterCompilation
 
         OV_ASSERT_NO_THROW(req3.infer());
 
+        req1 = {};
+
         ov::AnyMap modelConfiguration;
         modelConfiguration[workload_type.name()] = WorkloadType::DEFAULT;
         OV_ASSERT_NO_THROW(execNet.set_property(modelConfiguration));
         ASSERT_EQ(execNet.get_property(workload_type.name()).as<WorkloadType>(), WorkloadType::DEFAULT);
-        OV_ASSERT_NO_THROW(req2 = execNet.create_infer_request());
+        OV_ASSERT_NO_THROW(req2 = execNet.create_infer_request())
         OV_ASSERT_NO_THROW(req2.infer());
 
         modelConfiguration[workload_type.name()] = WorkloadType::EFFICIENT;
@@ -254,7 +256,6 @@ TEST_P(OVCompileAndInferRequest, CompiledModelWorkloadTypeUpdateAfterCompilation
         OV_ASSERT_NO_THROW(req2.wait());
         ASSERT_TRUE(isCalled);
 
-        req1 = {};
         req2 = {};
         req3 = {};
 
@@ -372,6 +373,7 @@ TEST_P(OVCompileAndInferRequesOnNewerDrivers, MultipleCompiledModelsTestsSyncInf
                 OV_ASSERT_NO_THROW(infer_reqs[i].infer());
 
                 infer_reqs[i] = {};
+                compiled_models[i] = {};
             });
         }
 


### PR DESCRIPTION
### Details:
 - *Another option for [PR#28661](https://github.com/openvinotoolkit/openvino/pull/28661)*
 -  *Using a global command queue per core and not creating different queues for each compiled model. The plugin will create a different queue only if the properties for using them are different from a compiled model to another or if the properties(workload type) are changing at runtime*

### Tickets:
 - *E#154336*
