### PR TITLE
[Py OV] Change approach to openvino.runtime lazy loading

### DIFF
--- a/src/bindings/python/src/openvino/__init__.py
+++ b/src/bindings/python/src/openvino/__init__.py
@@ -60,8 +60,8 @@ from openvino._ov_api import AsyncInferQueue
 from openvino._ov_api import Op
 
 # Import all public modules
-from openvino.package_utils import lazy_import
-runtime = lazy_import("openvino.runtime")
+from openvino.package_utils import LazyLoader
+runtime = LazyLoader("openvino.runtime")
 from openvino import frontend as frontend
 from openvino import helpers as helpers
 from openvino import experimental as experimental

--- a/src/bindings/python/src/openvino/package_utils.py
+++ b/src/bindings/python/src/openvino/package_utils.py
@@ -118,16 +118,29 @@ def deprecatedclassproperty(name: Any = None, version: str = "", message: str = 
 
 
 def lazy_import(module_name: str) -> ModuleType:
-    spec = importlib.util.find_spec(module_name)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Module {module_name} not found")
+    # spec = importlib.util.find_spec(module_name)
+    # if spec is None or spec.loader is None:
+    #     raise ImportError(f"Module {module_name} not found")
 
-    loader = importlib.util.LazyLoader(spec.loader)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
+    # loader = importlib.util.LazyLoader(spec.loader)
+    # module = importlib.util.module_from_spec(spec)
+    # sys.modules[module_name] = module
 
-    try:
-        loader.exec_module(module)
-    except Exception as e:
-        raise ImportError(f"Failed to load module {module_name}") from e
-    return module
+    # try:
+    #     loader.exec_module(module)
+    # except Exception as e:
+    #     raise ImportError(f"Failed to load module {module_name}") from e
+    # return module
+    return LazyLoader(module_name)
+
+class LazyLoader:
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+        self._module = None
+
+    def __getattr__(self, item: str) -> Any:
+        if self._module is None:
+            self._module = importlib.import_module(self.module_name)
+            self.__dict__.update(self._module.__dict__)
+        return getattr(self._module, item)
+    

--- a/tools/benchmark_tool/openvino/__init__.py
+++ b/tools/benchmark_tool/openvino/__init__.py
@@ -60,8 +60,8 @@ from openvino._ov_api import AsyncInferQueue
 from openvino._ov_api import Op
 
 # Import all public modules
-from openvino.package_utils import lazy_import
-runtime = lazy_import("openvino.runtime")
+from openvino.package_utils import LazyLoader
+runtime = LazyLoader("openvino.runtime")
 from openvino import frontend as frontend
 from openvino import helpers as helpers
 from openvino import experimental as experimental

--- a/tools/ovc/openvino/__init__.py
+++ b/tools/ovc/openvino/__init__.py
@@ -60,8 +60,8 @@ from openvino._ov_api import AsyncInferQueue
 from openvino._ov_api import Op
 
 # Import all public modules
-from openvino.package_utils import lazy_import
-runtime = lazy_import("openvino.runtime")
+from openvino.package_utils import LazyLoader
+runtime = LazyLoader("openvino.runtime")
 from openvino import frontend as frontend
 from openvino import helpers as helpers
 from openvino import experimental as experimental


### PR DESCRIPTION
### Details:
 - In current approach for lazy import, we use `importlib.util.LazyLoader`. This approach first creates a module, adds it to python `sys.module`s, and then LazyLoader executes the module when sb tries to access e.g. `openvino.runtime` attribute.

 - The issue is that in this approach `openvino.runtime` might be initialized too early, e.g. by [`inspect` module](https://github.com/python/cpython/blob/140e69c4a878d7a0a26d4406bdad55e56ddae0b7/Lib/inspect.py#L915) which iterates over modules present in `sys.modules`, e.g.:

![torch_issue_25_0](https://github.com/user-attachments/assets/19d9e2e5-858a-4917-b9a4-c1ff1ede203e)
 
 Proposal: 
- Change the lazy loading approach. Import `openvino.runtime` and add it to `sys.modules` only when an attribute is accessed. Possible thanks to overloading `__getattr__` and `__dir__` methods. 
![torch_issue_25_1](https://github.com/user-attachments/assets/561121f5-2f22-4408-82c3-269dd31d2a79)



### Tickets:
 - *ticket-id*
