### PR TITLE
[ONNX] Extended NodeContext interface

### DIFF
--- a/src/frontends/onnx/frontend/include/openvino/frontend/onnx/node_context.hpp
+++ b/src/frontends/onnx/frontend/include/openvino/frontend/onnx/node_context.hpp
@@ -21,6 +21,8 @@ public:
 
     Output<ov::Node> get_input(int port_idx) const override;
 
+    const std::string& get_name() const override;
+
     ov::Any get_attribute_as_any(const std::string& name) const override;
 
 protected:

--- a/src/frontends/onnx/frontend/src/node_context.cpp
+++ b/src/frontends/onnx/frontend/src/node_context.cpp
@@ -15,6 +15,10 @@ ov::Output<ov::Node> ov::frontend::onnx::NodeContext::get_input(int port_idx) co
     return m_inputs.at(port_idx);
 }
 
+const std::string& ov::frontend::onnx::NodeContext::get_name() const {
+    return m_context.get_name();
+}
+
 ov::Any ov::frontend::onnx::NodeContext::get_attribute_as_any(const std::string& name) const {
     try {
         return m_context.get_attribute_value<ov::Any>(name);


### PR DESCRIPTION
### Details:
 - Added a get_name() method's implementation for onnx::NodeContext to be more compatible with other FrontEnds

### Tickets:
 - N/A
