### PR TITLE
[GHA] [CPU] Extend nightly scope for CPU func. tests

### DIFF
--- a/.github/workflows/debian_10_arm.yml
+++ b/.github/workflows/debian_10_arm.yml
@@ -122,6 +122,7 @@ jobs:
       runner: 'aks-linux-16-cores-arm'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.debian_10_arm }}
       python-version: '3.7'
+      scope: ${{ github.event_name == 'workflow_dispatch' && 'nightly' || 'smoke' }}
 
   Overall_Status:
     name: ci/gha_overall_status_debian_10_arm

--- a/.github/workflows/job_cpu_functional_tests.yml
+++ b/.github/workflows/job_cpu_functional_tests.yml
@@ -106,7 +106,7 @@ jobs:
           # Needed as ze_loader.so is under INSTALL_TEST_DIR
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INSTALL_TEST_DIR}
 
-          python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1 --gtest_filter=*smoke*
+          python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1
         timeout-minutes: 25
 
       - name: Save tests execution time

--- a/.github/workflows/job_cpu_functional_tests.yml
+++ b/.github/workflows/job_cpu_functional_tests.yml
@@ -40,6 +40,7 @@ jobs:
       INSTALL_TEST_DIR: ${{ github.workspace }}/install/tests
       PARALLEL_TEST_SCRIPT: ${{ github.workspace }}/install/tests/functional_test_utils/layer_tests_summary/run_parallel.py
       PARALLEL_TEST_CACHE: ${{ github.workspace }}/install/tests/test_cache.lst
+      GTEST_FILTER: ${{ inputs.scope == 'nightly' && '' || '--gtest_filter=smoke' }}
     steps:
       - name: Download OpenVINO package
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -111,8 +112,8 @@ jobs:
           # Needed as ze_loader.so is under INSTALL_TEST_DIR
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INSTALL_TEST_DIR}
 
-          python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1
-        timeout-minutes: 125
+          python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1 ${{ env.GTEST_FILTER }}
+        timeout-minutes: ${{ inputs.scope == 'nightly' && 125 || 25 }}
 
       - name: Save tests execution time
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2

--- a/.github/workflows/job_cpu_functional_tests.yml
+++ b/.github/workflows/job_cpu_functional_tests.yml
@@ -16,6 +16,11 @@ on:
         description: 'Python version to setup. E.g., "3.11"'
         type: string
         required: true
+      scope:
+        description: 'Defines tests scope {nightly | smoke}'
+        type: string
+        required: false
+        default: 'smoke'
 
 permissions: read-all
 

--- a/.github/workflows/job_cpu_functional_tests.yml
+++ b/.github/workflows/job_cpu_functional_tests.yml
@@ -107,7 +107,7 @@ jobs:
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INSTALL_TEST_DIR}
 
           python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1
-        timeout-minutes: 25
+        timeout-minutes: 125
 
       - name: Save tests execution time
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2

--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -223,6 +223,7 @@ jobs:
       runner: 'aks-linux-16-cores-arm'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_20_04_arm64 }}
       python-version: '3.11'
+      scope: ${{ github.event_name == 'workflow_dispatch' && 'nightly' || 'smoke' }}
 
   TensorFlow_Models_Tests:
     name: TensorFlow Models tests

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -416,6 +416,7 @@ jobs:
     with:
       runner: 'macos-13'
       python-version: '3.11'
+      scope: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)  && 'nightly' || 'smoke' }}
 
   upload_artifacts:
     name: Upload OpenVINO artifacts

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -376,3 +376,4 @@ jobs:
     with:
       runner: 'macos-13-xlarge'
       python-version: '3.11'
+      scope: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)  && 'nightly' || 'smoke' }}

--- a/.github/workflows/ubuntu_22.yml
+++ b/.github/workflows/ubuntu_22.yml
@@ -363,6 +363,7 @@ jobs:
       runner: 'aks-linux-8-cores-32gb'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_22_04_x64 }}
       python-version: '3.11'
+      scope: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)  && 'nightly' || 'smoke' }}
 
   TensorFlow_Models_Tests_Precommit:
     name: TensorFlow Models tests

--- a/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
@@ -70,7 +70,8 @@ static std::string model_full_path(const char* path) {
                                      path);
 }
 
-TEST(Extension, XmlModelWithCustomAbs) {
+TEST(DISABLED_Extension, XmlModelWithCustomAbs) {
+    // Issue: 163252
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>

--- a/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
@@ -193,6 +193,7 @@ TEST(Extension, smoke_XmlModelWithExtensionFromDSO) {
 }
 
 TEST(DISABLED_Extension, OnnxModelWithExtensionFromDSO) {
+    // Issue: 163252
     std::vector<float> input_values{1, 2, 3, 4, 5, 6, 7, 8};
     std::vector<float> expected{1, 2, 3, 4, 5, 6, 7, 8};
 

--- a/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
@@ -192,7 +192,7 @@ TEST(Extension, smoke_XmlModelWithExtensionFromDSO) {
     infer_model(core, compiled_model, input_values, expected);
 }
 
-TEST(Extension, OnnxModelWithExtensionFromDSO) {
+TEST(DISABLED_Extension, OnnxModelWithExtensionFromDSO) {
     std::vector<float> input_values{1, 2, 3, 4, 5, 6, 7, 8};
     std::vector<float> expected{1, 2, 3, 4, 5, 6, 7, 8};
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
@@ -20,7 +20,8 @@ using Device = std::string;
 using Config = ov::AnyMap;
 using CpuReservationTest = ::testing::Test;
 
-TEST_F(CpuReservationTest, Mutiple_CompiledModel_Reservation) {
+TEST_F(DISABLED_CpuReservationTest, Mutiple_CompiledModel_Reservation) {
+    // Issue: 163348
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
@@ -19,10 +19,10 @@ using namespace testing;
 using Device = std::string;
 using Config = ov::AnyMap;
 using CpuReservationTest = ::testing::Test;
+// Issue: 163348
 using DISABLED_CpuReservationTest = ::testing::Test;
 
 TEST_F(DISABLED_CpuReservationTest, Mutiple_CompiledModel_Reservation) {
-    // Issue: 163348
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);
@@ -58,7 +58,7 @@ TEST_F(DISABLED_CpuReservationTest, Mutiple_CompiledModel_Reservation) {
     }
 }
 
-TEST_F(CpuReservationTest, Cpu_Reservation_NoAvailableCores) {
+TEST_F(DISABLED_CpuReservationTest, Cpu_Reservation_NoAvailableCores) {
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);
@@ -75,7 +75,7 @@ TEST_F(CpuReservationTest, Cpu_Reservation_NoAvailableCores) {
 }
 
 #if defined(__linux__)
-TEST_F(CpuReservationTest, Cpu_Reservation_CpuPinning) {
+TEST_F(DISABLED_CpuReservationTest, Cpu_Reservation_CpuPinning) {
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
@@ -19,6 +19,7 @@ using namespace testing;
 using Device = std::string;
 using Config = ov::AnyMap;
 using CpuReservationTest = ::testing::Test;
+using DISABLED_CpuReservationTest = ::testing::Test;
 
 TEST_F(DISABLED_CpuReservationTest, Mutiple_CompiledModel_Reservation) {
     // Issue: 163348

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -304,7 +304,9 @@ std::vector<std::string> disabledTestPatterns() {
         // Issue: 163230
         R"(.*ProposalLayerTest.*)",
         // Issue: 163232
-        R"(.*FC_3D_BF16.*MatMulLayerCPUTestest.*)",
+        R"(.*FC_3D_BF16.*MatMulLayerCPUTest.*)",
+        // Issue: 163242
+        R"(.*bf16.*RNNSequenceCPUTest.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -317,7 +317,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*Deconv_2D_Planar_FP16.*DeconvolutionLayerCPUTest.*)",
         // Issue: 163275
         R"(.*NoReshapeAndReshapeDynamic.*CodegenGelu.*)",
-        // Issue: 163083
+        // Issue: 163348
         R"(.*CpuReservationTest.*Mutiple_CompiledModel_Reservation.*)",
         // Issue: 163351
         R"(.*CoreThreadingTestsWithIter.*nightly_AsyncInfer_ShareInput.*)",

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -317,6 +317,10 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*Deconv_2D_Planar_FP16.*DeconvolutionLayerCPUTest.*)",
         // Issue: 163275
         R"(.*NoReshapeAndReshapeDynamic.*CodegenGelu.*)",
+        // Issue: 163083
+        R"(.*CpuReservationTest.*Mutiple_CompiledModel_Reservation.*)",
+        // Issue: 163351
+        R"(.*CoreThreadingTestsWithIter.*nightly_AsyncInfer_ShareInput.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -301,6 +301,8 @@ std::vector<std::string> disabledTestPatterns() {
         // Issue: 163227
         R"(.*QuantizedModelsTests\.MaxPoolFQ.*)",
         R"(.*QuantizedModelsTests\.MaxPoolQDQ.*)",
+        // Issue: 163268
+        R"(.*QuantizedModelsTests\.ConvolutionFQ.*)",
         // Issue: 163230
         R"(.*ProposalLayerTest.*)",
         // Issue: 163232
@@ -309,8 +311,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*bf16.*RNNSequenceCPUTest.*)",
         // Issue: 163250
         R"(.*OnnxModelWithExtensionFromDSO.*)",
-        // Issue: 163252
-        R"(.*ConvolutionQDQ.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -307,6 +307,10 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*FC_3D_BF16.*MatMulLayerCPUTest.*)",
         // Issue: 163242
         R"(.*bf16.*RNNSequenceCPUTest.*)",
+        // Issue: 163250
+        R"(.*OnnxModelWithExtensionFromDSO.*)",
+        // Issue: 163252
+        R"(.*ConvolutionQDQ.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -278,6 +278,33 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*Snippets.*MatMulTransposeB.*i8.*i8.*)",
         // Issue: 136881
         R"(.*smoke_CompareWithRefs_4D_BitwiseShift_overflow_i32_cast.*_eltwise_op_type=BitwiseLeft.*_model_type=.*(i16|u16).*)",
+        // Issue: 163083
+        // Issue: 163116
+        R"(.*RandomUniformLayerTestCPU.*OutPrc=bf16.*)",
+        // Issue: 163117
+        R"(.*InterpolateCubic_Layout_Test.*)",
+        // Issue: 163171
+        R"(.*CPUDetectionOutputDynamic3InLargeTensor.*)",
+        // Issue: 163168
+        R"(.*UniqueLayerTestCPU.*)",
+        // Issue: 163175
+        R"(.*GridSampleLayerTestCPU.*dataPrc=i8.*)",
+        R"(.*GridSampleLayerTestCPU.*dataPrc=bf16.*)",
+        // Issue: 163177
+        R"(.*NmsRotatedOpTest.*ScoreThr=0\.4.*)",
+        // Issue: 163222
+        R"(.*bf16.*LSTMSequenceCPUTest.*)",
+        // Issue: 163223
+        R"(.*bf16.*AUGRUSequenceCPUTest.*)",
+        // Issue: 163224
+        R"(.*bf16.*GRUSequenceCPUTest.*)",
+        // Issue: 163227
+        R"(.*QuantizedModelsTests\.MaxPoolFQ.*)",
+        R"(.*QuantizedModelsTests\.MaxPoolQDQ.*)",
+        // Issue: 163230
+        R"(.*ProposalLayerTest.*)",
+        // Issue: 163232
+        R"(.*FC_3D_BF16.*MatMulLayerCPUTestest.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -302,6 +302,7 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*QuantizedModelsTests\.MaxPoolFQ.*)",
         R"(.*QuantizedModelsTests\.MaxPoolQDQ.*)",
         // Issue: 163268
+        R"(.*QuantizedModelsTests\.ConvolutionQDQ.*)",
         R"(.*QuantizedModelsTests\.ConvolutionFQ.*)",
         // Issue: 163230
         R"(.*ProposalLayerTest.*)",
@@ -311,6 +312,11 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*bf16.*RNNSequenceCPUTest.*)",
         // Issue: 163250
         R"(.*OnnxModelWithExtensionFromDSO.*)",
+        // Issue: 163273
+        // todo: define correct area
+        R"(.*Deconv_2D_Planar_FP16.*DeconvolutionLayerCPUTest.*)",
+        // Issue: 163275
+        R"(.*NoReshapeAndReshapeDynamic.*CodegenGelu.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue


### PR DESCRIPTION
### Details:
 - *smoke filter for nightly cpu func. test removed*

### Tickets:
 - *161534*
