### PR TITLE
[NPU] Move compatibility check skip before reading metadata

### DIFF
--- a/src/plugins/intel_npu/src/plugin/include/metadata.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metadata.hpp
@@ -149,7 +149,7 @@ public:
      *
      *              - true: if all versions match.
      *
-     * @note The version check can be disabled if the "NPU_DISABLE_VERSION_CHECK" environment variable is set to '1'.
+     * @note The version check can be disabled if the "OV_NPU_DISABLE_VERSION_CHECK" environment variable is set to '1'.
      */
     bool is_compatible() override;
 

--- a/src/plugins/intel_npu/src/plugin/include/metadata.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/metadata.hpp
@@ -35,6 +35,8 @@ public:
 
     virtual ~MetadataBase() = default;
 
+    static std::streampos getFileSize(std::istream& stream);
+
     /**
      * @brief Returns a uint32_t value which represents two uint16_t values concatenated.
      * @details Convention for bumping the metadata version:

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -846,8 +846,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream, c
         bool skipCompatibility = false;
 
 #ifdef NPU_PLUGIN_DEVELOPER_BUILD
-        if (auto envVar = std::getenv("NPU_DISABLE_VERSION_CHECK")) {
-            if (envVarStrToBool("NPU_DISABLE_VERSION_CHECK", envVar)) {
+        if (auto envVar = std::getenv("OV_NPU_DISABLE_VERSION_CHECK")) {
+            if (envVarStrToBool("OV_NPU_DISABLE_VERSION_CHECK", envVar)) {
                 _logger.info("Blob compatibility check skipped.");
                 skipCompatibility = true;
             }


### PR DESCRIPTION
### Details:
 - a flaw has been noticed in the current code. The compatibility check skip won't work if the blob contains no NPU metadata. Therefore, I moved the skip inside plugin.cpp.
### Tickets:
 - none
