### PR TITLE
[CPU] Replace OPENVINO_ASSERT macros usage in nodes with CPU_NODE_ASSERT

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/composite.cpp
+++ b/src/plugins/intel_cpu/src/nodes/composite.cpp
@@ -33,7 +33,7 @@ Composite::Composite(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     const auto& subModel = ov::as_type_ptr<SubModel>(op);
-    OPENVINO_ASSERT(subModel, "Attempt to create SubGraph node from an invalid op type: ", op);
+    CPU_NODE_ASSERT(subModel, "Attempt to create SubGraph node from an invalid op type: ", op);
 
     m_body = subModel->get_function();
 }
@@ -78,27 +78,27 @@ void Composite::createPrimitive() {
 }
 
 int Composite::registerToAllocationContext(int offset, AllocationContext& context) {
-    OPENVINO_ASSERT(getOriginalInputsNumber() == m_graph.inputsNumber(),
+    CPU_NODE_ASSERT(getOriginalInputsNumber() == m_graph.inputsNumber(),
                     "Number of node inputs must be equal the number of inner graph's inputs");
 
     for (size_t i = 0; i < getOriginalInputsNumber(); i++) {
         auto parentEdge = getParentEdgeAt(i);
         auto inputEdges = m_graph.getInputNodeByIndex(i)->getChildEdgesAtPort(0);
         for (const auto& inputEdge : inputEdges) {
-            OPENVINO_ASSERT(inputEdge->getStatus() == Edge::Status::Uninitialized,
+            CPU_NODE_ASSERT(inputEdge->getStatus() == Edge::Status::Uninitialized,
                             "Expected Uninitialized state for edge: ",
                             *this);
             inputEdge->sharedMemFrom(parentEdge);
         }
     }
 
-    OPENVINO_ASSERT(getOriginalOutputsNumber() == m_graph.outputsNumber(),
+    CPU_NODE_ASSERT(getOriginalOutputsNumber() == m_graph.outputsNumber(),
                     "Number of node outputs must be equal the number of inner graph's outputs");
 
     for (size_t i = 0; i < getOriginalOutputsNumber(); i++) {
         auto childEdge = getChildEdgeAt(i);
         auto outputEdge = m_graph.getOutputNodeByIndex(i)->getParentEdgeAt(0);
-        OPENVINO_ASSERT(outputEdge->getStatus() == Edge::Status::Uninitialized,
+        CPU_NODE_ASSERT(outputEdge->getStatus() == Edge::Status::Uninitialized,
                         "Expected Uninitialized state for edge: ",
                         *outputEdge);
         outputEdge->sharedMemFrom(childEdge);

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -732,7 +732,7 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
     auto itr = std::find_if(edges.begin(), edges.end(), [](const EdgePtr& edge) {
         return edge->getStatus() == Edge::Status::Allocated;
     });
-    CPU_NODE_ASSERT(itr != edges.end(), "Could not find allocated child edge for concat node: ", getName());
+    CPU_NODE_ASSERT(itr != edges.end(), "Could not find allocated child edge");
 
     auto baseMemBlock = (*itr)->getMemory().getMemoryBlock();
     CPU_NODE_ASSERT(baseMemBlock != nullptr, "NULL base memory block in concat node: ", getName());

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -735,7 +735,7 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
     CPU_NODE_ASSERT(itr != edges.end(), "Could not find allocated child edge");
 
     auto baseMemBlock = (*itr)->getMemory().getMemoryBlock();
-    CPU_NODE_ASSERT(baseMemBlock != nullptr, "NULL base memory block in concat node: ", getName());
+    CPU_NODE_ASSERT(baseMemBlock != nullptr, "NULL base memory block");
 
     ptrdiff_t offset = 0;
     for (size_t i = 0; i < numberOfInputs; ++i) {

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -726,31 +726,27 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
     size_t inplaceOutIndx = selected_pd->getConfig().inConfs[0].inPlace();
     auto baseDim = outputShapes.front().getDims()[axis];
     CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM,
-                    " Concat node: ",
-                    getName(),
-                    " can't use inPlace memory with concatenation on dynamic dimension");
+                    "can't use inPlace memory with concatenation on dynamic dimension");
 
     auto edges = getChildEdgesAtPort(inplaceOutIndx);
     auto itr = std::find_if(edges.begin(), edges.end(), [](const EdgePtr& edge) {
         return edge->getStatus() == Edge::Status::Allocated;
     });
-    CPU_NODE_ASSERT(itr != edges.end(), " Could not find allocated child edge for concat node: ", getName());
+    CPU_NODE_ASSERT(itr != edges.end(), "Could not find allocated child edge for concat node: ", getName());
 
     auto baseMemBlock = (*itr)->getMemory().getMemoryBlock();
-    CPU_NODE_ASSERT(baseMemBlock != nullptr, " NULL base memory block in concat node: ", getName());
+    CPU_NODE_ASSERT(baseMemBlock != nullptr, "NULL base memory block in concat node: ", getName());
 
     ptrdiff_t offset = 0;
     for (size_t i = 0; i < numberOfInputs; ++i) {
         auto partDim = inputShapes[i].getDims()[axis];
         CPU_NODE_ASSERT(partDim != Shape::UNDEFINED_DIM,
-                        " Concat node: ",
-                        getName(),
-                        " can't use inPlace memory with concatenation on dynamic dimension");
+                        "can't use inPlace memory with concatenation on dynamic dimension");
 
         auto parentEdge = getParentEdgeAt(i);
 
         CPU_NODE_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated,
-                        " Unexpected inplace resolve call to an allocated edge: ",
+                        "Unexpected inplace resolve call to an allocated edge: ",
                         *parentEdge);
 
         auto memDesc = selected_pd->getConfig().inConfs[i].getMemDesc();

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -725,7 +725,7 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
     size_t numberOfInputs = config.inConfs.size();
     size_t inplaceOutIndx = selected_pd->getConfig().inConfs[0].inPlace();
     auto baseDim = outputShapes.front().getDims()[axis];
-    OPENVINO_ASSERT(baseDim != Shape::UNDEFINED_DIM,
+    CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM,
                     " Concat node: ",
                     getName(),
                     " can't use inPlace memory with concatenation on dynamic dimension");
@@ -734,22 +734,22 @@ void Concat::resolveInPlaceEdges(Edge::LOOK look) {
     auto itr = std::find_if(edges.begin(), edges.end(), [](const EdgePtr& edge) {
         return edge->getStatus() == Edge::Status::Allocated;
     });
-    OPENVINO_ASSERT(itr != edges.end(), " Could not find allocated child edge for concat node: ", getName());
+    CPU_NODE_ASSERT(itr != edges.end(), " Could not find allocated child edge for concat node: ", getName());
 
     auto baseMemBlock = (*itr)->getMemory().getMemoryBlock();
-    OPENVINO_ASSERT(baseMemBlock != nullptr, " NULL base memory block in concat node: ", getName());
+    CPU_NODE_ASSERT(baseMemBlock != nullptr, " NULL base memory block in concat node: ", getName());
 
     ptrdiff_t offset = 0;
     for (size_t i = 0; i < numberOfInputs; ++i) {
         auto partDim = inputShapes[i].getDims()[axis];
-        OPENVINO_ASSERT(partDim != Shape::UNDEFINED_DIM,
+        CPU_NODE_ASSERT(partDim != Shape::UNDEFINED_DIM,
                         " Concat node: ",
                         getName(),
                         " can't use inPlace memory with concatenation on dynamic dimension");
 
         auto parentEdge = getParentEdgeAt(i);
 
-        OPENVINO_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated,
+        CPU_NODE_ASSERT(parentEdge->getStatus() == Edge::Status::NotAllocated,
                         " Unexpected inplace resolve call to an allocated edge: ",
                         *parentEdge);
 

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2192,7 +2192,7 @@ void Eltwise::appendPostOps(dnnl::post_ops& ops,
     std::vector<MemoryPtr> postOpsMemPtrs;
     appendPostOpsImpl(ops, postOpDims, postOpsMemPtrs, channelAxis);
 
-    OPENVINO_ASSERT(postOpsMemPtrs.size() <= 1, "at most 1 post ops memory args can be appended.");
+    CPU_NODE_ASSERT(postOpsMemPtrs.size() <= 1, "at most 1 post ops memory args can be appended.");
 
     if (!postOpsMemPtrs.empty()) {
         postOpsMem[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = postOpsMemPtrs[0];

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1217,7 +1217,7 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
             if (isInputLowBroadcasted) {
                 binarizationThresholds.push_back(inputLowData[0]);
             } else {
-                OPENVINO_ASSERT(axisSize != -1);
+                CPU_NODE_ASSERT(axisSize != -1, "axisSize is not set");
                 binarizationThresholds.resize(rnd_up(axisSize, 16));
                 for (int i = 0; i < axisSize; i++) {
                     binarizationThresholds[i] = inputLowData[i];
@@ -1227,7 +1227,7 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
             if (isOutputHighBroadcasted) {
                 binarizationOutputMask.push_back(outputHighData[0] == 1.f ? 0xffffffff : 0x00000000);
             } else {
-                OPENVINO_ASSERT(axisSize != -1);
+                CPU_NODE_ASSERT(axisSize != -1, "axisSize is not set");
                 binarizationOutputMask.resize(rnd_up(axisSize, 16));
                 for (int i = 0; i < axisSize; i++) {
                     binarizationOutputMask[i] = outputHighData[i] == 1.f ? 0xffffffff : 0x00000000;
@@ -1563,7 +1563,7 @@ void FakeQuantize::prepareParams() {
     if (isBinarization()) {
         const size_t axisSize = getParentEdgeAt(0)->getMemory().getShape().getStaticDims()[getAxis()];
         const size_t newPaddedSize = rnd_up(axisSize, 16);
-        OPENVINO_ASSERT(newPaddedSize != 0);
+        CPU_NODE_ASSERT(newPaddedSize != 0, "newPaddedSize is 0");
 
         if (internalBlobMemory.empty() || newPaddedSize != rnd_up(currentAxisSize, 16) ||
             ((isInputLowBroadcasted || isOutputHighBroadcasted) && axisSize != currentAxisSize)) {
@@ -2140,7 +2140,7 @@ void FakeQuantize::appendPostOps(dnnl::post_ops& ops,
     std::vector<MemoryPtr> postOpsMemPtrs;
     appendPostOpsImpl(ops, postOpDims, postOpsMemPtrs);
 
-    OPENVINO_ASSERT(postOpsMemPtrs.size() <= 1, "at most 1 post ops memory args can be appended.");
+    CPU_NODE_ASSERT(postOpsMemPtrs.size() <= 1, "at most 1 post ops memory args can be appended.");
 
     if (!postOpsMemPtrs.empty()) {
         postOpsMem[DNNL_ARG_ATTR_MULTIPLE_POST_OP(ops.len() - 1) | DNNL_ARG_SRC_1] = postOpsMemPtrs[0];
@@ -2187,12 +2187,12 @@ void FakeQuantize::updateOptimizedFormula(bool do_rounding) {
                           outputScale.size(),
                           outputShift.size()});
 
-    OPENVINO_ASSERT(inputScale.size() == 1 || inputScale.size() == OC);
-    OPENVINO_ASSERT(inputShift.size() == 1 || inputShift.size() == OC);
-    OPENVINO_ASSERT(cropLow.size() == 1 || cropLow.size() == OC);
-    OPENVINO_ASSERT(cropHigh.size() == 1 || cropHigh.size() == OC);
-    OPENVINO_ASSERT(outputScale.size() == 1 || outputScale.size() == OC);
-    OPENVINO_ASSERT(outputShift.size() == 1 || outputShift.size() == OC);
+    CPU_NODE_ASSERT(inputScale.size() == 1 || inputScale.size() == OC, "inputScale.size() == ", inputScale.size());
+    CPU_NODE_ASSERT(inputShift.size() == 1 || inputShift.size() == OC, "inputShift.size() == ", inputShift.size());
+    CPU_NODE_ASSERT(cropLow.size() == 1 || cropLow.size() == OC, "cropLow.size() == ", cropLow.size());
+    CPU_NODE_ASSERT(cropHigh.size() == 1 || cropHigh.size() == OC, "cropHigh.size() == ", cropHigh.size());
+    CPU_NODE_ASSERT(outputScale.size() == 1 || outputScale.size() == OC, "outputScale.size() == ", outputScale.size());
+    CPU_NODE_ASSERT(outputShift.size() == 1 || outputShift.size() == OC, "outputShift.size() == ", outputShift.size());
 
     // WA: a per-Tensor input shift may little drift away randomly
     //     from it's orginal value when FQ was fused with any

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -228,7 +228,7 @@ void FullyConnected::needPrepareParamsForTensorParallel() {
         if (dim < 0) {
             dim += dims.size();
         }
-        OPENVINO_ASSERT(static_cast<int>(dims[dim]) >= tp_cfg.w_size,
+        CPU_NODE_ASSERT(static_cast<int>(dims[dim]) >= tp_cfg.w_size,
                         getName() + " dim[" + std::to_string(dim) + "] is " + std::to_string(dims[dim]) +
                             ", which is larger than w_size " + std::to_string(tp_cfg.w_size));
         auto splited_dim_vec = split_parts(dims[dim], tp_cfg.w_size);
@@ -252,7 +252,7 @@ void FullyConnected::prepareParams() {
 void FullyConnected::initTensorParallelSync() {
     if (tp_cfg.enable_tensor_parallel) {
         tp_cfg.id = tp_cfg.sub_memory->get_memory_id(tp_cfg.w_rank);
-        OPENVINO_ASSERT(tp_cfg.id >= 0, "Tensor Parallel Config ID cannot be negative.");
+        CPU_NODE_ASSERT(tp_cfg.id >= 0, "Tensor Parallel Config ID cannot be negative.");
         tp_cfg.sub_memory->set_memory_used(tp_cfg.id, tp_cfg.w_rank);
         while (true) {
             std::lock_guard<std::mutex> lock(tp_cfg.sub_memory->_flagMutex);

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -972,7 +972,7 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
     auto& config = selected_pd->getConfig();
     size_t inplaceInpIndx = selected_pd->getConfig().outConfs[outputPort].inPlace();
     const auto baseDim = inputShapes.front().getDims()[axis];
-    OPENVINO_ASSERT(baseDim != Shape::UNDEFINED_DIM,
+    CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM,
                     "Gather node: ",
                     getName(),
                     " can not use inPlace memory with splitting on dynamic dimention");
@@ -981,7 +981,7 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
     const ptrdiff_t offset = index < 0 ? baseDim + index : index;
     const auto& childEdges = getChildEdgesAtPort(outputPort);
     for (auto& childEdge : childEdges) {
-        OPENVINO_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated,
+        CPU_NODE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated,
                         " Unexpected edge status in node: ",
                         getName(),
                         " with type ",

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -973,19 +973,13 @@ void Gather::resolveInPlaceEdges(Edge::LOOK look) {
     size_t inplaceInpIndx = selected_pd->getConfig().outConfs[outputPort].inPlace();
     const auto baseDim = inputShapes.front().getDims()[axis];
     CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM,
-                    "Gather node: ",
-                    getName(),
-                    " can not use inPlace memory with splitting on dynamic dimention");
+                    "can not use inPlace memory with splitting on dynamic dimention");
     auto baseMemBlock = getParentEdgeAt(inplaceInpIndx)->getMemory().getMemoryBlock();
     const auto index = constIndices.front();
     const ptrdiff_t offset = index < 0 ? baseDim + index : index;
     const auto& childEdges = getChildEdgesAtPort(outputPort);
     for (auto& childEdge : childEdges) {
-        CPU_NODE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated,
-                        " Unexpected edge status in node: ",
-                        getName(),
-                        " with type ",
-                        getTypeStr());
+        CPU_NODE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated, "Unexpected edge status");
 
         auto memBlock = std::make_shared<PartitionedMemoryBlock>(baseMemBlock, baseDim, offset);
         auto newMem = std::make_shared<Memory>(getEngine(), config.outConfs[outputPort].getMemDesc(), memBlock);

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -74,7 +74,7 @@ bool If::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::st
 If::If(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
     : Node(op, context, InternalDynShapeInferFactory()),
       m_op(ov::as_type_ptr<ov::op::v8::If>(op)) {
-    OPENVINO_ASSERT(m_op, "'If' operation is expected");
+    CPU_NODE_ASSERT(m_op, "'If' operation is expected");
 
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage)) {

--- a/src/plugins/intel_cpu/src/nodes/lora.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lora.cpp
@@ -33,7 +33,7 @@ LoRA::LoRA(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& contex
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
     }
     const auto& loraModel = ov::as_type_ptr<ov::op::internal::LoraSubgraph>(op);
-    OPENVINO_ASSERT(loraModel,
+    CPU_NODE_ASSERT(loraModel,
                     "Attempt to create LoRA node from an invalid op type: ",
                     op,
                     " with name ",
@@ -96,7 +96,7 @@ int LoRA::registerToAllocationContext(int offset, AllocationContext& context) {
         auto parentEdge = getParentEdgeAt(i);
         auto inputEdges = m_graph.getInputNodeByIndex(i)->getChildEdgesAtPort(0);
         for (const auto& inputEdge : inputEdges) {
-            OPENVINO_ASSERT(inputEdge->getStatus() == Edge::Status::Uninitialized,
+            CPU_NODE_ASSERT(inputEdge->getStatus() == Edge::Status::Uninitialized,
                             "Expected Uninitialized Edge instead of: ",
                             static_cast<int>(inputEdge->getStatus()));
             inputEdge->sharedMemFrom(parentEdge);

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -376,7 +376,7 @@ std::pair<Shape, Shape> MatMul::makeDummyInputShapes(const Shape& in0, const Sha
         OPENVINO_THROW("Can't create dummy inputs with rank less 2");
     }
 
-    OPENVINO_ASSERT((in0.getRank() == in1.getRank()) && (in1.getRank() == out.getRank()),
+    CPU_NODE_ASSERT((in0.getRank() == in1.getRank()) && (in1.getRank() == out.getRank()),
                     "Can't create dummy inputs if argument shapes ranks are not equal");
 
     auto swapTranspDims = [&](VectorDims& in0, VectorDims& in1) {
@@ -587,7 +587,7 @@ void MatMul::prepareParams() {
     if (src0MemPtr->getDesc().getShape().hasZeroDims() && src0MemPtr->getDesc().getShape().hasZeroDims() &&
         !dstMemPtr->getDesc().getShape().hasZeroDims()) {
         // todo: obviously we need a special executor that would process fused ops providing a correct result
-        OPENVINO_ASSERT(!withBiases && fusedWith.empty(),
+        CPU_NODE_ASSERT(!withBiases && fusedWith.empty(),
                         "Matmul doesn't support a degenerate case when other ops are fused");
         // reset executor
         execPtr.reset();

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -159,7 +159,7 @@ MemoryOutputBase::~MemoryOutputBase() {
 }
 
 MemoryInputBase& MemoryOutputBase::getInputNode() {
-    CPU_NODE_ASSERT(inputNode, "MemoryOutput ", getName(), " doesn't have sibling input");
+    CPU_NODE_ASSERT(inputNode, " doesn't have sibling input");
     return *inputNode;
 }
 
@@ -202,8 +202,6 @@ void MemoryOutputBase::initOptimalPrimitiveDescriptor() {
 
     auto selected_pd = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selected_pd,
-                    "MemoryOutput ",
-                    getName(),
                     " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     auto config = selected_pd->getConfig();
@@ -230,7 +228,7 @@ void MemoryOutputBase::executeDynamicImpl(const dnnl::stream& strm) {
 }
 
 void MemoryOutputBase::assignState(const MemStatePtr& newState) {
-    CPU_NODE_ASSERT(newState, "MemoryOutput ", getName(), " got null state");
+    CPU_NODE_ASSERT(newState, " got null state");
     state = newState;
     assignExtMemory(state->output_mem(), state->internal_desc());
 }
@@ -272,8 +270,6 @@ void MemoryOutput::resolveInPlaceEdges(Edge::LOOK look) {
 
     auto selected_pd = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selected_pd,
-                    "MemoryOutput ",
-                    getName(),
                     " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     auto parentEdge = getParentEdgeAt(0);  // always only one parent edge
@@ -290,10 +286,10 @@ void MemoryOutput::resolveInPlaceEdges(Edge::LOOK look) {
 
 void MemoryOutput::assignExtMemory(const MemoryPtr& mem, const MemoryDescPtr& memDesc) {
     assignedMem = mem;
-    CPU_NODE_ASSERT(assignedMem, "MemoryOutput ", getName(), " assigned state has null memory ptr");
+    CPU_NODE_ASSERT(assignedMem, " assigned state has null memory ptr");
 
     extMemDesc = memDesc;
-    CPU_NODE_ASSERT(extMemDesc, "MemoryOutput ", getName(), " assigned state has null base mem desc ptr");
+    CPU_NODE_ASSERT(extMemDesc, " assigned state has null base mem desc ptr");
 
     if (!memBlock) {
         return;
@@ -309,7 +305,7 @@ void MemoryOutput::assignExtMemory(const MemoryPtr& mem, const MemoryDescPtr& me
 
 void MemoryOutput::runStatic(dnnl::stream strm) {
     auto inputMem = getSrcMemoryAtPort(0);
-    CPU_NODE_ASSERT(assignedMem, "MemoryOutput ", getName(), " uninitialized assigned memory");
+    CPU_NODE_ASSERT(assignedMem, " uninitialized assigned memory");
 
     if (inputMem->getData() != assignedMem->getData()) {
         assignedMem->load(*inputMem);
@@ -320,13 +316,13 @@ void MemoryOutput::runDynamic(dnnl::stream strm) {
     // first we have to resize the output memory
     auto inputMem = getSrcMemoryAtPort(0);
 
-    CPU_NODE_ASSERT(assignedMem, "MemoryOutput ", getName(), " uninitialized assigned memory");
+    CPU_NODE_ASSERT(assignedMem, " uninitialized assigned memory");
 
     const auto& newShape = inputMem->getShape();
     const auto& stateShape = assignedMem->getShape();
 
     if (stateShape.isDynamic() || stateShape.getStaticDims() != newShape.getStaticDims()) {
-        CPU_NODE_ASSERT(extMemDesc, "MemoryOutput ", getName(), " uninitialized assigned memory");
+        CPU_NODE_ASSERT(extMemDesc, " uninitialized assigned memory");
         auto newExternDesc = extMemDesc->cloneWithNewDims(newShape.getStaticDims());
         assignedMem->redefineDesc(newExternDesc);
     }
@@ -357,8 +353,6 @@ void MemoryOutputStub::resolveInPlaceEdges(Edge::LOOK look) {
 
     auto selected_pd = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selected_pd,
-                    "MemoryOutput ",
-                    getName(),
                     " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     auto parentEdge = getParentEdgeAt(0);  // always only one parent edge
@@ -458,7 +452,7 @@ MemoryInputBase::~MemoryInputBase() {
 }
 
 MemoryOutputBase& MemoryInputBase::getOutputNode() {
-    CPU_NODE_ASSERT(outputNode, "MemoryInput ", getName(), " doesn't have sibling output");
+    CPU_NODE_ASSERT(outputNode, " doesn't have sibling output");
     return *outputNode;
 }
 
@@ -560,7 +554,7 @@ MemoryOutputBase* MemoryStatesRegister::getMemoryOutputByName(const std::string&
 }
 
 void MemoryInputBase::assignState(MemStatePtr newState) {
-    CPU_NODE_ASSERT(newState, "MemoryInput ", getName(), " got null state");
+    CPU_NODE_ASSERT(newState, " got null state");
     state = newState;
     assignStateHook();
 }
@@ -668,8 +662,6 @@ void MemoryInput::initOptimalPrimitiveDescriptor() {
 
     auto selectedPd = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selectedPd,
-                    "MemoryInput ",
-                    getName(),
                     " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     auto config = selectedPd->getConfig();
@@ -752,9 +744,9 @@ int MemoryInput::registerToAllocationContext(int offset, AllocationContext& cont
 void MemoryInput::runDynamic(dnnl::stream strm) {
     auto assignedMem = getAssignedState()->input_mem();
 
-    CPU_NODE_ASSERT(assignedMem, "MemoryInput ", getName(), " assigned state has null memory ptr");
+    CPU_NODE_ASSERT(assignedMem, " assigned state has null memory ptr");
 
-    CPU_NODE_ASSERT(memBlock, "MemoryInput ", getName(), " has uninitialized memory block.");
+    CPU_NODE_ASSERT(memBlock, " has uninitialized memory block.");
 
     // check whether we can share memory block
     const auto& shape = assignedMem->getShape();

--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -797,9 +797,7 @@ void MemoryInput::runDynamic(dnnl::stream strm) {
             // external graph or override the src pointer with the memory pointer pointing to the subgraph output
             // memory
             CPU_NODE_ASSERT(subGraph->outputsNumber() == 1,
-                            "MemoryInput ",
-                            getName(),
-                            " has unexpected number of outputs");
+                            "has unexpected number of outputs");
             src = subGraph->getOutputNodeByIndex(0)->getSrcMemoryAtPort(0);
 
             // since the shape inference(InternalDynShapeInfer, do nothing) is performed, a memory of the extra child
@@ -830,21 +828,19 @@ void MemoryInput::runDynamic(dnnl::stream strm) {
 void MemoryInput::runStatic(dnnl::stream strm) {
     auto assignedMem = getAssignedState()->input_mem();
 
-    CPU_NODE_ASSERT(assignedMem, "MemoryInput ", getName(), " assigned state has null memory ptr");
+    CPU_NODE_ASSERT(assignedMem, "assigned state has null memory ptr");
 
     const auto& stateDims = assignedMem->getStaticDims();
     const auto& expectedDims = getBaseMemDescAtOutputPort(0)->getShape().getStaticDims();
     CPU_NODE_ASSERT(expectedDims == stateDims,
-                    "MemoryInput ",
-                    getName(),
-                    " unexpected state shape: ",
+                    "unexpected state shape: ",
                     vec2str(stateDims),
                     ", while the expected shape: ",
                     vec2str(expectedDims));
 
     auto internDesc = getBaseMemDescAtOutputPort(0);
 
-    CPU_NODE_ASSERT(memBlock, "MemoryInput ", getName(), " has uninitialized memory block.");
+    CPU_NODE_ASSERT(memBlock, "has uninitialized memory block.");
 
     if (internDesc->isCompatible(assignedMem->getDesc())) {
         memBlock->setMemBlock(assignedMem->getMemoryBlock());
@@ -859,10 +855,7 @@ void MemoryInput::runStatic(dnnl::stream strm) {
             subGraph->ResetInferCount();
             subGraph->Infer();
 
-            CPU_NODE_ASSERT(subGraph->outputsNumber() == 1,
-                            "MemoryInput ",
-                            getName(),
-                            " has unexpected number of outputs");
+            CPU_NODE_ASSERT(subGraph->outputsNumber() == 1, "has unexpected number of outputs");
             src = subGraph->getOutputNodeByIndex(0)->getSrcMemoryAtPort(0);
         } else {
             src = getSrcMemoryAtPort(0);
@@ -884,16 +877,14 @@ void MemoryInput::resolveInPlaceEdges(Edge::LOOK look) {
 
     auto selected_pd = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selected_pd,
-                    "MemoryInput ",
-                    getName(),
-                    " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
+                    "failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     auto memDesc = selected_pd->getConfig().outConfs.front().getMemDesc();
     memBlock = std::make_shared<ProxyMemoryBlock>();
 
     for (auto&& edge : getChildEdgesAtPort(0)) {  // always only one child port
         CPU_NODE_ASSERT(one_of(edge->getStatus(), Edge::Status::Uninitialized, Edge::Status::NotAllocated),
-                        " Unexpected inplace resolve call to an allocated edge: ",
+                        "Unexpected inplace resolve call to an allocated edge: ",
                         *edge);
 
         auto edgeMem = std::make_shared<Memory>(getEngine(), memDesc, memBlock);

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -83,7 +83,7 @@ void PagedAttention::initSupportedPrimitiveDescriptors() {
         creatorsMap.at(LayoutType::ncsp)
             ->createSharedDesc(rtPrecision, getInputShapeAtPort(PagedAttentionExecutor::ID_V)));
 
-    OPENVINO_ASSERT(orgInputNumber == 13 || orgInputNumber == 16,
+    CPU_NODE_ASSERT(orgInputNumber == 13 || orgInputNumber == 16,
                     "The input number of PagedAttention should be 13 or 16.");
     // kvcache, float, []
     auto past_key_input_mem_precision = getOriginalInputPrecisionAtPort(PagedAttentionExecutor::ID_KCACHE);

--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -373,7 +373,7 @@ void QKVProjection::initSupportedPrimitiveDescriptors() {
         }
     }
 
-    OPENVINO_ASSERT(rtPrecision == ov::element::bf16 || rtPrecision == ov::element::f16,
+    CPU_NODE_ASSERT(rtPrecision == ov::element::bf16 || rtPrecision == ov::element::f16,
                     "Unexpected rtPrecision:",
                     rtPrecision);
 

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -405,9 +405,9 @@ void RoPE::initSupportedPrimitiveDescriptors() {
             rtPrecision = ov::element::f32;
         }
     } else if (m_config.is_interleaved) {
-        OPENVINO_ASSERT(m_config.slice_start == 0);
-        OPENVINO_ASSERT(m_config.slice_stop == 0);
-        OPENVINO_ASSERT(m_config.gather_position_arg_id == 0);
+        CPU_NODE_ASSERT(m_config.slice_start == 0, "slice_start must be 0 for interleaved mode");
+        CPU_NODE_ASSERT(m_config.slice_stop == 0, "slice_stop must be 0 for interleaved mode");
+        CPU_NODE_ASSERT(m_config.gather_position_arg_id == 0, "gather_position_arg_id must be 0 for interleaved mode");
         if (rtPrecision == ov::element::f16) {
             m_executor = std::make_shared<RoPEExecutorInterleaved<ov::float16>>(m_config);
         } else if (rtPrecision == ov::element::bf16) {

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -1093,10 +1093,9 @@ ScaledDotProductAttention::ScaledDotProductAttention(const std::shared_ptr<ov::N
     const auto valueDims = getInputShapeAtPort(2).getDims();
     const auto keyS = *(keyDims.end() - 1);
     const auto valueS = *(valueDims.end() - 1);
-    OPENVINO_ASSERT(valueCachePrecision == keyCachePrecision,
-                    "CPU: SDPA node only supports same key/value cache precision");
-    OPENVINO_ASSERT(one_of(keyCachePrecision, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8),
-                    "CPU: SDPA only supports key/value cache precision f32, f16, bf16, u8 but gets ",
+    CPU_NODE_ASSERT(valueCachePrecision == keyCachePrecision, "supports same key/value cache precision");
+    CPU_NODE_ASSERT(one_of(keyCachePrecision, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8),
+                    "supports key/value cache precision f32, f16, bf16, u8 but gets ",
                     keyCachePrecision);
     m_key_quant_param.groupSize = (cpuConfig.keyCacheGroupSize == 0 || keyS % cpuConfig.keyCacheGroupSize != 0)
                                       ? keyS
@@ -1387,7 +1386,7 @@ void ScaledDotProductAttention::resetBeamTablePastkv(const MemoryPtr& mem_cur_k,
     // 1. check beam idx if it's valid
     auto* table = beam_idx.ptr<int32_t>();
     for (size_t i = 0; i < B; i++) {
-        OPENVINO_ASSERT(static_cast<size_t>(table[i]) < B_state,
+        CPU_NODE_ASSERT(static_cast<size_t>(table[i]) < B_state,
                         "beam_idx[",
                         i,
                         "]=",
@@ -1583,11 +1582,11 @@ void ScaledDotProductAttention::updateBeamTable(const MemoryPtr& mem_beam_idx, s
     auto&& v_dims = getParentEdgeAt(inputNumber - 1)->getMemory().getStaticDims();
     size_t L0 = v_dims.at(order[2]);
     auto B_state = v_dims.at(order[0]);
-    OPENVINO_ASSERT(m_k_state->is_reset_state() == m_v_state->is_reset_state(),
+    CPU_NODE_ASSERT(m_k_state->is_reset_state() == m_v_state->is_reset_state(),
                     "KV state must be reset simultaneously, please also reset state for ",
                     (m_k_state->is_reset_state() ? m_v_state->get_name() : m_k_state->get_name()));
-    OPENVINO_ASSERT(B == B_state, "beam idx batch: ", B, " is not equal to batch of state: ", B_state);
-    OPENVINO_ASSERT(B * (L0 + L1) > 0, "B or (L0+L1) is zero, B: ", B, ", L0: ", L0, ", L1: ", L1);
+    CPU_NODE_ASSERT(B == B_state, "beam idx batch: ", B, " is not equal to batch of state: ", B_state);
+    CPU_NODE_ASSERT(B * (L0 + L1) > 0, "B or (L0+L1) is zero, B: ", B, ", L0: ", L0, ", L1: ", L1);
     // resize buffer
     bool need_redefine = true;
     if (B * (L0 + L1) > m_k_state->hidden_state_max_size()) {
@@ -1727,8 +1726,8 @@ void ScaledDotProductAttention::updatePastkv(const MemoryPtr& mem_cur_k, const M
     auto&& v_dims = getParentEdgeAt(inputNumber - 1)->getMemory().getStaticDims();
     size_t L0 = v_dims.at(order[2]);
     auto B_state = v_dims.at(order[0]);
-    OPENVINO_ASSERT(B == B_state, "pastkv batch: ", B, " is not equal to batch of state: ", B_state);
-    OPENVINO_ASSERT(B * (L0 + L1) > 0, "B or (L0+L1) is zero, B: ", B, ", L0: ", L0, ", L1: ", L1);
+    CPU_NODE_ASSERT(B == B_state, "pastkv batch: ", B, " is not equal to batch of state: ", B_state);
+    CPU_NODE_ASSERT(B * (L0 + L1) > 0, "B or (L0+L1) is zero, B: ", B, ", L0: ", L0, ", L1: ", L1);
     // resize buffer
     ov::element::Type kvcache_precision = m_k_state->internal_desc()->getPrecision();
     bool need_redefine = true;

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -566,7 +566,7 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
     if (axis < 0) {
         axis += updates_rank;
     }
-    OPENVINO_ASSERT(axis >= 0 && axis < static_cast<int>(updates_rank), "Invalid axis.");
+    CPU_NODE_ASSERT(axis >= 0 && axis < static_cast<int>(updates_rank), "Invalid axis.");
 
     const int64_t data_dim_size = static_cast<int64_t>(data_shape[axis]);
     const auto index_dim_size = indices_shape[axis];
@@ -682,7 +682,7 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
                                           int axis,
                                           const scatter_reductions::ReduceMean& kernel) {
     using namespace scatter_elements_update;
-    OPENVINO_ASSERT(reduction_type == ScatterUpdate::Reduction::MEAN, "The reduction type should be MEAN here.");
+    CPU_NODE_ASSERT(reduction_type == ScatterUpdate::Reduction::MEAN, "The reduction type should be MEAN here.");
     DataType* dataPtr = mem_data->getDataAs<DataType>();
     DataType* updatePtr = mem_updates->getDataAs<DataType>();
     uint8_t* indicesPtr = mem_indices->getDataAs<uint8_t>();
@@ -694,7 +694,7 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
     if (axis < 0) {
         axis += updates_rank;
     }
-    OPENVINO_ASSERT(axis >= 0 && axis < static_cast<int>(updates_rank), "Invalid axis.");
+    CPU_NODE_ASSERT(axis >= 0 && axis < static_cast<int>(updates_rank), "Invalid axis.");
 
     const int64_t data_dim_size = static_cast<int64_t>(data_shape[axis]);
     const auto index_dim_size = indices_shape[axis];
@@ -1079,7 +1079,7 @@ void ScatterUpdate::scatterNDUpdate(const MemoryPtr& mem_data,
                                     const MemoryPtr& mem_indices,
                                     const MemoryPtr& mem_updates,
                                     const KernelType& kernel) {
-    OPENVINO_ASSERT(reduction_type != ScatterUpdate::Reduction::NONE, "The reduction should not be NONE.");
+    CPU_NODE_ASSERT(reduction_type != ScatterUpdate::Reduction::NONE, "The reduction should not be NONE.");
     uint8_t* indices = mem_indices->getDataAs<uint8_t>();
     DataType* update = mem_updates->getDataAs<DataType>();
     DataType* dstData = mem_data->getDataAs<DataType>();

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -62,9 +62,6 @@ void ShapeOf::initOptimalPrimitiveDescriptor() {
     auto parent = parentEdge->getParent();
     auto parentPd = parent->getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(parentPd,
-                    parent->getTypeStr(),
-                    " ",
-                    parent->getName(),
                     "failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     const auto& parentConfig = parentPd->getConfig();
@@ -72,9 +69,7 @@ void ShapeOf::initOptimalPrimitiveDescriptor() {
 
     auto selected_pd = getSelectedPrimitiveDescriptor();
     CPU_NODE_ASSERT(selected_pd,
-                    "ShapeOf ",
-                    getName(),
-                    " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
+                    "failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");
 
     auto config = selected_pd->getConfig();
     config.inConfs.front().setMemDesc(mem_desc);

--- a/src/plugins/intel_cpu/src/nodes/shapeof.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.cpp
@@ -61,7 +61,7 @@ void ShapeOf::initOptimalPrimitiveDescriptor() {
     auto parentEdge = getParentEdgeAt(0);
     auto parent = parentEdge->getParent();
     auto parentPd = parent->getSelectedPrimitiveDescriptor();
-    OPENVINO_ASSERT(parentPd,
+    CPU_NODE_ASSERT(parentPd,
                     parent->getTypeStr(),
                     " ",
                     parent->getName(),
@@ -71,7 +71,7 @@ void ShapeOf::initOptimalPrimitiveDescriptor() {
     auto mem_desc = parentConfig.outConfs[parentEdge->getInputNum()].getMemDesc();
 
     auto selected_pd = getSelectedPrimitiveDescriptor();
-    OPENVINO_ASSERT(selected_pd,
+    CPU_NODE_ASSERT(selected_pd,
                     "ShapeOf ",
                     getName(),
                     " failed getSelectedPrimitiveDescriptor() call, preferable primitive descriptor is not set");

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -318,7 +318,7 @@ void Split::execute(const dnnl::stream& strm) {
     }
 
     uint8_t* srcData = srcMem.getDataAs<uint8_t>();
-    OPENVINO_ASSERT(execPtr != nullptr);
+    CPU_NODE_ASSERT(execPtr != nullptr, "Split executor is not initialized");
     execPtr->exec(srcData, getRawDstMemPtrs());
 }
 
@@ -335,7 +335,7 @@ void Split::initOptimalPrimitiveDescriptor() {
 
     auto config = selected_pd->getConfig();
     canUseOptimizedNspc2Ncsp = false;
-    OPENVINO_ASSERT(config.inConfs.size() > 0);
+    CPU_NODE_ASSERT(config.inConfs.size() > 0, "Incorrect number of input configurations");
     const auto inConfDesc = config.inConfs[0].getMemDesc();
     if (axis == 1 && one_of(inConfDesc->getShape().getRank(), 4u, 5u) && inConfDesc->hasLayoutType(LayoutType::nspc)) {
         canUseOptimizedNspc2Ncsp = true;
@@ -571,7 +571,7 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
     size_t numberOfOutputs = config.outConfs.size();
     size_t inplaceInpIndx = selected_pd->getConfig().outConfs[0].inPlace();
     auto baseDim = inputShapes.front().getDims()[axis];
-    OPENVINO_ASSERT(baseDim != Shape::UNDEFINED_DIM,
+    CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM,
                     " Split node: ",
                     getName(),
                     " can not use inPlace memory with splitting on dynamic dimension");
@@ -579,13 +579,13 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
     ptrdiff_t offset = 0;
     for (size_t i = 0; i < numberOfOutputs; ++i) {
         auto partDim = outputShapes[i].getDims()[axis];
-        OPENVINO_ASSERT(partDim != Shape::UNDEFINED_DIM,
+        CPU_NODE_ASSERT(partDim != Shape::UNDEFINED_DIM,
                         " Split node: ",
                         getName(),
                         " can not use inPlace memory with splitting on dynamic dimension");
         const auto& childEdges = getChildEdgesAtPort(i);
         for (auto& childEdge : childEdges) {
-            OPENVINO_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated,
+            CPU_NODE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated,
                             " Unexpected edge status in node: ",
                             getName(),
                             " with type ",

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -571,25 +571,16 @@ void Split::resolveInPlaceEdges(Edge::LOOK look) {
     size_t numberOfOutputs = config.outConfs.size();
     size_t inplaceInpIndx = selected_pd->getConfig().outConfs[0].inPlace();
     auto baseDim = inputShapes.front().getDims()[axis];
-    CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM,
-                    " Split node: ",
-                    getName(),
-                    " can not use inPlace memory with splitting on dynamic dimension");
+    CPU_NODE_ASSERT(baseDim != Shape::UNDEFINED_DIM, "can not use inPlace memory with splitting on dynamic dimension");
     auto baseMemBlock = getParentEdgeAt(inplaceInpIndx)->getMemory().getMemoryBlock();
     ptrdiff_t offset = 0;
     for (size_t i = 0; i < numberOfOutputs; ++i) {
         auto partDim = outputShapes[i].getDims()[axis];
         CPU_NODE_ASSERT(partDim != Shape::UNDEFINED_DIM,
-                        " Split node: ",
-                        getName(),
-                        " can not use inPlace memory with splitting on dynamic dimension");
+                        "can not use inPlace memory with splitting on dynamic dimension");
         const auto& childEdges = getChildEdgesAtPort(i);
         for (auto& childEdge : childEdges) {
-            CPU_NODE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated,
-                            " Unexpected edge status in node: ",
-                            getName(),
-                            " with type ",
-                            getTypeStr());
+            CPU_NODE_ASSERT(childEdge->getStatus() == Edge::Status::NotAllocated, "Unexpected edge status");
 
             auto memDesc = selected_pd->getConfig().outConfs[i].getMemDesc();
             MemoryPtr newMem;

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -475,7 +475,7 @@ void TensorIterator::createPrimitive() {
         std::string type_name = desc->get_type_info().name;
         if (type_name == "ConcatOutputDescription") {
             auto output_desc = ov::as_type_ptr<const ov::op::util::SubGraphOp::ConcatOutputDescription>(desc);
-            OPENVINO_ASSERT(output_desc != nullptr);
+            CPU_NODE_ASSERT(output_desc != nullptr, "Incorrect type of the output description");
 
             outputPortMap.emplace_back(PortMap{static_cast<int>(output_desc->m_output_index),
                                                static_cast<int>(body_output_idx),
@@ -486,7 +486,7 @@ void TensorIterator::createPrimitive() {
                                                static_cast<int>(output_desc->m_part_size)});
         } else if (type_name == "BodyOutputDescription") {
             auto output_desc = ov::as_type_ptr<const ov::op::util::SubGraphOp::BodyOutputDescription>(desc);
-            OPENVINO_ASSERT(output_desc != nullptr);
+            CPU_NODE_ASSERT(output_desc != nullptr, "Incorrect type of the output description");
 
             outputPortMap.emplace_back(PortMap{static_cast<int>(output_desc->m_output_index),
                                                static_cast<int>(body_output_idx),


### PR DESCRIPTION
### Details:
 - Replace custom OPENVINO_ASSERT macros usage for error reporting in nodes implementation with CPU_NODE_ASSERT
 - Add assertion message where it is missing

### Tickets:
 - 160275
