### PR TITLE
[CORE] New cmake option ENABLE_JIT_IN_CORE

### DIFF
--- a/cmake/features.cmake
+++ b/cmake/features.cmake
@@ -208,6 +208,8 @@ ov_dependent_option(ENABLE_JS "Enables JS API building" ${ENABLE_JS_DEFAULT} "NO
 
 ov_option(ENABLE_OPENVINO_DEBUG "Enable output for OPENVINO_DEBUG statements" OFF)
 
+ov_option(ENABLE_JIT_IN_CORE "Enable JIT kernel generation and execution in the Core part" ON)
+
 if(NOT BUILD_SHARED_LIBS AND ENABLE_OV_TF_FRONTEND)
     set(FORCE_FRONTENDS_USE_PROTOBUF ON)
 else()
@@ -228,6 +230,10 @@ endif()
 
 if (ENABLE_SNIPPETS_DEBUG_CAPS)
     add_definitions(-DSNIPPETS_DEBUG_CAPS)
+endif()
+
+if (ENABLE_JIT_IN_CORE)
+    add_definitions(-DDEF_JIT_IN_CORE)
 endif()
 
 ov_print_enabled_features()

--- a/src/core/src/runtime/compute_hash.cpp
+++ b/src/core/src/runtime/compute_hash.cpp
@@ -14,7 +14,7 @@
 
 #include "openvino/core/visibility.hpp"
 
-#if !defined(OS_CHROMEOS) && (defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64))
+#if defined(DEF_JIT_IN_CORE) && !defined(OS_CHROMEOS) && (defined(OPENVINO_ARCH_X86) || defined(OPENVINO_ARCH_X86_64))
 #    define OV_CORE_USE_XBYAK_JIT
 #endif
 


### PR DESCRIPTION
### Details:
 - *New cmake option ENABLE_JIT_IN_CORE to enable/disable JIT code in the Core part*

### Tickets:
 - *162440*
