### PR TITLE
[LPT TRANSFORMATIONS] Enable MarkDequantization & KeepConstPrecision to process more complex patterns

### DIFF
--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -8,12 +8,181 @@
 #include "transformations/fp16_compression/mark_decompression_convert_constant_folding.hpp"
 #include "transformations/rt_info/decompression.hpp"
 #include "transformations/rt_info/dequantization_node.hpp"
+#include "transformations/rt_info/disable_constant_folding.hpp"
 #include "transformations/rt_info/keep_const_precision.hpp"
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "transformations/convert_precision.hpp"
 
 using namespace ov;
+
+static std::shared_ptr<ov::Node> make_branch(const std::shared_ptr<ov::op::v0::Convert> zp_convert,
+                                             const ov::Shape& lp_const_shape,
+                                             const std::vector<size_t>& sub_mul_shape,
+                                             bool ref_model = false) {
+        // const data path
+        const auto lp_const = std::make_shared<opset10::Constant>(element::i8, lp_const_shape, 1);
+        const auto data_convert = std::make_shared<opset10::Convert>(lp_const, element::f32);
+
+        const auto zp_target_shape = std::make_shared<opset10::Constant>(ov::element::i64, ov::Shape{sub_mul_shape.size()}, sub_mul_shape);
+        const auto zp_reshape = std::make_shared<opset10::Reshape>(zp_convert, zp_target_shape, false);
+
+        const auto subtract = std::make_shared<opset10::Subtract>(data_convert, zp_reshape);
+
+        // scale
+        std::shared_ptr<ov::Node> scale_const;
+        std::shared_ptr<ov::Node> scale_reshape;
+        if (ref_model) {
+            scale_const = std::make_shared<opset10::Constant>(element::f32, ov::Shape{sub_mul_shape}, 1);
+            scale_reshape = scale_const;
+        } else {
+            scale_const = std::make_shared<opset10::Constant>(element::f32, ov::Shape{64}, 1);
+            auto scale_target_shape = std::make_shared<opset10::Constant>(ov::element::i64, ov::Shape{sub_mul_shape.size()}, sub_mul_shape);
+            scale_reshape = std::make_shared<opset10::Reshape>(scale_const, scale_target_shape, false);
+        }
+
+        const auto multiply = std::make_shared<opset10::Multiply>(subtract, scale_reshape);
+
+        if (ref_model) {
+            mark_as_dequantization_node(subtract);
+            mark_as_dequantization_node(multiply);
+            disable_constant_folding(data_convert);
+            disable_constant_folding(zp_convert);
+            enable_keep_const_precision(lp_const);
+            disable_keep_const_precision(scale_const);
+        }
+
+        return multiply;
+}
+
+/* Construct a following graph that will have only Scale constant
+   folded during Constant folding as swapping of ZP Reshape & Convert
+   is not possible due to different shapes, hence no CF here.
+
+                              ZP Const
+                                 │
+                                 ▼
+         Input                Convert                Input
+           │                  │     │                  │
+           ▼                  ▼     ▼                  ▼
+Scale      Convert      Reshape     Reshape      Convert      Scale
+    |            │    (64,1,1,1)   (1,64,1,1)    │            │
+    |            │      │                 │      │            |
+    ▼            ▼      ▼                 ▼      ▼            ▼
+    Reshape      Subtract                 Subtract      Reshape
+          |      |                               |      |
+          ▼      ▼                               ▼      ▼
+          Multiply                               Multiply
+*/
+
+TEST_F(TransformationTestsF, KeepConstPrecision2BranchesDiffShapes) {
+    {
+
+        // zero points
+        const auto zp_const = std::make_shared<opset10::Constant>(element::i8, ov::Shape{64}, 1);
+        const auto zp_convert = std::make_shared<opset10::Convert>(zp_const, element::f32);
+
+        const auto right_branch = make_branch(zp_convert, {128,64,2,2}, {1, 64, 1, 1});
+        const auto result_right = std::make_shared<opset10::Result>(right_branch);
+
+        // -----
+
+        const auto left_branch = make_branch(zp_convert, {64,3,3,3}, {64, 1, 1, 1});
+        const auto result_left = std::make_shared<opset10::Result>(left_branch);
+
+        model = std::make_shared<Model>(ResultVector{result_right, result_left}, ParameterVector{});
+    }
+
+    manager.register_pass<pass::MarkDequantization>(element::TypeVector{ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4});
+    manager.register_pass<pass::ConstantFolding>();
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::i8});
+    manager.register_pass<pass::ConvertPrecision>(ov::element::u4, ov::element::u8, type_to_fuse_map{}, false, false);
+
+    {
+        // zero points
+        const auto zp_const = std::make_shared<opset10::Constant>(element::i8, ov::Shape{64}, 1);
+        enable_keep_const_precision(zp_const);
+        const auto zp_convert = std::make_shared<opset10::Convert>(zp_const, element::f32);
+
+        const auto right_branch = make_branch(zp_convert, {128, 64, 2, 2}, {1, 64, 1, 1}, true);
+        const auto result_right = std::make_shared<opset10::Result>(right_branch);
+
+        // -----
+
+        const auto left_branch = make_branch(zp_convert, {64, 3, 3, 3}, {64, 1, 1, 1}, true);
+        const auto result_left = std::make_shared<opset10::Result>(left_branch);
+
+        model_ref = std::make_shared<Model>(ResultVector{result_right, result_left}, ParameterVector{});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
+}
+
+
+static std::shared_ptr<ov::Node> make_branch_same(const std::shared_ptr<ov::op::v0::Convert> zp_convert) {
+    // const data
+    const auto lp_const = std::make_shared<opset10::Constant>(element::i8, ov::Shape{64, 3, 3, 3}, 1);
+    const auto data_convert = std::make_shared<opset10::Convert>(lp_const, element::f32);
+
+    const auto subtract = std::make_shared<opset10::Subtract>(data_convert, zp_convert);
+
+    // scale
+    const auto scale_const = std::make_shared<opset10::Constant>(element::f32, ov::Shape{64, 1, 1, 1}, 1);
+    const auto multiply = std::make_shared<opset10::Multiply>(subtract, scale_const);
+
+    enable_keep_const_precision(lp_const);
+    disable_constant_folding(data_convert);
+    mark_as_dequantization_node(subtract);
+    mark_as_dequantization_node(multiply);
+    disable_keep_const_precision(scale_const);
+
+    return multiply;
+}
+
+/* Construct the same as graph above, but with shapes being identical, hence
+   possible to swap and then Constant fold*/
+
+TEST_F(TransformationTestsF, KeepConstPrecision2BranchesSameShapes) {
+    {
+
+        // zero points
+        const auto zp_const = std::make_shared<opset10::Constant>(element::i8, ov::Shape{64}, 1);
+        const auto zp_convert = std::make_shared<opset10::Convert>(zp_const, element::f32);
+
+        const auto right_branch = make_branch(zp_convert, {64, 3, 3, 3}, {64, 1, 1, 1});
+        const auto result_right = std::make_shared<opset10::Result>(right_branch);
+
+        // -----
+
+        const auto left_branch = make_branch(zp_convert, {64, 3, 3, 3}, {64, 1, 1, 1});
+        const auto result_left = std::make_shared<opset10::Result>(left_branch);
+
+        model = std::make_shared<Model>(ResultVector{result_right, result_left}, ParameterVector{});
+    }
+
+    manager.register_pass<pass::MarkDequantization>(element::TypeVector{ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4});
+    manager.register_pass<pass::ConstantFolding>();
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::i8});
+    manager.register_pass<pass::ConvertPrecision>(ov::element::u4, ov::element::u8, type_to_fuse_map{}, false, false);
+
+    {
+        // zero points
+        const auto zp_const = std::make_shared<opset10::Constant>(element::i8, ov::Shape{64, 1, 1, 1}, 1);
+        const auto zp_convert = std::make_shared<opset10::Convert>(zp_const, element::f32);
+
+        const auto multiply_left = make_branch_same(zp_convert);
+        const auto result_left = std::make_shared<opset10::Result>(multiply_left);
+
+        // -----
+
+        const auto multiply_right = make_branch_same(zp_convert);
+        const auto result_right = std::make_shared<opset10::Result>(multiply_right);
+
+        model_ref = std::make_shared<Model>(ResultVector{result_right, result_left}, ParameterVector{});
+    }
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
+}
 
 TEST_F(TransformationTestsF, KeepConstPrecision) {
     {
@@ -33,7 +202,7 @@ TEST_F(TransformationTestsF, KeepConstPrecision) {
 
     manager.register_pass<pass::MarkDequantization>(element::TypeVector{element::u4});
     manager.register_pass<pass::ConstantFolding>();
-    manager.register_pass<pass::KeepConstsPrecision>(element::TypeVector{element::u4});
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::u4});
     manager.register_pass<pass::ConvertPrecision>(ov::element::u4, ov::element::u8, type_to_fuse_map{}, false, false);
 
     {
@@ -124,7 +293,7 @@ TEST_F(TransformationTestsF, MarkDequantizationTransformation) {
     }
 
     manager.register_pass<pass::MarkDequantization>(element::TypeVector{element::u8, element::i8});
-    manager.register_pass<pass::KeepConstsPrecision>(element::TypeVector{element::u8, element::i8});
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::u8, element::i8});
     manager.register_pass<pass::ConstantFolding>();
 
     {
@@ -240,7 +409,7 @@ TEST_F(TransformationTestsF, MarkDequantizationTransformationNoZeroPoint) {
     }
 
     manager.register_pass<pass::MarkDequantization>(element::TypeVector{element::u8, element::i8});
-    manager.register_pass<pass::KeepConstsPrecision>(element::TypeVector{element::u8, element::i8});
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::u8, element::i8});
     manager.register_pass<pass::ConstantFolding>();
 
     {
@@ -349,7 +518,7 @@ TEST_F(TransformationTestsF, MarkDequantizationTransformationNoZeroPointFP16) {
     }
 
     manager.register_pass<pass::MarkDequantization>(element::TypeVector{element::u8, element::i8});
-    manager.register_pass<pass::KeepConstsPrecision>(element::TypeVector{element::u8, element::i8});
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::u8, element::i8});
 
     {
         auto parameter = std::make_shared<opset10::Parameter>(element::f32, Shape{1, 16, 14, 14});
@@ -469,7 +638,7 @@ TEST_F(TransformationTestsF, MarkDequantizationTransformationNotConstantWeights)
     }
 
     manager.register_pass<pass::MarkDequantization>(element::TypeVector{element::u8, element::i8});
-    manager.register_pass<pass::KeepConstsPrecision>(element::TypeVector{element::u8, element::i8});
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::u8, element::i8});
     manager.register_pass<pass::ConstantFolding>();
 
     {
@@ -556,7 +725,7 @@ TEST_F(TransformationTestsF, MarkDequantizationTransformationFoldSubConst) {
     }
 
     manager.register_pass<pass::MarkDequantization>(element::TypeVector{element::u8}, true);
-    manager.register_pass<pass::KeepConstsPrecision>(element::TypeVector{element::u8}, true);
+    manager.register_pass<pass::KeepConstPrecision>(element::TypeVector{element::u8}, true);
     manager.register_pass<pass::ConstantFolding>();
 
     {

--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -85,8 +85,6 @@ TEST_F(TransformationTestsF, KeepConstPrecision2BranchesDiffShapes) {
         const auto right_branch = make_branch(zp_convert, {128,64,2,2}, {1, 64, 1, 1});
         const auto result_right = std::make_shared<opset10::Result>(right_branch);
 
-        // -----
-
         const auto left_branch = make_branch(zp_convert, {64,3,3,3}, {64, 1, 1, 1});
         const auto result_left = std::make_shared<opset10::Result>(left_branch);
 
@@ -106,8 +104,6 @@ TEST_F(TransformationTestsF, KeepConstPrecision2BranchesDiffShapes) {
 
         const auto right_branch = make_branch(zp_convert, {128, 64, 2, 2}, {1, 64, 1, 1}, true);
         const auto result_right = std::make_shared<opset10::Result>(right_branch);
-
-        // -----
 
         const auto left_branch = make_branch(zp_convert, {64, 3, 3, 3}, {64, 1, 1, 1}, true);
         const auto result_left = std::make_shared<opset10::Result>(left_branch);
@@ -152,8 +148,6 @@ TEST_F(TransformationTestsF, KeepConstPrecision2BranchesSameShapes) {
         const auto right_branch = make_branch(zp_convert, {64, 3, 3, 3}, {64, 1, 1, 1});
         const auto result_right = std::make_shared<opset10::Result>(right_branch);
 
-        // -----
-
         const auto left_branch = make_branch(zp_convert, {64, 3, 3, 3}, {64, 1, 1, 1});
         const auto result_left = std::make_shared<opset10::Result>(left_branch);
 
@@ -172,8 +166,6 @@ TEST_F(TransformationTestsF, KeepConstPrecision2BranchesSameShapes) {
 
         const auto multiply_left = make_branch_same(zp_convert);
         const auto result_left = std::make_shared<opset10::Result>(multiply_left);
-
-        // -----
 
         const auto multiply_right = make_branch_same(zp_convert);
         const auto result_right = std::make_shared<opset10::Result>(multiply_right);

--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -49,7 +49,7 @@ public:
 /**
  * @ingroup ov_transformation_common_api
  *
- * @brief KeepConstsPrecision matches Dequantization subgraphs and if Input/ZeroPoints/Scale are Constants
+ * @brief KeepConstPrecision matches Dequantization subgraphs and if Input/ZeroPoints/Scale are Constants
  * they might be marked with keep_const_precision attribute.
  *
  * Dequantization subgraph may have two forms: with and without Subtract.
@@ -68,10 +68,10 @@ public:
  *                Multiply                     Multiply
  *
  */
-class TRANSFORMATIONS_API KeepConstsPrecision : public ov::pass::MatcherPass {
+class TRANSFORMATIONS_API KeepConstPrecision : public ov::pass::MatcherPass {
 public:
-    OPENVINO_MATCHER_PASS_RTTI("KeepConstsPrecision");
-    explicit KeepConstsPrecision(const element::TypeVector& precisions,
+    OPENVINO_MATCHER_PASS_RTTI("KeepConstPrecision");
+    explicit KeepConstPrecision(const element::TypeVector& precisions,
                                  bool fold_subtract_const = false,
                                  bool fold_multiply_const = true);
 };

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -47,13 +47,46 @@ void set_rt_info(const PatternValueMap& pt_map,
     }
 };
 
+bool can_swap(const PatternValueMap& pt_map,
+              const std::shared_ptr<Node>& first_pattern,
+              const std::shared_ptr<Node>& second_pattern) {
+    if (pt_map.count(first_pattern) && pt_map.count(second_pattern)) {
+        auto first_node = pt_map.at(first_pattern).get_node_shared_ptr();
+        auto second_node = pt_map.at(second_pattern).get_node_shared_ptr();
+
+        if (first_pattern->output(0).get_target_inputs().size() == 1)
+            return true;
+
+        auto target_inputs = first_node->output(0).get_target_inputs();
+
+        if (target_inputs.begin()->get_node()->get_output_partial_shape(0).is_static()) {
+            auto first_shape = target_inputs.begin()->get_node()->output(0).get_shape();
+
+            // Step 1
+            if (std::all_of(std::next(target_inputs.begin()), target_inputs.end(),
+                            [&](const ov::Input<ov::Node>& input) {
+                                return input.get_node()->get_output_partial_shape(0).is_static() &&
+                                       input.get_node()->get_shape() == first_shape;
+                            })) {
+                                return true;
+            } else if (second_node->get_output_partial_shape(0).is_static() &&
+                       first_node->get_output_shape(0) == second_node->get_output_shape(0)) {
+            // Step 2
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    return false;
+}
+
 bool swap_nodes(const PatternValueMap& pt_map,
                 const std::shared_ptr<Node>& first,
                 const std::shared_ptr<Node>& second) {
-    if (pt_map.count(first) && pt_map.count(second)) {
+    if (can_swap(pt_map, first, second)) {
         auto first_node = pt_map.at(first).get_node_shared_ptr();
         auto second_node = pt_map.at(second).get_node_shared_ptr();
-
         auto target_inputs = second_node->output(0).get_target_inputs();
         second_node->input(0).replace_source_output(first_node->input_value(0));
         first_node->input(0).replace_source_output(second_node->output(0));
@@ -66,6 +99,88 @@ bool swap_nodes(const PatternValueMap& pt_map,
     }
     return false;
 }
+
+/*
+In some cases we cannot swap Convert and Reshape because it would
+lead to incorrect shapes.
+If we have a following graph with Convert working for several Zero-Point Subgraphs
+
+                               ZP Const
+                                  │
+                                  ▼
+          Input                Convert                Input  
+            │                  │     │                  │    
+            ▼                  ▼     ▼                  ▼    
+ Scale      Convert      Reshape     Reshape      Convert      Scale
+     |            │    (64,1,1,1)   (1,64,1,1)    │            │
+     |            │      │                 │      │            |
+     ▼            ▼      ▼                 ▼      ▼            ▼   
+     Reshape      Subtract                 Subtract      Reshape
+           |      |                               |      |
+           ▼      ▼                               ▼      ▼
+           Multiply                               Multiply
+
+Though, we can perform swapping if the shapes are same for all branches: e.g.
+
+                               ZP Const
+                                  │
+                                  ▼
+          Input                Convert                Input  
+            │                  │     │                  │    
+            ▼                  ▼     ▼                  ▼    
+            Convert      Reshape     Reshape      Convert
+ Scale            │    (64,1,1,1)   (64,1,1,1)    │            Scale
+     |            │      │                 │      │            |
+     ▼            ▼      ▼                 ▼      ▼            ▼   
+     Reshape      Subtract                 Subtract      Reshape
+           |      |                               |      |
+           ▼      ▼                               ▼      ▼
+           Multiply                               Multiply
+
+Step 1: the left part of the graph would be matched transforming the graph into the following form:
+
+                      ZP Const
+                         │
+                         ▼
+          Input       Reshape
+            │        (64,1,1,1)
+            │            │
+            ▼            ▼
+Scale       Convert   Convert          Input
+    │          │      │     │            |
+    ▼          ▼      ▼     ▼            ▼
+    Reshape    Subtract     Reshape   Convert         Scale
+          |      |         (64,1,1,1)    │            │
+          ▼      ▼                │      │            |
+          Multiply                ▼      ▼            ▼
+                                  Subtract      Reshape
+                                         |      |
+                                         ▼      ▼
+                                         Multiply                               
+    
+Step 2: the right part of the graph would be matched transforming the graph into the final form:
+
+                        ZP Const
+                           │
+                           ▼
+                        Reshape
+                       (64,1,1,1)
+                           │
+                           ▼
+         Input          Reshape          Input
+           │           (64,1,1,1)          │
+           │               │               │
+           ▼               ▼               ▼
+Scale      Convert      Convert      Convert      Scale
+    │            │      │     │      │            │
+    ▼            ▼      ▼     ▼      ▼            ▼
+    Reshape      Subtract     Subtract      Reshape
+          |      |                   |      |
+          ▼      ▼                   ▼      ▼
+          Multiply                   Multiply
+
+The double Reshapes are going to be foled in the next ConstantFolding
+*/
 
 }  // namespace
 
@@ -133,10 +248,10 @@ ov::pass::MarkDequantization::MarkDequantization(const element::TypeVector& prec
     this->register_matcher(m, callback);
 }
 
-ov::pass::KeepConstsPrecision::KeepConstsPrecision(const element::TypeVector& precisions,
-                                                   bool fold_subtract_const,
-                                                   bool fold_multiply_const) {
-    MATCHER_SCOPE(KeepConstsPrecision);
+ov::pass::KeepConstPrecision::KeepConstPrecision(const element::TypeVector& precisions,
+                                                 bool fold_subtract_const,
+                                                 bool fold_multiply_const) {
+    MATCHER_SCOPE(KeepConstPrecision);
 
     // data input:
     auto input_pattern = any_input();
@@ -145,12 +260,14 @@ ov::pass::KeepConstsPrecision::KeepConstsPrecision(const element::TypeVector& pr
     // zero points:
     auto zp_pattern = any_input();
     auto zp_convert_pattern = pattern::optional<v0::Convert>(zp_pattern);
-    auto subtract_pattern = pattern::optional<v1::Subtract>({convert_pattern, zp_convert_pattern});
+    auto zp_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({zp_convert_pattern, any_input()});
+    auto subtract_pattern = pattern::optional<v1::Subtract>({convert_pattern, zp_reshape_pattern});
 
     // scale:
     auto scale_pattern = any_input();
     auto scale_convert_pattern = pattern::optional<v0::Convert>(scale_pattern);
-    auto multiply_pattern = wrap_type<v1::Multiply>({subtract_pattern, scale_convert_pattern});
+    auto scale_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({scale_convert_pattern, any_input()});
+    auto multiply_pattern = wrap_type<v1::Multiply>({subtract_pattern, scale_reshape_pattern});
 
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](Matcher& m) -> bool {
         const auto& pt_map = m.get_pattern_value_map();
@@ -180,6 +297,6 @@ ov::pass::KeepConstsPrecision::KeepConstsPrecision(const element::TypeVector& pr
         return false;
     };
 
-    auto m = std::make_shared<Matcher>(multiply_pattern, "KeepConstsPrecision");
+    auto m = std::make_shared<Matcher>(multiply_pattern, "KeepConstPrecision");
     this->register_matcher(m, callback);
 }

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -447,13 +447,13 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::AUGRUCellFusion);
     CPU_REGISTER_PASS_COMMON(manager, SDPASubgraphFusion);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::CommonOptimizations);
-    CPU_REGISTER_PASS_X64(manager, ov::pass::KeepConstsPrecision, decompression_precisions, false, true);
+    CPU_REGISTER_PASS_X64(manager, ov::pass::KeepConstPrecision, decompression_precisions, false, true);
     CPU_SET_CALLBACK_X64(
         manager,
         [&](const_node_ptr& node) -> bool {
             return !is_decompression_multiply(node);
         },
-        ov::pass::KeepConstsPrecision);
+        ov::pass::KeepConstPrecision);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::WrapInterpolateIntoTransposes);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::TransposeSinking);
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConvertSequenceToTensorIterator);

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -384,9 +384,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         // Disable subtract folding only for the dGPUs to meet the requirements of oneDNN:
         // it expects to have the same data type for weights and zero points (apply it only for u8 data type, since other compression
         // types are not supported by oneDNN)
-        manager.register_pass<ov::pass::KeepConstsPrecision>(supported_woq_types, !device_info.supports_immad);
+        manager.register_pass<ov::pass::KeepConstPrecision>(supported_woq_types, !device_info.supports_immad);
         pass_config->set_callback<ov::pass::MarkDequantization,
-                ov::pass::KeepConstsPrecision>([&](const std::shared_ptr<const ov::Node> node) {
+                ov::pass::KeepConstPrecision>([&](const std::shared_ptr<const ov::Node> node) {
             return !is_decompression_multiply(node, device_info.supports_immad);
         });
 


### PR DESCRIPTION
The MarkDequantization transformation finds and marks nodes of a certain subgraph as dequantization nodes, enable/disable constant folding for some nodes and swaps nodes in the Convert -> Reshape to allow for Constant folding.

However, in some cases the Convert may have more than one consumer. In these cases the swapping is not always possible as this may break the consistency of the graph.

Allow for swapping only in cases when we are sure it's not going to break the consistency of the graph.

Make KeepConstPrecision to handle more patterns not seen before.

Tickets:
* CVS-161437

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>

