### PR TITLE
[GPU] improving accuracy of activations scaling

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
@@ -277,8 +277,8 @@ ov::pass::activations_scaling::MulShareTransformation::MulShareTransformation() 
                         double scale_const_val = scale_const->cast_vector<double>()[0];
                         rms->set_epsilon(eps * scale_const_val * scale_const_val);
                     } else if (pattern_map.count(group_norm_m)) {
-                        auto group_norm =
-                            ov::as_type_ptr<ov::op::v12::GroupNormalization>(pattern_map.at(group_norm_m).get_node_shared_ptr());
+                        auto group_norm = ov::as_type_ptr<ov::op::v12::GroupNormalization>(
+                            pattern_map.at(group_norm_m).get_node_shared_ptr());
                         auto eps = group_norm->get_epsilon();
                         double scale_const_val = scale_const->cast_vector<double>()[0];
                         group_norm->set_epsilon(eps * scale_const_val * scale_const_val);

--- a/src/common/transformations/tests/common_optimizations/activations_scaling_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/activations_scaling_test.cpp
@@ -70,14 +70,16 @@ TEST_F(TransformationTestsF, ScaleDownSingleLayerTest) {
 }
 
 TEST_F(TransformationTestsF, EliminateScalarMulTest) {
+    double epsilon = 1.f;
+    float scale_factor = 8.f;
     {
-        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 16, 16});
-        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1}, {10});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 4, 4});
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1}, {scale_factor});
         auto mul = std::make_shared<ov::op::v1::Multiply>(input, scale_const);
         auto norm_scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{3}, {10});
         auto norm_bias_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{3}, {10});
         auto group_norm =
-            std::make_shared<ov::op::v12::GroupNormalization>(mul, norm_scale_const, norm_bias_const, 1, 0.01f);
+            std::make_shared<ov::op::v12::GroupNormalization>(mul, norm_scale_const, norm_bias_const, 1, epsilon);
         auto convert = std::make_shared<ov::op::v0::Convert>(group_norm, ov::element::f32);
         auto result = std::make_shared<ov::op::v0::Result>(convert);
 
@@ -85,16 +87,18 @@ TEST_F(TransformationTestsF, EliminateScalarMulTest) {
         manager.register_pass<ov::pass::activations_scaling::EliminateScalarMul>();
     }
     {
-        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 16, 16});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 4, 4});
         auto norm_scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{3}, {10});
         auto norm_bias_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{3}, {10});
+        epsilon /= scale_factor;
         auto group_norm =
-            std::make_shared<ov::op::v12::GroupNormalization>(input, norm_scale_const, norm_bias_const, 1, 0.01f);
+            std::make_shared<ov::op::v12::GroupNormalization>(input, norm_scale_const, norm_bias_const, 1, epsilon);
         auto convert = std::make_shared<ov::op::v0::Convert>(group_norm, ov::element::f32);
         auto result = std::make_shared<ov::op::v0::Result>(convert);
 
         model_ref = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input});
     }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
 
 TEST_F(TransformationTestsF, MoveDownScalarMulTest) {
@@ -124,12 +128,15 @@ TEST_F(TransformationTestsF, MoveDownScalarMulTest) {
 }
 
 TEST_F(TransformationTestsF, MulShareTransformationTest) {
+    float epsilon = 1.f;
+    float scale_factor = 8.f;
     {
-        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{6, 12, 10, 24});
-        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(input);
-        auto convert0 = std::make_shared<ov::op::v0::Convert>(shape_of, ov::element::f32);
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 4, 4});
+        auto mvn_axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 3});
+        auto mvn = std::make_shared<ov::op::v6::MVN>(input, mvn_axes, true, epsilon, ov::op::MVNEpsMode::INSIDE_SQRT);
+        auto convert0 = std::make_shared<ov::op::v0::Convert>(mvn, ov::element::f32);
         auto result0 = std::make_shared<ov::op::v0::Result>(convert0);
-        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1}, {10});
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1}, {scale_factor});
         auto mul = std::make_shared<ov::op::v1::Multiply>(input, scale_const);
         auto convert1 = std::make_shared<ov::op::v0::Convert>(mul, ov::element::f32);
         auto result1 = std::make_shared<ov::op::v0::Result>(convert1);
@@ -138,15 +145,18 @@ TEST_F(TransformationTestsF, MulShareTransformationTest) {
         manager.register_pass<ov::pass::activations_scaling::MulShareTransformation>();
     }
     {
-        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{6, 12, 10, 24});
-        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1}, {10});
+        auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape{1, 3, 4, 4});
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{1}, {scale_factor});
         auto mul = std::make_shared<ov::op::v1::Multiply>(input, scale_const);
-        auto shape_of = std::make_shared<ov::op::v3::ShapeOf>(mul);
-        auto convert0 = std::make_shared<ov::op::v0::Convert>(shape_of, ov::element::f32);
+        auto mvn_axes = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{3}, {0, 2, 3});
+        epsilon *= scale_factor * scale_factor;
+        auto mvn = std::make_shared<ov::op::v6::MVN>(mul, mvn_axes, true, epsilon, ov::op::MVNEpsMode::INSIDE_SQRT);
+        auto convert0 = std::make_shared<ov::op::v0::Convert>(mvn, ov::element::f32);
         auto result0 = std::make_shared<ov::op::v0::Result>(convert0);
         auto convert1 = std::make_shared<ov::op::v0::Convert>(mul, ov::element::f32);
         auto result1 = std::make_shared<ov::op::v0::Result>(convert1);
 
         model_ref = std::make_shared<ov::Model>(ov::ResultVector{result0, result1}, ov::ParameterVector{input});
     }
+    comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -72,6 +72,7 @@
 #include "plugin/transformations/fc_horizontal_fusion.hpp"
 #include "plugin/transformations/kv_cache_fusion.hpp"
 #include "plugin/transformations/move_fc_reshape_to_weights.hpp"
+// #include "plugin/transformations/move_eltwise_down_data_movement.hpp"
 #include "plugin/transformations/bcast_and_pad_zp_buffers.hpp"
 #include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/fc_per_layer_scaling.hpp"
@@ -1191,6 +1192,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         // Remove Pad in front of MaxPool if both the pads_begin and pads_end are zero.
         manager.register_pass<ov::pass::EliminatePad>();
+
+        // manager.register_pass<ov::intel_gpu::MoveMulDownThroughTranspose>();
 
         // This is supposed to be the last pass to ensure that we don't have name collisions until
         // GPU plugin stops using friendly names for program creation

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -72,7 +72,6 @@
 #include "plugin/transformations/fc_horizontal_fusion.hpp"
 #include "plugin/transformations/kv_cache_fusion.hpp"
 #include "plugin/transformations/move_fc_reshape_to_weights.hpp"
-// #include "plugin/transformations/move_eltwise_down_data_movement.hpp"
 #include "plugin/transformations/bcast_and_pad_zp_buffers.hpp"
 #include "plugin/transformations/print_model_statistics.hpp"
 #include "plugin/transformations/fc_per_layer_scaling.hpp"
@@ -1192,8 +1191,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         // Remove Pad in front of MaxPool if both the pads_begin and pads_end are zero.
         manager.register_pass<ov::pass::EliminatePad>();
-
-        // manager.register_pass<ov::intel_gpu::MoveMulDownThroughTranspose>();
 
         // This is supposed to be the last pass to ensure that we don't have name collisions until
         // GPU plugin stops using friendly names for program creation


### PR DESCRIPTION
### Details:
 - scales down epsilon values of RMS, MVN and GroupNormalization layers to improve accuracy.
 - updates not to apply activations scaling to layers marked as `decompressed_to_f32`.

### Tickets:
 - 161987
