### PR TITLE
[NPU] If context is already destroyed it will not return success

### DIFF
--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -10,7 +10,6 @@
 
 #include "intel_npu/common/blob_container.hpp"
 #include "intel_npu/network_metadata.hpp"
-#include "intel_npu/utils/zero/zero_init.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "intel_npu/utils/zero/zero_wrappers.hpp"
 #include "openvino/runtime/profiling_info.hpp"

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_graph.cpp
@@ -163,12 +163,21 @@ bool DriverGraph::release_blob(const Config& config) {
 };
 
 DriverGraph::~DriverGraph() {
+    // make sure all the context-dependent components are destroyed before the zero context is destroyed
     if (_handle != nullptr) {
         auto result = _zeGraphExt->destroyGraph(_handle);
 
         if (ZE_RESULT_SUCCESS == result) {
             _handle = nullptr;
         }
+    }
+
+    if (!_last_submitted_event.empty()) {
+        _last_submitted_event.clear();
+    }
+
+    if (_command_queue != nullptr) {
+        _command_queue.reset();
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/plugin_graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/plugin_graph.cpp
@@ -135,12 +135,21 @@ void PluginGraph::initialize(const Config& config) {
 }
 
 PluginGraph::~PluginGraph() {
+    // make sure all the context-dependent components are destroyed before the zero context is destroyed
     if (_handle != nullptr) {
         auto result = _zeGraphExt->destroyGraph(_handle);
 
         if (ZE_RESULT_SUCCESS == result) {
             _handle = nullptr;
         }
+    }
+
+    if (_last_submitted_event.size()) {
+        _last_submitted_event.clear();
+    }
+
+    if (_command_queue != nullptr) {
+        _command_queue.reset();
     }
 }
 

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
@@ -90,11 +90,11 @@ private:
 #define symbol_statement(symbol)                                                                            \
     template <typename... Args>                                                                             \
     inline typename std::invoke_result<decltype(&::symbol), Args...>::type wrapped_##symbol(Args... args) { \
-        const auto& ref = ZeroApi::getInstance();                                                           \
-        if (ref->symbol == nullptr) {                                                                       \
+        const auto& ptr = ZeroApi::getInstance();                                                           \
+        if (ptr->symbol == nullptr) {                                                                       \
             OPENVINO_THROW("Unsupported symbol " #symbol);                                                  \
         }                                                                                                   \
-        return ref->symbol(std::forward<Args>(args)...);                                                    \
+        return ptr->symbol(std::forward<Args>(args)...);                                                    \
     }
 symbols_list();
 weak_symbols_list();

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_api.hpp
@@ -70,34 +70,31 @@ namespace intel_npu {
 
 class ZeroApi {
 public:
+    ZeroApi();
     ZeroApi(const ZeroApi& other) = delete;
     ZeroApi(ZeroApi&& other) = delete;
     void operator=(const ZeroApi&) = delete;
     void operator=(ZeroApi&&) = delete;
 
-    static ZeroApi& getInstance() {
-        static ZeroApi instance;
-        return instance;
-    }
+    static const std::shared_ptr<ZeroApi>& getInstance();
+
 #define symbol_statement(symbol) decltype(&::symbol) symbol;
     symbols_list();
     weak_symbols_list();
 #undef symbol_statement
 
 private:
-    ZeroApi();
-
     std::shared_ptr<void> lib;
 };
 
 #define symbol_statement(symbol)                                                                            \
     template <typename... Args>                                                                             \
     inline typename std::invoke_result<decltype(&::symbol), Args...>::type wrapped_##symbol(Args... args) { \
-        auto& ref = ZeroApi::getInstance();                                                                 \
-        if (ref.symbol == nullptr) {                                                                        \
+        const auto& ref = ZeroApi::getInstance();                                                           \
+        if (ref->symbol == nullptr) {                                                                       \
             OPENVINO_THROW("Unsupported symbol " #symbol);                                                  \
         }                                                                                                   \
-        return ref.symbol(std::forward<Args>(args)...);                                                     \
+        return ref->symbol(std::forward<Args>(args)...);                                                    \
     }
 symbols_list();
 weak_symbols_list();

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 
 #include "intel_npu/utils/logger/logger.hpp"
+#include "intel_npu/utils/zero/zero_api.hpp"
 #include "intel_npu/utils/zero/zero_types.hpp"
 
 namespace intel_npu {
@@ -74,6 +75,9 @@ public:
 
 private:
     void initNpuDriver();
+
+    // keep zero_api alive until context is destroyed
+    std::shared_ptr<ZeroApi> zero_api;
 
     static const ze_driver_uuid_t uuid;
     Logger log;

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
@@ -49,4 +49,9 @@ ZeroApi::ZeroApi() {
 #undef symbol_statement
 }
 
+const std::shared_ptr<ZeroApi>& ZeroApi::getInstance() {
+    static std::shared_ptr<ZeroApi> instance = std::make_shared<ZeroApi>();
+    return instance;
+}
+
 }  // namespace intel_npu

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -4,12 +4,10 @@
 
 #include "intel_npu/utils/zero/zero_init.hpp"
 
-#include <loader/ze_loader.h>
 #include <ze_command_queue_npu_ext.h>
 
 #include <regex>
 
-#include "intel_npu/utils/zero/zero_api.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 
 #ifdef _WIN32
@@ -135,7 +133,9 @@ void ZeroInitStructsHolder::initNpuDriver() {
     fallbackToZeDriverGet();
 }
 
-ZeroInitStructsHolder::ZeroInitStructsHolder() : log("NPUZeroInitStructsHolder", Logger::global().level()) {
+ZeroInitStructsHolder::ZeroInitStructsHolder()
+    : zero_api(ZeroApi::getInstance()),
+      log("NPUZeroInitStructsHolder", Logger::global().level()) {
     log.debug("ZeroInitStructsHolder - performing zeInit on NPU only");
     THROW_ON_FAIL_FOR_LEVELZERO("zeInit", zeInit(ZE_INIT_FLAG_VPU_ONLY));
 
@@ -323,7 +323,7 @@ ZeroInitStructsHolder::~ZeroInitStructsHolder() {
     if (context) {
         log.debug("ZeroInitStructsHolder - performing zeContextDestroy");
         auto result = zeContextDestroy(context);
-        if (ZE_RESULT_SUCCESS != result) {
+        if (result != ZE_RESULT_SUCCESS && result != ZE_RESULT_ERROR_UNINITIALIZED) {
             log.error("zeContextDestroy failed %#X", uint64_t(result));
         }
     }


### PR DESCRIPTION
### Details:
 - *In the case of a static CORE object, it will be destroyed after the application exits. In this case, the libs will be detached in the reverse order of how they were created. We need to make sure that the 'ze_loader' lib is alive and to understand if the context was already destroyed by detaching the lib or not*

### Tickets:
 - *E#150895*
