### PR TITLE
[PYTHON] add __deepcopy__, __copy__ for Tensor

### DIFF
--- a/src/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -498,7 +498,7 @@ void regclass_Tensor(py::module m) {
     });
 
     cls.def("__copy__", [](const ov::Tensor& self) {
-            ov::Tensor dst = self;
+        ov::Tensor dst = self;
         return dst;
     });
 

--- a/src/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -497,6 +497,11 @@ void regclass_Tensor(py::module m) {
         return "<" + Common::get_class_name(self) + ": " + ss.str() + ">";
     });
 
+    cls.def("__copy__", [](const ov::Tensor& self) {
+        ov::Tensor dst(self);
+        return dst;
+    });
+
     cls.def("__deepcopy__", [](const ov::Tensor& self, py::dict& memo) {
         ov::Tensor dst(self.get_element_type(), self.get_shape());
         std::memcpy(dst.data(), self.data(), self.get_byte_size());

--- a/src/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -498,7 +498,7 @@ void regclass_Tensor(py::module m) {
     });
 
     cls.def("__copy__", [](const ov::Tensor& self) {
-        ov::Tensor dst(self);
+            ov::Tensor dst = self;
         return dst;
     });
 

--- a/src/bindings/python/src/pyopenvino/core/tensor.cpp
+++ b/src/bindings/python/src/pyopenvino/core/tensor.cpp
@@ -496,4 +496,10 @@ void regclass_Tensor(py::module m) {
 
         return "<" + Common::get_class_name(self) + ": " + ss.str() + ">";
     });
+
+    cls.def("__deepcopy__", [](const ov::Tensor& self, py::dict& memo) {
+        ov::Tensor dst(self.get_element_type(), self.get_shape());
+        std::memcpy(dst.data(), self.data(), self.get_byte_size());
+        return dst;
+    });
 }

--- a/src/bindings/python/tests/test_runtime/test_tensor.py
+++ b/src/bindings/python/tests/test_runtime/test_tensor.py
@@ -621,7 +621,7 @@ def test_tensor_keeps_memory():
 
 
 @pytest.mark.parametrize(
-    "copy_func, should_share_data", [(copy, True), (deepcopy, False)]
+    ("copy_func", "should_share_data"), [(copy, True), (deepcopy, False)]
 )
 def test_copy_and_deepcopy(copy_func, should_share_data):
     shape = (3, 4)

--- a/src/bindings/python/tests/test_runtime/test_tensor.py
+++ b/src/bindings/python/tests/test_runtime/test_tensor.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy, copy
 import os
 import subprocess
 import sys
@@ -617,3 +618,19 @@ def test_tensor_keeps_memory():
 
     tensor = get_tensor()
     assert np.allclose(tensor.data[0][0][0:3], [0, 0, 1])
+
+
+def test_deepcopy():
+    tensor = ov.Tensor(np.ones([1, 3, 32, 32]))
+    tensor_deepcopy = deepcopy(tensor)
+    assert np.array_equal(tensor_deepcopy.data, tensor.data)
+    assert tensor_deepcopy is not tensor
+    assert tensor_deepcopy.data is not tensor.data
+
+
+def test_copy():
+    tensor = ov.Tensor(np.ones([1, 3, 32, 32]))
+    tensor_deepcopy = copy(tensor)
+    assert np.array_equal(tensor_deepcopy.data, tensor.data)
+    assert tensor_deepcopy is not tensor
+    assert tensor_deepcopy.data is tensor.data

--- a/src/bindings/python/tests/test_runtime/test_tensor.py
+++ b/src/bindings/python/tests/test_runtime/test_tensor.py
@@ -630,7 +630,7 @@ def test_deepcopy():
 
 def test_copy():
     tensor = ov.Tensor(np.ones([1, 3, 32, 32]))
-    tensor_deepcopy = copy(tensor)
-    assert np.array_equal(tensor_deepcopy.data, tensor.data)
-    assert tensor_deepcopy is not tensor
-    assert tensor_deepcopy.data is tensor.data
+    tensor_copy = copy(tensor)
+    assert np.array_equal(tensor_copy.data, tensor.data)
+    assert tensor_copy is not tensor
+    assert tensor_copy.data is tensor.data


### PR DESCRIPTION
### Details:
Add support of `deepcopy()` and `copy()` for ov.Tensor Python API
`copy()` returns a shallow copy, `deepcopy()` a new object with its own data buffer

### Ticket:
161969