### PR TITLE
License whitelist for dependency checker update

### DIFF
--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -11,6 +11,7 @@ allow-licenses:
   - 'Python-2.0'
   - 'LGPL-3.0'
   - 'MPL-2.0'
+  - 'BSD-2-Clause AND BSD-3-Clause'
 fail-on-scopes:
   - 'runtime'
   - 'development'


### PR DESCRIPTION
Update of whitelist for dependency checker.

Required for PR:  https://github.com/openvinotoolkit/openvino/pull/28349   