### PR TITLE
[CPU][DEBUG_CAPS] Enable verbose mode for ov data types

### DIFF
--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -47,7 +47,9 @@ uint8_t DnnlExtensionUtils::sizeOfDataType(dnnl::memory::data_type dataType) {
     }
 }
 
-dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataType(const ov::element::Type& elementType) {
+std::optional<dnnl::memory::data_type> DnnlExtensionUtils::ElementTypeToDataType(
+    const ov::element::Type& elementType,
+    DnnlExtensionUtils::nothrow_tag) noexcept {
     switch (elementType) {
     case ov::element::f32:
         return memory::data_type::f32;
@@ -81,9 +83,16 @@ dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataType(const ov::elem
     case ov::element::undefined:
         return memory::data_type::undef;
     default: {
-        OPENVINO_THROW("CPU plugin does not support ", elementType.to_string(), " for use with oneDNN.");
+        return {};
     }
     }
+}
+
+dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataType(const ov::element::Type& elementType,
+                                                                  DnnlExtensionUtils::throw_tag) {
+    auto&& result = ElementTypeToDataType(elementType, nothrow_tag{});
+    OPENVINO_ASSERT(result, "CPU plugin does not support ", elementType.to_string(), " for use with oneDNN.");
+    return result.value();
 }
 
 ov::element::Type DnnlExtensionUtils::DataTypeToElementType(const dnnl::memory::data_type& dataType) {

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.h
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "common/c_types_map.hpp"
@@ -26,8 +27,17 @@ class IMemory;
 
 class DnnlExtensionUtils {
 public:
+    struct throw_tag {};
+    struct nothrow_tag {};
+
+public:
     static uint8_t sizeOfDataType(dnnl::memory::data_type dataType);
-    static dnnl::memory::data_type ElementTypeToDataType(const ov::element::Type& elementType);
+    static dnnl::memory::data_type ElementTypeToDataType(const ov::element::Type& elementType,
+                                                         throw_tag tag = throw_tag{});
+
+    static std::optional<dnnl::memory::data_type> ElementTypeToDataType(const ov::element::Type& elementType,
+                                                                        nothrow_tag) noexcept;
+
     static ov::element::Type DataTypeToElementType(const dnnl::memory::data_type& dataType);
     static Dim convertToDim(const dnnl::memory::dim& dim);
     static dnnl::memory::dim convertToDnnlDim(const Dim& dim);


### PR DESCRIPTION
### Details:
Not all the ov types are supported in oneDNN. This fact leads to an exception being thrown if the CPU graph contains tensors of such data types.
This PR enables verbose mode to dump such tensor descriptors.

### Tickets:
N/A
