### PR TITLE
NPUW: Fix SPATIAL execution mode

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -733,12 +733,18 @@ void ov::npuw::JustInferRequest::unsafe_infer(std::size_t real_idx) {
             // Collect spatial inputs for this offset
             for (auto&& param : spatial.params) {
                 const auto& iport = comp_model_desc.compiled_model->inputs()[param.idx];
-                r->set_tensor(
-                    iport,
-                    ov::npuw::util::view(m_spatial_io[real_idx].inputs.at(param.idx), param.dim, offset, spatial.nway));
+                const auto& iview = ov::npuw::util::view(m_spatial_io[real_idx].inputs.at(param.idx),
+                                                         param.dim, offset,
+                                                         spatial.nway);
+                // FIXME: Eliminate copy once strided tensors are back
+                iview->copy_to(r->get_tensor(iport)._ptr);
+                // What it should be:
+                // r->set_tensor(iport, iview);
             }  // for(params)
 
-            // Now set the spatial outputs
+            // Now set the spatial outputs.
+            // FIXME: Bring back with strided tensors
+            #if 0
             for (std::size_t out_idx = 0u; out_idx < num_outputs; out_idx++) {
                 const auto& oport = comp_model_desc.compiled_model->outputs()[out_idx];
                 r->set_tensor(oport,
@@ -747,9 +753,20 @@ void ov::npuw::JustInferRequest::unsafe_infer(std::size_t real_idx) {
                                                    offset,
                                                    spatial.nway));
             }  // for(outputs)
+            #endif
 
             // Now run the part
             r->infer();
+
+            // FIXME: Remove this copy after strided tensors are back
+            for (std::size_t out_idx = 0u; out_idx < num_outputs; out_idx++) {
+                const auto& oport = comp_model_desc.compiled_model->outputs()[out_idx];
+                const auto& oview = ov::npuw::util::view(m_spatial_io[real_idx].outputs.at(out_idx),
+                                                         spatial.out_dim,
+                                                         offset,
+                                                         spatial.nway);
+                r->get_tensor(oport)->copy_to(oview._ptr);
+            }  // for(outputs)
         }  // for(full_nway_times)
 
         // Now process the tail, if required

--- a/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/just_sync_infer_request.cpp
@@ -736,15 +736,10 @@ void ov::npuw::JustInferRequest::unsafe_infer(std::size_t real_idx) {
                 const auto& iview = ov::npuw::util::view(m_spatial_io[real_idx].inputs.at(param.idx),
                                                          param.dim, offset,
                                                          spatial.nway);
-                // FIXME: Eliminate copy once strided tensors are back
-                iview->copy_to(r->get_tensor(iport)._ptr);
-                // What it should be:
-                // r->set_tensor(iport, iview);
+                r->set_tensor(iport, iview);
             }  // for(params)
 
-            // Now set the spatial outputs.
-            // FIXME: Bring back with strided tensors
-            #if 0
+            // Now set the spatial outputs
             for (std::size_t out_idx = 0u; out_idx < num_outputs; out_idx++) {
                 const auto& oport = comp_model_desc.compiled_model->outputs()[out_idx];
                 r->set_tensor(oport,
@@ -753,20 +748,9 @@ void ov::npuw::JustInferRequest::unsafe_infer(std::size_t real_idx) {
                                                    offset,
                                                    spatial.nway));
             }  // for(outputs)
-            #endif
 
             // Now run the part
             r->infer();
-
-            // FIXME: Remove this copy after strided tensors are back
-            for (std::size_t out_idx = 0u; out_idx < num_outputs; out_idx++) {
-                const auto& oport = comp_model_desc.compiled_model->outputs()[out_idx];
-                const auto& oview = ov::npuw::util::view(m_spatial_io[real_idx].outputs.at(out_idx),
-                                                         spatial.out_dim,
-                                                         offset,
-                                                         spatial.nway);
-                r->get_tensor(oport)->copy_to(oview._ptr);
-            }  // for(outputs)
         }  // for(full_nway_times)
 
         // Now process the tail, if required

--- a/src/plugins/intel_npu/src/plugin/npuw/util.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util.cpp
@@ -360,11 +360,32 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::view(const ov::SoPtr<ov::ITensor>& src,
                                             std::size_t offset,
                                             std::size_t len) {
     const auto& shape = src->get_shape();
+    NPUW_ASSERT(dim < shape.size());
     View view_start = View(shape.size(), 0u);
     View view_end = shape;
     view_start[dim] = offset;
     view_end[dim] = offset + len;
-    return ov::npuw::util::view(src, view_start, view_end);
+
+    auto ret_view = ov::npuw::util::view(src, view_start, view_end);
+
+    // Check if a tensor view can be faked as "continuous"
+    // FIXME: This trick should be removed after strided tensor
+    // checks are relaxed
+    if (std::all_of(shape.begin(), shape.begin() + dim, [](std::size_t d) { return d == 1u; })) {
+        // If all dimensions up to the sub-ranged dimension are 1s,
+        // This tensor can be faked as continuous
+        const auto type = src->get_element_type();
+        const auto view_shape = ret_view->get_shape();
+        ov::Strides fake_strides(shape.size());
+        fake_strides.back() = type.size();
+        std::transform(view_shape.crbegin(),
+                       view_shape.crend() - 1,
+                       fake_strides.rbegin(),
+                       fake_strides.rbegin() + 1,
+                       std::multiplies<size_t>());
+        return ov::get_tensor_impl(ov::Tensor(type, view_shape, ret_view->data(), fake_strides));
+    }
+    return ret_view;
 }
 
 template <typename InT>


### PR DESCRIPTION
### Details:
 - This is mainly a workaround, but it allows to keep using strided tensors without a copy.

### Tickets:
 - *E-156237*, *E-156237*
