### PR TITLE
[CPU] Apply 'modernize-*' clang-tidy remarks

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -27,16 +27,19 @@
 # -google-default-arguments,
 # -google-explicit-constructor,
 # -google-readability-casting,
+# -modernize-avoid-c-arrays,
 # -readability-implicit-bool-conversion,
 # -readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers
 # -readability-function-cognitive-complexity. Reasonable way to enforce splitting complex code into simple functions
+# Remove warning disablement after CI pipeline migrates to C++17 from C++20 for:
+# -modernize-use-constraints,
+# -modernize-use-std-numbers
 
 Checks: >
   -*,
   performance-*,
   google-*,
-  modernize-loop-convert,
-  modernize-pass-by-value,
+  modernize-*,
   cppcoreguidelines-prefer-member-initializer,
   readability-else-after-return,
   -bugprone-easily-swappable-parameters,
@@ -49,6 +52,9 @@ Checks: >
   -google-readability-casting,
   -google-readability-todo,
   -readability-braces-around-statements,
+  -modernize-avoid-c-arrays,
+  -modernize-use-constraints,
+  -modernize-use-std-numbers,
   -modernize-use-trailing-return-type,
   -readability-identifier-length,
   -readability-implicit-bool-conversion,
@@ -74,6 +80,8 @@ CheckOptions:
     value: reasonable
   - key: modernize-pass-by-value.IncludeStyle
     value: google
+  - key: modernize-use-auto.MinTypeNameLength
+    value: "3"
 ### To be considered to enable:
 #  # Unifies the usage of the statements
 #  - key: readability-braces-around-statements.ShortStatementLines

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -32,8 +32,8 @@ BlockedMemoryDescPtr IMemory::getDescWithType<BlockedMemoryDesc, 0, 0>() const {
 
 namespace {
 inline void setSubnormalsToZeroAndbf16Saturation(float* data, size_t size, bool ftz, bool bf16saturation) {
-    uint32_t* u32data = reinterpret_cast<uint32_t*>(data);
-    float* floatdata = reinterpret_cast<float*>(data);
+    auto* u32data = reinterpret_cast<uint32_t*>(data);
+    auto* floatdata = reinterpret_cast<float*>(data);
     if (ftz && bf16saturation) {
         for (size_t i = 0; i < size; ++i) {
             if ((u32data[i] & (0xFF << 23)) == 0) {
@@ -583,7 +583,7 @@ bool mbind_move(void* data, size_t size, int targetNode) {
     int realNode = ov::get_org_numa_id(targetNode);
     auto pagesize = getpagesize();
     auto page_count = (size + pagesize - 1) / pagesize;
-    char* pages = reinterpret_cast<char*>(  // NOLINT(performance-no-int-to-ptr)
+    auto* pages = reinterpret_cast<char*>(  // NOLINT(performance-no-int-to-ptr)
         ((reinterpret_cast<uintptr_t>(data)) & ~(static_cast<uintptr_t>(pagesize - 1))));
     uint64_t mask = 0;
     unsigned flags = 0;
@@ -663,7 +663,7 @@ MemoryPtr split_horizontal(const dnnl::engine& eng,
     VectorDims stride_dims = dims;
     stride_dims[dim] = splited_dim_vec[0];
     size_t stride =
-        std::accumulate(stride_dims.begin(), stride_dims.end(), static_cast<size_t>(1), std::multiplies<size_t>()) *
+        std::accumulate(stride_dims.begin(), stride_dims.end(), static_cast<size_t>(1), std::multiplies<>()) *
         prec.size();
 
     // create new shape for target memory

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -24,8 +24,8 @@
 using namespace ov;
 using namespace ov::threading;
 
-#define INIT_VAL     -100
-#define TP_CPU_LIMIT 32
+constexpr int INIT_VAL = -100;
+constexpr int TP_CPU_LIMIT = 32;
 
 namespace ov::intel_cpu {
 
@@ -165,7 +165,7 @@ std::vector<std::vector<int>> get_streams_info_table(
 
     auto check_threads_per_stream = [&]() {
         int count = 0;
-        while (1) {
+        while (true) {
             for (int n_type = MAIN_CORE_PROC; n_type <= HYPER_THREADING_PROC; n_type++) {
                 count += static_cast<int>(proc_type_table[0][n_type] / n_threads_per_stream);
             }

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -148,7 +148,7 @@ VectorDims DnnlExtensionUtils::convertToVectorDims(const memory::dims& dims) {
 }
 
 VectorDims DnnlExtensionUtils::convertToVectorDims(const dnnl::impl::dims_t dims, const int ndims) {
-    return VectorDims(dims, dims + ndims);
+    return {dims, dims + ndims};
 }
 
 memory::dims DnnlExtensionUtils::convertToDnnlDims(const VectorDims& dims) {
@@ -227,7 +227,7 @@ std::string DnnlExtensionUtils::query_impl_info_str(const const_dnnl_primitive_d
     if (status != dnnl_success) {
         OPENVINO_THROW("query_impl_info_str failed.");
     }
-    return std::string(res);
+    return res;
 }
 
 bool DnnlExtensionUtils::find_implementation(dnnl::primitive_desc& desc, impl_desc_type impl_type) {

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_conversion_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_conversion_emitters.cpp
@@ -242,8 +242,8 @@ template <cpu_isa_t isa>
 void jit_convert_truncation_emitter::emit_isa(const std::vector<size_t>& in_idxs,
                                               const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_idxs[0]);
-    TReg dst = TReg(out_idxs[0]);
+    auto src = TReg(in_idxs[0]);
+    auto dst = TReg(out_idxs[0]);
     jit_convert_process<TReg>(src, dst, input_type, output_type, false);
 }
 
@@ -267,8 +267,8 @@ template <cpu_isa_t isa>
 void jit_convert_saturation_emitter::emit_isa(const std::vector<size_t>& in_idxs,
                                               const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_idxs[0]);
-    TReg dst = TReg(out_idxs[0]);
+    auto src = TReg(in_idxs[0]);
+    auto dst = TReg(out_idxs[0]);
     jit_convert_process<TReg>(src, dst, input_type, output_type, true);
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_eltwise_emitters.cpp
@@ -62,8 +62,8 @@ void jit_abs_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->fabs(dst.s, src.s);
 }
@@ -100,9 +100,9 @@ void jit_add_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src0 = TReg(in_vec_idxs[0]);
-    TReg src1 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src0 = TReg(in_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->uni_fadd(dst.s, src0.s, src1.s);
 }
@@ -169,9 +169,9 @@ void jit_clamp_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg aux = TReg(aux_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto aux = TReg(aux_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->ld1r(aux.s, table_val2("min"));
     h->fmax(dst.s, src.s, aux.s);
@@ -214,9 +214,9 @@ void jit_divide_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src0 = TReg(in_vec_idxs[0]);
-    TReg src1 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src0 = TReg(in_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->uni_fdiv(dst.s, src0.s, src1.s);
 }
@@ -603,8 +603,8 @@ void jit_floor_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
     h->frintm(dst.s, src.s);
 }
 
@@ -648,10 +648,10 @@ void jit_floor_mod_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg dividend = TReg(in_vec_idxs[0]);
-    TReg divisor = TReg(in_vec_idxs[1]);
-    TReg r = TReg(out_vec_idxs[0]);
-    TReg aux = TReg(aux_vec_idxs[0]);
+    auto dividend = TReg(in_vec_idxs[0]);
+    auto divisor = TReg(in_vec_idxs[1]);
+    auto r = TReg(out_vec_idxs[0]);
+    auto aux = TReg(aux_vec_idxs[0]);
 
     h->fdiv(aux.s, dividend.s, divisor.s);
     h->frintm(aux.s, aux.s);
@@ -700,8 +700,8 @@ void jit_ceiling_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
     h->frintp(dst.s, src.s);
 }
 
@@ -742,8 +742,8 @@ void jit_negative_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
     h->fneg(dst.s, src.s);
 }
 
@@ -1140,10 +1140,10 @@ void jit_hswish_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
-    TReg aux0 = TReg(aux_vec_idxs[0]);
-    TReg aux1 = TReg(aux_vec_idxs[1]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
+    auto aux0 = TReg(aux_vec_idxs[0]);
+    auto aux1 = TReg(aux_vec_idxs[1]);
 
     // result = (x * min(max(x + 3, 0), 6)) / 6
     h->ld1r(aux0.s, table_val2("three"));
@@ -1222,10 +1222,10 @@ void jit_is_finite_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
-    TReg aux0 = TReg(aux_vec_idxs[0]);
-    TReg aux1 = TReg(aux_vec_idxs[1]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
+    auto aux0 = TReg(aux_vec_idxs[0]);
+    auto aux1 = TReg(aux_vec_idxs[1]);
 
     // According to the IEEE standard, NaN values have the odd property that comparisons involving them are always
     // false.
@@ -1402,9 +1402,9 @@ void jit_is_nan_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
-    TReg aux = TReg(aux_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
+    auto aux = TReg(aux_vec_idxs[0]);
 
     // According to the IEEE standard, NaN values have the odd property that comparisons involving them are always
     // false.
@@ -1707,9 +1707,9 @@ void jit_logical_not_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
-    TReg tmp1 = TReg(aux_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
+    auto tmp1 = TReg(aux_vec_idxs[0]);
 
     h->eor(tmp1.b16, tmp1.b16, tmp1.b16);
     h->fcmeq(tmp1.s, tmp1.s, src.s);
@@ -1818,9 +1818,9 @@ void jit_maximum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src1 = TReg(in_vec_idxs[0]);
-    TReg src2 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[0]);
+    auto src2 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->fmaxnm(dst.s, src1.s, src2.s);
 }
@@ -1860,9 +1860,9 @@ void jit_minimum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src1 = TReg(in_vec_idxs[0]);
-    TReg src2 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[0]);
+    auto src2 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->fminnm(dst.s, src1.s, src2.s);
 }
@@ -1998,10 +1998,10 @@ void jit_mod_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg dividend = TReg(in_vec_idxs[0]);
-    TReg divisor = TReg(in_vec_idxs[1]);
-    TReg r = TReg(out_vec_idxs[0]);
-    TReg aux = TReg(aux_vec_idxs[0]);
+    auto dividend = TReg(in_vec_idxs[0]);
+    auto divisor = TReg(in_vec_idxs[1]);
+    auto r = TReg(out_vec_idxs[0]);
+    auto aux = TReg(aux_vec_idxs[0]);
 
     h->fdiv(aux.s, dividend.s, divisor.s);
     h->frintz(aux.s, aux.s);
@@ -2108,9 +2108,9 @@ void jit_multiply_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src0 = TReg(in_vec_idxs[0]);
-    TReg src1 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src0 = TReg(in_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->uni_fmul(dst.s, src0.s, src1.s);
 }
@@ -2189,7 +2189,7 @@ void jit_power_static_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     if (power == 0.f) {
         h->fmov(dst.s, 1.);
@@ -2201,7 +2201,7 @@ void jit_power_static_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
         return get_from_dst ? TReg(out_vec_idxs[0]) : TReg(in_vec_idxs[0]);
     };
 
-    TReg aux = TReg(aux_vec_idxs[0]);
+    auto aux = TReg(aux_vec_idxs[0]);
     if (scale != 1.f) {
         auto adr = table_val2("scale");
         h->ld1r(aux.s, adr);
@@ -2306,10 +2306,10 @@ void jit_prelu_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg tmp = TReg(aux_vec_idxs[0]);
-    TReg src1 = TReg(in_vec_idxs[0]);
-    TReg src2 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto tmp = TReg(aux_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[0]);
+    auto src2 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->fcmge(dst.s, src1.s, 0.0);
     h->fmul(tmp.s, src1.s, src2.s);
@@ -2354,9 +2354,9 @@ void jit_relu_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const st
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg tmp = TReg(aux_vec_idxs[0]);
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto tmp = TReg(aux_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->movi(tmp.s, 0);
     h->fmaxnm(dst.s, src.s, tmp.s);
@@ -2400,8 +2400,8 @@ void jit_round_half_away_from_zero_emitter::emit_isa(const std::vector<size_t>& 
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->frinta(dst.s, src.s);
 }
@@ -2442,8 +2442,8 @@ void jit_round_half_to_even_emitter::emit_isa(const std::vector<size_t>& in_vec_
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
 
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->frintn(dst.s, src.s);
 }
@@ -2694,8 +2694,8 @@ void jit_sqrt_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const st
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->fsqrt(dst.s, src.s);
 }
@@ -2777,9 +2777,9 @@ void jit_subtract_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src0 = TReg(in_vec_idxs[0]);
-    TReg src1 = TReg(in_vec_idxs[1]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src0 = TReg(in_vec_idxs[0]);
+    auto src1 = TReg(in_vec_idxs[1]);
+    auto dst = TReg(out_vec_idxs[0]);
 
     h->uni_fsub(dst.s, src0.s, src1.s);
 }
@@ -2916,10 +2916,10 @@ void jit_tanh_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const st
     OV_CPU_JIT_EMITTER_ASSERT(exec_prc_ == ov::element::f32, "unsupported precision: " + exec_prc_.to_string());
 
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_vec_idxs[0]);
-    TReg dst = TReg(out_vec_idxs[0]);
+    auto src = TReg(in_vec_idxs[0]);
+    auto dst = TReg(out_vec_idxs[0]);
 
-    TReg aux = TReg(aux_vec_idxs[0]);
+    auto aux = TReg(aux_vec_idxs[0]);
 
     h->ld1r(aux.s, table_val2("two"));
     h->uni_fmul(aux.s, src.s, aux.s);

--- a/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/aarch64/jit_load_store_emitters.cpp
@@ -41,10 +41,10 @@ void jit_load_emitter::emit_impl(const std::vector<size_t>& in_idxs, const std::
 template <cpu_isa_t isa>
 void jit_load_emitter::load_qbyte(const std::vector<size_t>& in_idxs, const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    XReg src = XReg(in_idxs[0]);
-    TReg dst = TReg(out_idxs[0]);
-    SReg dst_s = SReg(out_idxs[0]);
-    DReg dst_d = DReg(out_idxs[0]);
+    auto src = XReg(in_idxs[0]);
+    auto dst = TReg(out_idxs[0]);
+    auto dst_s = SReg(out_idxs[0]);
+    auto dst_d = DReg(out_idxs[0]);
 
     switch (load_num_) {
     case 0:
@@ -56,7 +56,7 @@ void jit_load_emitter::load_qbyte(const std::vector<size_t>& in_idxs, const std:
         h->ldr(dst_d, ptr(src, byte_offset_));
         break;
     case 3: {
-        XReg prc = XReg(aux_gpr_idxs[0]);
+        auto prc = XReg(aux_gpr_idxs[0]);
         h->ldr(dst_d, ptr(src, byte_offset_));
         h->add_imm(prc, src, byte_offset_ + 2 * sizeof(float), h->X_DEFAULT_ADDR);
         h->ld1(dst.s[2], ptr(prc));
@@ -73,11 +73,11 @@ void jit_load_emitter::load_qbyte(const std::vector<size_t>& in_idxs, const std:
 template <cpu_isa_t isa>
 void jit_load_emitter::load_dbyte(const std::vector<size_t>& in_idxs, const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    XReg src = XReg(in_idxs[0]);
-    TReg dst = TReg(out_idxs[0]);
-    HReg dst_h = HReg(out_idxs[0]);
-    SReg dst_s = SReg(out_idxs[0]);
-    DReg dst_d = DReg(out_idxs[0]);
+    auto src = XReg(in_idxs[0]);
+    auto dst = TReg(out_idxs[0]);
+    auto dst_h = HReg(out_idxs[0]);
+    auto dst_s = SReg(out_idxs[0]);
+    auto dst_d = DReg(out_idxs[0]);
 
     switch (load_num_) {
     case 0:
@@ -89,7 +89,7 @@ void jit_load_emitter::load_dbyte(const std::vector<size_t>& in_idxs, const std:
         h->ldr(dst_s, ptr(src, byte_offset_));
         break;
     case 3: {
-        XReg prc = XReg(aux_gpr_idxs[0]);
+        auto prc = XReg(aux_gpr_idxs[0]);
         h->ldr(dst_s, ptr(src, byte_offset_));
         h->add_imm(prc, src, byte_offset_ + 2 * sizeof(uint16_t), h->X_DEFAULT_ADDR);
         h->ld1(dst.h[2], ptr(prc));
@@ -106,11 +106,11 @@ void jit_load_emitter::load_dbyte(const std::vector<size_t>& in_idxs, const std:
 template <cpu_isa_t isa>
 void jit_load_emitter::load_byte(const std::vector<size_t>& in_idxs, const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    XReg src = XReg(in_idxs[0]);
-    TReg dst = TReg(out_idxs[0]);
-    BReg dst_b = BReg(out_idxs[0]);
-    HReg dst_h = HReg(out_idxs[0]);
-    SReg dst_s = SReg(out_idxs[0]);
+    auto src = XReg(in_idxs[0]);
+    auto dst = TReg(out_idxs[0]);
+    auto dst_b = BReg(out_idxs[0]);
+    auto dst_h = HReg(out_idxs[0]);
+    auto dst_s = SReg(out_idxs[0]);
 
     switch (load_num_) {
     case 0:
@@ -122,7 +122,7 @@ void jit_load_emitter::load_byte(const std::vector<size_t>& in_idxs, const std::
         h->ldr(dst_h, ptr(src, byte_offset_));
         break;
     case 3: {
-        XReg prc = XReg(aux_gpr_idxs[0]);
+        auto prc = XReg(aux_gpr_idxs[0]);
         h->ldr(dst_h, ptr(src, byte_offset_));
         h->add_imm(prc, src, byte_offset_ + 2 * sizeof(int8_t), h->X_DEFAULT_ADDR);
         h->ld1(dst.b[2], ptr(prc));
@@ -196,11 +196,11 @@ void jit_store_emitter::emit_impl(const std::vector<size_t>& in_idxs, const std:
 template <cpu_isa_t isa>
 void jit_store_emitter::store_qbyte(const std::vector<size_t>& in_idxs, const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_idxs[0]);
-    SReg src_s = SReg(in_idxs[0]);
-    DReg src_d = DReg(in_idxs[0]);
-    QReg src_q = QReg(in_idxs[0]);
-    XReg dst = XReg(out_idxs[0]);
+    auto src = TReg(in_idxs[0]);
+    auto src_s = SReg(in_idxs[0]);
+    auto src_d = DReg(in_idxs[0]);
+    auto src_q = QReg(in_idxs[0]);
+    auto dst = XReg(out_idxs[0]);
 
     switch (store_num_) {
     case 0:
@@ -212,7 +212,7 @@ void jit_store_emitter::store_qbyte(const std::vector<size_t>& in_idxs, const st
         h->str(src_d, ptr(dst, byte_offset_));
         break;
     case 3: {
-        XReg prc = XReg(aux_gpr_idxs[0]);
+        auto prc = XReg(aux_gpr_idxs[0]);
         h->str(src_d, ptr(dst, byte_offset_));
         h->add_imm(prc, dst, byte_offset_ + 2 * sizeof(float), h->X_DEFAULT_ADDR);
         h->st1(src.s[2], ptr(prc));
@@ -229,11 +229,11 @@ void jit_store_emitter::store_qbyte(const std::vector<size_t>& in_idxs, const st
 template <cpu_isa_t isa>
 void jit_store_emitter::store_dbyte(const std::vector<size_t>& in_idxs, const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_idxs[0]);
-    HReg src_h = HReg(in_idxs[0]);
-    SReg src_s = SReg(in_idxs[0]);
-    DReg src_d = DReg(in_idxs[0]);
-    XReg dst = XReg(out_idxs[0]);
+    auto src = TReg(in_idxs[0]);
+    auto src_h = HReg(in_idxs[0]);
+    auto src_s = SReg(in_idxs[0]);
+    auto src_d = DReg(in_idxs[0]);
+    auto dst = XReg(out_idxs[0]);
 
     switch (store_num_) {
     case 0:
@@ -245,7 +245,7 @@ void jit_store_emitter::store_dbyte(const std::vector<size_t>& in_idxs, const st
         h->str(src_s, ptr(dst, byte_offset_));
         break;
     case 3: {
-        XReg prc = XReg(aux_gpr_idxs[0]);
+        auto prc = XReg(aux_gpr_idxs[0]);
         h->str(src_s, ptr(dst, byte_offset_));
         h->add_imm(prc, dst, byte_offset_ + 2 * sizeof(uint16_t), h->X_DEFAULT_ADDR);
         h->st1(src.h[2], ptr(prc));
@@ -262,11 +262,11 @@ void jit_store_emitter::store_dbyte(const std::vector<size_t>& in_idxs, const st
 template <cpu_isa_t isa>
 void jit_store_emitter::store_byte(const std::vector<size_t>& in_idxs, const std::vector<size_t>& out_idxs) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in_idxs[0]);
-    BReg src_b = BReg(in_idxs[0]);
-    HReg src_h = HReg(in_idxs[0]);
-    SReg src_s = SReg(in_idxs[0]);
-    XReg dst = XReg(out_idxs[0]);
+    auto src = TReg(in_idxs[0]);
+    auto src_b = BReg(in_idxs[0]);
+    auto src_h = HReg(in_idxs[0]);
+    auto src_s = SReg(in_idxs[0]);
+    auto dst = XReg(out_idxs[0]);
 
     switch (store_num_) {
     case 0:
@@ -278,7 +278,7 @@ void jit_store_emitter::store_byte(const std::vector<size_t>& in_idxs, const std
         h->str(src_h, ptr(dst, byte_offset_));
         break;
     case 3: {
-        XReg prc = XReg(aux_gpr_idxs[0]);
+        auto prc = XReg(aux_gpr_idxs[0]);
         h->str(src_h, ptr(dst, byte_offset_));
         h->add_imm(prc, dst, byte_offset_ + 2 * sizeof(int8_t), h->X_DEFAULT_ADDR);
         h->st1(src.b[2], ptr(prc));

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/debug_capabilities.cpp
@@ -36,10 +36,10 @@ void RegPrinter::print_reg_prc(const char* name, const char* ori_name, T* ptr) {
         ss << name << " | ";
     }
     ss << ori_name << ": ";
-    if (std::is_floating_point<T>::value) {
+    if (std::is_floating_point_v<T>) {
         ss << *ptr;
     } else {
-        if (std::is_signed<T>::value) {
+        if (std::is_signed_v<T>) {
             ss << static_cast<int64_t>(*ptr);
         } else {
             ss << static_cast<uint64_t>(*ptr);

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/debug_capabilities.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/debug_capabilities.hpp
@@ -55,15 +55,11 @@ namespace ov::intel_cpu {
 class RegPrinter {
 public:
     using jit_generator = dnnl::impl::cpu::x64::jit_generator;
-    template <typename PRC_T,
-              typename REG_T,
-              typename std::enable_if<std::is_base_of<Xbyak::Xmm, REG_T>::value, int>::type = 0>
+    template <typename PRC_T, typename REG_T, std::enable_if_t<std::is_base_of_v<Xbyak::Xmm, REG_T>, int> = 0>
     static void print(jit_generator& h, REG_T reg, const char* name = nullptr) {
         print_vmm<PRC_T, REG_T>(h, reg, name);
     }
-    template <typename PRC_T,
-              typename REG_T,
-              typename std::enable_if<!std::is_base_of<Xbyak::Xmm, REG_T>::value, int>::type = 0>
+    template <typename PRC_T, typename REG_T, std::enable_if_t<!std::is_base_of_v<Xbyak::Xmm, REG_T>, int> = 0>
     static void print(jit_generator& h, REG_T reg, const char* name = nullptr) {
         print_reg<PRC_T, REG_T>(h, reg, name);
     }

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_conversion_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_conversion_emitters.cpp
@@ -4,6 +4,8 @@
 
 #include "jit_conversion_emitters.hpp"
 
+#include <memory>
+
 #include "utils/bfloat16.hpp"
 
 using namespace dnnl::impl::utils;
@@ -21,7 +23,7 @@ jit_convert_emitter::jit_convert_emitter(jit_generator* host,
       input_type(node->get_input_element_type(0)),
       output_type(node->get_output_element_type(0)) {
     if (output_type == ov::element::bf16) {
-        uni_vcvtneps2bf16.reset(new jit_uni_vcvtneps2bf16(host, host_isa));
+        uni_vcvtneps2bf16 = std::make_shared<jit_uni_vcvtneps2bf16>(host, host_isa);
     }
 }
 
@@ -55,8 +57,8 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_convert_emitter::float2bfloat(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
     if (!uni_vcvtneps2bf16) {
         OV_CPU_JIT_EMITTER_THROW("Converter from float to bf16 isn't initialized!");
     }
@@ -95,11 +97,11 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_convert_truncation_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                               const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
-    Xmm xmm_dst = Xmm(out_vec_idxs[0]);
-    Ymm ymm_dst = Ymm(out_vec_idxs[0]);
+    auto xmm_dst = Xmm(out_vec_idxs[0]);
+    auto ymm_dst = Ymm(out_vec_idxs[0]);
 
     // For Truncation behavior we can just move data from src to dst if we want convert i8 -> u8 or u8 -> i8
     if ((input_type == output_type) || is_i8_and_u8_case()) {
@@ -208,11 +210,11 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_convert_truncation_emitter::dword2int8(const std::vector<size_t>& in_vec_idxs,
                                                 const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
 
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Xmm xmm_dst = Xmm(out_vec_idxs[0]);
-    Ymm ymm_dst = Ymm(out_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto xmm_dst = Xmm(out_vec_idxs[0]);
+    auto ymm_dst = Ymm(out_vec_idxs[0]);
 
     if (isa == dnnl::impl::cpu::x64::avx512_core) {
         h->vpmovdb(xmm_dst, vmm_src);
@@ -250,11 +252,11 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_convert_saturation_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                               const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
-    Xmm xmm_dst = Xmm(out_vec_idxs[0]);
-    Ymm ymm_dst = Ymm(out_vec_idxs[0]);
+    auto xmm_dst = Xmm(out_vec_idxs[0]);
+    auto ymm_dst = Ymm(out_vec_idxs[0]);
 
     if (input_type == output_type) {
         h->uni_vmovups(vmm_dst, vmm_src);
@@ -358,17 +360,17 @@ void jit_convert_saturation_emitter::dword2int8(const std::vector<size_t>& in_ve
                                                 const std::vector<size_t>& out_vec_idxs,
                                                 bool is_signed) const {
     using Vmm = typename conditional3<isa == cpu::x64::sse41, Xmm, isa == cpu::x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
 
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Xmm xmm_dst = Xmm(out_vec_idxs[0]);
-    Ymm ymm_dst = Ymm(out_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto xmm_dst = Xmm(out_vec_idxs[0]);
+    auto ymm_dst = Ymm(out_vec_idxs[0]);
 
     if (isa == dnnl::impl::cpu::x64::avx512_core) {
         if (is_signed) {
             h->vpmovsdb(xmm_dst, vmm_src);
         } else {
-            Vmm vmm_zero = Vmm(aux_vec_idxs[0]);
+            auto vmm_zero = Vmm(aux_vec_idxs[0]);
             h->vpxord(vmm_zero, vmm_zero, vmm_zero);
             h->vpmaxsd(vmm_dst, vmm_src, vmm_zero);
             h->vpmovusdb(xmm_dst, vmm_dst);

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_emitters.cpp
@@ -22,9 +22,7 @@ jit_dnnl_emitter::jit_dnnl_emitter(jit_generator* host,
                                    const std::shared_ptr<ov::Node>& node,
                                    ov::element::Type exec_prc)
     : jit_emitter(host, host_isa, exec_prc),
-      kind(dnnl_eltwise_tanh),
-      alpha(0.f),
-      beta(0.f) {
+      kind(dnnl_eltwise_tanh) {
     set_injector();
 }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -4,13 +4,17 @@
 
 #include "jit_eltwise_emitters.hpp"
 
+#include <memory>
+
 using namespace dnnl::impl::utils;
 using namespace dnnl::impl::cpu;
 using namespace Xbyak;
 
-#define CONST_1_F    0x3f800000  // 1.f
-#define INF_MASK     0x7F800000
-#define INF_NEG_MASK 0xFF800000
+enum {
+    CONST_1_F = 0x3f800000,  // 1.f
+    INF_MASK = 0x7F800000,
+    INF_NEG_MASK = 0xFF800000
+};
 
 namespace ov::intel_cpu {
 
@@ -59,9 +63,9 @@ void jit_add_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const st
 template <x64::cpu_isa_t isa>
 void jit_add_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vadd = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -117,11 +121,11 @@ template <x64::cpu_isa_t isa>
 void jit_mul_add_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                    const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_src2 = Vmm(in_vec_idxs[2]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_src2 = Vmm(in_vec_idxs[2]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vfmadd231_xmm = [this](Xmm vmm_dst, Xmm vmm_src0, Xmm vmm_src1, Xmm vmm_src2) {
         h->uni_vmovups(vmm_dst, vmm_src0);
@@ -220,9 +224,9 @@ template <x64::cpu_isa_t isa>
 void jit_subtract_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                     const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vsub = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -281,9 +285,9 @@ template <x64::cpu_isa_t isa>
 void jit_multiply_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                     const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vmul = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -341,9 +345,9 @@ template <x64::cpu_isa_t isa>
 void jit_divide_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                   const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vdiv = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -352,7 +356,7 @@ void jit_divide_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
             break;
         }
         case ov::element::i32: {
-            Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
+            auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
 
             // The opset doesn't contain vector instruction for integer divide operation
             // As WA we emulate its behavior via fp divide followed by rounding to zero
@@ -420,8 +424,8 @@ template <x64::cpu_isa_t isa>
 void jit_floor_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                  const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
     h->uni_vroundps(vmm_dst, vmm_src, 1);
 }
 
@@ -460,8 +464,8 @@ template <x64::cpu_isa_t isa>
 void jit_ceiling_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                    const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
     h->uni_vroundps(vmm_dst, vmm_src, 2);
 }
 
@@ -502,10 +506,10 @@ template <x64::cpu_isa_t isa>
 void jit_floor_mod_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                      const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
 
     if (isa == x64::sse41) {
         if (vmm_dst.getIdx() != vmm_src0.getIdx()) {
@@ -563,10 +567,10 @@ void jit_mod_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const st
 template <x64::cpu_isa_t isa>
 void jit_mod_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
 
     if (isa == x64::sse41) {
         if (vmm_dst.getIdx() != vmm_src0.getIdx()) {
@@ -621,9 +625,9 @@ template <x64::cpu_isa_t isa>
 void jit_maximum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                    const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vmax = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -682,9 +686,9 @@ template <x64::cpu_isa_t isa>
 void jit_minimum_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                    const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vmin = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -746,9 +750,9 @@ template <x64::cpu_isa_t isa>
 void jit_squared_difference_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                               const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     auto uni_vsqdiff = [this](Vmm vmm_dst, Vmm vmm_src0, Vmm vmm_src1) {
         switch (exec_prc_) {
@@ -817,11 +821,11 @@ template <x64::cpu_isa_t isa>
 void jit_power_dynamic_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                          const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
-    Xmm xmm0 = Xmm(0), xmm1 = Xmm(1);
+    auto xmm0 = Xmm(0), xmm1 = Xmm(1);
 
     // caller obligation to save gprs as callee may use them
     size_t gpr_size = 8;
@@ -945,11 +949,11 @@ template <x64::cpu_isa_t isa>
 void jit_equal_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                  const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->movups(vmm_aux0, vmm_src0);
@@ -1018,11 +1022,11 @@ template <x64::cpu_isa_t isa>
 void jit_not_equal_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                      const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->movups(vmm_aux0, vmm_src0);
@@ -1089,11 +1093,11 @@ template <x64::cpu_isa_t isa>
 void jit_greater_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                    const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->movups(vmm_aux0, vmm_src0);
@@ -1162,11 +1166,11 @@ template <x64::cpu_isa_t isa>
 void jit_greater_equal_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                          const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->movups(vmm_aux0, vmm_src0);
@@ -1231,11 +1235,11 @@ void jit_less_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
 template <x64::cpu_isa_t isa>
 void jit_less_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->movups(vmm_aux0, vmm_src0);
@@ -1304,12 +1308,12 @@ template <x64::cpu_isa_t isa>
 void jit_less_equal_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                       const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->movups(vmm_aux0, vmm_src0);
@@ -1378,12 +1382,12 @@ template <x64::cpu_isa_t isa>
 void jit_logical_and_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
-    Vmm vmm_aux2 = Vmm(aux_vec_idxs[2]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_aux2 = Vmm(aux_vec_idxs[2]);
 
     if (isa == x64::sse41) {
         h->pxor(vmm_aux0, vmm_aux0);
@@ -1471,12 +1475,12 @@ template <x64::cpu_isa_t isa>
 void jit_logical_or_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                       const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
-    Vmm vmm_aux2 = Vmm(aux_vec_idxs[2]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_aux2 = Vmm(aux_vec_idxs[2]);
 
     if (isa == x64::sse41) {
         h->pxor(vmm_aux0, vmm_aux0);
@@ -1564,12 +1568,12 @@ template <x64::cpu_isa_t isa>
 void jit_logical_xor_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
-    Vmm vmm_aux2 = Vmm(aux_vec_idxs[2]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_aux2 = Vmm(aux_vec_idxs[2]);
 
     if (isa == x64::sse41) {
         h->pxor(vmm_aux0, vmm_aux0);
@@ -1657,10 +1661,10 @@ template <x64::cpu_isa_t isa>
 void jit_logical_not_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->pxor(vmm_aux0, vmm_aux0);
@@ -1745,11 +1749,11 @@ template <x64::cpu_isa_t isa>
 void jit_power_static_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                         const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
 
-    Xmm xmm0 = Xmm(0), xmm1 = Xmm(1);
+    auto xmm0 = Xmm(0), xmm1 = Xmm(1);
 
     if (scale != 1.f || shift != 0.f) {
         if (isa == x64::sse41) {
@@ -1944,11 +1948,11 @@ template <x64::cpu_isa_t isa>
 void jit_prelu_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                  const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
 
     if (isa == x64::sse41) {
         h->pxor(vmm_aux0, vmm_aux0);
@@ -2011,8 +2015,8 @@ void jit_sqrt_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
 template <x64::cpu_isa_t isa>
 void jit_sqrt_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     h->uni_vsqrtps(vmm_dst, vmm_src0);
 }
@@ -2054,8 +2058,8 @@ template <x64::cpu_isa_t isa>
 void jit_negative_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                     const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
     h->uni_vpxor(vmm_dst, vmm_dst, vmm_dst);
     h->uni_vsubps(vmm_dst, vmm_dst, vmm_src);
 }
@@ -2097,12 +2101,12 @@ void jit_exp_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const st
 template <x64::cpu_isa_t isa>
 void jit_exp_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     Vmm vmm_mask = need_vmm_mask() ? Vmm(aux_vec_idxs[0]) : Vmm();
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0 + static_cast<size_t>(need_vmm_mask())]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1 + static_cast<size_t>(need_vmm_mask())]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0 + static_cast<size_t>(need_vmm_mask())]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1 + static_cast<size_t>(need_vmm_mask())]);
 
     auto compute_cmp_mask = [&](const Vmm& vmm_src, const Xbyak::Operand& compare_operand, int cmp_predicate) {
         if (host_isa_ == x64::avx512_core) {
@@ -2188,7 +2192,7 @@ size_t jit_exp_emitter::aux_vecs_count() const {
 /// ERF ///
 jit_erf_emitter::jit_erf_emitter(x64::jit_generator* host, x64::cpu_isa_t host_isa, ov::element::Type exec_prc)
     : jit_emitter(host, host_isa, exec_prc) {
-    m_exp_emitter.reset(new jit_exp_emitter(host, host_isa, exec_prc));
+    m_exp_emitter = std::make_unique<jit_exp_emitter>(host, host_isa, exec_prc);
     prepare_table();
 }
 
@@ -2221,13 +2225,13 @@ void jit_erf_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const st
 template <x64::cpu_isa_t isa>
 void jit_erf_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
-    Vmm vmm_aux0 = Vmm(aux_vec_idxs[0]);
-    Vmm vmm_aux1 = Vmm(aux_vec_idxs[1]);
-    Vmm vmm_aux2 = Vmm(aux_vec_idxs[2]);
-    Vmm vmm_aux3 = Vmm(aux_vec_idxs[3]);
+    auto vmm_aux0 = Vmm(aux_vec_idxs[0]);
+    auto vmm_aux1 = Vmm(aux_vec_idxs[1]);
+    auto vmm_aux2 = Vmm(aux_vec_idxs[2]);
+    auto vmm_aux3 = Vmm(aux_vec_idxs[3]);
 
     // IMPORTANT: we use vmm_aux3 to save `x` as exp_compute does not use it.
     h->uni_vmovups(vmm_aux3, vmm_src);
@@ -2339,8 +2343,8 @@ template <x64::cpu_isa_t isa>
 void jit_soft_sign_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                      const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     h->uni_vmovups(vmm_dst, vmm_src);                             // y = x
     h->uni_vandps(vmm_src, vmm_src, table_val("positive_mask"));  // x = abs(x)
@@ -2412,8 +2416,8 @@ void jit_is_finite_emitter::register_table_entries() {
 template <>
 void jit_is_inf_emitter::emit_isa<x64::avx512_core>(const std::vector<size_t>& in_vec_idxs,
                                                     const std::vector<size_t>& out_vec_idxs) const {
-    Zmm vmm_src = Zmm(in_vec_idxs[0]);
-    Zmm vmm_dst = Zmm(out_vec_idxs[0]);
+    auto vmm_src = Zmm(in_vec_idxs[0]);
+    auto vmm_dst = Zmm(out_vec_idxs[0]);
 
     if (detect_negative || detect_positive) {
         auto& ones_mask = h->k1;
@@ -2582,14 +2586,14 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_select_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                   const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_cond = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src0 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[2]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_cond = Vmm(in_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[1]);
+    auto vmm_src1 = Vmm(in_vec_idxs[2]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     if (isa == x64::sse41) {
-        Vmm vmm_mask = Vmm(aux_vec_idxs[0]);
-        Vmm vmm_zero = Vmm(aux_vec_idxs[1]);
+        auto vmm_mask = Vmm(aux_vec_idxs[0]);
+        auto vmm_zero = Vmm(aux_vec_idxs[1]);
         h->uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
         h->uni_vcmpps(vmm_cond, vmm_cond, vmm_zero, 0x4);
         if (vmm_mask.getIdx() != vmm_cond.getIdx()) {
@@ -2600,7 +2604,7 @@ void jit_select_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
         }
         h->uni_vblendvps(vmm_dst, vmm_dst, vmm_src0, vmm_mask);
     } else if (isa == x64::avx2) {
-        Vmm vmm_zero = Vmm(aux_vec_idxs[0]);
+        auto vmm_zero = Vmm(aux_vec_idxs[0]);
         h->uni_vpxor(vmm_zero, vmm_zero, vmm_zero);
         h->uni_vcmpps(vmm_cond, vmm_cond, vmm_zero, 0x4);
         h->uni_vblendvps(vmm_dst, vmm_src1, vmm_src0, vmm_cond);
@@ -2648,9 +2652,9 @@ template <x64::cpu_isa_t isa>
 void jit_bitwise_and_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     if (isa == x64::sse41) {
         if (vmm_dst.getIdx() != vmm_src0.getIdx()) {
@@ -2710,8 +2714,8 @@ template <x64::cpu_isa_t isa>
 void jit_bitwise_not_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src = Vmm(in_vec_idxs[0]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src = Vmm(in_vec_idxs[0]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     if (isa == x64::sse41) {
         if (vmm_dst.getIdx() != vmm_src.getIdx()) {
@@ -2767,9 +2771,9 @@ template <x64::cpu_isa_t isa>
 void jit_bitwise_or_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                       const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     if (isa == x64::sse41) {
         if (vmm_dst.getIdx() != vmm_src0.getIdx()) {
@@ -2821,9 +2825,9 @@ template <x64::cpu_isa_t isa>
 void jit_bitwise_xor_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
                                        const std::vector<size_t>& out_vec_idxs) const {
     using Vmm = typename conditional3<isa == x64::sse41, Xmm, isa == x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_src0 = Vmm(in_vec_idxs[0]);
-    Vmm vmm_src1 = Vmm(in_vec_idxs[1]);
-    Vmm vmm_dst = Vmm(out_vec_idxs[0]);
+    auto vmm_src0 = Vmm(in_vec_idxs[0]);
+    auto vmm_src1 = Vmm(in_vec_idxs[1]);
+    auto vmm_dst = Vmm(out_vec_idxs[0]);
 
     h->uni_vxorps(vmm_dst, vmm_src0, vmm_src1);
 }

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
@@ -28,7 +28,7 @@ enum emitter_in_out_map {
 
 // structure for storage of emitter parameters to hash in map
 struct emitter_params {
-    virtual size_t hash() const = 0;
+    [[nodiscard]] virtual size_t hash() const = 0;
 };
 
 class jit_emitter : public ov::snippets::Emitter {

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.cpp
@@ -4,6 +4,7 @@
 
 #include "jit_load_store_emitters.hpp"
 
+#include <memory>
 #include <utility>
 
 #include "utils/bfloat16.hpp"
@@ -718,7 +719,7 @@ jit_store_emitter::jit_store_emitter(dnnl::impl::cpu::x64::jit_generator* host,
       dst_prc_(dst_prc),
       mode_(mode) {
     prepare_table();
-    uni_vcvtneps2bf16_.reset(new jit_uni_vcvtneps2bf16(host, host_isa));
+    uni_vcvtneps2bf16_ = std::make_shared<jit_uni_vcvtneps2bf16>(host, host_isa);
 }
 
 inline bool jit_store_emitter::is_saturation() const {

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.hpp
@@ -23,7 +23,7 @@ struct load_emitter_params : public emitter_params {
           is_fill_(is_fill),
           fill_value_(std::move(fill_value)) {}
 
-    size_t hash() const override;
+    [[nodiscard]] size_t hash() const override;
 
     ov::element::Type src_prc_;
     ov::element::Type dst_prc_;
@@ -38,7 +38,7 @@ struct store_emitter_params : public emitter_params {
           dst_prc_(dst_prc),
           store_num_(store_num) {}
 
-    size_t hash() const override;
+    [[nodiscard]] size_t hash() const override;
 
     ov::element::Type src_prc_;
     ov::element::Type dst_prc_;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.cpp
@@ -30,10 +30,9 @@ inline snippets::Reg Xbyak2SnippetsReg(const Xbyak::Reg& xb_reg) {
     return {get_reg_type(xb_reg), static_cast<size_t>(xb_reg.getIdx())};
 }
 
-template <
-    cpu_isa_t isa,
-    typename std::enable_if<dnnl::impl::utils::one_of(isa, cpu_isa_t::sse41, cpu_isa_t::avx2, cpu_isa_t::avx512_core),
-                            bool>::type = true>
+template <cpu_isa_t isa,
+          std::enable_if_t<dnnl::impl::utils::one_of(isa, cpu_isa_t::sse41, cpu_isa_t::avx2, cpu_isa_t::avx512_core),
+                           bool> = true>
 struct regs_to_spill {
     static std::vector<Xbyak::Reg> get(const std::set<snippets::Reg>& live_regs) {
         std::vector<Xbyak::Reg> regs_to_spill;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.hpp
@@ -29,7 +29,7 @@ class EmitABIRegSpills {
 public:
     EmitABIRegSpills(dnnl::impl::cpu::x64::jit_generator* h);
     ~EmitABIRegSpills();
-    size_t get_num_spilled_regs() const {
+    [[nodiscard]] size_t get_num_spilled_regs() const {
         return m_regs_to_spill.size();
     }
     /**

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -4,6 +4,8 @@
 
 #include "cpu_generator.hpp"
 
+#include <memory>
+
 #include "emitters/plugin/aarch64/jit_conversion_emitters.hpp"
 #include "emitters/plugin/aarch64/jit_eltwise_emitters.hpp"
 #include "emitters/snippets/aarch64/jit_fill_emitter.hpp"
@@ -120,7 +122,7 @@ class jit_snippet : public dnnl::impl::cpu::aarch64::jit_generator {
 public:
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_snippet)
 
-    virtual ~jit_snippet() = default;
+    ~jit_snippet() override = default;
 
     jit_snippet() : jit_generator() {}
 
@@ -240,7 +242,7 @@ snippets::CompiledSnippetPtr CPUTargetMachine::get_snippet() {
     const auto& result =
         std::make_shared<CompiledSnippetCPU>(std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator>(h.release()));
     // Note that we reset all the generated code, since it was copied into CompiledSnippetCPU
-    h.reset(new jit_snippet());
+    h = std::make_unique<jit_snippet>();
     return result;
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.hpp
@@ -14,9 +14,9 @@ namespace ov::intel_cpu::aarch64 {
 class CompiledSnippetCPU : public snippets::CompiledSnippet {
 public:
     explicit CompiledSnippetCPU(std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator> h);
-    const uint8_t* get_code() const override;
-    size_t get_code_size() const override;
-    bool empty() const override;
+    [[nodiscard]] const uint8_t* get_code() const override;
+    [[nodiscard]] size_t get_code_size() const override;
+    [[nodiscard]] bool empty() const override;
 
 private:
     const std::unique_ptr<const dnnl::impl::cpu::aarch64::jit_generator> h_compiled;
@@ -25,16 +25,16 @@ private:
 class CPUTargetMachine : public snippets::TargetMachine {
 public:
     explicit CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr);
-    std::shared_ptr<snippets::TargetMachine> clone() const override;
-    bool is_supported() const override;
+    [[nodiscard]] std::shared_ptr<snippets::TargetMachine> clone() const override;
+    [[nodiscard]] bool is_supported() const override;
     snippets::CompiledSnippetPtr get_snippet() override;
-    size_t get_lanes() const override;
+    [[nodiscard]] size_t get_lanes() const override;
 
-    std::vector<snippets::Reg> get_abi_arg_regs() const override;
-    std::vector<snippets::Reg> get_gp_reg_pool() const override;
-    std::vector<snippets::Reg> get_vec_reg_pool() const override;
+    [[nodiscard]] std::vector<snippets::Reg> get_abi_arg_regs() const override;
+    [[nodiscard]] std::vector<snippets::Reg> get_gp_reg_pool() const override;
+    [[nodiscard]] std::vector<snippets::Reg> get_vec_reg_pool() const override;
 
-    dnnl::impl::cpu::aarch64::cpu_isa_t get_isa() const;
+    [[nodiscard]] dnnl::impl::cpu::aarch64::cpu_isa_t get_isa() const;
 
 private:
     std::unique_ptr<dnnl::impl::cpu::aarch64::jit_generator> h;

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_fill_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_fill_emitter.cpp
@@ -60,7 +60,7 @@ void jit_fill_emitter::emit_isa(const std::vector<size_t>& in, const std::vector
 template <cpu_isa_t isa>
 void jit_fill_emitter::fill_full(const std::vector<size_t>& out) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg dst = TReg(out[0]);
+    auto dst = TReg(out[0]);
 
     // Optimized impl for zero
     if (is_optimized()) {
@@ -75,7 +75,7 @@ void jit_fill_emitter::fill_full(const std::vector<size_t>& out) const {
 template <cpu_isa_t isa>
 void jit_fill_emitter::fill_tail(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg dst = TReg(out[0]);
+    auto dst = TReg(out[0]);
 
     switch (offset) {
     case 1:

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
@@ -222,8 +222,8 @@ void jit_kernel_static_emitter::init_data_pointers(const std::vector<XReg>& arg_
     XReg reg_runtime_params = arg_regs[0];
     XReg reg_indexes = arg_regs[1];
 
-    XReg reg_tmp = XReg(h->X_TMP_0);
-    XReg reg_aux = XReg(h->X_TMP_1);
+    auto reg_tmp = XReg(h->X_TMP_0);
+    auto reg_aux = XReg(h->X_TMP_1);
 
     const auto num_params = num_inputs + num_outputs;
     // Note that we don't need offset for the last dim, since it's handled directly by Tile emitter

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.cpp
@@ -48,7 +48,7 @@ void jit_loop_begin_emitter::emit_code_impl(const std::vector<size_t>& in,
 }
 
 void jit_loop_begin_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
-    XReg reg_work_amount = XReg(out[0]);
+    auto reg_work_amount = XReg(out[0]);
     if (!evaluate_once) {
         h->mov(reg_work_amount, work_amount);
     }
@@ -136,13 +136,13 @@ void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::v
     data_ptr_reg_idxs.reserve(num_inputs + num_outputs);
     std::copy(in.begin(), in.end() - 1, std::back_inserter(data_ptr_reg_idxs));
 
-    XReg reg_work_amount = XReg(in.back());
+    auto reg_work_amount = XReg(in.back());
     if (!evaluate_once) {
         for (size_t idx = 0; idx < data_ptr_reg_idxs.size(); idx++) {
             if (!is_incremented[idx] || ptr_increments[idx] == 0) {
                 continue;
             }
-            XReg data_reg = XReg(data_ptr_reg_idxs[idx]);
+            auto data_reg = XReg(data_ptr_reg_idxs[idx]);
             if (ptr_increments[idx] > 0) {
                 h->add_imm(data_reg, data_reg, ptr_increments[idx] * wa_increment * data_sizes[idx], h->X_TMP_0);
             } else if (ptr_increments[idx] < 0) {
@@ -158,7 +158,7 @@ void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::v
         if (!is_incremented[idx] || finalization_offsets[idx] == 0) {
             continue;
         }
-        XReg data_reg = XReg(static_cast<int>(data_ptr_reg_idxs[idx]));
+        auto data_reg = XReg(static_cast<int>(data_ptr_reg_idxs[idx]));
         if (finalization_offsets[idx] > 0) {
             h->add_imm(data_reg, data_reg, finalization_offsets[idx] * data_sizes[idx], h->X_TMP_0);
         } else if (finalization_offsets[idx] < 0) {

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
@@ -4,6 +4,8 @@
 
 #include "jit_memory_emitters.hpp"
 
+#include <memory>
+
 #include "emitters/utils.hpp"
 
 using namespace Xbyak_aarch64;
@@ -33,7 +35,7 @@ jit_load_memory_emitter::jit_load_memory_emitter(jit_generator* h, cpu_isa_t isa
     count = load->get_count();
     byte_offset = load->get_offset();
     in_out_type_ = emitter_in_out_map::gpr_to_vec;
-    load_emitter.reset(new jit_load_emitter(h, isa, src_prc, dst_prc, count, byte_offset));
+    load_emitter = std::make_unique<jit_load_emitter>(h, isa, src_prc, dst_prc, count, byte_offset);
 }
 
 void jit_load_memory_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
@@ -81,8 +83,8 @@ void jit_load_broadcast_emitter::emit_impl(const std::vector<size_t>& in, const 
 template <cpu_isa_t isa>
 void jit_load_broadcast_emitter::emit_isa(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    XReg src = XReg(in[0]);
-    TReg dst = TReg(out[0]);
+    auto src = XReg(in[0]);
+    auto dst = TReg(out[0]);
 
     h->uni_ld1rw(dst.s, src, byte_offset);
 }
@@ -99,7 +101,7 @@ jit_store_memory_emitter::jit_store_memory_emitter(jit_generator* h, cpu_isa_t i
     count = store->get_count();
     byte_offset = store->get_offset();
     in_out_type_ = emitter_in_out_map::vec_to_gpr;
-    store_emitter.reset(new jit_store_emitter(h, isa, src_prc, dst_prc, count, byte_offset));
+    store_emitter = std::make_unique<jit_store_emitter>(h, isa, src_prc, dst_prc, count, byte_offset);
 }
 
 void jit_store_memory_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_snippets_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_snippets_emitters.cpp
@@ -45,8 +45,8 @@ void jit_broadcast_move_emitter::emit_impl(const std::vector<size_t>& in, const 
 template <cpu_isa_t isa>
 void jit_broadcast_move_emitter::emit_isa(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg src = TReg(in[0]);
-    TReg dst = TReg(out[0]);
+    auto src = TReg(in[0]);
+    auto dst = TReg(out[0]);
 
     switch (byte_size) {
     case 4:
@@ -89,7 +89,7 @@ void jit_scalar_emitter::emit_impl(const std::vector<size_t>& in, const std::vec
 template <cpu_isa_t isa>
 void jit_scalar_emitter::emit_isa(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     using TReg = typename dnnl::impl::cpu::aarch64::cpu_isa_traits<isa>::TReg;
-    TReg dst = TReg(out[0]);
+    auto dst = TReg(out[0]);
     AdrImm src = table_val("scalar");
 
     h->uni_ld1rw(dst.s, src.getXn(), src.getImm());

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_kernel_executor_table.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_kernel_executor_table.hpp
@@ -29,7 +29,7 @@ protected:
     struct Key {
         explicit Key(Conf c) : config{std::move(c)} {}
         const Conf config;
-        size_t hash() const {
+        [[nodiscard]] size_t hash() const {
             return config.hash();
         }
         bool operator==(const Key& rhs) const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -44,7 +44,7 @@ public:
 
     // Note: This method is temporarily used only by `BrgemmExternalRepackingAdjuster` to create kernels for repacking.
     //       Please, remove this method when the adjuster is deprecated
-    const ov::intel_cpu::MultiCacheWeakPtr& get_cache() const {
+    [[nodiscard]] const ov::intel_cpu::MultiCacheWeakPtr& get_cache() const {
         return compiled_kernel_cache;
     }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/repacked_input.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/repacked_input.hpp
@@ -21,17 +21,16 @@ struct RepackedInput {
                   VectorDims in_offsets,
                   VectorDims out_offsets);
 
-    template <class T = RepackedInputKernel,
-              typename std::enable_if<std::is_base_of<RepackedInputKernel, T>::value, bool>::type = true>
+    template <class T = RepackedInputKernel, std::enable_if_t<std::is_base_of_v<RepackedInputKernel, T>, bool> = true>
     std::shared_ptr<const T> kernel() const {
         const auto ker = std::dynamic_pointer_cast<const T>(m_kernel);
         OPENVINO_ASSERT(ker, "Kernel is empty!");
         return ker;
     }
 
-    const CpuBlockedMemoryDescPtr& desc() const;
-    const VectorDims& in_offsets() const;
-    const VectorDims& out_offsets() const;
+    [[nodiscard]] const CpuBlockedMemoryDescPtr& desc() const;
+    [[nodiscard]] const VectorDims& in_offsets() const;
+    [[nodiscard]] const VectorDims& out_offsets() const;
 
 private:
     std::shared_ptr<const RepackedInputKernel> m_kernel{nullptr};

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -4,6 +4,7 @@
 
 #include "cpu_generator.hpp"
 
+#include <memory>
 #include <openvino/opsets/opset5.hpp>
 
 #include "emitters/plugin/x64/jit_conversion_emitters.hpp"
@@ -154,7 +155,7 @@ class jit_snippet : public dnnl::impl::cpu::x64::jit_generator {
 public:
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_snippet)
 
-    ~jit_snippet() = default;
+    ~jit_snippet() override = default;
 
     jit_snippet() : jit_generator(jit_name()) {}
 
@@ -397,7 +398,7 @@ snippets::CompiledSnippetPtr intel_cpu::CPUTargetMachine::get_snippet() {
     const auto& result =
         std::make_shared<CompiledSnippetCPU>(std::unique_ptr<dnnl::impl::cpu::x64::jit_generator>(h.release()));
     // Note that we reset all the generated code, since it was copied into CompiledSnippetCPU
-    h.reset(new jit_snippet());
+    h = std::make_unique<jit_snippet>();
     return result;
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
@@ -21,25 +21,25 @@ class CompiledSnippetCPU : public snippets::CompiledSnippet {
     const std::unique_ptr<const dnnl::impl::cpu::x64::jit_generator> h_compiled;
 
 public:
-    const uint8_t* get_code() const override;
-    size_t get_code_size() const override;
-    bool empty() const override;
+    [[nodiscard]] const uint8_t* get_code() const override;
+    [[nodiscard]] size_t get_code_size() const override;
+    [[nodiscard]] bool empty() const override;
     explicit CompiledSnippetCPU(std::unique_ptr<dnnl::impl::cpu::x64::jit_generator> h);
 };
 
 class CPUTargetMachine : public snippets::TargetMachine {
 public:
     explicit CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr);
-    std::shared_ptr<snippets::TargetMachine> clone() const override;
-    bool is_supported() const override;
+    [[nodiscard]] std::shared_ptr<snippets::TargetMachine> clone() const override;
+    [[nodiscard]] bool is_supported() const override;
     snippets::CompiledSnippetPtr get_snippet() override;
-    size_t get_lanes() const override;
+    [[nodiscard]] size_t get_lanes() const override;
 
-    std::vector<snippets::Reg> get_abi_arg_regs() const override;
-    std::vector<snippets::Reg> get_gp_reg_pool() const override;
-    std::vector<snippets::Reg> get_vec_reg_pool() const override;
+    [[nodiscard]] std::vector<snippets::Reg> get_abi_arg_regs() const override;
+    [[nodiscard]] std::vector<snippets::Reg> get_gp_reg_pool() const override;
+    [[nodiscard]] std::vector<snippets::Reg> get_vec_reg_pool() const override;
 
-    dnnl::impl::cpu::x64::cpu_isa_t get_isa() const;
+    [[nodiscard]] dnnl::impl::cpu::x64::cpu_isa_t get_isa() const;
 #ifdef SNIPPETS_DEBUG_CAPS
     SnippetsDebugCapsConfig debug_config;
 #endif

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.cpp
@@ -20,8 +20,7 @@ jit_binary_call_emitter::jit_binary_call_emitter(dnnl::impl::cpu::x64::jit_gener
                                                  dnnl::impl::cpu::x64::cpu_isa_t isa,
                                                  std::set<snippets::Reg> live_regs)
     : jit_emitter(h, isa),
-      m_regs_to_spill(std::move(live_regs)),
-      m_regs_initialized(false) {}
+      m_regs_to_spill(std::move(live_regs)) {}
 
 void jit_binary_call_emitter::init_binary_call_regs(size_t num_binary_args,
                                                     const std::vector<size_t>& in,

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.cpp
@@ -111,7 +111,7 @@ void jit_brgemm_emitter::emit_impl(const std::vector<size_t>& in, const std::vec
     }
 }
 
-template <typename T, typename std::enable_if<std::is_base_of<BrgemmBaseKernelExecutor, T>::value, bool>::type>
+template <typename T, std::enable_if_t<std::is_base_of_v<BrgemmBaseKernelExecutor, T>, bool>>
 void jit_brgemm_emitter::emit_call(const std::vector<size_t>& mem_ptrs_idxs) const {
     const Xbyak::Reg64& aux_reg = get_call_address_reg();
     const Xbyak::Reg64& callee_saved_reg = get_callee_saved_reg();

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.hpp
@@ -28,8 +28,7 @@ private:
     void validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
-    template <typename T,
-              typename std::enable_if<std::is_base_of<x64::BrgemmBaseKernelExecutor, T>::value, bool>::type = true>
+    template <typename T, std::enable_if_t<std::is_base_of_v<x64::BrgemmBaseKernelExecutor, T>, bool> = true>
     void emit_call(const std::vector<size_t>& mem_ptrs_idxs) const;
 
     // Note: offsets order: A, B, C (+ scratchpad, if needed). Values can be dynamic_value if offset is calculated in

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_fill_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_fill_emitter.cpp
@@ -57,8 +57,8 @@ void jit_fill_emitter::emit_isa(const std::vector<size_t>& in, const std::vector
     using Vmm = typename dnnl::impl::utils::
         conditional3<isa == dnnl::impl::cpu::x64::sse41, Xmm, isa == dnnl::impl::cpu::x64::avx2, Ymm, Zmm>::type;
 
-    Vmm src_vmm = Vmm(in[0]);
-    Vmm dst_vmm = Vmm(out[0]);
+    auto src_vmm = Vmm(in[0]);
+    auto dst_vmm = Vmm(out[0]);
 
     const size_t supported_et_size = 4;
     const auto register_capacity = (src_vmm.getBit() / 8) / supported_et_size;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_horizon_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_horizon_emitter.cpp
@@ -43,23 +43,23 @@ void jit_horizon_emitter::emit_isa(const std::vector<size_t>& in, const std::vec
                                                          Xbyak::Ymm,
                                                          Xbyak::Zmm>::type;
 
-    Vmm src_vmm = Vmm(in[0]);
-    Vmm dst_vmm = Vmm(out[0]);
-    Vmm aux_vmm = Vmm(aux_vec_idxs[0]);
+    auto src_vmm = Vmm(in[0]);
+    auto dst_vmm = Vmm(out[0]);
+    auto aux_vmm = Vmm(aux_vec_idxs[0]);
 
     if (in[0] != out[0]) {
         h->uni_vmovups(dst_vmm, src_vmm);
     }
     if (isa == dnnl::impl::cpu::x64::avx512_core) {
-        Xbyak::Zmm dst_zmm = Xbyak::Zmm(out[0]);
-        Xbyak::Zmm aux_zmm = Xbyak::Zmm(aux_vec_idxs[0]);
+        auto dst_zmm = Xbyak::Zmm(out[0]);
+        auto aux_zmm = Xbyak::Zmm(aux_vec_idxs[0]);
         h->vshuff32x4(aux_zmm, dst_zmm, dst_zmm, 0x4E);
         perform_op<Xbyak::Zmm>(dst_zmm, dst_zmm, aux_zmm);
         h->vshuff32x4(aux_zmm, dst_zmm, dst_zmm, 0xB1);
         perform_op<Xbyak::Zmm>(dst_zmm, dst_zmm, aux_zmm);
     } else if (isa == dnnl::impl::cpu::x64::avx2) {
-        Xbyak::Ymm dst_ymm = Xbyak::Ymm(out[0]);
-        Xbyak::Ymm aux_ymm = Xbyak::Ymm(aux_vec_idxs[0]);
+        auto dst_ymm = Xbyak::Ymm(out[0]);
+        auto aux_ymm = Xbyak::Ymm(aux_vec_idxs[0]);
         h->vperm2i128(aux_ymm, dst_ymm, dst_ymm, 0x01);
         perform_op<Xbyak::Ymm>(dst_ymm, dst_ymm, aux_ymm);
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
@@ -41,7 +41,7 @@ public:
         }
     }
 
-    const Reg64& get_reg() const {
+    [[nodiscard]] const Reg64& get_reg() const {
         return m_aux_gpr_idx;
     }
 
@@ -97,7 +97,7 @@ void jit_loop_begin_emitter::emit_impl(const std::vector<size_t>& in, const std:
         return;
     }
 
-    Reg64 reg_work_amount = Reg64(static_cast<int>(out.back()));
+    auto reg_work_amount = Reg64(static_cast<int>(out.back()));
     if (is_work_amount_dynamic) {
         jit_aux_gpr_holder gpr_holder(h, aux_gpr_idxs, out);  // loop_begin has only output registers
         Reg64 reg_loop_args_ptr = gpr_holder.get_reg();
@@ -248,7 +248,7 @@ void jit_loop_end_emitter::emit_impl(const std::vector<size_t>& in, const std::v
     if (!evaluate_once) {
         apply_increments(are_ptr_increments_dynamic, GET_OFF_LOOP_ARGS(m_ptr_increments), ptr_increments, wa_increment);
 
-        Reg64 reg_work_amount = Reg64(in.back());
+        auto reg_work_amount = Reg64(in.back());
         h->sub(reg_work_amount, wa_increment);
         h->cmp(reg_work_amount, wa_increment);
         h->jge(*loop_begin_label, Xbyak::CodeGenerator::T_NEAR);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_memory_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_memory_emitters.cpp
@@ -4,6 +4,8 @@
 
 #include "jit_memory_emitters.hpp"
 
+#include <memory>
+
 #include "emitters/snippets/jit_snippets_call_args.hpp"
 #include "snippets/op/buffer.hpp"
 #include "transformations/snippets/x64/op/load_convert.hpp"
@@ -96,7 +98,7 @@ void jit_memory_emitter::emit_code_impl(const std::vector<size_t>& in_idxs,
                                         const std::vector<size_t>& pool_gpr_idxs) const {
     emitter_preamble(in_idxs, out_idxs, pool_vec_idxs, pool_gpr_idxs);
 
-    Reg64 reg_runtime_params = abi_param1;  // defined by jit_kernel_emitter
+    auto reg_runtime_params = abi_param1;  // defined by jit_kernel_emitter
     Reg64 aux_gpr = is_offset_runtime ? Reg64(static_cast<int>(aux_gpr_idxs.back())) : Reg64();
 
     Reg64 data_reg;
@@ -125,7 +127,7 @@ void jit_memory_emitter::emit_code_impl(const std::vector<size_t>& in_idxs,
 jit_load_memory_emitter::jit_load_memory_emitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
     : jit_memory_emitter(h, isa, expr, emitter_in_out_map::gpr_to_vec) {
     OV_CPU_JIT_EMITTER_ASSERT(ov::is_type<snippets::op::Load>(expr->get_node()), "expects Load node");
-    load_emitter.reset(new jit_load_emitter(h, isa, src_prc, dst_prc, count));
+    load_emitter = std::make_unique<jit_load_emitter>(h, isa, src_prc, dst_prc, count);
 }
 
 void jit_load_memory_emitter::emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
@@ -165,7 +167,7 @@ void jit_load_broadcast_emitter::emit_isa(const std::vector<size_t>& in, const s
     using Vmm = typename dnnl::impl::utils::
         conditional3<isa == dnnl::impl::cpu::x64::sse41, Xmm, isa == dnnl::impl::cpu::x64::avx2, Ymm, Zmm>::type;
     Reg64 in_reg(in[0]);
-    Vmm vmm_dst = Vmm(out[0]);
+    auto vmm_dst = Vmm(out[0]);
 
     // It doesn't really matter if we broadcast or `movss` for vector tails so keep only one version for
     // `BroadcastLoad`, key point here is not to add post-increment, it might be fixed by some other approach in future
@@ -187,11 +189,13 @@ void jit_load_broadcast_emitter::emit_isa(const std::vector<size_t>& in, const s
 jit_store_memory_emitter::jit_store_memory_emitter(jit_generator* h, cpu_isa_t isa, const ExpressionPtr& expr)
     : jit_memory_emitter(h, isa, expr, emitter_in_out_map::vec_to_gpr) {
     if (ov::is_type<ov::intel_cpu::StoreConvertTruncation>(expr->get_node())) {
-        store_emitter.reset(new jit_store_emitter(h, isa, src_prc, dst_prc, count, arithmetic_mode::truncation));
+        store_emitter =
+            std::make_unique<jit_store_emitter>(h, isa, src_prc, dst_prc, count, arithmetic_mode::truncation);
     } else if (ov::is_type<ov::intel_cpu::StoreConvertSaturation>(expr->get_node())) {
-        store_emitter.reset(new jit_store_emitter(h, isa, src_prc, dst_prc, count, arithmetic_mode::saturation));
+        store_emitter =
+            std::make_unique<jit_store_emitter>(h, isa, src_prc, dst_prc, count, arithmetic_mode::saturation);
     } else if (ov::is_type<ov::snippets::op::Store>(expr->get_node())) {
-        store_emitter.reset(new jit_store_emitter(h, isa, src_prc, dst_prc, count));
+        store_emitter = std::make_unique<jit_store_emitter>(h, isa, src_prc, dst_prc, count);
     } else {
         OV_CPU_JIT_EMITTER_THROW("expects Store node");
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_segfault_detector_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_segfault_detector_emitter.hpp
@@ -6,7 +6,7 @@
 
 #    pragma once
 
-#    include <string.h>
+#    include <cstring>
 
 #    include "emitters/plugin/x64/jit_emitter.hpp"
 #    include "openvino/runtime/threading/thread_local.hpp"

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_snippets_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_snippets_emitters.cpp
@@ -60,8 +60,8 @@ template <cpu_isa_t isa>
 void jit_broadcast_move_emitter::emit_isa(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     using Vmm = typename dnnl::impl::utils::
         conditional3<isa == dnnl::impl::cpu::x64::sse41, Xmm, isa == dnnl::impl::cpu::x64::avx2, Ymm, Zmm>::type;
-    Xmm xmm_src0 = Xmm(in[0]);
-    Vmm vmm_dst = Vmm(out[0]);
+    auto xmm_src0 = Xmm(in[0]);
+    auto vmm_dst = Vmm(out[0]);
 
     switch (byte_size) {
     case 4:
@@ -123,7 +123,7 @@ template <cpu_isa_t isa>
 void jit_scalar_emitter::emit_isa(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     using Vmm = typename dnnl::impl::utils::
         conditional3<isa == dnnl::impl::cpu::x64::sse41, Xmm, isa == dnnl::impl::cpu::x64::avx2, Ymm, Zmm>::type;
-    Vmm vmm_dst = Vmm(out[0]);
+    auto vmm_dst = Vmm(out[0]);
     h->uni_vbroadcastss(vmm_dst, table_val("scalar"));
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.cpp
@@ -4,6 +4,8 @@
 
 #include "brgemm.hpp"
 
+#include <memory>
+
 #include "common/utils.hpp"
 #include "dnnl_extension_utils.h"
 #include "transformations/snippets/x64/op/brgemm_cpu.hpp"
@@ -98,7 +100,7 @@ BrgemmKernelReferenceExecutor::BrgemmKernelReferenceExecutor(ov::intel_cpu::Mult
 
 std::shared_ptr<BrgemmCompiledKernel> BrgemmKernelReferenceExecutor::compile_kernel(const BrgemmKernelConfig& c) const {
     const auto& res = std::make_shared<BrgemmCompiledKernel>();
-    res->brgemm_kernel.reset(new brgemm_ref_kernel(c));
+    res->brgemm_kernel = std::make_shared<brgemm_ref_kernel>(c);
     return res;
 }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#include "emitters/snippets/x64/kernel_executors/brgemm_base.hpp"
+#include <memory>
+
+#include "brgemm_base.hpp"
 
 namespace ov::intel_cpu::x64 {
 
@@ -16,11 +18,11 @@ public:
                        dnnl::impl::cpu::x64::cpu_isa_t primitive_isa);
     BrgemmKernelConfig() = delete;
 
-    std::unique_ptr<snippets::KernelExecutorBase::GenericConfig> get_clone_ptr() const override {
-        return std::unique_ptr<BrgemmKernelConfig>(new BrgemmKernelConfig(*this));
+    [[nodiscard]] std::unique_ptr<snippets::KernelExecutorBase::GenericConfig> get_clone_ptr() const override {
+        return std::make_unique<BrgemmKernelConfig>(*this);
     }
 
-    bool is_with_comp() const {
+    [[nodiscard]] bool is_with_comp() const {
         return m_static_params->is_with_comp;
     }
 
@@ -38,13 +40,13 @@ private:
             return !(*this == rhs);
         }
 #ifdef SNIPPETS_DEBUG_CAPS
-        std::string to_string() const;
+        [[nodiscard]] std::string to_string() const;
 #endif
     private:
         static size_t compute_hash(bool is_with_comp);
     };
 
-    std::shared_ptr<StaticBaseParams> get_static_params() const override {
+    [[nodiscard]] std::shared_ptr<StaticBaseParams> get_static_params() const override {
         return m_static_params;
     }
 
@@ -73,7 +75,7 @@ public:
     static void execute(const BrgemmKernelExecutor* executor, call_args* args);
 
 protected:
-    std::shared_ptr<BrgemmCompiledKernel> compile_kernel(const BrgemmKernelConfig& c) const override;
+    [[nodiscard]] std::shared_ptr<BrgemmCompiledKernel> compile_kernel(const BrgemmKernelConfig& c) const override;
 
     void update_config(const ov::snippets::lowered::ExpressionPtr& expr,
                        const ov::snippets::lowered::LinearIRCPtr& linear_ir,
@@ -88,7 +90,7 @@ public:
     using BrgemmKernelExecutor::execute;
 
 protected:
-    std::shared_ptr<BrgemmCompiledKernel> compile_kernel(const BrgemmKernelConfig& c) const override;
+    [[nodiscard]] std::shared_ptr<BrgemmCompiledKernel> compile_kernel(const BrgemmKernelConfig& c) const override;
 };
 
 struct brgemm_ref_kernel : public dnnl::impl::cpu::x64::brgemm_kernel_t {
@@ -97,7 +99,7 @@ struct brgemm_ref_kernel : public dnnl::impl::cpu::x64::brgemm_kernel_t {
     dnnl_status_t create_kernel() override {
         return dnnl_status_t::dnnl_success;
     }
-    const dnnl::impl::cpu::x64::jit_generator* get_jit_generator() const override {
+    [[nodiscard]] const dnnl::impl::cpu::x64::jit_generator* get_jit_generator() const override {
         OV_CPU_JIT_EMITTER_THROW("get_jit_generator should not be called for reference kernel");
         return nullptr;
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_amx.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_amx.cpp
@@ -84,7 +84,7 @@ struct BrgemmCopyAKey {
           src_stride{src_stride},
           LDA{LDA} {}
 
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         size_t seed = 0;
         HASH(isa);
         HASH(dt);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_amx.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_amx.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cpu/x64/matmul/brgemm_matmul_copy_utils.hpp>
+#include <memory>
 
 #include "emitters/plugin/x64/jit_emitter.hpp"
 #include "emitters/snippets/jit_snippets_call_args.hpp"
@@ -19,18 +20,18 @@ public:
                           dnnl::impl::cpu::x64::cpu_isa_t primitive_isa);
     BrgemmAMXKernelConfig() = delete;
 
-    std::unique_ptr<GenericConfig> get_clone_ptr() const override {
-        return std::unique_ptr<BrgemmAMXKernelConfig>(new BrgemmAMXKernelConfig(*this));
+    [[nodiscard]] std::unique_ptr<GenericConfig> get_clone_ptr() const override {
+        return std::make_unique<BrgemmAMXKernelConfig>(*this);
     }
 
-    dnnl_dim_t get_inner_K_blk() const {
+    [[nodiscard]] dnnl_dim_t get_inner_K_blk() const {
         return m_static_params->inner_k_blk;
     }
-    dnnl_dim_t get_vnni_factor() const {
+    [[nodiscard]] dnnl_dim_t get_vnni_factor() const {
         return m_static_params->vnni_factor;
     }
 
-    bool need_copy_a(dnnl_dim_t K) const;
+    [[nodiscard]] bool need_copy_a(dnnl_dim_t K) const;
 
 private:
     struct StaticParams : StaticBaseParams {
@@ -46,13 +47,13 @@ private:
             return !(*this == rhs);
         }
 #ifdef SNIPPETS_DEBUG_CAPS
-        std::string to_string() const;
+        [[nodiscard]] std::string to_string() const;
 #endif
     private:
         static size_t compute_hash(dnnl_dim_t inner_k_blk, dnnl_dim_t vnni_factor);
     };
 
-    std::shared_ptr<StaticBaseParams> get_static_params() const override {
+    [[nodiscard]] std::shared_ptr<StaticBaseParams> get_static_params() const override {
         return m_static_params;
     }
 
@@ -88,7 +89,8 @@ public:
     static void execute(const BrgemmAMXKernelExecutor* executor, call_args* args);
 
 protected:
-    std::shared_ptr<BrgemmAMXCompiledKernel> compile_kernel(const BrgemmAMXKernelConfig& c) const override;
+    [[nodiscard]] std::shared_ptr<BrgemmAMXCompiledKernel> compile_kernel(
+        const BrgemmAMXKernelConfig& c) const override;
 
     void update_config(const ov::snippets::lowered::ExpressionPtr& expr,
                        const ov::snippets::lowered::LinearIRCPtr& linear_ir,

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_base.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_base.hpp
@@ -15,30 +15,31 @@ struct BrgemmBaseKernelConfig : public ov::intel_cpu::BrgemmGenericKernelConfig 
 public:
     BrgemmBaseKernelConfig() = default;
 
-    size_t hash() const override {
+    [[nodiscard]] size_t hash() const override {
         return m_hash;
     }
+
+    void update(dnnl_dim_t M, dnnl_dim_t N, dnnl_dim_t K, dnnl_dim_t LDA, dnnl_dim_t LDB, dnnl_dim_t LDC, float beta)
+        override;
 
     bool operator==(const BrgemmBaseKernelConfig& rhs) const;
     bool operator!=(const BrgemmBaseKernelConfig& rhs) const {
         return !(*this == rhs);
     }
 
-    void update(int64_t M, int64_t N, int64_t K, int64_t LDA, int64_t LDB, int64_t LDC, float beta) override;
-
-    dnnl_data_type_t get_dt_in0() const {
+    [[nodiscard]] dnnl_data_type_t get_dt_in0() const {
         return get_static_params()->dt_in0;
     }
-    dnnl_data_type_t get_dt_in1() const {
+    [[nodiscard]] dnnl_data_type_t get_dt_in1() const {
         return get_static_params()->dt_in1;
     }
 
-    dnnl::impl::cpu::x64::cpu_isa_t get_isa() const {
+    [[nodiscard]] dnnl::impl::cpu::x64::cpu_isa_t get_isa() const {
         return get_static_params()->isa;
     }
 
 #ifdef SNIPPETS_DEBUG_CAPS
-    std::string to_string() const override;
+    [[nodiscard]] std::string to_string() const override;
 #endif
 
 protected:
@@ -52,7 +53,7 @@ protected:
         const dnnl_data_type_t dt_in0{dnnl_f32}, dt_in1{dnnl_f32};
         const dnnl::impl::cpu::x64::cpu_isa_t isa{dnnl::impl::cpu::x64::isa_undef};
 
-        size_t hash() const {
+        [[nodiscard]] size_t hash() const {
             return m_hash;
         }
 
@@ -61,7 +62,7 @@ protected:
             return !(*this == rhs);
         }
 #ifdef SNIPPETS_DEBUG_CAPS
-        std::string to_string() const;
+        [[nodiscard]] std::string to_string() const;
 #endif
     protected:
         static size_t compute_hash(size_t hash_seed,
@@ -72,8 +73,11 @@ protected:
         const size_t m_hash{0};
     };
 
-    virtual std::shared_ptr<StaticBaseParams> get_static_params() const = 0;
-    size_t compute_hash() const;
+    [[nodiscard]] virtual std::shared_ptr<StaticBaseParams> get_static_params() const = 0;
+    [[nodiscard]] size_t compute_hash() const;
+
+    dnnl_dim_t m_M{0}, m_N{0}, m_K{0}, m_LDA{0}, m_LDB{0}, m_LDC{0};
+    float m_beta{0};
     size_t m_hash{SIZE_MAX};
 };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.hpp
@@ -6,6 +6,7 @@
 
 #include <cpu/x64/brgemm/brgemm.hpp>
 #include <cpu/x64/matmul/brgemm_matmul_copy_utils.hpp>
+#include <memory>
 
 #include "emitters/plugin/x64/jit_emitter.hpp"
 #include "emitters/snippets/cpu_kernel_executor_table.hpp"
@@ -29,12 +30,12 @@ public:
         return !(*this == rhs);
     }
 
-    std::unique_ptr<GenericConfig> get_clone_ptr() const override {
-        return std::unique_ptr<BrgemmCopyBKernelConfig>(new BrgemmCopyBKernelConfig(*this));
+    [[nodiscard]] std::unique_ptr<GenericConfig> get_clone_ptr() const override {
+        return std::make_unique<BrgemmCopyBKernelConfig>(*this);
     }
 
-    bool is_empty() const;
-    bool is_completed() const override;
+    [[nodiscard]] bool is_empty() const;
+    [[nodiscard]] bool is_completed() const override;
 
     void update(dnnl_dim_t N,
                 dnnl_dim_t N_blk,
@@ -43,57 +44,57 @@ public:
                 dnnl_dim_t copy_B_wei_stride,
                 dnnl_dim_t LDB);
 
-    size_t hash() const override {
+    [[nodiscard]] size_t hash() const override {
         return m_hash;
     }
 
-    dnnl_data_type_t get_src_dt() const {
+    [[nodiscard]] dnnl_data_type_t get_src_dt() const {
         return m_static_params->src_dt;
     }
-    dnnl_data_type_t get_wei_dt() const {
+    [[nodiscard]] dnnl_data_type_t get_wei_dt() const {
         return m_static_params->wei_dt;
     }
 
-    dnnl::impl::cpu::x64::cpu_isa_t get_isa() const {
+    [[nodiscard]] dnnl::impl::cpu::x64::cpu_isa_t get_isa() const {
         return m_static_params->isa;
     }
-    bool is_with_comp() const {
+    [[nodiscard]] bool is_with_comp() const {
         return m_static_params->is_with_comp;
     }
-    bool is_transposed_B() const {
+    [[nodiscard]] bool is_transposed_B() const {
         return m_static_params->is_transposed_B;
     }
 
-    dnnl_dim_t get_N() const {
+    [[nodiscard]] dnnl_dim_t get_N() const {
         return m_N;
     }
-    dnnl_dim_t get_N_blk() const {
+    [[nodiscard]] dnnl_dim_t get_N_blk() const {
         return m_N_blk;
     }
-    dnnl_dim_t get_N_tail() const {
+    [[nodiscard]] dnnl_dim_t get_N_tail() const {
         return m_N % m_N_blk;
     }
-    dnnl_dim_t get_wei_N_blk() const {
+    [[nodiscard]] dnnl_dim_t get_wei_N_blk() const {
         return m_static_params->wei_N_blk;
     }
-    dnnl_dim_t get_wei_N_tail() const {
+    [[nodiscard]] dnnl_dim_t get_wei_N_tail() const {
         return m_N_blk % m_static_params->wei_N_blk;
     }
-    dnnl_dim_t get_K() const {
+    [[nodiscard]] dnnl_dim_t get_K() const {
         return m_K;
     }
-    dnnl_dim_t get_K_blk() const {
+    [[nodiscard]] dnnl_dim_t get_K_blk() const {
         return m_K_blk;
     }
-    dnnl_dim_t get_copy_B_wei_stride() const {
+    [[nodiscard]] dnnl_dim_t get_copy_B_wei_stride() const {
         return m_copy_B_wei_stride;
     }
-    dnnl_dim_t get_LDB() const {
+    [[nodiscard]] dnnl_dim_t get_LDB() const {
         return m_LDB;
     }
 
 #ifdef SNIPPETS_DEBUG_CAPS
-    std::string to_string() const override;
+    [[nodiscard]] std::string to_string() const override;
 #endif
 
 private:
@@ -118,7 +119,7 @@ private:
         }
 
 #ifdef SNIPPETS_DEBUG_CAPS
-        std::string to_string() const;
+        [[nodiscard]] std::string to_string() const;
 #endif
 
     private:
@@ -130,7 +131,7 @@ private:
                                 dnnl_dim_t wei_N_blk);
     };
 
-    size_t compute_hash() const;
+    [[nodiscard]] size_t compute_hash() const;
 
     std::shared_ptr<StaticParams> m_static_params;
     dnnl_dim_t m_N{0}, m_N_blk{0};
@@ -199,7 +200,7 @@ public:
     static void execute(const BrgemmCopyBKernelExecutor* executor, BrgemmCopyBKernel::call_args* args);
 
 protected:
-    std::shared_ptr<BrgemmCopyBKernel> compile_kernel(const BrgemmCopyBKernelConfig& c) const override;
+    [[nodiscard]] std::shared_ptr<BrgemmCopyBKernel> compile_kernel(const BrgemmCopyBKernelConfig& c) const override;
 
     void update_config(const ov::snippets::lowered::ExpressionPtr& expr,
                        const ov::snippets::lowered::LinearIRCPtr& linear_ir,

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/utils.cpp
@@ -20,7 +20,7 @@ size_t get_buffer_cluster_id(const ov::snippets::lowered::ExpressionPort& port) 
     };
     const auto& ma_op = std::dynamic_pointer_cast<ov::snippets::modifier::MemoryAccess>(port.get_expr()->get_node());
     OPENVINO_ASSERT(ma_op, "Expected MemoryAccess op!");
-    size_t offset = ov::snippets::utils::get_dynamic_value<size_t>();
+    auto offset = ov::snippets::utils::get_dynamic_value<size_t>();
     size_t id = SIZE_MAX;
     switch (port.get_type()) {
     case ov::snippets::lowered::ExpressionPort::Type::Input:

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/verbose.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/verbose.hpp
@@ -12,17 +12,13 @@ namespace ov::intel_cpu {
 class jit_emitter;
 struct jit_emitter_info_t {
     jit_emitter_info_t() = default;
-    jit_emitter_info_t(const jit_emitter_info_t& rhs) : str_(rhs.str_), is_initialized_(rhs.is_initialized_) {}
-    jit_emitter_info_t& operator=(const jit_emitter_info_t& rhs) {
-        is_initialized_ = rhs.is_initialized_;
-        str_ = rhs.str_;
-        return *this;
-    }
+    jit_emitter_info_t(const jit_emitter_info_t& rhs) = default;
+    jit_emitter_info_t& operator=(const jit_emitter_info_t& rhs) = default;
 
-    const char* c_str() const {
+    [[nodiscard]] const char* c_str() const {
         return str_.c_str();
     }
-    bool is_initialized() const {
+    [[nodiscard]] bool is_initialized() const {
         return is_initialized_;
     }
 

--- a/src/plugins/intel_cpu/src/emitters/tpp/x64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/tpp/x64/jit_eltwise_emitters.hpp
@@ -65,7 +65,7 @@ public:
 class ReferenceUnaryEltwiseTppEmitter : public UnaryEltwiseTppEmitter {
 public:
     // Note: can create template to suppport different executor signatures
-    typedef std::function<float(float)> executor_function;
+    using executor_function = std::function<float(float)>;
     ReferenceUnaryEltwiseTppEmitter(dnnl::impl::cpu::x64::jit_generator* h,
                                     dnnl::impl::cpu::x64::cpu_isa_t isa,
                                     const ov::snippets::lowered::ExpressionPtr& expr,
@@ -87,10 +87,9 @@ public:
 private:
     executor_function executor{nullptr};
 
-    template <
-        class Tin,
-        class Tout,
-        typename std::enable_if<!std::is_same<Tin, Tout>::value || !std::is_same<Tin, float>::value, bool>::type = true>
+    template <class Tin,
+              class Tout,
+              std::enable_if_t<!std::is_same_v<Tin, Tout> || !std::is_same_v<Tin, float>, bool> = true>
     void evaluate_reference_impl(Tin* in0, Tout* out0) {
         for (int n = 0; n < m_shape.n; n++) {
             auto in0_row = in0;

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -44,7 +44,7 @@ public:
     TypeRelaxedExtension() : m_ext_type(Op::get_type_info_static().name, "type_relaxed_opset") {}
     ~TypeRelaxedExtension() override = default;
 
-    const ov::DiscreteTypeInfo& get_type_info() const override {
+    [[nodiscard]] const ov::DiscreteTypeInfo& get_type_info() const override {
         return m_ext_type;
     }
 
@@ -52,7 +52,7 @@ public:
         return ov::OpExtension<ov::op::TypeRelaxed<Op>>::create(inputs, visitor);
     }
 
-    std::vector<ov::Extension::Ptr> get_attached_extensions() const override {
+    [[nodiscard]] std::vector<ov::Extension::Ptr> get_attached_extensions() const override {
         return {};
     }
 

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -664,7 +664,7 @@ void Graph::ResolveEdgeConflicts() {
 void Graph::ResolveComplexInplaceConflicts() {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "Graph::ResolveComplexInplaceConflicts");
 
-    ptrdiff_t numberOfEdges = static_cast<ptrdiff_t>(graphEdges.size());
+    auto numberOfEdges = static_cast<ptrdiff_t>(graphEdges.size());
 
     std::unordered_set<std::string> uniqueLayerNames = getUniqueLayerNames(graphNodes);
 
@@ -960,7 +960,7 @@ static EdgeClusters FormEdgeClusters(const std::vector<EdgePtr>& graphEdges) {
         // create an edge cluster when the base edge is visited for the first time
         // so the base edge is always the first edge in the cluster
         if (edge == nullptr) {
-            edgeClusters.emplace_back(EdgeCluster{});
+            edgeClusters.emplace_back();
             return edgeClusters.size() - 1;
         }
 
@@ -1242,10 +1242,9 @@ void Graph::PullOutputData(std::unordered_map<std::size_t, ov::SoPtr<ITensor>>& 
         bool isScalarOutput = false;
         if (ext_blob->get_shape().empty() && ext_blob->get_size() == 1) {
             const auto& actualDims = expected_desc_ptr->getShape().getStaticDims();
-            isScalarOutput = !actualDims.empty() && std::accumulate(actualDims.begin(),
-                                                                    actualDims.end(),
-                                                                    static_cast<size_t>(1),
-                                                                    std::multiplies<size_t>()) == 1;
+            isScalarOutput =
+                !actualDims.empty() &&
+                std::accumulate(actualDims.begin(), actualDims.end(), static_cast<size_t>(1), std::multiplies<>()) == 1;
         }
 
         auto outDims = intr_blob.getStaticDims();

--- a/src/plugins/intel_cpu/src/graph_context.cpp
+++ b/src/plugins/intel_cpu/src/graph_context.cpp
@@ -22,7 +22,7 @@ GraphContext::GraphContext(Config config,
       m_isGraphQuantizedFlag(isGraphQuantized),
       m_streamExecutor(std::move(streamExecutor)),
       m_subMemoryManager(std::move(sub_memory_manager)),
-      m_numNumaNodes(1),
+
       m_memoryStatesRegister(std::make_shared<node::MemoryStatesRegister>()),
       m_auxiliaryNetworkMemoryControl(std::make_shared<NetworkMemoryControl>()),
       m_memoryControl(m_auxiliaryNetworkMemoryControl->createMemoryControlUnit()) {

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -319,7 +319,7 @@ void summary_perf(const Graph& graph) {
         std::vector<std::pair<std::string, double>> A;
         A.reserve(perf_by_type.size());
         for (auto& it : perf_by_type) {
-            A.push_back(it);
+            A.emplace_back(it);
         }
         sort(A.begin(), A.end(), [](std::pair<std::string, double>& a, std::pair<std::string, double>& b) {
             return a.second > b.second;
@@ -327,7 +327,7 @@ void summary_perf(const Graph& graph) {
 
         for (auto& it : A) {
             std::stringstream ss;
-            int percentage = static_cast<int>(it.second * 100 / total_avg);
+            auto percentage = static_cast<int>(it.second * 100 / total_avg);
             if (percentage == 0) {
                 break;
             }
@@ -341,7 +341,7 @@ void summary_perf(const Graph& graph) {
         std::vector<std::pair<NodePtr, double>> A;
         A.reserve(perf_by_node.size());
         for (auto& it : perf_by_node) {
-            A.push_back(it);
+            A.emplace_back(it);
         }
         sort(A.begin(), A.end(), [](std::pair<NodePtr, double>& a, std::pair<NodePtr, double>& b) {
             return a.second > b.second;

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -56,7 +56,7 @@ using namespace ov::intel_cpu::node;
 
 namespace ov::intel_cpu {
 
-GraphOptimizer::GraphOptimizer() {}
+GraphOptimizer::GraphOptimizer() = default;
 
 void GraphOptimizer::ApplyCommonGraphOptimizations(Graph& graph) {
     // For conv with input zp, canBeExecutedInInt8() check has dependency on input zero point check.
@@ -282,7 +282,7 @@ void GraphOptimizer::FuseConvMatmulFCDeconvAndDQScales(Graph& graph) {
         }
         auto scalesDims = getNormalizedDimsBySize(scales->getOutputShapeAtPort(0).getDims(),
                                                   node->getOutputShapeAtPort(0).getDims().size());
-        auto scaleSize = std::accumulate(scalesDims.begin(), scalesDims.end(), 1, std::multiplies<size_t>());
+        auto scaleSize = std::accumulate(scalesDims.begin(), scalesDims.end(), 1, std::multiplies<>());
         node->fuseDQScales(scalesData, scaleSize);
         return true;
     };
@@ -2155,7 +2155,7 @@ void GraphOptimizer::ShareReorders(Graph& graph) {
         if (node->getType() != Type::Reorder) {
             return nullptr;
         }
-        Reorder* reorder = dynamic_cast<Reorder*>(node.get());
+        auto* reorder = dynamic_cast<Reorder*>(node.get());
         if (reorder == nullptr) {
             OPENVINO_THROW("Cannot get reorder layer ", node->getName());
         }
@@ -2231,11 +2231,11 @@ void GraphOptimizer::DropDoubleReorders(Graph& graph) {
         if (processed.find(node) == processed.end() && node->getType() == Type::Reorder &&
             node->getChildEdges().size() == 1 && node->getChildEdgeAt(0)->getChild()->getType() == Type::Reorder) {
             auto nextNode = node->getChildEdgeAt(0)->getChild();
-            Reorder* n = dynamic_cast<Reorder*>(node.get());
+            auto* n = dynamic_cast<Reorder*>(node.get());
             if (n == nullptr) {
                 OPENVINO_THROW("Cannot get reorder layer ", node->getName());
             }
-            Reorder* nn = dynamic_cast<Reorder*>(nextNode.get());
+            auto* nn = dynamic_cast<Reorder*>(nextNode.get());
             if (nn == nullptr) {
                 OPENVINO_THROW("Cannot get reorder layer ", nextNode->getName());
             }
@@ -2450,7 +2450,7 @@ void GraphOptimizer::FusePerformedAsScaleShiftAndFakeQuantize(Graph& graph) {
         std::vector<float> zeroShift(newInputScale.size(), 0.f);
 
         const auto isSubnormal = [](const float value) {
-            const uint32_t* u32data = reinterpret_cast<const uint32_t*>(&value);
+            const auto* u32data = reinterpret_cast<const uint32_t*>(&value);
             return (*u32data) && (((*u32data) & (0xFF << 23)) == 0);
         };
 

--- a/src/plugins/intel_cpu/src/hash_builder.hpp
+++ b/src/plugins/intel_cpu/src/hash_builder.hpp
@@ -16,14 +16,14 @@ namespace ov::intel_cpu::hash {
 // Copyright 2005-2014 Daniel James.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
-template <typename T, typename std::enable_if<!std::is_enum<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<!std::is_enum_v<T>, int> = 0>
 size_t combine(size_t seed, const T& v) {
     return seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-template <typename T, typename std::enable_if<std::is_enum<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
 size_t combine(size_t seed, const T& v) {
-    using underlying_t = typename std::underlying_type<T>::type;
+    using underlying_t = std::underlying_type_t<T>;
     return combine(seed, static_cast<underlying_t>(v));
 }
 

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -553,7 +553,7 @@ void SyncInferRequest::init_tensor(const std::size_t& port_index, const ov::ISyn
 
                         tensor = control_block.tensor();
                         if (model_prec == graph_prec) {
-                            m_outputControlBlocks.emplace(std::make_pair(port_index, std::move(control_block)));
+                            m_outputControlBlocks.emplace(port_index, std::move(control_block));
                         }
                     }
                 } else {

--- a/src/plugins/intel_cpu/src/memory_control.cpp
+++ b/src/plugins/intel_cpu/src/memory_control.cpp
@@ -23,7 +23,7 @@ public:
         OPENVINO_ASSERT(m_pBlock, "Memory block is uninitialized");
     }
 
-    void* getRawPtr() const noexcept override {
+    [[nodiscard]] void* getRawPtr() const noexcept override {
         return static_cast<uint8_t*>(m_pBlock->getRawPtr()) + m_offset;
     }
     void setExtBuff(void* ptr, size_t size) override {
@@ -33,7 +33,7 @@ public:
         // don't pass over as it's static memory
         return false;
     }
-    bool hasExtBuffer() const noexcept override {
+    [[nodiscard]] bool hasExtBuffer() const noexcept override {
         return m_pBlock->hasExtBuffer();
     }
     void registerMemory(Memory* memPtr) override {
@@ -56,7 +56,7 @@ public:
         m_pBlock = std::make_shared<DnnlMemoryBlock>(std::move(pInternalMem));
     }
 
-    void* getRawPtr() const noexcept override {
+    [[nodiscard]] void* getRawPtr() const noexcept override {
         return m_pBlock->getRawPtr();
     }
     void setExtBuff(void* ptr, size_t size) override {
@@ -65,7 +65,7 @@ public:
     bool resize(size_t size) override {
         return m_pBlock->resize(size);
     }
-    bool hasExtBuffer() const noexcept override {
+    [[nodiscard]] bool hasExtBuffer() const noexcept override {
         return m_pBlock->hasExtBuffer();
     }
     void registerMemory(Memory* memPtr) override {
@@ -270,7 +270,7 @@ public:
         return true;
     }
 
-    const MemoryControl::MemorySolution& lastSolution() const {
+    [[nodiscard]] const MemoryControl::MemorySolution& lastSolution() const {
         return m_memManager->lastSolution();
     }
 

--- a/src/plugins/intel_cpu/src/memory_control.hpp
+++ b/src/plugins/intel_cpu/src/memory_control.hpp
@@ -37,7 +37,7 @@ public:
 
     MemorySolution solve();
 
-    bool allocated() const {
+    [[nodiscard]] bool allocated() const {
         return m_allocated;
     }
 

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -356,7 +356,7 @@ size_t CpuBlockedMemoryDesc::getPaddedElementsCount() const {
         })) {
         OPENVINO_THROW("Can't compute padded elements count for non undefined blocked dims");
     }
-    return std::accumulate(blockedDims.begin(), blockedDims.end(), size_t{1}, std::multiplies<size_t>());
+    return std::accumulate(blockedDims.begin(), blockedDims.end(), size_t{1}, std::multiplies<>());
 }
 
 MemoryDescPtr CpuBlockedMemoryDesc::cloneWithNewPrecision(const ov::element::Type prec) const {

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.cpp
@@ -42,17 +42,17 @@ DnnlMemoryDescPtr MemoryDescUtils::convertToDnnlMemoryDesc(const MemoryDescPtr& 
 
 DnnlBlockedMemoryDesc MemoryDescUtils::convertToDnnlBlockedMemoryDesc(const MemoryDesc& desc) {
     if (MemoryDescType::DnnlBlocked == desc.getType()) {
-        return DnnlBlockedMemoryDesc(*desc.as<DnnlBlockedMemoryDesc>());
+        return {*desc.as<DnnlBlockedMemoryDesc>()};
     }
     if (MemoryDescType::Blocked == desc.getType()) {
         const auto cpuDesc = desc.as<CpuBlockedMemoryDesc>();
-        return DnnlBlockedMemoryDesc(cpuDesc->getPrecision(),
-                                     cpuDesc->getShape(),
-                                     cpuDesc->getBlockDims(),
-                                     cpuDesc->getOrder(),
-                                     cpuDesc->getOffsetPadding(),
-                                     cpuDesc->getOffsetPaddingToData(),
-                                     cpuDesc->getStrides());
+        return {cpuDesc->getPrecision(),
+                cpuDesc->getShape(),
+                cpuDesc->getBlockDims(),
+                cpuDesc->getOrder(),
+                cpuDesc->getOffsetPadding(),
+                cpuDesc->getOffsetPaddingToData(),
+                cpuDesc->getStrides()};
     }
     OPENVINO_THROW("Cannot convert MemoryDesc to DnnlBlockedMemoryDesc");
 }

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -615,7 +615,7 @@ size_t DnnlBlockedMemoryDesc::getPaddedElementsCount() const {
     return std::accumulate(std::begin(padded_dims),
                            std::begin(padded_dims) + desc.get_ndims(),
                            size_t{1},
-                           std::multiplies<int64_t>());
+                           std::multiplies<>());
 }
 
 bool DnnlBlockedMemoryDesc::blocksExtended() const {

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -49,10 +49,8 @@ Node::NodesFactory& Node::factory() {
 }
 
 Node::Node(const std::shared_ptr<ov::Node>& op, GraphContext::CPtr ctx, const ShapeInferFactory& shapeInferFactory)
-    : selectedPrimitiveDescriptorIndex(-1),
-      constant(ConstantType::NoConst),
-      context(std::move(ctx)),
-      algorithm(Algorithm::Default),
+    : context(std::move(ctx)),
+
       fusingPort(-1),
       engine(context->getEngine()),
       name(op->get_friendly_name()),
@@ -183,8 +181,7 @@ Node::Node(const std::string& type,
            const GraphContext::CPtr& ctx)
     : inputShapes(std::move(inShapes)),
       outputShapes(std::move(outShapes)),
-      selectedPrimitiveDescriptorIndex(-1),
-      constant(ConstantType::NoConst),
+
       context(ctx),
       originalInputPrecisions(std::move(inputPrecisions)),
       originalOutputPrecisions(std::move(outputPrecisions)),
@@ -341,7 +338,7 @@ void Node::selectPreferPrimitiveDescriptor(const std::vector<impl_desc_type>& pr
 
 bool Node::isOneDimShape(const ov::PartialShape& pshape) {
     int value_1_num = 0;
-    int sz = static_cast<int>(pshape.size());
+    auto sz = static_cast<int>(pshape.size());
     for (const auto& s : pshape) {
         if (s.is_static() && s.get_length() == 1) {
             value_1_num++;

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.cpp
@@ -4,8 +4,7 @@
 
 #include "adaptive_pooling.h"
 
-#include <math.h>
-
+#include <cmath>
 #include <openvino/opsets/opset8.hpp>
 #include <string>
 #include <utils/bfloat16.hpp>
@@ -167,15 +166,15 @@ void AdaptivePooling::execute(const dnnl::stream& strm) {
     }
 
     auto inputDimVector = srcMemory0.getStaticDims();
-    const int N = static_cast<int>(inputDimVector[0]);
-    const int C = static_cast<int>(inputDimVector[1]);
-    const int ID = static_cast<int>(spatialDimsCount == 3 ? inputDimVector[2] : 1);
-    const int IH = static_cast<int>(spatialDimsCount >= 2 ? inputDimVector[spatialDimsCount] : 1);
-    const int IW = static_cast<int>(inputDimVector[spatialDimsCount + 1]);
+    const auto N = static_cast<int>(inputDimVector[0]);
+    const auto C = static_cast<int>(inputDimVector[1]);
+    const auto ID = static_cast<int>(spatialDimsCount == 3 ? inputDimVector[2] : 1);
+    const auto IH = static_cast<int>(spatialDimsCount >= 2 ? inputDimVector[spatialDimsCount] : 1);
+    const auto IW = static_cast<int>(inputDimVector[spatialDimsCount + 1]);
 
-    const int OD = static_cast<int>(spatialDimsCount == 3 ? srcPooledSpatialShapes[0] : 1);
-    const int OH = static_cast<int>(spatialDimsCount >= 2 ? srcPooledSpatialShapes[spatialDimsCount - 2] : 1);
-    const int OW = static_cast<int>(srcPooledSpatialShapes[spatialDimsCount - 1]);
+    const auto OD = static_cast<int>(spatialDimsCount == 3 ? srcPooledSpatialShapes[0] : 1);
+    const auto OH = static_cast<int>(spatialDimsCount >= 2 ? srcPooledSpatialShapes[spatialDimsCount - 2] : 1);
+    const auto OW = static_cast<int>(srcPooledSpatialShapes[spatialDimsCount - 1]);
 
     const int iHW = IH * IW;
     const int oDHW = OD * OH * OW, oHW = OH * OW;

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -223,7 +223,7 @@ private:
     nstl::vector<std::shared_ptr<jit_uni_depthwise_injector_f32<isa>>> depthwise_injectors;
 
     void cvt2ps(dnnl::memory::data_type type_in, Vmm vmm_in, const Xbyak::Operand& op, bool scalar_load) {
-        Xmm xmm_in = Xmm(vmm_in.getIdx());
+        auto xmm_in = Xmm(vmm_in.getIdx());
 
         switch (type_in) {
         case memory::data_type::f32:
@@ -261,8 +261,8 @@ private:
     }
 
     void store_dst(const Xbyak::Address& op, Vmm vmm_dst, bool scalar_store) {
-        Ymm ymm_dst = Ymm(vmm_dst.getIdx());
-        Xmm xmm_dst = Xmm(vmm_dst.getIdx());
+        auto ymm_dst = Ymm(vmm_dst.getIdx());
+        auto xmm_dst = Xmm(vmm_dst.getIdx());
 
         switch (jcp_.dst_dt) {
         case memory::data_type::f32:
@@ -634,7 +634,7 @@ private:
                 } else if (post_op.is_sum(false)) {
                     for (int ii = 0; ii < oc_blocks; ii++) {
                         for (int jj = 0; jj < ur_w; jj++) {
-                            Vmm vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + ur_w * ii + jj);
+                            auto vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + ur_w * ii + jj);
 
                             if (is_scalar_store) {
                                 if (isa == x64::avx512_core) {
@@ -654,7 +654,7 @@ private:
                                         if (oc < jcp_.oc_block / 2) {
                                             uni_vpslldq(vmm_sum, vmm_sum, oc * sizeof(float));
                                         } else {
-                                            Ymm ymm_prev_dst = Ymm(vmm_sum.getIdx());
+                                            auto ymm_prev_dst = Ymm(vmm_sum.getIdx());
                                             vperm2i128(ymm_prev_dst, ymm_prev_dst, ymm_prev_dst, 0x01);
                                             uni_vpslldq(vmm_sum, vmm_sum, (oc - jcp_.oc_block / 2) * sizeof(float));
                                         }
@@ -702,7 +702,7 @@ private:
                             vmm_out_mask,
                             ptr[reg_b_out_mask + (ii * jcp_.oc_block + r * (jcp_.oc_block / 2)) * sizeof(float)]);
 
-                        Vmm vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + ur_w * ii + jj);
+                        auto vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + ur_w * ii + jj);
 
                         if (isa == x64::avx512_core) {
                             vcmpps(bin_mask0, vmm_dst, vmm_thr, _cmp_gt_os);
@@ -746,7 +746,7 @@ private:
                 bool is_scalar_store = isa == x64::sse41 ? tail_size < jcp_.oc_block / 2 : tail_size < jcp_.oc_block;
                 if (is_scalar_store) {
                     for (int jj = 0; jj < ur_w; jj++) {
-                        Vmm vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + jj);
+                        auto vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + jj);
 
                         if (isa == x64::avx512_core) {
                             size_t o_off;
@@ -771,7 +771,7 @@ private:
                                 if (isa == x64::sse41) {
                                     psrldq(vmm_dst, jcp_.typesize_out);
                                 } else {
-                                    Ymm ymm_dst = Ymm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + jj);
+                                    auto ymm_dst = Ymm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + jj);
 
                                     vperm2i128(ymm_tmp, ymm_dst, ymm_dst, 0x01);
                                     vpalignr(ymm_dst, vmm_tmp, ymm_dst, jcp_.typesize_out);
@@ -782,7 +782,7 @@ private:
                 } else {
                     for (int ii = 0; ii < oc_blocks; ii++) {
                         for (int jj = 0; jj < ur_w; jj++) {
-                            Vmm vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + ur_w * ii + jj);
+                            auto vmm_dst = Vmm(1 + r * jcp_.ur_w * jcp_.nb_oc_blocking + ur_w * ii + jj);
 
                             size_t o_off;
                             if (jcp_.with_dw_conv) {
@@ -1066,7 +1066,7 @@ void BinaryConvolution::initSupportedPrimitiveDescriptors() {
             config.inConfs.push_back(config.outConfs[0]);
             config.outConfs[0].inPlace(2);
         }
-        supportedPrimitiveDescriptors.push_back({config, implType});
+        supportedPrimitiveDescriptors.emplace_back(config, implType);
     } else {
         // reference implementation
         auto weiCreator = BlockedDescCreator::getCommonCreators().at(LayoutType::ncsp);
@@ -1075,7 +1075,7 @@ void BinaryConvolution::initSupportedPrimitiveDescriptors() {
         config.inConfs[0].setMemDesc(nspcCreator->createSharedDesc(ov::element::u1, getInputShapeAtPort(0)));
         config.inConfs[1].setMemDesc(weiCreator->createSharedDesc(ov::element::u1, getInputShapeAtPort(1)));
         config.outConfs[0].setMemDesc(nspcCreator->createSharedDesc(ov::element::f32, getOutputShapeAtPort(0)));
-        supportedPrimitiveDescriptors.push_back({config, implType});
+        supportedPrimitiveDescriptors.emplace_back(config, implType);
     }
 }
 
@@ -1166,11 +1166,12 @@ void BinaryConvolution::createPrimitive() {
 #if defined(OPENVINO_ARCH_X86_64)
     jit_dw_conv_params jcp_dw_conv = {};
     if (implType == impl_desc_type::jit_avx512) {
-        bin_conv_kernel.reset(new jit_uni_bin_conv_kernel_f32<x64::avx512_core>(jcp, jcp_dw_conv, *attr.get()));
+        bin_conv_kernel =
+            std::make_shared<jit_uni_bin_conv_kernel_f32<x64::avx512_core>>(jcp, jcp_dw_conv, *attr.get());
     } else if (implType == impl_desc_type::jit_avx2) {
-        bin_conv_kernel.reset(new jit_uni_bin_conv_kernel_f32<x64::avx2>(jcp, jcp_dw_conv, *attr.get()));
+        bin_conv_kernel = std::make_shared<jit_uni_bin_conv_kernel_f32<x64::avx2>>(jcp, jcp_dw_conv, *attr.get());
     } else if (implType == impl_desc_type::sse42) {
-        bin_conv_kernel.reset(new jit_uni_bin_conv_kernel_f32<x64::sse41>(jcp, jcp_dw_conv, *attr.get()));
+        bin_conv_kernel = std::make_shared<jit_uni_bin_conv_kernel_f32<x64::sse41>>(jcp, jcp_dw_conv, *attr.get());
     }
     if (bin_conv_kernel) {
         bin_conv_kernel->create_ker();

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -119,12 +119,12 @@ bool Broadcast::needPrepareParams() const {
 void Broadcast::prepareParams() {
     if (!constMap[TARGET_SHAPE_IDX]) {
         const auto& targetShapeMem = getParentEdgeAt(TARGET_SHAPE_IDX)->getMemory();
-        const int32_t* targetShapeData = targetShapeMem.getDataAs<const int32_t>();
+        const auto* targetShapeData = targetShapeMem.getDataAs<const int32_t>();
         targetShape.assign(targetShapeData, targetShapeData + targetShapeMem.getStaticDims()[0]);
     }
     if (broadcastType == EXPLICIT && !constMap[AXES_MAPPING_IDX]) {
         const auto& axesMapMem = getParentEdgeAt(AXES_MAPPING_IDX)->getMemory();
-        const int32_t* axesMapData = axesMapMem.getDataAs<const int32_t>();
+        const auto* axesMapData = axesMapMem.getDataAs<const int32_t>();
         axesMapping.assign(axesMapData, axesMapData + axesMapMem.getStaticDims()[0]);
     }
 
@@ -165,7 +165,7 @@ bool Broadcast::needShapeInfer() const {
         if (targetShape.empty()) {
             return true;
         }
-        const int32_t* targetShapeData = getSrcDataAtPortAs<const int32_t>(TARGET_SHAPE_IDX);
+        const auto* targetShapeData = getSrcDataAtPortAs<const int32_t>(TARGET_SHAPE_IDX);
         for (size_t i = 0lu; i < targetShape.size(); i++) {
             if (targetShape[i] != targetShapeData[i]) {
                 return true;
@@ -176,7 +176,7 @@ bool Broadcast::needShapeInfer() const {
         if (axesMapping.empty()) {
             return true;
         }
-        const int32_t* axesMappingData = getSrcDataAtPortAs<const int32_t>(AXES_MAPPING_IDX);
+        const auto* axesMappingData = getSrcDataAtPortAs<const int32_t>(AXES_MAPPING_IDX);
         for (size_t i = 0lu; i < axesMapping.size(); i++) {
             if (axesMapping[i] != axesMappingData[i]) {
                 return true;

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -216,7 +216,7 @@ void Bucketize::prepareParams() {
     num_values = std::accumulate(input_tensor_dims.begin(),
                                  input_tensor_dims.end(),
                                  static_cast<size_t>(1),
-                                 std::multiplies<size_t>());
+                                 std::multiplies<>());
 }
 
 bool Bucketize::neverExecute() const {

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -46,7 +46,7 @@ class Converter : public ColorConvert::Converter {
 public:
     Converter(Node* node);
 
-    bool singlePlane() const;
+    [[nodiscard]] bool singlePlane() const;
 
     template <typename T>
     std::tuple<T, T, T> yuv_to_rgb(float y, float u, float v);
@@ -93,7 +93,7 @@ struct jit_uni_converter : public jit_kernel {
         uint8_t colorFormat;  // RGB: 0, BGR: !=0
     };
 
-    typedef void (*function_t)(const Params*);
+    using function_t = void (*)(const Params*);
 
     void init();
 
@@ -192,8 +192,8 @@ void jit_uni_converter::yuv_to_rgb(const variable<float[N]>& y,
 
         auto blendWithMask = [&](int offset, const variable<float[N]>& result) {
             static const uint32_t blendMasks[2] = {0x92492492, 0x24924924};
-            const uint16_t mask0 = static_cast<const uint16_t>(blendMasks[0] >> ((offset * N) % 3));
-            const uint16_t mask1 = static_cast<const uint16_t>(blendMasks[1] >> ((offset * N) % 3));
+            const auto mask0 = static_cast<const uint16_t>(blendMasks[0] >> ((offset * N) % 3));
+            const auto mask1 = static_cast<const uint16_t>(blendMasks[1] >> ((offset * N) % 3));
 
             result = r;
             result.blend(g, mask0);
@@ -420,7 +420,7 @@ void JitConverter<T[N]>::generate() {
     static const float data[8] = {16.f, 128.f, 1.164f, 1.596f, 0.391f, 2.018f, 0.813f, 255.f};
     _consts = data;
 
-    const size_t reg_capacity_log = static_cast<size_t>(std::logb(N));
+    const auto reg_capacity_log = static_cast<size_t>(std::logb(N));
     const size_t step = N * sizeof(T);
 
     width >>= reg_capacity_log;
@@ -755,7 +755,7 @@ void JitConverter<T[N]>::generate() {
     static const float data[8] = {16.f, 128.f, 1.164f, 1.596f, 0.391f, 2.018f, 0.813f, 255.f};
     _consts = data;
 
-    const size_t reg_capacity_log = static_cast<size_t>(std::logb(N));
+    const auto reg_capacity_log = static_cast<size_t>(std::logb(N));
     const size_t step = N * sizeof(T);
 
     width >>= reg_capacity_log;

--- a/src/plugins/intel_cpu/src/nodes/common/arbitrary_order_desc_creator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/arbitrary_order_desc_creator.cpp
@@ -28,7 +28,7 @@ CpuBlockedMemoryDesc ArbitraryOrderDescCreator::createDesc(const ov::element::Ty
         blkDims[i] = dims[m_order[i]];
     }
 
-    return CpuBlockedMemoryDesc(precision, srcShape, blkDims, m_order);
+    return {precision, srcShape, blkDims, m_order};
 }
 
 size_t ArbitraryOrderDescCreator::getMinimalRank() const {

--- a/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.cpp
@@ -13,19 +13,21 @@ constexpr size_t channelsPos = 1lu;
 
 class PlainFormatCreator : public BlockedDescCreator {
 public:
-    CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision, const Shape& srcShape) const override {
+    [[nodiscard]] CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
+                                                  const Shape& srcShape) const override {
         VectorDims order(srcShape.getRank());
         std::iota(order.begin(), order.end(), 0);
-        return CpuBlockedMemoryDesc(precision, srcShape, srcShape.getDims(), order);
+        return {precision, srcShape, srcShape.getDims(), order};
     }
-    size_t getMinimalRank() const override {
+    [[nodiscard]] size_t getMinimalRank() const override {
         return 0lu;
     }
 };
 
 class PerChannelCreator : public BlockedDescCreator {
 public:
-    CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision, const Shape& srcShape) const override {
+    [[nodiscard]] CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
+                                                  const Shape& srcShape) const override {
         VectorDims order(srcShape.getRank());
         std::iota(order.begin(), order.end(), 0);
         VectorDims blkDims = srcShape.getDims();
@@ -39,9 +41,9 @@ public:
             moveElementBack(blkDims, channelsPos);
         }
 
-        return CpuBlockedMemoryDesc(precision, srcShape, blkDims, order);
+        return {precision, srcShape, blkDims, order};
     }
-    size_t getMinimalRank() const override {
+    [[nodiscard]] size_t getMinimalRank() const override {
         return 3lu;
     }
 };
@@ -49,7 +51,8 @@ public:
 class ChannelBlockedCreator : public BlockedDescCreator {
 public:
     ChannelBlockedCreator(size_t blockSize) : _blockSize(blockSize) {}
-    CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision, const Shape& srcShape) const override {
+    [[nodiscard]] CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
+                                                  const Shape& srcShape) const override {
         if (srcShape.getRank() < 2) {
             OPENVINO_THROW("Can't create blocked tensor descriptor!");
         }
@@ -64,9 +67,9 @@ public:
         }
         blkDims.push_back(_blockSize);
 
-        return CpuBlockedMemoryDesc(precision, srcShape, blkDims, order);
+        return {precision, srcShape, blkDims, order};
     }
-    size_t getMinimalRank() const override {
+    [[nodiscard]] size_t getMinimalRank() const override {
         return 3lu;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -31,10 +31,10 @@ enum f8_type : uint8_t { none, f8e4m3, f8e5m2 };
 
 template <typename src_t, typename dst_t>
 f8_type get_f8_type() {
-    if (std::is_same<src_t, ov::float8_e4m3>::value || std::is_same<dst_t, ov::float8_e4m3>::value) {
+    if (std::is_same_v<src_t, ov::float8_e4m3> || std::is_same_v<dst_t, ov::float8_e4m3>) {
         return f8_type::f8e4m3;
     }
-    if (std::is_same<src_t, ov::float8_e5m2>::value || std::is_same<dst_t, ov::float8_e5m2>::value) {
+    if (std::is_same_v<src_t, ov::float8_e5m2> || std::is_same_v<dst_t, ov::float8_e5m2>) {
         return f8_type::f8e5m2;
     }
     return f8_type::none;
@@ -123,15 +123,15 @@ class jit_convert_array : public jit_kernel {
     }
 
 public:
-    typedef struct {
+    using args_t = struct {
         const void* src;
         void* out;
         const size_t count;
-    } args_t;
+    };
 
-    typedef void (*fn_t)(const args_t*);
+    using fn_t = void (*)(const args_t*);
 
-    typedef void (*convert_vec_t)(jit_generator&, const RegExp&, const RegExp&);
+    using convert_vec_t = void (*)(jit_generator&, const RegExp&, const RegExp&);
 
     jit_convert_array(convert_vec_t convert_vec)
         : jit_kernel(jit_name()),
@@ -390,11 +390,10 @@ struct PrecisionInfo<ov::element::boolean> {
     using value_type = uint8_t;
 };
 
-template <typename T,
-          typename U = typename std::conditional<std::is_same<ov::float16, T>::value ||
-                                                     std::is_same<ov::intel_cpu::bfloat16_t, T>::value,
-                                                 float,
-                                                 T>::type>
+template <
+    typename T,
+    typename U =
+        std::conditional_t<std::is_same_v<ov::float16, T> || std::is_same_v<ov::intel_cpu::bfloat16_t, T>, float, T>>
 struct Range {
     const std::tuple<U, U>& fit(const ov::element::Type& prec);
 
@@ -486,8 +485,8 @@ const std::tuple<U, U>& Range<T, U>::fit(const ov::element::Type& prec) {
         default:
             OPENVINO_THROW("Unsupported precision");
         }
-        using ltype = typename std::conditional<std::is_floating_point<U>::value, double, int64_t>::type;
-        using utype = typename std::conditional<std::is_floating_point<U>::value, double, uint64_t>::type;
+        using ltype = std::conditional_t<std::is_floating_point<U>::value, double, int64_t>;
+        using utype = std::conditional_t<std::is_floating_point<U>::value, double, uint64_t>;
         std::get<0>(_range) =
             static_cast<U>(std::max(static_cast<ltype>(std::get<0>(_range)), static_cast<ltype>(lbound)));
         std::get<1>(_range) =
@@ -505,7 +504,7 @@ struct ConvertContext {
     bool converted;
 
     template <typename T>
-    std::tuple<T, T> range() const {
+    [[nodiscard]] std::tuple<T, T> range() const {
         Range<T> r;
         r.fit(interimPrc);
         return r.fit(dstPrc);
@@ -621,7 +620,7 @@ struct ConvertPrecision<std::tuple<src_t, ov::float16>> {
             parallel_for(iterations, [&](size_t i) {
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
-                if (std::is_same<typename std::remove_cv<src_t>::type, float>::value) {  // fp32 -> fp16
+                if (std::is_same<std::remove_cv_t<src_t>, float>::value) {  // fp32 -> fp16
                     jit_convert(reinterpret_cast<const float*>(src) + offset, dst + offset, current_batch_size);
                 } else {
                     batch_type tmp;
@@ -674,7 +673,7 @@ struct ConvertPrecision<std::tuple<ov::float16, dst_t>> {
             parallel_for(iterations, [&](size_t i) {
                 const size_t offset = i * batch;
                 const size_t current_batch_size = std::min(ctx.size - offset, batch);
-                if (std::is_same<typename std::remove_cv<dst_t>::type, float>::value) {  // fp16 -> fp32
+                if (std::is_same<std::remove_cv_t<dst_t>, float>::value) {  // fp16 -> fp32
                     jit_convert(src + offset, reinterpret_cast<float*>(dst) + offset, current_batch_size);
                 } else {
                     batch_type tmp;

--- a/src/plugins/intel_cpu/src/nodes/common/permute_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/permute_kernel.cpp
@@ -4,6 +4,7 @@
 
 #include "permute_kernel.h"
 
+#include <memory>
 #include <vector>
 
 #include "common/primitive_hashing_utils.hpp"
@@ -172,11 +173,11 @@ PermuteKernel::PermuteKernel(const PermuteParams& params) : params(params) {
     jcp = TransposeExecutor::prepareParams(params);
 #if defined(OPENVINO_ARCH_X86_64)
     if (mayiuse(cpu::x64::avx512_core)) {
-        permute_kernel.reset(new jit_uni_permute_kernel_f32<cpu::x64::avx512_core>(jcp));
+        permute_kernel = std::make_shared<jit_uni_permute_kernel_f32<cpu::x64::avx512_core>>(jcp);
     } else if (mayiuse(cpu::x64::avx2)) {
-        permute_kernel.reset(new jit_uni_permute_kernel_f32<cpu::x64::avx2>(jcp));
+        permute_kernel = std::make_shared<jit_uni_permute_kernel_f32<cpu::x64::avx2>>(jcp);
     } else if (mayiuse(cpu::x64::sse41)) {
-        permute_kernel.reset(new jit_uni_permute_kernel_f32<cpu::x64::sse41>(jcp));
+        permute_kernel = std::make_shared<jit_uni_permute_kernel_f32<cpu::x64::sse41>>(jcp);
     }
 #endif  // OPENVINO_ARCH_X86_64
 

--- a/src/plugins/intel_cpu/src/nodes/common/reorder_prim.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/reorder_prim.cpp
@@ -19,7 +19,7 @@ namespace ov::intel_cpu {
 struct ReorderKey {
     dnnl::memory::desc src;
     dnnl::memory::desc dest;
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const ReorderKey& rhs) const;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <memory>
 #include <vector>
 
 #include "cpu/x64/injectors/jit_uni_eltwise_injector.hpp"
@@ -39,15 +40,15 @@ struct jit_softmax_config_params {
 };
 
 struct jit_uni_softmax_kernel {
-    void (*ker_)(const jit_args_softmax*);
+    void (*ker_)(const jit_args_softmax*){nullptr};
 
     void operator()(const jit_args_softmax* args) {
         assert(ker_);
         ker_(args);
     }
 
-    jit_uni_softmax_kernel() : ker_(nullptr) {}
-    virtual ~jit_uni_softmax_kernel() {}
+    jit_uni_softmax_kernel() = default;
+    virtual ~jit_uni_softmax_kernel() = default;
 
     virtual void create_ker() = 0;
 };
@@ -71,7 +72,7 @@ struct jit_uni_softmax_kernel_f32 : public jit_uni_softmax_kernel, public jit_ge
             new jit_uni_eltwise_injector<isa>(this, dnnl::impl::alg_kind::eltwise_exp, 0.f, 0.f, 1.0f, data_type::f32));
 
         if (mayiuse(avx512_core)) {
-            uni_vcvtneps2bf16.reset(new jit_uni_vcvtneps2bf16(this, isa));
+            uni_vcvtneps2bf16 = std::make_unique<jit_uni_vcvtneps2bf16>(this, isa);
         }
 
         this->preamble();
@@ -220,7 +221,7 @@ private:
         }
     }
     inline void store_vector(const Xbyak::Address& op, Vmm vmm_dst, ov::element::Type dst_dt) {
-        Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
+        auto ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
 
         switch (dst_dt) {
         case ov::element::f32:
@@ -253,13 +254,13 @@ SoftmaxGeneric::SoftmaxGeneric(ov::element::Type inpPrc, ov::element::Type outPr
     jcp.dst_dt = outPrc;
 
     if (mayiuse(x64::avx512_core)) {
-        softmax_kernel.reset(new jit_uni_softmax_kernel_f32<x64::avx512_core>(jcp));
+        softmax_kernel = std::make_shared<jit_uni_softmax_kernel_f32<x64::avx512_core>>(jcp);
         block_size = 16;
     } else if (mayiuse(x64::avx2)) {
-        softmax_kernel.reset(new jit_uni_softmax_kernel_f32<x64::avx2>(jcp));
+        softmax_kernel = std::make_shared<jit_uni_softmax_kernel_f32<x64::avx2>>(jcp);
         block_size = 8;
     } else if (mayiuse(x64::sse41)) {
-        softmax_kernel.reset(new jit_uni_softmax_kernel_f32<x64::sse41>(jcp));
+        softmax_kernel = std::make_shared<jit_uni_softmax_kernel_f32<x64::sse41>>(jcp);
         block_size = 4;
     }
     if (softmax_kernel) {

--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.cpp
@@ -139,7 +139,7 @@ std::vector<NodeDesc> TileBroadcastCommon::getSupportedConfigs(const Node* node,
             outConf.setMemDesc(
                 std::make_shared<DnnlBlockedMemoryDesc>(node->getOutputShapeAtPort(0), dataType, outFormat));
         }
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::ref});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     };
 
     if (!repeats.empty() && inDataShape.getRank() == outDataShapeRank &&
@@ -177,7 +177,7 @@ std::vector<NodeDesc> TileBroadcastCommon::getSupportedConfigs(const Node* node,
             config.outConfs[i].setMemDesc(
                 std::make_shared<CpuBlockedMemoryDesc>(precision, node->getOutputShapeAtPort(i)));
         }
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::ref});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     } else {
         pushDesc(inFmt, outFmt);
     }

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -565,7 +565,7 @@ void Concat::exec1DCase() {
 void Concat::execNspcSpecCase() {
     const auto& dst_memory = getChildEdgeAt(0)->getMemory();
     const size_t num_src = getParentEdges().size();
-    uint8_t* dst_ptr = dst_memory.getDataAs<uint8_t>();
+    auto* dst_ptr = dst_memory.getDataAs<uint8_t>();
     const size_t dataSize = DnnlExtensionUtils::sizeOfDataType(dst_memory.getDataType());
 
     std::vector<size_t> channelsDataSize;
@@ -607,7 +607,7 @@ void Concat::execNspcSpecCase() {
 void Concat::execRef() {
     const size_t numSrc = getParentEdges().size();
     const auto& dstMemory = getChildEdgeAt(0)->getMemory();
-    uint8_t* dstPtr = dstMemory.getDataAs<uint8_t>();
+    auto* dstPtr = dstMemory.getDataAs<uint8_t>();
     for (size_t i = 0; i < numSrc; i++) {
         const auto& srcMem = getParentEdgeAt(i)->getMemory();
         srcPtrs[i] = srcMem.getDataAs<const uint8_t>();

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -59,7 +59,7 @@ struct ConvKey {
 
     bool constWeight;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const ConvKey& rhs) const;
 };
 
@@ -115,7 +115,7 @@ bool ConvKey::operator==(const ConvKey& rhs) const {
 class Convolution::FusedSubgraph {
 public:
     FusedSubgraph(const std::vector<NodePtr>& opList, const Convolution& conv, const GraphContext::CPtr& context) {
-        _graph = std::unique_ptr<Graph>(new Graph());
+        _graph = std::make_unique<Graph>();
 
         std::unordered_set<NodePtr> nodesSet;
         std::vector<EdgePtr> edges;
@@ -191,7 +191,7 @@ public:
         _graph->Activate();
     }
 
-    std::shared_ptr<Input> getInput(size_t idx) const {
+    [[nodiscard]] std::shared_ptr<Input> getInput(size_t idx) const {
         if (idx < inputs.size()) {
             return inputs[idx];
         }
@@ -201,7 +201,7 @@ public:
                        inputs.size());
     }
 
-    std::shared_ptr<Input> getOutput(size_t idx) const {
+    [[nodiscard]] std::shared_ptr<Input> getOutput(size_t idx) const {
         if (idx < outputs.size()) {
             return outputs[idx];
         }
@@ -430,7 +430,7 @@ void Convolution::getSupportedDescriptors() {
     attrs.reserve(2);
     withBiases = getOriginalInputsNumber() == 3;
 
-    int expectedInputEdgesNum = static_cast<int>(getOriginalInputsNumber());
+    auto expectedInputEdgesNum = static_cast<int>(getOriginalInputsNumber());
     for (auto& i : fusedWith) {
         if (i->getType() == Type::Convolution) {
             expectedInputEdgesNum += static_cast<int>(i->getOriginalInputsNumber()) - 1;
@@ -1099,7 +1099,8 @@ void Convolution::addLegacyZeroPoints(dnnl::primitive_attr& attr) {
         attr.set_input_zero_points(legacyInputZeroPoints.size(), 1 << 1 /*through C dim*/);
         if (!legacyInputZeroPointsMemPtr) {
             DnnlBlockedMemoryDesc memoryDesc(ov::element::u8, {legacyInputZeroPoints.size()});
-            legacyInputZeroPointsMemPtr.reset(new Memory(getEngine(), memoryDesc, legacyInputZeroPoints.data()));
+            legacyInputZeroPointsMemPtr =
+                std::make_shared<Memory>(getEngine(), memoryDesc, legacyInputZeroPoints.data());
         }
     }
 

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
@@ -72,9 +72,9 @@ void CTCGreedyDecoder::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoder::execute(const dnnl::stream& strm) {
-    const float* probabilities = getSrcDataAtPortAs<const float>(DATA_INDEX);
-    const float* sequenceMask = getSrcDataAtPortAs<const float>(SEQUENCE_LENGTH_INDEX);
-    float* outputSequences = getDstDataAtPortAs<float>(0);
+    const auto* probabilities = getSrcDataAtPortAs<const float>(DATA_INDEX);
+    const auto* sequenceMask = getSrcDataAtPortAs<const float>(SEQUENCE_LENGTH_INDEX);
+    auto* outputSequences = getDstDataAtPortAs<float>(0);
 
     const size_t T = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[1];

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.cpp
@@ -78,10 +78,10 @@ void CTCGreedyDecoderSeqLen::initSupportedPrimitiveDescriptors() {
 }
 
 void CTCGreedyDecoderSeqLen::execute(const dnnl::stream& strm) {
-    const float* probabilities = getSrcDataAtPortAs<const float>(DATA_INDEX);
-    const int* sequenceLengths = getSrcDataAtPortAs<const int>(SEQUENCE_LENGTH_INDEX);
-    int* decodedClasses = getDstDataAtPortAs<int>(DECODED_CLASSES_INDEX);
-    int* decodedClassesLength = getDstDataAtPortAs<int>(DECODED_CLASSES_LENGTH_INDEX);
+    const auto* probabilities = getSrcDataAtPortAs<const float>(DATA_INDEX);
+    const auto* sequenceLengths = getSrcDataAtPortAs<const int>(SEQUENCE_LENGTH_INDEX);
+    auto* decodedClasses = getDstDataAtPortAs<int>(DECODED_CLASSES_INDEX);
+    auto* decodedClassesLength = getDstDataAtPortAs<int>(DECODED_CLASSES_LENGTH_INDEX);
 
     const size_t B = getParentEdgeAt(DATA_INDEX)->getMemory().getStaticDims()[0];
     ;

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -63,11 +63,11 @@ void CTCLoss::executeDynamicImpl(const dnnl::stream& strm) {
 void CTCLoss::execute(const dnnl::stream& strm) {
     int32_t returnCode = 0;
 
-    const float* logits = getSrcDataAtPortAs<const float>(0);
-    const int* logitsLength = getSrcDataAtPortAs<const int>(1);
-    const int* labels = getSrcDataAtPortAs<const int>(2);
-    const int* labelsLength = getSrcDataAtPortAs<const int>(3);
-    float* dstData = getDstDataAtPortAs<float>(0);
+    const auto* logits = getSrcDataAtPortAs<const float>(0);
+    const auto* logitsLength = getSrcDataAtPortAs<const int>(1);
+    const auto* labels = getSrcDataAtPortAs<const int>(2);
+    const auto* labelsLength = getSrcDataAtPortAs<const int>(3);
+    auto* dstData = getDstDataAtPortAs<float>(0);
 
     const auto& inDims = getParentEdgeAt(0)->getMemory().getStaticDims();
     const size_t batchNum = inDims[0];

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.cpp
@@ -155,10 +155,8 @@ void CumSum::cumSum(const dataType* input, dataType* output, const VectorDims& s
         }
         iterationRange[j++] = shape[i];
     }
-    size_t work_amount_dst = std::accumulate(iterationRange.begin(),
-                                             iterationRange.end(),
-                                             static_cast<size_t>(1),
-                                             std::multiplies<size_t>());
+    size_t work_amount_dst =
+        std::accumulate(iterationRange.begin(), iterationRange.end(), static_cast<size_t>(1), std::multiplies<>());
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
         VectorDims counters(numOfDims - 1, 0);
@@ -249,7 +247,7 @@ inline size_t CumSum::getStartOffset(const std::vector<size_t>& forStartOffset,
 
 size_t CumSum::getAxis(const IMemory& _axis, const IMemory& _data) const {
     const auto& axisPrecision = _axis.getDesc().getPrecision();
-    const int64_t dataShapeSize = static_cast<int64_t>(_data.getShape().getRank());
+    const auto dataShapeSize = static_cast<int64_t>(_data.getShape().getRank());
     int64_t axisValueFromBlob = 0;
     switch (axisPrecision) {
     case ov::element::i32: {

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -60,7 +60,7 @@ struct DeconvKey {
     dnnl::primitive_attr attr;
     impl_desc_type implType;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const DeconvKey& rhs) const;
 };
 
@@ -127,7 +127,7 @@ class DeconvolutionShapeInferFactory : public ShapeInferFactory {
 public:
     DeconvolutionShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
 
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<DeconvolutionShapeInfer>(m_op);
     }
 
@@ -151,7 +151,7 @@ private:
             return m_shape_infer->get_pads_end();
         }
 
-        port_mask_t get_port_mask() const override {
+        [[nodiscard]] port_mask_t get_port_mask() const override {
             return m_port_mask;
         };
 
@@ -880,9 +880,9 @@ bool Deconvolution::isImplicit1x1PaddingAsymmetric(const VectorDims& inputDims) 
             return (i - 1) * s + 1 - o;
         };
         for (size_t i = 0; i < spatialRank; i++) {
-            int64_t inputDim = static_cast<int64_t>(inputDims[i + 2]);
-            int64_t outputDim = static_cast<int64_t>(lastOutputSpatialDims[i]);
-            int64_t stride = static_cast<int64_t>(deconvAttrs.stride[i]);
+            auto inputDim = static_cast<int64_t>(inputDims[i + 2]);
+            auto outputDim = static_cast<int64_t>(lastOutputSpatialDims[i]);
+            auto stride = static_cast<int64_t>(deconvAttrs.stride[i]);
             if (calPaddingEnd(inputDim, outputDim, stride) > 0) {
                 return true;
             }
@@ -1229,7 +1229,7 @@ std::vector<int32_t> Deconvolution::readOutputSpatialDims() const {
     if (shapeMemPtr->getStaticDims()[0] != spDimsNum) {
         OPENVINO_THROW("Can't read output spatial dims, beause 'output_shape' input has incorrect number of elements");
     }
-    const int32_t* outShapePtr = shapeMemPtr->getDataAs<const int32_t>();
+    const auto* outShapePtr = shapeMemPtr->getDataAs<const int32_t>();
     std::vector<int32_t> outSpDims(outShapePtr, outShapePtr + shapeMemPtr->getStaticDims()[0]);
     return outSpDims;
 }

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -4,9 +4,9 @@
 
 #include "def_conv.h"
 
-#include <math.h>
-
+#include <cmath>
 #include <common/dnnl_thread.hpp>
+#include <memory>
 #include <openvino/op/deformable_convolution.hpp>
 #include <string>
 #include <vector>
@@ -336,31 +336,31 @@ private:
                         mov(aux3_reg_input_buffer, aux2_reg_input_buffer);
                         add(aux3_reg_input_buffer, (ow * jcp_.kh * jcp_.kw * jcp_.ic) * jcp_.typesize_in);
 
-                        Xmm xmm_v1_off = Xmm(9);
-                        Xmm xmm_v2_off = Xmm(10);
-                        Xmm xmm_v3_off = Xmm(11);
-                        Xmm xmm_v4_off = Xmm(12);
+                        auto xmm_v1_off = Xmm(9);
+                        auto xmm_v2_off = Xmm(10);
+                        auto xmm_v3_off = Xmm(11);
+                        auto xmm_v4_off = Xmm(12);
 
-                        Xmm xmm_w1 = Xmm(4);
-                        Xmm xmm_w2 = Xmm(1);
-                        Xmm xmm_w3 = Xmm(8);
-                        Xmm xmm_w4 = Xmm(5);
+                        auto xmm_w1 = Xmm(4);
+                        auto xmm_w2 = Xmm(1);
+                        auto xmm_w3 = Xmm(8);
+                        auto xmm_w4 = Xmm(5);
 
-                        Xmm xmm_v1 = Xmm(2);
-                        Xmm xmm_v2 = Xmm(3);
+                        auto xmm_v1 = Xmm(2);
+                        auto xmm_v2 = Xmm(3);
                         ;
-                        Xmm xmm_v3 = Xmm(6);
-                        Xmm xmm_v4 = Xmm(7);
+                        auto xmm_v3 = Xmm(6);
+                        auto xmm_v4 = Xmm(7);
 
-                        Vmm vmm_w1 = Vmm(xmm_w1.getIdx());
-                        Vmm vmm_w2 = Vmm(xmm_w2.getIdx());
-                        Vmm vmm_w3 = Vmm(xmm_w3.getIdx());
-                        Vmm vmm_w4 = Vmm(xmm_w4.getIdx());
+                        auto vmm_w1 = Vmm(xmm_w1.getIdx());
+                        auto vmm_w2 = Vmm(xmm_w2.getIdx());
+                        auto vmm_w3 = Vmm(xmm_w3.getIdx());
+                        auto vmm_w4 = Vmm(xmm_w4.getIdx());
 
-                        Vmm vmm_v1 = Vmm(xmm_v1.getIdx());
-                        Vmm vmm_v2 = Vmm(xmm_v2.getIdx());
-                        Vmm vmm_v3 = Vmm(xmm_v3.getIdx());
-                        Vmm vmm_v4 = Vmm(xmm_v4.getIdx());
+                        auto vmm_v1 = Vmm(xmm_v1.getIdx());
+                        auto vmm_v2 = Vmm(xmm_v2.getIdx());
+                        auto vmm_v3 = Vmm(xmm_v3.getIdx());
+                        auto vmm_v4 = Vmm(xmm_v4.getIdx());
 
                         // offsets computation
                         size_t ind_off_hh = sampledPointsPerPixel *
@@ -598,8 +598,8 @@ private:
                                 psrldq(vmm_dst, jcp_.typesize_out);
                             } else {
                                 Ymm ymm_dst = get_ymm_acc(ow);
-                                Vmm vmm_tmp = Vmm(0);
-                                Ymm ymm_tmp = Ymm(0);
+                                auto vmm_tmp = Vmm(0);
+                                auto ymm_tmp = Ymm(0);
 
                                 vperm2i128(ymm_tmp, ymm_dst, ymm_dst, 0x01);
                                 vpalignr(ymm_dst, vmm_tmp, ymm_dst, jcp_.typesize_out);
@@ -718,7 +718,7 @@ struct DefConvKey {
     DeformableConvolution::DefConvAttr defConvAttr;
     impl_desc_type implType;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const DefConvKey& rhs) const;
 };
 
@@ -899,7 +899,7 @@ void DeformableConvolution::initSupportedPrimitiveDescriptors() {
         }
         config.outConfs[0].setMemDesc(
             std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(DATA_ID), memory::data_type::f32, dataFormat));
-        supportedPrimitiveDescriptors.push_back({config, impl_type});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_type);
     } else {
         // reference implementation
         config.inConfs[DATA_ID].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getInputShapeAtPort(DATA_ID),
@@ -919,7 +919,7 @@ void DeformableConvolution::initSupportedPrimitiveDescriptors() {
         config.outConfs[0].setMemDesc(std::make_shared<DnnlBlockedMemoryDesc>(getOutputShapeAtPort(DATA_ID),
                                                                               memory::data_type::f32,
                                                                               memory::format_tag::nchw));
-        supportedPrimitiveDescriptors.push_back({config, impl_type});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_type);
     }
 }
 
@@ -1129,11 +1129,11 @@ DeformableConvolution::DefConvJitExecutor::DefConvJitExecutor(
     : DefConvExecutor(defConvAttr, descVector) {
 #if defined(OPENVINO_ARCH_X86_64)
     if (mayiuse(cpu::x64::avx512_core)) {
-        def_conv_kernel.reset(new jit_uni_def_conv_kernel_f32<cpu::x64::avx512_core>(jcp));
+        def_conv_kernel = std::make_shared<jit_uni_def_conv_kernel_f32<cpu::x64::avx512_core>>(jcp);
     } else if (mayiuse(cpu::x64::avx2)) {
-        def_conv_kernel.reset(new jit_uni_def_conv_kernel_f32<cpu::x64::avx2>(jcp));
+        def_conv_kernel = std::make_shared<jit_uni_def_conv_kernel_f32<cpu::x64::avx2>>(jcp);
     } else if (mayiuse(cpu::x64::sse41)) {
-        def_conv_kernel.reset(new jit_uni_def_conv_kernel_f32<cpu::x64::sse41>(jcp));
+        def_conv_kernel = std::make_shared<jit_uni_def_conv_kernel_f32<cpu::x64::sse41>>(jcp);
     } else {
         OPENVINO_THROW("Can't create DefConvJitExecutor");
     }
@@ -1357,7 +1357,7 @@ void DeformableConvolution::execute(const dnnl::stream& strm) {
         modulation = getSrcDataAtPortAs<float>(3);
     }
 
-    float* dst = dstMemory.getDataAs<float>();
+    auto* dst = dstMemory.getDataAs<float>();
 
     auto selectedPrimitiveDescriptor = getSelectedPrimitiveDescriptor();
     if (!selectedPrimitiveDescriptor) {

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -5,6 +5,7 @@
 #include "depth_to_space.h"
 
 #include <cmath>
+#include <memory>
 #include <string>
 
 #include "common/blocked_desc_creator.h"
@@ -301,7 +302,7 @@ DepthToSpace::DepthToSpaceExecutor::DepthToSpaceExecutor(const DepthToSpaceAttrs
         params.dst_block_dims[i] = params.src_block_dims[params.order[i]];
     }
 
-    permuteKernel = std::unique_ptr<PermuteKernel>(new PermuteKernel(params));
+    permuteKernel = std::make_unique<PermuteKernel>(params);
 }
 
 void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const int MB) {
@@ -309,8 +310,8 @@ void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const 
         OPENVINO_THROW("Could not execute. Kernel for Transpose node was not compiled.");
     }
 
-    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
-    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
+    const auto* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    auto* dstData = dstMemPtr->getDataAs<uint8_t>();
 
     permuteKernel->execute(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.cpp
@@ -174,16 +174,16 @@ void DetectionOutput::executeDynamicImpl(const dnnl::stream& strm) {
 }
 
 void DetectionOutput::execute(const dnnl::stream& strm) {
-    float* dstData = getDstDataAtPortAs<float>(0);
+    auto* dstData = getDstDataAtPortAs<float>(0);
 
-    const float* locData = getSrcDataAtPortAs<const float>(ID_LOC);
-    const float* confData = getSrcDataAtPortAs<const float>(ID_CONF);
-    const float* priorData = getSrcDataAtPortAs<const float>(ID_PRIOR);
+    const auto* locData = getSrcDataAtPortAs<const float>(ID_LOC);
+    const auto* confData = getSrcDataAtPortAs<const float>(ID_CONF);
+    const auto* priorData = getSrcDataAtPortAs<const float>(ID_PRIOR);
     const float* ARMConfData = inputShapes.size() > 3 ? getSrcDataAtPortAs<const float>(ID_ARM_CONF) : nullptr;
     const float* ARMLocData = inputShapes.size() > 4 ? getSrcDataAtPortAs<const float>(ID_ARM_LOC) : nullptr;
 
     float* reorderedConfData = reorderedConf.data();
-    int* reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConf.data());
+    auto* reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConf.data());
 
     float* decodedBboxesData = decodedBboxes.data();
     float* bboxSizesData = bboxSizes.data();
@@ -403,7 +403,7 @@ void DetectionOutput::execute(const dnnl::stream& strm) {
                 for (int i = 0; i < detections; ++i) {
                     int pr = pindices[i];
                     mtx.lock();
-                    confIndicesClassMap.push_back(std::make_pair(pconf[pr], std::make_pair(c, pr)));
+                    confIndicesClassMap.emplace_back(pconf[pr], std::make_pair(c, pr));
                     mtx.unlock();
                 }
             });
@@ -568,7 +568,7 @@ inline void DetectionOutput::confReorderAndFilterSparsityCF(const float* confDat
                                                             int* indicesData,
                                                             int* indicesBufData,
                                                             int* detectionsData) {
-    int* reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConfData);
+    auto* reorderedConfDataIndices = reinterpret_cast<int*>(reorderedConfData);
     for (int n = 0; n < imgNum; ++n) {
         const int off = n * priorsNum * classesNum;
         const int offV = n * priorsNum;  // vertical info

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -5,6 +5,7 @@
 #include "dft.h"
 
 #include <cmath>
+#include <memory>
 #include <openvino/opsets/opset7.hpp>
 #include <string>
 #include <vector>
@@ -100,7 +101,7 @@ void DFT::initSupportedPrimitiveDescriptors() {
     std::vector<PortConfigurator> inDataConfigurators(
         {{LayoutType::ncsp, ov::element::f32}, {LayoutType::ncsp, ov::element::i32}});
     if (inputShapes.size() > SIGNAL_SIZE_INDEX) {
-        inDataConfigurators.push_back({LayoutType::ncsp, ov::element::i32});
+        inDataConfigurators.emplace_back(LayoutType::ncsp, ov::element::i32);
     }
 
     addSupportedPrimDesc(inDataConfigurators, {{LayoutType::ncsp, ov::element::f32}}, impl_desc_type::ref_any);
@@ -205,9 +206,9 @@ void copyDataToOutputWithSignalSize(const float* input,
                                     const std::vector<size_t>& outputShape,
                                     const std::vector<size_t>& outputStrides) {
     auto totalInput =
-        std::accumulate(inputShape.begin(), inputShape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+        std::accumulate(inputShape.begin(), inputShape.end(), static_cast<size_t>(1), std::multiplies<>());
     auto totalOutput =
-        std::accumulate(outputShape.begin(), outputShape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+        std::accumulate(outputShape.begin(), outputShape.end(), static_cast<size_t>(1), std::multiplies<>());
     std::fill_n(output, totalOutput, 0.f);
     size_t lastChangedDim = 0;
     for (size_t index = inputShape.size() - 1; index > 0; --index) {
@@ -232,7 +233,7 @@ void copyDataToOutputWithSignalSize(const float* input,
     const size_t blockSize = std::accumulate(inputShape.begin() + lastChangedDim + 1,
                                              inputShape.end(),
                                              static_cast<size_t>(1),
-                                             std::multiplies<size_t>());
+                                             std::multiplies<>());
     const size_t blockSizeBytes = blockSize * sizeof(float);
     std::vector<size_t> iterationCounter(iterationRange.size(), 0);
     do {
@@ -281,7 +282,7 @@ void DFT::execute(const dnnl::stream& strm) {
         copyDataToOutputWithSignalSize(src, inputShape, inputStrides, dst, outputShape, outputStrides);
     } else {
         auto totalElements =
-            std::accumulate(inputShape.begin(), inputShape.end(), static_cast<size_t>(1), std::multiplies<size_t>());
+            std::accumulate(inputShape.begin(), inputShape.end(), static_cast<size_t>(1), std::multiplies<>());
         cpu_memcpy(dst, src, totalElements * sizeof(float));
     }
 
@@ -582,11 +583,11 @@ void DFT::createJITKernels(bool hasDFT, bool hasFFT) {
 #if defined(OPENVINO_ARCH_X86_64)
     if (hasDFT && dftKernel == nullptr) {
         if (mayiuse(cpu::x64::avx512_core)) {
-            dftKernel.reset(new jit_uni_dft_kernel_f32<cpu::x64::avx512_core>());
+            dftKernel = std::make_unique<jit_uni_dft_kernel_f32<cpu::x64::avx512_core>>();
         } else if (mayiuse(cpu::x64::avx2)) {
-            dftKernel.reset(new jit_uni_dft_kernel_f32<cpu::x64::avx2>());
+            dftKernel = std::make_unique<jit_uni_dft_kernel_f32<cpu::x64::avx2>>();
         } else if (mayiuse(cpu::x64::sse41)) {
-            dftKernel.reset(new jit_uni_dft_kernel_f32<cpu::x64::sse41>());
+            dftKernel = std::make_unique<jit_uni_dft_kernel_f32<cpu::x64::sse41>>();
         } else {
             THROW_CPU_NODE_ERR("Can't create jit DFT kernel");
         }
@@ -598,11 +599,11 @@ void DFT::createJITKernels(bool hasDFT, bool hasFFT) {
 
     if (hasFFT && fftKernel == nullptr) {
         if (mayiuse(cpu::x64::avx512_core)) {
-            fftKernel.reset(new jit_uni_fft_kernel_f32<cpu::x64::avx512_core>());
+            fftKernel = std::make_unique<jit_uni_fft_kernel_f32<cpu::x64::avx512_core>>();
         } else if (mayiuse(cpu::x64::avx2)) {
-            fftKernel.reset(new jit_uni_fft_kernel_f32<cpu::x64::avx2>());
+            fftKernel = std::make_unique<jit_uni_fft_kernel_f32<cpu::x64::avx2>>();
         } else if (mayiuse(cpu::x64::sse41)) {
-            fftKernel.reset(new jit_uni_fft_kernel_f32<cpu::x64::sse41>());
+            fftKernel = std::make_unique<jit_uni_fft_kernel_f32<cpu::x64::sse41>>();
         } else {
             THROW_CPU_NODE_ERR("Can't create jit FFT kernel");
         }

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.cpp
@@ -92,10 +92,10 @@ void EmbeddingBagOffset::initSupportedPrimitiveDescriptors() {
                                                        {LayoutType::ncsp, ov::element::i32},
                                                        {LayoutType::ncsp, ov::element::i32}});
     if (inputShapes.size() > DEFAULT_INDEX_IDX) {
-        inDataConfigurators.push_back({LayoutType::ncsp, ov::element::i32});
+        inDataConfigurators.emplace_back(LayoutType::ncsp, ov::element::i32);
     }
     if (inputShapes.size() > PER_SAMPLE_WEIGHTS_IDX) {
-        inDataConfigurators.push_back({LayoutType::ncsp, inDataPrecision});
+        inDataConfigurators.emplace_back(LayoutType::ncsp, inDataPrecision);
     }
 
     addSupportedPrimDesc(inDataConfigurators, {{LayoutType::ncsp, inDataPrecision}}, impl_desc_type::ref_any);

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.cpp
@@ -87,7 +87,7 @@ void EmbeddingBagPacked::initSupportedPrimitiveDescriptors() {
     std::vector<PortConfigurator> inDataConfigurators(
         {{LayoutType::ncsp, inDataPrecision}, {LayoutType::ncsp, ov::element::i32}});
     if (inputShapes.size() > PER_SAMPLE_WEIGHTS_IDX) {
-        inDataConfigurators.push_back({LayoutType::ncsp, inDataPrecision});
+        inDataConfigurators.emplace_back(LayoutType::ncsp, inDataPrecision);
     }
 
     addSupportedPrimDesc(inDataConfigurators, {{LayoutType::ncsp, inDataPrecision}}, impl_desc_type::ref_any);

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.cpp
@@ -76,10 +76,10 @@ void EmbeddingSegmentsSum::initSupportedPrimitiveDescriptors() {
                                                        {LayoutType::ncsp, ov::element::i32},
                                                        {LayoutType::ncsp, ov::element::i32}});
     if (inputShapes.size() > DEFAULT_INDEX_IDX) {
-        inDataConfigurators.push_back({LayoutType::ncsp, ov::element::i32});
+        inDataConfigurators.emplace_back(LayoutType::ncsp, ov::element::i32);
     }
     if (inputShapes.size() > PER_SAMPLE_WEIGHTS_IDX) {
-        inDataConfigurators.push_back({LayoutType::ncsp, inDataPrecision});
+        inDataConfigurators.emplace_back(LayoutType::ncsp, inDataPrecision);
     }
 
     addSupportedPrimDesc(inDataConfigurators, {{LayoutType::ncsp, inDataPrecision}}, impl_desc_type::ref_any);

--- a/src/plugins/intel_cpu/src/nodes/executors/aarch64/jit_eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/aarch64/jit_eltwise.hpp
@@ -30,7 +30,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void* post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return impl_desc_type::asimd;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.hpp
@@ -29,7 +29,7 @@ public:
     virtual void updateTensorsShapes(ACLShapes& aclMemoryShapes) = 0;
     virtual arm_compute::Status validateTensorsInfo(const ACLInfos& aclMemoryInfos) = 0;
     virtual ACLFunction configureFunction(const ACLTensors& aclMemoryTensors) = 0;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::acl;
     }
     void execute(const MemoryArgs& memory) override;
@@ -37,7 +37,7 @@ public:
     arm_compute::TensorInfo& getTensorInfo(ACLArgs index) {
         return *aclMemoryInfos[index].get();
     }
-    ~ACLCommonExecutor();
+    ~ACLCommonExecutor() override;
 
 protected:
     ACLTensorAttrs aclTensorAttrs;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_convert.hpp
@@ -18,7 +18,7 @@ public:
               const MemoryDescPtr& dstDesc,
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::acl;
     };
 
@@ -32,10 +32,10 @@ protected:
 
 class ACLConvertExecutorBuilder : public ConvertExecutorBuilder {
 public:
-    bool isSupported(const ConvertParams& convertParams,
-                     const MemoryDescPtr& srcDesc,
-                     const MemoryDescPtr& dstDesc) const override;
-    ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] bool isSupported(const ConvertParams& convertParams,
+                                   const MemoryDescPtr& srcDesc,
+                                   const MemoryDescPtr& dstDesc) const override;
+    [[nodiscard]] ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<ACLConvertExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.hpp
@@ -35,7 +35,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void* post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return implType;
     }
 
@@ -56,13 +56,13 @@ public:
                                   const std::vector<MemoryDescPtr>& srcDescs,
                                   const std::vector<MemoryDescPtr>& dstDescs);
 
-    bool isSupported(const DeconvAttrs& deconvAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
+    [[nodiscard]] bool isSupported(const DeconvAttrs& deconvAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override {
         return customIsSupported(deconvAttrs, srcDescs, dstDescs);
     }
 
-    DeconvExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] DeconvExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<AclDeconvExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_eltwise.hpp
@@ -24,7 +24,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void* post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return implType;
     }
 
@@ -37,11 +37,11 @@ private:
 
 class AclEltwiseExecutorBuilder : public EltwiseExecutorBuilder {
 public:
-    bool isSupported(const EltwiseAttrs& eltwiseAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override;
+    [[nodiscard]] bool isSupported(const EltwiseAttrs& eltwiseAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
 
-    EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<AclEltwiseExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
@@ -310,7 +310,7 @@ static void initFCAttrs(const FCAttrs& attrs,
 }
 
 arm_compute::TensorShape acl_fc_executor::normalizeDimsTo2D(const arm_compute::TensorShape shape) {
-    size_t norm_dim = std::accumulate(shape.begin() + 1, shape.end(), 1, std::multiplies<size_t>());
+    size_t norm_dim = std::accumulate(shape.begin() + 1, shape.end(), 1, std::multiplies<>());
     return arm_compute::TensorShape(shape[0], norm_dim);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_ie_scheduler.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_ie_scheduler.hpp
@@ -18,7 +18,7 @@ class ACLScheduler final : public IScheduler {
 public:
     ACLScheduler();
     ~ACLScheduler() override = default;
-    std::uint32_t num_threads() const override;
+    [[nodiscard]] std::uint32_t num_threads() const override;
     void set_num_threads(unsigned int num_threads) override;
     void schedule(ICPPKernel* kernel, const Hints& hints) override;
     void schedule_op(ICPPKernel* kernel, const Hints& hints, const Window& window, ITensorPack& tensors) override;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_interpolate.hpp
@@ -23,7 +23,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void* post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return implType;
     }
 
@@ -38,11 +38,11 @@ private:
 
 class ACLInterpolateExecutorBuilder : public InterpolateExecutorBuilder {
 public:
-    bool isSupported(const InterpolateAttrs& interpolateAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override;
+    [[nodiscard]] bool isSupported(const InterpolateAttrs& interpolateAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
 
-    InterpolateExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] InterpolateExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<ACLInterpolateExecutor>(context);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
@@ -25,7 +25,7 @@ public:
 
     ACLFunction configureFunction(const ACLTensors& aclMemoryTensors) override;
 
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::gemm_acl;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_mvn.hpp
@@ -23,7 +23,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void* post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return implType;
     }
 
@@ -37,11 +37,11 @@ private:
 
 class AclMVNExecutorBuilder : public MVNExecutorBuilder {
 public:
-    bool isSupported(const MVNAttrs& mvnAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override;
+    [[nodiscard]] bool isSupported(const MVNAttrs& mvnAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
 
-    MVNExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] MVNExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<AclMVNExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_pooling.hpp
@@ -33,7 +33,7 @@ public:
                             arm_compute::Pooling3dLayerInfo* pool3d_info,
                             bool ignoreOutShapeErrors = false);
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return implType;
     }
 
@@ -50,9 +50,9 @@ private:
 
 class AclPoolingExecutorBuilder : public PoolingExecutorBuilder {
 public:
-    bool isSupported(const PoolingAttrs& poolingAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
+    [[nodiscard]] bool isSupported(const PoolingAttrs& poolingAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override {
         if ((srcDescs[0]->getPrecision() != ov::element::f32 && dstDescs[0]->getPrecision() != ov::element::f32) &&
             (srcDescs[0]->getPrecision() != ov::element::f16 && dstDescs[0]->getPrecision() != ov::element::f16)) {
             DEBUG_LOG("AclPoolingExecutor does not support precisions:",
@@ -124,7 +124,7 @@ public:
         return true;
     }
 
-    PoolingExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] PoolingExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<AclPoolingExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_reduce.hpp
@@ -24,7 +24,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void* post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return implType;
     }
 
@@ -40,9 +40,9 @@ private:
 
 class AclReduceExecutorBuilder : public ReduceExecutorBuilder {
 public:
-    bool isSupported(const ReduceAttrs& reduceAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
+    [[nodiscard]] bool isSupported(const ReduceAttrs& reduceAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override {
         if (reduceAttrs.operation == Algorithm::ReduceMean) {
             if (srcDescs[0]->getPrecision() != dstDescs[0]->getPrecision() ||
                 (srcDescs[0]->getPrecision() != ov::element::f32 && srcDescs[0]->getPrecision() != ov::element::f16)) {
@@ -95,7 +95,7 @@ public:
         return true;
     }
 
-    ReduceExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] ReduceExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<AclReduceExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_transpose.hpp
@@ -20,7 +20,7 @@ public:
               const std::vector<MemoryDescPtr>& dstDescs,
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::acl;
     }
 
@@ -31,9 +31,9 @@ private:
 
 class ACLTransposeExecutorBuilder : public TransposeExecutorBuilder {
 public:
-    bool isSupported(const TransposeParams& transposeParams,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
+    [[nodiscard]] bool isSupported(const TransposeParams& transposeParams,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override {
         if (!(srcDescs[0]->hasLayoutType(LayoutType::ncsp) && dstDescs[0]->hasLayoutType(LayoutType::ncsp)) &&
             !(srcDescs[0]->hasLayoutType(LayoutType::nspc) && dstDescs[0]->hasLayoutType(LayoutType::nspc))) {
             DEBUG_LOG("NEPermute does not support layout:",
@@ -55,7 +55,7 @@ public:
         return true;
     }
 
-    TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<ACLTransposeExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
@@ -34,7 +34,7 @@ OV_CPU_MAYBE_UNUSED_FUNCTION static std::vector<float> getDeQuantizedScales(cons
     auto scalesDims = getNormalizedDimsBySize(dqScalesShape.getDims(), dstShape.getDims().size());
 
     auto scaleSize =
-        std::accumulate(scalesDims.begin(), scalesDims.end(), static_cast<std::size_t>(1), std::multiplies<size_t>());
+        std::accumulate(scalesDims.begin(), scalesDims.end(), static_cast<std::size_t>(1), std::multiplies<>());
 
     std::vector<float> DQScales(scaleSize, 1.0);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_convert.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_convert.hpp
@@ -16,7 +16,7 @@ public:
               const MemoryDescPtr& dstDesc,
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return implDescType;
     };
     static bool isSupported(ov::element::Type srcPrc, ov::element::Type dstPrc);
@@ -29,13 +29,13 @@ protected:
 
 class CommonConvertExecutorBuilder : public ConvertExecutorBuilder {
 public:
-    ~CommonConvertExecutorBuilder() = default;
-    bool isSupported(const ConvertParams& convertParams,
-                     const MemoryDescPtr& srcDesc,
-                     const MemoryDescPtr& dstDesc) const override {
+    ~CommonConvertExecutorBuilder() override = default;
+    [[nodiscard]] bool isSupported(const ConvertParams& convertParams,
+                                   const MemoryDescPtr& srcDesc,
+                                   const MemoryDescPtr& dstDesc) const override {
         return true;
     }
-    ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<CommonConvertExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_opt_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_opt_transpose.hpp
@@ -17,16 +17,16 @@ public:
               const std::vector<MemoryDescPtr>& dstDescs,
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::ref;
     }
 };
 
 class RefOptimizedTransposeExecutorBuilder : public TransposeExecutorBuilder {
 public:
-    bool isSupported(const TransposeParams& transposeParams,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
+    [[nodiscard]] bool isSupported(const TransposeParams& transposeParams,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override {
         static const std::vector<std::vector<size_t>> optimizedOrders = {
             std::vector<size_t>{0, 3, 1, 2},
             std::vector<size_t>{0, 4, 1, 2, 3},
@@ -41,7 +41,7 @@ public:
         return false;
     }
 
-    TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<RefOptimizedTransposeExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.cpp
@@ -41,7 +41,7 @@ void RefTransposeExecutor::referenceExecute(const uint8_t* src_data,
         dst_dims[0] = mb;
     }
 
-    size_t work_amount = std::accumulate(dst_dims.begin(), dst_dims.end(), 1, std::multiplies<size_t>());
+    size_t work_amount = std::accumulate(dst_dims.begin(), dst_dims.end(), 1, std::multiplies<>());
 
     auto get_idx = [ndims, data_size](const VectorDims& indexes, const VectorDims& strides) {
         size_t idx = 0;
@@ -69,8 +69,8 @@ void RefTransposeExecutor::referenceExecute(const uint8_t* src_data,
 }
 
 void RefTransposeExecutor::exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) {
-    const uint8_t* src_data = src[0]->getDataAs<const uint8_t>();
-    uint8_t* dst_data = dst[0]->getDataAs<uint8_t>();
+    const auto* src_data = src[0]->getDataAs<const uint8_t>();
+    auto* dst_data = dst[0]->getDataAs<uint8_t>();
     const int MB = src[0]->getStaticDims()[0];
     referenceExecute(src_data, dst_data, jcp, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.hpp
@@ -19,7 +19,7 @@ public:
               const std::vector<MemoryDescPtr>& dstDescs,
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::ref;
     }
 
@@ -29,13 +29,13 @@ private:
 
 class RefTransposeExecutorBuilder : public TransposeExecutorBuilder {
 public:
-    bool isSupported(const TransposeParams& transposeParams,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override {
+    [[nodiscard]] bool isSupported(const TransposeParams& transposeParams,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override {
         return true;
     }
 
-    TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<RefTransposeExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/convert.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convert.hpp
@@ -24,7 +24,7 @@ public:
                       const MemoryDescPtr& srcDesc,
                       const MemoryDescPtr& dstDesc,
                       const dnnl::primitive_attr& attr) = 0;
-    virtual ~ConvertExecutor() = default;
+    ~ConvertExecutor() override = default;
 
 protected:
     ConvertParams convertParams;
@@ -36,10 +36,10 @@ using ConvertExecutorCPtr = std::shared_ptr<const ConvertExecutor>;
 class ConvertExecutorBuilder {
 public:
     virtual ~ConvertExecutorBuilder() = default;
-    virtual bool isSupported(const ConvertParams& convertParams,
-                             const MemoryDescPtr& srcDesc,
-                             const MemoryDescPtr& dstDesc) const = 0;
-    virtual ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const ConvertParams& convertParams,
+                                           const MemoryDescPtr& srcDesc,
+                                           const MemoryDescPtr& dstDesc) const = 0;
+    [[nodiscard]] virtual ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using ConvertExecutorBuilderPtr = std::shared_ptr<ConvertExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/convert_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convert_list.hpp
@@ -37,7 +37,7 @@ public:
         }
     }
 
-    ~ConvertExecutorFactory() = default;
+    ~ConvertExecutorFactory() override = default;
     virtual ConvertExecutorPtr makeExecutor(const ConvertParams& convertParams,
                                             const MemoryDescPtr& srcDesc,
                                             const MemoryDescPtr& dstDesc,

--- a/src/plugins/intel_cpu/src/nodes/executors/deconv.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/deconv.hpp
@@ -41,7 +41,7 @@ public:
                       const std::vector<MemoryPtr>& dst,
                       const void* post_ops_data_) = 0;
     virtual ~DeconvExecutor() = default;
-    virtual impl_desc_type getImplType() const = 0;
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
 
 protected:
     DeconvAttrs deconvAttrs;
@@ -54,10 +54,10 @@ using DeconvExecutorCPtr = std::shared_ptr<const DeconvExecutor>;
 class DeconvExecutorBuilder {
 public:
     ~DeconvExecutorBuilder() = default;
-    virtual bool isSupported(const DeconvAttrs& convAttrs,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual DeconvExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const DeconvAttrs& convAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual DeconvExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using DeconvExecutorBuilderPtr = std::shared_ptr<DeconvExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/deconv_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/deconv_list.hpp
@@ -36,7 +36,7 @@ public:
         }
     }
 
-    ~DeconvExecutorFactory() = default;
+    ~DeconvExecutorFactory() override = default;
     virtual DeconvExecutorPtr makeExecutor(const DeconvAttrs& deconvAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
@@ -29,7 +29,7 @@ class DnnlConvolutionPrimitive {
 
         const dnnl::primitive_attr attr;
 
-        size_t hash() const;
+        [[nodiscard]] size_t hash() const;
         bool operator==(const Key& rhs) const;
     };
 
@@ -40,23 +40,23 @@ public:
 
     void execute(const dnnl_primitive_args& primArgs) const;
 
-    const DnnlMemoryDescPtr srcDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr srcDesc() const {
         return m_srcDesc;
     }
 
-    const DnnlMemoryDescPtr dstDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr dstDesc() const {
         return m_dstDesc;
     }
 
-    const DnnlMemoryDescPtr weightsDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr weightsDesc() const {
         return m_weiDesc;
     }
 
-    const DnnlMemoryDescPtr scratchPadDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr scratchPadDesc() const {
         return m_scratchPadDesc;
     }
 
-    impl_desc_type implType() const {
+    [[nodiscard]] impl_desc_type implType() const {
         return m_implType;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
@@ -66,7 +66,7 @@ public:
         m_primitive->execute(m_primArgs);
     }
 
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return m_primitive ? m_primitive->implType() : undef;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
@@ -306,13 +306,13 @@ static dnnl::inner_product_forward::primitive_desc createDescriptorInternal(cons
         useSparseWeights ? dnnl::memory::desc().sparse_desc(normalizedWeightDesc.get_dims(), wdt)
                          : dnnl::memory::desc(normalizedWeightDesc.get_dims(), wdt, memory::format_tag::any);
 
-    return dnnl::inner_product_forward::primitive_desc(engine,
-                                                       dnnl::prop_kind::forward_inference,
-                                                       normalizedInputDesc,
-                                                       weightsDesc,
-                                                       biasDesc,
-                                                       normalizedOutputDesc,
-                                                       attr);
+    return {engine,
+            dnnl::prop_kind::forward_inference,
+            normalizedInputDesc,
+            weightsDesc,
+            biasDesc,
+            normalizedOutputDesc,
+            attr};
 }
 
 static primitive_desc createPrimitiveDesc(const dnnl::memory::desc& inputDesc,

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
@@ -25,7 +25,7 @@ class DnnlFCPrimitive {
         bool sparseWeights;
         Config::ModelType modelType;
 
-        size_t hash() const;
+        [[nodiscard]] size_t hash() const;
         bool operator==(const Key& rhs) const;
     };
 
@@ -34,23 +34,23 @@ public:
 
     void execute(const dnnl_primitive_args& primArgs) const;
 
-    const DnnlMemoryDescPtr srcDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr srcDesc() const {
         return m_srcDesc;
     }
 
-    const DnnlMemoryDescPtr dstDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr dstDesc() const {
         return m_dstDesc;
     }
 
-    const DnnlMemoryDescPtr weightsDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr weightsDesc() const {
         return m_weiDesc;
     }
 
-    const DnnlMemoryDescPtr scratchPadDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr scratchPadDesc() const {
         return m_scratchPadDesc;
     }
 
-    impl_desc_type implType() const {
+    [[nodiscard]] impl_desc_type implType() const {
         return m_implType;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
@@ -211,7 +211,7 @@ static dnnl::matmul::primitive_desc createDescriptorInternal(const dnnl::memory:
 
     const dnnl::memory::desc weightsDesc = dnnl::memory::desc(weiDims, wdt, memory::format_tag::any);
 
-    return dnnl::matmul::primitive_desc(engine, inputsDesc, weightsDesc, newBiasDesc, outputsDesc, attr);
+    return {engine, inputsDesc, weightsDesc, newBiasDesc, outputsDesc, attr};
 }
 
 static primitive_desc createPrimitiveDesc(const dnnl::memory::desc& inputDesc,

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
@@ -23,7 +23,7 @@ class DnnlMatMulPrimitive {
         DnnlMemoryDescCPtr dst;
         dnnl::primitive_attr attr;
 
-        size_t hash() const;
+        [[nodiscard]] size_t hash() const;
         bool operator==(const Key& rhs) const;
     };
 
@@ -32,23 +32,23 @@ public:
 
     void execute(const dnnl_primitive_args& primArgs) const;
 
-    const DnnlMemoryDescPtr srcDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr srcDesc() const {
         return m_srcDesc;
     }
 
-    const DnnlMemoryDescPtr dstDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr dstDesc() const {
         return m_dstDesc;
     }
 
-    const DnnlMemoryDescPtr weightsDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr weightsDesc() const {
         return m_weiDesc;
     }
 
-    const DnnlMemoryDescPtr scratchPadDesc() const {
+    [[nodiscard]] const DnnlMemoryDescPtr scratchPadDesc() const {
         return m_scratchPadDesc;
     }
 
-    impl_desc_type implType() const {
+    [[nodiscard]] impl_desc_type implType() const {
         return m_implType;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise.hpp
@@ -93,7 +93,7 @@ public:
                       const void* post_ops_data_) = 0;
     virtual ~EltwiseExecutor() = default;
 
-    virtual impl_desc_type getImplType() const = 0;
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
 
 protected:
     EltwiseAttrs eltwiseAttrs;
@@ -106,10 +106,10 @@ using EltwiseExecutorCPtr = std::shared_ptr<const EltwiseExecutor>;
 class EltwiseExecutorBuilder {
 public:
     ~EltwiseExecutorBuilder() = default;
-    virtual bool isSupported(const EltwiseAttrs& eltwiseAttrs,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const EltwiseAttrs& eltwiseAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using EltwiseExecutorBuilderPtr = std::shared_ptr<EltwiseExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise_list.hpp
@@ -40,7 +40,7 @@ public:
         }
     }
 
-    ~EltwiseExecutorFactory() = default;
+    ~EltwiseExecutorFactory() override = default;
     virtual EltwiseExecutorPtr makeExecutor(const EltwiseAttrs& eltwiseAttrs,
                                             const std::vector<MemoryDescPtr>& srcDescs,
                                             const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -106,29 +106,29 @@ public:
         curNumaNodeId = std::max(0, cpuStreamsExecutor ? cpuStreamsExecutor->get_numa_node_id() : curNumaNodeId);
     }
 
-    MultiCachePtr getRuntimeCache() const {
+    [[nodiscard]] MultiCachePtr getRuntimeCache() const {
         auto runtimeCachePtr = runtimeCache.lock();
         assert(runtimeCachePtr);
         return runtimeCachePtr;
     }
 
-    DnnlScratchPadPtr getScratchPad() const {
+    [[nodiscard]] DnnlScratchPadPtr getScratchPad() const {
         return scratchPads[curNumaNodeId];
     }
 
-    std::shared_ptr<std::unordered_map<std::string, MemoryPtr>> getPrivateWeighCache() const {
+    [[nodiscard]] std::shared_ptr<std::unordered_map<std::string, MemoryPtr>> getPrivateWeighCache() const {
         return privateWeighCache;
     }
 
-    const dnnl::engine& getEngine() const {
+    [[nodiscard]] const dnnl::engine& getEngine() const {
         return engine;
     }
 
-    const std::vector<impl_desc_type>& getImplPriorities() const {
+    [[nodiscard]] const std::vector<impl_desc_type>& getImplPriorities() const {
         return implPriorities;
     }
 
-    const WeightsSharing::Ptr getWeightsCache() const {
+    [[nodiscard]] const WeightsSharing::Ptr getWeightsCache() const {
         return weightsCache;
     }
 
@@ -173,7 +173,7 @@ public:
     virtual void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) {
         OPENVINO_THROW_NOT_IMPLEMENTED("This version of the 'execute' method is not implemented by executor");
     }
-    virtual impl_desc_type implType() const = 0;
+    [[nodiscard]] virtual impl_desc_type implType() const = 0;
     virtual void moveMemToNumaNode(int numaID) {
         OPENVINO_THROW_NOT_IMPLEMENTED("This version of the 'moveMemToNumaNode' method is not implemented by executor");
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_factory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_factory.hpp
@@ -50,7 +50,7 @@ public:
      * @note The main use case is to avoid a fallback during the creation of an executor
      *       by passing proper memory descriptors to the make() method
      */
-    MemoryDescArgs getProperMemoryDescriptors(const MemoryDescArgs& descriptors) const {
+    [[nodiscard]] MemoryDescArgs getProperMemoryDescriptors(const MemoryDescArgs& descriptors) const {
         DEBUG_LOG("Preconfiguring memory descriptors");
 
         const auto& impl = m_suitableImplementations.front();

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
@@ -59,7 +59,7 @@ public:
         return {};
     }
 
-    bool acceptsShapes(const MemoryArgs& memory) const {
+    [[nodiscard]] bool acceptsShapes(const MemoryArgs& memory) const {
         if (m_acceptsShape) {
             return m_acceptsShape(memory);
         }
@@ -79,19 +79,19 @@ public:
         return nullptr;
     }
 
-    bool shapeAgnostic() const {
+    [[nodiscard]] bool shapeAgnostic() const {
         return m_shapeRelation == ShapeTolerance::Agnostic;
     }
 
-    const char* name() const {
+    [[nodiscard]] const char* name() const {
         return m_name;
     }
 
-    const ExecutorType type() const {
+    [[nodiscard]] const ExecutorType type() const {
         return m_type;
     }
 
-    const OperationType operationType() const {
+    [[nodiscard]] const OperationType operationType() const {
         return m_operationType;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -196,8 +196,8 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinearOnnx(const VectorDims& sr
     int ID = srcDimPad5d[2], IH = srcDimPad5d[3], IW = srcDimPad5d[4];
     int OD = dstDim5d[2], OH = dstDim5d[3], OW = dstDim5d[4];
 
-    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, 0);
-    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, 0);
+    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, nullptr);
+    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, nullptr);
     if (layout == InterpolateLayoutType::planar) {
         // FrontTopLeft:0, FrontTopRight:1, FrontBottomLeft:2, FrontBottomRight:3,
         // EndTopLeft:4,   EndTopRight:5,   EndBottomLeft:6,   EndBottomRight:7
@@ -328,19 +328,19 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
         int sizeOH = OH * diaOH;
         int sizeOW = OW * diaOW;
         indexTable.resize((sizeOD + sizeOH + sizeOW) * 2);
-        float* weightTable = reinterpret_cast<float*>(&indexTable[0]);
-        float* weightOD = static_cast<float*>(&weightTable[0]);
-        float* weightOH = static_cast<float*>(&weightTable[sizeOD]);
-        float* weightOW = static_cast<float*>(&weightTable[sizeOD + sizeOH]);
+        auto* weightTable = reinterpret_cast<float*>(&indexTable[0]);
+        auto* weightOD = static_cast<float*>(&weightTable[0]);
+        auto* weightOH = static_cast<float*>(&weightTable[sizeOD]);
+        auto* weightOW = static_cast<float*>(&weightTable[sizeOD + sizeOH]);
 
-        int* idxTable = static_cast<int*>(&indexTable[sizeOD + sizeOH + sizeOW]);
-        int* idxOD = static_cast<int*>(&idxTable[0]);
-        int* idxOH = static_cast<int*>(&idxTable[sizeOD]);
-        int* idxOW = static_cast<int*>(&idxTable[sizeOD + sizeOH]);
+        auto* idxTable = static_cast<int*>(&indexTable[sizeOD + sizeOH + sizeOW]);
+        auto* idxOD = static_cast<int*>(&idxTable[0]);
+        auto* idxOH = static_cast<int*>(&idxTable[sizeOD]);
+        auto* idxOW = static_cast<int*>(&idxTable[sizeOD + sizeOH]);
 
         for (int oz = 0; oz < static_cast<int>(OD); oz++) {
             float iz = coordTransToInput(oz, fz, ID, OD);
-            int iz_r = static_cast<int>(std::round(iz));
+            auto iz_r = static_cast<int>(std::round(iz));
             for (int r = iz_r - rz, i = 0; r <= iz_r + rz; r++, i++) {
                 idxOD[oz * diaOD + i] = r;
                 if (r < 0 || r >= static_cast<int>(ID)) {
@@ -353,7 +353,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
         }
         for (int oy = 0; oy < static_cast<int>(OH); oy++) {
             float iy = coordTransToInput(oy, fy, IH, OH);
-            int iy_r = static_cast<int>(std::round(iy));
+            auto iy_r = static_cast<int>(std::round(iy));
             for (int r = iy_r - ry, i = 0; r <= iy_r + ry; r++, i++) {
                 idxOH[oy * diaOH + i] = r;
                 if (r < 0 || r >= static_cast<int>(IH)) {
@@ -366,7 +366,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
         }
         for (int ox = 0; ox < static_cast<int>(OW); ox++) {
             float ix = coordTransToInput(ox, fx, IW, OW);
-            int ix_r = static_cast<int>(std::round(ix));
+            auto ix_r = static_cast<int>(std::round(ix));
             for (int r = ix_r - rx, i = 0; r <= ix_r + rx; r++, i++) {
                 idxOW[ox * diaOW + i] = r;
                 if (r < 0 || r >= static_cast<int>(IW)) {
@@ -416,12 +416,12 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
     }
 
     int tblAdvance = 0;
-    int* xOrigin = static_cast<int*>(&indexTable[tblAdvance]);
+    auto* xOrigin = static_cast<int*>(&indexTable[tblAdvance]);
     tblAdvance += OW;
-    float* xFactor = reinterpret_cast<float*>(&indexTable[tblAdvance]);
+    auto* xFactor = reinterpret_cast<float*>(&indexTable[tblAdvance]);
     for (int ox = 0; ox < OW; ox++) {
         float ix = coordTransToInput(ox, fx, IW, OW);
-        int ix_r = static_cast<int>(std::floor(ix));
+        auto ix_r = static_cast<int>(std::floor(ix));
         xOrigin[ox] = ix_r;
         float m = ix - ix_r;
         std::vector<float> coffes = getCubicCoeffs(m, cubicCoeff);
@@ -432,12 +432,12 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
     }
 
     tblAdvance += CUBIC_GRID_LEN * OW;
-    int* yOrigin = static_cast<int*>(&indexTable[tblAdvance]);
+    auto* yOrigin = static_cast<int*>(&indexTable[tblAdvance]);
     tblAdvance += OH;
-    float* yFactor = reinterpret_cast<float*>(&indexTable[tblAdvance]);
+    auto* yFactor = reinterpret_cast<float*>(&indexTable[tblAdvance]);
     for (int oy = 0; oy < OH; oy++) {
         float iy = coordTransToInput(oy, fy, IH, OH);
-        int iy_r = static_cast<int>(std::floor(iy));
+        auto iy_r = static_cast<int>(std::floor(iy));
         yOrigin[oy] = iy_r;
         float m = iy - iy_r;
         std::vector<float> coffes = getCubicCoeffs(m, cubicCoeff);
@@ -449,9 +449,9 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
 
     if (layout == InterpolateLayoutType::planar) {
         tblAdvance += CUBIC_GRID_LEN * OH;
-        int* sequenceOH = static_cast<int*>(&indexTable[tblAdvance]);
+        auto* sequenceOH = static_cast<int*>(&indexTable[tblAdvance]);
         tblAdvance += OH * OW;
-        int* sequenceOW = static_cast<int*>(&indexTable[tblAdvance]);
+        auto* sequenceOW = static_cast<int*>(&indexTable[tblAdvance]);
         for (int h = 0; h < OH; ++h) {
             int offset = h * OW;
             for (int w = 0; w < OW; ++w) {
@@ -502,7 +502,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
 
         if (interpAttrs.layout == InterpolateLayoutType::planar) {
             srcPadded.resize(inShapePadBlock[0] * srcDataSize, 0);
-            uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
+            auto* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
             parallel_for4d(srcDim5d[0], srcDim5d[1], srcDim5d[2], srcDim5d[3], [&](int n, int c, int d, int h) {
                 const uint8_t* src = src_data_origin + (inShapeBlock[1] * n + inShapeBlock[2] * c +
                                                         inShapeBlock[3] * d + inShapeBlock[4] * h) *
@@ -516,7 +516,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
             src_data = src_data_pad;
         } else if (interpAttrs.layout == InterpolateLayoutType::by_channel) {
             srcPadded.resize(inShapePadBlock[0] * srcDataSize, 0);
-            uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
+            auto* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
             parallel_for4d(srcDim5d[0], srcDim5d[2], srcDim5d[3], srcDim5d[4], [&](int n, int d, int h, int w) {
                 const uint8_t* src = src_data_origin +
                                      (inShapeBlock[1] * n +
@@ -536,7 +536,7 @@ const uint8_t* ov::intel_cpu::InterpolateExecutor::padPreprocess(const std::vect
             size_t CB = div_up(srcDimPad5d[1], blkSize);
             size_t eltsTotal = srcDimPad5d[0] * CB * srcDimPad5d[2] * srcDimPad5d[3] * srcDimPad5d[4] * blkSize;
             srcPadded.resize(eltsTotal * srcDataSize, 0x0);
-            uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
+            auto* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
             if ((srcDim5d[0] != srcDimPad5d[0]) || (srcDim5d[1] != srcDimPad5d[1])) {
                 OPENVINO_THROW("Interpolate executor does not support padding on batch and channel dimensions");
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -8,7 +8,7 @@
 
 #include "node.h"
 
-#define MAX_INPUT_INTERPOLATE 8
+enum { MAX_INPUT_INTERPOLATE = 8 };
 
 namespace ov::intel_cpu {
 
@@ -112,10 +112,10 @@ public:
     virtual void exec(const std::vector<MemoryCPtr>& src,
                       const std::vector<MemoryPtr>& dst,
                       const void* post_ops_data_) = 0;
-    virtual impl_desc_type getImplType() const = 0;
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
 
     virtual ~InterpolateExecutor() = default;
-    VectorDims getSrcDimPad5d() const {
+    [[nodiscard]] VectorDims getSrcDimPad5d() const {
         return srcDimPad5d;
     }
     const uint8_t* padPreprocess(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst);
@@ -141,8 +141,8 @@ private:
                        float cubicCoeff,
                        InterpolateLayoutType layout);
 
-    float coordTransToInput(int outCoord, float scale, int inShape, int outShape) const;
-    int nearestRound(float origin, bool isDownsample, InterpolateNearestMode nearestMode) const;
+    [[nodiscard]] float coordTransToInput(int outCoord, float scale, int inShape, int outShape) const;
+    [[nodiscard]] int nearestRound(float origin, bool isDownsample, InterpolateNearestMode nearestMode) const;
     void linearOnnxCF(int outCoord,
                       float scale,
                       int inShape,
@@ -169,10 +169,10 @@ using InterpolateExecutorCPtr = std::shared_ptr<const InterpolateExecutor>;
 class InterpolateExecutorBuilder {
 public:
     ~InterpolateExecutorBuilder() = default;
-    virtual bool isSupported(const InterpolateAttrs& InterpolateAttrs,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual InterpolateExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const InterpolateAttrs& InterpolateAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual InterpolateExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using InterpolateExecutorBuilderPtr = std::shared_ptr<InterpolateExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate_list.hpp
@@ -36,7 +36,7 @@ public:
         }
     }
 
-    ~InterpolateExecutorFactory() = default;
+    ~InterpolateExecutorFactory() override = default;
     virtual InterpolateExecutorPtr makeExecutor(const InterpolateAttrs& interpolateAttrs,
                                                 const std::vector<MemoryDescPtr>& srcDescs,
                                                 const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -23,7 +23,7 @@ using namespace dnnl;
 using namespace ov::element;
 
 static Dim batchDim(const VectorDims& dims) {
-    return std::accumulate(dims.begin(), dims.end() - 1, 1, std::multiplies<Dim>());
+    return std::accumulate(dims.begin(), dims.end() - 1, 1, std::multiplies<>());
 }
 
 static MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory,
@@ -40,12 +40,12 @@ static MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory,
     auto packedBsize = mlas_sgemm_pack_get_size(N, K);
 
     auto create = [&]() {
-        float* weightPtr = weightsMemory->getDataAs<float>();
+        auto* weightPtr = weightsMemory->getDataAs<float>();
         size_t ldb = weightsTransposed ? K : N;
 
         MemoryPtr _ptr = std::make_shared<Memory>(context->getEngine(),
                                                   intel_cpu::CpuBlockedMemoryDesc(i8, intel_cpu::Shape{packedBsize}));
-        float* prepackedDst = _ptr->getDataAs<float>();
+        auto* prepackedDst = _ptr->getDataAs<float>();
         DEBUG_LOG("MlasGemmExecutor: cache miss, perform packing");
         mlas_sgemm_pack(weightsTransposed ? "T" : "F", N, K, ldb, weightPtr, prepackedDst);
         return _ptr;

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
@@ -21,7 +21,7 @@ public:
 
     void execute(const MemoryArgs& memory) override;
 
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::gemm_mlas;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.cpp
@@ -23,7 +23,7 @@ template <>
 struct has_mlas_transpose<uint32_t> : std::true_type {};
 
 template <typename T>
-typename std::enable_if<!has_mlas_transpose<T>::value, void>::type SimpleTransposeSingleAxisOutwards(
+std::enable_if_t<!has_mlas_transpose<T>::value, void> SimpleTransposeSingleAxisOutwards(
     const T* input_data,
     T* output_data,
     int64_t num_loops,
@@ -48,7 +48,7 @@ typename std::enable_if<!has_mlas_transpose<T>::value, void>::type SimpleTranspo
 }
 
 template <typename T>
-typename std::enable_if<has_mlas_transpose<T>::value, void>::type SimpleTransposeSingleAxisOutwards(
+std::enable_if_t<has_mlas_transpose<T>::value, void> SimpleTransposeSingleAxisOutwards(
     const T* input_data,
     T* output_data,
     int64_t num_loops,
@@ -66,7 +66,7 @@ typename std::enable_if<has_mlas_transpose<T>::value, void>::type SimpleTranspos
 }
 
 template <typename T>
-typename std::enable_if<!has_mlas_transpose<T>::value, void>::type SimpleTransposeSingleAxisInwards(
+std::enable_if_t<!has_mlas_transpose<T>::value, void> SimpleTransposeSingleAxisInwards(
     const T* input_data,
     T* output_data,
     int64_t num_loops,
@@ -91,7 +91,7 @@ typename std::enable_if<!has_mlas_transpose<T>::value, void>::type SimpleTranspo
 }
 
 template <typename T>
-typename std::enable_if<has_mlas_transpose<T>::value, void>::type SimpleTransposeSingleAxisInwards(
+std::enable_if_t<has_mlas_transpose<T>::value, void> SimpleTransposeSingleAxisInwards(
     const T* input_data,
     T* output_data,
     int64_t num_loops,

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.hpp
@@ -16,7 +16,7 @@ public:
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
 
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::mlas;
     }
 
@@ -32,11 +32,11 @@ private:
 
 class MlasTransposeExecutorBuilder : public TransposeExecutorBuilder {
 public:
-    bool isSupported(const TransposeParams& transposeParams,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override;
+    [[nodiscard]] bool isSupported(const TransposeParams& transposeParams,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
 
-    TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override;
+    [[nodiscard]] TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
@@ -39,7 +39,7 @@ public:
                       const void* post_ops_data_) = 0;
     virtual ~MVNExecutor() = default;
 
-    virtual impl_desc_type getImplType() const = 0;
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
 
     static VectorDims transformTo5DCase(const VectorDims& shape, bool initAcrossChannels);
 
@@ -54,10 +54,10 @@ using MVNExecutorCPtr = std::shared_ptr<const MVNExecutor>;
 class MVNExecutorBuilder {
 public:
     ~MVNExecutorBuilder() = default;
-    virtual bool isSupported(const MVNAttrs& mvnAttrs,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual MVNExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const MVNAttrs& mvnAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual MVNExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using MVNExecutorBuilderPtr = std::shared_ptr<MVNExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/mvn_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mvn_list.hpp
@@ -36,7 +36,7 @@ public:
         }
     }
 
-    ~MVNExecutorFactory() = default;
+    ~MVNExecutorFactory() override = default;
     virtual MVNExecutorPtr makeExecutor(const MVNAttrs& mvnAttrs,
                                         const std::vector<MemoryDescPtr>& srcDescs,
                                         const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
@@ -50,7 +50,7 @@ public:
                       std::unordered_map<int, MemoryPtr> postOpsArgs) = 0;
     virtual ~PoolingExecutor() = default;
 
-    virtual impl_desc_type getImplType() const = 0;
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
 
 protected:
     PoolingAttrs poolingAttrs;
@@ -63,10 +63,10 @@ using PoolingExecutorCPtr = std::shared_ptr<const PoolingExecutor>;
 class PoolingExecutorBuilder {
 public:
     ~PoolingExecutorBuilder() = default;
-    virtual bool isSupported(const PoolingAttrs& poolingAttrs,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual PoolingExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const PoolingAttrs& poolingAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual PoolingExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using PoolingExecutorBuilderPtr = std::shared_ptr<PoolingExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/pooling_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/pooling_list.hpp
@@ -33,7 +33,7 @@ public:
         }
     }
 
-    ~PoolingExecutorFactory() = default;
+    ~PoolingExecutorFactory() override = default;
     virtual PoolingExecutorPtr makeExecutor(const PoolingAttrs& poolingAttrs,
                                             const std::vector<MemoryDescPtr>& srcDescs,
                                             const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/precision_translation.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/precision_translation.hpp
@@ -87,18 +87,18 @@ public:
           m_translation(std::move(translation)),
           m_enabled(std::move(enabled)) {}
 
-    const InOutTypeMask& mask() const {
+    [[nodiscard]] const InOutTypeMask& mask() const {
         return m_mask;
     }
 
-    InOutTypes translate(const InOutTypes& types) const {
+    [[nodiscard]] InOutTypes translate(const InOutTypes& types) const {
         if (m_translation) {
             return m_translation(types);
         }
         return {};
     }
 
-    bool enabled() const {
+    [[nodiscard]] bool enabled() const {
         if (m_enabled) {
             return m_enabled();
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
@@ -30,7 +30,7 @@ public:
                       const void* post_ops_data_) = 0;
     virtual ~ReduceExecutor() = default;
 
-    virtual impl_desc_type getImplType() const = 0;
+    [[nodiscard]] virtual impl_desc_type getImplType() const = 0;
 
 protected:
     ReduceAttrs reduceAttrs;
@@ -43,10 +43,10 @@ using ReduceExecutorCPtr = std::shared_ptr<const ReduceExecutor>;
 class ReduceExecutorBuilder {
 public:
     ~ReduceExecutorBuilder() = default;
-    virtual bool isSupported(const ReduceAttrs& reduceAttrs,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual ReduceExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const ReduceAttrs& reduceAttrs,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual ReduceExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using ReduceExecutorBuilderPtr = std::shared_ptr<ReduceExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/reduce_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/reduce_list.hpp
@@ -36,7 +36,7 @@ public:
         }
     }
 
-    ~ReduceExecutorFactory() = default;
+    ~ReduceExecutorFactory() override = default;
     virtual ReduceExecutorPtr makeExecutor(const ReduceAttrs& reduceAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
@@ -53,7 +53,7 @@ public:
     }
 
 private:
-    std::shared_ptr<typename std::remove_pointer<T>::type> m_ptr = nullptr;
+    std::shared_ptr<std::remove_pointer_t<T>> m_ptr = nullptr;
 
 protected:
     bool operator==(const T other) const { return other == m_ptr.get(); }
@@ -107,16 +107,16 @@ struct ShlTensor : public ShlStructure<csinn_tensor*> {
         csinn_tensor_copy(get(), another.get());
     }
 
-    csinn_layout_enum getLayout() const {
+    [[nodiscard]] csinn_layout_enum getLayout() const {
         // csinn_tensor contains `layout` as int32_t
         return static_cast<csinn_layout_enum>(get()->layout);
     }
 
-    csinn_dtype_enum getPrecision() const {
+    [[nodiscard]] csinn_dtype_enum getPrecision() const {
         return get()->dtype;
     }
 
-    VectorDims getShape() const {
+    [[nodiscard]] VectorDims getShape() const {
         VectorDims shape(get()->dim_count);
         for (size_t i = 0; i < shape.size(); ++i) {
             shape[i] = static_cast<size_t>(get()->dim[i]);
@@ -124,7 +124,7 @@ struct ShlTensor : public ShlStructure<csinn_tensor*> {
         return shape;
     }
 
-    void* getData() const {
+    [[nodiscard]] void* getData() const {
         return get()->data;
     }
 
@@ -132,7 +132,7 @@ struct ShlTensor : public ShlStructure<csinn_tensor*> {
         get()->data = data;
     }
 
-    ShlTensor cloneWithNewShape(const VectorDims& shape) const {
+    [[nodiscard]] ShlTensor cloneWithNewShape(const VectorDims& shape) const {
         ShlTensor cloned(*this);
         cloned.setShape(shape);
         return cloned;
@@ -169,19 +169,19 @@ private:
 struct IShlParams {
 public:
     virtual ~IShlParams() = default;
-    virtual void* get(bool allow_empty) const = 0;
+    [[nodiscard]] virtual void* get(bool allow_empty) const = 0;
 };
 
 template <typename T, typename traits = ShlStructureTraits<T>>
 struct ShlParams : public ShlStructure<T>, public IShlParams {
     ShlParams() {
-        T params = static_cast<T>(csinn_alloc_params(sizeof(typename std::remove_pointer<T>::type), nullptr));
+        T params = static_cast<T>(csinn_alloc_params(sizeof(std::remove_pointer_t<T>), nullptr));
         OPENVINO_ASSERT(params != nullptr, "Failed to create csinn_params");
         this->reset(params);
     }
 
     ShlParams(const ShlSession& session) {
-        T params = static_cast<T>(csinn_alloc_params(sizeof(typename std::remove_pointer<T>::type), session.get()));
+        T params = static_cast<T>(csinn_alloc_params(sizeof(std::remove_pointer_t<T>), session.get()));
         OPENVINO_ASSERT(params != nullptr, "Failed to create csinn_params");
         this->reset(params);
     }
@@ -190,13 +190,13 @@ struct ShlParams : public ShlStructure<T>, public IShlParams {
         setAPI(api);
     }
 
-    void* get(bool allow_empty) const override {
+    [[nodiscard]] void* get(bool allow_empty) const override {
         return this->ShlStructure<T, traits>::get(allow_empty);
     }
 
 private:
     void setAPI(csinn_api_enum api) {
-        auto params = static_cast<typename std::remove_pointer<T>::type*>(this->get());
+        auto params = static_cast<std::remove_pointer_t<T>*>(this->get());
         params->base.api = api;
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_eltwise.hpp
@@ -24,7 +24,7 @@ public:
               const std::vector<MemoryPtr>& dst,
               const void *post_ops_data_) override;
 
-    impl_desc_type getImplType() const override {
+    [[nodiscard]] impl_desc_type getImplType() const override {
         return impl_desc_type::shl;
     }
 
@@ -38,11 +38,11 @@ private:
 
 class ShlEltwiseExecutorBuilder : public EltwiseExecutorBuilder {
 public:
-    bool isSupported(const EltwiseAttrs& eltwiseAttrs,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override;
+    [[nodiscard]] bool isSupported(const EltwiseAttrs& eltwiseAttrs,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
 
-    EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<ShlEltwiseExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
@@ -123,7 +123,7 @@ bool ShlFCExecutor::update(const MemoryArgs& memory) {
     const auto src_shape = src.getShape();
     const auto dst_shape = dst.getShape();
     dim_M =
-        std::accumulate(dst_shape.rbegin() + 1, dst_shape.rend(), static_cast<size_t>(1), std::multiplies<size_t>());
+        std::accumulate(dst_shape.rbegin() + 1, dst_shape.rend(), static_cast<size_t>(1), std::multiplies<>());
     dim_In = src_shape.back();
     dim_Out = dst_shape.back();
     LDA = dim_In * memory.at(ARG_SRC)->getPrecision().size();

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
@@ -18,7 +18,7 @@ public:
 
     void execute(const MemoryArgs& memory) override;
 
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::gemm_shl;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/subgraph.cpp
@@ -85,7 +85,7 @@ SubgraphBaseExecutor::SubgraphBaseExecutor(const std::shared_ptr<CPURuntimeConfi
     m_harness_work_amount = std::accumulate(m_parallel_exec_domain.cbegin(),
                                             m_parallel_exec_domain.cend(),
                                             static_cast<size_t>(1),
-                                            std::multiplies<size_t>());
+                                            std::multiplies<>());
     m_nthreads = std::min(parallel_get_max_threads(), static_cast<int>(m_harness_work_amount));
 
     m_buffer_scratchpad_size = snippet_config->buffer_scratchpad_size;

--- a/src/plugins/intel_cpu/src/nodes/executors/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/subgraph.hpp
@@ -29,7 +29,7 @@ public:
     SubgraphCodeGenerator(const std::shared_ptr<SubgraphAttrs>& snippet_attrs,
                           const std::shared_ptr<CPURuntimeConfig>& config);
 
-    const std::shared_ptr<snippets::Schedule>& get() const {
+    [[nodiscard]] const std::shared_ptr<snippets::Schedule>& get() const {
         return schedule;
     }
 
@@ -105,7 +105,7 @@ public:
     virtual ~SubgraphStaticBaseExecutor() = default;
 
 protected:
-    typedef void (*kernel)(const void*, const void*);
+    using kernel = void (*)(const void*, const void*);
 
     inline void init_call_args(jit_snippets_call_args& call_args,
                                const std::vector<MemoryPtr>& srcMemPtrs,
@@ -135,7 +135,7 @@ public:
     virtual ~SubgraphDynamicSpecializedBaseExecutor() = default;
 
 protected:
-    typedef void (*dynamic_kernel)(const void*);
+    using dynamic_kernel = void (*)(const void*);
 
     inline void init_call_args(jit_snippets_call_args& call_args, size_t ithr) {
         call_args.register_loops(m_loop_args);

--- a/src/plugins/intel_cpu/src/nodes/executors/transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/transpose.hpp
@@ -23,7 +23,7 @@ public:
                       const std::vector<MemoryDescPtr>& srcDescs,
                       const std::vector<MemoryDescPtr>& dstDescs,
                       const dnnl::primitive_attr& attr) = 0;
-    virtual ~TransposeExecutor() = default;
+    ~TransposeExecutor() override = default;
 
 protected:
     PermuteParams permuteParams;
@@ -35,10 +35,10 @@ using TransposeExecutorCPtr = std::shared_ptr<const TransposeExecutor>;
 class TransposeExecutorBuilder {
 public:
     virtual ~TransposeExecutorBuilder() = default;
-    virtual bool isSupported(const TransposeParams& transposeParams,
-                             const std::vector<MemoryDescPtr>& srcDescs,
-                             const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    virtual TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual bool isSupported(const TransposeParams& transposeParams,
+                                           const std::vector<MemoryDescPtr>& srcDescs,
+                                           const std::vector<MemoryDescPtr>& dstDescs) const = 0;
+    [[nodiscard]] virtual TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
 };
 
 using TransposeExecutorBuilderPtr = std::shared_ptr<TransposeExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/transpose_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/transpose_list.hpp
@@ -40,7 +40,7 @@ public:
         }
     }
 
-    ~TransposeExecutorFactory() = default;
+    ~TransposeExecutorFactory() override = default;
     virtual TransposeExecutorPtr makeExecutor(const TransposeParams& transposeParams,
                                               const std::vector<MemoryDescPtr>& srcDescs,
                                               const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/variable_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/variable_executor.hpp
@@ -61,7 +61,7 @@ public:
         m_executors[m_implId]->execute(memory);
     }
 
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return m_executors[m_implId]->implType();
     }
 
@@ -86,7 +86,7 @@ private:
         return implementationRequiresFallback;
     }
 
-    size_t select(const MemoryArgs& memory, const size_t startIdx) const {
+    [[nodiscard]] size_t select(const MemoryArgs& memory, const size_t startIdx) const {
         OPENVINO_ASSERT(startIdx < m_suitableImplementations.size(),
                         "Failed to find an implementation since start indx: ",
                         startIdx,

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/jit_transpose.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/jit_transpose.cpp
@@ -15,8 +15,8 @@ void JitTransposeExecutor::exec(const std::vector<MemoryCPtr>& src, const std::v
         OPENVINO_THROW("Could not execute. Kernel for Transpose node was not compiled.");
     }
 
-    const uint8_t* srcData = src[0]->getDataAs<const uint8_t>();
-    uint8_t* dstData = dst[0]->getDataAs<uint8_t>();
+    const auto* srcData = src[0]->getDataAs<const uint8_t>();
+    auto* dstData = dst[0]->getDataAs<uint8_t>();
     const int MB = src[0]->getStaticDims()[0];
 
     pKernel->execute(srcData, dstData, MB);

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/jit_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/jit_transpose.hpp
@@ -17,7 +17,7 @@ public:
               const std::vector<MemoryDescPtr>& dstDescs,
               const dnnl::primitive_attr& attr) override;
     void exec(const std::vector<MemoryCPtr>& src, const std::vector<MemoryPtr>& dst) override;
-    impl_desc_type implType() const override {
+    [[nodiscard]] impl_desc_type implType() const override {
         return impl_desc_type::jit;
     }
 
@@ -27,10 +27,10 @@ private:
 
 class JitTransposeExecutorBuilder : public TransposeExecutorBuilder {
 public:
-    bool isSupported(const TransposeParams& transposeParams,
-                     const std::vector<MemoryDescPtr>& srcDescs,
-                     const std::vector<MemoryDescPtr>& dstDescs) const override;
-    TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
+    [[nodiscard]] bool isSupported(const TransposeParams& transposeParams,
+                                   const std::vector<MemoryDescPtr>& srcDescs,
+                                   const std::vector<MemoryDescPtr>& dstDescs) const override;
+    [[nodiscard]] TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override {
         return std::make_shared<JitTransposeExecutor>(context);
     }
 };

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.cpp
@@ -10,7 +10,7 @@
 #include "snippets/op/subgraph.hpp"
 
 #if defined(__linux__) && defined(SNIPPETS_DEBUG_CAPS)
-#    include <signal.h>
+#    include <csignal>
 
 #    include "emitters/snippets/x64/jit_segfault_detector_emitter.hpp"
 std::mutex err_print_lock;
@@ -38,7 +38,7 @@ inline void parallelNd_repacking(const BrgemmCopyBKernel* ker,
                                  const VectorDims& out_str,
                                  const uint8_t* src,
                                  uint8_t* dst) {
-    const size_t batch = std::accumulate(dom.rbegin() + 2, dom.rend(), 1lu, std::multiplies<size_t>());
+    const size_t batch = std::accumulate(dom.rbegin() + 2, dom.rend(), 1lu, std::multiplies<>());
     parallel_nt_static(0, [&](const int ithr, const int nthr) {
         BrgemmCopyBKernel::call_args args;
         size_t start = 0, end = 0;

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
@@ -17,7 +17,7 @@ struct Indexer {
     std::vector<int> dims_;
     int total_{1};
 
-    explicit Indexer(std::vector<int> dims) : dims_(std::move(dims)), total_(1) {
+    explicit Indexer(std::vector<int> dims) : dims_(std::move(dims)) {
         for (const auto dim : dims_) {
             total_ *= dim;
         }
@@ -352,7 +352,7 @@ void ExperimentalDetectronDetectionOutput::execute(const dnnl::stream& strm) {
         for (int i = 0; i < n; ++i) {
             int idx = indices[indices_offset + i];
             float score = refined_scores[refined_score_idx({c, idx})];
-            conf_index_class_map.push_back(std::make_pair(score, std::make_pair(c, idx)));
+            conf_index_class_map.emplace_back(score, std::make_pair(c, idx));
         }
         indices_offset += n;
     }

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
@@ -369,13 +369,13 @@ void ExperimentalDetectronGenerateProposalsSingleImage::execute(const dnnl::stre
         }
 
         // Prepare memory
-        const float* p_deltas_item = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
-        const float* p_scores_item = getSrcDataAtPortAs<const float>(INPUT_SCORES);
-        const float* p_anchors_item = getSrcDataAtPortAs<const float>(INPUT_ANCHORS);
-        const float* p_img_info_cpu = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
+        const auto* p_deltas_item = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
+        const auto* p_scores_item = getSrcDataAtPortAs<const float>(INPUT_SCORES);
+        const auto* p_anchors_item = getSrcDataAtPortAs<const float>(INPUT_ANCHORS);
+        const auto* p_img_info_cpu = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
 
-        float* p_roi_item = getDstDataAtPortAs<float>(OUTPUT_ROIS);
-        float* p_roi_score_item = getDstDataAtPortAs<float>(OUTPUT_SCORES);
+        auto* p_roi_item = getDstDataAtPortAs<float>(OUTPUT_ROIS);
+        auto* p_roi_score_item = getDstDataAtPortAs<float>(OUTPUT_SCORES);
 
         const int anchors_num = scoreDims[0];
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
@@ -79,8 +79,8 @@ void pre_calc_for_bilinear_interpolate(const int height,
                         x = 0;
                     }
 
-                    int y_low = static_cast<int>(y);
-                    int x_low = static_cast<int>(x);
+                    auto y_low = static_cast<int>(y);
+                    auto x_low = static_cast<int>(x);
                     int y_high = 0;
                     int x_high = 0;
 

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -6,6 +6,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "common/primitive_hashing_utils.hpp"
@@ -102,7 +103,7 @@ private:
     Xbyak::Label gather_index_table;
 
     inline void load_scalar(Vmm vmm_arg, const Xbyak::Address& op) {
-        Xbyak::Xmm xmm_src = Xmm(vmm_arg.getIdx());
+        auto xmm_src = Xmm(vmm_arg.getIdx());
         switch (jpp.dtype_size) {
         case 4:
             uni_vmovss(vmm_arg, op);
@@ -118,7 +119,7 @@ private:
         }
     }
     inline void store_scalar(const Xbyak::Address& op, Vmm vmm_arg) {
-        Xbyak::Xmm xmm_dst = Xmm(vmm_arg.getIdx());
+        auto xmm_dst = Xmm(vmm_arg.getIdx());
         switch (jpp.dtype_size) {
         case 4:
             uni_vmovss(op, vmm_arg);
@@ -211,14 +212,14 @@ private:
         }
     }
     inline void emulate_gather(const Xbyak::Ymm& ymm_arg, reg64_t& mem_base) {
-        Xbyak::Xmm low_xmm = Xbyak::Xmm(ymm_arg.getIdx());
+        auto low_xmm = Xbyak::Xmm(ymm_arg.getIdx());
         emulate_gather(low_xmm, mem_base, 0);
         emulate_gather(xmm_aux, mem_base, 1);
         vinserti128(ymm_arg, ymm_arg, xmm_aux, 1);
     }
 
     inline void emulate_gather(const Xbyak::Zmm& zmm_arg, reg64_t& mem_base) {
-        Xbyak::Xmm low_xmm = Xbyak::Xmm(zmm_arg.getIdx());
+        auto low_xmm = Xbyak::Xmm(zmm_arg.getIdx());
         emulate_gather(low_xmm, mem_base, 0);
         for (int i = 1; i < 4; i++) {
             emulate_gather(xmm_aux, mem_base, i);
@@ -332,7 +333,7 @@ struct ExtractImagePatchesKey {
     VectorDims rates;
     ExtractImagePatches::ExtImgPatcherPadType padType;
     size_t prcSize;
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const ExtractImagePatchesKey& rhs) const;
 };
 
@@ -475,8 +476,8 @@ void ExtractImagePatches::ExtractImagePatchesRefExecutor::executeReference(void*
                                                                            void* dst,
                                                                            const VectorDims& istrides,
                                                                            const VectorDims& ostrides) const {
-    const char* src_data = reinterpret_cast<const char*>(src);
-    char* dst_data = reinterpret_cast<char*>(dst);
+    const auto* src_data = reinterpret_cast<const char*>(src);
+    auto* dst_data = reinterpret_cast<char*>(dst);
 
     const std::vector<size_t> ostrides_partial = {ostrides[0],
                                                   jpp.KW * IC * ostrides[1],
@@ -534,8 +535,8 @@ void ExtractImagePatches::ExtractImagePatchesJitExecutor::executeOptimizedGeneri
                                                                                   const VectorDims& istrides,
                                                                                   const VectorDims& ostrides) const {
 #if defined(OPENVINO_ARCH_X86_64)
-    const char* src_data = reinterpret_cast<const char*>(src);
-    char* dst_data = reinterpret_cast<char*>(dst);
+    const auto* src_data = reinterpret_cast<const char*>(src);
+    auto* dst_data = reinterpret_cast<char*>(dst);
     const auto& jpp = pKernel->jpp;
 
     const std::vector<size_t> ostrides_partial = {ostrides[0],
@@ -649,11 +650,11 @@ ExtractImagePatches::ExtractImagePatchesJitExecutor::ExtractImagePatchesJitExecu
 #if defined(OPENVINO_ARCH_X86_64)
     auto jpp = fillJpp(inDims, outDims, kSizes, strides, rates, padType, prcSize);
     if (mayiuse(x64::avx512_core)) {
-        pKernel.reset(new jit_extract_image_patches_kernel<x64::avx512_core>(jpp));
+        pKernel = std::make_unique<jit_extract_image_patches_kernel<x64::avx512_core>>(jpp);
     } else if (mayiuse(x64::avx2)) {
-        pKernel.reset(new jit_extract_image_patches_kernel<x64::avx2>(jpp));
+        pKernel = std::make_unique<jit_extract_image_patches_kernel<x64::avx2>>(jpp);
     } else if (mayiuse(x64::sse41)) {
-        pKernel.reset(new jit_extract_image_patches_kernel<x64::sse41>(jpp));
+        pKernel = std::make_unique<jit_extract_image_patches_kernel<x64::sse41>>(jpp);
     } else {
         OPENVINO_THROW("Can't create jit extract image patches kernel");
     }

--- a/src/plugins/intel_cpu/src/nodes/eye.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eye.cpp
@@ -108,7 +108,7 @@ void Eye::executeSpecified() {
     const size_t onesPerBatchNum =
         static_cast<size_t>(shift > 0 ? std::min(countByColumns, static_cast<int64_t>(rowNum))
                                       : std::min(countByRows, static_cast<int64_t>(colNum)));
-    const size_t dataShift = static_cast<size_t>(shift >= 0 ? shift : -shift * colNum);
+    const auto dataShift = static_cast<size_t>(shift >= 0 ? shift : -shift * colNum);
 
     if (spatialSize >= l2CacheSize) {
         parallel_nt(0, [&](const size_t ithr, const size_t nthr) {

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -86,7 +86,7 @@ private:
     }
 
     inline const size_t getBatchVolume(const std::vector<int>& batchShape) {
-        return std::accumulate(begin(batchShape), end(batchShape), 1, std::multiplies<size_t>());
+        return std::accumulate(begin(batchShape), end(batchShape), 1, std::multiplies<>());
     }
     bool withBatchShape = false;
 };

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -4,12 +4,12 @@
 
 #include "fake_quantize.h"
 
-#include <math.h>
 #include <memory_desc/cpu_memory_desc_utils.h>
 
 #include <algorithm>
 #include <cmath>
 #include <common/dnnl_thread.hpp>
+#include <memory>
 #include <set>
 #include <shape_inference/shape_inference_pass_through.hpp>
 #include <string>
@@ -913,7 +913,7 @@ private:
     }
 
     inline void store_vector(const Xbyak::Address& op, Ymm ymm_dst, ov::element::Type dst_prc) {
-        Xmm xmm_dst = Xmm(ymm_dst.getIdx());
+        auto xmm_dst = Xmm(ymm_dst.getIdx());
 
         if (dst_prc != ov::element::f32) {
             uni_vcvtps2dq(ymm_dst, ymm_dst);
@@ -1065,7 +1065,7 @@ bool FakeQuantize::isSupportedOperation(const std::shared_ptr<const ov::Node>& o
 namespace {
 struct FakeQuantKey {
     jit_quantize_params jqp;
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         using namespace dnnl::impl::primitive_hashing;
         size_t seed = 0;
         seed = hash_combine(seed, jqp.is_planar);
@@ -1527,7 +1527,7 @@ void FakeQuantize::initSupportedPrimitiveDescriptors() {
         dataConfig.setMemDesc(descCreator->createSharedDesc(getOutputPrecision(), getOutputShapeAtPort(0)));
         config.outConfs.push_back(dataConfig);
 
-        supportedPrimitiveDescriptors.push_back({config, impl_type});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_type);
     }
 }
 
@@ -2372,21 +2372,21 @@ FakeQuantize::FakeQuantizeJitExecutor::FakeQuantizeJitExecutor(const jit_quantiz
     bool isBinarization = _jqp.op_type == Algorithm::FQBinarization;
     if (mayiuse(cpu::x64::avx512_core)) {
         if (isBinarization) {
-            pKernel.reset(new jit_uni_binarization_kernel<cpu::x64::avx512_core>(_jqp));
+            pKernel = std::make_unique<jit_uni_binarization_kernel<cpu::x64::avx512_core>>(_jqp);
         } else {
-            pKernel.reset(new jit_uni_quantization_kernel<cpu::x64::avx512_core>(_jqp));
+            pKernel = std::make_unique<jit_uni_quantization_kernel<cpu::x64::avx512_core>>(_jqp);
         }
     } else if (mayiuse(cpu::x64::avx2)) {
         if (isBinarization) {
-            pKernel.reset(new jit_uni_binarization_kernel<cpu::x64::avx2>(_jqp));
+            pKernel = std::make_unique<jit_uni_binarization_kernel<cpu::x64::avx2>>(_jqp);
         } else {
-            pKernel.reset(new jit_uni_quantization_kernel<cpu::x64::avx2>(_jqp));
+            pKernel = std::make_unique<jit_uni_quantization_kernel<cpu::x64::avx2>>(_jqp);
         }
     } else if (mayiuse(cpu::x64::sse41)) {
         if (isBinarization) {
-            pKernel.reset(new jit_uni_binarization_kernel<cpu::x64::sse41>(_jqp));
+            pKernel = std::make_unique<jit_uni_binarization_kernel<cpu::x64::sse41>>(_jqp);
         } else {
-            pKernel.reset(new jit_uni_quantization_kernel<cpu::x64::sse41>(_jqp));
+            pKernel = std::make_unique<jit_uni_quantization_kernel<cpu::x64::sse41>>(_jqp);
         }
     } else {
         OPENVINO_THROW("Can't create jit fake quantize kernel");

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -7,6 +7,7 @@
 #include <partitioned_mem_blk.h>
 
 #include <cstdint>
+#include <memory>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/gather.hpp>
 #include <openvino/opsets/opset1.hpp>
@@ -55,8 +56,7 @@ bool Gather::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
 }
 
 Gather::Gather(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
-    : Node(op, context, GatherShapeInferFactory(op)),
-      batchDims(0) {
+    : Node(op, context, GatherShapeInferFactory(op)) {
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
@@ -132,10 +132,10 @@ void Gather::initSupportedPrimitiveDescriptors() {
     const auto& dataDims = getInputShapeAtPort(GATHER_DATA).getDims();
     if (isAxisInputConst && isDataShapeStat) {
         axisDim = dataDims[axis];
-        beforeAxisSize = std::accumulate(dataDims.begin(), dataDims.begin() + axis, 1lu, std::multiplies<Dim>());
+        beforeAxisSize = std::accumulate(dataDims.begin(), dataDims.begin() + axis, 1lu, std::multiplies<>());
         betweenBatchAndAxisSize =
-            std::accumulate(dataDims.begin() + batchDims, dataDims.begin() + axis, 1lu, std::multiplies<Dim>());
-        afterAxisSize = std::accumulate(dataDims.begin() + axis + 1, dataDims.end(), 1lu, std::multiplies<Dim>());
+            std::accumulate(dataDims.begin() + batchDims, dataDims.begin() + axis, 1lu, std::multiplies<>());
+        afterAxisSize = std::accumulate(dataDims.begin() + axis + 1, dataDims.end(), 1lu, std::multiplies<>());
 
         afterAxisSizeInBytes = afterAxisSize * dataTypeSize;
         axisAndAfterAxisSize = axisDim * afterAxisSize;
@@ -144,11 +144,11 @@ void Gather::initSupportedPrimitiveDescriptors() {
         srcAfterBatchSizeInBytes = betweenBatchAndAxisSize * axisAndAfterAxisSizeInBytes;
     }
     if (isDataShapeStat) {
-        beforeBatchSize = std::accumulate(dataDims.begin(), dataDims.begin() + batchDims, 1lu, std::multiplies<Dim>());
+        beforeBatchSize = std::accumulate(dataDims.begin(), dataDims.begin() + batchDims, 1lu, std::multiplies<>());
     }
     if (isIdxShapeStat) {
         const auto& idxDims = getInputShapeAtPort(GATHER_INDICES).getDims();
-        specIndicesSize = std::accumulate(idxDims.begin() + batchDims, idxDims.end(), 1lu, std::multiplies<Dim>());
+        specIndicesSize = std::accumulate(idxDims.begin() + batchDims, idxDims.end(), 1lu, std::multiplies<>());
 
         if (isDataShapeStat) {
             specIdxAndAfterAxSize = specIndicesSize * afterAxisSize;
@@ -287,9 +287,9 @@ void Gather::createPrimitive() {
         }
 
         if (x64::mayiuse(x64::avx512_core)) {
-            jitKernel.reset(new jitUniGatherKernel<x64::avx512_core>(jcp));
+            jitKernel = std::make_shared<jitUniGatherKernel<x64::avx512_core>>(jcp);
         } else if (x64::mayiuse(x64::avx2)) {
-            jitKernel.reset(new jitUniGatherKernel<x64::avx2>(jcp));
+            jitKernel = std::make_shared<jitUniGatherKernel<x64::avx2>>(jcp);
         }
         if (jitKernel) {
             jitKernel->create_ker();
@@ -376,11 +376,10 @@ void Gather::prepareParams() {
     if (!isDataShapeStat || !isAxisInputConst) {
         const auto& dataDims = dataMemPtr->getStaticDims();
         axisDim = dataDims[axis];
-        beforeBatchSize =
-            std::accumulate(dataDims.begin(), dataDims.begin() + batchDims, 1lu, std::multiplies<uint64_t>());
+        beforeBatchSize = std::accumulate(dataDims.begin(), dataDims.begin() + batchDims, 1lu, std::multiplies<>());
         betweenBatchAndAxisSize =
-            std::accumulate(dataDims.begin() + batchDims, dataDims.begin() + axis, 1lu, std::multiplies<uint64_t>());
-        afterAxisSize = std::accumulate(dataDims.begin() + axis + 1, dataDims.end(), 1lu, std::multiplies<uint64_t>());
+            std::accumulate(dataDims.begin() + batchDims, dataDims.begin() + axis, 1lu, std::multiplies<>());
+        afterAxisSize = std::accumulate(dataDims.begin() + axis + 1, dataDims.end(), 1lu, std::multiplies<>());
 
         afterAxisSizeInBytes = afterAxisSize * dataTypeSize;
         axisAndAfterAxisSize = axisDim * afterAxisSize;
@@ -397,7 +396,7 @@ void Gather::prepareParams() {
 
     if (!isIdxShapeStat) {
         const auto& idxDims = idxMemPtr->getStaticDims();
-        specIndicesSize = std::accumulate(idxDims.begin() + batchDims, idxDims.end(), 1lu, std::multiplies<uint64_t>());
+        specIndicesSize = std::accumulate(idxDims.begin() + batchDims, idxDims.end(), 1lu, std::multiplies<>());
 
         specIdxAndAfterAxSize = specIndicesSize * afterAxisSize;
         specIdxAndAfterAxSizeB = specIndicesSize * afterAxisSizeInBytes;
@@ -433,7 +432,7 @@ void Gather::execute(const dnnl::stream& strm) {
     if (jitKernel && jitKernel->isSupportedConfiguration(afterAxisSize)) {
         const void* srcIndices = getSrcDataAtPort(GATHER_INDICES);
         const void* srcData = getSrcDataAtPort(GATHER_DATA);
-        uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
+        auto* dstData = getDstDataAtPortAs<uint8_t>(0);
 
         const uint64_t dataElPerVec = jitKernel->getDataElPerVec();
 
@@ -501,7 +500,7 @@ void Gather::executeDynamicImpl(const dnnl::stream& strm) {
     if (jitKernel && jitKernel->isSupportedConfiguration(afterAxisSize)) {
         const void* srcIndices = getSrcDataAtPort(GATHER_INDICES);
         const void* srcData = getSrcDataAtPort(GATHER_DATA);
-        uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
+        auto* dstData = getDstDataAtPortAs<uint8_t>(0);
 
         const uint64_t dataElPerVec = jitKernel->getDataElPerVec();
 
@@ -638,9 +637,9 @@ void Gather::initShortParams(threadExecParams& p, const uint64_t start) {
 
 template <typename OUT_TYPE, int8_t get4Bit(const uint8_t&, bool)>
 void Gather::execCompressed4Bit() {
-    const int32_t* srcIndices = getSrcDataAtPortAs<const int32_t>(GATHER_INDICES);
-    const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(GATHER_DATA);
-    OUT_TYPE* dstData = getDstDataAtPortAs<OUT_TYPE>(0);
+    const auto* srcIndices = getSrcDataAtPortAs<const int32_t>(GATHER_INDICES);
+    const auto* srcData = getSrcDataAtPortAs<const uint8_t>(GATHER_DATA);
+    auto* dstData = getDstDataAtPortAs<OUT_TYPE>(0);
 
     // zp/scale
     float const_zp = 0;
@@ -722,9 +721,9 @@ void Gather::execCompressed4Bit() {
 
 template <typename OUT_TYPE, typename IN_TYPE>
 void Gather::execCompressed8Bit() {
-    const int32_t* srcIndices = getSrcDataAtPortAs<const int32_t>(GATHER_INDICES);
-    const IN_TYPE* srcData = getSrcDataAtPortAs<const IN_TYPE>(GATHER_DATA);
-    OUT_TYPE* dstData = getDstDataAtPortAs<OUT_TYPE>(0);
+    const auto* srcIndices = getSrcDataAtPortAs<const int32_t>(GATHER_INDICES);
+    const auto* srcData = getSrcDataAtPortAs<const IN_TYPE>(GATHER_DATA);
+    auto* dstData = getDstDataAtPortAs<OUT_TYPE>(0);
 
     // zp/scale
     float const_zp = 0;
@@ -883,9 +882,9 @@ void Gather::execCompressed() {
 }
 
 void Gather::execReference() {
-    const int32_t* srcIndices = getSrcDataAtPortAs<const int32_t>(GATHER_INDICES);
-    const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(GATHER_DATA);
-    uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
+    const auto* srcIndices = getSrcDataAtPortAs<const int32_t>(GATHER_INDICES);
+    const auto* srcData = getSrcDataAtPortAs<const uint8_t>(GATHER_DATA);
+    auto* dstData = getDstDataAtPortAs<uint8_t>(0);
 
     const size_t dstAfterBatchSize = betweenBatchAndAxisSize * specIdxAndAfterAxSizeB;
     parallel_for2d(beforeBatchSize, specIndicesSize, [&](const size_t b, const size_t j) {

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.cpp
@@ -115,19 +115,19 @@ GatherND::GatherNDExecutor::GatherNDExecutor(const GatherNDAttributes& attrs)
     : batchSize(std::accumulate(attrs.srcDims.begin(),
                                 attrs.srcDims.begin() + attrs.batchDims,
                                 static_cast<size_t>(1),
-                                std::multiplies<size_t>())),
+                                std::multiplies<>())),
       dataSize(attrs.dataSize),
       sliceRank(attrs.sliceRank),
       dataLength(std::accumulate(attrs.srcDims.begin() + sliceRank + attrs.batchDims,
                                  attrs.srcDims.end(),
                                  static_cast<size_t>(1),
-                                 std::multiplies<size_t>())),
+                                 std::multiplies<>())),
       cycles(attrs.dstElementCount / (dataLength * batchSize)),
       workAmount(batchSize * cycles),
       srcBatchStride(std::accumulate(attrs.srcDims.begin() + attrs.batchDims,
                                      attrs.srcDims.end(),
                                      static_cast<size_t>(1),
-                                     std::multiplies<size_t>())),
+                                     std::multiplies<>())),
       idxBatchStride(cycles * sliceRank),
       dstBatchStride(cycles * dataLength) {
     srcShifts.resize(attrs.sliceRank, 0);
@@ -175,9 +175,9 @@ void GatherND::GatherNDExecutor::exec(const MemoryPtr& srcMemPtr,
 void GatherND::GatherNDExecutor::gatherBlocks(const MemoryPtr& srcMemPtr,
                                               const MemoryPtr& idxMemPtr,
                                               const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
-    const int32_t* indices = idxMemPtr->getDataAs<const int32_t>();
-    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
+    const auto* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    const auto* indices = idxMemPtr->getDataAs<const int32_t>();
+    auto* dstData = dstMemPtr->getDataAs<uint8_t>();
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);
@@ -216,9 +216,9 @@ template <typename dataType>
 void GatherND::GatherNDExecutor::gatherElementwise(const MemoryPtr& srcMemPtr,
                                                    const MemoryPtr& idxMemPtr,
                                                    const MemoryPtr& dstMemPtr) {
-    const dataType* srcData = srcMemPtr->getDataAs<const dataType>();
-    const int32_t* indices = idxMemPtr->getDataAs<const int32_t>();
-    dataType* dstData = dstMemPtr->getDataAs<dataType>();
+    const auto* srcData = srcMemPtr->getDataAs<const dataType>();
+    const auto* indices = idxMemPtr->getDataAs<const int32_t>();
+    auto* dstData = dstMemPtr->getDataAs<dataType>();
 
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t start(0lu), end(0lu);

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.cpp
@@ -142,7 +142,7 @@ GatherTree::GatherTreeExecutor::GatherTreeExecutor(const VectorDims& stepIdxDims
       batchSize{stepIdxDims[1]},
       beamWidth{stepIdxDims[2]},
       bbSize{batchSize * beamWidth},
-      parentIdxSize{std::accumulate(parentIdxDims.cbegin(), parentIdxDims.cend(), 1lu, std::multiplies<size_t>())} {
+      parentIdxSize{std::accumulate(parentIdxDims.cbegin(), parentIdxDims.cend(), 1lu, std::multiplies<>())} {
     if (maxTime != static_cast<int32_t>(parentIdxDims[0]) || maxTime != static_cast<int32_t>(dstDims[0]) ||
         batchSize != parentIdxDims[1] || batchSize != dstDims[1] || batchSize != maxSeqLenDims[0] ||
         beamWidth != parentIdxDims[2] || beamWidth != dstDims[2]) {
@@ -172,7 +172,7 @@ void GatherTree::GatherTreeExecutor::exec(const MemoryPtr& stepIdxMemPtr,
                 finalIdx[idx + beam] = endToken;
             }
 
-            for (int32_t parent = static_cast<int32_t>(beam); time >= 0; time--, idx -= bbSize) {
+            for (auto parent = static_cast<int32_t>(beam); time >= 0; time--, idx -= bbSize) {
                 if (parent < 0 || parent >= static_cast<int32_t>(beamWidth) ||
                     static_cast<size_t>(idx + parent) >= parentIdxSize) {
                     incorrectResult = true;

--- a/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
@@ -280,10 +280,10 @@ void fill_output_blobs(const float* proposals,
     });
 
     if (roi_num_type == ov::element::i32) {
-        int32_t num = static_cast<int32_t>(num_rois);
+        auto num = static_cast<int32_t>(num_rois);
         memcpy(roi_num, &num, sizeof(int32_t));
     } else if (roi_num_type == ov::element::i64) {
-        int64_t num = static_cast<int64_t>(num_rois);
+        auto num = static_cast<int64_t>(num_rois);
         memcpy(roi_num, &num, sizeof(int64_t));
     } else {
         OPENVINO_THROW("Incorrect element type of roi_num!");
@@ -381,10 +381,10 @@ void GenerateProposals::execute(const dnnl::stream& strm) {
         }
 
         // Prepare memory
-        const float* p_deltas_item = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
-        const float* p_scores_item = getSrcDataAtPortAs<const float>(INPUT_SCORES);
-        const float* p_anchors_item = getSrcDataAtPortAs<const float>(INPUT_ANCHORS);
-        const float* p_img_info_cpu = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
+        const auto* p_deltas_item = getSrcDataAtPortAs<const float>(INPUT_DELTAS);
+        const auto* p_scores_item = getSrcDataAtPortAs<const float>(INPUT_SCORES);
+        const auto* p_anchors_item = getSrcDataAtPortAs<const float>(INPUT_ANCHORS);
+        const auto* p_img_info_cpu = getSrcDataAtPortAs<const float>(INPUT_IM_INFO);
 
         const int anchors_num = scoreDims[1];
 
@@ -422,7 +422,7 @@ void GenerateProposals::execute(const dnnl::stream& strm) {
         size_t total_num_rois = 0;
         std::vector<float> roi_item, score_item;
         std::vector<int64_t> roi_num(batch_size);
-        uint8_t* p_roi_num = reinterpret_cast<uint8_t*>(&roi_num[0]);
+        auto* p_roi_num = reinterpret_cast<uint8_t*>(&roi_num[0]);
         auto roi_num_type = getOriginalOutputPrecisionAtPort(OUTPUT_ROI_NUM);
         const auto roi_num_item_size = roi_num_type == ov::element::i32 ? sizeof(int32_t) : sizeof(int64_t);
         for (size_t n = 0; n < batch_size; ++n) {
@@ -495,9 +495,9 @@ void GenerateProposals::execute(const dnnl::stream& strm) {
         }
         // copy to out memory
         redefineOutputMemory({VectorDims{total_num_rois, 4}, VectorDims{total_num_rois}, VectorDims{batch_size}});
-        float* p_roi_item = getDstDataAtPortAs<float>(OUTPUT_ROIS);
-        float* p_roi_score_item = getDstDataAtPortAs<float>(OUTPUT_SCORES);
-        uint8_t* p_roi_num_item = getDstDataAtPortAs<uint8_t>(OUTPUT_ROI_NUM);
+        auto* p_roi_item = getDstDataAtPortAs<float>(OUTPUT_ROIS);
+        auto* p_roi_score_item = getDstDataAtPortAs<float>(OUTPUT_SCORES);
+        auto* p_roi_num_item = getDstDataAtPortAs<uint8_t>(OUTPUT_ROI_NUM);
         memcpy(p_roi_item, &roi_item[0], roi_item.size() * sizeof(float));
         memcpy(p_roi_score_item, &score_item[0], score_item.size() * sizeof(float));
         memcpy(p_roi_num_item, &roi_num[0], getDstMemoryAtPort(OUTPUT_ROI_NUM)->getSize());

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.hpp
@@ -19,7 +19,7 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     struct threadExecParams {
         uint64_t batchNum = 1lu;

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -101,8 +101,8 @@ void GRN::executeDynamicImpl(const dnnl::stream& strm) {
 }
 
 void GRN::execute(const dnnl::stream& strm) {
-    const float* src_data = getSrcDataAtPortAs<const float>(0);
-    float* dst_data = getDstDataAtPortAs<float>(0);
+    const auto* src_data = getSrcDataAtPortAs<const float>(0);
+    auto* dst_data = getDstDataAtPortAs<float>(0);
 
     parallel_for3d(N, H, W, [&](int b, int h, int w) {
         double variance = 0;

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -240,7 +240,7 @@ std::deque<MemoryPtr> If::getToMemories(const Node* node, const size_t port) con
 }
 
 void If::execute(const dnnl::stream& strm) {
-    const bool condition = static_cast<const bool>((getSrcDataAtPortAs<const uint8_t>(0))[0]);
+    const auto condition = static_cast<const bool>((getSrcDataAtPortAs<const uint8_t>(0))[0]);
 
     auto& beforeMappers = condition ? beforeThenMappers : beforeElseMappers;
     auto& afterMappers = condition ? afterThenMappers : afterElseMappers;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -24,13 +24,13 @@ namespace {
 struct jit_has_special_value_base : public jit_generator {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_has_special_value_base)
 
-    typedef struct {
+    using args_t = struct {
         const float* src;
         const size_t count;
         bool hasTargetValues;
-    } args_t;
+    };
 
-    typedef void (*fn_t)(const args_t*);
+    using fn_t = void (*)(const args_t*);
 
     jit_has_special_value_base() : jit_generator(jit_name()) {
         jit_ker_ = nullptr;
@@ -396,8 +396,8 @@ void Input::cloneBlobIfRequired() {
     // The presence of subnormals is better to determined at IR read time.
     auto checkSubnormalsAndBF16Overflows = [&](bool& has_subnormals, bool& has_bf16_overflows) {
         if (prec == ov::element::f32) {
-            uint32_t const* u32data = m_constOp->get_data_ptr<uint32_t>();
-            float const* f32data = m_constOp->get_data_ptr<float>();
+            auto const* u32data = m_constOp->get_data_ptr<uint32_t>();
+            auto const* f32data = m_constOp->get_data_ptr<float>();
 
             if (!size) {
                 return;
@@ -715,14 +715,14 @@ void Input::initSupportedPdDefault() {
     if (getType() == Type::Input || getType() == Type::MemoryInput) {
         auto precision = getOriginalOutputPrecisionAtPort(0);
 
-        outPortConfs.push_back({LayoutType::ncsp, precision});
+        outPortConfs.emplace_back(LayoutType::ncsp, precision);
         if (!getParentEdges().empty()) {
-            inPortConfs.push_back({LayoutType::ncsp, precision, true});
+            inPortConfs.emplace_back(LayoutType::ncsp, precision, true);
         }
     } else if (getType() == Type::Output) {
         auto precision = getOriginalInputPrecisionAtPort(0);
 
-        inPortConfs.push_back({LayoutType::ncsp, precision});
+        inPortConfs.emplace_back(LayoutType::ncsp, precision);
     }
 
     addSupportedPrimDesc(inPortConfs, outPortConfs, impl_desc_type::unknown);

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -5,6 +5,7 @@
 #include "interpolate.h"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -304,7 +305,7 @@ private:
                           const int offset = 0) {
         const auto seed = load_emitter_params(src_prc, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_load_emitter(this, isa, src_prc, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_load_emitter>(this, isa, src_prc, dst_prc, elt_num);
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), static_cast<size_t>(offset)},
@@ -316,7 +317,7 @@ private:
     inline void store(Vmm vmm_dst, Xbyak::Reg64 reg_dst, const int elt_num, const int offset = 0) {
         const auto seed = store_emitter_params(ov::element::f32, jcp_.dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_store_emitter(this, isa, ov::element::f32, jcp_.dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, ov::element::f32, jcp_.dst_prc, elt_num);
         }
 
         // for cases when Store emitter need 2 aux vmm we can use vmm_dst as second aux vmm
@@ -342,7 +343,7 @@ private:
         Xbyak::Reg64 reg_dst_xpass = r13;
         Xbyak::Reg64 reg_src_ypass = r14;
         Xbyak::Reg64 reg_dst_aux = r15;
-        Xbyak::Reg64 reg_params = abi_param1;
+        auto reg_params = abi_param1;
 
         mov(reg_src, ptr[reg_params + GET_OFF(src_ptr[0])]);
         mov(reg_dst, ptr[reg_params + GET_OFF(dst)]);
@@ -1631,7 +1632,7 @@ struct InterpolateKey {
     std::vector<float> dataScales;
     dnnl::primitive_attr attr;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const InterpolateKey& rhs) const;
 };
 
@@ -1870,7 +1871,7 @@ namespace {
 class InterpolateShapeInferFactory : public ShapeInferFactory {
 public:
     InterpolateShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         if (auto interp4 = ov::as_type_ptr<ov::opset4::Interpolate>(m_op)) {
             const auto& attr = interp4->get_attrs();
             const auto is_supported_mode = (attr.shape_calculation_mode == ngInterpShapeCalcMode::SCALES) ||
@@ -2243,10 +2244,10 @@ void Interpolate::initSupportedPrimitiveDescriptors() {
                 dstMemoryDescs,
                 std::make_shared<ExecutorContext>(context, getImplPriority()));
             if (!factory->isEmpty()) {
-                supportedPrimitiveDescriptors.push_back({config, implDetail, factory});
+                supportedPrimitiveDescriptors.emplace_back(config, implDetail, factory);
             }
         } else {
-            supportedPrimitiveDescriptors.push_back({config, implDetail});
+            supportedPrimitiveDescriptors.emplace_back(config, implDetail);
         }
     };
     if (is_version11) {
@@ -2343,7 +2344,7 @@ bool Interpolate::needShapeInfer() const {
         if (lastScales.empty()) {
             return true;
         }
-        const float* scales = getSrcDataAtPortAs<const float>(get_scale_id());
+        const auto* scales = getSrcDataAtPortAs<const float>(get_scale_id());
         for (size_t i = 0; i < lastScales.size(); i++) {
             if (lastScales[i] != scales[i]) {
                 return true;
@@ -2353,7 +2354,7 @@ bool Interpolate::needShapeInfer() const {
         if (lastSizes.empty()) {
             return true;
         }
-        const int32_t* sizes = getSrcDataAtPortAs<const int32_t>(TARGET_SHAPE_ID);
+        const auto* sizes = getSrcDataAtPortAs<const int32_t>(TARGET_SHAPE_ID);
         for (size_t i = 0; i < lastSizes.size(); i++) {
             if (sizes[i] != lastSizes[i]) {
                 return true;
@@ -2369,10 +2370,10 @@ void Interpolate::executeDynamicImpl(const dnnl::stream& strm) {
     const size_t port = interpAttrs.shapeCalcMode == InterpolateShapeCalcMode::sizes ? TARGET_SHAPE_ID : get_scale_id();
     const auto& memory = getParentEdgeAt(port)->getMemory();
     if (interpAttrs.shapeCalcMode == InterpolateShapeCalcMode::scales) {
-        const float* scales = memory.getDataAs<const float>();
+        const auto* scales = memory.getDataAs<const float>();
         lastScales.assign(scales, scales + memory.getDesc().getShape().getElementsCount());
     } else {
-        const int32_t* sizes = memory.getDataAs<const int32_t>();
+        const auto* sizes = memory.getDataAs<const int32_t>();
         lastSizes.assign(sizes, sizes + memory.getDesc().getShape().getElementsCount());
     }
 }
@@ -2455,7 +2456,7 @@ void Interpolate::prepareParams() {
     if (interpAttrs.shapeCalcMode == InterpolateShapeCalcMode::scales) {
         if (!isScaleConstant) {
             const auto& scalesMem = getParentEdgeAt(get_scale_id())->getMemory();
-            const float* scalesData = scalesMem.getDataAs<const float>();
+            const auto* scalesData = scalesMem.getDataAs<const float>();
             scales.assign(scalesData, scalesData + scalesMem.getStaticDims()[0]);
         }
     }
@@ -2628,7 +2629,7 @@ void Interpolate::execute(const dnnl::stream& strm) {
     auto srcMemPtr = getSrcMemoryAtPort(DATA_ID);
 
     if (execPtr) {
-        uint8_t* dst_data = dstMemPtr->getDataAs<uint8_t>();
+        auto* dst_data = dstMemPtr->getDataAs<uint8_t>();
         const uint8_t* src_data_origin = srcMemPtr->getDataAs<uint8_t>();
         const uint8_t* src_data = nullptr;
         std::vector<uint8_t> srcPadded;
@@ -2652,7 +2653,7 @@ void Interpolate::execute(const dnnl::stream& strm) {
 
             if (interpAttrs.layout == InterpolateLayoutType::planar) {
                 srcPadded.resize(inShapePadBlock[0] * srcDataSize, 0);
-                uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
+                auto* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
                 parallel_for4d(srcDim5d[0], srcDim5d[1], srcDim5d[2], srcDim5d[3], [&](int n, int c, int d, int h) {
                     const uint8_t* src = src_data_origin + (inShapeBlock[1] * n + inShapeBlock[2] * c +
                                                             inShapeBlock[3] * d + inShapeBlock[4] * h) *
@@ -2666,7 +2667,7 @@ void Interpolate::execute(const dnnl::stream& strm) {
                 src_data = src_data_pad;
             } else if (interpAttrs.layout == InterpolateLayoutType::by_channel) {
                 srcPadded.resize(inShapePadBlock[0] * srcDataSize, 0);
-                uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
+                auto* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
                 parallel_for4d(srcDim5d[0], srcDim5d[2], srcDim5d[3], srcDim5d[4], [&](int n, int d, int h, int w) {
                     const uint8_t* src =
                         src_data_origin +
@@ -2688,7 +2689,7 @@ void Interpolate::execute(const dnnl::stream& strm) {
                 size_t CB = div_up(srcDimPad5d[1], blkSize);
                 size_t eltsTotal = srcDimPad5d[0] * CB * srcDimPad5d[2] * srcDimPad5d[3] * srcDimPad5d[4] * blkSize;
                 srcPadded.resize(eltsTotal * srcDataSize, 0x0);
-                uint8_t* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
+                auto* src_data_pad = static_cast<uint8_t*>(&srcPadded[0]);
                 if ((srcDim5d[0] != srcDimPad5d[0]) || (srcDim5d[1] != srcDimPad5d[1])) {
                     THROW_CPU_NODE_ERR("does not support padding on batch and channel dimensions");
                 }
@@ -2741,9 +2742,9 @@ void Interpolate::InterpolateJitExecutor::NNCGathered(const uint8_t* in_ptr_,
                                                       int OD,
                                                       int OH,
                                                       int OW) {
-    int* index_d = static_cast<int*>(&auxTable[0]);
-    int* index_h = static_cast<int*>(&auxTable[OD]);
-    int* index_w = static_cast<int*>(&auxTable[OD + OH]);
+    auto* index_d = static_cast<int*>(&auxTable[0]);
+    auto* index_h = static_cast<int*>(&auxTable[OD]);
+    auto* index_w = static_cast<int*>(&auxTable[OD + OH]);
 
     bool is_nhwc = (configured_for_layout == by_channel);
 
@@ -2807,9 +2808,9 @@ void Interpolate::InterpolateJitExecutor::NNPlanar(const uint8_t* in_ptr_,
                                                    int OD,
                                                    int OH,
                                                    int OW) {
-    int* index_d = static_cast<int*>(&auxTable[0]);
-    int* index_h = static_cast<int*>(&auxTable[OD]);
-    int* index_w = static_cast<int*>(&auxTable[OD + OH]);
+    auto* index_d = static_cast<int*>(&auxTable[0]);
+    auto* index_h = static_cast<int*>(&auxTable[OD]);
+    auto* index_w = static_cast<int*>(&auxTable[OD + OH]);
 
     std::vector<int> index_kernel(OH + OW);
     // index_h * IW * srcDataSize to reduce and simplify redundant compute
@@ -2851,10 +2852,10 @@ void Interpolate::InterpolateJitExecutor::linearOnnxPlanar(const uint8_t* in_ptr
                                                            int OW) {
     // FrontTopLeft:0, FrontTopRight:1, FrontBottomLeft:2, FrontBottomRight:3, EndTopLeft:4,   EndTopRight:5,
     // EndBottomLeft:6,   EndBottomRight:7 weight: Left:0, ritht:1, top:2, bottom:3, front:4, end:5
-    int* index = static_cast<int*>(&auxTable[0]);
+    auto* index = static_cast<int*>(&auxTable[0]);
     int eltInGrid = (spatialDimSize > 2) ? MAX_INPUT_INTERPOLATE : ((spatialDimSize > 1) ? 4 : 2);
     int scratchLen = rnd_up(eltInGrid * OW * OH * OD, 16);
-    float* weight = reinterpret_cast<float*>(&auxTable[scratchLen]);
+    auto* weight = reinterpret_cast<float*>(&auxTable[scratchLen]);
 
     parallel_for2d(B, C, [&](size_t b, size_t c) {
         uint8_t* out_ptr_nc = out_ptr_ + (OH * OW * OD * C * b + OH * OW * OD * c) * dstDataSize;
@@ -2883,8 +2884,8 @@ void Interpolate::InterpolateJitExecutor::linearOnnxCGathered(const uint8_t* in_
                                                               int OH,
                                                               int OW) {
     // left:OW right:OW Top:OH Bottom:OH Front:OD End:OD
-    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, 0);
-    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, 0);
+    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, nullptr);
+    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, nullptr);
     size_t scratchLen = rnd_up(OW + OW + OH + OH + OD + OD, 16);
     indexPtr[0] = static_cast<int*>(&auxTable[0]);
     indexPtr[1] = static_cast<int*>(&auxTable[OW]);
@@ -2962,10 +2963,10 @@ void Interpolate::InterpolateJitExecutor::cubicCGathered(const uint8_t* in_ptr_,
                                                          int OH,
                                                          int OW) {
     const int idxNum = 1;
-    int* xOrigin = static_cast<int*>(&auxTable[0]);
-    float* xFactor = reinterpret_cast<float*>(&auxTable[OW]);
-    int* yOrigin = static_cast<int*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW]);
-    float* yFactor = reinterpret_cast<float*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW + OH]);
+    auto* xOrigin = static_cast<int*>(&auxTable[0]);
+    auto* xFactor = reinterpret_cast<float*>(&auxTable[OW]);
+    auto* yOrigin = static_cast<int*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW]);
+    auto* yFactor = reinterpret_cast<float*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW + OH]);
 
     int blkSize = mayiuse(cpu::x64::avx512_core) ? 16 : 8;
     int CB = div_up(C, blkSize);
@@ -3016,18 +3017,18 @@ void Interpolate::InterpolateJitExecutor::cubicPlanar(const uint8_t* in_ptr_,
                                                       int OH,
                                                       int OW) {
     int tblAdvance = 0;
-    int* xOrigin = static_cast<int*>(&auxTable[tblAdvance]);
+    auto* xOrigin = static_cast<int*>(&auxTable[tblAdvance]);
     tblAdvance += OW;
-    float* xFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
+    auto* xFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
     tblAdvance += CUBIC_GRID_LEN * OW;
-    int* yOrigin = static_cast<int*>(&auxTable[tblAdvance]);
+    auto* yOrigin = static_cast<int*>(&auxTable[tblAdvance]);
     tblAdvance += OH;
-    float* yFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
+    auto* yFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
 
     tblAdvance += CUBIC_GRID_LEN * OH;
-    int* sequenceOH = static_cast<int*>(&auxTable[tblAdvance]);
+    auto* sequenceOH = static_cast<int*>(&auxTable[tblAdvance]);
     tblAdvance += OW * OH;
-    int* sequenceOW = static_cast<int*>(&auxTable[tblAdvance]);
+    auto* sequenceOW = static_cast<int*>(&auxTable[tblAdvance]);
 
     parallel_for2d(B, C, [&](size_t n, size_t c) {
         const uint8_t* in_ptr_nc = in_ptr_ + (IW * IH * C * n + IW * IH * c) * srcDataSize;
@@ -3068,7 +3069,7 @@ void Interpolate::InterpolateJitExecutor::pillowCGathered(const uint8_t* in_ptr_
         if (xPass && yPass) {
             size_t parallel_num = B;
             // IH * OW * C buf needed
-            size_t buffer_size = static_cast<size_t>(OW * IH * C);
+            auto buffer_size = static_cast<size_t>(OW * IH * C);
             if (parallel_num < m_threads_num) {
                 arg.src_ptr[1] = static_cast<uint8_t*>(&pillow_working_buf[b * buffer_size * srcDataSize]);
             } else {
@@ -3225,8 +3226,8 @@ void Interpolate::InterpolateExecutorBase::buildTblLinearOnnx(const VectorDims& 
     int ID = srcDimPad5d[2], IH = srcDimPad5d[3], IW = srcDimPad5d[4];
     int OD = dstDim5d[2], OH = dstDim5d[3], OW = dstDim5d[4];
 
-    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, 0);
-    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, 0);
+    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, nullptr);
+    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, nullptr);
     if (layout == InterpolateLayoutType::planar) {
         // FrontTopLeft:0, FrontTopRight:1, FrontBottomLeft:2, FrontBottomRight:3,
         // EndTopLeft:4,   EndTopRight:5,   EndBottomLeft:6,   EndBottomRight:7
@@ -3357,19 +3358,19 @@ void Interpolate::InterpolateExecutorBase::buildTblLinear(const VectorDims& srcD
         int sizeOH = OH * diaOH;
         int sizeOW = OW * diaOW;
         auxTable.resize((sizeOD + sizeOH + sizeOW) * 2);
-        float* weightTable = reinterpret_cast<float*>(&auxTable[0]);
-        float* weightOD = static_cast<float*>(&weightTable[0]);
-        float* weightOH = static_cast<float*>(&weightTable[sizeOD]);
-        float* weightOW = static_cast<float*>(&weightTable[sizeOD + sizeOH]);
+        auto* weightTable = reinterpret_cast<float*>(&auxTable[0]);
+        auto* weightOD = static_cast<float*>(&weightTable[0]);
+        auto* weightOH = static_cast<float*>(&weightTable[sizeOD]);
+        auto* weightOW = static_cast<float*>(&weightTable[sizeOD + sizeOH]);
 
-        int* idxTable = static_cast<int*>(&auxTable[sizeOD + sizeOH + sizeOW]);
-        int* idxOD = static_cast<int*>(&idxTable[0]);
-        int* idxOH = static_cast<int*>(&idxTable[sizeOD]);
-        int* idxOW = static_cast<int*>(&idxTable[sizeOD + sizeOH]);
+        auto* idxTable = static_cast<int*>(&auxTable[sizeOD + sizeOH + sizeOW]);
+        auto* idxOD = static_cast<int*>(&idxTable[0]);
+        auto* idxOH = static_cast<int*>(&idxTable[sizeOD]);
+        auto* idxOW = static_cast<int*>(&idxTable[sizeOD + sizeOH]);
 
         for (size_t oz = 0; oz < OD; oz++) {
             float iz = coordTransToInput(oz, fz, ID, OD);
-            int iz_r = static_cast<int>(std::round(iz));
+            auto iz_r = static_cast<int>(std::round(iz));
             for (int r = iz_r - rz, i = 0; r <= iz_r + rz; r++, i++) {
                 idxOD[oz * diaOD + i] = r;
                 if (r < 0 || r >= static_cast<int>(ID)) {
@@ -3382,7 +3383,7 @@ void Interpolate::InterpolateExecutorBase::buildTblLinear(const VectorDims& srcD
         }
         for (size_t oy = 0; oy < OH; oy++) {
             float iy = coordTransToInput(oy, fy, IH, OH);
-            int iy_r = static_cast<int>(std::round(iy));
+            auto iy_r = static_cast<int>(std::round(iy));
             for (int r = iy_r - ry, i = 0; r <= iy_r + ry; r++, i++) {
                 idxOH[oy * diaOH + i] = r;
                 if (r < 0 || r >= static_cast<int>(IH)) {
@@ -3395,7 +3396,7 @@ void Interpolate::InterpolateExecutorBase::buildTblLinear(const VectorDims& srcD
         }
         for (size_t ox = 0; ox < OW; ox++) {
             float ix = coordTransToInput(ox, fx, IW, OW);
-            int ix_r = static_cast<int>(std::round(ix));
+            auto ix_r = static_cast<int>(std::round(ix));
             for (int r = ix_r - rx, i = 0; r <= ix_r + rx; r++, i++) {
                 idxOW[ox * diaOW + i] = r;
                 if (r < 0 || r >= static_cast<int>(IW)) {
@@ -3445,12 +3446,12 @@ void Interpolate::InterpolateExecutorBase::buildTblCubic(const VectorDims& srcDi
     }
 
     int tblAdvance = 0;
-    int* xOrigin = static_cast<int*>(&auxTable[tblAdvance]);
+    auto* xOrigin = static_cast<int*>(&auxTable[tblAdvance]);
     tblAdvance += OW;
-    float* xFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
+    auto* xFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
     for (int ox = 0; ox < OW; ox++) {
         float ix = coordTransToInput(ox, fx, IW, OW);
-        int ix_r = static_cast<int>(std::floor(ix));
+        auto ix_r = static_cast<int>(std::floor(ix));
         xOrigin[ox] = ix_r;
         float m = ix - ix_r;
         std::vector<float> coffes = getCubicCoeffs(m, cubicCoeff);
@@ -3461,12 +3462,12 @@ void Interpolate::InterpolateExecutorBase::buildTblCubic(const VectorDims& srcDi
     }
 
     tblAdvance += CUBIC_GRID_LEN * OW;
-    int* yOrigin = static_cast<int*>(&auxTable[tblAdvance]);
+    auto* yOrigin = static_cast<int*>(&auxTable[tblAdvance]);
     tblAdvance += OH;
-    float* yFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
+    auto* yFactor = reinterpret_cast<float*>(&auxTable[tblAdvance]);
     for (int oy = 0; oy < OH; oy++) {
         float iy = coordTransToInput(oy, fy, IH, OH);
-        int iy_r = static_cast<int>(std::floor(iy));
+        auto iy_r = static_cast<int>(std::floor(iy));
         yOrigin[oy] = iy_r;
         float m = iy - iy_r;
         std::vector<float> coffes = getCubicCoeffs(m, cubicCoeff);
@@ -3478,9 +3479,9 @@ void Interpolate::InterpolateExecutorBase::buildTblCubic(const VectorDims& srcDi
 
     if (layout == InterpolateLayoutType::planar) {
         tblAdvance += CUBIC_GRID_LEN * OH;
-        int* sequenceOH = static_cast<int*>(&auxTable[tblAdvance]);
+        auto* sequenceOH = static_cast<int*>(&auxTable[tblAdvance]);
         tblAdvance += OH * OW;
-        int* sequenceOW = static_cast<int*>(&auxTable[tblAdvance]);
+        auto* sequenceOW = static_cast<int*>(&auxTable[tblAdvance]);
         for (int h = 0; h < OH; ++h) {
             int offset = h * OW;
             for (int w = 0; w < OW; ++w) {
@@ -3557,13 +3558,13 @@ void Interpolate::InterpolateExecutorBase::buildTblPillow(const VectorDims& srcD
     auxTable[offset] = filterArgsX.filterLen;
     auxTable[offset + 1] = filterArgsY.filterLen;
     offset += 2;
-    float* weightX = reinterpret_cast<float*>(&auxTable[offset]);
+    auto* weightX = reinterpret_cast<float*>(&auxTable[offset]);
     offset += filterArgsX.filterLen * OW;
-    float* weightY = reinterpret_cast<float*>(&auxTable[offset]);
+    auto* weightY = reinterpret_cast<float*>(&auxTable[offset]);
     offset += filterArgsY.filterLen * OH;
-    int* indexX = static_cast<int*>(&auxTable[offset]);
+    auto* indexX = static_cast<int*>(&auxTable[offset]);
     offset += 2 * OW;
-    int* indexY = static_cast<int*>(&auxTable[offset]);
+    auto* indexY = static_cast<int*>(&auxTable[offset]);
 
     auto generateTbl = [&](int inLen, int outLen, float fScale, filterArgs args, float* weightTbl, int* idxTbl) {
         int min = 0;
@@ -3620,12 +3621,12 @@ void Interpolate::InterpolateRefExecutor::NNRef(const uint8_t* in_ptr_,
                                                 int OD,
                                                 int OH,
                                                 int OW) {
-    int* index_d = static_cast<int*>(&auxTable[0]);
-    int* index_h = static_cast<int*>(&auxTable[OD]);
-    int* index_w = static_cast<int*>(&auxTable[OD + OH]);
+    auto* index_d = static_cast<int*>(&auxTable[0]);
+    auto* index_h = static_cast<int*>(&auxTable[OD]);
+    auto* index_w = static_cast<int*>(&auxTable[OD + OH]);
 
-    const float* in_ptr_f32 = reinterpret_cast<const float*>(in_ptr_);
-    float* out_ptr_f32 = reinterpret_cast<float*>(out_ptr_);
+    const auto* in_ptr_f32 = reinterpret_cast<const float*>(in_ptr_);
+    auto* out_ptr_f32 = reinterpret_cast<float*>(out_ptr_);
 
     parallel_for3d(B, C, OD, [&](size_t b, size_t c, size_t od) {
         const float* in_ptr = in_ptr_f32 + (IW * IH * ID * C * b + IW * IH * ID * c + IW * IH * index_d[od]);
@@ -3650,8 +3651,8 @@ void Interpolate::InterpolateRefExecutor::linearOnnxRef(const uint8_t* in_ptr_,
                                                         int OD,
                                                         int OH,
                                                         int OW) {
-    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, 0);
-    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, 0);
+    std::vector<int*> indexPtr(MAX_INPUT_INTERPOLATE, nullptr);
+    std::vector<float*> weightPtr(MAX_INPUT_INTERPOLATE, nullptr);
     // FrontTopLeft:0, FrontTopRight:1, FrontBottomLeft:2, FrontBottomRight:3,
     // EndTopLeft:4,   EndTopRight:5,   EndBottomLeft:6,   EndBottomRight:7
     // weight: Left:0, ritht:1, top:2, bottom:3, front:4, end:5
@@ -3678,8 +3679,8 @@ void Interpolate::InterpolateRefExecutor::linearOnnxRef(const uint8_t* in_ptr_,
         weightPtr[5] = reinterpret_cast<float*>(&auxTable[scratchLen + 5 * OW * OH * OD]);
     }
 
-    const float* in_ptr_f32 = reinterpret_cast<const float*>(in_ptr_);
-    float* out_ptr_f32 = reinterpret_cast<float*>(out_ptr_);
+    const auto* in_ptr_f32 = reinterpret_cast<const float*>(in_ptr_);
+    auto* out_ptr_f32 = reinterpret_cast<float*>(out_ptr_);
 
     parallel_for2d(B, C, [&](size_t b, size_t c) {
         float* out_ptr_nc = out_ptr_f32 + (OD * OH * OW * C * b + OD * OH * OW * c);
@@ -3748,13 +3749,13 @@ void Interpolate::InterpolateRefExecutor::cubicRef(const uint8_t* in_ptr_,
                                                    int OH,
                                                    int OW) {
     const int idxNum = 1;
-    int* xOrigin = static_cast<int*>(&auxTable[0]);
-    float* xFactor = reinterpret_cast<float*>(&auxTable[OW]);
-    int* yOrigin = static_cast<int*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW]);
-    float* yFactor = reinterpret_cast<float*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW + OH]);
+    auto* xOrigin = static_cast<int*>(&auxTable[0]);
+    auto* xFactor = reinterpret_cast<float*>(&auxTable[OW]);
+    auto* yOrigin = static_cast<int*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW]);
+    auto* yFactor = reinterpret_cast<float*>(&auxTable[(CUBIC_GRID_LEN + idxNum) * OW + OH]);
 
-    const float* in_ptr_f32 = reinterpret_cast<const float*>(in_ptr_);
-    float* out_ptr_f32 = reinterpret_cast<float*>(out_ptr_);
+    const auto* in_ptr_f32 = reinterpret_cast<const float*>(in_ptr_);
+    auto* out_ptr_f32 = reinterpret_cast<float*>(out_ptr_);
 
     parallel_for4d(B, C, OH, OW, [&](size_t n, size_t c, size_t oy, size_t ox) {
         const float* in_ptr_nc = in_ptr_f32 + (IW * IH * C * n + IW * IH * c);
@@ -3786,17 +3787,17 @@ float Interpolate::InterpolateRefExecutor::getValue(const uint8_t* base, size_t 
         break;
     }
     case ov::element::i8: {
-        const int8_t* valuePtr = reinterpret_cast<const int8_t*>(baseOffset);
+        const auto* valuePtr = reinterpret_cast<const int8_t*>(baseOffset);
         return static_cast<float>(*valuePtr);
         break;
     }
     case ov::element::bf16: {
-        const uint16_t* valuePtr = reinterpret_cast<const uint16_t*>(baseOffset);
+        const auto* valuePtr = reinterpret_cast<const uint16_t*>(baseOffset);
         return bfloat16_t::from_bits(*valuePtr);
         break;
     }
     case ov::element::f32: {
-        const float* valuePtr = reinterpret_cast<const float*>(baseOffset);
+        const auto* valuePtr = reinterpret_cast<const float*>(baseOffset);
         return *valuePtr;
         break;
     }
@@ -3811,12 +3812,12 @@ void Interpolate::InterpolateRefExecutor::setValue(uint8_t* base, size_t offset,
     uint8_t* baseOffset = base + offset;
     switch (prec) {
     case ov::element::u8: {
-        uint8_t data = static_cast<uint8_t>(value < 0 ? 0 : value);
+        auto data = static_cast<uint8_t>(value < 0 ? 0 : value);
         cpu_memcpy(baseOffset, &data, 1);
         break;
     }
     case ov::element::i8: {
-        int8_t data = static_cast<int8_t>(value);
+        auto data = static_cast<int8_t>(value);
         cpu_memcpy(baseOffset, &data, 1);
         break;
     }
@@ -3885,15 +3886,15 @@ void Interpolate::InterpolateRefExecutor::linearInterpolation(const uint8_t* in_
     int sizeOH = OH * diaOH;
     int sizeOW = OW * diaOW;
 
-    float* weightTable = reinterpret_cast<float*>(&auxTable[0]);
-    float* weightOD = static_cast<float*>(&weightTable[0]);
-    float* weightOH = static_cast<float*>(&weightTable[sizeOD]);
-    float* weightOW = static_cast<float*>(&weightTable[sizeOD + sizeOH]);
+    auto* weightTable = reinterpret_cast<float*>(&auxTable[0]);
+    auto* weightOD = static_cast<float*>(&weightTable[0]);
+    auto* weightOH = static_cast<float*>(&weightTable[sizeOD]);
+    auto* weightOW = static_cast<float*>(&weightTable[sizeOD + sizeOH]);
 
-    int* idxTable = static_cast<int*>(&auxTable[sizeOD + sizeOH + sizeOW]);
-    int* idxOD = static_cast<int*>(&idxTable[0]);
-    int* idxOH = static_cast<int*>(&idxTable[sizeOD]);
-    int* idxOW = static_cast<int*>(&idxTable[sizeOD + sizeOH]);
+    auto* idxTable = static_cast<int*>(&auxTable[sizeOD + sizeOH + sizeOW]);
+    auto* idxOD = static_cast<int*>(&idxTable[0]);
+    auto* idxOH = static_cast<int*>(&idxTable[sizeOD]);
+    auto* idxOW = static_cast<int*>(&idxTable[sizeOD + sizeOH]);
 
     parallel_for2d(B, C, [&](size_t b, size_t c) {
         const uint8_t* in_ptr_nc = in_ptr_ + (IW * IH * ID * C * b + IW * IH * ID * c) * srcDataSize;
@@ -3983,13 +3984,13 @@ void Interpolate::InterpolateRefExecutor::pillowRef(const uint8_t* in_ptr_,
     int filterLenX = auxTable[offset];
     int filterLenY = auxTable[offset + 1];
     offset += 2;
-    float* weightX = reinterpret_cast<float*>(&auxTable[offset]);
+    auto* weightX = reinterpret_cast<float*>(&auxTable[offset]);
     offset += filterLenX * OW;
-    float* weightY = reinterpret_cast<float*>(&auxTable[offset]);
+    auto* weightY = reinterpret_cast<float*>(&auxTable[offset]);
     offset += filterLenY * OH;
-    int* indexX = static_cast<int*>(&auxTable[offset]);
+    auto* indexX = static_cast<int*>(&auxTable[offset]);
     offset += 2 * OW;
-    int* indexY = static_cast<int*>(&auxTable[offset]);
+    auto* indexY = static_cast<int*>(&auxTable[offset]);
 
     // workBuffer needed when both pass is true
     bool xPass = IW != OW;
@@ -4021,7 +4022,7 @@ void Interpolate::InterpolateRefExecutor::pillowRef(const uint8_t* in_ptr_,
                     static_cast<const uint8_t*>(&pillow_working_buf[(OW * IH * C * b + OW * IH * c) * srcDataSize]);
             } else {
                 size_t threadsIdx = parallel_get_thread_num();
-                size_t buffer_size = static_cast<size_t>(OW * IH);
+                auto buffer_size = static_cast<size_t>(OW * IH);
                 xpass_out_ptr_nc = static_cast<uint8_t*>(&pillow_working_buf[threadsIdx * buffer_size * srcDataSize]);
                 ypass_in_ptr_nc =
                     static_cast<const uint8_t*>(&pillow_working_buf[threadsIdx * buffer_size * srcDataSize]);
@@ -4176,15 +4177,16 @@ Interpolate::InterpolateJitExecutor::InterpolateJitExecutor(const InterpolateAtt
 #if defined(OPENVINO_ARCH_X86_64)
     if (jcp.layout != InterpolateLayoutType::planar) {
         if (mayiuse(cpu::x64::avx512_core)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx512_core>(jcp, *attr.get()));
+            interpolateKernel =
+                std::make_shared<jit_uni_interpolate_kernel_f32<cpu::x64::avx512_core>>(jcp, *attr.get());
         } else if (mayiuse(cpu::x64::avx2)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx2>(jcp, *attr.get()));
+            interpolateKernel = std::make_shared<jit_uni_interpolate_kernel_f32<cpu::x64::avx2>>(jcp, *attr.get());
         } else if (mayiuse(cpu::x64::sse41)) {
-            interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::sse41>(jcp, *attr.get()));
+            interpolateKernel = std::make_shared<jit_uni_interpolate_kernel_f32<cpu::x64::sse41>>(jcp, *attr.get());
         }
     } else if (mayiuse(cpu::x64::avx2) && interpAttrs.inPrc == ov::element::f32) {
         // gather ISA(for planar JIT kernel) for avx2 and fp32
-        interpolateKernel.reset(new jit_uni_interpolate_kernel_f32<cpu::x64::avx2>(jcp, *attr.get()));
+        interpolateKernel = std::make_shared<jit_uni_interpolate_kernel_f32<cpu::x64::avx2>>(jcp, *attr.get());
     } else {
         OPENVINO_THROW("Can't create InterpolateJitExecutor");
     }

--- a/src/plugins/intel_cpu/src/nodes/inverse.hpp
+++ b/src/plugins/intel_cpu/src/nodes/inverse.hpp
@@ -17,7 +17,7 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
 
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -25,7 +25,7 @@ public:
 
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/istft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/istft.cpp
@@ -10,9 +10,7 @@
 #include "openvino/op/istft.hpp"
 #include "openvino/reference/istft.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 bool ISTFT::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
@@ -108,6 +106,4 @@ bool ISTFT::needShapeInfer() const {
            (!m_has_signal_length_input && !(m_is_frame_size_const && m_is_frame_step_const)) || Node::needShapeInfer();
 }
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/istft.h
+++ b/src/plugins/intel_cpu/src/nodes/istft.h
@@ -6,9 +6,7 @@
 
 #include "node.h"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ISTFT : public Node {
 public:
@@ -47,6 +45,4 @@ private:
     static constexpr size_t SIGNAL_LENGTH_IDX = 4lu;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/brgemm_kernel.hpp
@@ -36,10 +36,10 @@ public:
 
     void copy_buffer_b(void* b, void* scratch_b);
     // bytes needed to place scratch buffer a
-    const size_t get_scratch_a_size() const;
+    [[nodiscard]] const size_t get_scratch_a_size() const;
     // bytes needed to place scratch buffer b
-    const size_t get_scratch_b_size() const;
-    const size_t get_wsp_size() const {
+    [[nodiscard]] const size_t get_scratch_b_size() const;
+    [[nodiscard]] const size_t get_wsp_size() const {
         return 4 * 1024;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.hpp
@@ -53,15 +53,15 @@ struct jit_eltwise_call_args_indexes {
 };
 
 struct jit_uni_eltwise_kernel {
-    void (*ker_)(const jit_eltwise_call_args_ptrs*, const jit_eltwise_call_args_indexes*);
+    void (*ker_)(const jit_eltwise_call_args_ptrs*, const jit_eltwise_call_args_indexes*){nullptr};
 
     void operator()(const jit_eltwise_call_args_ptrs* const_args, const jit_eltwise_call_args_indexes* indexes) {
         assert(ker_);
         ker_(const_args, indexes);
     }
 
-    explicit jit_uni_eltwise_kernel(jit_eltwise_params jep) : ker_(nullptr), jep_(std::move(jep)) {}
-    virtual ~jit_uni_eltwise_kernel() {}
+    explicit jit_uni_eltwise_kernel(jit_eltwise_params jep) : jep_(std::move(jep)) {}
+    virtual ~jit_uni_eltwise_kernel() = default;
 
     virtual void create_ker() = 0;
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_memcpy.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_memcpy.cpp
@@ -1,8 +1,7 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <float.h>
-
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 #include <iostream>

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
@@ -1,8 +1,7 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <float.h>
-
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 #include <iostream>
@@ -271,16 +270,12 @@ static void quant_u4(const T* src, void* dst, size_t n, float& scale, float& zp)
     }
 }
 
-template <typename T,
-          ov::element::Type_t DST_PREC,
-          typename std::enable_if<DST_PREC == ov::element::u8, bool>::type = true>
+template <typename T, ov::element::Type_t DST_PREC, std::enable_if_t<DST_PREC == ov::element::u8, bool> = true>
 static void quantize(const T* src, uint8_t* dst, size_t n, float* scale_zp) {
     quant_u8(src, dst, n, *scale_zp, *(scale_zp + 1));
 }
 
-template <typename T,
-          ov::element::Type_t DST_PREC,
-          typename std::enable_if<DST_PREC == ov::element::u4, bool>::type = true>
+template <typename T, ov::element::Type_t DST_PREC, std::enable_if_t<DST_PREC == ov::element::u4, bool> = true>
 static void quantize(const T* src, void* dst, size_t n, float* scale_zp) {
     quant_u4(src, dst, n, *scale_zp, *(scale_zp + 1));
 }
@@ -343,7 +338,7 @@ static void paged_attn_quant_mt(const ov::intel_cpu::PlainTensor& k_src,
 
         for (size_t src_offset = 0, dst_offset = 0; src_offset < SV; src_offset += value_group_size,
                     dst_offset += value_group_size / sub_byte_multiplier + sizeof(float) + sizeof(float)) {
-            uint8_t* v_base = reinterpret_cast<uint8_t*>(
+            auto* v_base = reinterpret_cast<uint8_t*>(
                 v_dst.m_ptr.get() +
                 (block_number * v_dst.m_strides[0] + h * v_dst.m_strides[1] + block_offset * v_dst.m_strides[2]) /
                     sub_byte_multiplier +

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant_kernel.hpp
@@ -23,7 +23,7 @@ template <typename TDST,
 void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, float zp) {
     size_t i = 0;
     // loadu_si128/epi64 does not support const qualifier
-    uint8_t* src_nc = const_cast<uint8_t*>(src);
+    auto* src_nc = const_cast<uint8_t*>(src);
 #if defined(HAVE_AVX512F)
     auto v_zp = _mm512_set1_ps(zp);
     auto v_scale = _mm512_set1_ps(scale);
@@ -68,7 +68,7 @@ void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, f
        0,1,2,3,4,5,6,7
     */
     size_t i = 0;
-    uint8_t* src_nc = const_cast<uint8_t*>(src);
+    auto* src_nc = const_cast<uint8_t*>(src);
 #if defined(HAVE_AVX512F)
     auto v_scale = _mm512_set1_ps(scale);
     auto v_zp_scale = _mm512_set1_ps(zp * scale);

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -1,8 +1,7 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <float.h>
-
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 #include <iostream>
@@ -81,10 +80,9 @@ size_t inline get_sub_byte_multiplier(ov::element::Type type) {
 
 template <typename T,
           ov::element::Type_t SRC_PREC,
-          typename std::enable_if<(std::is_same<T, ov::bfloat16>::value || std::is_same<T, ov::float16>::value ||
-                                   std::is_same<T, float>::value) &&
-                                      (SRC_PREC != ov::element::u8 || SRC_PREC != ov::element::u4),
-                                  bool>::type = true>
+          std::enable_if_t<(std::is_same_v<T, ov::bfloat16> || std::is_same_v<T, ov::float16> ||
+                            std::is_same_v<T, float>)&&(SRC_PREC != ov::element::u8 || SRC_PREC != ov::element::u4),
+                           bool> = true>
 static void attn_acc_value_block(float* out,
                                  float* weight,
                                  T* v,
@@ -217,9 +215,7 @@ static void attn_acc_value_block(float* out,
         v += S;
     }
 }
-template <typename T,
-          ov::element::Type_t SRC_PREC,
-          typename std::enable_if<SRC_PREC == ov::element::u8, bool>::type = true>
+template <typename T, ov::element::Type_t SRC_PREC, std::enable_if_t<SRC_PREC == ov::element::u8, bool> = true>
 static void attn_acc_value_block(float* out,
                                  float* weight,
                                  uint8_t* v,
@@ -364,9 +360,7 @@ static void attn_acc_value_block(float* out,
     }
 }
 
-template <typename T,
-          ov::element::Type_t SRC_PREC,
-          typename std::enable_if<SRC_PREC == ov::element::u4, bool>::type = true>
+template <typename T, ov::element::Type_t SRC_PREC, std::enable_if_t<SRC_PREC == ov::element::u4, bool> = true>
 static void attn_acc_value_block(float* out,
                                  float* weight,
                                  void* v,
@@ -376,7 +370,7 @@ static void attn_acc_value_block(float* out,
     size_t src_offset = 0;
     size_t dst_offset = 0;
     const size_t params_offset = sizeof(float) * 2;
-    uint8_t* v_ptr = reinterpret_cast<uint8_t*>(v);
+    auto* v_ptr = reinterpret_cast<uint8_t*>(v);
     auto sub_byte_multiplier = 8 / 4;
     const size_t src_stride = S / group_size * (group_size / sub_byte_multiplier + params_offset);
     auto extract_half_byte = [](uint8_t val, bool high_half) -> uint8_t {
@@ -857,7 +851,7 @@ static void attn_reduce(T* dst, float* temp, size_t M, size_t S, size_t temp_str
 // N must be multiple of 16
 template <typename TDST,
           ov::element::Type_t SRC_PREC,
-          typename std::enable_if<(SRC_PREC != ov::element::u8 && SRC_PREC != ov::element::u4), bool>::type = true>
+          std::enable_if_t<(SRC_PREC != ov::element::u8 && SRC_PREC != ov::element::u4), bool> = true>
 void transpose_16NxK(TDST* dst,
                      void* src,
                      TDST* tmp,
@@ -910,9 +904,7 @@ static void transpose_16NxK(T* dst,
 }
 #    endif
 
-template <typename TDST,
-          ov::element::Type_t SRC_PREC,
-          typename std::enable_if<SRC_PREC == ov::element::u8, bool>::type = true>
+template <typename TDST, ov::element::Type_t SRC_PREC, std::enable_if_t<SRC_PREC == ov::element::u8, bool> = true>
 void transpose_16NxK(TDST* dst,
                      void* src,
                      TDST* tmp,
@@ -950,21 +942,19 @@ void transpose_16NxK(TDST* dst,
 // dequant f16/u8 to float
 template <typename T,
           ov::element::Type_t SRC_PREC,
-          typename std::enable_if<SRC_PREC != ov::element::u8 && precision_of<T>::value == SRC_PREC, bool>::type = true>
+          std::enable_if_t<SRC_PREC != ov::element::u8 && precision_of<T>::value == SRC_PREC, bool> = true>
 static inline void dequant(T* dst, void* src, const size_t N, const size_t K, const size_t group_size) {
     // never called
     OPENVINO_THROW("dequant: should not be called.");
 }
-template <typename T,
-          ov::element::Type_t SRC_PREC,
-          typename std::enable_if<SRC_PREC == ov::element::f16, bool>::type = true>
+template <typename T, ov::element::Type_t SRC_PREC, std::enable_if_t<SRC_PREC == ov::element::f16, bool> = true>
 static inline void dequant(float* dst, void* src, const size_t N, const size_t K, const size_t group_size) {
     cvt_copy(dst, reinterpret_cast<ov::float16*>(src), K * N);
 }
 
 template <typename TDST,
           ov::element::Type_t SRC_PREC,
-          typename std::enable_if<SRC_PREC == ov::element::u4 || SRC_PREC == ov::element::u8, bool>::type = true>
+          std::enable_if_t<SRC_PREC == ov::element::u4 || SRC_PREC == ov::element::u8, bool> = true>
 void dequant(TDST* dst, uint8_t* src, const size_t N, const size_t K, const size_t group_size) {
     // The layout for per token per head:
     // |scale(f32)|zeropoint(f32)|quantized feature(u8,idx_1)|quantized feature(u8,idx_2)|...|quantized
@@ -1139,7 +1129,7 @@ static void pack_32NxK(TDST* dst,
 
 template <typename TDST,
           ov::element::Type_t SRC_PREC,
-          typename std::enable_if<precision_of<TDST>::value == ov::element::f32, bool>::type = true>
+          std::enable_if_t<precision_of<TDST>::value == ov::element::f32, bool> = true>
 static void pack_32NxK(TDST* dst,
                        void* src,
                        TDST* tmp,
@@ -1182,8 +1172,8 @@ void rotate_kv_cache(PlainTensor& key_cache,
     size_t embedding_size = key_cache.size(3);  // S;
 
     size_t num_rotated_blocks = rotated_block_indices.size(0);
-    int32_t* rotated_block_indices_data = rotated_block_indices.ptr<int32_t>();
-    float* rotation_trig_lut_data = rotation_trig_lut.ptr<float>();
+    auto* rotated_block_indices_data = rotated_block_indices.ptr<int32_t>();
+    auto* rotation_trig_lut_data = rotation_trig_lut.ptr<float>();
 
     size_t rotation_deltas_token_stride = 0;
     size_t rotation_deltas_block_stride = 1;
@@ -1200,14 +1190,14 @@ void rotate_kv_cache(PlainTensor& key_cache,
 
         int32_t* rotation_deltas_block_data = rotation_deltas.ptr<int32_t>() + i * rotation_deltas_block_stride;
 
-        float* rotation_coefficient_block_data = rotation_coefficients_scratch.ptr<float>();
+        auto* rotation_coefficient_block_data = rotation_coefficients_scratch.ptr<float>();
         fill_rotation_coefficients_from_lut(rotation_coefficient_block_data,
                                             rotation_deltas_block_data,
                                             rotation_deltas_token_stride,
                                             rotation_trig_lut_data,
                                             block_size,
                                             embedding_size);
-        KVCACHE_TYPE* cache_block_ptr = key_cache.ptr<KVCACHE_TYPE>(rotated_block_index);
+        auto* cache_block_ptr = key_cache.ptr<KVCACHE_TYPE>(rotated_block_index);
         rotate_kv_cache_block(cache_block_ptr, rotation_coefficient_block_data, num_heads, block_size, embedding_size);
     }
 }
@@ -1437,7 +1427,7 @@ struct MHAHelper {
         auto cur_kv_len_blocks = div_up(cur_kv_len, _block_size);
         for (size_t h = hq_beg; h < hq_end; h++) {
             auto* q_ptr = query.ptr<DATA_TYPE>(h, q_start, 0);
-            float* c_ptr = _weight.ptr<float>(ithr, h, 0, 0);
+            auto* c_ptr = _weight.ptr<float>(ithr, h, 0, 0);
             // for each query block, loop through all key block
             // for blocks:
             // 1 0 0 0 ...
@@ -1924,25 +1914,25 @@ struct MHA {
             //     return left_kv_blocks > right_kv_blocks;
             // });
         }
-        const AttnWorkItem& get_attn_work_item(size_t idx) const {
+        [[nodiscard]] const AttnWorkItem& get_attn_work_item(size_t idx) const {
             return attn_items[idx];
         }
-        size_t attn_work_size() const {
+        [[nodiscard]] size_t attn_work_size() const {
             return attn_items.size();
         }
-        const ReorderWorkItem& get_reorder_work_item(size_t idx) const {
+        [[nodiscard]] const ReorderWorkItem& get_reorder_work_item(size_t idx) const {
             return reorder_items[idx];
         }
-        size_t reorder_work_size() const {
+        [[nodiscard]] size_t reorder_work_size() const {
             return reorder_items.size();
         }
-        size_t get_reorder_max_batch_size() const {
+        [[nodiscard]] size_t get_reorder_max_batch_size() const {
             return static_cast<size_t>(max_batch_in_reorder);
         }
-        size_t get_reorder_max_kv_len() const {
+        [[nodiscard]] size_t get_reorder_max_kv_len() const {
             return static_cast<size_t>(max_kv_len_in_reorder);
         }
-        size_t get_total_kv_len() const {
+        [[nodiscard]] size_t get_total_kv_len() const {
             return static_cast<size_t>(total_kv_len);
         }
     };

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa_common.cpp
@@ -3,8 +3,7 @@
 //
 #include "executor_pa_common.hpp"
 
-#include <float.h>
-
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 #include <iostream>

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
@@ -1,8 +1,7 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <float.h>
-
+#include <cfloat>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -1160,7 +1159,7 @@ static void mha_single_token_kernel(const ov::intel_cpu::PlainTensor& query,
     auto SV = present_value.size(3);
     auto h_group_num = present_value.size(1);
     auto precision = ov::element::f32;
-    if (std::is_same<T3, ov::float16>::value) {
+    if (std::is_same_v<T3, ov::float16>) {
         precision = ov::element::f16;
     }
     size_t h_each_group_len = 1;

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/softmax.cpp
@@ -1,8 +1,7 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <float.h>
-
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 #include <iostream>

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/softmax_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/softmax_kernel.hpp
@@ -949,8 +949,7 @@ inline void multiply_scalar(float* a, float* a_dst, const float val, const size_
 }
 
 template <typename T,
-          typename = typename std::
-              enable_if<(std::is_same<T, ov::bfloat16>::value || std::is_same<T, ov::float16>::value), bool>::type>
+          typename = std::enable_if_t<(std::is_same_v<T, ov::bfloat16> || std::is_same_v<T, ov::float16>), bool>>
 inline void multiply_scalar(float* a, T* a_dst, const float val, const size_t size) {
     size_t i = 0;
 #if defined(HAVE_AVX512F)

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/brgemm_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/brgemm_kernel.hpp
@@ -36,16 +36,16 @@ public:
 
     void copy_buffer_b(void* b, void* scratch_b);
     // bytes needed to place scratch buffer a
-    const size_t get_scratch_a_size() const;
+    [[nodiscard]] const size_t get_scratch_a_size() const;
     // bytes needed to place scratch buffer b
-    const size_t get_scratch_b_size() const;
-    const size_t get_mblk_size() const {
+    [[nodiscard]] const size_t get_scratch_b_size() const;
+    [[nodiscard]] const size_t get_mblk_size() const {
         return matmulOptimalM;
     }
-    const size_t get_k_blk() const {
+    [[nodiscard]] const size_t get_k_blk() const {
         return K_blk;
     }
-    const size_t get_wsp_size() const {
+    [[nodiscard]] const size_t get_wsp_size() const {
         return 4 * 1024;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.cpp
@@ -67,15 +67,15 @@ void jit_uni_dft_kernel_f32<isa>::generate() {
     L(main_loop_end_label);
 
     if (mayiuse(cpu::x64::avx512_core)) {
-        Xbyak::Zmm zmm_sum = Xbyak::Zmm(vmm_sum.getIdx());
-        Xbyak::Ymm ymm_sum = Xbyak::Ymm(vmm_sum.getIdx());
-        Xbyak::Ymm ymm_sum_2 = Xbyak::Ymm(vmm_sum_2.getIdx());
+        auto zmm_sum = Xbyak::Zmm(vmm_sum.getIdx());
+        auto ymm_sum = Xbyak::Ymm(vmm_sum.getIdx());
+        auto ymm_sum_2 = Xbyak::Ymm(vmm_sum_2.getIdx());
 
         vextractf64x4(ymm_sum_2, zmm_sum, 1);
         vaddps(ymm_sum, ymm_sum, ymm_sum_2);
     }
     if (mayiuse(cpu::x64::avx2)) {
-        Xbyak::Ymm ymm_sum = Xbyak::Ymm(vmm_sum.getIdx());
+        auto ymm_sum = Xbyak::Ymm(vmm_sum.getIdx());
 
         vextractf128(xmm_sum_2, ymm_sum, 1);
         vaddps(xmm_sum, xmm_sum, xmm_sum_2);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
@@ -29,29 +29,29 @@ struct jit_args_fft {
 };
 
 struct jit_uni_dft_kernel {
-    void (*ker_)(const jit_args_dft*);
+    void (*ker_)(const jit_args_dft*){nullptr};
 
     void operator()(const jit_args_dft* args) {
         assert(ker_);
         ker_(args);
     }
 
-    jit_uni_dft_kernel() : ker_(nullptr) {}
-    virtual ~jit_uni_dft_kernel() {}
+    jit_uni_dft_kernel() = default;
+    virtual ~jit_uni_dft_kernel() = default;
 
     virtual void create_ker() = 0;
 };
 
 struct jit_uni_fft_kernel {
-    void (*ker_)(const jit_args_fft*);
+    void (*ker_)(const jit_args_fft*){nullptr};
 
     void operator()(const jit_args_fft* args) {
         assert(ker_);
         ker_(args);
     }
 
-    jit_uni_fft_kernel() : ker_(nullptr) {}
-    virtual ~jit_uni_fft_kernel() {}
+    jit_uni_fft_kernel() = default;
+    virtual ~jit_uni_fft_kernel() = default;
 
     virtual void create_ker() = 0;
 };

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.cpp
@@ -303,7 +303,7 @@ void jitUniGatherKernel<isa>::generate() {
             uni_vpaddd(vmmAfterAxisPermMask, vmmAfterAxisPermMask, ptr[regAux1]);
             for (int i = 0; i < 6; i++) {
                 if (isa == x64::avx512_core) {
-                    Xbyak::Opmask kMask2 = Xbyak::Opmask(vAux2.getIdx());
+                    auto kMask2 = Xbyak::Opmask(vAux2.getIdx());
                     vpcmpgtd(kMask2, vAux0, vmmAfterAxisPermMask);
                     uni_vpsubd(vmmAfterAxisPermMask | kMask2, vmmAfterAxisPermMask, vAux1);
                 } else {
@@ -662,7 +662,7 @@ void jitUniGatherKernel<isa>::calcSrcShiftShortBlock(Vmm* vAuxPool, bool shiftFi
                     Xbyak::Xmm& xAux0 = xmmAuxContainer[vAux0.getIdx()];
                     uni_vpbroadcastd(vAux1, xAux0);
                     if (isa == x64::avx512_core) {
-                        Xbyak::Opmask kMask0 = Xbyak::Opmask(kAuxMask0.getIdx());
+                        auto kMask0 = Xbyak::Opmask(kAuxMask0.getIdx());
                         vpcmpgtd(kMask0, vAux1, vAux0);
                         uni_vmovups(vAux1, vmmSrcBeforeAxisSumB);
                         uni_vpaddd(vAux1 | kMask0, vmmSrcBeforeAxisSumB, vmmAxisAndAfterAxisSizeB);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
@@ -69,18 +69,17 @@ struct gatherJitExecArgs {
 };
 
 struct jitGatherKernelBase {
-    void (*ker_)(const gatherJitExecArgs*);
+    void (*ker_)(const gatherJitExecArgs*){nullptr};
     void operator()(const gatherJitExecArgs* args) {
         assert(ker_);
         ker_(args);
     }
     explicit jitGatherKernelBase(const jGatherConfParams& jcp, uint64_t vlen, uint64_t indicesTypeSize)
-        : ker_(nullptr),
-          jcp(jcp),
+        : jcp(jcp),
           vlen(vlen),
           dataElPerVec(vlen / jcp.dataTypeSize),
           idxElPerVec(vlen / indicesTypeSize) {}
-    virtual ~jitGatherKernelBase() {}
+    virtual ~jitGatherKernelBase() = default;
 
     virtual void create_ker() = 0;
     uint64_t getVecLen() {

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
@@ -64,7 +64,7 @@ enum coord { w, h };
 
 class GridSampleKernelBase : public JitKernelBase {
 public:
-    void (*ker_)(const GridSamplesKernelExecArgs*);
+    void (*ker_)(const GridSamplesKernelExecArgs*){nullptr};
     void operator()(const GridSamplesKernelExecArgs* args) {
         assert(ker_);
         ker_(args);
@@ -74,7 +74,7 @@ public:
                                   dnnl::impl::cpu::x64::cpu_isa_t isa,
                                   uint64_t vlen)
         : JitKernelBase(name, isa),
-          ker_(nullptr),
+
           jcp(jcp),
           vlen(vlen),
           dataTypeSize(jcp.inDataPrc.size()),

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.cpp
@@ -442,7 +442,7 @@ const jit_kernel::reg_indices& jit_kernel::free_rmmregs() const {
 }
 
 jit_kernel::stack_frame jit_kernel::stack(size_t size, uint32_t alignment) {
-    return stack_frame(*this, size, alignment);
+    return {*this, size, alignment};
 }
 
 void jit_kernel::uni_vpermps(const Xmm& x1, const uint8_t mask[4], const Operand& op) {

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <common/nstl.hpp>
 #include <functional>
+#include <memory>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -213,10 +214,8 @@ private:
     friend class then_expression<T>;
 };
 
-typedef struct register_tag {
-} register_tag;
-typedef struct memory_tag {
-} memory_tag;
+using register_tag = struct register_tag {};
+using memory_tag = struct memory_tag {};
 
 template <typename T, typename Tag>
 class variable_base;
@@ -231,11 +230,11 @@ public:
     variable_base(const variable_base&);
     variable_base(variable_base&&) noexcept;
 
-    reg_type& reg() const {
+    [[nodiscard]] reg_type& reg() const {
         return *_reg;
     }
 
-    const shared_reg<reg_type>& shreg() const {
+    [[nodiscard]] const shared_reg<reg_type>& shreg() const {
         return _reg;
     }
 
@@ -279,23 +278,22 @@ protected:
 
 template <typename T>
 class variable<T, register_tag>
-    : public variable_base<typename std::enable_if<!std::is_floating_point<T>::value, T>::type, register_tag> {
+    : public variable_base<std::enable_if_t<!std::is_floating_point_v<T>, T>, register_tag> {
 public:
     using type = T;
     using base = variable_base<type, register_tag>;
     using reg_type = const typename base::reg_type;
-    using arithmetic_type = typename std::conditional<std::is_pointer<T>::value, size_t, T>::type;
+    using arithmetic_type = std::conditional_t<std::is_pointer_v<T>, size_t, T>;
 
     variable(variable&&) noexcept = default;
     variable(jit_kernel& krnl);
     variable(jit_kernel& krnl, const shared_reg<reg_type>& reg);
 
-    typename std::conditional<std::is_pointer<T>::value &&
-                                  !std::is_pointer<typename std::remove_pointer<T>::type>::value,
-                              variable<typename std::remove_pointer<T>::type, memory_tag>,
-                              void>::type
+    std::conditional_t<std::is_pointer_v<T> && !std::is_pointer_v<std::remove_pointer_t<T>>,
+                       variable<std::remove_pointer_t<T>, memory_tag>,
+                       void>
     operator*() const {
-        return variable<typename std::remove_pointer<T>::type, memory_tag>(base::_kernel, base::shreg());
+        return variable<std::remove_pointer_t<T>, memory_tag>(base::_kernel, base::shreg());
     }
 
     const variable& operator=(reg_type& rhs) const {
@@ -541,14 +539,14 @@ public:
 };
 
 class stack_frame {
+public:
     stack_frame(const stack_frame&) = delete;
     stack_frame& operator=(const stack_frame&) = delete;
 
-public:
     stack_frame(jit_kernel& kernel, size_t size, uint32_t alignment = 1);
     stack_frame(stack_frame&& rhs) noexcept;
     ~stack_frame();
-    const Xbyak::Reg64& pointer() const;
+    [[nodiscard]] const Xbyak::Reg64& pointer() const;
     void clear() const;
 
 private:
@@ -563,10 +561,10 @@ ov::element::Type type2precision();
 dnnl::impl::cpu::x64::cpu_isa_t get_current_isa();
 
 class consts_table {
+public:
     consts_table(const consts_table&) = delete;
     consts_table& operator=(const consts_table&) = delete;
 
-public:
     consts_table() = default;
     const void* store(const void* data, size_t size);
 
@@ -725,8 +723,8 @@ void jit_kernel::load(const variable<DstT[N]>& dst, const variable<SrcT>& src, s
     static_assert(std::is_same<typename variable<SrcT>::reg_type, const Xbyak::Reg64>::value,
                   "Source register must be Reg64");
 
-    using src_type = typename std::remove_cv<typename std::remove_pointer<SrcT>::type>::type;
-    using dst_type = typename std::remove_cv<typename std::remove_pointer<DstT>::type>::type;
+    using src_type = std::remove_cv_t<std::remove_pointer_t<SrcT>>;
+    using dst_type = std::remove_cv_t<std::remove_pointer_t<DstT>>;
 
     const std::vector<size_t> pool_vec_idxs(_free_rmmregs.begin(), _free_rmmregs.end());
     const std::vector<size_t> pool_gpr_idxs(_free_x64regs.begin(), _free_x64regs.end());
@@ -736,7 +734,8 @@ void jit_kernel::load(const variable<DstT[N]>& dst, const variable<SrcT>& src, s
 
     const auto key = load_emitter_params(src_prc, dst_prc, length).hash();
     if (!_emitters[key]) {
-        _emitters[key].reset(new jit_load_emitter(this, internal::get_current_isa(), src_prc, dst_prc, length));
+        _emitters[key] =
+            std::make_unique<jit_load_emitter>(this, internal::get_current_isa(), src_prc, dst_prc, length);
     }
     _emitters[key]->emit_code({static_cast<size_t>(static_cast<const Xbyak::Operand&>(src).getIdx())},
                               {static_cast<size_t>(static_cast<const Xbyak::Operand&>(dst).getIdx())},
@@ -746,7 +745,7 @@ void jit_kernel::load(const variable<DstT[N]>& dst, const variable<SrcT>& src, s
 
 template <typename DstT, size_t N, typename SrcT>
 void jit_kernel::load(const variable<DstT[N]>& dst, const variable<SrcT>& src, const variable<size_t>& length) {
-    using src_type = typename std::remove_cv<typename std::remove_pointer<SrcT>::type>::type;
+    using src_type = std::remove_cv_t<std::remove_pointer_t<SrcT>>;
 
     auto s = stack(N * sizeof(src_type));
     s.clear();
@@ -764,8 +763,8 @@ void jit_kernel::store(const variable<DstT>& dst, const variable<SrcT[N]>& src, 
     static_assert(std::is_same<typename variable<DstT>::reg_type, const Xbyak::Reg64>::value,
                   "Destination register must be Reg64");
 
-    using src_type = typename std::remove_cv<typename std::remove_pointer<SrcT>::type>::type;
-    using dst_type = typename std::remove_cv<typename std::remove_pointer<DstT>::type>::type;
+    using src_type = std::remove_cv_t<std::remove_pointer_t<SrcT>>;
+    using dst_type = std::remove_cv_t<std::remove_pointer_t<DstT>>;
 
     const std::vector<size_t> pool_vec_idxs(_free_rmmregs.begin(), _free_rmmregs.end());
     const std::vector<size_t> pool_gpr_idxs(_free_x64regs.begin(), _free_x64regs.end());
@@ -775,7 +774,8 @@ void jit_kernel::store(const variable<DstT>& dst, const variable<SrcT[N]>& src, 
 
     const auto key = store_emitter_params(src_prc, dst_prc, length).hash();
     if (!_emitters[key]) {
-        _emitters[key].reset(new jit_store_emitter(this, internal::get_current_isa(), src_prc, dst_prc, length));
+        _emitters[key] =
+            std::make_unique<jit_store_emitter>(this, internal::get_current_isa(), src_prc, dst_prc, length);
     }
     _emitters[key]->emit_code({static_cast<size_t>(static_cast<const Xbyak::Operand&>(src).getIdx())},
                               {static_cast<size_t>(static_cast<const Xbyak::Operand&>(dst).getIdx())},
@@ -785,7 +785,7 @@ void jit_kernel::store(const variable<DstT>& dst, const variable<SrcT[N]>& src, 
 
 template <typename DstT, typename SrcT, size_t N>
 void jit_kernel::store(const variable<DstT>& dst, const variable<SrcT[N]>& src, const variable<size_t>& length) {
-    using dst_type = typename std::remove_cv<typename std::remove_pointer<DstT>::type>::type;
+    using dst_type = std::remove_cv_t<std::remove_pointer_t<DstT>>;
 
     auto s = stack(N * sizeof(dst_type));
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.cpp
@@ -250,7 +250,7 @@ void JitKernelBase::gatherdd(const Xbyak::Xmm& v_dst,
         vpgatherdd(v_dst, ptr[rSrcPtr + vSrcShift], vReadMask);
     } else {
         auto rAux = getReg64();
-        Xbyak::Reg32 r32Aux = Xbyak::Reg32(rAux.getIdx());
+        auto r32Aux = Xbyak::Reg32(rAux.getIdx());
         const uint8_t elPerVec = x64::cpu_isa_traits<x64::sse41>::vlen / sizeof(int);
 
         for (uint8_t i = 0; i < elPerVec; i++) {
@@ -290,8 +290,8 @@ void JitKernelBase::gatherdd(const Xbyak::Ymm& v_dst,
 
         vpgatherdd(v_dst, ptr[rSrcPtr + vSrcShift], vReadMask);
     } else {
-        Xbyak::Xmm xmmDst = Xbyak::Xmm(v_dst.getIdx()), xmmSrcShft = Xbyak::Xmm(vSrcShift.getIdx()),
-                   xmmReadMask = Xbyak::Xmm(vReadMask.getIdx());
+        auto xmmDst = Xbyak::Xmm(v_dst.getIdx()), xmmSrcShft = Xbyak::Xmm(vSrcShift.getIdx()),
+             xmmReadMask = Xbyak::Xmm(vReadMask.getIdx());
         for (uint8_t i = 0; i < 2; i++) {
             gatherdd(xmmDst, rSrcPtr, xmmSrcShft, xmmReadMask, useMask, zeroFill);
 
@@ -619,7 +619,7 @@ void JitKernelBase::memMovDD(const Xbyak::Reg64& rDst,
                              const bool zeroFill) {
     Xbyak::Label lEnd;
     auto rAux = getReg64();
-    Xbyak::Reg32 r32Aux = Xbyak::Reg32(rAux.getIdx());
+    auto r32Aux = Xbyak::Reg32(rAux.getIdx());
     const uint8_t typeSize = sizeof(int);
     const uint8_t elPerVec = x64::cpu_isa_traits<x64::sse41>::vlen / typeSize;
 
@@ -665,7 +665,7 @@ void JitKernelBase::memMovDD(const Xbyak::Reg64& rDst,
     } else if (isValidIsa(x64::avx)) {
         const uint8_t typeSize = sizeof(int);
         const uint8_t elPerXmm = x64::cpu_isa_traits<x64::sse41>::vlen / typeSize;
-        Xbyak::Xmm xmmReadMask = Xbyak::Xmm(vReadMask.getIdx()), xmmSrcShft = Xbyak::Xmm(vSrcShift.getIdx());
+        auto xmmReadMask = Xbyak::Xmm(vReadMask.getIdx()), xmmSrcShft = Xbyak::Xmm(vSrcShift.getIdx());
         for (uint8_t i = 0; i < 2; i++) {
             memMovDD(rDst, rSrc, xmmReadMask, xmmSrcShft, rToStoreNum, useMask, zeroFill);
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.hpp
@@ -196,8 +196,7 @@ public:
 
     explicit JitKernel(const char* name, const CompileParams& jcp, dnnl::impl::cpu::x64::cpu_isa_t max_cpu_isa)
         : JitKernelBase{name, max_cpu_isa},
-          m_jcp{jcp},
-          m_func{nullptr} {}
+          m_jcp{jcp} {}
 
     ~JitKernel() override = default;
 
@@ -253,7 +252,7 @@ protected:
     CompileParams m_jcp;
 
 private:
-    KernelFunc m_func;
+    KernelFunc m_func{nullptr};
 };
 
 #endif  // OPENVINO_ARCH_X86_64

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_uni_eltwise_generic.cpp
@@ -4,6 +4,7 @@
 
 #include "jit_uni_eltwise_generic.hpp"
 
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -59,7 +60,7 @@ void jit_uni_eltwise_generic<isa>::generate() {
     }
 
     if (mayiuse(avx512_core) || mayiuse(avx2_vnni_2)) {
-        uni_vcvtneps2bf16.reset(new jit_uni_vcvtneps2bf16(this, isa));
+        uni_vcvtneps2bf16 = std::make_shared<jit_uni_vcvtneps2bf16>(this, isa);
     }
 
     const auto& jep = jep_;
@@ -521,7 +522,7 @@ void jit_uni_eltwise_generic<isa>::load_vector(Vmm vmm_src,
                                                ov::element::Type src_prc,
                                                ov::element::Type dst_prc,
                                                bool broadcast) {
-    Xmm xmm_src = Xmm(vmm_src.getIdx());
+    auto xmm_src = Xmm(vmm_src.getIdx());
 
     if (src_prc == dst_prc) {
         if (broadcast) {
@@ -664,8 +665,8 @@ void jit_uni_eltwise_generic<isa>::store_vector(const Xbyak::Address& op,
                                                 Vmm vmm_dst,
                                                 ov::element::Type src_prc,
                                                 ov::element::Type dst_prc) {
-    Xmm xmm_dst = Xmm(vmm_dst.getIdx());
-    Ymm ymm_dst = Ymm(vmm_dst.getIdx());
+    auto xmm_dst = Xmm(vmm_dst.getIdx());
+    auto ymm_dst = Ymm(vmm_dst.getIdx());
 
     if (src_prc == dst_prc) {
         uni_vmovups(op, vmm_dst);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.cpp
@@ -18,17 +18,17 @@ using TileConfiger = ov::Extensions::Cpu::TileConfiger;
 namespace ov::intel_cpu {
 
 void MKernel::generate_2x2() {
-    Xbyak::Reg64 reg_A_addr = abi_param2;
-    Xbyak::Reg64 reg_A_stride = abi_param3;
-    Xbyak::Reg64 reg_B_addr = abi_param4;
+    auto reg_A_addr = abi_param2;
+    auto reg_A_stride = abi_param3;
+    auto reg_B_addr = abi_param4;
 #ifdef _WIN32
-    Xbyak::Reg64 reg_C_addr = rdi;
-    Xbyak::Reg64 reg_C_stride = rsi;
+    auto reg_C_addr = rdi;
+    auto reg_C_stride = rsi;
     push(rdi);
     push(rsi);
 #else
-    Xbyak::Reg64 reg_C_addr = abi_param5;
-    Xbyak::Reg64 reg_C_stride = abi_param6;
+    auto reg_C_addr = abi_param5;
+    auto reg_C_stride = abi_param6;
 #endif
 
     Xbyak::Reg64 reg_ktiles = rax;
@@ -181,17 +181,17 @@ void MKernel::tile_config_M(TileConfig& tile_cfg, int M) {
 }
 
 void MKernel::generate_1x2() {
-    Xbyak::Reg64 reg_A_addr = abi_param2;
-    Xbyak::Reg64 reg_A_stride = abi_param3;
-    Xbyak::Reg64 reg_B_addr = abi_param4;
+    auto reg_A_addr = abi_param2;
+    auto reg_A_stride = abi_param3;
+    auto reg_B_addr = abi_param4;
 #ifdef _WIN32
-    Xbyak::Reg64 reg_C_addr = rdi;
-    Xbyak::Reg64 reg_C_stride = rsi;
+    auto reg_C_addr = rdi;
+    auto reg_C_stride = rsi;
     push(rdi);
     push(rsi);
 #else
-    Xbyak::Reg64 reg_C_addr = abi_param5;
-    Xbyak::Reg64 reg_C_stride = abi_param6;
+    auto reg_C_addr = abi_param5;
+    auto reg_C_stride = abi_param6;
 #endif
 
     Xbyak::Reg64 reg_ktiles = rax;
@@ -287,7 +287,7 @@ public:
 
     void generate() override {
         Xbyak::Label loop_begin;
-        Xbyak::Reg64 src = abi_param1;
+        auto src = abi_param1;
         for (int i = 0; i < 16; i++) {
             vcvtph2ps(zmm0, ptr[src]);
             vcvtph2ps(zmm1, ptr[src + 32]);
@@ -301,13 +301,13 @@ public:
 };
 
 template <typename Tdst>
-static typename std::enable_if<std::is_same<ov::bfloat16, Tdst>::value || std::is_same<ov::float16, Tdst>::value>::type
+static std::enable_if_t<std::is_same_v<ov::bfloat16, Tdst> || std::is_same_v<ov::float16, Tdst>>
 repackB(Tdst* dst, ov::float16* src, int N_stride, int N, int K) {
     static FP16ToBF16Kernel fp16_to_bf16;
     if (N == 16 && K == 32) {
         // SIMD optimized version
         ov::Extensions::Cpu::XARCH::llm_mlp_transpose_epi32_16x16(dst, src, N_stride * sizeof(Tdst));
-        if (std::is_same<ov::bfloat16, Tdst>::value) {
+        if (std::is_same_v<ov::bfloat16, Tdst>) {
             fp16_to_bf16(dst);
         }
         return;
@@ -560,10 +560,10 @@ void MatrixDynQuantPerRow::quantize(size_t BM, ov::float16* psrc, int src_stride
 void GateUpCombine::generate() {
     Xbyak::Label loop_begin;
 
-    Xbyak::Reg64 src = abi_param1;
-    Xbyak::Reg64 dst = abi_param2;
-    Xbyak::Reg64 prefetch_dst = abi_param3;
-    Xbyak::Reg64 BN = abi_param4;
+    auto src = abi_param1;
+    auto dst = abi_param2;
+    auto prefetch_dst = abi_param3;
+    auto BN = abi_param4;
 
     Xbyak::Reg64 loop_i = rax;
     const auto zmm_gate = zmm5;
@@ -620,11 +620,11 @@ void GateUpCombine::generate() {
 
 void ReduceAdd2bh::generate() {
     if (m_do_reduce2) {
-        Xbyak::Reg64 src0 = rdx;
-        Xbyak::Reg64 src1 = r8;
-        Xbyak::Reg64 dst = r9;
-        Xbyak::Reg64 prefetch_dst = r10;
-        Xbyak::Reg64 BN = r11;
+        auto src0 = rdx;
+        auto src1 = r8;
+        auto dst = r9;
+        auto prefetch_dst = r10;
+        auto BN = r11;
 
         mov(src0, ptr[abi_param1 + offsetof(CallArgs, src0)]);
         mov(src1, ptr[abi_param1 + offsetof(CallArgs, src1)]);
@@ -663,10 +663,10 @@ void ReduceAdd2bh::generate() {
 
         ret();
     } else {
-        Xbyak::Reg64 src0 = rdx;
-        Xbyak::Reg64 dst = r9;
-        Xbyak::Reg64 prefetch_dst = r10;
-        Xbyak::Reg64 BN = r11;
+        auto src0 = rdx;
+        auto dst = r9;
+        auto prefetch_dst = r10;
+        auto BN = r11;
 
         mov(src0, ptr[abi_param1 + offsetof(CallArgs, src0)]);
         mov(dst, ptr[abi_param1 + offsetof(CallArgs, dst)]);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
@@ -10,23 +10,23 @@
 #include "utils/plain_tensor.hpp"
 
 // register blocking size for K dimension (1x2 AMX B-tiles)
-#define REG_BLK_K_SIZE    32
-#define REG_BLK_K_SIZE_I8 64
+constexpr int REG_BLK_K_SIZE = 32;
+constexpr int REG_BLK_K_SIZE_I8 = 64;
 
 // register blocking size for N dimension (1x2 AMX B-tiles)
-#define REG_BLK_N_SIZE 32
+constexpr int REG_BLK_N_SIZE = 32;
 
 // cache blocking sie for K dimension
-#define CACHE_BLK_K_SIZE 256
+constexpr int CACHE_BLK_K_SIZE = 256;
 
 // cache blocking sie for M dimension
-#define CACHE_BLK_M_SIZE 256
+constexpr int CACHE_BLK_M_SIZE = 256;
 
 namespace ov::intel_cpu {
 
 class AutoTileConfiger {
 public:
-    AutoTileConfiger() {}
+    AutoTileConfiger() = default;
     ~AutoTileConfiger() {
         do_config(nullptr);
     }

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.cpp
@@ -64,15 +64,15 @@ void jit_dft_kernel_f32<isa>::generate() {
     lea(output_ptr, ptr[output_ptr + output_type_size * output_start]);
 
     size_t reg_idx = 0;
-    Xmm xmm_signal_size = Xmm(reg_idx);
-    Vmm vmm_signal_size = Vmm(reg_idx);
+    auto xmm_signal_size = Xmm(reg_idx);
+    auto vmm_signal_size = Vmm(reg_idx);
     if (is_inverse_) {
         reg_idx++;
         uni_vbroadcastss(vmm_signal_size, ptr[param1 + GET_OFF(signal_size)]);
         uni_vcvtdq2ps(vmm_signal_size, vmm_signal_size);
     }
 
-    Xmm neg_mask = Xmm(reg_idx);
+    auto neg_mask = Xmm(reg_idx);
     if (kernel_type_ == complex_to_complex) {
         reg_idx++;
         uni_vpxor(neg_mask, neg_mask, neg_mask);
@@ -81,14 +81,14 @@ void jit_dft_kernel_f32<isa>::generate() {
     }
 
     size_t vmm_reg_idx = reg_idx;
-    Vmm inp_real = Vmm(vmm_reg_idx++);
-    Vmm inp_imag = Vmm(vmm_reg_idx++);
-    Vmm cos = Vmm(vmm_reg_idx++);
-    Vmm sin = Vmm(vmm_reg_idx++);
+    auto inp_real = Vmm(vmm_reg_idx++);
+    auto inp_imag = Vmm(vmm_reg_idx++);
+    auto cos = Vmm(vmm_reg_idx++);
+    auto sin = Vmm(vmm_reg_idx++);
     const Vmm& twiddles = cos;
-    Vmm tmp = Vmm(vmm_reg_idx++);
-    Vmm output_real = Vmm(vmm_reg_idx++);
-    Vmm output_imag = Vmm(vmm_reg_idx++);
+    auto tmp = Vmm(vmm_reg_idx++);
+    auto output_real = Vmm(vmm_reg_idx++);
+    auto output_imag = Vmm(vmm_reg_idx++);
     const Vmm& output = output_real;
     perm_low = Vmm(vmm_reg_idx++);
     perm_high = Vmm(vmm_reg_idx++);
@@ -98,9 +98,9 @@ void jit_dft_kernel_f32<isa>::generate() {
     mov(rax, reinterpret_cast<uint64_t>(perm_high_values.data()));
     uni_vmovups(perm_high, ptr[rax]);
 
-    Xmm xmm_input = Xbyak::Xmm(reg_idx++);
-    Xmm xmm_twiddles = Xbyak::Xmm(reg_idx++);
-    Xmm xmm_output = Xbyak::Xmm(reg_idx++);
+    auto xmm_input = Xbyak::Xmm(reg_idx++);
+    auto xmm_twiddles = Xbyak::Xmm(reg_idx++);
+    auto xmm_output = Xbyak::Xmm(reg_idx++);
 
     mov(rax, signal_size);
     and_(rax, 1);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
@@ -43,8 +43,8 @@ struct jit_dft_kernel {
         ker_(args);
     }
 
-    jit_dft_kernel() : ker_(nullptr) {}
-    virtual ~jit_dft_kernel() {}
+    jit_dft_kernel() = default;
+    virtual ~jit_dft_kernel() = default;
 
     virtual void create_ker() = 0;
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/registers_pool.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/registers_pool.hpp
@@ -44,7 +44,7 @@ public:
         friend class RegistersPool;
 
     public:
-        Reg() {}
+        Reg() = default;
         Reg(const RegistersPool::Ptr& regPool) {
             initialize(regPool);
         }
@@ -130,7 +130,7 @@ public:
     static Ptr create(dnnl::impl::cpu::x64::cpu_isa_t isa, std::initializer_list<Xbyak::Reg> regsToExclude);
 
     template <typename TReg>
-    size_t countFree() const {
+    [[nodiscard]] size_t countFree() const {
         static_assert(is_any_of<TReg,
                                 Xbyak::Xmm,
                                 Xbyak::Ymm,
@@ -195,7 +195,7 @@ protected:
             isFreeIndexVector.at(reg.getIdx()) = false;
         }
 
-        size_t countUnused() const {
+        [[nodiscard]] size_t countUnused() const {
             size_t count = 0;
             for (const auto& isFree : isFreeIndexVector) {
                 if (isFree) {
@@ -225,7 +225,7 @@ protected:
     virtual void returnOpmaskToPool(int idx) {
         OPENVINO_THROW("returnOpmaskToPool: The Opmask is not supported in current instruction set");
     }
-    virtual size_t countUnusedOpmask() const {
+    [[nodiscard]] virtual size_t countUnusedOpmask() const {
         OPENVINO_THROW("countUnusedOpmask: The Opmask is not supported in current instruction set");
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rms_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rms_kernel.cpp
@@ -4,6 +4,8 @@
 
 #include "rms_kernel.hpp"
 
+#include <memory>
+
 using namespace dnnl::impl::cpu::x64;
 using namespace Xbyak;
 
@@ -230,8 +232,14 @@ void jit_rms_kernel<isa>::load(const Vmm& vmm_dst,
                                size_t offset) {
     const auto seed = load_emitter_params(src_prc, ov::element::f32, elt_num, fill, "float_min").hash();
     if (!emitters[seed]) {
-        emitters[seed].reset(
-            new jit_load_emitter(this, isa, src_prc, ov::element::f32, elt_num, ov::element::f32, fill, "float_min"));
+        emitters[seed] = std::make_unique<jit_load_emitter>(this,
+                                                            isa,
+                                                            src_prc,
+                                                            ov::element::f32,
+                                                            elt_num,
+                                                            ov::element::f32,
+                                                            fill,
+                                                            "float_min");
     }
     emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), offset},
                               {static_cast<size_t>(vmm_dst.getIdx())},
@@ -247,7 +255,7 @@ void jit_rms_kernel<isa>::store(const Xbyak::Reg64& reg_dst,
                                 size_t offset) {
     const auto seed = store_emitter_params(ov::element::f32, dst_prc, elt_num).hash();
     if (!emitters[seed]) {
-        emitters[seed].reset(new jit_store_emitter(this, isa, ov::element::f32, dst_prc, elt_num));
+        emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, ov::element::f32, dst_prc, elt_num);
     }
     emitters[seed]->emit_code({static_cast<size_t>(vmm_src.getIdx())},
                               {static_cast<size_t>(reg_dst.getIdx()), offset},

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rope_kernel.cpp
@@ -4,6 +4,8 @@
 
 #include "rope_kernel.hpp"
 
+#include <memory>
+
 using namespace dnnl::impl::cpu::x64;
 
 namespace ov::intel_cpu::kernel {
@@ -191,8 +193,14 @@ void jit_rotary_kernel<isa>::load(const Vmm& vmm_dst,
                                   size_t offset) {
     const auto seed = load_emitter_params(src_prc, ov::element::f32, elt_num, fill, "float_min").hash();
     if (!emitters[seed]) {
-        emitters[seed].reset(
-            new jit_load_emitter(this, isa, src_prc, ov::element::f32, elt_num, ov::element::f32, fill, "float_min"));
+        emitters[seed] = std::make_unique<jit_load_emitter>(this,
+                                                            isa,
+                                                            src_prc,
+                                                            ov::element::f32,
+                                                            elt_num,
+                                                            ov::element::f32,
+                                                            fill,
+                                                            "float_min");
     }
     emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), offset},
                               {static_cast<size_t>(vmm_dst.getIdx())},
@@ -208,7 +216,7 @@ void jit_rotary_kernel<isa>::store(const Xbyak::Reg64& reg_dst,
                                    size_t offset) {
     const auto seed = store_emitter_params(ov::element::f32, dst_prc, elt_num).hash();
     if (!emitters[seed]) {
-        emitters[seed].reset(new jit_store_emitter(this, isa, ov::element::f32, dst_prc, elt_num));
+        emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, ov::element::f32, dst_prc, elt_num);
     }
     emitters[seed]->emit_code({static_cast<size_t>(vmm_src.getIdx())},
                               {static_cast<size_t>(reg_dst.getIdx()), offset},

--- a/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
+++ b/src/plugins/intel_cpu/src/nodes/llm_mlp.cpp
@@ -34,7 +34,7 @@ public:
 
     WeightBuffer wbuffer;
 
-    LinearKsplit2() {}
+    LinearKsplit2() = default;
 
     // weight [N, K]
     // Gate & Up are interleaved in N dimension: 16-gate / 16-up
@@ -174,7 +174,7 @@ public:
 
     int used_nthr = 0;
 
-    LinearGateUp() {}
+    LinearGateUp() = default;
 
     WeightBuffer wbuffer;
 
@@ -430,7 +430,7 @@ struct LLMMLP::Executor : public LLMMLP::ExecutorBase {
     void execute() override {
         auto input = m_pnode->getSrcMemoryAtPort(0);
         const auto& ishape = input->getStaticDims();
-        uint8_t* pA = input->getDataAs<uint8_t>();
+        auto* pA = input->getDataAs<uint8_t>();
         const auto& srcStrides = input->getDescWithType<BlockedMemoryDesc>()->getStrides();
 
         int strideA = srcStrides[srcStrides.size() - 2];
@@ -470,7 +470,7 @@ struct LLMMLP::Executor : public LLMMLP::ExecutorBase {
                               m_quant_act,
                               m_w_scale_gateup.ptr<float>());
 
-            uint8_t* p_up_act = reinterpret_cast<uint8_t*>(m_actUp.ptr<T>());
+            auto* p_up_act = reinterpret_cast<uint8_t*>(m_actUp.ptr<T>());
             size_t stride_up_act = m_actUp.stride_bytes(0);
             if (m_config.down_quantized) {
                 m_quant_up_act.quantize(BM, m_actUp.ptr<T>(), m_actUp.stride(0));

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -94,8 +94,8 @@ void LogSoftmax::executeDynamicImpl(const dnnl::stream& strm) {
 }
 
 void LogSoftmax::execute(const dnnl::stream& strm) {
-    const float* srcData = getSrcDataAtPortAs<const float>(0);
-    float* dstData = getDstDataAtPortAs<float>(0);
+    const auto* srcData = getSrcDataAtPortAs<const float>(0);
+    auto* dstData = getDstDataAtPortAs<float>(0);
 
     if (isLastDim) {
         parallel_for(axisStep, [&](size_t i) {

--- a/src/plugins/intel_cpu/src/nodes/lora.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lora.cpp
@@ -61,7 +61,7 @@ void LoRA::selectOptimalPrimitiveDescriptor() {
 
     std::vector<Input::OutputConfig> graphOutputConfig;
     // enforce the same memory descriptor on the output as on the input to allow inPlace memory
-    graphOutputConfig.emplace_back(node::Input::OutputConfig{inConfs.front().getMemDesc(), isInPlace});
+    graphOutputConfig.emplace_back(inConfs.front().getMemDesc(), isInPlace);
 
     // configure the inner graph to get the information about output memory descriptors
     m_graph.Init(m_body, context, graphInputConfig, graphOutputConfig);

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -28,7 +28,7 @@ struct LrnKey {
     float beta;
     dnnl::primitive_attr attr;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const LrnKey& rhs) const;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/mathematics.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.cpp
@@ -38,10 +38,7 @@ bool Math::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::
 }
 
 Math::Math(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
-    : Node(op, context, PassThroughShapeInferFactory()),
-      alpha(0.f),
-      beta(0.f),
-      gamma(0.f) {
+    : Node(op, context, PassThroughShapeInferFactory()) {
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
@@ -70,8 +67,8 @@ void Math::executeDynamicImpl(const dnnl::stream& strm) {
 
 void Math::execute(const dnnl::stream& strm) {
     size_t dataSize = getChildEdgeAt(0)->getMemory().getShape().getElementsCount();
-    const float* src_data = getSrcDataAtPortAs<const float>(0);
-    float* dst_data = getDstDataAtPortAs<float>(0);
+    const auto* src_data = getSrcDataAtPortAs<const float>(0);
+    auto* dst_data = getDstDataAtPortAs<float>(0);
 
     switch (getAlgorithm()) {
     case Algorithm::MathAbs:

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -35,7 +35,7 @@ struct MatMulKey {
     dnnl::primitive_attr attr;
     impl_desc_type implType;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const MatMulKey& rhs) const;
 };
 
@@ -263,7 +263,7 @@ dnnl::memory::desc MatMul::getBiasDescFrom(const DnnlMemoryDescCPtr& outMemDesc)
     biasDims[chIdx] = outDims[chIdx];
     const auto bdt = DnnlExtensionUtils::ElementTypeToDataType(getOriginalInputPrecisionAtPort(2));
 
-    return dnnl::memory::desc(DnnlExtensionUtils::convertToDnnlDims(biasDims), bdt, memory::format_tag::any);
+    return {DnnlExtensionUtils::convertToDnnlDims(biasDims), bdt, memory::format_tag::any};
 }
 
 void MatMul::getSupportedDescriptors() {

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -327,8 +327,8 @@ void MatrixNms::executeDynamicImpl(const dnnl::stream& strm) {
 }
 
 void MatrixNms::execute(const dnnl::stream& strm) {
-    const float* boxes = getSrcDataAtPortAs<const float>(NMS_BOXES);
-    const float* scores = getSrcDataAtPortAs<const float>(NMS_SCORES);
+    const auto* boxes = getSrcDataAtPortAs<const float>(NMS_BOXES);
+    const auto* scores = getSrcDataAtPortAs<const float>(NMS_SCORES);
 
     ov::parallel_for2d(m_numBatches, m_numClasses, [&](size_t batchIdx, size_t classIdx) {
         if (classIdx == static_cast<size_t>(m_backgroundClass)) {
@@ -424,9 +424,9 @@ void MatrixNms::execute(const dnnl::stream& strm) {
         OPENVINO_ASSERT(totalBox > 0, "Total number of boxes is less or equal than 0");
         redefineOutputMemory({{static_cast<size_t>(totalBox), 6}, {static_cast<size_t>(totalBox), 1}, {m_numBatches}});
     }
-    float* selectedOutputs = selectedOutputsMemPtr->getDataAs<float>();
-    int* selectedIndices = selectedIndicesMemPtr->getDataAs<int>();
-    int* validOutputs = validOutputsMemPtr->getDataAs<int>();
+    auto* selectedOutputs = selectedOutputsMemPtr->getDataAs<float>();
+    auto* selectedIndices = selectedIndicesMemPtr->getDataAs<int>();
+    auto* validOutputs = validOutputsMemPtr->getDataAs<int>();
     for (size_t i = 0; i < m_numPerBatch.size(); i++) {
         validOutputs[i] = static_cast<int>(m_numPerBatch[i]);
     }

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -27,7 +27,7 @@ namespace {
 class MemoryStub : public IMemory {
 public:
     class MemoryBlockStub : public IMemoryBlockObserver {
-        void* getRawPtr() const noexcept override {
+        [[nodiscard]] void* getRawPtr() const noexcept override {
             return nullptr;
         }
         void setExtBuff(void* ptr, size_t size) override {
@@ -37,7 +37,7 @@ public:
             // pass
             return false;
         }
-        bool hasExtBuffer() const noexcept override {
+        [[nodiscard]] bool hasExtBuffer() const noexcept override {
             // pass
             return false;
         }
@@ -55,27 +55,27 @@ public:
           m_pMemDesc(std::move(pMemDesc)),
           m_pMemoryBlock(std::make_shared<MemoryBlockStub>()) {}
 
-    const MemoryDesc& getDesc() const override {
+    [[nodiscard]] const MemoryDesc& getDesc() const override {
         return *m_pMemDesc;
     }
 
-    MemoryDescPtr getDescPtr() const override {
+    [[nodiscard]] MemoryDescPtr getDescPtr() const override {
         return m_pMemDesc;
     }
 
-    void* getData() const override {
+    [[nodiscard]] void* getData() const override {
         OPENVINO_THROW("Unexpected call MemoryStub::getData()");
     }
 
-    size_t getSize() const override {
+    [[nodiscard]] size_t getSize() const override {
         return 0;
     }
 
-    const Shape& getShape() const override {
+    [[nodiscard]] const Shape& getShape() const override {
         return m_pMemDesc->getShape();
     }
 
-    const VectorDims& getStaticDims() const override {
+    [[nodiscard]] const VectorDims& getStaticDims() const override {
         return m_pMemDesc->getShape().getStaticDims();
     }
 
@@ -87,11 +87,11 @@ public:
         OPENVINO_THROW("Unexpected call MemoryStub::load()");
     }
 
-    MemoryBlockPtr getMemoryBlock() const override {
+    [[nodiscard]] MemoryBlockPtr getMemoryBlock() const override {
         return m_pMemoryBlock;
     }
 
-    dnnl::memory getPrimitive() const override {
+    [[nodiscard]] dnnl::memory getPrimitive() const override {
         OPENVINO_THROW("Unexpected call MemoryStub::getPrimitive()");
     }
 
@@ -680,7 +680,7 @@ void MemoryInput::initOptimalPrimitiveDescriptor() {
         std::vector<Input::OutputConfig> graphOutputConfig;
         for (auto&& portConfig : config.outConfs) {
             auto desc = portConfig.getMemDesc();
-            graphOutputConfig.emplace_back(node::Input::OutputConfig{desc, true});
+            graphOutputConfig.emplace_back(desc, true);
         }
 
         // configure the inner graph to get the information about output memory descriptors

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -178,7 +178,7 @@ protected:
     }
 
 private:
-    using executeHookPtr = void (MemoryInputBase::*)(void);
+    using executeHookPtr = void (MemoryInputBase::*)();
 
 private:
     void assignState();

--- a/src/plugins/intel_cpu/src/nodes/mha.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mha.cpp
@@ -4,6 +4,7 @@
 
 #include "mha.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -38,7 +39,7 @@ struct jit_mul_add_softmax_kernel : public jit_uni_mul_add_softmax_kernel, publi
           jit_generator(jit_name()),
           vec_size(dnnl::impl::cpu::x64::cpu_isa_traits<isa>::vlen / sizeof(float)),
           exp_emitter(std::make_shared<jit_dnnl_aux_emitter>(this, isa, dnnl_eltwise_exp, 0.f, 0.f)) {}
-    virtual ~jit_mul_add_softmax_kernel() {}
+    ~jit_mul_add_softmax_kernel() override = default;
 
     void create_ker() override {
         jit_generator::create_kernel();
@@ -290,14 +291,14 @@ private:
                      bool fill) {
         const auto seed = load_emitter_params(src_prc, ov::element::f32, elt_num, fill, "float_min").hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_load_emitter(this,
-                                                      isa,
-                                                      src_prc,
-                                                      ov::element::f32,
-                                                      elt_num,
-                                                      ov::element::f32,
-                                                      fill,
-                                                      "float_min"));
+            emitters[seed] = std::make_unique<jit_load_emitter>(this,
+                                                                isa,
+                                                                src_prc,
+                                                                ov::element::f32,
+                                                                elt_num,
+                                                                ov::element::f32,
+                                                                fill,
+                                                                "float_min");
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), 0},
@@ -308,7 +309,7 @@ private:
     inline void store(const Xbyak::Reg64& reg_dst, const Vmm& vmm_src, ov::element::Type dst_prc, const int& elt_num) {
         const auto seed = store_emitter_params(ov::element::f32, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_store_emitter(this, isa, ov::element::f32, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, ov::element::f32, dst_prc, elt_num);
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(vmm_src.getIdx())},
@@ -382,7 +383,7 @@ struct jit_convert_reorder_kernel : public jit_uni_convert_reorder_kernel, publi
         : jit_uni_convert_reorder_kernel(jcp),
           jit_generator(jit_name()),
           vec_size(dnnl::impl::cpu::x64::cpu_isa_traits<isa>::vlen / sizeof(float)) {}
-    virtual ~jit_convert_reorder_kernel() {}
+    ~jit_convert_reorder_kernel() override = default;
 
     void create_ker() override {
         jit_generator::create_kernel();
@@ -490,14 +491,14 @@ private:
                      bool fill) {
         const auto seed = load_emitter_params(src_prc, ov::element::f32, elt_num, fill, "float_min").hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_load_emitter(this,
-                                                      isa,
-                                                      src_prc,
-                                                      ov::element::f32,
-                                                      elt_num,
-                                                      ov::element::f32,
-                                                      fill,
-                                                      "float_min"));
+            emitters[seed] = std::make_unique<jit_load_emitter>(this,
+                                                                isa,
+                                                                src_prc,
+                                                                ov::element::f32,
+                                                                elt_num,
+                                                                ov::element::f32,
+                                                                fill,
+                                                                "float_min");
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), 0},
@@ -508,7 +509,7 @@ private:
     inline void store(const Xbyak::Reg64& reg_dst, const Vmm& vmm_src, ov::element::Type dst_prc, const int& elt_num) {
         const auto seed = store_emitter_params(ov::element::f32, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_store_emitter(this, isa, ov::element::f32, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, ov::element::f32, dst_prc, elt_num);
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(vmm_src.getIdx())},
@@ -549,7 +550,7 @@ struct jit_convert_transpose_kernel : public jit_uni_convert_transpose_kernel, p
         interm_prc = jcp_.with_scales ? ov::element::f32 : jcp_.src_prc;
         vec_size = dnnl::impl::cpu::x64::cpu_isa_traits<isa>::vlen / interm_prc.size();
     }
-    virtual ~jit_convert_transpose_kernel() {}
+    ~jit_convert_transpose_kernel() override = default;
 
     void create_ker() override {
         jit_generator::create_kernel();
@@ -670,8 +671,14 @@ private:
                      bool fill) {
         const auto seed = load_emitter_params(src_prc, dst_prc, elt_num, fill, "float_min").hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(
-                new jit_load_emitter(this, isa, src_prc, dst_prc, elt_num, ov::element::f32, fill, "float_min"));
+            emitters[seed] = std::make_unique<jit_load_emitter>(this,
+                                                                isa,
+                                                                src_prc,
+                                                                dst_prc,
+                                                                elt_num,
+                                                                ov::element::f32,
+                                                                fill,
+                                                                "float_min");
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), 0},
@@ -686,7 +693,7 @@ private:
                       const int& elt_num) {
         const auto seed = store_emitter_params(src_prc, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_store_emitter(this, isa, src_prc, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, src_prc, dst_prc, elt_num);
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(vmm_src.getIdx())},
@@ -1202,11 +1209,11 @@ void MHA::prepareParams() {
 
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            mulAddSoftmaxKernel.reset(new jit_mul_add_softmax_kernel<cpu_isa_t::avx512_core>(jcp));
+            mulAddSoftmaxKernel = std::make_unique<jit_mul_add_softmax_kernel<cpu_isa_t::avx512_core>>(jcp);
         } else if (mayiuse(cpu_isa_t::avx2)) {
-            mulAddSoftmaxKernel.reset(new jit_mul_add_softmax_kernel<cpu_isa_t::avx2>(jcp));
+            mulAddSoftmaxKernel = std::make_unique<jit_mul_add_softmax_kernel<cpu_isa_t::avx2>>(jcp);
         } else if (mayiuse(cpu_isa_t::sse41)) {
-            mulAddSoftmaxKernel.reset(new jit_mul_add_softmax_kernel<cpu_isa_t::sse41>(jcp));
+            mulAddSoftmaxKernel = std::make_unique<jit_mul_add_softmax_kernel<cpu_isa_t::sse41>>(jcp);
         }
 #endif  // OPENVINO_ARCH_X86_64
         if (!mulAddSoftmaxKernel) {
@@ -1226,11 +1233,11 @@ void MHA::prepareParams() {
 
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            convertReorderKernel.reset(new jit_convert_reorder_kernel<cpu_isa_t::avx512_core>(jcp));
+            convertReorderKernel = std::make_unique<jit_convert_reorder_kernel<cpu_isa_t::avx512_core>>(jcp);
         } else if (mayiuse(cpu_isa_t::avx2)) {
-            convertReorderKernel.reset(new jit_convert_reorder_kernel<cpu_isa_t::avx2>(jcp));
+            convertReorderKernel = std::make_unique<jit_convert_reorder_kernel<cpu_isa_t::avx2>>(jcp);
         } else if (mayiuse(cpu_isa_t::sse41)) {
-            convertReorderKernel.reset(new jit_convert_reorder_kernel<cpu_isa_t::sse41>(jcp));
+            convertReorderKernel = std::make_unique<jit_convert_reorder_kernel<cpu_isa_t::sse41>>(jcp);
         }
 #endif  // OPENVINO_ARCH_X86_64
         if (!convertReorderKernel) {
@@ -1252,11 +1259,11 @@ void MHA::prepareParams() {
 
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu_isa_t::avx512_core)) {
-            convertTransposeKernel.reset(new jit_convert_transpose_kernel<cpu_isa_t::avx512_core>(jcp));
+            convertTransposeKernel = std::make_unique<jit_convert_transpose_kernel<cpu_isa_t::avx512_core>>(jcp);
         } else if (mayiuse(cpu_isa_t::avx2)) {
-            convertTransposeKernel.reset(new jit_convert_transpose_kernel<cpu_isa_t::avx2>(jcp));
+            convertTransposeKernel = std::make_unique<jit_convert_transpose_kernel<cpu_isa_t::avx2>>(jcp);
         } else if (mayiuse(cpu_isa_t::sse41)) {
-            convertTransposeKernel.reset(new jit_convert_transpose_kernel<cpu_isa_t::sse41>(jcp));
+            convertTransposeKernel = std::make_unique<jit_convert_transpose_kernel<cpu_isa_t::sse41>>(jcp);
         }
 #endif  // OPENVINO_ARCH_X86_64
 
@@ -1328,11 +1335,11 @@ void MHA::callBrgemm(brgemmCtx& ctx,
 
 template <typename in1_type>
 void MHA::mhaImpl() {
-    const uint8_t* pTranspose0In0 = getSrcDataAtPortAs<const uint8_t>(0);
-    const uint8_t* pTranspose1In0 = getSrcDataAtPortAs<const uint8_t>(1);
-    const float* pAddIn1 = getSrcDataAtPortAs<const float>(2);
-    const uint8_t* pTranspose2In0 = getSrcDataAtPortAs<const uint8_t>(3);
-    uint8_t* pout = getDstDataAtPortAs<uint8_t>(0);
+    const auto* pTranspose0In0 = getSrcDataAtPortAs<const uint8_t>(0);
+    const auto* pTranspose1In0 = getSrcDataAtPortAs<const uint8_t>(1);
+    const auto* pAddIn1 = getSrcDataAtPortAs<const float>(2);
+    const auto* pTranspose2In0 = getSrcDataAtPortAs<const uint8_t>(3);
+    auto* pout = getDstDataAtPortAs<uint8_t>(0);
 
     auto outPrcSize = outputPrecision.size();
 

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -241,8 +241,8 @@ void MultiClassNms::executeDynamicImpl(const dnnl::stream& strm) {
 }
 
 void MultiClassNms::execute(const dnnl::stream& strm) {
-    const float* boxes = getSrcDataAtPortAs<const float>(NMS_BOXES);
-    const float* scores = getSrcDataAtPortAs<const float>(NMS_SCORES);
+    const auto* boxes = getSrcDataAtPortAs<const float>(NMS_BOXES);
+    const auto* scores = getSrcDataAtPortAs<const float>(NMS_SCORES);
 
     auto dims_boxes = getParentEdgeAt(NMS_BOXES)->getMemory().getStaticDims();
     auto dims_scores = getParentEdgeAt(NMS_SCORES)->getMemory().getStaticDims();
@@ -386,9 +386,9 @@ void MultiClassNms::execute(const dnnl::stream& strm) {
         size_t totalBox = std::accumulate(m_selected_num.begin(), m_selected_num.end(), static_cast<size_t>(0));
         redefineOutputMemory({{totalBox, 6}, {totalBox, 1}, {m_numBatches}});
     }
-    int* selected_indices = selectedIndicesMemPtr->getDataAs<int>();
-    float* selected_outputs = selectedOutputsMemPtr->getDataAs<float>();
-    int* selected_num = validOutputsMemPtr->getDataAs<int>();
+    auto* selected_indices = selectedIndicesMemPtr->getDataAs<int>();
+    auto* selected_outputs = selectedOutputsMemPtr->getDataAs<float>();
+    auto* selected_num = validOutputsMemPtr->getDataAs<int>();
 
     auto _flattened_index = [](int batch_idx, int box_idx, int num_box) {
         return batch_idx * num_box + box_idx;
@@ -451,7 +451,7 @@ bool MultiClassNms::created() const {
 
 float MultiClassNms::intersectionOverUnion(const float* boxesI, const float* boxesJ, const bool normalized) {
     float yminI, xminI, ymaxI, xmaxI, yminJ, xminJ, ymaxJ, xmaxJ;
-    const float norm = static_cast<float>(normalized == false);
+    const auto norm = static_cast<float>(normalized == false);
 
     // to align with reference
     yminI = boxesI[0];
@@ -542,7 +542,7 @@ void MultiClassNms::nmsWithEta(const float* boxes,
                             adaptive_threshold *= m_nmsEta;
                         }
                         if (currBox.score == origScore) {
-                            fb.push_back({currBox.score, batch_idx, class_idx, currBox.idx});
+                            fb.emplace_back(currBox.score, batch_idx, class_idx, currBox.idx);
                             continue;
                         }
                         if (currBox.score > m_scoreThreshold) {
@@ -621,7 +621,7 @@ void MultiClassNms::nmsWithoutEta(const float* boxes,
             int cur_numBoxes = shared ? m_numBoxes : roisnum[batch_idx];
             for (int box_idx = 0; box_idx < cur_numBoxes; box_idx++) {
                 if (scoresPtr[box_idx] >= m_scoreThreshold) {  // align with ref
-                    sorted_boxes.emplace_back(std::make_pair(scoresPtr[box_idx], box_idx));
+                    sorted_boxes.emplace_back(scoresPtr[box_idx], box_idx);
                 }
             }
 

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -21,15 +21,15 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return false;
     }
     void prepareParams() override;

--- a/src/plugins/intel_cpu/src/nodes/multinomial.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.cpp
@@ -183,7 +183,7 @@ void Multinomial::execute_convert_type() {
     // TODO RandomUniform - should use RandomUniform kernel to match other frameworks' seed results
     std::mt19937 gen;
     if (m_global_seed == 0 && m_op_seed == 0) {
-        gen.seed(std::time(NULL));
+        gen.seed(std::time(nullptr));
     } else {
         std::seed_seq seed{m_global_seed, m_op_seed};
         gen.seed(seed);

--- a/src/plugins/intel_cpu/src/nodes/multinomial.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.hpp
@@ -19,25 +19,25 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
 
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void prepareParams() override;
 
     void createPrimitive() override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
 protected:
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
 
 private:
     /// Multinomial params

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -41,7 +41,7 @@ struct MVNKey {
     MVNAttrs mvnAttrs;
     dnnl::primitive_attr attr;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const MVNKey& rhs) const;
 };
 
@@ -683,7 +683,7 @@ private:
     inline void worker_vector_unroll() {
         // if mean(sum) for continous data, then fast pass for major part
         if (!jcp_.normalize_variance && jcp_.layout == MVNLayoutType::mvn_planar) {
-            Vmm vmm_one = Vmm(15);
+            auto vmm_one = Vmm(15);
             // i8/u8 fast path
             if (mayiuse(avx512_core_vnni) && jcp_.src_data_size == 1) {
                 uni_vmovups(vmm_one, ptr[reg_table]);
@@ -895,13 +895,13 @@ private:
         if (isa == cpu::x64::sse41) {
             reduce_sum_store_xmm(Xmm(vmm_idx));
         } else if (isa == cpu::x64::avx2) {
-            Xbyak::Ymm ymm_sum = Xbyak::Ymm(vmm_idx);
+            auto ymm_sum = Xbyak::Ymm(vmm_idx);
             vextractf128(xmm_aux1, ymm_sum, 0);
             vextractf128(xmm_aux2, ymm_sum, 1);
             uni_vaddps(xmm_aux1, xmm_aux1, xmm_aux2);
             reduce_sum_store_xmm(xmm_aux1);
         } else {
-            Xbyak::Zmm zmm_sum = Xbyak::Zmm(vmm_idx);
+            auto zmm_sum = Xbyak::Zmm(vmm_idx);
             vextractf32x4(xmm_aux1, zmm_sum, 0);
             vextractf32x4(xmm_aux2, zmm_sum, 1);
             uni_vaddps(xmm_aux1, xmm_aux1, xmm_aux2);
@@ -2030,10 +2030,10 @@ void MVN::initSupportedPrimitiveDescriptors() {
                                                      dstMemoryDescs,
                                                      std::make_shared<ExecutorContext>(context, getImplPriority()));
             if (!factory->isEmpty()) {
-                supportedPrimitiveDescriptors.push_back({config, impl_type, factory});
+                supportedPrimitiveDescriptors.emplace_back(config, impl_type, factory);
             }
         } else {
-            supportedPrimitiveDescriptors.push_back({config, impl_type});
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
         }
     };
 
@@ -2100,28 +2100,28 @@ MVN::MVNJitExecutor::MVNJitExecutor(const MVNAttrs& mvnAttrs, const dnnl::primit
     jcp.across_channels = mvnAttrs.execAcrossChannels_;
 #if defined(OPENVINO_ARCH_X86_64)
     if (mayiuse(cpu::x64::avx512_core)) {
-        mvn_kernel.reset(new jit_uni_mvn_kernel_f32<cpu::x64::avx512_core>(jcp, *attr.get()));
+        mvn_kernel = std::make_shared<jit_uni_mvn_kernel_f32<cpu::x64::avx512_core>>(jcp, *attr.get());
         jcp.normalize_variance = false;
-        mvn_mean_kernel.reset(new jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx512_core>(jcp));
+        mvn_mean_kernel = std::make_shared<jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx512_core>>(jcp);
         if (mvnAttrs.normalizeVariance_) {
             jcp.normalize_variance = true;
-            mvn_variance_kernel.reset(new jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx512_core>(jcp));
+            mvn_variance_kernel = std::make_shared<jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx512_core>>(jcp);
         }
     } else if (mayiuse(cpu::x64::avx2)) {
-        mvn_kernel.reset(new jit_uni_mvn_kernel_f32<cpu::x64::avx2>(jcp, *attr.get()));
+        mvn_kernel = std::make_shared<jit_uni_mvn_kernel_f32<cpu::x64::avx2>>(jcp, *attr.get());
         jcp.normalize_variance = false;
-        mvn_mean_kernel.reset(new jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx2>(jcp));
+        mvn_mean_kernel = std::make_shared<jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx2>>(jcp);
         if (mvnAttrs.normalizeVariance_) {
             jcp.normalize_variance = true;
-            mvn_variance_kernel.reset(new jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx2>(jcp));
+            mvn_variance_kernel = std::make_shared<jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::avx2>>(jcp);
         }
     } else if (mayiuse(cpu::x64::sse41)) {
-        mvn_kernel.reset(new jit_uni_mvn_kernel_f32<cpu::x64::sse41>(jcp, *attr.get()));
+        mvn_kernel = std::make_shared<jit_uni_mvn_kernel_f32<cpu::x64::sse41>>(jcp, *attr.get());
         jcp.normalize_variance = false;
-        mvn_mean_kernel.reset(new jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::sse41>(jcp));
+        mvn_mean_kernel = std::make_shared<jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::sse41>>(jcp);
         if (mvnAttrs.normalizeVariance_) {
             jcp.normalize_variance = true;
-            mvn_variance_kernel.reset(new jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::sse41>(jcp));
+            mvn_variance_kernel = std::make_shared<jit_uni_mvn_mean_variance_kernel_f32<cpu::x64::sse41>>(jcp);
         }
     } else {
         OPENVINO_THROW("Can't create jit MVN kernel");
@@ -2314,8 +2314,8 @@ void MVN::execute(const dnnl::stream& strm) {
     auto srcMemPtr = getSrcMemoryAtPort(0);
 
     if (execPtr) {
-        uint8_t* dst_data = dstMemPtr->getDataAs<uint8_t>();
-        uint8_t* src_data = srcMemPtr->getDataAs<uint8_t>();
+        auto* dst_data = dstMemPtr->getDataAs<uint8_t>();
+        auto* src_data = srcMemPtr->getDataAs<uint8_t>();
         execPtr->exec(src_data, dst_data, postOpsDataPtrs.data(), shape5D);
     } else if (aclExecPtr) {
         aclExecPtr->exec({srcMemPtr}, {dstMemPtr}, postOpsDataPtrs.data());
@@ -2470,8 +2470,8 @@ void MVN::MVNJitExecutor::mvn_pln(const uint8_t* src_data,
 }
 
 void MVN::MVNRefExecutor::mvn_ref(const uint8_t* src_data, uint8_t* dst_data, const VectorDims& shape5d) {
-    const float* src_data_ptr = reinterpret_cast<const float*>(src_data);
-    float* dst_data_ptr = reinterpret_cast<float*>(dst_data);
+    const auto* src_data_ptr = reinterpret_cast<const float*>(src_data);
+    auto* dst_data_ptr = reinterpret_cast<float*>(dst_data);
     const size_t N = shape5d[0];
     const size_t C = shape5d[1];
     const size_t D = shape5d[2];

--- a/src/plugins/intel_cpu/src/nodes/ngram.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ngram.cpp
@@ -70,8 +70,8 @@ void Ngram::prepareParams() {
     const auto& outDims = getDstMemoryAtPort(0)->getStaticDims();
     ;
 
-    idcesShapeSize = std::accumulate(srcIndicesDims.begin(), srcIndicesDims.end(), 1, std::multiplies<size_t>());
-    numOutElems = std::accumulate(outDims.begin(), outDims.end(), 1, std::multiplies<size_t>());
+    idcesShapeSize = std::accumulate(srcIndicesDims.begin(), srcIndicesDims.end(), 1, std::multiplies<>());
+    numOutElems = std::accumulate(outDims.begin(), outDims.end(), 1, std::multiplies<>());
     idcesStride = getSrcMemoryAtPort(1)->getDescWithType<BlockedMemoryDesc>()->getStrides()[0];
     numIdces = srcIndicesDims[0];
 

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -156,7 +156,7 @@ void NonZero::executeSpecified() {
         VectorDims newDims{inRank, totalNonZeroCount};
         redefineOutputMemory({newDims});
     }
-    int* dst = dstMemPtr->getDataAs<int>();
+    auto* dst = dstMemPtr->getDataAs<int>();
     if (totalNonZeroCount == 0) {
         return;
     }

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -4,6 +4,7 @@
 
 #include "normalize.h"
 
+#include <memory>
 #include <shape_inference/shape_inference_pass_through.hpp>
 #include <utility>
 
@@ -44,7 +45,7 @@ struct NormalizeKey {
     dnnl::primitive_attr kernel_attrs;
     VectorDims dims;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const NormalizeKey& rhs) const;
 };
 
@@ -133,13 +134,13 @@ struct jit_uni_normalize_modulo_kernel_f32 : public jit_uni_normalize_modulo_ker
             if (isa == cpu::x64::sse41) {
                 hsum_store(vmm_sqr_sum);
             } else if (isa == cpu::x64::avx2) {
-                Xbyak::Ymm ymm_sqr_sum = Xbyak::Ymm(vmm_sqr_sum.getIdx());
+                auto ymm_sqr_sum = Xbyak::Ymm(vmm_sqr_sum.getIdx());
                 vextractf128(xmm_aux1, ymm_sqr_sum, 0);
                 vextractf128(xmm_aux2, ymm_sqr_sum, 1);
                 uni_vaddps(xmm_aux1, xmm_aux1, xmm_aux2);
                 hsum_store(xmm_aux1);
             } else {
-                Xbyak::Zmm zmm_sqr_sum = Xbyak::Zmm(vmm_sqr_sum.getIdx());
+                auto zmm_sqr_sum = Xbyak::Zmm(vmm_sqr_sum.getIdx());
                 vextractf32x4(xmm_aux1, zmm_sqr_sum, 0);
                 vextractf32x4(xmm_aux2, zmm_sqr_sum, 1);
                 uni_vaddps(xmm_aux1, xmm_aux1, xmm_aux2);
@@ -242,7 +243,7 @@ struct jit_uni_normalize_kernel_f32 : public jit_uni_normalize_kernel, public ji
         }
 
         if (mayiuse(avx512_core)) {
-            uni_vcvtneps2bf16.reset(new jit_uni_vcvtneps2bf16(this, isa));
+            uni_vcvtneps2bf16 = std::make_unique<jit_uni_vcvtneps2bf16>(this, isa);
         }
 
         this->preamble();
@@ -582,8 +583,8 @@ private:
     }
 
     inline void store_vector(const Xbyak::Address& op, Vmm vmm_dst, memory::data_type dst_dt) {
-        Ymm ymm_dst = Ymm(vmm_dst.getIdx());
-        Xmm xmm_dst = Xmm(vmm_dst.getIdx());
+        auto ymm_dst = Ymm(vmm_dst.getIdx());
+        auto xmm_dst = Xmm(vmm_dst.getIdx());
 
         if (dst_dt == memory::data_type::f32) {
             uni_vmovups(op, vmm_dst);
@@ -873,7 +874,7 @@ void NormalizeL2::initSupportedPrimitiveDescriptors() {
         config.inConfs[1].setMemDesc(std::move(a));
         a = creatorsMap.at(format)->createSharedDesc(outputPrecision, getOutputShapeAtPort(DATA));
         config.outConfs[0].setMemDesc(std::move(a));
-        supportedPrimitiveDescriptors.push_back({config, impl_type});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_type);
     };
 
     impl_desc_type impl_type = impl_desc_type::unknown;
@@ -1001,8 +1002,8 @@ void NormalizeL2::execute(const dnnl::stream& strm) {
         THROW_CPU_NODE_ERR("doesn't have a compiled executor.");
     }
 
-    const uint8_t* src_ptr = getSrcDataAtPortAs<const uint8_t>(DATA);
-    uint8_t* dst_ptr = getDstDataAtPortAs<uint8_t>(DATA);
+    const auto* src_ptr = getSrcDataAtPortAs<const uint8_t>(DATA);
+    auto* dst_ptr = getDstDataAtPortAs<uint8_t>(DATA);
     execPtr->exec(src_ptr, dst_ptr, postOpsDataPtrs.data());
 }
 
@@ -1012,7 +1013,7 @@ template <typename in_data_t, typename out_data_t>
 class NormalizeL2::NormalizeL2CornerCaseExecutor : public NormalizeL2::NormalizeL2Executor {
 public:
     NormalizeL2CornerCaseExecutor(const VectorDims& dims)
-        : workAmount(std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<size_t>())) {}
+        : workAmount(std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>())) {}
 
     void exec(const uint8_t* src_ptr, uint8_t* dst_ptr, const void** post_ops_data) override {
         normalize(reinterpret_cast<const in_data_t*>(src_ptr), reinterpret_cast<out_data_t*>(dst_ptr));
@@ -1062,16 +1063,18 @@ public:
 
         if (mayiuse(cpu::x64::avx512_core)) {
             blk_size = 16;
-            normalize_modulo_kernel.reset(new jit_uni_normalize_modulo_kernel_f32<cpu::x64::avx512_core>(jcp));
-            normalize_kernel.reset(new jit_uni_normalize_kernel_f32<cpu::x64::avx512_core>(jcp, *kernel_attrs.get()));
+            normalize_modulo_kernel = std::make_shared<jit_uni_normalize_modulo_kernel_f32<cpu::x64::avx512_core>>(jcp);
+            normalize_kernel =
+                std::make_shared<jit_uni_normalize_kernel_f32<cpu::x64::avx512_core>>(jcp, *kernel_attrs.get());
         } else if (mayiuse(cpu::x64::avx2)) {
             blk_size = 8;
-            normalize_modulo_kernel.reset(new jit_uni_normalize_modulo_kernel_f32<cpu::x64::avx2>(jcp));
-            normalize_kernel.reset(new jit_uni_normalize_kernel_f32<cpu::x64::avx2>(jcp, *kernel_attrs.get()));
+            normalize_modulo_kernel = std::make_shared<jit_uni_normalize_modulo_kernel_f32<cpu::x64::avx2>>(jcp);
+            normalize_kernel = std::make_shared<jit_uni_normalize_kernel_f32<cpu::x64::avx2>>(jcp, *kernel_attrs.get());
         } else if (mayiuse(cpu::x64::sse41)) {
             blk_size = jcp.is_blk ? 8 : 4;
-            normalize_modulo_kernel.reset(new jit_uni_normalize_modulo_kernel_f32<cpu::x64::sse41>(jcp));
-            normalize_kernel.reset(new jit_uni_normalize_kernel_f32<cpu::x64::sse41>(jcp, *kernel_attrs.get()));
+            normalize_modulo_kernel = std::make_shared<jit_uni_normalize_modulo_kernel_f32<cpu::x64::sse41>>(jcp);
+            normalize_kernel =
+                std::make_shared<jit_uni_normalize_kernel_f32<cpu::x64::sse41>>(jcp, *kernel_attrs.get());
         } else {
             OPENVINO_THROW("Jit Executor for NormalizeL2 cannot create kernels!");
         }
@@ -1486,7 +1489,7 @@ private:
         int eltwise_inj_idx = 0;
         int depthwise_inj_idx = 0;
         // reinterpret cast from (pointer to const void) to (pointer to const pointer to const float)
-        const float** post_ops_data = reinterpret_cast<const float**>(post_ops_data_);
+        const auto** post_ops_data = reinterpret_cast<const float**>(post_ops_data_);
         for (int i = 0; i < p.len(); i++) {
             auto& post_op = p.entry_[i];
             if (post_op.is_eltwise()) {

--- a/src/plugins/intel_cpu/src/nodes/pad.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pad.cpp
@@ -143,7 +143,7 @@ void Pad::initSupportedPrimitiveDescriptors() {
 
         config.outConfs[0].setMemDesc(
             creatorsMap.at(memoryFormat)->createSharedDesc(precision, getOutputShapeAtPort(DATA_ID)));
-        supportedPrimitiveDescriptors.push_back({config, impl_desc_type::ref});
+        supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref);
     };
 
     if (numOfDims == 4 || numOfDims == 5) {
@@ -252,7 +252,7 @@ void Pad::PadExecutor::paramsInitialization(const PadAttrs& attrs,
     params.dataSize = params.attrs.prc.size();
 
     auto fillingInParameters = [&](VectorIdxs& parameter, const size_t type, const size_t size, const int value) {
-        const int* ptr = srcMemory[type]->getDataAs<const int32_t>();
+        const auto* ptr = srcMemory[type]->getDataAs<const int32_t>();
         parameter.resize(size);
         for (size_t i = 0; i < size; i++) {
             parameter[i] = static_cast<int>(ptr[i]);
@@ -512,8 +512,8 @@ void Pad::PadExecutor::padConstantCommon(const MemoryPtr& srcMemPtr, const Memor
 }
 
 void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
-    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
+    const auto* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    auto* dstData = dstMemPtr->getDataAs<uint8_t>();
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -557,8 +557,8 @@ void Pad::PadExecutor::padConstantZero(const MemoryPtr& srcMemPtr, const MemoryP
 }
 
 void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr) {
-    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
-    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
+    const auto* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    auto* dstData = dstMemPtr->getDataAs<uint8_t>();
 
     parallel_nt(params.nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -604,8 +604,8 @@ void Pad::PadExecutor::padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstM
 void Pad::PadExecutor::padReflectOrSymmetric(const MemoryPtr& srcMemPtr,
                                              const MemoryPtr& dstMemPtr,
                                              const bool isSymmetric) {
-    const uint8_t* srcData = srcMemPtr->getDataAs<const uint8_t>();
-    uint8_t* dstData = dstMemPtr->getDataAs<uint8_t>();
+    const auto* srcData = srcMemPtr->getDataAs<const uint8_t>();
+    auto* dstData = dstMemPtr->getDataAs<uint8_t>();
     const size_t shift = isSymmetric ? 1 : 0;
     const size_t endSrcShift =
         (params.srcDimsForReflectOrSymmetric[params.nDimsForWork] - params.srcODims[params.nDimsForWork]) *

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -33,7 +33,7 @@ namespace ov::intel_cpu::node {
 struct PagedAttentionKey {
     ov::element::Type rtPrecision;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const PagedAttentionKey& rhs) const;
 };
 
@@ -242,7 +242,7 @@ bool PagedAttention::isSupportedOperation(const std::shared_ptr<const ov::Node>&
                 return false;
             }
         }
-        int orgInput = static_cast<int>(op->get_input_size());
+        auto orgInput = static_cast<int>(op->get_input_size());
         if (op->get_type_name() == std::string("PagedAttentionExtension") &&
             orgInput == PagedAttentionExecutor::ID_SLIDING_WINDOW + 1) {
             return true;

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -53,7 +53,7 @@ struct PoolingKey {
     dnnl::algorithm alg;
     impl_desc_type implType;
 
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         using namespace dnnl::impl;
         using namespace dnnl::impl::primitive_hashing;
         size_t seed = 0;

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -152,7 +152,7 @@ void PriorBox::execute(const dnnl::stream& strm) {
     const int OH = 4 * H * W * number_of_priors;
     const int OW = 1;
 
-    float* dst_data = getDstDataAtPortAs<float>(0);
+    auto* dst_data = getDstDataAtPortAs<float>(0);
 
     float step_ = step;
     auto min_size_ = min_size;

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -109,7 +109,7 @@ void PriorBoxClustered::execute(const dnnl::stream& strm) {
         step_h = static_cast<float>(img_height) / layer_height;
     }
 
-    float* dst_data = getDstDataAtPortAs<float>(0);
+    auto* dst_data = getDstDataAtPortAs<float>(0);
     const auto& out_shape = getChildEdgeAt(0)->getMemory().getShape().getStaticDims();
 
     size_t var_size = variances.size();

--- a/src/plugins/intel_cpu/src/nodes/proposal.cpp
+++ b/src/plugins/intel_cpu/src/nodes/proposal.cpp
@@ -27,7 +27,7 @@ static std::vector<float> generate_anchors(proposal_conf& conf) {
     auto anchors_ptr = anchors.data();
 
     // base box's width & height & center location
-    const float base_area = static_cast<float>(base_size * base_size);
+    const auto base_area = static_cast<float>(base_size * base_size);
     const float half_base_size = base_size * 0.5f;
     const float center = 0.5f * (base_size - coordinates_offset);
 
@@ -161,10 +161,10 @@ void Proposal::executeDynamicImpl(const dnnl::stream& strm) {
 
 void Proposal::execute(const dnnl::stream& strm) {
     try {
-        const float* probabilitiesData = getSrcDataAtPortAs<const float>(PROBABILITIES_IN_IDX);
-        const float* anchorsData = getSrcDataAtPortAs<const float>(ANCHORS_IN_IDX);
-        const float* imgInfoData = getSrcDataAtPortAs<const float>(IMG_INFO_IN_IDX);
-        float* outRoiData = reinterpret_cast<float*>(getDstDataAtPort(ROI_OUT_IDX));
+        const auto* probabilitiesData = getSrcDataAtPortAs<const float>(PROBABILITIES_IN_IDX);
+        const auto* anchorsData = getSrcDataAtPortAs<const float>(ANCHORS_IN_IDX);
+        const auto* imgInfoData = getSrcDataAtPortAs<const float>(IMG_INFO_IN_IDX);
+        auto* outRoiData = reinterpret_cast<float*>(getDstDataAtPort(ROI_OUT_IDX));
         float* outProbData = nullptr;
         if (store_prob) {
             outProbData = reinterpret_cast<float*>(getDstDataAtPort(PROBABILITIES_OUT_IDX));

--- a/src/plugins/intel_cpu/src/nodes/proposal_imp.cpp
+++ b/src/plugins/intel_cpu/src/nodes/proposal_imp.cpp
@@ -43,8 +43,8 @@ static void enumerate_proposals_cpu(const float* bottom4d,
     const float* p_anchors_hp = anchors + 3 * num_anchors;
 
     parallel_for2d(bottom_H, bottom_W, [&](size_t h, size_t w) {
-        const float x = static_cast<float>((swap_xy ? h : w) * feat_stride);
-        const float y = static_cast<float>((swap_xy ? w : h) * feat_stride);
+        const auto x = static_cast<float>((swap_xy ? h : w) * feat_stride);
+        const auto y = static_cast<float>((swap_xy ? w : h) * feat_stride);
 
         const float* p_box = d_anchor4d + h * bottom_W + w;
         const float* p_score = bottom4d + h * bottom_W + w;

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -176,10 +176,10 @@ void PSROIPooling::initSupportedPrimitiveDescriptors() {
 
 template <typename inputType>
 inline float bilinearInterp(const inputType* data, const float x, const float y, const int width_) {
-    int x1 = static_cast<int>(std::floor(x));
-    int x2 = static_cast<int>(std::ceil(x));
-    int y1 = static_cast<int>(std::floor(y));
-    int y2 = static_cast<int>(std::ceil(y));
+    auto x1 = static_cast<int>(std::floor(x));
+    auto x2 = static_cast<int>(std::ceil(x));
+    auto y1 = static_cast<int>(std::floor(y));
+    auto y2 = static_cast<int>(std::ceil(y));
     float distX = x - x1;
     float distY = y - y1;
 
@@ -288,18 +288,18 @@ void PSROIPooling::executeAverage(const inputType* srcData,
         float binSizeH = roiHeight / static_cast<float>(pooledHeight);
         float binSizeW = roiWidth / static_cast<float>(pooledWidth);
 
-        int hStart = static_cast<int>(floor(static_cast<float>(h + 0) * binSizeH + roiStartH));
-        int hEnd = static_cast<int>(ceil(static_cast<float>(h + 1) * binSizeH + roiStartH));
+        auto hStart = static_cast<int>(floor(static_cast<float>(h + 0) * binSizeH + roiStartH));
+        auto hEnd = static_cast<int>(ceil(static_cast<float>(h + 1) * binSizeH + roiStartH));
 
         hStart = std::min<int>(std::max<int>(hStart, 0), height);
         hEnd = std::min<int>(std::max<int>(hEnd, 0), height);
-        int wStart = static_cast<int>(floor(static_cast<float>(w + 0) * binSizeW + roiStartW));
-        int wEnd = static_cast<int>(ceil(static_cast<float>(w + 1) * binSizeW + roiStartW));
+        auto wStart = static_cast<int>(floor(static_cast<float>(w + 0) * binSizeW + roiStartW));
+        auto wEnd = static_cast<int>(ceil(static_cast<float>(w + 1) * binSizeW + roiStartW));
 
         wStart = std::min<int>(std::max<int>(wStart, 0), width);
         wEnd = std::min<int>(std::max<int>(wEnd, 0), width);
 
-        const float binArea = static_cast<float>((hEnd - hStart) * (wEnd - wStart));
+        const auto binArea = static_cast<float>((hEnd - hStart) * (wEnd - wStart));
 
         size_t dstIndex = binOffOut + h * hOutputStride + w * wOutputStride + outBlkRes;
         dstData[dstIndex] = 0;
@@ -416,10 +416,10 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
                     nw > 1 ? (w * widthScale + boxXmin * (width - 1)) : 0.5f * (boxXmin + boxXmax) * (width - 1);
 
                 if (!(inY < 0 || inY > height - 1 || inX < 0 || inX > width - 1)) {
-                    const int topYIndex = static_cast<int>(floorf(inY));
-                    int bottomYIndex = static_cast<int>(ceilf(inY));
-                    const int leftXIndex = static_cast<int>(floorf(inX));
-                    int rightXIndex = static_cast<int>(ceilf(inX));
+                    const auto topYIndex = static_cast<int>(floorf(inY));
+                    auto bottomYIndex = static_cast<int>(ceilf(inY));
+                    const auto leftXIndex = static_cast<int>(floorf(inX));
+                    auto rightXIndex = static_cast<int>(ceilf(inX));
 
                     if (rightXIndex > width - 1) {
                         rightXIndex = width - 1;
@@ -537,7 +537,7 @@ void PSROIPooling::executeBilinearDeformable(const inputType* srcData,
                 }
                 w1 = static_cast<float>((std::min)((std::max)(static_cast<double>(w1), 0.0), width - 1.0));
                 h1 = static_cast<float>((std::min)((std::max)(static_cast<double>(h1), 0.0), height - 1.0));
-                int c1 = static_cast<int>((c * groupSize + gh) * groupSize + gw);
+                auto c1 = static_cast<int>((c * groupSize + gh) * groupSize + gw);
                 float val = bilinearInterp<inputType>(offsetBottomData + c1 * height * width, w1, h1, width);
 
                 sum += val;
@@ -559,7 +559,7 @@ void PSROIPooling::executeSpecified() {
 
     int realRois = 0;
     for (; realRois < nn; realRois++) {
-        int roiBatchInd = static_cast<int>(bottomRoisBeginning[realRois * 5]);
+        auto roiBatchInd = static_cast<int>(bottomRoisBeginning[realRois * 5]);
         if (roiBatchInd == -1) {
             break;
         }
@@ -578,7 +578,7 @@ void PSROIPooling::executeSpecified() {
 
     parallel_for(realRois, [&](int currentRoi) {
         const float* bottomRois = bottomRoisBeginning + currentRoi * 5;
-        int roiBatchInd = static_cast<int>(bottomRois[0]);
+        auto roiBatchInd = static_cast<int>(bottomRois[0]);
         if (getAlgorithm() == Algorithm::PSROIPoolingAverage) {
             executeAverage(srcData, dstData, bottomRois, currentRoi, roiBatchInd, *srcDesc, *dstDesc);
         } else if (getAlgorithm() == Algorithm::PSROIPoolingBilinear) {

--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -204,7 +204,7 @@ struct QKVProjection::Executor : public QKVProjection::ExecutorBase {
 
         auto input = m_node->getSrcMemoryAtPort(0);
         const auto& ishape = input->getStaticDims();
-        uint8_t* psrc0 = input->getDataAs<uint8_t>();
+        auto* psrc0 = input->getDataAs<uint8_t>();
         int M = shape_size(ishape) / ishape[ishape.size() - 1];
         auto* dst0 = m_node->getDstMemoryAtPort(0)->getDataAs<T>();
         auto* dst1 = m_node->getDstMemoryAtPort(1)->getDataAs<T>();

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -140,7 +140,7 @@ bool RandomUniform::needPrepareParams() const {
 
 void RandomUniform::prepareParams() {
     m_out_shape = getDstMemoryAtPort(0)->getShape().getStaticDims();
-    m_output_elements_count = std::accumulate(m_out_shape.begin(), m_out_shape.end(), 1lu, std::multiplies<Dim>());
+    m_output_elements_count = std::accumulate(m_out_shape.begin(), m_out_shape.end(), 1lu, std::multiplies<>());
 
     if (m_algo == PHILOX) {
         m_skip_count = m_output_elements_count * SKIP_CONST;
@@ -442,9 +442,9 @@ inline void raiseKey(uint32_t* key) {
 }
 
 inline void runPhilox(uint64_t key, uint64_t counter, uint64_t n, uint32_t* res) {
-    uint32_t* key_32 = reinterpret_cast<uint32_t*>(&key);
-    uint32_t* counter_32 = reinterpret_cast<uint32_t*>(&counter);
-    uint32_t* n_32 = reinterpret_cast<uint32_t*>(&n);
+    auto* key_32 = reinterpret_cast<uint32_t*>(&key);
+    auto* counter_32 = reinterpret_cast<uint32_t*>(&counter);
+    auto* n_32 = reinterpret_cast<uint32_t*>(&n);
 
     // Loop unwarping for better performance
     calculateRound(key_32, counter_32, n_32);
@@ -486,7 +486,7 @@ inline void convertToOutputTypePhilox(const uint32_t* in, float16 min, float16 r
     RandomUniform::OutputType out_val;
 
     for (size_t i = 0lu; i < el_to_copy; i++) {
-        uint16_t x_uint16 = static_cast<uint16_t>(in[i]);
+        auto x_uint16 = static_cast<uint16_t>(in[i]);
         out_val.u16 = 0x3c00 | (x_uint16 & 0x03ffu);
         out[i] = (out_val.f16 - static_cast<float16>(1)) * range + min;
     }
@@ -500,7 +500,7 @@ inline void convertToOutputTypePhilox(const uint32_t* in,
     RandomUniform::OutputType out_val;
 
     for (size_t i = 0lu; i < el_to_copy; i++) {
-        uint16_t x_uint16 = static_cast<uint16_t>(in[i]);
+        auto x_uint16 = static_cast<uint16_t>(in[i]);
         out_val.u16 = 0x3f80 | (x_uint16 & 0x7fu);
         out[i] = (out_val.bf16 - static_cast<bfloat16>(1)) * range + min;
     }

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
@@ -31,7 +31,7 @@ public:
 
     void initSupportedPrimitiveDescriptors() override;
 
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
 
     void prepareParams() override;
 
@@ -39,23 +39,23 @@ public:
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
 
     void createPrimitive() override;
 
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    std::string getPrimitiveDescriptorType() const override;
+    [[nodiscard]] std::string getPrimitiveDescriptorType() const override;
 
 protected:
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
 
 private:
     void evalRange();

--- a/src/plugins/intel_cpu/src/nodes/range.cpp
+++ b/src/plugins/intel_cpu/src/nodes/range.cpp
@@ -132,8 +132,8 @@ size_t Range::getWorkAmount(data_t* startPtr, data_t* stopPtr, data_t* stepPtr) 
     const data_t span = *stopPtr - *startPtr;
     const data_t step = *stepPtr;
     if (std::is_same<data_t, int>::value) {
-        int iSpan = static_cast<int>(span);
-        int iStep = static_cast<int>(step);
+        auto iSpan = static_cast<int>(span);
+        auto iStep = static_cast<int>(step);
         return static_cast<size_t>(div_up(iSpan < 0 ? -iSpan : iSpan, iStep < 0 ? -iStep : iStep));
     }
     return static_cast<size_t>(std::ceil(std::fabs(span) / std::fabs(step)));
@@ -147,7 +147,7 @@ Range::StatusCode Range::rangeKernel() {
         VectorDims newOutputShape{work_amount_dst};
         redefineOutputMemory({newOutputShape});
     }
-    data_t* dst_data = getDstDataAtPortAs<data_t>(0);
+    auto* dst_data = getDstDataAtPortAs<data_t>(0);
     parallel_nt(0, [&](const int ithr, const int nthr) {
         size_t iwork = 0, end = 0;
         splitter(work_amount_dst, nthr, ithr, iwork, end);

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -5,6 +5,7 @@
 #include "rdft.h"
 
 #include <cmath>
+#include <memory>
 #include <openvino/op/constant.hpp>
 #include <openvino/op/irdft.hpp>
 #include <openvino/op/rdft.hpp>
@@ -143,7 +144,7 @@ void RDFT::initSupportedPrimitiveDescriptors() {
     std::vector<PortConfigurator> configurators(
         {{LayoutType::ncsp, ov::element::f32}, {LayoutType::ncsp, ov::element::i32}});
     if (inputShapes.size() > SIGNAL_SIZE_INDEX) {
-        configurators.push_back({LayoutType::ncsp, ov::element::i32});
+        configurators.emplace_back(LayoutType::ncsp, ov::element::i32);
     }
 
     addSupportedPrimDesc(configurators, {{LayoutType::ncsp, ov::element::f32}}, impl_desc_type::ref_any);
@@ -637,8 +638,8 @@ void RDFTExecutor::dftOnAxis(enum dft_type type,
 
     bool useFFT = canUseFFT(signalSize);
 
-    size_t totalWorkSize = std::accumulate(iterationRange.begin(), iterationRange.end(), 1, std::multiplies<size_t>()) /
-                           iterationRange[axis];
+    size_t totalWorkSize =
+        std::accumulate(iterationRange.begin(), iterationRange.end(), 1, std::multiplies<>()) / iterationRange[axis];
     bool parallelizeOuterAxes = totalWorkSize > signalSize;
 
     if (parallelizeOuterAxes) {
@@ -752,8 +753,8 @@ void RDFTExecutor::irdftNd(float* inputPtr,
 
     float* output = outputPtr;
     std::vector<float> tmp;
-    size_t inputShapeSize = std::accumulate(inputShape.begin(), inputShape.end(), 1, std::multiplies<size_t>());
-    size_t outputShapeSize = std::accumulate(outputShape.begin(), outputShape.end(), 1, std::multiplies<size_t>());
+    size_t inputShapeSize = std::accumulate(inputShape.begin(), inputShape.end(), 1, std::multiplies<>());
+    size_t outputShapeSize = std::accumulate(outputShape.begin(), outputShape.end(), 1, std::multiplies<>());
     if (inputShapeSize > outputShapeSize) {
         tmp.resize(inputShapeSize);
         output = &tmp[0];
@@ -837,22 +838,22 @@ struct RDFTJitExecutor : public RDFTExecutor {
     RDFTJitExecutor(bool inverse, NodeDesc* primDesc) : RDFTExecutor(inverse) {
         enum dft_type rdftType = isInverse ? complex_to_real : real_to_complex;
         if (mayiuse(cpu::x64::avx512_core)) {
-            rdftKernel.reset(new jit_dft_kernel_f32<cpu::x64::avx512_core>(isInverse, rdftType));
-            dftKernel.reset(new jit_dft_kernel_f32<cpu::x64::avx512_core>(isInverse, complex_to_complex));
+            rdftKernel = std::make_unique<jit_dft_kernel_f32<cpu::x64::avx512_core>>(isInverse, rdftType);
+            dftKernel = std::make_unique<jit_dft_kernel_f32<cpu::x64::avx512_core>>(isInverse, complex_to_complex);
             vlen = cpu_isa_traits<cpu::x64::avx512_core>::vlen;
             if (primDesc) {
                 primDesc->setImplementationType(jit_avx512);
             }
         } else if (mayiuse(cpu::x64::avx2)) {
-            rdftKernel.reset(new jit_dft_kernel_f32<cpu::x64::avx2>(isInverse, rdftType));
-            dftKernel.reset(new jit_dft_kernel_f32<cpu::x64::avx2>(isInverse, complex_to_complex));
+            rdftKernel = std::make_unique<jit_dft_kernel_f32<cpu::x64::avx2>>(isInverse, rdftType);
+            dftKernel = std::make_unique<jit_dft_kernel_f32<cpu::x64::avx2>>(isInverse, complex_to_complex);
             vlen = cpu_isa_traits<cpu::x64::avx2>::vlen;
             if (primDesc) {
                 primDesc->setImplementationType(jit_avx2);
             }
         } else if (mayiuse(cpu::x64::sse41)) {
-            rdftKernel.reset(new jit_dft_kernel_f32<cpu::x64::sse41>(isInverse, rdftType));
-            dftKernel.reset(new jit_dft_kernel_f32<cpu::x64::sse41>(isInverse, complex_to_complex));
+            rdftKernel = std::make_unique<jit_dft_kernel_f32<cpu::x64::sse41>>(isInverse, rdftType);
+            dftKernel = std::make_unique<jit_dft_kernel_f32<cpu::x64::sse41>>(isInverse, complex_to_complex);
             vlen = cpu_isa_traits<cpu::x64::sse41>::vlen;
             if (primDesc) {
                 primDesc->setImplementationType(jit_sse42);

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -5,6 +5,7 @@
 #include "reduce.h"
 
 #include <algorithm>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -89,7 +90,7 @@ struct ReduceKey {
     jit_reduce_config_params jcp;
     dnnl::post_ops postOps;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const ReduceKey& rhs) const;
 };
 
@@ -996,8 +997,8 @@ private:
     }
 
     inline void store_vector(const Xbyak::Address& op, Vmm vmm_dst, memory::data_type dst_dt) {
-        Xmm xmm_dst = Xmm(vmm_dst.getIdx());
-        Ymm ymm_dst = Ymm(vmm_dst.getIdx());
+        auto xmm_dst = Xmm(vmm_dst.getIdx());
+        auto ymm_dst = Ymm(vmm_dst.getIdx());
         if (jcp_.round_to_zero && !support_intermediate_int) {
             uni_vroundps(vmm_dst, vmm_dst, 3);  // rounding to zero
         }
@@ -1105,13 +1106,13 @@ private:
         if (isa == cpu::x64::sse41) {
             horiz_store(vmm_dst, dst_dt, load_embedded);
         } else if (isa == cpu::x64::avx2) {
-            Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
+            auto ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
             vextractf128(xmm_aux1, ymm_dst, 0);
             vextractf128(xmm_aux2, ymm_dst, 1);
             horiz_ps(xmm_aux1, xmm_aux2);
             horiz_store(xmm_aux1, dst_dt, load_embedded);
         } else {
-            Xbyak::Zmm zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
+            auto zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
             vextractf32x4(xmm_aux1, zmm_dst, 0);
             vextractf32x4(xmm_aux2, zmm_dst, 1);
             horiz_ps(xmm_aux1, xmm_aux2);
@@ -1750,8 +1751,8 @@ private:
     }
 
     inline void store_vector(const Xbyak::Address& op, Vmm vmm_dst, memory::data_type dst_dt) {
-        Xmm xmm_dst = Xmm(vmm_dst.getIdx());
-        Ymm ymm_dst = Ymm(vmm_dst.getIdx());
+        auto xmm_dst = Xmm(vmm_dst.getIdx());
+        auto ymm_dst = Ymm(vmm_dst.getIdx());
         // If there is post ops fusing, necessary rounding has ready been done, no need to do it again.
         if (!post_ops_fusing && jcp_.round_to_zero) {
             uni_vroundps(vmm_dst, vmm_dst, 3);
@@ -1860,13 +1861,13 @@ private:
         if (isa == cpu::x64::sse41) {
             horiz_store(vmm_dst, dst_dt, load_embedded);
         } else if (isa == cpu::x64::avx2) {
-            Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
+            auto ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
             vextractf128(xmm_aux1, ymm_dst, 0);
             vextractf128(xmm_aux2, ymm_dst, 1);
             horiz_ps(xmm_aux1, xmm_aux2);
             horiz_store(xmm_aux1, dst_dt, load_embedded);
         } else {
-            Xbyak::Zmm zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
+            auto zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
             vextractf32x4(xmm_aux1, zmm_dst, 0);
             vextractf32x4(xmm_aux2, zmm_dst, 1);
             horiz_ps(xmm_aux1, xmm_aux2);
@@ -2176,7 +2177,7 @@ void Reduce::initSupportedPrimitiveDescriptors() {
             }
 #endif
         } else {
-            supportedPrimitiveDescriptors.push_back({config, impl_type});
+            supportedPrimitiveDescriptors.emplace_back(config, impl_type);
         }
     };
 
@@ -2293,11 +2294,11 @@ void Reduce::prepareParams() {
         std::shared_ptr<jit_uni_reduce_post_kernel> post_kernel;
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu::x64::avx512_core)) {
-            post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::avx512_core>(key.jcp, *attr.get()));
+            post_kernel = std::make_shared<jit_uni_reduce_post_kernel_f32<cpu::x64::avx512_core>>(key.jcp, *attr.get());
         } else if (mayiuse(cpu::x64::avx2)) {
-            post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::avx2>(key.jcp, *attr.get()));
+            post_kernel = std::make_shared<jit_uni_reduce_post_kernel_f32<cpu::x64::avx2>>(key.jcp, *attr.get());
         } else if (mayiuse(cpu::x64::sse41)) {
-            post_kernel.reset(new jit_uni_reduce_post_kernel_f32<cpu::x64::sse41>(key.jcp, *attr.get()));
+            post_kernel = std::make_shared<jit_uni_reduce_post_kernel_f32<cpu::x64::sse41>>(key.jcp, *attr.get());
         }
 #endif  // OPENVINO_ARCH_X86_64
         if (post_kernel) {
@@ -2421,11 +2422,11 @@ void Reduce::createPrimitive() {
 void Reduce::create_reduce_kernel(std::shared_ptr<jit_uni_reduce_kernel>& kernel, const jit_reduce_config_params& jcp) {
 #if defined(OPENVINO_ARCH_X86_64)
     if (mayiuse(cpu::x64::avx512_core)) {
-        kernel.reset(new jit_uni_reduce_kernel_f32<cpu::x64::avx512_core>(jcp));
+        kernel = std::make_shared<jit_uni_reduce_kernel_f32<cpu::x64::avx512_core>>(jcp);
     } else if (mayiuse(cpu::x64::avx2)) {
-        kernel.reset(new jit_uni_reduce_kernel_f32<cpu::x64::avx2>(jcp));
+        kernel = std::make_shared<jit_uni_reduce_kernel_f32<cpu::x64::avx2>>(jcp);
     } else if (mayiuse(cpu::x64::sse41)) {
-        kernel.reset(new jit_uni_reduce_kernel_f32<cpu::x64::sse41>(jcp));
+        kernel = std::make_shared<jit_uni_reduce_kernel_f32<cpu::x64::sse41>>(jcp);
     }
 #endif  // OPENVINO_ARCH_X86_64
     if (kernel) {
@@ -2442,8 +2443,8 @@ void Reduce::execute(const dnnl::stream& strm) {
     auto dstMemPtr = getDstMemoryAtPort(0);
     auto srcMemPtr = getSrcMemoryAtPort(REDUCE_DATA);
 
-    const uint8_t* src_data = srcMemPtr->getDataAs<const uint8_t>();
-    uint8_t* dst_data = dstMemPtr->getDataAs<uint8_t>();
+    const auto* src_data = srcMemPtr->getDataAs<const uint8_t>();
+    auto* dst_data = dstMemPtr->getDataAs<uint8_t>();
 
     if (empty_input && dst_size > 0) {
 #if defined(OPENVINO_ARCH_X86_64)
@@ -3020,7 +3021,7 @@ inline void Reduce::reduce_kernel_process(const uint8_t* in_p,
 inline void Reduce::reduce_kernel_post_process(uint8_t* out_ptr) {
     const uint8_t* in_ptr = fuse_low_precision ? static_cast<uint8_t*>(&intermediate_buf[0]) : nullptr;
     const size_t integerDivisor = empty_input ? 1 : IB * IC * ID * IH * IW / (OB * OC * OD * OH * OW);
-    const float divisor = static_cast<float>(integerDivisor);
+    const auto divisor = static_cast<float>(integerDivisor);
     if (layout == ReduceLayoutType::reduce_ncsp) {
         parallel_for2d(OB, OC, [&](size_t ob, size_t oc) {
             const uint8_t* in_p = in_ptr + (ob * OC + oc) * OD * OH * OW * intermediate_data_size;
@@ -3036,7 +3037,7 @@ inline void Reduce::reduce_kernel_post_process(uint8_t* out_ptr) {
             (*reduce_post_kernel)(&arg);
         });
     } else if (layout == ReduceLayoutType::reduce_nspc) {
-        const size_t num_threads = static_cast<size_t>(parallel_get_max_threads());
+        const auto num_threads = static_cast<size_t>(parallel_get_max_threads());
         size_t OP = OB * OC >= num_threads ? OB * OC : OB * OC * OD;
         if (OP < num_threads && OW > blk_size) {
             OP *= OH;
@@ -3442,8 +3443,8 @@ inline void Reduce::calc_process_dst_dims(std::vector<int>& reduce_axes, const V
         }
     }
     if (jit_mode && jit_beyond_5D) {
-        if (std::accumulate(out_dims.begin(), out_dims.end(), static_cast<size_t>(1), std::multiplies<size_t>()) !=
-            std::accumulate(dst_dims.begin(), dst_dims.end(), static_cast<size_t>(1), std::multiplies<size_t>())) {
+        if (std::accumulate(out_dims.begin(), out_dims.end(), static_cast<size_t>(1), std::multiplies<>()) !=
+            std::accumulate(dst_dims.begin(), dst_dims.end(), static_cast<size_t>(1), std::multiplies<>())) {
             THROW_CPU_NODE_ERR("gets incorrect number of output dimensions!");
         }
     } else {

--- a/src/plugins/intel_cpu/src/nodes/reference.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reference.cpp
@@ -137,10 +137,10 @@ ov::TensorVector Reference::prepareInputs() const {
         if (std::any_of(shape.begin(), shape.end(), [](const size_t dim) {
                 return dim == 0lu;
             })) {
-            inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape));
+            inputs.emplace_back(ovCoreNode->get_input_element_type(i), shape);
         } else {
             CPU_NODE_ASSERT(srcDataPtr, "has empty input data on port ", i);
-            inputs.push_back(ov::Tensor(ovCoreNode->get_input_element_type(i), shape, srcDataPtr));
+            inputs.emplace_back(ovCoreNode->get_input_element_type(i), shape, srcDataPtr);
         }
     }
     return inputs;
@@ -157,10 +157,10 @@ ov::TensorVector Reference::prepareOutputs() const {
         if (std::any_of(shape.begin(), shape.end(), [](const size_t dim) {
                 return dim == 0lu;
             })) {
-            outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape));
+            outputs.emplace_back(ovCoreNode->get_output_element_type(i), shape);
         } else {
             CPU_NODE_ASSERT(dstDataPtr, "has empty output data on port ", i);
-            outputs.push_back(ov::Tensor(ovCoreNode->get_output_element_type(i), shape, dstDataPtr));
+            outputs.emplace_back(ovCoreNode->get_output_element_type(i), shape, dstDataPtr);
         }
     }
     return outputs;

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -5,6 +5,7 @@
 #include "region_yolo.h"
 
 #include <cmath>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -48,7 +49,7 @@ struct jit_uni_logistic_kernel_f32 : public jit_uni_logistic_kernel, public jit_
             new jit_uni_eltwise_injector<isa>(this, dnnl::impl::alg_kind::eltwise_exp, 0.f, 0.f, 1.f, data_type::f32));
 
         if (mayiuse(avx512_core)) {
-            uni_vcvtneps2bf16.reset(new jit_uni_vcvtneps2bf16(this, isa));
+            uni_vcvtneps2bf16 = std::make_unique<jit_uni_vcvtneps2bf16>(this, isa);
         }
 
         this->preamble();
@@ -197,7 +198,7 @@ private:
         }
     }
     inline void store_vector(const Xbyak::Address& op, Vmm vmm_dst, ov::element::Type dst_dt) {
-        Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
+        auto ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
 
         switch (dst_dt) {
         case ov::element::f32:
@@ -326,13 +327,13 @@ void RegionYolo::createPrimitive() {
 
     block_size = 1;
     if (mayiuse(x64::avx512_core)) {
-        logistic_kernel.reset(new jit_uni_logistic_kernel_f32<x64::avx512_core>(jcp));
+        logistic_kernel = std::make_shared<jit_uni_logistic_kernel_f32<x64::avx512_core>>(jcp);
         block_size = 16;
     } else if (mayiuse(x64::avx2)) {
-        logistic_kernel.reset(new jit_uni_logistic_kernel_f32<x64::avx2>(jcp));
+        logistic_kernel = std::make_shared<jit_uni_logistic_kernel_f32<x64::avx2>>(jcp);
         block_size = 8;
     } else if (mayiuse(x64::sse41)) {
-        logistic_kernel.reset(new jit_uni_logistic_kernel_f32<x64::sse41>(jcp));
+        logistic_kernel = std::make_shared<jit_uni_logistic_kernel_f32<x64::sse41>>(jcp);
         block_size = 4;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/reshape.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reshape.cpp
@@ -62,7 +62,7 @@ bool Reshape::needShapeInfer() const {
     if (lastSecondInputValues.empty()) {
         lastSecondInputValues.resize(mem.getStaticDims()[0], 0);
     }
-    const int32_t* sndInput = mem.getDataAs<const int32_t>();
+    const auto* sndInput = mem.getDataAs<const int32_t>();
     for (size_t i = 0; i < lastSecondInputValues.size(); i++) {
         if (lastSecondInputValues[i] != sndInput[i]) {
             for (size_t i = 0; i < lastSecondInputValues.size(); i++) {

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.cpp
@@ -34,7 +34,7 @@ struct RMSNormKey {
     size_t data_size;
     size_t scale_size;
     float eps;
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const RMSNormKey& rhs) const;
 };
 
@@ -97,7 +97,7 @@ struct RMSNorm::RMSNormExecutor : public RMSNorm::Executor {
     void execute(const std::vector<MemoryPtr>& inputs, const MemoryPtr output) override {
         auto src = inputs[0]->getDataAs<uint8_t>();
         auto dst = output->getDataAs<uint8_t>();
-        float* scale = inputs[1]->getDataAs<float>();
+        auto* scale = inputs[1]->getDataAs<float>();
 
         const auto& src_strides = inputs[0]->getDescWithType<BlockedMemoryDesc>()->getStrides();
         const auto& dst_strides = output->getDescWithType<BlockedMemoryDesc>()->getStrides();

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -146,7 +146,7 @@ struct RNNKey {
     dnnl::algorithm cellAct;
     dnnl::rnn_direction direction;
     dnnl::primitive_attr attr;
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const RNNKey& rhs) const;
 };
 
@@ -404,7 +404,7 @@ public:
         return m_shape_infer->get_pads_end();
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return m_shape_infer->get_port_mask();
     }
 
@@ -417,7 +417,7 @@ private:
 class RnnShapeInferFactory final : public ShapeInferFactory {
 public:
     RnnShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<RnnShapeInfer>(m_op);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -4,8 +4,8 @@
 
 #include "roi_align.h"
 
-#include <math.h>
-
+#include <cmath>
+#include <memory>
 #include <openvino/opsets/opset9.hpp>
 #include <string>
 #include <utils/bfloat16.hpp>
@@ -188,7 +188,7 @@ private:
                           const int offset = 0) {
         const auto seed = load_emitter_params(src_prc, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_load_emitter(this, isa, src_prc, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_load_emitter>(this, isa, src_prc, dst_prc, elt_num);
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), static_cast<size_t>(offset)},
@@ -205,7 +205,7 @@ private:
                            const int offset = 0) {
         const auto seed = store_emitter_params(src_prc, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_store_emitter(this, isa, src_prc, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, src_prc, dst_prc, elt_num);
         }
 
         // for cases when Store emitter need 2 aux vmm we can use vmm_dst as second aux vmm
@@ -646,19 +646,19 @@ private:
 
     // horizontal add for vmm_dst, temp1 and temp2 as aux
     inline void horizontal_add() {
-        Xbyak::Xmm xmm_dst = Xbyak::Xmm(vmm_dst.getIdx());
-        Xbyak::Xmm xmm_temp1 = Xbyak::Xmm(vmm_temp1.getIdx());
-        Xbyak::Xmm xmm_temp2 = Xbyak::Xmm(vmm_temp2.getIdx());
+        auto xmm_dst = Xbyak::Xmm(vmm_dst.getIdx());
+        auto xmm_temp1 = Xbyak::Xmm(vmm_temp1.getIdx());
+        auto xmm_temp2 = Xbyak::Xmm(vmm_temp2.getIdx());
         if (isa == cpu::x64::sse41) {
             horizontal_add_xmm(xmm_dst, xmm_temp1);
         } else if (isa == cpu::x64::avx2) {
-            Xbyak::Ymm ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
+            auto ymm_dst = Xbyak::Ymm(vmm_dst.getIdx());
             vextractf128(xmm_temp1, ymm_dst, 0);
             vextractf128(xmm_temp2, ymm_dst, 1);
             uni_vaddps(xmm_dst, xmm_temp1, xmm_temp2);
             horizontal_add_xmm(xmm_dst, xmm_temp1);
         } else {
-            Xbyak::Zmm zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
+            auto zmm_dst = Xbyak::Zmm(vmm_dst.getIdx());
             vextractf32x4(xmm_temp1, zmm_dst, 0);
             vextractf32x4(xmm_temp2, zmm_dst, 1);
             uni_vaddps(xmm_temp1, xmm_temp1, xmm_temp2);
@@ -774,11 +774,11 @@ void ROIAlign::createJitKernel(const ov::element::Type& dataPrec, const ROIAlign
     jcp.pooled_w = pooledW;
 #if defined(OPENVINO_ARCH_X86_64)
     if (mayiuse(cpu::x64::avx512_core)) {
-        roi_align_kernel.reset(new jit_uni_roi_align_kernel_f32<cpu::x64::avx512_core>(jcp));
+        roi_align_kernel = std::make_shared<jit_uni_roi_align_kernel_f32<cpu::x64::avx512_core>>(jcp);
     } else if (mayiuse(cpu::x64::avx2)) {
-        roi_align_kernel.reset(new jit_uni_roi_align_kernel_f32<cpu::x64::avx2>(jcp));
+        roi_align_kernel = std::make_shared<jit_uni_roi_align_kernel_f32<cpu::x64::avx2>>(jcp);
     } else if (mayiuse(cpu::x64::sse41)) {
-        roi_align_kernel.reset(new jit_uni_roi_align_kernel_f32<cpu::x64::sse41>(jcp));
+        roi_align_kernel = std::make_shared<jit_uni_roi_align_kernel_f32<cpu::x64::sse41>>(jcp);
     }
     if (roi_align_kernel) {
         roi_align_kernel->create_ker();
@@ -819,11 +819,11 @@ void ROIAlign::initSupportedPrimitiveDescriptors() {
     std::vector<std::pair<LayoutType, LayoutType>> supportedFormats{{LayoutType::ncsp, LayoutType::ncsp}};
 
     if (mayiuse(cpu::x64::sse41)) {
-        supportedFormats.push_back(std::make_pair(LayoutType::nspc, LayoutType::nspc));
+        supportedFormats.emplace_back(LayoutType::nspc, LayoutType::nspc);
         if (impl_desc_type::jit_avx512 == impl_type) {
-            supportedFormats.push_back(std::make_pair(LayoutType::nCsp16c, LayoutType::nCsp16c));
+            supportedFormats.emplace_back(LayoutType::nCsp16c, LayoutType::nCsp16c);
         } else {
-            supportedFormats.push_back(std::make_pair(LayoutType::nCsp8c, LayoutType::nCsp8c));
+            supportedFormats.emplace_back(LayoutType::nCsp8c, LayoutType::nCsp8c);
         }
     }
 
@@ -909,9 +909,9 @@ void ROIAlign::executeSpecified() {
     auto nominalRoiCount = static_cast<int>(srcMemory1.getStaticDims()[0]);
     int realRois = 0;
     auto inputDimVector = srcMemory0.getStaticDims();
-    const int C = static_cast<int>(inputDimVector[1]);
-    const int H = static_cast<int>(inputDimVector[2]);
-    const int W = static_cast<int>(inputDimVector[3]);
+    const auto C = static_cast<int>(inputDimVector[1]);
+    const auto H = static_cast<int>(inputDimVector[2]);
+    const auto W = static_cast<int>(inputDimVector[3]);
 
     const int binCount = pooledH * pooledW;
 
@@ -1119,7 +1119,7 @@ void ROIAlign::executeSpecified() {
                 arg.num_samples = numSamplesROI;
                 float numSamplesInBinInvert = 1.f / numSamplesROI;
                 arg.scale = static_cast<const float*>(&numSamplesInBinInvert);
-                float* threadBuf = static_cast<float*>(
+                auto* threadBuf = static_cast<float*>(
                     &workingBuf[static_cast<size_t>(parallel_get_thread_num()) * static_cast<size_t>(bufSize)]);
                 memset(threadBuf, 0, bufSize * sizeof(float));
                 arg.buffer = threadBuf;

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -45,9 +45,9 @@ struct jit_uni_roi_pooling_kernel_f32 : public jit_uni_roi_pooling_kernel, publi
     };
 
     void generate() override {
-        load_emitter.reset(new jit_load_emitter(this, isa, jpp_.src_prc, ov::element::f32, step));
-        store_emitter.reset(new jit_store_emitter(this, isa, ov::element::f32, jpp_.dst_prc, step));
-        store_empty_roi_emitter.reset(new jit_store_emitter(this, isa, jpp_.src_prc, jpp_.dst_prc, step));
+        load_emitter = std::make_unique<jit_load_emitter>(this, isa, jpp_.src_prc, ov::element::f32, step);
+        store_emitter = std::make_unique<jit_store_emitter>(this, isa, ov::element::f32, jpp_.dst_prc, step);
+        store_empty_roi_emitter = std::make_unique<jit_store_emitter>(this, isa, jpp_.src_prc, jpp_.dst_prc, step);
 
         this->preamble();
 
@@ -342,7 +342,7 @@ namespace {
 struct RoiPoolingKey {
     jit_roi_pooling_params refParams;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const RoiPoolingKey& rhs) const;
 };
 
@@ -561,11 +561,11 @@ public:
     ROIPoolingJitExecutor(const jit_roi_pooling_params& jpp) {
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu::x64::avx512_core)) {
-            roi_pooling_kernel.reset(new jit_uni_roi_pooling_kernel_f32<cpu::x64::avx512_core>(jpp));
+            roi_pooling_kernel = std::make_shared<jit_uni_roi_pooling_kernel_f32<cpu::x64::avx512_core>>(jpp);
         } else if (mayiuse(cpu::x64::avx2)) {
-            roi_pooling_kernel.reset(new jit_uni_roi_pooling_kernel_f32<cpu::x64::avx2>(jpp));
+            roi_pooling_kernel = std::make_shared<jit_uni_roi_pooling_kernel_f32<cpu::x64::avx2>>(jpp);
         } else if (mayiuse(cpu::x64::sse41)) {
-            roi_pooling_kernel.reset(new jit_uni_roi_pooling_kernel_f32<cpu::x64::sse41>(jpp));
+            roi_pooling_kernel = std::make_shared<jit_uni_roi_pooling_kernel_f32<cpu::x64::sse41>>(jpp);
         } else {
             OPENVINO_THROW("Can't create jit RoiPooling kernel");
         }
@@ -606,7 +606,7 @@ private:
             size_t roi_off = real_rois * src_roi_step;
 
             const auto* src_roi_ptr = &src_roi[roi_off];
-            int roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
+            auto roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
             if (roi_batch_ind == -1) {
                 break;
             }
@@ -626,13 +626,13 @@ private:
                 size_t roi_off = n * src_roi_step;
                 const auto* src_roi_ptr = &src_roi[roi_off];
 
-                int roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
+                auto roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
 
                 if (jpp.alg == Algorithm::ROIPoolingMax) {
-                    int roi_start_w = static_cast<int>(round(src_roi_ptr[1] * jpp.spatial_scale));
-                    int roi_start_h = static_cast<int>(round(src_roi_ptr[2] * jpp.spatial_scale));
-                    int roi_end_w = static_cast<int>(round(src_roi_ptr[3] * jpp.spatial_scale));
-                    int roi_end_h = static_cast<int>(round(src_roi_ptr[4] * jpp.spatial_scale));
+                    auto roi_start_w = static_cast<int>(round(src_roi_ptr[1] * jpp.spatial_scale));
+                    auto roi_start_h = static_cast<int>(round(src_roi_ptr[2] * jpp.spatial_scale));
+                    auto roi_end_w = static_cast<int>(round(src_roi_ptr[3] * jpp.spatial_scale));
+                    auto roi_end_h = static_cast<int>(round(src_roi_ptr[4] * jpp.spatial_scale));
 
                     int hstart, hend, wstart, wend;
                     std::tie(hstart, hend, wstart, wend) = getBordersForMaxMode(roi_start_h,
@@ -677,10 +677,10 @@ private:
                         arg.dst =
                             &dst[n * dst_strides[0] + cb * dst_strides[1] + oh * dst_strides[2] + ow * dst_strides[3]];
                     } else {
-                        int top_y_index = static_cast<int>(floorf(in_y));
-                        int bottom_y_index = static_cast<int>(ceilf(in_y));
-                        int left_x_index = static_cast<int>(floorf(in_x));
-                        int right_x_index = static_cast<int>(ceilf(in_x));
+                        auto top_y_index = static_cast<int>(floorf(in_y));
+                        auto bottom_y_index = static_cast<int>(ceilf(in_y));
+                        auto left_x_index = static_cast<int>(floorf(in_x));
+                        auto right_x_index = static_cast<int>(ceilf(in_x));
 
                         if (right_x_index > jpp.iw - 1) {
                             right_x_index = jpp.iw - 1;
@@ -742,7 +742,7 @@ public:
             size_t roi_off = real_rois * src_roi_step;
 
             const auto* src_roi_ptr = &src_roi[roi_off];
-            int roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
+            auto roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
             if (roi_batch_ind == -1) {
                 break;
             }
@@ -767,13 +767,13 @@ public:
                 size_t roi_off = n * src_roi_step;
                 const auto* src_roi_ptr = &src_roi[roi_off];
 
-                int roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
+                auto roi_batch_ind = static_cast<int>(src_roi_ptr[0]);
 
                 if (jpp.alg == Algorithm::ROIPoolingMax) {
-                    int roi_start_w = static_cast<int>(round(src_roi_ptr[1] * jpp.spatial_scale));
-                    int roi_start_h = static_cast<int>(round(src_roi_ptr[2] * jpp.spatial_scale));
-                    int roi_end_w = static_cast<int>(round(src_roi_ptr[3] * jpp.spatial_scale));
-                    int roi_end_h = static_cast<int>(round(src_roi_ptr[4] * jpp.spatial_scale));
+                    auto roi_start_w = static_cast<int>(round(src_roi_ptr[1] * jpp.spatial_scale));
+                    auto roi_start_h = static_cast<int>(round(src_roi_ptr[2] * jpp.spatial_scale));
+                    auto roi_end_w = static_cast<int>(round(src_roi_ptr[3] * jpp.spatial_scale));
+                    auto roi_end_h = static_cast<int>(round(src_roi_ptr[4] * jpp.spatial_scale));
 
                     int hstart, hend, wstart, wend;
                     std::tie(hstart, hend, wstart, wend) = getBordersForMaxMode(roi_start_h,
@@ -842,10 +842,10 @@ public:
                             }
                         }
                     } else {
-                        int top_y_index = static_cast<int>(floorf(in_y));
-                        int bottom_y_index = static_cast<int>(ceilf(in_y));
-                        int left_x_index = static_cast<int>(floorf(in_x));
-                        int right_x_index = static_cast<int>(ceilf(in_x));
+                        auto top_y_index = static_cast<int>(floorf(in_y));
+                        auto bottom_y_index = static_cast<int>(ceilf(in_y));
+                        auto left_x_index = static_cast<int>(floorf(in_x));
+                        auto right_x_index = static_cast<int>(ceilf(in_x));
 
                         if (right_x_index > jpp.iw - 1) {
                             right_x_index = jpp.iw - 1;

--- a/src/plugins/intel_cpu/src/nodes/roll.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roll.cpp
@@ -171,7 +171,7 @@ Roll::RollExecutor::RollExecutor(const VectorDims& dataDims,
                                  const VectorDims& dstDims)
     : numOfDims{dataDims.size()},
       blockSize{dataDims.back()},
-      numOfIterations{std::accumulate(dataDims.cbegin(), dataDims.cend(), 1ul, std::multiplies<size_t>()) / blockSize},
+      numOfIterations{std::accumulate(dataDims.cbegin(), dataDims.cend(), 1ul, std::multiplies<>()) / blockSize},
       axesLength{axesDims[0]} {
     for (size_t i = 0; i < dataDims.size(); ++i) {
         if (dataDims[i] != dstDims[i]) {

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -552,9 +552,9 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
                                           int axis,
                                           const KernelType& kernel) {
     using namespace scatter_elements_update;
-    DataType* dataPtr = mem_data->getDataAs<DataType>();
-    DataType* updatePtr = mem_updates->getDataAs<DataType>();
-    uint8_t* indicesPtr = mem_indices->getDataAs<uint8_t>();
+    auto* dataPtr = mem_data->getDataAs<DataType>();
+    auto* updatePtr = mem_updates->getDataAs<DataType>();
+    auto* indicesPtr = mem_indices->getDataAs<uint8_t>();
 
     const auto& data_shape = mem_data->getStaticDims();
     const auto& indices_shape = mem_indices->getStaticDims();
@@ -565,7 +565,7 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
     }
     CPU_NODE_ASSERT(axis >= 0 && axis < static_cast<int>(updates_rank), "Invalid axis.");
 
-    const int64_t data_dim_size = static_cast<int64_t>(data_shape[axis]);
+    const auto data_dim_size = static_cast<int64_t>(data_shape[axis]);
     const auto index_dim_size = indices_shape[axis];
 
     VectorDims squashed_indices_shape(indices_shape);
@@ -680,9 +680,9 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
                                           const scatter_reductions::ReduceMean& kernel) {
     using namespace scatter_elements_update;
     CPU_NODE_ASSERT(reduction_type == ScatterUpdate::Reduction::MEAN, "The reduction type should be MEAN here.");
-    DataType* dataPtr = mem_data->getDataAs<DataType>();
-    DataType* updatePtr = mem_updates->getDataAs<DataType>();
-    uint8_t* indicesPtr = mem_indices->getDataAs<uint8_t>();
+    auto* dataPtr = mem_data->getDataAs<DataType>();
+    auto* updatePtr = mem_updates->getDataAs<DataType>();
+    auto* indicesPtr = mem_indices->getDataAs<uint8_t>();
 
     const auto& data_shape = mem_data->getStaticDims();
     const auto& indices_shape = mem_indices->getStaticDims();
@@ -693,7 +693,7 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
     }
     CPU_NODE_ASSERT(axis >= 0 && axis < static_cast<int>(updates_rank), "Invalid axis.");
 
-    const int64_t data_dim_size = static_cast<int64_t>(data_shape[axis]);
+    const auto data_dim_size = static_cast<int64_t>(data_shape[axis]);
     const auto index_dim_size = indices_shape[axis];
 
     VectorDims squashed_indices_shape(indices_shape);
@@ -846,10 +846,10 @@ void ScatterUpdate::execute(const dnnl::stream& strm) {
     auto indicesMemPtr = getSrcMemoryAtPort(INDICES_ID);
     auto updateMemPtr = getSrcMemoryAtPort(UPDATE_ID);
 
-    uint8_t* dstPtr = dstMemPtr->getDataAs<uint8_t>();
-    uint8_t* srcPtr = srcMemPtr->getDataAs<uint8_t>();
-    uint8_t* indicesPtr = indicesMemPtr->getDataAs<uint8_t>();
-    uint8_t* updatePtr = updateMemPtr->getDataAs<uint8_t>();
+    auto* dstPtr = dstMemPtr->getDataAs<uint8_t>();
+    auto* srcPtr = srcMemPtr->getDataAs<uint8_t>();
+    auto* indicesPtr = indicesMemPtr->getDataAs<uint8_t>();
+    auto* updatePtr = updateMemPtr->getDataAs<uint8_t>();
 
     const auto& srcDataDim = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims();
     const auto& indicesDim = getParentEdgeAt(INDICES_ID)->getMemory().getStaticDims();
@@ -880,7 +880,7 @@ void ScatterUpdate::execute(const dnnl::stream& strm) {
     int axis = 0;
     if (axisRelaxed) {
         auto axisMemPtr = getSrcMemoryAtPort(AXIS_ID);
-        uint8_t* axisPtr = axisMemPtr->getDataAs<uint8_t>();
+        auto* axisPtr = axisMemPtr->getDataAs<uint8_t>();
         if (axisSize == 4) {
             auto* axisPtr32 = reinterpret_cast<int32_t*>(axisPtr);
             axis = *axisPtr32;
@@ -1031,9 +1031,9 @@ void ScatterUpdate::scatterNDUpdate(const MemoryPtr& mem_data,
                                     const MemoryPtr& mem_indices,
                                     const MemoryPtr& mem_updates,
                                     const scatter_reductions::ReduceNone& kernel) {
-    uint8_t* indices = mem_indices->getDataAs<uint8_t>();
-    uint8_t* update = mem_updates->getDataAs<uint8_t>();
-    uint8_t* dstData = mem_data->getDataAs<uint8_t>();
+    auto* indices = mem_indices->getDataAs<uint8_t>();
+    auto* update = mem_updates->getDataAs<uint8_t>();
+    auto* dstData = mem_data->getDataAs<uint8_t>();
     const auto& srcDataDim = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims();
     const auto elementsCount = getParentEdgeAt(DATA_ID)->getMemory().getShape().getElementsCount();
     const auto& indicesDim = getParentEdgeAt(INDICES_ID)->getMemory().getStaticDims();
@@ -1077,9 +1077,9 @@ void ScatterUpdate::scatterNDUpdate(const MemoryPtr& mem_data,
                                     const MemoryPtr& mem_updates,
                                     const KernelType& kernel) {
     CPU_NODE_ASSERT(reduction_type != ScatterUpdate::Reduction::NONE, "The reduction should not be NONE.");
-    uint8_t* indices = mem_indices->getDataAs<uint8_t>();
-    DataType* update = mem_updates->getDataAs<DataType>();
-    DataType* dstData = mem_data->getDataAs<DataType>();
+    auto* indices = mem_indices->getDataAs<uint8_t>();
+    auto* update = mem_updates->getDataAs<DataType>();
+    auto* dstData = mem_data->getDataAs<DataType>();
     const auto& srcDataDim = getParentEdgeAt(DATA_ID)->getMemory().getStaticDims();
     const auto elementsCount = getParentEdgeAt(DATA_ID)->getMemory().getShape().getElementsCount();
     const auto& indicesDim = getParentEdgeAt(INDICES_ID)->getMemory().getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -5,6 +5,7 @@
 #include "shuffle_channels.h"
 
 #include <cmath>
+#include <memory>
 #include <openvino/op/shuffle_channels.hpp>
 #include <string>
 
@@ -270,7 +271,7 @@ ShuffleChannels::ShuffleChannelsExecutor::ShuffleChannelsExecutor(const ShuffleC
         params.dst_block_dims[i] = params.src_block_dims[params.order[i]];
     }
 
-    permuteKernel = std::unique_ptr<PermuteKernel>(new PermuteKernel(params));
+    permuteKernel = std::make_unique<PermuteKernel>(params);
 }
 
 void ShuffleChannels::ShuffleChannelsExecutor::exec(const uint8_t* srcData, uint8_t* dstData, const int MB) {
@@ -296,8 +297,8 @@ void ShuffleChannels::execute(const dnnl::stream& strm) {
 
     int MB = (attrs.axis != 0) ? getSrcMemoryAtPort(0)->getStaticDims()[0] : -1;
 
-    const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(0);
-    uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
+    const auto* srcData = getSrcDataAtPortAs<const uint8_t>(0);
+    auto* dstData = getDstDataAtPortAs<uint8_t>(0);
     execPtr->exec(srcData, dstData, MB);
 }
 

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -26,7 +26,7 @@ struct SoftmaxKey {
     size_t axis;
     dnnl::primitive_attr attr;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const SoftmaxKey& rhs) const;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.cpp
@@ -5,6 +5,7 @@
 #include "space_to_depth.h"
 
 #include <cmath>
+#include <memory>
 #include <string>
 
 #include "common/blocked_desc_creator.h"
@@ -301,7 +302,7 @@ SpaceToDepth::SpaceToDepthExecutor::SpaceToDepthExecutor(const SpaceToDepthAttrs
         params.dst_block_dims[i] = params.src_block_dims[params.order[i]];
     }
 
-    permuteKernel = std::unique_ptr<PermuteKernel>(new PermuteKernel(params));
+    permuteKernel = std::make_unique<PermuteKernel>(params);
 }
 
 void SpaceToDepth::SpaceToDepthExecutor::exec(const uint8_t* srcData, uint8_t* dstData, const int MB) {
@@ -315,8 +316,8 @@ void SpaceToDepth::execute(const dnnl::stream& strm) {
     if (!execPtr) {
         THROW_CPU_NODE_ERR("doesn't have a compiled executor.");
     }
-    const uint8_t* srcData = getSrcDataAtPortAs<const uint8_t>(0);
-    uint8_t* dstData = getDstDataAtPortAs<uint8_t>(0);
+    const auto* srcData = getSrcDataAtPortAs<const uint8_t>(0);
+    auto* dstData = getDstDataAtPortAs<uint8_t>(0);
     const int MB = getSrcMemoryAtPort(0)->getStaticDims()[0];
     execPtr->exec(srcData, dstData, MB);
 }

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -316,7 +316,7 @@ void Split::execute(const dnnl::stream& strm) {
         return;
     }
 
-    uint8_t* srcData = srcMem.getDataAs<uint8_t>();
+    auto* srcData = srcMem.getDataAs<uint8_t>();
     CPU_NODE_ASSERT(execPtr != nullptr, "Split executor is not initialized");
     execPtr->exec(srcData, getRawDstMemPtrs());
 }

--- a/src/plugins/intel_cpu/src/nodes/stft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/stft.cpp
@@ -100,9 +100,9 @@ static void transpose_out4d(const uint8_t* in,
 }  // namespace
 
 void STFT::execute(const dnnl::stream& strm) {
-    const float* signal = getSrcDataAtPortAs<const float>(DATA_IDX);
-    const float* window = getSrcDataAtPortAs<const float>(WINDOW_IDX);
-    float* rdft_result = getDstDataAtPortAs<float>(0);
+    const auto* signal = getSrcDataAtPortAs<const float>(DATA_IDX);
+    const auto* window = getSrcDataAtPortAs<const float>(WINDOW_IDX);
+    auto* rdft_result = getDstDataAtPortAs<float>(0);
     const VectorDims& signal_shape = getSrcMemoryAtPort(DATA_IDX)->getStaticDims();
     const VectorDims& window_shape = getSrcMemoryAtPort(WINDOW_IDX)->getStaticDims();
     const int64_t frame_size = (getSrcDataAtPortAs<const int32_t>(FRAME_SIZE_IDX))[0];
@@ -142,7 +142,7 @@ void STFT::execute(const dnnl::stream& strm) {
                        signal_slice.end(),
                        pad_window.begin(),
                        signal_slice.begin(),
-                       std::multiplies<float>());
+                       std::multiplies<>());
 
         const auto result_idx = (batch_frames_out + frame_idx) * fft_out_shape_size;
         auto twiddles = rdft_executor->generateTwiddles({static_cast<int>(signal_slice.size())}, fft_out_shape, {0});

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -453,7 +453,7 @@ void StridedSlice::StridedSliceCommonExecutor::paramsInitialization(const Stride
     const size_t nDims = std::max(inputRank, outputRank);
 
     auto fillingInParameters = [&](std::vector<int>& parameter, const size_t type, const size_t size, const int value) {
-        const int* ptr = srcMemory[type]->getDataAs<const int32_t>();
+        const auto* ptr = srcMemory[type]->getDataAs<const int32_t>();
         parameter.assign(ptr, ptr + size);
 
         if (type != attrs.AXES_ID && params.attrs.ellipsisMaskCounter == 0 && size < nDims) {
@@ -823,8 +823,8 @@ void StridedSlice::StridedSliceCommonExecutor::indicesCalculationForOptimized() 
 
 void StridedSlice::StridedSliceCommonExecutor::execStridedSlice(const std::vector<MemoryCPtr>& srcMemory,
                                                                 const std::vector<MemoryCPtr>& dstMemory) {
-    const uint8_t* srcData = srcMemory[0]->getDataAs<const uint8_t>();
-    uint8_t* dstData = dstMemory[0]->getDataAs<uint8_t>();
+    const auto* srcData = srcMemory[0]->getDataAs<const uint8_t>();
+    auto* dstData = dstMemory[0]->getDataAs<uint8_t>();
     const uint8_t* srcShiftedData = srcData + srcShift;
     parallel_nt(nThreads, [&](const int ithr, const int nthr) {
         size_t start = 0, end = 0;
@@ -838,9 +838,9 @@ void StridedSlice::StridedSliceCommonExecutor::execStridedSlice(const std::vecto
 
 void StridedSlice::StridedSliceCommonExecutor::execSliceScatter(const std::vector<MemoryCPtr>& srcMemory,
                                                                 const std::vector<MemoryCPtr>& dstMemory) {
-    const uint8_t* srcData = srcMemory[0]->getDataAs<const uint8_t>();
-    const uint8_t* srcUpdates = srcMemory[1]->getDataAs<const uint8_t>();
-    uint8_t* dstData = dstMemory[0]->getDataAs<uint8_t>();
+    const auto* srcData = srcMemory[0]->getDataAs<const uint8_t>();
+    const auto* srcUpdates = srcMemory[1]->getDataAs<const uint8_t>();
+    auto* dstData = dstMemory[0]->getDataAs<uint8_t>();
     cpu_parallel_memcpy(dstData, srcData, srcMemory[0]->getSize());
     if (srcMemory[1]->getSize() == 0) {
         // Updates are empty - do not apply

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_unpack.cpp
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_unpack.cpp
@@ -57,7 +57,7 @@ void StringTensorUnpack::executeDynamicImpl(const dnnl::stream& strm) {
     const auto& srcMemory = getSrcMemoryAtPort(0);
     const auto& srcDataDims = srcMemory->getStaticDims();
     const auto& srcData = srcMemory->getDataAs<std::string>();
-    Dim stringCount = std::accumulate(srcDataDims.begin(), srcDataDims.end(), 1, std::multiplies<Dim>());
+    Dim stringCount = std::accumulate(srcDataDims.begin(), srcDataDims.end(), 1, std::multiplies<>());
     size_t totalCharLength = 0;
     for (Dim i = 0; i < stringCount; ++i) {
         totalCharLength += srcData[i].length();

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -74,7 +74,7 @@ struct SubgraphKey {
           in_shapes(std::move(in_shapes_)) {}
     virtual ~SubgraphKey() = default;
 
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         using namespace dnnl::impl;
         using namespace dnnl::impl::primitive_hashing;
 
@@ -98,7 +98,7 @@ struct SubgraphCodeGeneratorKey {
         : attrs(std::move(attrs_)),
           broadcasting_mask(mask_) {}
 
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         using namespace dnnl::impl;
         using namespace dnnl::impl::primitive_hashing;
 
@@ -119,7 +119,7 @@ struct SubgraphShapeInferResultKey {
         : in_shapes(std::move(in_shapes_)),
           body_hash(body_hash_) {}
 
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         using namespace dnnl::impl;
         using namespace dnnl::impl::primitive_hashing;
 

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -4,6 +4,7 @@
 
 #include "tensoriterator.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -265,9 +266,8 @@ void DynamicBuffer::init(const dnnl::engine& eng) {
     const auto& src_mem = from->getPrimitive();
     const auto& src_desc = src_mem.get_desc();
     const auto& dims = src_desc.get_dims();
-    count =
-        std::accumulate(dims.begin(), dims.begin() + map_rule.axis, static_cast<size_t>(1), std::multiplies<size_t>());
-    len = std::accumulate(dims.begin() + map_rule.axis + 1, dims.end(), elem_size, std::multiplies<size_t>());
+    count = std::accumulate(dims.begin(), dims.begin() + map_rule.axis, static_cast<size_t>(1), std::multiplies<>());
+    len = std::accumulate(dims.begin() + map_rule.axis + 1, dims.end(), elem_size, std::multiplies<>());
     chunk_unit_in_byte = abs_stride * len;
 
     if (!mem_holder_buffer) {  // else reuse buffer holder of last inference
@@ -554,10 +554,10 @@ void TensorIterator::createPrimitive() {
     }
 
     if (loopBodyConditionOutputIdx == -1) {
-        continue_cond_check.reset(new staticValueCheck(true));  // always true
+        continue_cond_check = std::make_shared<staticValueCheck>(true);  // always true
     }
     if (loopExecutionConditionIdx == -1) {
-        initial_cond_check.reset(new staticValueCheck(true));
+        initial_cond_check = std::make_shared<staticValueCheck>(true);
         lastUsedCond = initial_cond_check->getStatus();
     }
 
@@ -795,7 +795,7 @@ void TensorIterator::prepareLoopBodyCurrentIteration() {
 void TensorIterator::prepareContinueCond() {
     if (loopBodyConditionOutputIdx != -1 || !continue_cond_check) {
         auto mem = output_mem[loopBodyConditionOutputIdx];
-        continue_cond_check.reset(new asBoolCheck(mem));
+        continue_cond_check = std::make_shared<asBoolCheck>(mem);
     }
 }
 
@@ -803,7 +803,7 @@ void TensorIterator::prepareInitialCond(const bool compileStage) {
     if (loopExecutionConditionIdx != -1 || !initial_cond_check) {
         auto edge = getParentEdgeAt(loopExecutionConditionIdx);
         auto mem = edge->getMemoryPtr();
-        initial_cond_check.reset(new asBoolCheck(mem));
+        initial_cond_check = std::make_shared<asBoolCheck>(mem);
         if (IMPLICATION(compileStage, edge->getParent()->isConstant())) {
             lastUsedCond = initial_cond_check->getStatus();
         }
@@ -813,12 +813,12 @@ void TensorIterator::prepareInitialCond(const bool compileStage) {
 void TensorIterator::prepareTripCount(const bool compileStage) {
     bool read_data = false;
     if (loopTripCountIdx == -1) {
-        trip_count_check.reset(new staticValueCheck(getNumIteration(inputPortMap, outputPortMap)));
+        trip_count_check = std::make_shared<staticValueCheck>(getNumIteration(inputPortMap, outputPortMap));
         read_data = true;
     } else {
         auto edge = getParentEdgeAt(loopTripCountIdx);
         auto mem = edge->getMemoryPtr();
-        trip_count_check.reset(new asIntCheck(mem));
+        trip_count_check = std::make_shared<asIntCheck>(mem);
         read_data = IMPLICATION(compileStage, edge->getParent()->isConstant());
     }
     if (read_data) {
@@ -906,7 +906,7 @@ void TensorIterator::restoreSubgraphInputByBackEdges() {
             redefineToMemories(to_mems, desc);
 
             // update first_mappers to replace its legacy input memory addr.
-            input_map.second.reset(new BackEdgePortHelper(context->getParamsCache(), from_mem, to_mem));
+            input_map.second = std::make_shared<BackEdgePortHelper>(context->getParamsCache(), from_mem, to_mem);
         }
     }
 }
@@ -927,8 +927,8 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
                                " (out of range)");
         }
         const auto space = dimensions[axis];
-        const int start = static_cast<int>((rule.start < 0 ? (space + 1) : 0) + rule.start);
-        const int end = static_cast<int>((rule.end < 0 ? (space + 1) : 0) + rule.end);
+        const auto start = static_cast<int>((rule.start < 0 ? (space + 1) : 0) + rule.start);
+        const auto end = static_cast<int>((rule.end < 0 ? (space + 1) : 0) + rule.end);
 
         const auto stride = rule.stride;
         if (stride == 0) {

--- a/src/plugins/intel_cpu/src/nodes/tile.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tile.cpp
@@ -119,7 +119,7 @@ void Tile::prepareParams() {
     if (!constMap[TILE_REPEATS]) {
         const auto& repeatsMem = getParentEdgeAt(TILE_REPEATS)->getMemory();
 
-        const int32_t* repeatsData = repeatsMem.getDataAs<const int32_t>();
+        const auto* repeatsData = repeatsMem.getDataAs<const int32_t>();
         originRepeats.assign(repeatsData, repeatsData + repeatsMem.getStaticDims()[0]);
 
         repeats.assign(std::max(originRepeats.size(), getInputShapeAtPort(TILE_INPUT).getRank()), 1lu);
@@ -144,7 +144,7 @@ bool Tile::needShapeInfer() const {
         if (originRepeats.empty()) {
             return true;
         }
-        const int32_t* repeatsData = getSrcDataAtPortAs<const int32_t>(TILE_REPEATS);
+        const auto* repeatsData = getSrcDataAtPortAs<const int32_t>(TILE_REPEATS);
         for (size_t i = 0lu; i < originRepeats.size(); i++) {
             if (originRepeats[i] != static_cast<size_t>(repeatsData[i])) {
                 return true;
@@ -174,8 +174,8 @@ void Tile::plainExecute(const dnnl::stream& strm) {
 
     auto& srcMemory = getParentEdgeAt(TILE_INPUT)->getMemory();
 
-    const uint8_t* src_ptr = srcMemory.getDataAs<const uint8_t>();
-    uint8_t* dst_ptr = getDstDataAtPortAs<uint8_t>(0);
+    const auto* src_ptr = srcMemory.getDataAs<const uint8_t>();
+    auto* dst_ptr = getDstDataAtPortAs<uint8_t>(0);
 
     int m_inner_dim = 1;
     int m_outer_dim = 1;

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -5,6 +5,7 @@
 #include "topk.h"
 
 #include <algorithm>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
@@ -264,7 +265,7 @@ private:
                           const int offset = 0) {
         const auto seed = load_emitter_params(src_prc, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_load_emitter(this, isa, src_prc, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_load_emitter>(this, isa, src_prc, dst_prc, elt_num);
         }
 
         emitters[seed]->emit_code({static_cast<size_t>(reg_src.getIdx()), static_cast<size_t>(offset)},
@@ -281,7 +282,7 @@ private:
                            const int offset = 0) {
         const auto seed = store_emitter_params(src_prc, dst_prc, elt_num).hash();
         if (!emitters[seed]) {
-            emitters[seed].reset(new jit_store_emitter(this, isa, src_prc, dst_prc, elt_num));
+            emitters[seed] = std::make_unique<jit_store_emitter>(this, isa, src_prc, dst_prc, elt_num);
         }
 
         // for cases when Store emitter need 2 aux vmm we can use vmm_dst as second aux vmm
@@ -2119,7 +2120,7 @@ void TopK::prepareParams() {
                 algorithm = TopKAlgorithm::topk_heap_sort;
             } else {
                 auto log_axis_dim = log2(axis_dim);
-                size_t alg_cost_bitonic = static_cast<size_t>((axis_dim / 4.0f) * log_axis_dim * (log_axis_dim + 1));
+                auto alg_cost_bitonic = static_cast<size_t>((axis_dim / 4.0f) * log_axis_dim * (log_axis_dim + 1));
                 size_t alg_cost_bubble = top_k * (top_k - 1) / 2 + (axis_dim - top_k) * top_k;
                 if (alg_cost_bitonic < alg_cost_bubble) {
                     algorithm = TopKAlgorithm::topk_bitonic_sort;
@@ -2200,11 +2201,11 @@ void TopK::createPrimitive() {
         }
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu::x64::avx512_core)) {
-            topk_kernel.reset(new jit_uni_topk_kernel_f32<cpu::x64::avx512_core>(jcp));
+            topk_kernel = std::make_shared<jit_uni_topk_kernel_f32<cpu::x64::avx512_core>>(jcp);
         } else if (mayiuse(cpu::x64::avx2)) {
-            topk_kernel.reset(new jit_uni_topk_kernel_f32<cpu::x64::avx2>(jcp));
+            topk_kernel = std::make_shared<jit_uni_topk_kernel_f32<cpu::x64::avx2>>(jcp);
         } else if (mayiuse(cpu::x64::sse41)) {
-            topk_kernel.reset(new jit_uni_topk_kernel_f32<cpu::x64::sse41>(jcp));
+            topk_kernel = std::make_shared<jit_uni_topk_kernel_f32<cpu::x64::sse41>>(jcp);
         }
 
         if (topk_kernel) {
@@ -2223,9 +2224,9 @@ void TopK::execute(const dnnl::stream& strm) {
     auto dstMemPtr = getDstMemoryAtPort(TOPK_DATA);
     auto dstIndexesMemPtr = getDstMemoryAtPort(TOPK_INDEX);
 
-    const uint8_t* src_data = srcMemPtr->getDataAs<const uint8_t>();
-    uint8_t* dst_data = dstMemPtr->getDataAs<uint8_t>();
-    uint8_t* dst_idx = dstIndexesMemPtr->getDataAs<uint8_t>();
+    const auto* src_data = srcMemPtr->getDataAs<const uint8_t>();
+    auto* dst_data = dstMemPtr->getDataAs<uint8_t>();
+    auto* dst_idx = dstIndexesMemPtr->getDataAs<uint8_t>();
 
     if (jit_mode) {
         topk_process(src_data, dst_data, dst_idx);
@@ -2255,7 +2256,7 @@ void TopK::topk_process(const uint8_t* in_ptr, uint8_t* out_ptr, uint8_t* out_id
                 uint8_t* out_ptr_a = out_ptr + (o * OA * I + i) * blk_size * data_size;
                 uint8_t* out_idx_ptr_a = out_idx_ptr + (o * OA * I + i) * blk_size * sizeof(int32_t);
                 size_t work_amount = 1;
-                topk_kernel_process(in_ptr_a, out_ptr_a, out_idx_ptr_a, NULL, NULL, work_amount);
+                topk_kernel_process(in_ptr_a, out_ptr_a, out_idx_ptr_a, nullptr, nullptr, work_amount);
             });
         } else if (algorithm == TopKAlgorithm::topk_bitonic_sort) {
             parallel_for(O, [&](size_t o) {
@@ -2372,7 +2373,7 @@ inline void TopK::prepare_original_idx() {
 //   empty tail: p-n elements in the rear don't need sorting,
 inline void TopK::bitonic_push_idx(int p, int n, std::vector<int>& vec, int& cnt, bool cmp_val) {
     // memory stride of adjacent elements in sorting
-    int sort_stride = static_cast<int>(I);
+    auto sort_stride = static_cast<int>(I);
     cnt = 0;
     for (int len = 2; len < p; len <<= 1) {
         for (int start = 0; start < p; start += len) {
@@ -2520,7 +2521,7 @@ void TopK::topk_ref_process(const float* src_data,
         if (sort_index) {
             for (int i2 = 0; i2 < top_k - 1; i2++) {
                 for (int i3 = top_k - 1; i3 > i2; i3--) {
-                    if (std::greater<int>()(max_indexes[i3 - 1], max_indexes[i3])) {
+                    if (std::greater<>()(max_indexes[i3 - 1], max_indexes[i3])) {
                         swap_func(i3, i3 - 1);
                     }
                 }

--- a/src/plugins/intel_cpu/src/nodes/unique.cpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.cpp
@@ -74,12 +74,12 @@ void Unique::initSupportedPrimitiveDescriptors() {
 
     std::vector<PortConfigurator> inPortConfigs = {{LayoutType::ncsp, dataPrecision}};
     if (!flattened) {
-        inPortConfigs.push_back({LayoutType::ncsp, axisPrecision});
+        inPortConfigs.emplace_back(LayoutType::ncsp, axisPrecision);
     }
     std::vector<PortConfigurator> outPortConfigs;
     outPortConfigs.reserve(4);
     for (int i = 0; i < 4; i++) {
-        outPortConfigs.push_back({LayoutType::ncsp, i == 0 ? dataPrecision : axisPrecision});
+        outPortConfigs.emplace_back(LayoutType::ncsp, i == 0 ? dataPrecision : axisPrecision);
     }
 
     addSupportedPrimDesc(inPortConfigs, outPortConfigs, implType);
@@ -159,7 +159,7 @@ void Unique::executeDynamicImpl(const dnnl::stream& strm) {
     VectorDims dstDataDims;
     Dim uniqLen = 1;
     if (flattened) {
-        uniqLen = std::accumulate(srcDataDims.begin(), srcDataDims.end(), 1, std::multiplies<Dim>());
+        uniqLen = std::accumulate(srcDataDims.begin(), srcDataDims.end(), 1, std::multiplies<>());
         dstDataDims = {uniqLen};
     } else {
         uniqLen = srcDataDims[axis];
@@ -266,7 +266,7 @@ void Unique::flattenTensorExec() {
     T* uniDataPtr = getDstDataAtPortAs<T>(UNIQUE_DATA);
     cpu_parallel_memcpy(uniDataPtr, uniDataTmpPtr, uniqueLen * sizeof(T));
     if (definedOutputs[FIRST_UNIQUE_IDX]) {
-        int* firstPtr = getDstDataAtPortAs<int>(FIRST_UNIQUE_IDX);
+        auto* firstPtr = getDstDataAtPortAs<int>(FIRST_UNIQUE_IDX);
         cpu_parallel_memcpy(firstPtr, firstUniTmp.data(), uniqueLen * sizeof(int));
     }
     if (definedOutputs[INPUT_TO_UNIQ_IDX]) {
@@ -299,11 +299,11 @@ void Unique::slicedTensorExec() {
     const auto axisDim = srcDataShape[axis];
     int64_t outerLen = 1lu;
     if (axis > 0) {
-        outerLen = std::accumulate(srcDataShape.begin(), srcDataShape.begin() + axis, 1, std::multiplies<Dim>());
+        outerLen = std::accumulate(srcDataShape.begin(), srcDataShape.begin() + axis, 1, std::multiplies<>());
     }
     int64_t innerLen = 1;
     if (static_cast<size_t>(axis) < srcDataShape.size() - 1) {
-        innerLen = std::accumulate(srcDataShape.begin() + axis + 1, srcDataShape.end(), 1, std::multiplies<Dim>());
+        innerLen = std::accumulate(srcDataShape.begin() + axis + 1, srcDataShape.end(), 1, std::multiplies<>());
     }
     const auto innerSizeB = innerLen * sizeof(T);
     const auto srcOuterStep = innerLen * axisDim;

--- a/src/plugins/intel_cpu/src/nodes/unique.hpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.hpp
@@ -17,14 +17,14 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override {
+    [[nodiscard]] bool created() const override {
         return getType() == Type::Unique;
     }
 
 protected:
     void executeDynamicImpl(const dnnl::stream& strm) override;
     void prepareParams() override;
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -23,9 +23,10 @@
 #include "weights_cache.hpp"
 
 #if defined(__linux__)
-#    include <signal.h>
 #    include <sys/auxv.h>
 #    include <sys/mman.h>
+
+#    include <csignal>
 #endif
 
 #include "cpu/x64/cpu_isa_traits.hpp"
@@ -54,7 +55,7 @@ static std::string getDeviceFullName() {
 #    else
         __cpuid(regs[0], regs[0], regs[1], regs[2], regs[3]);
 #    endif
-        char* ch = reinterpret_cast<char*>(&regs[0]);
+        auto* ch = reinterpret_cast<char*>(&regs[0]);
         for (size_t j = 0; j < sizeof(regs); j++) {
             if (ch[j] != '\0') {
                 brand_string += ch[j];
@@ -74,8 +75,8 @@ static std::string getDeviceFullName() {
 #    endif
 
 class SigAltStackSetup {
-    stack_t new_stack{0};
-    stack_t old_stack{0};
+    stack_t new_stack{nullptr};
+    stack_t old_stack{nullptr};
 
 public:
     SigAltStackSetup() {
@@ -84,7 +85,8 @@ public:
 
         auto minsigstksz = getauxval(AT_MINSIGSTKSZ);
         auto new_size = minsigstksz + SIGSTKSZ;
-        void* altstack = mmap(NULL, new_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+        void* altstack =
+            mmap(nullptr, new_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
         if (altstack == MAP_FAILED) {
             return;
         }
@@ -103,9 +105,9 @@ public:
         stack_t current_stack;
         if (new_stack.ss_sp) {
             // restore old stack if new_stack is still the current one
-            if (sigaltstack(NULL, &current_stack) == 0) {
+            if (sigaltstack(nullptr, &current_stack) == 0) {
                 if (current_stack.ss_sp == new_stack.ss_sp) {
-                    sigaltstack(&old_stack, NULL);
+                    sigaltstack(&old_stack, nullptr);
                 }
             }
             munmap(new_stack.ss_sp, new_stack.ss_size);
@@ -478,18 +480,18 @@ ov::Any Plugin::get_ro_property(const std::string& name, const ov::AnyMap& optio
         std::vector<std::string> capabilities;
         if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16) ||
             dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni_2)) {
-            capabilities.push_back(ov::device::capability::BF16);
+            capabilities.emplace_back(ov::device::capability::BF16);
         }
         if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core)) {
-            capabilities.push_back(ov::device::capability::WINOGRAD);
+            capabilities.emplace_back(ov::device::capability::WINOGRAD);
         }
-        capabilities.push_back(ov::device::capability::FP32);
+        capabilities.emplace_back(ov::device::capability::FP32);
         if (hasHardwareSupport(ov::element::f16)) {
-            capabilities.push_back(ov::device::capability::FP16);
+            capabilities.emplace_back(ov::device::capability::FP16);
         }
-        capabilities.push_back(ov::device::capability::INT8);
-        capabilities.push_back(ov::device::capability::BIN);
-        capabilities.push_back(ov::device::capability::EXPORT_IMPORT);
+        capabilities.emplace_back(ov::device::capability::INT8);
+        capabilities.emplace_back(ov::device::capability::BIN);
+        capabilities.emplace_back(ov::device::capability::EXPORT_IMPORT);
         return decltype(ov::device::capabilities)::value_type(std::move(capabilities));
     } else if (name == ov::range_for_async_infer_requests) {
         const std::tuple<unsigned int, unsigned int, unsigned int> range = std::make_tuple(1, 1, 1);

--- a/src/plugins/intel_cpu/src/post_ops.hpp
+++ b/src/plugins/intel_cpu/src/post_ops.hpp
@@ -61,19 +61,19 @@ struct ActivationPostOp : PostOp {
           m_beta(beta),
           m_gamma(gamma) {}
 
-    float alpha() const {
+    [[nodiscard]] float alpha() const {
         return m_alpha;
     }
 
-    float beta() const {
+    [[nodiscard]] float beta() const {
         return m_beta;
     }
 
-    float gamma() const {
+    [[nodiscard]] float gamma() const {
         return m_gamma;
     }
 
-    Type type() const {
+    [[nodiscard]] Type type() const {
         return m_type;
     }
 
@@ -100,15 +100,15 @@ struct ScaleShiftPostOp : PostOp {
           m_scales(std::move(_scales)),
           m_shifts(std::move(_shifts)) {}
 
-    const std::vector<float>& scales() const {
+    [[nodiscard]] const std::vector<float>& scales() const {
         return m_scales;
     }
 
-    const std::vector<float>& shifts() const {
+    [[nodiscard]] const std::vector<float>& shifts() const {
         return m_shifts;
     }
 
-    Type type() const {
+    [[nodiscard]] Type type() const {
         return m_type;
     }
 
@@ -134,31 +134,31 @@ struct FakeQuantizePostOp : PostOp {
           m_outputShift(std::move(outputShift)),
           m_levels(levels) {}
 
-    const std::vector<float>& cropLow() const {
+    [[nodiscard]] const std::vector<float>& cropLow() const {
         return m_cropLow;
     }
 
-    const std::vector<float>& cropHigh() const {
+    [[nodiscard]] const std::vector<float>& cropHigh() const {
         return m_cropHigh;
     }
 
-    const std::vector<float>& inputScale() const {
+    [[nodiscard]] const std::vector<float>& inputScale() const {
         return m_inputScale;
     }
 
-    const std::vector<float>& inputShift() const {
+    [[nodiscard]] const std::vector<float>& inputShift() const {
         return m_inputShift;
     }
 
-    const std::vector<float>& outputScale() const {
+    [[nodiscard]] const std::vector<float>& outputScale() const {
         return m_outputScale;
     }
 
-    const std::vector<float>& outputShift() const {
+    [[nodiscard]] const std::vector<float>& outputShift() const {
         return m_outputShift;
     }
 
-    size_t levels() const {
+    [[nodiscard]] size_t levels() const {
         return m_levels;
     }
 

--- a/src/plugins/intel_cpu/src/shape_inference/custom/adaptive_pooling.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/adaptive_pooling.hpp
@@ -24,7 +24,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(1);
     }
 
@@ -35,7 +35,7 @@ private:
 class AdaptivePoolingShapeInferFactory : public ShapeInferFactory {
 public:
     AdaptivePoolingShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/color_convert.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/color_convert.hpp
@@ -23,7 +23,7 @@ public:
     ColorConvertShapeInfer(bool singlePlain) : m_singlePlain(singlePlain) {}
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -34,7 +34,7 @@ private:
 class ColorConvertShapeInferFactory : public ShapeInferFactory {
 public:
     ColorConvertShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/eltwise.hpp
@@ -20,14 +20,14 @@ class EltwiseShapeInfer : public ShapeInferEmptyPads {
 public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 };
 
 class EltwiseShapeInferFactory : public ShapeInferFactory {
 public:
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<EltwiseShapeInfer>();
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/custom/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/fullyconnected.cpp
@@ -21,7 +21,7 @@ Result FCShapeInfer::infer(const std::vector<std::reference_wrapper<const Vector
     // NC           CoC       NCo
     VectorDims outputShape(out_rank, 1);
     // set Co
-    outputShape.back() = std::accumulate(weightShape.begin(), weightShape.end() - 1, 1, std::multiplies<Dim>());
+    outputShape.back() = std::accumulate(weightShape.begin(), weightShape.end() - 1, 1, std::multiplies<>());
     // set batch dims
     size_t batchRank = activationRank - channelRank;
     size_t startIdx = out_rank - batchRank - 1;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/fullyconnected.hpp
@@ -17,7 +17,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -28,7 +28,7 @@ private:
 class FCShapeInferFactory : public ShapeInferFactory {
 public:
     FCShapeInferFactory(const std::shared_ptr<ov::Node>& op) : m_op(op) {}
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<FCShapeInfer>(m_op->get_output_partial_shape(0).rank().get_length());
     }
 

--- a/src/plugins/intel_cpu/src/shape_inference/custom/gather.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/gather.hpp
@@ -23,7 +23,7 @@ public:
 
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(2);
     }
 
@@ -37,7 +37,7 @@ private:
 class GatherShapeInferFactory : public ShapeInferFactory {
 public:
     GatherShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/matmul.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/matmul.hpp
@@ -23,7 +23,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -37,7 +37,7 @@ private:
 class MMShapeInferFactory : public ShapeInferFactory {
 public:
     MMShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/ngram.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/ngram.hpp
@@ -18,7 +18,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -29,7 +29,7 @@ private:
 class NgramShapeInferFactory : public ShapeInferFactory {
 public:
     NgramShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/one_hot.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/one_hot.hpp
@@ -23,7 +23,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(1);
     }
 
@@ -34,7 +34,7 @@ private:
 class OneHotShapeInferFactory : public ShapeInferFactory {
 public:
     OneHotShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/priorbox.cpp
@@ -17,7 +17,7 @@ namespace ov::intel_cpu::node {
  */
 Result PriorBoxShapeInfer::infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) {
-    const int* in_data = data_dependency.at(0)->getDataAs<const int>();
+    const auto* in_data = data_dependency.at(0)->getDataAs<const int>();
     const int H = in_data[0];
     const int W = in_data[1];
     const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);

--- a/src/plugins/intel_cpu/src/shape_inference/custom/priorbox.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/priorbox.hpp
@@ -25,7 +25,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(0);
     }
 
@@ -36,7 +36,7 @@ private:
 class PriorBoxShapeInferFactory : public ShapeInferFactory {
 public:
     explicit PriorBoxShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/priorbox_clustered.cpp
@@ -17,7 +17,7 @@ namespace ov::intel_cpu::node {
  */
 Result PriorBoxClusteredShapeInfer::infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                                           const std::unordered_map<size_t, MemoryPtr>& data_dependency) {
-    const int* in_data = data_dependency.at(0)->getDataAs<const int>();
+    const auto* in_data = data_dependency.at(0)->getDataAs<const int>();
     const int H = in_data[0];
     const int W = in_data[1];
     const auto output = static_cast<size_t>(4 * H * W * m_number_of_priors);

--- a/src/plugins/intel_cpu/src/shape_inference/custom/priorbox_clustered.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/priorbox_clustered.hpp
@@ -25,7 +25,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(0);
     }
 
@@ -36,7 +36,7 @@ private:
 class PriorBoxClusteredShapeInferFactory : public ShapeInferFactory {
 public:
     explicit PriorBoxClusteredShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/reshape.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/reshape.cpp
@@ -19,7 +19,7 @@ Result ReshapeShapeInfer::infer(const std::vector<std::reference_wrapper<const V
     const auto& memPtr = data_dependency.at(RESHAPE_PATTERN);
     const auto data = memPtr->getData();
     const auto& dims = memPtr->getStaticDims();
-    const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
+    const auto outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>());
     std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(memPtr->getDesc().getPrecision(),
                                                                    data,
                                                                    outputPatternSize,
@@ -54,8 +54,8 @@ Result ReshapeShapeInfer::infer(const std::vector<std::reference_wrapper<const V
             outputShape[minusOneIdx] = 0;
         }
     }
-    inputProduct = std::accumulate(inputShape.begin(), inputShape.end(), 1, std::multiplies<Dim>());
-    outputProduct = std::accumulate(outputShape.begin(), outputShape.end(), 1, std::multiplies<Dim>());
+    inputProduct = std::accumulate(inputShape.begin(), inputShape.end(), 1, std::multiplies<>());
+    outputProduct = std::accumulate(outputShape.begin(), outputShape.end(), 1, std::multiplies<>());
     if (minusOneCount > 1 || inputProduct != outputProduct) {
         OPENVINO_THROW("[cpu]reshape: the shape of input data ",
                        ov::intel_cpu::vec2str(inputShape),
@@ -78,7 +78,7 @@ Result SqueezeShapeInfer::infer(const std::vector<std::reference_wrapper<const V
         const auto data = memPtr->getData();
         const auto& dims = memPtr->getStaticDims();
         if (dims.size() != 0) {
-            const size_t outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
+            const size_t outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>());
             std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(memPtr->getDesc().getPrecision(),
                                                                            data,
                                                                            outputPatternSize,
@@ -124,7 +124,7 @@ Result UnsqueezeShapeInfer::infer(const std::vector<std::reference_wrapper<const
     const auto& memPtr = data_dependency.at(UNSQUEEZE_PATTERN);
     const auto data = memPtr->getData();
     const auto& dims = memPtr->getStaticDims();
-    size_t outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<Dim>());
+    size_t outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>());
     std::vector<int64_t> originOutPattern = ov::get_raw_data_as<int64_t>(memPtr->getDesc().getPrecision(),
                                                                          data,
                                                                          outputPatternSize,

--- a/src/plugins/intel_cpu/src/shape_inference/custom/reshape.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/reshape.hpp
@@ -17,7 +17,7 @@ public:
     ReshapeShapeInfer(bool specialZero) : m_specialZero(specialZero) {}
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(1);
     }
 
@@ -27,20 +27,20 @@ private:
 
 class SqueezeShapeInfer : public ShapeInferEmptyPads {
 public:
-    SqueezeShapeInfer() {}
+    SqueezeShapeInfer() = default;
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(1);
     }
 };
 
 class UnsqueezeShapeInfer : public ShapeInferEmptyPads {
 public:
-    UnsqueezeShapeInfer() {}
+    UnsqueezeShapeInfer() = default;
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return PortMask(1);
     }
 };
@@ -48,7 +48,7 @@ public:
 class ReshapeShapeInferFactory : public ShapeInferFactory {
 public:
     ReshapeShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.cpp
@@ -8,7 +8,7 @@ namespace ov::intel_cpu::node {
 
 class RMSNormShapeInfer : public ShapeInferEmptyPads {
 public:
-    RMSNormShapeInfer() {}
+    RMSNormShapeInfer() = default;
 
     IShapeInfer::Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                               const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
@@ -16,7 +16,7 @@ public:
         return {{dims}, ShapeInferStatus::success};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.hpp
@@ -15,7 +15,7 @@ namespace ov::intel_cpu::node {
 class RMSNormShapeInferFactory : public ShapeInferFactory {
 public:
     RMSNormShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
@@ -64,7 +64,7 @@ public:
         return {{output_dims, present_k_dims, present_v_dims}, ShapeInferStatus::success};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 

--- a/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.hpp
@@ -15,7 +15,7 @@ namespace ov::intel_cpu::node {
 class SDPAShapeInferFactory : public ShapeInferFactory {
 public:
     SDPAShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/shapeof.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/shapeof.hpp
@@ -25,14 +25,14 @@ public:
         return {{VectorDims{input_shapes.front().get().size()}}, ShapeInferStatus::success};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 };
 
 class ShapeOfShapeInferFactory : public ShapeInferFactory {
 public:
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<ShapeOfShapeInfer>();
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/custom/strided_slice.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/strided_slice.hpp
@@ -41,7 +41,7 @@ private:
 class StridedSliceShapeInferFactory : public ShapeInferFactory {
 public:
     StridedSliceShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     const std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/custom/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/subgraph.hpp
@@ -28,7 +28,7 @@ public:
         return {snippets_result.dims, m_status_map.at(snippets_result.status)};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -43,7 +43,7 @@ public:
         m_subgraph = ov::as_type_ptr<snippets::op::Subgraph>(op);
         OPENVINO_ASSERT(m_subgraph, "Invalid node type detected in SnippetShapeInferFactory");
     }
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<SnippetShapeInfer>(m_subgraph);
     }
 

--- a/src/plugins/intel_cpu/src/shape_inference/custom/transpose.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/transpose.hpp
@@ -20,7 +20,7 @@ public:
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         OPENVINO_THROW("TODO: Support parameterized Order input for dynamic shapes.");
     }
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -34,7 +34,7 @@ public:
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -48,7 +48,7 @@ private:
 class TransposeShapeInferFactory : public ShapeInferFactory {
 public:
     TransposeShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     const std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -141,7 +141,7 @@ public:
     using iface_type = IStaticShapeInfer;
 
     ShapeInferBase(std::shared_ptr<Node> node) : m_input_ranks{}, m_node{std::move(node)} {
-        static_assert(std::is_same<int64_t, Dimension::value_type>::value, "Rank type not match to input_ranks type.");
+        static_assert(std::is_same_v<int64_t, Dimension::value_type>, "Rank type not match to input_ranks type.");
         for (size_t i = 0; i < m_node->get_input_size(); ++i) {
             const auto& shape = m_node->get_input_partial_shape(i);
             const auto& rank_length = shape.rank().is_static() ? shape.rank().get_length() : -1;
@@ -184,7 +184,7 @@ public:
         return m_input_ranks;
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 
@@ -243,12 +243,12 @@ public:
         ov::OutputVector new_inputs;
         for (size_t i = 0; i < op->get_input_size(); ++i) {
             if (auto t = tensor_accessor(i)) {
-                new_inputs.push_back(std::make_shared<ov::opset1::Constant>(t));
+                new_inputs.emplace_back(std::make_shared<ov::opset1::Constant>(t));
             } else if (auto c = ov::as_type<const op::v0::Constant>(op->get_input_node_ptr(i))) {
-                new_inputs.push_back(c->clone_with_new_inputs(ov::OutputVector{}));
+                new_inputs.emplace_back(c->clone_with_new_inputs(ov::OutputVector{}));
             } else {
-                new_inputs.push_back(std::make_shared<op::v0::Parameter>(op->get_input_element_type(i),
-                                                                         input_shapes[i].to_partial_shape()));
+                new_inputs.emplace_back(std::make_shared<op::v0::Parameter>(op->get_input_element_type(i),
+                                                                            input_shapes[i].to_partial_shape()));
             }
         }
         local_op = op->clone_with_new_inputs(new_inputs);
@@ -268,7 +268,7 @@ public:
         return {std::move(output_shapes)};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         // For fallback return full port mask to try get data for all node's inputs
         return FULL_PORT_MASK;
     }
@@ -284,7 +284,7 @@ public:
         return {shape_infer(static_cast<TOp*>(m_node.get()), input_shapes, tensor_accessor)};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return MASK;
     }
 };
@@ -340,7 +340,7 @@ public:
         return {shape_infer(static_cast<TOp*>(m_node.get()), input_shapes, m_pads_begin, m_pads_end, tensor_accessor)};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return MASK;
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
@@ -55,7 +55,7 @@ public:
      *
      * @return port_mask_t a bit mask where each bit corresponds to an input port number.
      */
-    virtual port_mask_t get_port_mask() const = 0;
+    [[nodiscard]] virtual port_mask_t get_port_mask() const = 0;
 };
 
 /**
@@ -85,7 +85,7 @@ constexpr IShapeInfer::port_mask_t FULL_PORT_MASK = 0xffffffff;
 class ShapeInferFactory {
 public:
     virtual ~ShapeInferFactory() = default;
-    virtual ShapeInferPtr makeShapeInfer() const = 0;
+    [[nodiscard]] virtual ShapeInferPtr makeShapeInfer() const = 0;
 };
 
 /**
@@ -101,7 +101,7 @@ public:
      */
     NgraphShapeInferFactory(std::shared_ptr<ov::Node> op);
 
-    ShapeInferPtr makeShapeInfer() const override;
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:
     std::shared_ptr<ov::Node> m_op;

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_internal_dyn.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_internal_dyn.hpp
@@ -21,14 +21,14 @@ public:
         return {{}, ShapeInferStatus::skip};
     }
 
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return FULL_PORT_MASK;
     }
 };
 
 class InternalDynShapeInferFactory final : public ShapeInferFactory {
 public:
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<InternalDynShapeInfer>();
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_pass_through.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_pass_through.hpp
@@ -21,14 +21,14 @@ public:
         OPENVINO_ASSERT(!input_shapes.empty());
         return {{input_shapes.front()}, ShapeInferStatus::success};
     }
-    port_mask_t get_port_mask() const override {
+    [[nodiscard]] port_mask_t get_port_mask() const override {
         return EMPTY_PORT_MASK;
     }
 };
 
 class PassThroughShapeInferFactory final : public ShapeInferFactory {
 public:
-    ShapeInferPtr makeShapeInfer() const override {
+    [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<ShapeInferPassThrough>();
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/static_dimension.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_dimension.cpp
@@ -30,7 +30,7 @@ bool StaticDimension::operator!=(const StaticDimension& dim) const {
 }
 
 StaticDimension StaticDimension::operator+(const StaticDimension& dim) const {
-    return StaticDimension(m_dimension + dim.m_dimension);
+    return {m_dimension + dim.m_dimension};
 }
 
 StaticDimension& StaticDimension::operator+=(const StaticDimension& dim) {
@@ -38,11 +38,11 @@ StaticDimension& StaticDimension::operator+=(const StaticDimension& dim) {
 }
 
 StaticDimension StaticDimension::operator-(const StaticDimension& dim) const {
-    return StaticDimension(m_dimension - dim.m_dimension);
+    return {m_dimension - dim.m_dimension};
 }
 
 StaticDimension StaticDimension::operator*(const StaticDimension& dim) const {
-    return StaticDimension(m_dimension * dim.m_dimension);
+    return {m_dimension * dim.m_dimension};
 }
 
 StaticDimension& StaticDimension::operator*=(const StaticDimension& dim) {
@@ -55,7 +55,7 @@ StaticDimension StaticDimension::operator/(const value_type divisor) const {
     if (m_dimension % divisor) {
         return StaticDimension{};
     }
-    return StaticDimension(m_dimension / divisor);
+    return {m_dimension / divisor};
 }
 
 StaticDimension& StaticDimension::operator/=(const value_type divisor) {

--- a/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
@@ -52,18 +52,18 @@ public:
         return false;
     }
 
-    value_type get_length() const;
-    value_type get_min_length() const;
-    value_type get_max_length() const;
+    [[nodiscard]] value_type get_length() const;
+    [[nodiscard]] value_type get_min_length() const;
+    [[nodiscard]] value_type get_max_length() const;
 
-    Interval& get_interval() const {
+    [[nodiscard]] Interval& get_interval() const {
         static Interval dummy{};
         OPENVINO_THROW("[shape infer] Shoudn't call get_interval() in StaticDimension.");
         return dummy;
     }
 
-    bool same_scheme(const StaticDimension& dim) const;
-    bool compatible(const StaticDimension& d) const;
+    [[nodiscard]] bool same_scheme(const StaticDimension& dim) const;
+    [[nodiscard]] bool compatible(const StaticDimension& d) const;
     static bool merge(StaticDimension& dst, const StaticDimension& d1, const StaticDimension& d2);
     static bool broadcast_merge(StaticDimension& dst, const StaticDimension& d1, const StaticDimension& d2);
 

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.cpp
@@ -128,7 +128,7 @@ bool StaticShape::broadcast_merge_into(StaticShape& dst,
 
 //-- Shape as reference
 StaticShapeRef::StaticShapeAdapter(const StaticShape& shape) : m_dims{&(*shape)} {}
-StaticShapeRef::StaticShapeAdapter(const ov::PartialShape&) : m_dims{} {
+StaticShapeRef::StaticShapeAdapter(const ov::PartialShape&) {
     partial_shape_convert_throw();
 }
 

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
@@ -33,8 +33,8 @@ using StaticShape = StaticShapeAdapter<VectorDims>;
 
 template <class T>
 constexpr bool is_static_shape_adapter() {
-    using U = typename std::decay<T>::type;
-    return std::is_same<U, StaticShapeRef>::value || std::is_same<U, StaticShape>::value;
+    using U = std::decay_t<T>;
+    return std::is_same_v<U, StaticShapeRef> || std::is_same_v<U, StaticShape>;
 }
 
 /**
@@ -54,9 +54,9 @@ public:
     using iterator = typename TDims::iterator;
     using const_iterator = typename TDims::const_iterator;
 
-    static_assert(std::is_same<dim_type, typename StaticDimension::value_type>::value,
+    static_assert(std::is_same_v<dim_type, typename StaticDimension::value_type>,
                   "Static dimension must be of the same type as the CPU dimension.");
-    static_assert(std::is_standard_layout<StaticDimension>::value,
+    static_assert(std::is_standard_layout_v<StaticDimension>,
                   "StaticShape must be standard layout to cast on CPU dimension type.");
     static_assert(sizeof(dim_type) == sizeof(StaticDimension),
                   "StaticDimension must have the same number of bytes as the CPU dimension type.");
@@ -100,24 +100,24 @@ public:
     }
 
     template <class T>
-    constexpr typename std::enable_if<is_static_shape_adapter<T>(), bool>::type compatible(const T& other) const {
+    constexpr std::enable_if_t<is_static_shape_adapter<T>(), bool> compatible(const T& other) const {
         // for static shape compatible == both shape equals
         return *this == other;
     }
 
     template <class T>
-    constexpr typename std::enable_if<is_static_shape_adapter<T>(), bool>::type same_scheme(const T& other) const {
+    constexpr std::enable_if_t<is_static_shape_adapter<T>(), bool> same_scheme(const T& other) const {
         // for static shape same_scheme == compatible;
         return compatible(other);
     }
 
-    ov::Rank rank() const;
+    [[nodiscard]] ov::Rank rank() const;
     bool merge_rank(const ov::Rank& r);
-    ov::Shape to_shape() const;
-    ov::Shape get_max_shape() const;
-    ov::Shape get_min_shape() const;
-    ov::Shape get_shape() const;
-    ov::PartialShape to_partial_shape() const;
+    [[nodiscard]] ov::Shape to_shape() const;
+    [[nodiscard]] ov::Shape get_max_shape() const;
+    [[nodiscard]] ov::Shape get_min_shape() const;
+    [[nodiscard]] ov::Shape get_shape() const;
+    [[nodiscard]] ov::PartialShape to_partial_shape() const;
 
     static bool merge_into(StaticShapeAdapter& dst, const StaticShapeAdapter& src);
     static bool broadcast_merge_into(StaticShapeAdapter& dst,
@@ -125,11 +125,11 @@ public:
                                      const ov::op::AutoBroadcastSpec& autob);
 
     //-- Container functions
-    const_iterator cbegin() const noexcept {
+    [[nodiscard]] const_iterator cbegin() const noexcept {
         return m_dims.cbegin();
     }
 
-    const_iterator begin() const noexcept {
+    [[nodiscard]] const_iterator begin() const noexcept {
         return cbegin();
     }
 
@@ -137,11 +137,11 @@ public:
         return m_dims.begin();
     }
 
-    const_iterator cend() const noexcept {
+    [[nodiscard]] const_iterator cend() const noexcept {
         return m_dims.cend();
     }
 
-    const_iterator end() const noexcept {
+    [[nodiscard]] const_iterator end() const noexcept {
         return cend();
     }
 
@@ -149,11 +149,11 @@ public:
         return m_dims.end();
     }
 
-    size_t size() const {
+    [[nodiscard]] size_t size() const {
         return m_dims.size();
     }
 
-    bool empty() const {
+    [[nodiscard]] bool empty() const {
         return m_dims.empty();
     }
 
@@ -212,16 +212,16 @@ public:
     using iterator = typename TDims::const_iterator;
     using const_iterator = typename TDims::const_iterator;
 
-    static_assert(std::is_same<dim_type, typename StaticDimension::value_type>::value,
+    static_assert(std::is_same_v<dim_type, typename StaticDimension::value_type>,
                   "Static dimension must be of the same type as the CPU dimension.");
-    static_assert(std::is_standard_layout<StaticDimension>::value,
+    static_assert(std::is_standard_layout_v<StaticDimension>,
                   "StaticShape must be standard layout to cast on CPU dimension type.");
     static_assert(sizeof(dim_type) == sizeof(StaticDimension),
                   "StaticDimension must have the same number of bytes as the CPU dimension type.");
 
-    constexpr StaticShapeAdapter() : m_dims{} {}
+    constexpr StaticShapeAdapter() = default;
     constexpr StaticShapeAdapter(const TDims& dims) : m_dims{&dims} {}
-    constexpr StaticShapeAdapter(const StaticShapeAdapter<const TDims>& other) : m_dims{other.m_dims} {}
+    constexpr StaticShapeAdapter(const StaticShapeAdapter<const TDims>& other) = default;
 
     StaticShapeAdapter(const StaticShape& shape);
     StaticShapeAdapter(const ov::PartialShape&);
@@ -248,47 +248,47 @@ public:
     }
 
     template <class T>
-    constexpr typename std::enable_if<is_static_shape_adapter<T>(), bool>::type compatible(const T& other) const {
+    constexpr std::enable_if_t<is_static_shape_adapter<T>(), bool> compatible(const T& other) const {
         // for static shape compatible == both shape equals
         return *this == other;
     }
 
     template <class T>
-    constexpr typename std::enable_if<is_static_shape_adapter<T>(), bool>::type same_scheme(const T& other) const {
+    constexpr std::enable_if_t<is_static_shape_adapter<T>(), bool> same_scheme(const T& other) const {
         // for static shape same_scheme == compatible;
         return compatible(other);
     }
 
-    ov::Rank rank() const;
+    [[nodiscard]] ov::Rank rank() const;
     bool merge_rank(const ov::Rank& r);
-    ov::Shape to_shape() const;
-    ov::Shape get_max_shape() const;
-    ov::Shape get_min_shape() const;
-    ov::Shape get_shape() const;
-    ov::PartialShape to_partial_shape() const;
+    [[nodiscard]] ov::Shape to_shape() const;
+    [[nodiscard]] ov::Shape get_max_shape() const;
+    [[nodiscard]] ov::Shape get_min_shape() const;
+    [[nodiscard]] ov::Shape get_shape() const;
+    [[nodiscard]] ov::PartialShape to_partial_shape() const;
 
     //-- Container functions
-    const_iterator cbegin() const noexcept {
+    [[nodiscard]] const_iterator cbegin() const noexcept {
         return m_dims ? m_dims->cbegin() : const_iterator{};
     }
 
-    const_iterator begin() const noexcept {
+    [[nodiscard]] const_iterator begin() const noexcept {
         return cbegin();
     }
 
-    const_iterator cend() const noexcept {
+    [[nodiscard]] const_iterator cend() const noexcept {
         return m_dims ? m_dims->cend() : const_iterator{};
     }
 
-    const_iterator end() const noexcept {
+    [[nodiscard]] const_iterator end() const noexcept {
         return cend();
     }
 
-    size_t size() const noexcept {
+    [[nodiscard]] size_t size() const noexcept {
         return m_dims ? m_dims->size() : 0;
     }
 
-    bool empty() const {
+    [[nodiscard]] bool empty() const {
         return m_dims ? m_dims->empty() : true;
     }
 
@@ -297,8 +297,7 @@ private:
 };
 
 template <class T>
-typename std::enable_if<is_static_shape_adapter<T>(), std::ostream&>::type operator<<(std::ostream& out,
-                                                                                      const T& shape) {
+std::enable_if_t<is_static_shape_adapter<T>(), std::ostream&> operator<<(std::ostream& out, const T& shape) {
     out << '{';
     if (!shape.empty()) {
         std::copy(shape.cbegin(), shape.cend() - 1, std::ostream_iterator<StaticDimension>(out, ","));
@@ -309,7 +308,7 @@ typename std::enable_if<is_static_shape_adapter<T>(), std::ostream&>::type opera
 }
 
 template <class T, class U>
-constexpr typename std::enable_if<is_static_shape_adapter<T>() && is_static_shape_adapter<U>(), bool>::type operator==(
+constexpr std::enable_if_t<is_static_shape_adapter<T>() && is_static_shape_adapter<U>(), bool> operator==(
     const T& lhs,
     const U& rhs) {
     // The CPU dimension type and StaticDimension::value_type is same,

--- a/src/plugins/intel_cpu/src/sub_memory_manager.hpp
+++ b/src/plugins/intel_cpu/src/sub_memory_manager.hpp
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <assert.h>
-
+#include <cassert>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
@@ -179,7 +179,7 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
             return false;
         }
 
-        const float* input_scale_ptr = input_scale_constant->get_data_ptr<float>();
+        const auto* input_scale_ptr = input_scale_constant->get_data_ptr<float>();
         if (*input_scale_ptr == 0.f) {
             OPENVINO_THROW("Cannot handle zero input scale");
         }
@@ -204,7 +204,7 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
         if (input_shift_it != pattern_map.end()) {
             const auto input_shift_constant =
                 ov::as_type_ptr<op::v0::Constant>(input_shift_it->second.get_node_shared_ptr());
-            const float* input_shift_ptr = input_shift_constant->get_data_ptr<float>();
+            const auto* input_shift_ptr = input_shift_constant->get_data_ptr<float>();
             runtime_info["inputShift"] = *input_shift_ptr;
         }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_power_static.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_power_static.cpp
@@ -78,21 +78,21 @@ std::shared_ptr<ov::Node> convert(const std::shared_ptr<BaseOp>& node) {
     std::shared_ptr<ov::opset1::Constant> powerNode =
         ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(constPort));
     const float value = powerNode->cast_vector<float>()[0];
-    if (std::is_same<BaseOp, ov::opset1::Power>::value) {
+    if (std::is_same_v<BaseOp, ov::opset1::Power>) {
         return std::make_shared<ov::intel_cpu::PowerStaticNode>(node->input(nonConstPort).get_source_output(),
                                                                 value,
                                                                 1.0f,
                                                                 0.0f,
                                                                 node->output(0).get_element_type());
     }
-    if (std::is_same<BaseOp, ov::opset1::Add>::value) {
+    if (std::is_same_v<BaseOp, ov::opset1::Add>) {
         return std::make_shared<ov::intel_cpu::PowerStaticNode>(node->input(nonConstPort).get_source_output(),
                                                                 1.0f,
                                                                 1.0f,
                                                                 value,
                                                                 node->output(0).get_element_type());
     }
-    if (std::is_same<BaseOp, ov::opset1::Subtract>::value) {
+    if (std::is_same_v<BaseOp, ov::opset1::Subtract>) {
         float scale = 1.0f;
         float shift = value;
         if (constPort == 0) {
@@ -106,7 +106,7 @@ std::shared_ptr<ov::Node> convert(const std::shared_ptr<BaseOp>& node) {
                                                                 shift,
                                                                 node->output(0).get_element_type());
     }
-    if (std::is_same<BaseOp, ov::opset1::Multiply>::value) {
+    if (std::is_same_v<BaseOp, ov::opset1::Multiply>) {
         return std::make_shared<ov::intel_cpu::PowerStaticNode>(node->input(nonConstPort).get_source_output(),
                                                                 1.f,
                                                                 value,

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/rnn_sequences_optimization.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/rnn_sequences_optimization.cpp
@@ -148,6 +148,7 @@ ov::intel_cpu::OptimizeLSTMSequenceTransposes::OptimizeLSTMSequenceTransposes() 
     this->register_matcher(m, callback);
 }
 
+// NOLINTNEXTLINE(modernize-use-equals-default)
 ov::intel_cpu::OptimizeSequenceTransposes::OptimizeSequenceTransposes() {
     ADD_MATCHER_FOR_THIS(OptimizeLSTMSequenceTransposes)
     ADD_MATCHER_FOR_THIS(OptimizeRNNSequenceTransposes)

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
@@ -132,8 +132,8 @@ ov::intel_cpu::QKVProjFusion::QKVProjFusion() {
             }
 
             proj_size.push_back(wshape[0]);
-            args.push_back(constw);
-            deq_scales.push_back(deq_scale);
+            args.emplace_back(constw);
+            deq_scales.emplace_back(deq_scale);
             outputs.push_back(mm->get_default_output());
         }
 
@@ -262,9 +262,9 @@ ov::intel_cpu::QKVProjFusion2::QKVProjFusion2() {
         OutputVector args = {pattern_map.at(input), qkv_proj_weight_node, qkv_proj_weight_node, qkv_proj_weight_node};
         if (is_quantized_int8) {
             auto scales = pattern_map.at(qkv_proj_weight_scales_per_OC).get_node_shared_ptr();
-            args.push_back(scales);
-            args.push_back(scales);
-            args.push_back(scales);
+            args.emplace_back(scales);
+            args.emplace_back(scales);
+            args.emplace_back(scales);
         }
         auto old_node = root;
         auto new_node = std::make_shared<QKVProjectionNode>(args, config);

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/shape_inference.hpp
@@ -20,8 +20,8 @@ protected:
      * @brief get shape infer instances for operations from backend-specific opset
      * @return register ShapeInferPtr
      */
-    ShapeInferPtr get_specific_op_shape_infer(const ov::DiscreteTypeInfo& key,
-                                              const std::shared_ptr<ov::Node>& op) const override;
+    [[nodiscard]] ShapeInferPtr get_specific_op_shape_infer(const ov::DiscreteTypeInfo& key,
+                                                            const std::shared_ptr<ov::Node>& op) const override;
 };
 
 }  // namespace ov::snippets

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "cpu/x64/cpu_isa_traits.hpp"
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/type/element_type.hpp"
@@ -62,9 +64,8 @@ size_t compute_inner_n_block(const ov::element::Type& precision);
 size_t compute_inner_k_block(const ov::element::Type& precision);
 
 /// \brief  Computes N dim in output blocked shape of BrgemmCopyB. Depends on tensor precision
-template <
-    typename T,
-    typename = typename std::enable_if<(std::is_same<T, size_t>::value || std::is_same<T, int64_t>::value), bool>::type>
+template <typename T,
+          typename = typename std::enable_if_t<(std::is_same_v<T, size_t> || std::is_same_v<T, int64_t>), bool>>
 inline T compute_repacked_n_dim(T n, const ov::element::Type& precision) {
     return ov::snippets::utils::rnd_up(n, static_cast<T>(compute_inner_n_block(precision)));
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.cpp
@@ -18,10 +18,7 @@ std::shared_ptr<Node> PerfCountRdtscBegin::clone_with_new_inputs(const OutputVec
 }
 
 /////////////////////////PerfCountRdtscEnd//////////////////////
-PerfCountRdtscEnd::PerfCountRdtscEnd(const Output<Node>& pc_begin)
-    : ov::snippets::op::PerfCountEndBase({pc_begin}),
-      accumulation(0ul),
-      iteration(0u) {
+PerfCountRdtscEnd::PerfCountRdtscEnd(const Output<Node>& pc_begin) : ov::snippets::op::PerfCountEndBase({pc_begin}) {
     constructor_validate_and_infer_types();
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -38,7 +38,7 @@ public:
     OPENVINO_OP("PerfCountRdtscEnd", "SnippetsOpset", PerfCountEndBase);
     PerfCountRdtscEnd(const Output<Node>& pc_begin);
     PerfCountRdtscEnd() = default;
-    ~PerfCountRdtscEnd() {
+    ~PerfCountRdtscEnd() override {
         double avg = 0;
         if (iteration != 0) {
             // Note: theoretically accumulation could be larger than 2^53, however

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/expressions/brgemm_copy_b_buffer_expressions.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/expressions/brgemm_copy_b_buffer_expressions.cpp
@@ -4,6 +4,8 @@
 
 #include "brgemm_copy_b_buffer_expressions.hpp"
 
+#include <memory>
+
 #include "snippets/lowered/loop_manager.hpp"
 #include "snippets/utils/utils.hpp"
 #include "transformations/snippets/x64/op/brgemm_copy_b.hpp"
@@ -20,7 +22,7 @@ RepackedWeightsBufferExpression::RepackedWeightsBufferExpression(
     : BufferExpression(n, factory) {}
 
 snippets::lowered::ExpressionPtr RepackedWeightsBufferExpression::clone() const {
-    return std::shared_ptr<RepackedWeightsBufferExpression>(new RepackedWeightsBufferExpression(*this));
+    return std::make_shared<RepackedWeightsBufferExpression>(*this);
 }
 
 void RepackedWeightsBufferExpression::validate() const {
@@ -68,7 +70,7 @@ CompensationsBufferExpression::CompensationsBufferExpression(
     : BufferExpression(n, factory) {}
 
 snippets::lowered::ExpressionPtr CompensationsBufferExpression::clone() const {
-    return std::shared_ptr<CompensationsBufferExpression>(new CompensationsBufferExpression(*this));
+    return std::make_shared<CompensationsBufferExpression>(*this);
 }
 
 void CompensationsBufferExpression::validate() const {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
@@ -98,7 +98,7 @@ bool BrgemmExternalRepackingAdjuster::run(const snippets::lowered::LinearIR& lin
         // src data + dst data per kernel call
         const auto src_data = N * K * prc.size();
         const auto dst_data =
-            std::accumulate(blk_shape.rbegin(), blk_shape.rbegin() + 3, prc.size(), std::multiplies<size_t>());
+            std::accumulate(blk_shape.rbegin(), blk_shape.rbegin() + 3, prc.size(), std::multiplies<>());
         data_size += src_data + dst_data;
 
         update_kernel(p.second, shape, layout, N, K, prc);

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/shape_inference.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/shape_inference.hpp
@@ -20,8 +20,8 @@ protected:
      * @brief get shape infer instances for operations from backend-specific opset
      * @return register ShapeInferPtr
      */
-    ShapeInferPtr get_specific_op_shape_infer(const ov::DiscreteTypeInfo& key,
-                                              const std::shared_ptr<ov::Node>& op) const override;
+    [[nodiscard]] ShapeInferPtr get_specific_op_shape_infer(const ov::DiscreteTypeInfo& key,
+                                                            const std::shared_ptr<ov::Node>& op) const override;
 };
 
 }  // namespace ov::snippets

--- a/src/plugins/intel_cpu/src/transformations/tpp/common/op/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/common/op/brgemm.hpp
@@ -39,11 +39,11 @@ public:
               float beta = 1);
     BrgemmTPP() = default;
 
-    std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
+    [[nodiscard]] std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     bool visit_attributes(AttributeVisitor& visitor) override;
 
-    float get_beta() const {
+    [[nodiscard]] float get_beta() const {
         return m_beta;
     }
     void set_beta(float beta) {

--- a/src/plugins/intel_cpu/src/transformations/tpp/common/pass/lowered/brgemm_tpp_blocking.hpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/common/pass/lowered/brgemm_tpp_blocking.hpp
@@ -39,10 +39,11 @@ public:
     };
 
 private:
-    std::tuple<size_t, size_t, size_t> get_blocking_params(
+    [[nodiscard]] std::tuple<size_t, size_t, size_t> get_blocking_params(
         const ov::snippets::lowered::ExpressionPtr& brgemm_expr) const override;
-    ov::snippets::lowered::SpecificIterationHandlers get_k_loop_handlers(size_t work_amount,
-                                                                         size_t block_size) const override;
+    [[nodiscard]] ov::snippets::lowered::SpecificIterationHandlers get_k_loop_handlers(
+        size_t work_amount,
+        size_t block_size) const override;
 };
 
 }  // namespace ov::intel_cpu::tpp::pass

--- a/src/plugins/intel_cpu/src/transformations/tpp/common/pass/lowered/set_tpp_leading_dim.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/common/pass/lowered/set_tpp_leading_dim.cpp
@@ -110,7 +110,7 @@ size_t get_leading_dim(ExpressionPort port, const snippets::lowered::LoopManager
         }
     };
     return layout.size() == 1 ? shape.back()
-                              : std::accumulate(shape.cbegin() + dim() + 1, shape.cend(), 1, std::multiplies<size_t>());
+                              : std::accumulate(shape.cbegin() + dim() + 1, shape.cend(), 1, std::multiplies<>());
 }
 
 }  // namespace

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/op/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/op/eltwise.hpp
@@ -23,13 +23,13 @@ class EltwiseTPP : public modifier::TensorProcessingPrimitive {
 public:
     static bool is_supported(const std::shared_ptr<ov::Node>& node);
     bool visit_attributes(AttributeVisitor& visitor);
-    virtual OpDescTPP get_op_desc() const = 0;
+    [[nodiscard]] virtual OpDescTPP get_op_desc() const = 0;
 };
 
 class BinaryEltwiseTPP : public EltwiseTPP {
 public:
     BinaryEltwiseTPP(libxsmm_meltw_binary_type op_type);
-    OpDescTPP get_op_desc() const override {
+    [[nodiscard]] OpDescTPP get_op_desc() const override {
         return OpDescTPP(m_op_type, m_flags);
     }
 
@@ -44,7 +44,7 @@ protected:
 class UnaryEltwiseTPP : public EltwiseTPP {
 public:
     UnaryEltwiseTPP(libxsmm_meltw_unary_type op_type);
-    OpDescTPP get_op_desc() const override {
+    [[nodiscard]] OpDescTPP get_op_desc() const override {
         return OpDescTPP(m_op_type);
     }
 

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/op/factory.hpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/op/factory.hpp
@@ -12,8 +12,8 @@ class NodeFactory {
 public:
     static std::shared_ptr<ov::Node> create(const std::shared_ptr<ov::Node>& n);
     static bool is_supported(const std::shared_ptr<ov::Node>& n);
-    typedef std::function<std::shared_ptr<ov::Node>(const std::shared_ptr<ov::Node>&)> tpp_builder;
-    typedef std::function<bool(const std::shared_ptr<ov::Node>&)> tpp_matcher;
+    using tpp_builder = std::function<std::shared_ptr<ov::Node>(const std::shared_ptr<ov::Node>&)>;
+    using tpp_matcher = std::function<bool(const std::shared_ptr<ov::Node>&)>;
     struct TPPCustomBuilder {
         tpp_matcher matcher;
         tpp_builder builder;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -342,7 +342,7 @@ void Transformations::UpToLpt() {
     }
 }
 
-void Transformations::CpuSpecificOpSet(void) {
+void Transformations::CpuSpecificOpSet() {
     CPU_DEBUG_CAP_TRANSFORMATION_SCOPE(this, Specific);
 
     ConvertToCPUSpecificOpset(model, config);
@@ -1044,7 +1044,7 @@ void Transformations::PostLpt() {
     postLPTPassManager.run_passes(model);
 }
 
-void Transformations::MainSnippets(void) {
+void Transformations::MainSnippets() {
 // Disable MainSnippets for int8 models on arm platforms due to performance issues
 // Ticket: 163408
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
@@ -1197,7 +1197,7 @@ void Transformations::MainSnippets(void) {
             return false;
         }
         const auto parallel_work_amount =
-            std::accumulate(shape.rbegin() + 2, shape.rend(), ov::Dimension(1), std::multiplies<ov::Dimension>());
+            std::accumulate(shape.rbegin() + 2, shape.rend(), ov::Dimension(1), std::multiplies<>());
         // Ticket 160154: enable tokenization for MHA with insufficient parallel work amount
         const auto is_unsupported_parallel_work_amount =
             static_cast<size_t>(parallel_work_amount.get_length()) < tokenization_config.get_concurrency() &&
@@ -1399,7 +1399,7 @@ void Transformations::MainSnippets(void) {
     snippetsManager.run_passes(model);
 }
 
-void Transformations::PostSnippets(void) {
+void Transformations::PostSnippets() {
     ov::pass::Manager postSnippetsManager("CPU:PostSnippets");
     postSnippetsManager.set_per_pass_validation(false);
     CPU_REGISTER_PASS_COMMON(postSnippetsManager, ov::pass::FakeQuantizeDecomposition);
@@ -1415,7 +1415,7 @@ void Transformations::PostSnippets(void) {
     postSnippetsManager.run_passes(model);
 }
 
-void Transformations::Snippets(void) {
+void Transformations::Snippets() {
     const bool useSnippets = config.snippetsMode != Config::SnippetsMode::Disable &&
                              CPU_DEBUG_CAP_IS_TRANSFORMATION_ENABLED(config.debugCaps, Snippets);
     if (!useSnippets) {

--- a/src/plugins/intel_cpu/src/utils/bfloat16.hpp
+++ b/src/plugins/intel_cpu/src/utils/bfloat16.hpp
@@ -38,9 +38,9 @@ public:
         return F32{static_cast<uint32_t>(m_value) << 16}.vfloat;
     }
     static constexpr bfloat16_t from_bits(uint16_t bits) {
-        return bfloat16_t(bits, true);
+        return {bits, true};
     }
-    uint16_t to_bits() const {
+    [[nodiscard]] uint16_t to_bits() const {
         return m_value;
     }
 

--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -196,7 +196,7 @@ void BlobDumper::dumpAsTxt(std::ostream& stream) const {
     case ov::element::bf16: {
         auto* blob_ptr = reinterpret_cast<const bfloat16_t*>(ptr);
         for (size_t i = 0; i < data_size; i++) {
-            float fn = static_cast<float>(blob_ptr[desc.getElementOffset(i)]);
+            auto fn = static_cast<float>(blob_ptr[desc.getElementOffset(i)]);
             stream << fn << '\n';
         }
         break;

--- a/src/plugins/intel_cpu/src/utils/codec_xor.hpp
+++ b/src/plugins/intel_cpu/src/utils/codec_xor.hpp
@@ -13,8 +13,8 @@ void codec_xor(char* dst_str, const char* src_str, size_t len);
 
 std::string codec_xor_str(const std::string& source_str);
 
-typedef std::function<std::string(const std::string&)> CacheDecryptStr;
-typedef std::function<void(char* dst, const char* src, size_t size)> CacheDecryptChar;
+using CacheDecryptStr = std::function<std::string(const std::string&)>;
+using CacheDecryptChar = std::function<void(char*, const char*, size_t)>;
 
 union CacheDecrypt {
     CacheDecryptChar m_decrypt_char = nullptr;

--- a/src/plugins/intel_cpu/src/utils/cpu_utils.hpp
+++ b/src/plugins/intel_cpu/src/utils/cpu_utils.hpp
@@ -24,7 +24,7 @@ struct is_any_of : public std::false_type {};
 // otherwise call is_any_of<T, Rest...> recurrently
 template <class T, class U, class... Rest>
 struct is_any_of<T, U, Rest...>
-    : public std::conditional<std::is_same<T, U>::value, std::true_type, is_any_of<T, Rest...>>::type {};
+    : public std::conditional_t<std::is_same_v<T, U>, std::true_type, is_any_of<T, Rest...>> {};
 
 /**
  * @brief Returns normalized by size dims where missing dimensions are filled with units from the beginning
@@ -66,10 +66,8 @@ inline bool isPerTensorOrPerChannelBroadcastable(const VectorDims& firstInputDim
     if (secondInputDims.size() > firstInputDims.size()) {
         return false;
     }
-    if (std::accumulate(secondInputDims.begin(),
-                        secondInputDims.end(),
-                        static_cast<size_t>(1),
-                        std::multiplies<size_t>()) == 1) {
+    if (std::accumulate(secondInputDims.begin(), secondInputDims.end(), static_cast<size_t>(1), std::multiplies<>()) ==
+        1) {
         return true;
     }
 
@@ -182,7 +180,7 @@ std::vector<T> reshapeDownToRank(const std::vector<T>& dims, size_t rank) {
     }
 
     const auto accEnd = dims.begin() + (dims.size() - rank + 1);
-    const auto acc = std::accumulate(dims.begin(), accEnd, (T)1, std::multiplies<T>());
+    const auto acc = std::accumulate(dims.begin(), accEnd, (T)1, std::multiplies<>());
 
     std::vector<T> result{acc};
     result.insert(result.end(), accEnd, dims.end());

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
@@ -157,7 +157,7 @@ std::ostream& operator<<(std::ostream& os, const NodeDesc& desc) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Node& c_node) {
-    Node& node = const_cast<Node&>(c_node);
+    auto& node = const_cast<Node&>(c_node);
     const int align_col = 50;
     const char* comma = "";
     auto node_id = [](Node& node) {
@@ -662,7 +662,7 @@ std::string to_string(const T* values, size_t N, size_t maxsize) {
             ss << "..." << N << "in total";
             break;
         }
-        if (std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value) {
+        if (std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t>) {
             ss << static_cast<int>(values[i]);
         } else {
             ss << values[i];

--- a/src/plugins/intel_cpu/src/utils/multidim_map.hpp
+++ b/src/plugins/intel_cpu/src/utils/multidim_map.hpp
@@ -19,7 +19,7 @@ struct enum_hash {
 };
 
 template <typename K>
-using hash_t = typename std::conditional<std::is_enum<K>::value, enum_hash<K>, std::hash<K>>::type;
+using hash_t = std::conditional_t<std::is_enum_v<K>, enum_hash<K>, std::hash<K>>;
 
 }  // namespace internal
 

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -5,11 +5,11 @@
 #pragma once
 
 #include <node.h>
-#include <stdlib.h>
 
 #include <cassert>
 #include <climits>
 #include <cstdint>
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -104,28 +104,28 @@ struct PlainTensor {
         return m_ptr != nullptr;
     }
 
-    VectorDims shape() const {
+    [[nodiscard]] VectorDims shape() const {
         return VectorDims(m_dims, m_dims + m_rank);
     }
 
-    size_t size(int i) const {
+    [[nodiscard]] size_t size(int i) const {
         if (i < 0) {
             i += m_rank;
         }
         assert(static_cast<typename std::make_unsigned<decltype(i)>::type>(i) < m_rank);
         return m_dims[i];
     }
-    size_t stride(int i) const {
+    [[nodiscard]] size_t stride(int i) const {
         assert(i >= 0 && static_cast<typename std::make_unsigned<decltype(i)>::type>(i) < m_rank);
         return m_strides[i];
     }
 
-    size_t stride_bytes(int i) const {
+    [[nodiscard]] size_t stride_bytes(int i) const {
         return stride(i) * m_element_size;
     }
 
     template <typename T>
-    std::vector<T> get_strides() const {
+    [[nodiscard]] std::vector<T> get_strides() const {
         std::vector<T> strides(m_rank);
         for (size_t i = 0; i < m_rank; i++) {
             strides[i] = static_cast<T>(m_strides[i]);
@@ -169,7 +169,7 @@ struct PlainTensor {
                strides.data());
     }
 
-    ov::element::Type get_precision() const {
+    [[nodiscard]] ov::element::Type get_precision() const {
         return m_dt;
     }
 
@@ -238,7 +238,7 @@ struct PlainTensor {
     }
 
     // slice: return a sub-view (w/o ownership/refcount to original data)
-    PlainTensor slice(int axis, int start, int end, int step = 1) const {
+    [[nodiscard]] PlainTensor slice(int axis, int start, int end, int step = 1) const {
         PlainTensor sub_tensor;
         assert(axis >= 0 && static_cast<typename std::make_unsigned<decltype(axis)>::type>(axis) < m_rank);
 
@@ -272,7 +272,7 @@ struct PlainTensor {
         return sub_tensor;
     }
 
-    bool is_dense() const {
+    [[nodiscard]] bool is_dense() const {
         // check if it's dense tensor
         size_t stride = 1;
         for (int i = m_rank - 1; i >= 0; i--) {
@@ -300,7 +300,7 @@ struct PlainTensor {
 
        simplified form is when whole tensor is dense
     */
-    PlainTensor reshape(const std::vector<size_t>& target_shape) const {
+    [[nodiscard]] PlainTensor reshape(const std::vector<size_t>& target_shape) const {
         // only valid for dense memory
         PlainTensor new_tensor_view;
         assert(is_dense());
@@ -311,7 +311,7 @@ struct PlainTensor {
         return new_tensor_view;
     }
 
-    PlainTensor permute(const std::vector<size_t>& order) const {
+    [[nodiscard]] PlainTensor permute(const std::vector<size_t>& order) const {
         PlainTensor new_tensor_view;
         assert(order.size() == m_rank);
         new_tensor_view.m_capacity = 0;
@@ -384,7 +384,7 @@ struct PlainTensor {
     }
 
     template <int dim>
-    int64_t offset() const {
+    [[nodiscard]] int64_t offset() const {
         return m_offset;
     }
     template <int dim, typename I>
@@ -428,7 +428,7 @@ struct PlainTensor {
         // assign every element to value
         std::vector<size_t> index(m_rank, 0);
         auto* dst = reinterpret_cast<DT*>(m_ptr.get() + m_offset * m_element_size);
-        while (1) {
+        while (true) {
             size_t off = 0;
             for (int i = m_rank - 1; i >= 0; i--) {
                 if (index[i] >= m_dims[i]) {
@@ -486,7 +486,7 @@ struct PlainTensor {
 
     int max_repr_len = 256;
 
-    std::string repr(int max_total_lines = 16, int lines_per_row = 1) const {
+    [[nodiscard]] std::string repr(int max_total_lines = 16, int lines_per_row = 1) const {
         if (!m_ptr) {
             return "{empty}";
         }

--- a/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
@@ -24,14 +24,14 @@ protected:
 public:
     MemoryFormats() = default;
     explicit MemoryFormats(std::string _memory_format) : memory_format(std::move(_memory_format)) {}
-    std::string to_string() const override {
+    [[nodiscard]] std::string to_string() const override {
         return memory_format;
     };
-    bool is_copyable(const std::shared_ptr<ov::Node>& to) const override {
+    [[nodiscard]] bool is_copyable(const std::shared_ptr<ov::Node>& to) const override {
         return (!ov::op::util::is_constant(to));
     }
 
-    ov::Any merge(const ov::NodeVector& nodes) const override {
+    [[nodiscard]] ov::Any merge(const ov::NodeVector& nodes) const override {
         std::set<std::string> unique_mem_format;
 
         for (auto& node : nodes) {

--- a/src/plugins/intel_cpu/src/utils/serialize.hpp
+++ b/src/plugins/intel_cpu/src/utils/serialize.hpp
@@ -15,7 +15,7 @@ namespace ov::intel_cpu {
 
 class ModelSerializer {
 public:
-    typedef std::function<std::string(const std::string&)> CacheEncrypt;
+    using CacheEncrypt = std::function<std::string(const std::string&)>;
 
     ModelSerializer(std::ostream& ostream, CacheEncrypt encrypt_fn = {});
 
@@ -28,9 +28,8 @@ private:
 
 class ModelDeserializer {
 public:
-    typedef std::function<std::shared_ptr<ov::Model>(const std::shared_ptr<ov::AlignedBuffer>&,
-                                                     const std::shared_ptr<ov::AlignedBuffer>&)>
-        ModelBuilder;
+    using ModelBuilder = std::function<std::shared_ptr<ov::Model>(const std::shared_ptr<ov::AlignedBuffer>&,
+                                                                  const std::shared_ptr<ov::AlignedBuffer>&)>;
 
     ModelDeserializer(std::istream& model,
                       std::shared_ptr<ov::AlignedBuffer> model_buffer,

--- a/src/plugins/intel_cpu/src/weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/weights_cache.hpp
@@ -29,7 +29,7 @@ namespace ov::intel_cpu {
  */
 class WeightsSharing {
     struct MemoryInfo {
-        typedef std::shared_ptr<MemoryInfo> Ptr;
+        using Ptr = std::shared_ptr<MemoryInfo>;
 
         MemoryInfo(const MemoryPtr& memoryPtr, bool valid) : sharedMemory(memoryPtr), valid(valid) {}
 
@@ -39,16 +39,16 @@ class WeightsSharing {
     };
 
 public:
-    typedef std::shared_ptr<WeightsSharing> Ptr;
+    using Ptr = std::shared_ptr<WeightsSharing>;
 
     class SharedMemory {
     public:
-        typedef std::shared_ptr<SharedMemory> Ptr;
+        using Ptr = std::shared_ptr<SharedMemory>;
 
         SharedMemory(std::unique_lock<std::mutex>&& lock, MemoryInfo::Ptr memory, MemoryPtr newPtr = nullptr);
 
         operator MemoryPtr() const;
-        bool isValid() const;
+        [[nodiscard]] bool isValid() const;
         void valid(bool b);
 
     private:

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/unique.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/unique.cpp
@@ -123,7 +123,7 @@ protected:
             ov::Tensor tensor;
 
             if (funcInput.get_node()->get_friendly_name() == "data") {
-                int32_t range = std::accumulate(targetInputStaticShapes[0].begin(), targetInputStaticShapes[0].end(), 1, std::multiplies<size_t>());
+                int32_t range = std::accumulate(targetInputStaticShapes[0].begin(), targetInputStaticShapes[0].end(), 1, std::multiplies<>());
                 ov::test::utils::InputGenerateData in_data;
                 in_data.start_from = -range / 2;
                 in_data.range = range;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/fq_caching.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/fq_caching.cpp
@@ -171,13 +171,13 @@ protected:
             auto ranges = rangesVec[i];
 
             auto il = ov::op::v0::Constant::create(ngInPrec, ranges[0], extendData(rangesBounds[0],
-                std::accumulate(ranges[0].begin(), ranges[0].end(), 1, std::multiplies<size_t>())));
+                std::accumulate(ranges[0].begin(), ranges[0].end(), 1, std::multiplies<>())));
             auto ih = ov::op::v0::Constant::create(ngInPrec, ranges[1], extendData(rangesBounds[1],
-                std::accumulate(ranges[1].begin(), ranges[1].end(), 1, std::multiplies<size_t>())));
+                std::accumulate(ranges[1].begin(), ranges[1].end(), 1, std::multiplies<>())));
             auto ol = ov::op::v0::Constant::create(ngInPrec, ranges[2], extendData(rangesBounds[2],
-                std::accumulate(ranges[2].begin(), ranges[2].end(), 1, std::multiplies<size_t>())));
+                std::accumulate(ranges[2].begin(), ranges[2].end(), 1, std::multiplies<>())));
             auto oh = ov::op::v0::Constant::create(ngInPrec, ranges[3], extendData(rangesBounds[3],
-                std::accumulate(ranges[3].begin(), ranges[3].end(), 1, std::multiplies<size_t>())));
+                std::accumulate(ranges[3].begin(), ranges[3].end(), 1, std::multiplies<>())));
 
             auto fqNode = std::make_shared<ov::op::v0::FakeQuantize>(paramVect[i], il, ih, ol, oh, levels);
             fqNode->get_rt_info() = getCPUInfo();

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_desc_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_desc_test.cpp
@@ -283,7 +283,7 @@ TEST(MemDescTest, MemSize) {
     ASSERT_EQ(blockedDescDefUpper.getCurrentMemSize(), undefSize);
     auto maxElementsCount = std::accumulate(pluginShapeDefUpperBound.getMaxDims().begin(),
                                             pluginShapeDefUpperBound.getMaxDims().end(),
-                                            1, std::multiplies<size_t>());
+                                            1, std::multiplies<>());
     ASSERT_EQ(blockedDescDefUpper.getMaxMemSize(), maxElementsCount * iePrc.size());
 
     DnnlBlockedMemoryDesc memDescDefUpper(pluginShapeDefUpperBound, dnnlDataType, dnnl::memory::format_tag::nhwc);


### PR DESCRIPTION
### Details:
 - Fix "modernize-*" remarks reported by clang-tidy
 - Enable "modernize-*" clang-tidy checks on CI by default
 - Disable "modernize-avoid-c-arrays" due to big scope of changes (to be enabled separately)
 - Disable C++20 specific checks: "modernize-use-constraints", "modernize-use-std-numbers"

### Tickets:
 - N/A
