### PR TITLE
Bump cache-apt-pkgs-action in documentation workflow (#28495)

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -24,7 +24,7 @@ jobs:
           lfs: 'true'
 
       - name: Install apt-get dependencies
-        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
+        uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 # v1.4.3
         with:
           packages: graphviz texlive liblua5.2-0 libclang1-9 libclang-cpp9
           version: 3.0


### PR DESCRIPTION
### Details:
Old versions of `cache-apt-pkgs-action` used `upload-artifact@v3` action, which is deprecated and going to be disable on January 30.
