### PR TITLE
[OV JS] Update openvino-node package version to 2025.0.0

### DIFF
--- a/src/bindings/js/node/package-lock.json
+++ b/src/bindings/js/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-node",
-  "version": "2024.6.0",
+  "version": "2025.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-node",
-      "version": "2024.6.0",
+      "version": "2025.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [

--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvino-node",
-  "version": "2024.6.0",
+  "version": "2025.0.0",
   "description": "OpenVINO™ utils for using from Node.js environment",
   "repository": {
     "url": "git+https://github.com/openvinotoolkit/openvino.git",


### PR DESCRIPTION
### Details:
 - Bump OV nodejs recipe to 2025.0.0 version
