### PR TITLE
[Snippets][CPU] Remove deprecation warnings ignore

### DIFF
--- a/src/common/snippets/CMakeLists.txt
+++ b/src/common/snippets/CMakeLists.txt
@@ -16,10 +16,6 @@ source_group("src" FILES ${LIBRARY_SRC})
 source_group("include" FILES ${PUBLIC_HEADERS})
 
 # Create static library
-if((CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG) AND CMAKE_CXX_STANDARD GREATER_EQUAL 20)
-    set(CMAKE_CXX_FLAGS "-Wno-error=deprecated ${CMAKE_CXX_FLAGS}")
-endif()
-
 add_library(${TARGET_NAME} STATIC
             ${LIBRARY_SRC}
             ${PUBLIC_HEADERS})

--- a/src/common/snippets/include/snippets/kernel_executor_table.hpp
+++ b/src/common/snippets/include/snippets/kernel_executor_table.hpp
@@ -146,8 +146,7 @@ public:
 
     /*** Returns lambda function that contains current state of the table, and restores this state when called  */
     std::function<void()> get_state_reset() {
-        auto current_state = get_state();
-        return [=]() { reset_state(current_state); };
+        return [this]() { reset_state(get_state()); };
     }
 
     virtual ~KernelExecutorTable() = default;

--- a/src/common/snippets/include/snippets/kernel_executor_table.hpp
+++ b/src/common/snippets/include/snippets/kernel_executor_table.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "openvino/util/pp.hpp"
 #include "snippets/lowered/linear_ir.hpp"
 #include <typeinfo>
 #if defined(SNIPPETS_DEBUG_CAPS) && !defined(_WIN32)
@@ -146,7 +147,8 @@ public:
 
     /*** Returns lambda function that contains current state of the table, and restores this state when called  */
     std::function<void()> get_state_reset() {
-        return [this]() { reset_state(get_state()); };
+        auto current_state = get_state();
+        return [OV_CAPTURE_CPY_AND_THIS]() { reset_state(current_state); };
     }
 
     virtual ~KernelExecutorTable() = default;

--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -8,10 +8,6 @@ endif()
 
 set(TARGET_NAME "openvino_intel_cpu_plugin")
 
-if((CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG) AND CMAKE_CXX_STANDARD GREATER_EQUAL 20)
-    set(CMAKE_CXX_FLAGS "-Wno-error=deprecated ${CMAKE_CXX_FLAGS}")
-endif()
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # C4267, 4244 issues from oneDNN headers conversion from 'XXX' to 'YYY', possible loss of data
     ov_add_compiler_flags(/wd4018)

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/fc_bias_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/fc_bias_fusion.cpp
@@ -27,7 +27,7 @@ ov::intel_cpu::FullyConnectedBiasFusion::FullyConnectedBiasFusion() {
     auto m_bias = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto m_add = ov::pass::pattern::wrap_type<ov::op::v1::Add>({m_fc, m_bias});
 
-    ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
 
         auto add = pattern_to_output[m_add].get_node_shared_ptr();

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/mlp_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/mlp_fusion.cpp
@@ -103,7 +103,7 @@ ov::intel_cpu::MLPFusion::MLPFusion() {
 
     auto result = down_proj;
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         PatternValidator validator(m);
         if (!validator) {
             return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/qkv_proj_fusion.cpp
@@ -43,7 +43,7 @@ ov::intel_cpu::QKVProjFusion::QKVProjFusion() {
                                               {{"transpose_a", false}, {"transpose_b", true}});  //  [?,?,4096]
     auto result = q_proj;
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         PatternValidator validator(m);
         if (!validator) {
             return false;
@@ -205,7 +205,7 @@ ov::intel_cpu::QKVProjFusion2::QKVProjFusion2() {
 
     auto result = qkv_split->output(0);
 
-    matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
+    matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         PatternValidator validator(m);
         if (!validator) {
             return false;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/eliminate_brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/eliminate_brgemm_copy_b.cpp
@@ -22,7 +22,7 @@ pass::EliminateBrgemmCopyB::EliminateBrgemmCopyB() {
     auto m_rank_norm = ov::pass::pattern::optional<ov::snippets::op::RankNormalization>(m_param);
     auto m_copy_b = ov::pass::pattern::wrap_type<BrgemmCopyB>({m_param});
 
-    auto callback = [=](ov::pass::pattern::Matcher& m) {
+    auto callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "ov::intel_cpu::pass::EliminateBrgemmCopyB")
         const auto& pattern_map = m.get_pattern_value_map();
         const auto& copy_b_out = pattern_map.at(m_copy_b);

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/brgemm_to_brgemm_tpp.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/brgemm_to_brgemm_tpp.cpp
@@ -40,7 +40,7 @@ BrgemmToBrgemmTPP::BrgemmToBrgemmTPP() {
 
     auto m_brgemm = ov::pass::pattern::wrap_type<snippets::op::Brgemm>();
 
-    auto callback = [=](ov::pass::pattern::Matcher& m) {
+    auto callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "ov::intel_cpu::pass::BrgemmToBrgemmTPP")
         const auto node = m.get_match_root();
         const auto brgemm = ov::as_type_ptr<snippets::op::Brgemm>(node);

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/eltwise_to_eltwise_tpp.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/eltwise_to_eltwise_tpp.cpp
@@ -28,7 +28,7 @@ EltwiseToEltwiseTPP::EltwiseToEltwiseTPP() {
                                                           ov::op::util::BinaryElementwiseArithmetic,
                                                           ov::snippets::op::ReduceBase>(is_supported_by_tpp);
 
-    auto callback = [=](ov::pass::pattern::Matcher& m) {
+    auto callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "ov::intel_cpu::pass::EltwiseToEltwiseTPP")
         const auto node = m.get_match_root();
         if (node->is_dynamic()) {

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/scalar_to_scalar_tpp.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/scalar_to_scalar_tpp.cpp
@@ -21,7 +21,7 @@ ScalarToScalarTPP::ScalarToScalarTPP() {
 
     auto snippets_scalar = ov::pass::pattern::wrap_type<ov::snippets::op::Scalar>();
 
-    auto callback = [=](ov::pass::pattern::Matcher& m) {
+    auto callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "ov::intel_cpu::pass::ScalarToScalarTPP")
         const auto node = ov::as_type_ptr<ov::snippets::op::Scalar>(m.get_match_root());
         OPENVINO_ASSERT(node, "Failed to obtain a valid Scalar Op in ScalarToScalarTPP");


### PR DESCRIPTION
### Details:
 - Fix deprecated warnings related to implicit `this` capturing in lambdas
 - Remove `-Wno-error=deprecated` from CXX flags for Intel CPU plugin and common snippets directories

### Tickets:
 - N/A
