### PR TITLE
[DO NOT MERGE] [NPU] Using global command queue

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -40,6 +40,9 @@ public:
     void closeCommandListIndex(size_t command_list_index);
 
 protected:
+    void getCommandQueue();
+
+    std::shared_ptr<ZeroInitStructsHolder> _init_structs;
     std::shared_ptr<IGraph> _graph;
     const Config _config;
     const uint32_t _id;
@@ -59,9 +62,11 @@ protected:
     std::vector<std::unique_ptr<Fence>> _fences;
     std::shared_ptr<EventPool> _event_pool;
     std::vector<std::shared_ptr<Event>> _events;
-    bool sync_output_with_fences_ = true;
+    bool _sync_output_with_fences = true;
     std::shared_ptr<zeroProfiling::NpuInferProfiling> _npu_profiling;
     Logger _logger;
+
+    std::mutex _mutex;
 };
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -50,26 +50,6 @@ const std::shared_ptr<CommandQueue>& IGraph::get_command_queue() const {
     return _command_queue;
 }
 
-void IGraph::set_workload_type(const ov::WorkloadType workloadType) const {
-    if (_command_queue == nullptr) {
-        return;
-    }
-
-    ze_command_queue_workload_type_t zeWorkloadType;
-    switch (workloadType) {
-    case ov::WorkloadType::DEFAULT:
-        zeWorkloadType = ze_command_queue_workload_type_t::ZE_WORKLOAD_TYPE_DEFAULT;
-        break;
-    case ov::WorkloadType::EFFICIENT:
-        zeWorkloadType = ze_command_queue_workload_type_t::ZE_WORKLOAD_TYPE_BACKGROUND;
-        break;
-    default:
-        OPENVINO_THROW("Unknown value for WorkloadType!");
-    }
-
-    _command_queue->setWorkloadType(zeWorkloadType);
-}
-
 std::mutex& IGraph::get_mutex() {
     return _mutex;
 }

--- a/src/plugins/intel_npu/src/compiler_adapter/include/driver_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/driver_graph.hpp
@@ -32,10 +32,14 @@ public:
 
     void initialize(const Config& config) override;
 
+    void set_workload_type(const ov::WorkloadType workloadType) override;
+
     ~DriverGraph() override;
 
 private:
     bool release_blob(const Config& config);
+
+    void create_new_command_queue() override;
 
     std::shared_ptr<ZeGraphExtWrappers> _zeGraphExt;
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;

--- a/src/plugins/intel_npu/src/compiler_adapter/include/plugin_graph.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/plugin_graph.hpp
@@ -35,9 +35,13 @@ public:
 
     void initialize(const Config& config) override;
 
+    void set_workload_type(const ov::WorkloadType workloadType) override;
+
     ~PluginGraph() override;
 
 private:
+    void create_new_command_queue() override;
+
     std::shared_ptr<ZeGraphExtWrappers> _zeGraphExt;
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
 

--- a/src/plugins/intel_npu/src/compiler_adapter/include/ze_graph_ext_wrappers.hpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/include/ze_graph_ext_wrappers.hpp
@@ -48,7 +48,7 @@ public:
 
     void setGraphArgumentValue(ze_graph_handle_t graphHandle, uint32_t argi_, const void* argv) const;
 
-    void initializeGraph(ze_graph_handle_t graphHandle, const Config& config) const;
+    void initializeGraph(ze_graph_handle_t graphHandle) const;
 
 private:
     std::unordered_set<std::string> getQueryResultFromSupportedLayers(
@@ -60,7 +60,7 @@ private:
                      std::vector<IODescriptor>& inputs,
                      std::vector<IODescriptor>& outputs) const;
 
-    void initialize_graph_through_command_list(ze_graph_handle_t graphHandle, const Config& config) const;
+    void initialize_graph_through_command_list(ze_graph_handle_t graphHandle) const;
 
     std::shared_ptr<ZeroInitStructsHolder> _zeroInitStruct;
     uint32_t _graphExtVersion;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_graph.cpp
@@ -99,27 +99,7 @@ void DriverGraph::initialize(const Config& config) {
     _input_descriptors.shrink_to_fit();
     _output_descriptors.shrink_to_fit();
 
-    ze_device_properties_t deviceProperties = {};
-    deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
-    THROW_ON_FAIL_FOR_LEVELZERO("zeDeviceGetProperties",
-                                zeDeviceGetProperties(_zeroInitStruct->getDevice(), &deviceProperties));
-    auto groupOrdinal = zeroUtils::findGroupOrdinal(_zeroInitStruct->getDevice(), deviceProperties);
-
-    bool turbo = false;
-    if (config.has<TURBO>()) {
-        turbo = config.get<TURBO>();
-    }
-
-    _command_queue = std::make_shared<CommandQueue>(_zeroInitStruct,
-                                                    zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>()),
-                                                    groupOrdinal,
-                                                    turbo);
-
-    if (config.has<WORKLOAD_TYPE>()) {
-        set_workload_type(config.get<WORKLOAD_TYPE>());
-    }
-
-    _zeGraphExt->initializeGraph(_handle, config);
+    _zeGraphExt->initializeGraph(_handle);
 
     _logger.debug("Graph initialize finish");
 
@@ -127,6 +107,29 @@ void DriverGraph::initialize(const Config& config) {
     //  _zeGraphExt->initializeGraph(). The driver will not access the original blob from this moment on, so we are
     //  releasing it here to avoid unnecessary memory usage.
     _blobIsReleased = release_blob(config);
+
+    // Find the corresponding command queue group.
+    ze_device_properties_t deviceProperties = {};
+    deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+    THROW_ON_FAIL_FOR_LEVELZERO("zeDeviceGetProperties",
+                                zeDeviceGetProperties(_zeroInitStruct->getDevice(), &deviceProperties));
+    _group_ordinal = zeroUtils::findGroupOrdinal(_zeroInitStruct->getDevice(), deviceProperties);
+
+    _ze_queue_priority = zeroUtils::toZeQueuePriority(config.get<MODEL_PRIORITY>());
+
+    if (config.has<TURBO>()) {
+        _turbo = config.get<TURBO>();
+    }
+
+    if (config.has<WORKLOAD_TYPE>()) {
+        if (!_zeroInitStruct->getCommandQueueDdiTable().version()) {
+            OPENVINO_THROW("The WorkloadType property is not supported by the current Driver Version!");
+        }
+    }
+
+    _ze_workload_type = zeroUtils::toZeQueueWorkloadType(config.get<WORKLOAD_TYPE>());
+
+    create_new_command_queue();
 
     if (config.get<BATCH_MODE>() != ov::intel_npu::BatchMode::COMPILER) {
         _batch_size = get_batch_size(_metadata);
@@ -137,6 +140,26 @@ void DriverGraph::initialize(const Config& config) {
 
         _last_submitted_event.resize(number_of_command_lists);
     }
+}
+
+void DriverGraph::set_workload_type(const ov::WorkloadType workloadType) {
+    if (!_zeroInitStruct->getCommandQueueDdiTable().version()) {
+        OPENVINO_THROW("The WorkloadType property is not supported by the current Driver Version!");
+    }
+
+    _ze_workload_type = zeroUtils::toZeQueueWorkloadType(workloadType);
+
+    if (_command_queue) {
+        create_new_command_queue();
+    }
+}
+
+void DriverGraph::create_new_command_queue() {
+    _command_queue = CommandQueuePool::getInstance().getCommandQueue(_zeroInitStruct,
+                                                                     _ze_queue_priority,
+                                                                     _ze_workload_type,
+                                                                     _group_ordinal,
+                                                                     _turbo);
 }
 
 bool DriverGraph::release_blob(const Config& config) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -158,10 +158,10 @@ void ZeGraphExtWrappers::setGraphArgumentValue(ze_graph_handle_t graphHandle, ui
     THROW_ON_FAIL_FOR_LEVELZERO_EXT("zeGraphSetArgumentValue", result, _zeroInitStruct->getGraphDdiTable());
 }
 
-void ZeGraphExtWrappers::initializeGraph(ze_graph_handle_t graphHandle, const Config& config) const {
+void ZeGraphExtWrappers::initializeGraph(ze_graph_handle_t graphHandle) const {
     if (_zeroInitStruct->getGraphDdiTable().version() < ZE_GRAPH_EXT_VERSION_1_8) {
         _logger.debug("Use initialize_graph_through_command_list for ext version smaller than 1.8");
-        initialize_graph_through_command_list(graphHandle, config);
+        initialize_graph_through_command_list(graphHandle);
     } else {
         _logger.debug("Initialize graph based on graph properties for ext version larger than 1.8");
         ze_graph_properties_2_t properties = {};
@@ -175,13 +175,12 @@ void ZeGraphExtWrappers::initializeGraph(ze_graph_handle_t graphHandle, const Co
         }
 
         if (properties.initStageRequired & ZE_GRAPH_STAGE_COMMAND_LIST_INITIALIZE) {
-            initialize_graph_through_command_list(graphHandle, config);
+            initialize_graph_through_command_list(graphHandle);
         }
     }
 }
 
-void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t graphHandle,
-                                                               const Config& config) const {
+void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t graphHandle) const {
     ze_device_properties_t deviceProperties = {};
     deviceProperties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
     THROW_ON_FAIL_FOR_LEVELZERO("zeDeviceGetProperties",
@@ -191,7 +190,8 @@ void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t
     _logger.debug("initialize_graph_through_command_list init start - create graph_command_list");
     CommandList graph_command_list(_zeroInitStruct, groupOrdinal);
     _logger.debug("initialize_graph_through_command_list - create graph_command_queue");
-    CommandQueue graph_command_queue(_zeroInitStruct, ZE_COMMAND_QUEUE_PRIORITY_NORMAL, groupOrdinal, false);
+    CommandQueueDesc desc = {ZE_COMMAND_QUEUE_PRIORITY_NORMAL, ZE_WORKLOAD_TYPE_DEFAULT, false};
+    auto graph_command_queue = std::make_shared<CommandQueue>(_zeroInitStruct, desc, groupOrdinal);
     _logger.debug("initialize_graph_through_command_list - create fence");
     Fence fence(graph_command_queue);
 
@@ -201,7 +201,7 @@ void ZeGraphExtWrappers::initialize_graph_through_command_list(ze_graph_handle_t
     graph_command_list.close();
 
     _logger.debug("initialize_graph_through_command_list - performing executeCommandList");
-    graph_command_queue.executeCommandList(graph_command_list, fence);
+    graph_command_queue->executeCommandList(graph_command_list, fence);
     _logger.debug("initialize_graph_through_command_list - performing hostSynchronize");
     fence.hostSynchronize();
     _logger.debug("initialize_graph_through_command_list - hostSynchronize completed");

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -8,6 +8,8 @@
 #include <ze_api.h>
 #include <ze_graph_ext.h>
 
+#include <optional>
+
 #include "intel_npu/utils/logger/logger.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
 #include "intel_npu/utils/zero/zero_result.hpp"
@@ -50,6 +52,34 @@ namespace zeroUtils {
                        ze_result_to_description(result)); \
     }
 
+static inline size_t toPriorityVal(const ze_command_queue_priority_t& val) {
+    switch (val) {
+    case ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_LOW:
+        return 0;
+    case ZE_COMMAND_QUEUE_PRIORITY_NORMAL:
+        return 1;
+    case ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH:
+        return 2;
+    default:
+        OPENVINO_THROW("Incorrect queue priority.");
+    }
+}
+
+static inline size_t toWorkloadVal(const std::optional<ze_command_queue_workload_type_t>& val) {
+    if (!val.has_value()) {
+        return 0;
+    }
+
+    switch (*val) {
+    case ZE_WORKLOAD_TYPE_DEFAULT:
+        return 1;
+    case ZE_WORKLOAD_TYPE_BACKGROUND:
+        return 2;
+    default:
+        OPENVINO_THROW("Incorrect workload type.");
+    }
+}
+
 static inline ze_command_queue_priority_t toZeQueuePriority(const ov::hint::Priority& val) {
     switch (val) {
     case ov::hint::Priority::LOW:
@@ -60,6 +90,17 @@ static inline ze_command_queue_priority_t toZeQueuePriority(const ov::hint::Prio
         return ZE_COMMAND_QUEUE_PRIORITY_PRIORITY_HIGH;
     default:
         OPENVINO_THROW("Incorrect queue priority.");
+    }
+}
+
+static inline ze_command_queue_workload_type_t toZeQueueWorkloadType(const ov::WorkloadType& val) {
+    switch (val) {
+    case ov::WorkloadType::DEFAULT:
+        return ZE_WORKLOAD_TYPE_DEFAULT;
+    case ov::WorkloadType::EFFICIENT:
+        return ZE_WORKLOAD_TYPE_BACKGROUND;
+    default:
+        OPENVINO_THROW("Unknown value for WorkloadType.");
     }
 }
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_wrappers.cpp
@@ -14,105 +14,116 @@ EventPool::EventPool(ze_device_handle_t device_handle, const ze_context_handle_t
                                             nullptr,
                                             ZE_EVENT_POOL_FLAG_HOST_VISIBLE,
                                             event_count};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventPoolCreate",
-                                zeEventPoolCreate(context, &event_pool_desc, 1, &device_handle, &_handle));
+    auto result = zeEventPoolCreate(context, &event_pool_desc, 1, &device_handle, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventPoolCreate", result);
 }
 EventPool::~EventPool() {
     auto result = zeEventPoolDestroy(_handle);
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeEventPoolDestroy failed %#X", uint64_t(result));
     }
+
+    _handle = nullptr;
 }
 
 Event::Event(const std::shared_ptr<EventPool>& event_pool, uint32_t event_index)
     : _event_pool(event_pool),
       _log("Event", Logger::global().level()) {
     ze_event_desc_t event_desc = {ZE_STRUCTURE_TYPE_EVENT_DESC, nullptr, event_index, 0, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventCreate", zeEventCreate(_event_pool->handle(), &event_desc, &_handle));
+    auto result = zeEventCreate(_event_pool->handle(), &event_desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventCreate", result);
 }
 void Event::AppendSignalEvent(CommandList& command_list) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendSignalEvent",
-                                zeCommandListAppendSignalEvent(command_list.handle(), _handle));
+    auto result = zeCommandListAppendSignalEvent(command_list.handle(), _handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendSignalEvent", result);
 }
 void Event::AppendWaitOnEvent(CommandList& command_list) {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWaitOnEvents",
-                                zeCommandListAppendWaitOnEvents(command_list.handle(), 1, &_handle));
+    auto result = zeCommandListAppendWaitOnEvents(command_list.handle(), 1, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWaitOnEvents", result);
 }
 void Event::AppendEventReset(CommandList& command_list) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendEventReset",
-                                zeCommandListAppendEventReset(command_list.handle(), _handle));
+    auto result = zeCommandListAppendEventReset(command_list.handle(), _handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendEventReset", result);
 }
 void Event::hostSynchronize() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostSynchronize", zeEventHostSynchronize(_handle, UINT64_MAX));
+    auto result = zeEventHostSynchronize(_handle, UINT64_MAX);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostSynchronize", result);
 }
 void Event::reset() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", zeEventHostReset(_handle));
+    auto result = zeEventHostReset(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeEventHostReset", result);
 }
 Event::~Event() {
     auto result = zeEventDestroy(_handle);
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeEventDestroy failed %#X", uint64_t(result));
     }
+
+    _handle = nullptr;
 }
 
-CommandList::CommandList(const std::shared_ptr<ZeroInitStructsHolder>& initStructs,
+CommandList::CommandList(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                          const uint32_t& group_ordinal,
                          bool mtci_is_supported)
-    : _initStructs(initStructs),
+    : _init_structs(init_structs),
       _log("CommandList", Logger::global().level()) {
     ze_mutable_command_list_exp_desc_t mutable_desc = {ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_LIST_EXP_DESC, nullptr, 0};
     ze_command_list_desc_t desc = {ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC, &mutable_desc, group_ordinal, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO(
-        "zeCommandListCreate",
-        zeCommandListCreate(_initStructs->getContext(), _initStructs->getDevice(), &desc, &_handle));
+    auto result = zeCommandListCreate(_init_structs->getContext(), _init_structs->getDevice(), &desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListCreate", result);
 
     if (mtci_is_supported) {
         ze_mutable_command_id_exp_desc_t mutableCmdIdDesc = {ZE_STRUCTURE_TYPE_MUTABLE_COMMAND_ID_EXP_DESC,
                                                              nullptr,
                                                              ZE_MUTABLE_COMMAND_EXP_FLAG_GRAPH_ARGUMENT};
-        THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListGetNextCommandIdExp",
-                                    zeCommandListGetNextCommandIdExp(_handle, &mutableCmdIdDesc, &_command_id));
+        result = zeCommandListGetNextCommandIdExp(_handle, &mutableCmdIdDesc, &_command_id);
+        THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListGetNextCommandIdExp", result);
     }
 }
 void CommandList::reset() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListReset", zeCommandListReset(_handle));
+    auto result = zeCommandListReset(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListReset", result);
 }
 void CommandList::appendMemoryCopy(void* dst, const void* src, const std::size_t size) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendMemoryCopy",
-                                zeCommandListAppendMemoryCopy(_handle, dst, src, size, nullptr, 0, nullptr));
+    auto result = zeCommandListAppendMemoryCopy(_handle, dst, src, size, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendMemoryCopy", result);
 }
 void CommandList::appendGraphInitialize(const ze_graph_handle_t& graph_handle) const {
     ze_result_t result =
-        _initStructs->getGraphDdiTable().pfnAppendGraphInitialize(_handle, graph_handle, nullptr, 0, nullptr);
-    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnAppendGraphInitialize", result, _initStructs->getGraphDdiTable());
+        _init_structs->getGraphDdiTable().pfnAppendGraphInitialize(_handle, graph_handle, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnAppendGraphInitialize", result, _init_structs->getGraphDdiTable());
 }
 void CommandList::appendGraphExecute(const ze_graph_handle_t& graph_handle,
                                      const ze_graph_profiling_query_handle_t& profiling_query_handle) const {
-    ze_result_t result = _initStructs->getGraphDdiTable()
+    ze_result_t result = _init_structs->getGraphDdiTable()
                              .pfnAppendGraphExecute(_handle, graph_handle, profiling_query_handle, nullptr, 0, nullptr);
-    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnAppendGraphExecute", result, _initStructs->getGraphDdiTable());
+    THROW_ON_FAIL_FOR_LEVELZERO_EXT("pfnAppendGraphExecute", result, _init_structs->getGraphDdiTable());
 }
 void CommandList::appendNpuTimestamp(uint64_t* timestamp_buff) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWriteGlobalTimestamp",
-                                zeCommandListAppendWriteGlobalTimestamp(_handle, timestamp_buff, nullptr, 0, nullptr));
+    auto result = zeCommandListAppendWriteGlobalTimestamp(_handle, timestamp_buff, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendWriteGlobalTimestamp", result);
 }
 void CommandList::appendBarrier() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendBarrier", zeCommandListAppendBarrier(_handle, nullptr, 0, nullptr));
+    auto result = zeCommandListAppendBarrier(_handle, nullptr, 0, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListAppendBarrier", result);
 }
 void CommandList::close() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListClose", zeCommandListClose(_handle));
+    auto result = zeCommandListClose(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListClose", result);
 }
 CommandList::~CommandList() {
     auto result = zeCommandListDestroy(_handle);
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeCommandListDestroy failed %#X", uint64_t(result));
     }
+
+    _handle = nullptr;
 }
 void CommandList::updateMutableCommandList(uint32_t arg_index, const void* arg_value) const {
     ze_mutable_graph_argument_exp_desc_t desc = {
-        (ZE_MAJOR_VERSION(_initStructs->getZeDrvApiVersion()) > 1 ||
-         (ZE_MAJOR_VERSION(_initStructs->getZeDrvApiVersion()) == 1 &&
-          ZE_MINOR_VERSION(_initStructs->getZeDrvApiVersion()) >= 11))
+        (ZE_MAJOR_VERSION(_init_structs->getZeDrvApiVersion()) > 1 ||
+         (ZE_MAJOR_VERSION(_init_structs->getZeDrvApiVersion()) == 1 &&
+          ZE_MINOR_VERSION(_init_structs->getZeDrvApiVersion()) >= 11))
             ? ZE_STRUCTURE_TYPE_MUTABLE_GRAPH_ARGUMENT_EXP_DESC
             : static_cast<ze_structure_type_t>(ZE_STRUCTURE_TYPE_MUTABLE_GRAPH_ARGUMENT_EXP_DESC_DEPRECATED),
         nullptr,
@@ -124,45 +135,55 @@ void CommandList::updateMutableCommandList(uint32_t arg_index, const void* arg_v
                                                                   &desc,
                                                                   0};
 
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListUpdateMutableCommandsExp",
-                                zeCommandListUpdateMutableCommandsExp(_handle, &mutable_commands_exp_desc_t));
+    auto result = zeCommandListUpdateMutableCommandsExp(_handle, &mutable_commands_exp_desc_t);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandListUpdateMutableCommandsExp", result);
 }
 
-CommandQueue::CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& initStructs,
-                           const ze_command_queue_priority_t& priority,
-                           const uint32_t& group_ordinal,
-                           bool turbo)
-    : _initStructs(initStructs),
+CommandQueue::CommandQueue(const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+                           const CommandQueueDesc desc,
+                           const uint32_t& group_ordinal)
+    : _init_structs(init_structs),
       _log("CommandQueue", Logger::global().level()) {
-    ze_command_queue_desc_t queue_desc =
-        {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC, nullptr, group_ordinal, 0, 0, ZE_COMMAND_QUEUE_MODE_DEFAULT, priority};
+    ze_command_queue_desc_t queue_desc = {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+                                          nullptr,
+                                          group_ordinal,
+                                          0,
+                                          0,
+                                          ZE_COMMAND_QUEUE_MODE_DEFAULT,
+                                          desc.priority};
 
-    if (turbo) {
-        if (_initStructs->getCommandQueueDdiTable().version()) {
-            ze_command_queue_desc_npu_ext_t turbo_cfg = {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC_NPU_EXT, nullptr, turbo};
+    if (desc.turbo) {
+        if (_init_structs->getCommandQueueDdiTable().version()) {
+            ze_command_queue_desc_npu_ext_t turbo_cfg = {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC_NPU_EXT,
+                                                         nullptr,
+                                                         desc.turbo};
             queue_desc.pNext = &turbo_cfg;
         } else {
             OPENVINO_THROW("Turbo is not supported by the current driver");
         }
     }
 
-    THROW_ON_FAIL_FOR_LEVELZERO(
-        "zeCommandQueueCreate",
-        zeCommandQueueCreate(_initStructs->getContext(), _initStructs->getDevice(), &queue_desc, &_handle));
+    auto result = zeCommandQueueCreate(_init_structs->getContext(), _init_structs->getDevice(), &queue_desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueCreate", result);
+
+    if (_init_structs->getCommandQueueDdiTable().version()) {
+        auto result = _init_structs->getCommandQueueDdiTable().pfnSetWorkloadType(_handle, desc.workload);
+        THROW_ON_FAIL_FOR_LEVELZERO("zeSetWorkloadType", result);
+    }
 }
 void CommandQueue::executeCommandList(CommandList& command_list) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists",
-                                zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, nullptr));
+    auto result = zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, nullptr);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists", result);
 }
 void CommandQueue::executeCommandList(CommandList& command_list, Fence& fence) const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists",
-                                zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, fence.handle()));
+    auto result = zeCommandQueueExecuteCommandLists(_handle, 1, &command_list._handle, fence.handle());
+    THROW_ON_FAIL_FOR_LEVELZERO("zeCommandQueueExecuteCommandLists", result);
 }
 
-void CommandQueue::setWorkloadType(ze_command_queue_workload_type_t workloadType) const {
-    if (_initStructs->getCommandQueueDdiTable().version()) {
-        THROW_ON_FAIL_FOR_LEVELZERO("zeSetWorkloadType",
-                                    _initStructs->getCommandQueueDdiTable().pfnSetWorkloadType(_handle, workloadType));
+void CommandQueue::setWorkloadType(ze_command_queue_workload_type_t workload_type) const {
+    if (_init_structs->getCommandQueueDdiTable().version()) {
+        auto result = _init_structs->getCommandQueueDdiTable().pfnSetWorkloadType(_handle, workload_type);
+        THROW_ON_FAIL_FOR_LEVELZERO("zeSetWorkloadType", result);
     } else {
         OPENVINO_THROW("The WorkloadType property is not supported by the current Driver Version!");
     }
@@ -173,23 +194,71 @@ CommandQueue::~CommandQueue() {
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeCommandQueueDestroy failed %#X", uint64_t(result));
     }
+
+    _handle = nullptr;
 }
 
-Fence::Fence(const CommandQueue& command_queue) : _log("Fence", Logger::global().level()) {
+Fence::Fence(const std::shared_ptr<CommandQueue>& command_queue)
+    : _command_queue(command_queue),
+      _log("Fence", Logger::global().level()) {
     ze_fence_desc_t fence_desc = {ZE_STRUCTURE_TYPE_FENCE_DESC, nullptr, 0};
-    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceCreate", zeFenceCreate(command_queue.handle(), &fence_desc, &_handle));
+    auto result = zeFenceCreate(command_queue->handle(), &fence_desc, &_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceCreate", result);
 }
 void Fence::reset() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceReset", zeFenceReset(_handle));
+    auto result = zeFenceReset(_handle);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceReset", result);
 }
 void Fence::hostSynchronize() const {
-    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", zeFenceHostSynchronize(_handle, UINT64_MAX));
+    auto result = zeFenceHostSynchronize(_handle, UINT64_MAX);
+    THROW_ON_FAIL_FOR_LEVELZERO("zeFenceHostSynchronize", result);
 }
 Fence::~Fence() {
     auto result = zeFenceDestroy(_handle);
     if (ZE_RESULT_SUCCESS != result) {
         _log.error("zeFenceDestroy failed %#X", uint64_t(result));
     }
+
+    _handle = nullptr;
+}
+
+CommandQueuePool::CommandQueuePool() : _log("CommandQueue", Logger::global().level()) {}
+int CommandQueuePool::computeHash(CommandQueueDesc desc) {
+    return (static_cast<size_t>(desc.priority) & 0xFF) | (static_cast<size_t>(desc.workload) & 0xFF) << 8 |
+           (desc.turbo << 16);
+}
+CommandQueuePool& CommandQueuePool::getInstance() {
+    static CommandQueuePool instance;
+    return instance;
+}
+std::shared_ptr<CommandQueue> CommandQueuePool::getCommandQueue(
+    const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
+    const ze_command_queue_priority_t& priority,
+    const ze_command_queue_workload_type_t& workload_type,
+    const uint32_t& group_ordinal,
+    bool turbo) {
+    CommandQueueDesc desc = {priority, workload_type, turbo};
+
+    int hash = computeHash(desc);
+
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_pool.find(hash) != _pool.end()) {
+        // found one weak pointer in the pool
+        // is it valid?
+        auto obj = _pool.at(hash).lock();
+        if (obj) {
+            _log.debug("Get Command Queue");
+            return obj;
+        }
+    }  // otherwise create a new object
+
+    _log.debug("Create Command Queue");
+    auto new_obj = std::make_shared<CommandQueue>(init_structs, desc, group_ordinal);
+
+    auto pair = std::make_pair(hash, new_obj);
+    _pool.emplace(pair);
+
+    return new_obj;
 }
 
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -37,6 +37,12 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(configsInferRequestRunTests)),
                          InferRequestRunTests::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         InferRunTestsOnNewerDrivers,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configsInferRequestRunTests)),
+                         InferRequestRunTests::getTestCaseName);
+
 const std::vector<ov::AnyMap> batchingConfigs = {
     {ov::log::level(ov::log::Level::WARNING), ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)},
     {ov::log::level(ov::log::Level::WARNING), ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER)},

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/compile_and_infer.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_infer_request/compile_and_infer.cpp
@@ -31,4 +31,11 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
                                                 {ov::intel_npu::defer_weights_load(false)}})),
                          ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequestTurbo>);
 
+INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests,
+                         OVCompileAndInferRequesOnNewerDrivers,
+                         ::testing::Combine(::testing::Values(getConstantGraph(ov::element::f32)),
+                                            ::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(configs)),
+                         ov::test::utils::appendPlatformTypeTestName<OVCompileAndInferRequest>);
+
 }  // namespace


### PR DESCRIPTION
### Details:
 - *Using a global command queue per core and not creating different queues for each compiled model. The plugin will create a different queue only if the properties for using them are different from a compiled model to another or if the properties(workload type) are changing at runtime*
 - ***Creating a PR only to run CI validation***

### Tickets:
 - *ticket-id*
