### PR TITLE
Fix Device with "(CPU)" name is not registered when using "AUTO" and setting OPENVINO_LOG_LEVEL=5

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -580,6 +580,8 @@ ov::Plugin ov::CoreImpl::get_plugin(const std::string& pluginName) const {
     auto deviceName = pluginName;
     if (deviceName == ov::DEFAULT_DEVICE_NAME)
         deviceName = "AUTO";
+    if (deviceName == "(CPU)")
+        deviceName = "CPU";
     stripDeviceName(deviceName, "-");
     std::map<std::string, PluginDescriptor>::const_iterator it;
     {


### PR DESCRIPTION
### Details:
setting OPENVINO_LOG_LEVEL=5
ov_genai.VLMPipeline(model_path, "AUTO") will have error as below:

failed Exception from src\inference\src\cpp\core.cpp:223:
Exception from src\inference\src\dev\core_impl.cpp:609:
Device with "(CPU)" name is not registered in the OpenVINO Runtime

In latency mode, AUTO will use the CPU for acceleration, and the execution device name will be changed to (CPU)

### Tickets:
https://jira.devtools.intel.com/browse/CVS-160732