### PR TITLE
[GPU] Check if fused op has dynamic shape in GetParamsKey()

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_selector_params.cpp
@@ -500,6 +500,12 @@ ParamsKey base_params::GetParamsKey() const {
         dynamic_shapes |= i.is_dynamic();
     }
 
+    for (const auto& fused_op : fused_ops) {
+        for (const auto& tensor : fused_op.tensors) {
+            dynamic_shapes |= tensor.is_dynamic();
+        }
+    }
+
     k.EnableOutputDataType(outputs[0].GetDType());
     k.EnableOutputLayout(outputs[0].GetLayout());
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
@@ -212,15 +212,6 @@ bool PermuteKernel_f_y_axes::Validate(const Params& p) const {
     };
 
     const auto& params = dynamic_cast<const permute_params&>(p);
-    // permute_kernel_f_y_axes doesn't support dynamic shape.
-    // So it needs to check if fused ops have dynamic shape.
-    for (auto& fused_op : params.fused_ops) {
-        for (auto tensor : fused_op.tensors) {
-            if (tensor.is_dynamic())
-                return false;
-        }
-    }
-
     const auto& in = params.inputs[0];
     const auto in_layout = in.GetLayout();
     const auto& out = params.outputs[0];

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/permute/permute_kernel_f_y_axes.cpp
@@ -212,6 +212,15 @@ bool PermuteKernel_f_y_axes::Validate(const Params& p) const {
     };
 
     const auto& params = dynamic_cast<const permute_params&>(p);
+    // permute_kernel_f_y_axes doesn't support dynamic shape.
+    // So it needs to check if fused ops have dynamic shape.
+    for (auto& fused_op : params.fused_ops) {
+        for (auto tensor : fused_op.tensors) {
+            if (tensor.is_dynamic())
+                return false;
+        }
+    }
+
     const auto& in = params.inputs[0];
     const auto in_layout = in.GetLayout();
     const auto& out = params.outputs[0];

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -13,6 +13,9 @@
 #include <intel_gpu/primitives/fully_connected.hpp>
 #include <intel_gpu/primitives/reshape.hpp>
 #include <intel_gpu/primitives/crop.hpp>
+
+#include <pass_manager.h>
+#include <program_wrapper.h>
 #include <test_utils.h>
 
 #include "permute_inst.h"
@@ -2173,6 +2176,31 @@ TEST(permute_gpu_f32_dynamic, bfyx_0_2_3_1) {
     for (size_t i = 0; i < array_size; i++) {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
+}
+
+TEST(permute_gpu_f32_dynamic, fused_op_has_dynamic_shape) {
+    auto& engine = get_test_engine();
+
+    auto input1_layout = layout{ov::PartialShape{2, 512, 30}, data_types::f32, format::bfyx};
+    auto input2_layout = layout{ov::PartialShape{2, 30, 512}, data_types::f32, format::bfyx};
+    auto input3_layout = layout{ov::PartialShape::dynamic(3), data_types::f32, format::bfyx};
+
+    topology topology(
+        input_layout("input1", input1_layout),
+        input_layout("input2", input2_layout),
+        input_layout("input3", input3_layout),
+        permute("permute", input_info("input1"), { 0, 2, 1 }),
+        eltwise("add", input_info("permute"), input_info("input2"), eltwise_mode::sum),
+        eltwise("multiply", input_info("add"), input_info("input3"), eltwise_mode::prod),
+        permute("result", input_info("multiply"), {0, 1, 2})
+    );
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    auto program = program::build_program(engine, topology, config, false, false);
+    ASSERT_NE(program, nullptr);
 }
 
 TEST(permute_f_y_axes_fallback, b_fs_yx_fsv16) {


### PR DESCRIPTION
### Details:
 - After prepare_primitive_fusing, if static node has fused nodes which has dynamic shape, then requireKey for the static node should contain the key for the dynamic shape.

### Tickets:
 - 113414
