### PR TITLE
[GPU] Use usm_device for output buffer for BMG

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -10,6 +10,8 @@
 #include "intel_gpu/runtime/memory.hpp"
 
 #include "intel_gpu/runtime/shape_predictor.hpp"
+#include "intel_gpu/runtime/engine.hpp"
+#include "intel_gpu/runtime/device_info.hpp"
 #include "openvino/core/layout.hpp"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
@@ -31,6 +33,28 @@ enum class TensorType {
 
 #define TensorValue(val) static_cast<cldnn::tensor::value_type>(val)
 
+inline bool can_use_usm_host(cldnn::engine& engine, const uint64_t total_output_bytes) {
+    GPU_DEBUG_GET_INSTANCE(debug_config);
+    GPU_DEBUG_IF(debug_config->use_usm_host == 1) { return true; }
+    GPU_DEBUG_IF(debug_config->use_usm_host == 2) { return false; }
+
+    auto can_use_usm = engine.use_unified_shared_memory();
+    // When output size is large, it is better not to write to usm_host directly
+    const uint64_t LARGE_OUTPUT_BYTES_THRESHOLD = 4 * 1048576;
+
+    const auto& device_info = engine.get_device_info();
+    if ((device_info.gfx_ver.major == 12 && device_info.gfx_ver.minor == 60) ||
+        (device_info.gfx_ver.major >= 20 && device_info.dev_type == cldnn::device_type::discrete_gpu) ||
+        (device_info.dev_type == cldnn::device_type::discrete_gpu && total_output_bytes > LARGE_OUTPUT_BYTES_THRESHOLD)) {
+        // WA: Disable USM host memory for infer request`s tensors for PVC and subsequent dGPUs, as kernel access
+        // to system memory is slower than using an explicit memcpy (Host <-> Device) call with the copy engine
+        // Driver tickets with additional details: 6155, 10054
+        GPU_DEBUG_TRACE << "Do not use usm_host for performance issue" << std::endl;
+        can_use_usm = false;
+    }
+
+    return can_use_usm;
+}
 inline cldnn::tensor tensor_from_dims(const ov::Shape& dims, int def = 1) {
     switch (dims.size()) {
     case 0: return cldnn::tensor(cldnn::batch(def), cldnn::feature(def), cldnn::spatial(def, def));

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/broadcast_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/broadcast_si_test.cpp
@@ -122,7 +122,7 @@ TEST_P(broadcast_test_two_inputs_blocked_format, shape_infer) {
 
     auto outputs = network.execute();
     auto output = outputs.at("output").get_memory();
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     ASSERT_EQ(output->get_layout(), p.expected_layout);
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/broadcast_gpu_test.cpp
@@ -73,7 +73,7 @@ void start_broadcast_test(format cldnn_format, data_types cldnn_data_type, std::
     auto outputs = network.execute();
 
     auto output = outputs.at("output").get_memory();
-    cldnn::mem_lock<T> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<T, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     for (tensor::value_type b = 0; b < output_4d.at(0); ++b) {
         for (tensor::value_type f = 0; f < output_4d.at(1); ++f) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -7927,9 +7927,7 @@ TEST_P(convolution_grouped_gpu, base) {
     auto outputs = network.execute();
 
     auto out_mem = outputs.at("conv").get_memory();
-    auto out_lockable = engine.allocate_memory(out_mem->get_layout());
-    out_mem->copy_to(get_test_stream(), *out_lockable, true);
-    cldnn::mem_lock<float> out_ptr(out_lockable, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
     auto out_lay = out_mem->get_layout();
 
     ASSERT_EQ(out_mem->get_layout().format, input_data_format);
@@ -10632,14 +10630,9 @@ TEST_P(conv_dyn_test, convolution_gpu_bfyx_os_iyx_osv16_no_bias) {
     config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl_ref } }));
 
     auto output_memory_ref = calculate_ref(input, weights, config);
-    auto output_ref_lockable = get_test_engine().allocate_memory(output_memory_ref->get_layout());
-    output_memory_ref->copy_to(get_test_stream(), *output_ref_lockable, true);
-    cldnn::mem_lock<float> output_ptr_ref(output_ref_lockable, get_test_stream());
 
-    auto output_lockable = get_test_engine().allocate_memory(output_memory->get_layout());
-    output_memory->copy_to(get_test_stream(), *output_lockable, true);
-    cldnn::mem_lock<float> output_ptr(output_lockable, get_test_stream());
-
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr_ref(output_memory_ref, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
 
     ASSERT_EQ(outputs.at("conv").get_layout(), output_memory_ref->get_layout());
     for (size_t i = 0; i < output_ptr.size(); i++) {
@@ -10665,13 +10658,8 @@ TEST_P(conv_dyn_test, convolution_gpu_bfyx_os_iyx_osv16_no_bias) {
 
         auto output_memory = outputs.at("conv").get_memory();
         auto output_memory_ref = calculate_ref(input, weights, config);
-        auto output_ref_lockable = get_test_engine().allocate_memory(output_memory_ref->get_layout());
-        output_memory_ref->copy_to(get_test_stream(), *output_ref_lockable, true);
-        cldnn::mem_lock<float> output_ptr_ref(output_ref_lockable, get_test_stream());
-
-        auto output_lockable = get_test_engine().allocate_memory(output_memory->get_layout());
-        output_memory->copy_to(get_test_stream(), *output_lockable, true);
-        cldnn::mem_lock<float> output_ptr(output_lockable, get_test_stream());
+        cldnn::mem_lock<float, mem_lock_type::read> output_ptr_ref(output_memory_ref, get_test_stream());
+        cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output_memory, get_test_stream());
 
         ASSERT_EQ(outputs.at("conv").get_layout(), output_memory_ref->get_layout());
         for (size_t i = 0; i < output_ptr.size(); i++) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -7927,7 +7927,9 @@ TEST_P(convolution_grouped_gpu, base) {
     auto outputs = network.execute();
 
     auto out_mem = outputs.at("conv").get_memory();
-    cldnn::mem_lock<float> out_ptr(out_mem, get_test_stream());
+    auto out_lockable = engine.allocate_memory(out_mem->get_layout());
+    out_mem->copy_to(get_test_stream(), *out_lockable, true);
+    cldnn::mem_lock<float> out_ptr(out_lockable, get_test_stream());
     auto out_lay = out_mem->get_layout();
 
     ASSERT_EQ(out_mem->get_layout().format, input_data_format);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -2701,10 +2701,12 @@ public:
         }
 
         auto out_mem = result.at("deconv").get_memory();
+        auto output_lockable = get_test_engine().allocate_memory(out_mem->get_layout());
+        out_mem->copy_to(get_test_stream(), *output_lockable, true);
 
         // Compare results
         {
-            cldnn::mem_lock<OutputT> ptr(out_mem, get_test_stream());
+            cldnn::mem_lock<OutputT> ptr(output_lockable, get_test_stream());
 
             auto b = static_cast<size_t>(out_mem->get_layout().batch());
             auto of = static_cast<size_t>(out_mem->get_layout().feature());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -2701,12 +2701,10 @@ public:
         }
 
         auto out_mem = result.at("deconv").get_memory();
-        auto output_lockable = get_test_engine().allocate_memory(out_mem->get_layout());
-        out_mem->copy_to(get_test_stream(), *output_lockable, true);
 
         // Compare results
         {
-            cldnn::mem_lock<OutputT> ptr(output_lockable, get_test_stream());
+            cldnn::mem_lock<OutputT, mem_lock_type::read> ptr(out_mem, get_test_stream());
 
             auto b = static_cast<size_t>(out_mem->get_layout().batch());
             auto of = static_cast<size_t>(out_mem->get_layout().feature());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_to_space_gpu_test.cpp
@@ -190,7 +190,7 @@ TEST(depth_to_space_fp32_gpu, d1411_bs2) {
     auto outputs = network.execute();
 
     auto output = outputs.at("depth_to_space").get_memory();
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     std::vector<float> expected_results = {
         0.f, 1.f, 2.f, 3.f
@@ -230,7 +230,7 @@ TEST(depth_to_space_fp32_gpu, d112960540_bs2) {
     auto outputs = network_act.execute();
 
     auto output = outputs.at("depth_to_space").get_memory();
-    cldnn::mem_lock<ov::float16> output_ptr (output, get_test_stream());
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr (output, get_test_stream());
 
     std::vector<uint16_t> perm = { 0,3,4,1,5,2 };
 
@@ -255,7 +255,7 @@ TEST(depth_to_space_fp32_gpu, d112960540_bs2) {
     auto outputs_ref = network_ref.execute();
 
     auto output_ref = outputs_ref.at("reshape2").get_memory();
-    cldnn::mem_lock<ov::float16> output_ptr_ref(output_ref, get_test_stream());
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr_ref(output_ref, get_test_stream());
 
     for (size_t i = 0; i < output->get_layout().count(); ++i) {
         ASSERT_EQ(output_ptr_ref[i], output_ptr[i]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
@@ -155,12 +155,8 @@ public:
         std::cout << "Outputs number: " << ref_output_buffers.size() << "\n";
 
         for (size_t i = 0; i < ref_output_buffers.size(); i++) {
-            auto output_lockable = get_test_engine().allocate_memory(output_buffers[i]->get_layout());
-            output_buffers[i]->copy_to(get_test_stream(), *output_lockable, true);
-            cldnn::mem_lock<ov::float16> output_ptr(output_lockable, get_test_stream());
-            auto output_lockable_ref = get_test_engine().allocate_memory(ref_output_buffers[i]->get_layout());
-            ref_output_buffers[i]->copy_to(get_test_stream(), *output_lockable_ref, true);
-            cldnn::mem_lock<ov::float16> output_ptr_ref(output_lockable_ref, get_test_stream());
+            cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output_buffers[i], get_test_stream());
+            cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr_ref(ref_output_buffers[i], get_test_stream());
 
             for (size_t i = 0; i < output_ptr_ref.size(); ++i) {
                 auto abs_diff = std::abs(output_ptr_ref[i] - output_ptr[i]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dynamic_quantize_gpu_test.cpp
@@ -155,8 +155,12 @@ public:
         std::cout << "Outputs number: " << ref_output_buffers.size() << "\n";
 
         for (size_t i = 0; i < ref_output_buffers.size(); i++) {
-            cldnn::mem_lock<ov::float16> output_ptr(output_buffers[i], get_test_stream());
-            cldnn::mem_lock<ov::float16> output_ptr_ref(ref_output_buffers[i], get_test_stream());
+            auto output_lockable = get_test_engine().allocate_memory(output_buffers[i]->get_layout());
+            output_buffers[i]->copy_to(get_test_stream(), *output_lockable, true);
+            cldnn::mem_lock<ov::float16> output_ptr(output_lockable, get_test_stream());
+            auto output_lockable_ref = get_test_engine().allocate_memory(ref_output_buffers[i]->get_layout());
+            ref_output_buffers[i]->copy_to(get_test_stream(), *output_lockable_ref, true);
+            cldnn::mem_lock<ov::float16> output_ptr_ref(output_lockable_ref, get_test_stream());
 
             for (size_t i = 0; i < output_ptr_ref.size(); ++i) {
                 auto abs_diff = std::abs(output_ptr_ref[i] - output_ptr[i]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -3814,7 +3814,9 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
 
     auto golden_outputs = golden_network.execute();
     auto golden_output = golden_outputs.at("eltwise").get_memory();
-    cldnn::mem_lock<ov::float16> golden_ptr(golden_output, get_test_stream());
+    auto output_lockable_golden = engine.allocate_memory(golden_output->get_layout());
+    golden_output->copy_to(get_test_stream(), *output_lockable_golden, true);
+    cldnn::mem_lock<ov::float16> golden_ptr(output_lockable_golden, get_test_stream());
     // GOLDEN BFYX ELTWISE - END
     // MIXED INPUT, FS_B_YX_FSV32 OUTPUT
     topology FS_B_YX_FSV32_OUTPUT_topology;
@@ -3834,7 +3836,9 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
 
     auto FS_B_YX_FSV32_OUTPUT_outputs = FS_B_YX_FSV32_OUTPUT_network.execute();
     auto FS_B_YX_FSV32_OUTPUT_output = FS_B_YX_FSV32_OUTPUT_outputs.at("reorderOutput").get_memory();
-    cldnn::mem_lock<ov::float16> FS_B_YX_FSV32_OUTPUT_ptr(FS_B_YX_FSV32_OUTPUT_output, get_test_stream());
+    auto output_lockable_fsv32 = engine.allocate_memory(FS_B_YX_FSV32_OUTPUT_output->get_layout());
+    FS_B_YX_FSV32_OUTPUT_output->copy_to(get_test_stream(), *output_lockable_fsv32, true);
+    cldnn::mem_lock<ov::float16> FS_B_YX_FSV32_OUTPUT_ptr(output_lockable_fsv32, get_test_stream());
     // MIXED INPUT, FS_B_YX_FSV32 OUTPUT - END
     // MIXED INPUT, BYXF OUTPUT
     topology BYXF_OUTPUT_topology;
@@ -3854,7 +3858,9 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
 
     auto BYXF_OUTPUT_outputs = BYXF_OUTPUT_network.execute();
     auto BYXF_OUTPUT_output = BYXF_OUTPUT_outputs.at("reorderOutput").get_memory();
-    cldnn::mem_lock<ov::float16> BYXF_OUTPUT_ptr(BYXF_OUTPUT_output, get_test_stream());
+    auto output_lockable_byxf = engine.allocate_memory(BYXF_OUTPUT_output->get_layout());
+    BYXF_OUTPUT_output->copy_to(get_test_stream(), *output_lockable_byxf, true);
+    cldnn::mem_lock<ov::float16> BYXF_OUTPUT_ptr(output_lockable_byxf, get_test_stream());
     // MIXED INPUT, BYXF OUTPUT - END
 
     ASSERT_EQ(golden_ptr.size(), FS_B_YX_FSV32_OUTPUT_ptr.size());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -3814,9 +3814,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
 
     auto golden_outputs = golden_network.execute();
     auto golden_output = golden_outputs.at("eltwise").get_memory();
-    auto output_lockable_golden = engine.allocate_memory(golden_output->get_layout());
-    golden_output->copy_to(get_test_stream(), *output_lockable_golden, true);
-    cldnn::mem_lock<ov::float16> golden_ptr(output_lockable_golden, get_test_stream());
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> golden_ptr(golden_output, get_test_stream());
     // GOLDEN BFYX ELTWISE - END
     // MIXED INPUT, FS_B_YX_FSV32 OUTPUT
     topology FS_B_YX_FSV32_OUTPUT_topology;
@@ -3836,9 +3834,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
 
     auto FS_B_YX_FSV32_OUTPUT_outputs = FS_B_YX_FSV32_OUTPUT_network.execute();
     auto FS_B_YX_FSV32_OUTPUT_output = FS_B_YX_FSV32_OUTPUT_outputs.at("reorderOutput").get_memory();
-    auto output_lockable_fsv32 = engine.allocate_memory(FS_B_YX_FSV32_OUTPUT_output->get_layout());
-    FS_B_YX_FSV32_OUTPUT_output->copy_to(get_test_stream(), *output_lockable_fsv32, true);
-    cldnn::mem_lock<ov::float16> FS_B_YX_FSV32_OUTPUT_ptr(output_lockable_fsv32, get_test_stream());
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> FS_B_YX_FSV32_OUTPUT_ptr(FS_B_YX_FSV32_OUTPUT_output, get_test_stream());
     // MIXED INPUT, FS_B_YX_FSV32 OUTPUT - END
     // MIXED INPUT, BYXF OUTPUT
     topology BYXF_OUTPUT_topology;
@@ -3858,9 +3854,7 @@ TEST(eltwise_gpu_f16, bfyx_and_fs_b_yx_fsv32_output_padding) {
 
     auto BYXF_OUTPUT_outputs = BYXF_OUTPUT_network.execute();
     auto BYXF_OUTPUT_output = BYXF_OUTPUT_outputs.at("reorderOutput").get_memory();
-    auto output_lockable_byxf = engine.allocate_memory(BYXF_OUTPUT_output->get_layout());
-    BYXF_OUTPUT_output->copy_to(get_test_stream(), *output_lockable_byxf, true);
-    cldnn::mem_lock<ov::float16> BYXF_OUTPUT_ptr(output_lockable_byxf, get_test_stream());
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> BYXF_OUTPUT_ptr(BYXF_OUTPUT_output, get_test_stream());
     // MIXED INPUT, BYXF OUTPUT - END
 
     ASSERT_EQ(golden_ptr.size(), FS_B_YX_FSV32_OUTPUT_ptr.size());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gather_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gather_gpu_test.cpp
@@ -103,7 +103,7 @@ public:
         reorder_network.set_input_data("input0", input0);
         reorder_network.set_input_data("input1", input1);
         auto reorder_output = reorder_network.execute().at("reorder2").get_memory();
-        cldnn::mem_lock<T_dat> reorder_output_ptr(reorder_output, get_test_stream());
+        cldnn::mem_lock<T_dat, mem_lock_type::read> reorder_output_ptr(reorder_output, get_test_stream());
 
         topology planar_topo;
         planar_topo.add(input_layout("input0", input0->get_layout()));
@@ -114,7 +114,7 @@ public:
         planar_network.set_input_data("input0", input0);
         planar_network.set_input_data("input1", input1);
         auto planar_output = planar_network.execute().at("gather").get_memory();
-        cldnn::mem_lock<T_dat> planar_output_ptr(planar_output, get_test_stream());
+        cldnn::mem_lock<T_dat, mem_lock_type::read> planar_output_ptr(planar_output, get_test_stream());
 
         ASSERT_TRUE(
             !memcmp(reorder_output_ptr.data(), planar_output_ptr.data(), get_linear_size(shape_out) * sizeof(T_dat)));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -84,7 +84,7 @@ public:
         network_->set_input_data(bias_primitive_, bias_gpu_mem);
         auto outputs = network_->execute();
         auto output = outputs.at("output").get_memory();
-        cldnn::mem_lock<float> output_gpu_mem(output, get_test_stream());
+        cldnn::mem_lock<float, mem_lock_type::read> output_gpu_mem(output, get_test_stream());
 
         std::vector<float> reference_output(data_.size());
         ov::reference::group_normalization(data_.data(), scale_.data(), bias_.data(), reference_output.data(),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -141,7 +141,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_2_3)
 
     auto output = outputs.begin()->second.get_memory();
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
         ASSERT_FLOAT_EQ(values[i], output_ptr[i]);
@@ -218,7 +218,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2)
         -15.0f,  -15.0f,
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -247,7 +247,7 @@ TEST(permute_gpu_f32, basic_yxfb_permute_1_0_2_3)
 
     auto output = outputs.begin()->second.get_memory();
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     cldnn::mem_lock<float> input_ptr(input_mem, get_test_stream());
     for (int i = 0; i < 6400; i++)
     {
@@ -327,7 +327,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_0_1_3_2_input_padding)
         -15.0f,  -15.0f,
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -382,7 +382,7 @@ TEST(permute_gpu_f32, basic_yxfb_permute_batch_with_feature)
         5.2f, 8.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -437,7 +437,7 @@ TEST(permute_gpu_f32, basic_bfyx_permute_batch_with_feature)
         5.2f, 8.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 16; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -499,7 +499,7 @@ void permute_test_with_reorder()
         -15.0f,  -15.0f,
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 24; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -594,9 +594,9 @@ TEST(permute_fuse_reorder_gpu_f32, basic_b_fs_yx_fsv4_permute_1_8_16_1)
     auto outputs_fused = fused.execute();
     auto outputs_unfused = unfused.execute();
     auto output_fused = outputs_fused.begin()->second.get_memory();
-    cldnn::mem_lock<float> output_fused_ptr(output_fused, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_fused_ptr(output_fused, get_test_stream());
     auto output_unfused = outputs_unfused.begin()->second.get_memory();
-    cldnn::mem_lock<float> output_unfused_ptr(output_unfused, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_unfused_ptr(output_unfused, get_test_stream());
     ASSERT_EQ(output_fused->get_layout().format, cldnn::format::bfyx);
     ASSERT_EQ(output_unfused->get_layout().format, cldnn::format::bfyx);
     ASSERT_EQ(fused.get_executed_primitives().size(), 4);
@@ -702,7 +702,7 @@ TEST(fc_permute_gpu, basic_permute_bfyx)
     ASSERT_EQ(output->get_layout().format, cldnn::format::bfyx);
 
     cldnn::mem_lock<float> input_ptr(input_mem, get_test_stream());
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 5 * 256; i++)
         ASSERT_NEAR(input_ptr[i], output_ptr[i], 1e-3f);
 
@@ -764,7 +764,7 @@ TEST(permute_gpu_f32, permute_bfwzyx)
     ASSERT_EQ(l.spatial(3), 3);
     ASSERT_EQ(output->get_layout().format, cldnn::format::bfwzyx);
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < output_ptr.size(); ++i)
     {
@@ -848,7 +848,7 @@ TEST(permute_gpu_f32, 6D_reshape_permute_reshape)
 
     auto output = outputs.begin()->second.get_memory();
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
 
     for (size_t i = 0; i < output_ptr.size(); ++i)
     {
@@ -922,7 +922,7 @@ TEST(permute_gpu_f32, basic_bfzyx_permute_0_4_1_2_3)
         -15.0f, -15.0f, -15.0f, -15.0f,
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (int i = 0; i < 48; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -985,7 +985,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfyx_0_2_3_1) {
         142.f, 158.f, 174.f, 190.f, 206.f, 222.f, 238.f, 254.f, 143.f, 159.f, 175.f, 191.f, 207.f, 223.f, 239.f, 255.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1035,7 +1035,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfyx_0_2_3_1) {
         156.f,  93.f, 109.f, 125.f, 141.f, 157.f,  94.f, 110.f, 126.f, 142.f, 158.f,  95.f, 111.f, 127.f, 143.f, 159.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1091,7 +1091,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfyx_0_2_3_1) {
         88.f,  98.f, 108.f, 118.f, 128.f, 138.f, 148.f, 158.f,  89.f,  99.f, 109.f, 119.f, 129.f, 139.f, 149.f, 159.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1141,7 +1141,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfyx_0_2_3_1) {
         58.f,  68.f,  78.f,  88.f,  98.f,  59.f,  69.f,  79.f,  89.f,  99.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1204,7 +1204,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4_dynamic, normal_bfyx_0_2_3_1) {
         142.f, 158.f, 174.f, 190.f, 206.f, 222.f, 238.f, 254.f, 143.f, 159.f, 175.f, 191.f, 207.f, 223.f, 239.f, 255.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1261,7 +1261,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4_dynamic, f_remainder_bfyx_0_2_3_1) {
         156.f,  93.f, 109.f, 125.f, 141.f, 157.f,  94.f, 110.f, 126.f, 142.f, 158.f,  95.f, 111.f, 127.f, 143.f, 159.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1324,7 +1324,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4_dynamic, x_remainder_bfyx_0_2_3_1) {
         88.f,  98.f, 108.f, 118.f, 128.f, 138.f, 148.f, 158.f,  89.f,  99.f, 109.f, 119.f, 129.f, 139.f, 149.f, 159.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1381,7 +1381,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4_dynamic, xf_remainder_bfyx_0_2_3_1) {
         58.f,  68.f,  78.f,  88.f,  98.f,  59.f,  69.f,  79.f,  89.f,  99.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1444,7 +1444,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfzyx_0_2_3_4_1) {
         287.f, 319.f, 351.f, 383.f, 415.f, 447.f, 479.f, 511.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1498,7 +1498,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfzyx_0_2_3_4_1) {
         254.f, 286.f, 318.f, 191.f, 223.f, 255.f, 287.f, 319.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1552,7 +1552,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfzyx_0_2_3_4_1) {
         179.f, 199.f, 219.f, 239.f, 259.f, 279.f, 299.f, 319.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1606,7 +1606,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfzyx_0_2_3_4_1) {
         119.f, 139.f, 159.f, 179.f, 199.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1678,7 +1678,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, normal_bfwzyx_0_2_3_4_5_1) {
         572.f, 636.f, 700.f, 764.f, 828.f, 892.f, 956.f, 1020.f, 573.f, 637.f, 701.f, 765.f, 829.f, 893.f, 957.f, 1021.f, 574.f, 638.f, 702.f, 766.f, 830.f, 894.f, 958.f, 1022.f, 575.f, 639.f, 703.f, 767.f, 831.f, 895.f, 959.f, 1023.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1738,7 +1738,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, f_remainder_bfwzyx_0_2_3_4_5_1) {
         569.f, 633.f, 378.f, 442.f, 506.f, 570.f, 634.f, 379.f, 443.f, 507.f, 571.f, 635.f, 380.f, 444.f, 508.f, 572.f, 636.f, 381.f, 445.f, 509.f, 573.f, 637.f, 382.f, 446.f, 510.f, 574.f, 638.f, 383.f, 447.f, 511.f, 575.f, 639.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1798,7 +1798,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, x_remainder_bfwzyx_0_2_3_4_5_1) {
         356.f, 396.f, 436.f, 476.f, 516.f, 556.f, 596.f, 636.f, 357.f, 397.f, 437.f, 477.f, 517.f, 557.f, 597.f, 637.f, 358.f, 398.f, 438.f, 478.f, 518.f, 558.f, 598.f, 638.f, 359.f, 399.f, 439.f, 479.f, 519.f, 559.f, 599.f, 639.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1858,7 +1858,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfwzyx_0_2_3_4_5_1) {
         236.f, 276.f, 316.f, 356.f, 396.f, 237.f, 277.f, 317.f, 357.f, 397.f, 238.f, 278.f, 318.f, 358.f, 398.f, 239.f, 279.f, 319.f, 359.f, 399.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++)
     {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
@@ -1962,7 +1962,7 @@ void TiledPermuteTest::run_test(const std::vector<cldnn::tensor::value_type>& si
     network_ref->set_input_data("input", input);
     auto outputs_ref = network_ref->execute();
     auto output_ref = outputs_ref.begin()->second.get_memory();
-    cldnn::mem_lock<type> output_ref_ptr(output_ref, get_test_stream());
+    cldnn::mem_lock<type, mem_lock_type::read> output_ref_ptr(output_ref, get_test_stream());
 
     // run with optimized kernel, e.g. permute_tile_8x8_4x4_fsv16
     ExecutionConfig config_tile = get_test_default_config(engine);
@@ -1973,7 +1973,7 @@ void TiledPermuteTest::run_test(const std::vector<cldnn::tensor::value_type>& si
     network_tile->set_input_data("input", input);
     auto outputs_tile = network_tile->execute();
     auto output_tile = outputs_tile.begin()->second.get_memory();
-    cldnn::mem_lock<type> output_tile_ptr(output_tile, get_test_stream());
+    cldnn::mem_lock<type, mem_lock_type::read> output_tile_ptr(output_tile, get_test_stream());
 
     // compare results
     const size_t output_size= output_ref->get_layout().get_linear_size();
@@ -2169,7 +2169,7 @@ TEST(permute_gpu_f32_dynamic, bfyx_0_2_3_1) {
         58.f,  68.f,  78.f,  88.f,  98.f,  59.f,  69.f,  79.f,  89.f,  99.f
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++) {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }
@@ -2239,7 +2239,7 @@ TEST(permute_f_y_axes_fallback, b_fs_yx_fsv16) {
         0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f,
     };
 
-    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
     for (size_t i = 0; i < array_size; i++) {
         ASSERT_FLOAT_EQ(answers[i], output_ptr[i]);
     }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/pooling_gpu_test.cpp
@@ -231,9 +231,7 @@ TEST(pooling_forward_gpu, basic_max_byxf_f32_wsiz3x3_wstr1x1_i1x3x3x8_nopad) {
 
     auto output_prim = outputs.begin()->second.get_memory();
 
-    auto output_lockable = engine.allocate_memory(output_prim->get_layout());
-    output_prim->copy_to(get_test_stream(), *output_lockable, true);
-    cldnn::mem_lock<float> output_ptr (output_lockable, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr (output_prim, get_test_stream());
     ASSERT_EQ(4.0f, output_ptr[3]);
 }
 
@@ -1456,9 +1454,7 @@ TEST(pooling_forward_gpu, b_fs_yx_fsv4)
             auto searchC = outputs.find("pool_GOLD");
             ASSERT_FALSE(searchC == outputs.end());
             auto output = outputs.begin()->second.get_memory();
-            auto output_lockable = engine.allocate_memory(output->get_layout());
-            output->copy_to(get_test_stream(), *output_lockable, true);
-            cldnn::mem_lock<char> output_ptr(output_lockable, get_test_stream());
+            cldnn::mem_lock<char, mem_lock_type::read> output_ptr(output, get_test_stream());
             vGoldOutput.reserve(output_ptr.size());
             for (size_t i = 0; i < output_ptr.size(); i++)
                 vGoldOutput.push_back(output_ptr[i]);
@@ -1507,9 +1503,7 @@ TEST(pooling_forward_gpu, b_fs_yx_fsv4)
             auto searchC = outputs.find("reorder_UnSwizzelled");
             ASSERT_FALSE(searchC == outputs.end());
             auto output = outputs.begin()->second.get_memory();
-            auto output_lockable = engine.allocate_memory(output->get_layout());
-            output->copy_to(get_test_stream(), *output_lockable, true);
-            cldnn::mem_lock<char> output_ptr(output_lockable, get_test_stream());
+            cldnn::mem_lock<char, mem_lock_type::read> output_ptr(output, get_test_stream());
             vTestOutput.reserve(output_ptr.size());
             for (size_t i = 0; i < output_ptr.size(); i++)
                 vTestOutput.push_back(output_ptr[i]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/pooling_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/pooling_gpu_test.cpp
@@ -231,7 +231,9 @@ TEST(pooling_forward_gpu, basic_max_byxf_f32_wsiz3x3_wstr1x1_i1x3x3x8_nopad) {
 
     auto output_prim = outputs.begin()->second.get_memory();
 
-    cldnn::mem_lock<float> output_ptr (output_prim, get_test_stream());
+    auto output_lockable = engine.allocate_memory(output_prim->get_layout());
+    output_prim->copy_to(get_test_stream(), *output_lockable, true);
+    cldnn::mem_lock<float> output_ptr (output_lockable, get_test_stream());
     ASSERT_EQ(4.0f, output_ptr[3]);
 }
 
@@ -1454,7 +1456,9 @@ TEST(pooling_forward_gpu, b_fs_yx_fsv4)
             auto searchC = outputs.find("pool_GOLD");
             ASSERT_FALSE(searchC == outputs.end());
             auto output = outputs.begin()->second.get_memory();
-            cldnn::mem_lock<char> output_ptr(output, get_test_stream());
+            auto output_lockable = engine.allocate_memory(output->get_layout());
+            output->copy_to(get_test_stream(), *output_lockable, true);
+            cldnn::mem_lock<char> output_ptr(output_lockable, get_test_stream());
             vGoldOutput.reserve(output_ptr.size());
             for (size_t i = 0; i < output_ptr.size(); i++)
                 vGoldOutput.push_back(output_ptr[i]);
@@ -1503,7 +1507,9 @@ TEST(pooling_forward_gpu, b_fs_yx_fsv4)
             auto searchC = outputs.find("reorder_UnSwizzelled");
             ASSERT_FALSE(searchC == outputs.end());
             auto output = outputs.begin()->second.get_memory();
-            cldnn::mem_lock<char> output_ptr(output, get_test_stream());
+            auto output_lockable = engine.allocate_memory(output->get_layout());
+            output->copy_to(get_test_stream(), *output_lockable, true);
+            cldnn::mem_lock<char> output_ptr(output_lockable, get_test_stream());
             vTestOutput.reserve(output_ptr.size());
             for (size_t i = 0; i < output_ptr.size(); i++)
                 vTestOutput.push_back(output_ptr[i]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -2514,9 +2514,7 @@ TEST(reorder_gpu_f32, bfzyx_to_bfyx_padded) {
     auto output1 = outputs.at("reshape1").get_memory();
     auto output2 = outputs.at("reshape2").get_memory();
 
-    auto output0_lockable = engine.allocate_memory(output0->get_layout());
-    output0->copy_to(get_test_stream(), *output0_lockable, true);
-    cldnn::mem_lock<float> output_ptr0(output0_lockable, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr0(output0, get_test_stream());
     for (int b = 0; b < b_crop; ++b) {
         for (int f = 0; f < f_crop; ++f) {
             for (int z = 0; z < z_crop; ++z) {
@@ -2531,9 +2529,7 @@ TEST(reorder_gpu_f32, bfzyx_to_bfyx_padded) {
         }
     }
 
-    auto output1_lockable = engine.allocate_memory(output1->get_layout());
-    output1->copy_to(get_test_stream(), *output1_lockable, true);
-    cldnn::mem_lock<float> output_ptr1(output1_lockable, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr1(output1, get_test_stream());
     for (int b = 0; b < b_crop; ++b) {
         for (int f = 0; f < f_crop; ++f) {
             for (int z = 0; z < z_crop; ++z) {
@@ -2548,9 +2544,7 @@ TEST(reorder_gpu_f32, bfzyx_to_bfyx_padded) {
         }
     }
 
-    auto output2_lockable = engine.allocate_memory(output2->get_layout());
-    output2->copy_to(get_test_stream(), *output2_lockable, true);
-    cldnn::mem_lock<float> output_ptr2(output2_lockable, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_ptr2(output2, get_test_stream());
     for (int b = 0; b < b_crop; ++b) {
         for (int f = 0; f < f_crop; ++f) {
             for (int z = 0; z < z_crop; ++z) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -2514,7 +2514,9 @@ TEST(reorder_gpu_f32, bfzyx_to_bfyx_padded) {
     auto output1 = outputs.at("reshape1").get_memory();
     auto output2 = outputs.at("reshape2").get_memory();
 
-    cldnn::mem_lock<float> output_ptr0(output0, get_test_stream());
+    auto output0_lockable = engine.allocate_memory(output0->get_layout());
+    output0->copy_to(get_test_stream(), *output0_lockable, true);
+    cldnn::mem_lock<float> output_ptr0(output0_lockable, get_test_stream());
     for (int b = 0; b < b_crop; ++b) {
         for (int f = 0; f < f_crop; ++f) {
             for (int z = 0; z < z_crop; ++z) {
@@ -2529,7 +2531,9 @@ TEST(reorder_gpu_f32, bfzyx_to_bfyx_padded) {
         }
     }
 
-    cldnn::mem_lock<float> output_ptr1(output1, get_test_stream());
+    auto output1_lockable = engine.allocate_memory(output1->get_layout());
+    output1->copy_to(get_test_stream(), *output1_lockable, true);
+    cldnn::mem_lock<float> output_ptr1(output1_lockable, get_test_stream());
     for (int b = 0; b < b_crop; ++b) {
         for (int f = 0; f < f_crop; ++f) {
             for (int z = 0; z < z_crop; ++z) {
@@ -2544,7 +2548,9 @@ TEST(reorder_gpu_f32, bfzyx_to_bfyx_padded) {
         }
     }
 
-    cldnn::mem_lock<float> output_ptr2(output2, get_test_stream());
+    auto output2_lockable = engine.allocate_memory(output2->get_layout());
+    output2->copy_to(get_test_stream(), *output2_lockable, true);
+    cldnn::mem_lock<float> output_ptr2(output2_lockable, get_test_stream());
     for (int b = 0; b < b_crop; ++b) {
         for (int f = 0; f < f_crop; ++f) {
             for (int z = 0; z < z_crop; ++z) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -97,7 +97,9 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
         reshape_size.add(tensor(default_fmt, lower_sizes, 0)).add(tensor(default_fmt, upper_sizes, 0)));
 
     {
-        cldnn::mem_lock<const ElemType> output_ptr(output, get_test_stream());
+        auto output_lockable = engine.allocate_memory(output->get_layout());
+        output->copy_to(get_test_stream(), *output_lockable, true);
+        cldnn::mem_lock<const ElemType> output_ptr(output_lockable, get_test_stream());
         auto output_itr = output_ptr.begin();
 
         auto sizes = reshape_size.sizes(fmt);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -97,9 +97,7 @@ void generic_reshape_test(format fmt, tensor const& input_size, tensor const& re
         reshape_size.add(tensor(default_fmt, lower_sizes, 0)).add(tensor(default_fmt, upper_sizes, 0)));
 
     {
-        auto output_lockable = engine.allocate_memory(output->get_layout());
-        output->copy_to(get_test_stream(), *output_lockable, true);
-        cldnn::mem_lock<const ElemType> output_ptr(output_lockable, get_test_stream());
+        cldnn::mem_lock<const ElemType, mem_lock_type::read> output_ptr(output, get_test_stream());
         auto output_itr = output_ptr.begin();
 
         auto sizes = reshape_size.sizes(fmt);


### PR DESCRIPTION
### Details:
 - (refer to GSD-10054) Not to use usm_host for large output buffer in BMG
 - Perf check done 
 - After this PR, MiniCPM 2.6V first token latency reduced to 1/2

### Tickets:
 - CVS-161158
