### PR TITLE
[DOCS] Update hyperlinks in hello query device README

### DIFF
--- a/samples/cpp/hello_query_device/README.md
+++ b/samples/cpp/hello_query_device/README.md
@@ -2,14 +2,14 @@
 
 This sample demonstrates how to execute an query OpenVINO™ Runtime devices, prints their metrics and default configuration values, using [Properties API](https://docs.openvino.ai/2025/openvino-workflow/running-inference/inference-devices-and-modes/query-device-properties.html).
 
-For more detailed information on how this sample works, check the dedicated [article](https://docs.openvino.ai/2025/learn-openvino/openvino-samples/hello-query-device.html)
+For more detailed information on how this sample works, check the dedicated [article](https://docs.openvino.ai/2025/get-started/learn-openvino/openvino-samples/hello-query-device.html)
 
 ## Requirements
 
 | Options                       | Values                                                                                                                      |
 | ------------------------------| ----------------------------------------------------------------------------------------------------------------------------|
-| Supported devices             | [All](https://docs.openvino.ai/2025/about-openvino/compatibility-and-support/supported-devices.html)                         |
-| Other language realization    | [Python](https://docs.openvino.ai/2025/learn-openvino/openvino-samples/hello-query-device.html)                                           |
+| Supported devices             | [All](https://docs.openvino.ai/2025/documentation/compatibility-and-support/supported-devices.html)                         |
+| Other language realization    | [Python](https://docs.openvino.ai/2025/get-started/learn-openvino/openvino-samples/hello-query-device.html)                 |
 
 The following C++ API is used in the application:
 
@@ -18,4 +18,4 @@ The following C++ API is used in the application:
 | Available Devices        | ``ov::Core::get_available_devices``,  | Get available devices information and configuration for inference |
 |                          | ``ov::Core::get_property``            |                                                                   |
 
-Basic OpenVINO™ Runtime API is covered by [Hello Classification C++ sample](https://docs.openvino.ai/2025/learn-openvino/openvino-samples/hello-classification.html).
+Basic OpenVINO™ Runtime API is covered by [Hello Classification C++ sample](https://docs.openvino.ai/2025/get-started/learn-openvino/openvino-samples/hello-classification.html).


### PR DESCRIPTION
Some of the links in the README.md of hello query device is now 404. This commit fixes them by identifying the right hyperlinks and updating them.
