### PR TITLE
Fix acc_conformance tests path issue on windows

### DIFF
--- a/tests/llm/accuracy_conformance.py
+++ b/tests/llm/accuracy_conformance.py
@@ -49,7 +49,7 @@ def init_test_scope():
         tokenizer.save_pretrained(model_path)
 
         ov_model = OVModelForCausalLM.from_pretrained(model_path, load_in_8bit=True)
-        ov_model_path = model_path + os.path.join(tmp_dir, model_type + "_ov")
+        ov_model_path = os.path.join(tmp_dir, model_type + "_ov")
         ov_model.save_pretrained(ov_model_path)
         tokenizer.save_pretrained(ov_model_path)
         del ov_model
@@ -59,9 +59,7 @@ def init_test_scope():
         quantized_model = OVModelForCausalLM.from_pretrained(
             model_path, quantization_config=quantization_config
         )
-        quantized_model_path = model_path = os.path.join(
-            tmp_dir, model_type + "_ov_int4"
-        )
+        quantized_model_path = os.path.join(tmp_dir, model_type + "_ov_int4")
         quantized_model.save_pretrained(quantized_model_path)
         tokenizer.save_pretrained(quantized_model_path)
         del quantized_model


### PR DESCRIPTION
CVS-162391

This change ensures that all paths are constructed using `os.path.join`, which should help avoid issues with incorrect path syntax on Windows

tested locally:

```
================================================================================================================================= test session starts =================================================================================================================================
platform win32 -- Python 3.11.9, pytest-8.3.4, pluggy-1.5.0
rootdir: C:\IOTG\openvino_fork\openvino\tests\llm
collected 8 items / 4 deselected / 4 selected

accuracy_conformance.py ....
============================================================================================================ 4 passed, 4 deselected, 20784 warnings in 1004.69s (0:16:44) =============================================================================================================

(openvino_venv) C:\IOTG\openvino_fork\openvino\tests\llm>
```
