### PR TITLE
[CPU] Fix empty memory creation

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -514,6 +514,10 @@ MemoryBlockPtr StaticMemory::getMemoryBlock() const {
 
 // oneDNN specifics for backward compatibility
 dnnl::memory StaticMemory::getPrimitive() const {
+    if (!m_prim && !getDesc().empty()) {  // for an empty memory m_prim is expected to be empty
+        OPENVINO_THROW("Couldn't create dnnl::memory object: ", dnnlErrorCtx);
+    }
+
     return m_prim;
 }
 

--- a/src/plugins/intel_cpu/src/cpu_memory.cpp
+++ b/src/plugins/intel_cpu/src/cpu_memory.cpp
@@ -455,13 +455,16 @@ StaticMemory::StaticMemory(dnnl::engine eng, MemoryDescPtr desc, const void* dat
 
     try {
         auto dnnl_desc = MemoryDescUtils::convertToDnnlMemoryDesc(m_pMemDesc);
-        // ========================
         // Equivalent of constructor memory(const primitive_desc &desc, void *hdl)
         // but with ability to skip pads zeroing.
-        m_prim = dnnl::memory(dnnl_desc->getDnnlDesc(), m_eng, DNNL_MEMORY_NONE);
-        //
-        // ========================
-        m_prim.set_data_handle(m_pMemBlock->getRawPtr());
+        const auto& memory_desc = dnnl_desc->getDnnlDesc();
+        if (memory_desc.is_zero()) {
+            // dnnl memory created using an empty memory_desc is not empty, so use a default constructor
+            m_prim = dnnl::memory();
+        } else {
+            m_prim = dnnl::memory(memory_desc, m_eng, DNNL_MEMORY_NONE);
+            m_prim.set_data_handle(m_pMemBlock->getRawPtr());
+        }
     } catch (const std::exception& exc) {
         dnnlErrorCtx = exc.what();
     }
@@ -511,9 +514,6 @@ MemoryBlockPtr StaticMemory::getMemoryBlock() const {
 
 // oneDNN specifics for backward compatibility
 dnnl::memory StaticMemory::getPrimitive() const {
-    if (!m_prim) {
-        OPENVINO_THROW("Couldn't create dnnl::memory object: ", dnnlErrorCtx);
-    }
     return m_prim;
 }
 
@@ -616,6 +616,10 @@ bool mbind_move(const MemoryCPtr& mem, int numaNodeID) {
 }
 
 bool mbind_move(const dnnl::memory& mem, int numaNodeID) {
+    if (!mem) {
+        return true;
+    }
+
     void* data = mem.get_data_handle();
     auto desc = mem.get_desc();
     auto size = desc.get_size();

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
@@ -99,6 +99,6 @@ TEST(StaticMemoryTest, UnsupportedDnnlPrecision) {
     OV_ASSERT_NO_THROW(raw_data_ptr = testMemory->getData());
     ASSERT_FALSE(nullptr == raw_data_ptr);
     dnnl_memory = dnnl::memory();
-    ASSERT_THROW(dnnl_memory = testMemory->getPrimitive(), ov::Exception);
-    ASSERT_FALSE(dnnl_memory);
+    OV_ASSERT_NO_THROW(dnnl_memory = testMemory->getPrimitive());
+    ASSERT_TRUE(dnnl_memory.get(true) == nullptr);
 }

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_test.cpp
@@ -99,6 +99,6 @@ TEST(StaticMemoryTest, UnsupportedDnnlPrecision) {
     OV_ASSERT_NO_THROW(raw_data_ptr = testMemory->getData());
     ASSERT_FALSE(nullptr == raw_data_ptr);
     dnnl_memory = dnnl::memory();
-    OV_ASSERT_NO_THROW(dnnl_memory = testMemory->getPrimitive());
-    ASSERT_TRUE(dnnl_memory.get(true) == nullptr);
+    ASSERT_THROW(dnnl_memory = testMemory->getPrimitive(), ov::Exception);
+    ASSERT_FALSE(dnnl_memory);
 }


### PR DESCRIPTION
dnnl::memory created with an empty dnnl::memory_desc is not empty.
Default constructor should be used instead.
Adjust rest of memory logic to allow an empty dnnl::memory object