### PR TITLE
Make custom ThreadLocal implementation copyable

### DIFF
--- a/src/inference/dev_api/openvino/runtime/threading/thread_local.hpp
+++ b/src/inference/dev_api/openvino/runtime/threading/thread_local.hpp
@@ -59,10 +59,15 @@ struct ThreadLocal {
         _create = std::move(other._create);
         return *this;
     }
-    ThreadLocal(const ThreadLocal& other) : _map(other._map), _create(other._create) {}
+    ThreadLocal(const ThreadLocal& other) : _create(other._create) {
+        std::lock_guard<std::mutex> lock{other._mutex};
+        _map = other._map;
+    }
     ThreadLocal& operator=(const ThreadLocal& other) {
+        std::lock_guard<std::mutex> lock{other._mutex};
         _map = other._map;
         _create = other._create;
+        return *this;
     }
     explicit ThreadLocal(const Create& create_) : _create{create_} {}
 

--- a/src/inference/dev_api/openvino/runtime/threading/thread_local.hpp
+++ b/src/inference/dev_api/openvino/runtime/threading/thread_local.hpp
@@ -59,8 +59,11 @@ struct ThreadLocal {
         _create = std::move(other._create);
         return *this;
     }
-    ThreadLocal(const ThreadLocal&) = delete;
-    ThreadLocal& operator=(const ThreadLocal&&) = delete;
+    ThreadLocal(const ThreadLocal& other) : _map(other._map), _create(other._create) {}
+    ThreadLocal& operator=(const ThreadLocal& other) {
+        _map = other._map;
+        _create = other._create;
+    }
     explicit ThreadLocal(const Create& create_) : _create{create_} {}
 
     T& local() {


### PR DESCRIPTION
### Details:
Fix ARM 32-bit build with `-DENABLE_DEBUG_CAPS=ON` CMake configuration flag. Make `ThreadLocal` class implementation copyable where TBB threading is not enabled. Original `tbb::enumerable_thread_specific<T>` has copyable interface.

### Tickets:
 - N/A
