### PR TITLE
[NPU][IE-MDK] Load testing skip config at runtime

### DIFF
--- a/src/plugins/intel_npu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/functional/CMakeLists.txt
@@ -14,6 +14,9 @@ set(EXCLUDED_FUNC_TESTS_DIR "")
 set(OPTIONAL_FUNC_TESTS_INCLUDES "")
 set(OPTIONAL_FUNC_TESTS_LIBS "")
 
+set(SKIP_CONFIG "skip_tests.xml")
+set(SKIP_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/shared_tests_instances/${SKIP_CONFIG})
+
 list(APPEND OPTIONAL_FUNC_TESTS_INCLUDES
       "${OpenVINO_SOURCE_DIR}/src/plugins/intel_npu/src/compiler_adapter/include")
 
@@ -66,3 +69,7 @@ install(
   RUNTIME DESTINATION tests
           COMPONENT tests
           EXCLUDE_FROM_ALL)
+  
+install(FILES ${SKIP_CONFIG_PATH}
+        DESTINATION tests
+        COMPONENT tests)

--- a/src/plugins/intel_npu/tests/functional/CMakeLists.txt
+++ b/src/plugins/intel_npu/tests/functional/CMakeLists.txt
@@ -69,7 +69,9 @@ install(
   RUNTIME DESTINATION tests
           COMPONENT tests
           EXCLUDE_FROM_ALL)
-  
-install(FILES ${SKIP_CONFIG_PATH}
-        DESTINATION tests
-        COMPONENT tests)
+
+install(
+  FILES ${SKIP_CONFIG_PATH}
+  DESTINATION tests
+  COMPONENT tests
+  EXCLUDE_FROM_ALL)

--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.cpp
@@ -134,6 +134,10 @@ NpuTestEnvConfig::NpuTestEnvConfig() {
     if (auto var = std::getenv("IE_NPU_TESTS_PLATFORM")) {
         IE_NPU_TESTS_PLATFORM = var;
     }
+
+    if (auto var = std::getenv("OV_NPU_TESTS_SKIP_CONFIG_FILE")) {
+        OV_NPU_TESTS_SKIP_CONFIG_FILE = var;
+    }
 }
 
 const NpuTestEnvConfig& NpuTestEnvConfig::getInstance() {

--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
@@ -26,6 +26,7 @@ public:
     std::string IE_NPU_TESTS_DUMP_PATH;
     std::string IE_NPU_TESTS_LOG_LEVEL;
     std::string IE_NPU_TESTS_PLATFORM;
+    std::string OV_NPU_TESTS_SKIP_CONFIG_FILE;
 
     bool IE_NPU_TESTS_RUN_COMPILER = true;
     bool IE_NPU_TESTS_RUN_EXPORT = false;

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -177,14 +177,6 @@ Example:
         </filters>
     </skip_config>
     <skip_config>
-        <!-- EISW 67741 -->
-        <message>Cannot call setShape for Blobs</message>
-        <filters>
-            <filter>.*(smoke_Behavior|smoke_Auto_Behavior|smoke_Multi_Behavior).*OVInferRequestIOTensorTest.*canInferAfterIOBlobReallocation.*</filter>
-            <filter>.*(smoke_Behavior|smoke_Auto_Behavior|smoke_Multi_Behavior).*OVInferRequestIOTensorTest.*InferStaticNetworkSetChangedInputTensorThrow.*targetDevice=(NPU_|MULTI_configItem=MULTI_DEVICE_PRIORITIES_NPU).*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
         <!-- EISW 67749 -->
         <message>Can't loadNetwork without cache for ReadConcatSplitAssign with precision f32</message>
         <filters>
@@ -444,7 +436,7 @@ Example:
         <!-- EISW 83423 -->
         <message>Tests enabled only for L0 NPU3720</message>
         <enable_rules>
-            <backend>!LEVEL0</backend>
+            <backend>LEVEL0</backend>
             <device>!3720</device>
         </enable_rules>
         <filters>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -312,7 +312,7 @@ Example:
         <!-- EISW 70764 -->
         <message>Disabled for when backend is empty (i.e., no device)</message>
         <enable_rules>
-            <backend>empty</backend>
+            <backend></backend> <!-- special case for no device -->
         </enable_rules>
         <filters>
             <!-- Cannot run InferRequest tests without a device to infer to -->
@@ -636,7 +636,7 @@ Example:
             <backend>LEVEL0</backend>
         </enable_rules>
         <filters>
-            <filter>.*CoreThreadingTest.CoreThreadingTestsWithCacheEnabled.*</filter>
+            <filter>.*CoreThreadingTest.*CoreThreadingTestsWithCacheEnabled.*</filter>
         </filters>
     </skip_config>
     <skip_config>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -142,7 +142,7 @@ Example:
             <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*</filter>
             <filter>.*InferRequestCheckTensorPrecision.*type=bf16.*</filter>
             <filter>.*InferRequestCheckTensorPrecision.*type=f64.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=u1\\D.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u1.*</filter>
             <filter>.*InferRequestCheckTensorPrecision.*type=i64.*</filter>
         </filters>
     </skip_config>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -1,0 +1,809 @@
+<!--
+Example: 
+    <skip_config>
+        <message>skip_message_xxxxxx</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <backend>IMD</backend>
+            <device>3720</device>
+            <device>4000</device>
+            <operating_system>windows</operating_system>
+            <operating_system>linux</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>skip_filter_xxxxxxxxxx</filter>
+            <filter>skip_filter_xxxxxxxxxx</filter>
+            <filter>skip_filter_xxxxxxxxxx</filter>
+        </filters>
+    </skip_config>
+-->
+<skip_configs>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>Tests break due to starting infer on IA side</message>
+        <filters>
+            <filter>.*CorrectConfigAPITests.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>ARM CPU Plugin is not available on Yocto</message>
+        <filters>
+            <filter>.*IEClassLoadNetworkTest.*HETERO.*</filter>
+            <filter>.*IEClassLoadNetworkTest.*MULTI.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 30810 -->
+        <message>Hetero plugin doesn't throw an exception in case of big device ID</message>
+        <filters>
+            <filter>.*OVClassLoadNetworkTestNPU.*LoadNetworkHETEROWithBigDeviceIDThrows.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 30815 -->
+        <message>NPU Plugin doesn't handle DEVICE_ID in QueryNetwork implementation</message>
+        <filters>
+            <filter>.*OVClassQueryNetworkTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 12774 -->
+        <message>Cannot detect npu platform when it's not passed; Skip tests on Yocto which passes device without platform</message>
+        <filters>
+            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithDeviceIDNoThrow.*</filter>
+            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithBigDeviceIDThrows.*</filter>
+            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithInvalidDeviceIDThrows.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 28335 -->
+        <message>Disabled test E#28335</message>
+        <filters>
+            <filter>.*smoke_LoadNetworkToDefaultDeviceNoThrow.*</filter>
+        </filters>
+    </skip_config>
+        <skip_config>
+        <!-- EISW 32241 -->
+        <message>Disabled test E#28335</message>
+        <filters>
+            <filter>.*LoadNetwork.*CheckDeviceInBlob.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 27343 -->
+        <message>double free detected</message>
+        <filters>
+            <filter>.*InferConfigInTests\\.CanInferWithConfig.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
+        <filters>
+            <filter>.*checkGetExecGraphInfoIsNotNullptr.*</filter>
+            <filter>.*CanCreateTwoExeNetworksAndCheckFunction.*</filter>
+            <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
+            <filter>.*CheckExecGraphInfo.*</filter>
+            <filter>.*canLoadCorrectNetworkToGetExecutable.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 31074 -->
+        <message>Disabled test E#28335</message>
+        <filters>
+            <filter>.*checkInferTime.*</filter>
+            <filter>.*OVExecGraphImportExportTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 31074 -->
+        <message>Test uses legacy OpenVINO 1.0 API, no need to support it</message>
+        <filters>
+            <filter>.*ExecutableNetworkBaseTest.checkGetMetric.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 31074 -->
+        <message>SetConfig function is not implemented for ExecutableNetwork interface (implemented only for npu plugin)</message>
+        <filters>
+            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNet.*</filter>
+            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNetAndCheckConfigAndCheck.*</filter>
+            <filter>.*CanSetConfigToExecNet.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 30822 -->
+        <message>Exception 'Not implemented</message>
+        <filters>
+            <filter>.*OVClassNetworkTestP.*LoadNetworkCreateDefaultExecGraphResult.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>This is openvino specific test</message>
+        <filters>
+            <filter>.*ExecutableNetworkBaseTest.canExport.*</filter>
+        </filters>
+    </skip_config>
+        <skip_config>
+        <!-- EISW ##### -->
+        <message>TensorIterator layer is not supported</message>
+        <filters>
+            <filter>.*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*</filter>
+            <filter>.*OVInferRequestDynamicTests.*</filter>
+            <filter>.*OVInferenceChaining.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 97469 -->
+        <message>Tests with unsupported precision</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=bf16.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=f64.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u1\\D.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=i64.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 70764 -->
+        <!-- Confusing rule, it means that the tests should not be skipped for NPU3720 -->
+        <message>Tests enabled only for L0 NPU3720</message>
+        <enable_rules>
+            <backend>!LEVEL0</backend>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*</filter>
+            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
+            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 32075 -->
+        <message>Exception during loading to the device</message>
+        <filters>
+            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROwithMULTINoThrow.*</filter>
+            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkMULTIwithHETERONoThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>compiler: Unsupported arch kind: NPUX311X</message>
+        <filters>
+            <filter>.*CompilationForSpecificPlatform.*(3800|3900).*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 67741 -->
+        <message>Cannot call setShape for Blobs</message>
+        <filters>
+            <filter>.*(smoke_Behavior|smoke_Auto_Behavior|smoke_Multi_Behavior).*OVInferRequestIOTensorTest.*canInferAfterIOBlobReallocation.*</filter>
+            <filter>.*(smoke_Behavior|smoke_Auto_Behavior|smoke_Multi_Behavior).*OVInferRequestIOTensorTest.*InferStaticNetworkSetChangedInputTensorThrow.*targetDevice=(NPU_|MULTI_configItem=MULTI_DEVICE_PRIORITIES_NPU).*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 67749 -->
+        <message>Can't loadNetwork without cache for ReadConcatSplitAssign with precision f32</message>
+        <filters>
+            <filter>.*CachingSupportCase_NPU.*CompileModelCacheTestBase.*CompareWithRefImpl.*ReadConcatSplitAssign.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 99817 -->
+        <message>NPU Plugin currently fails to get a valid output in these test cases</message>
+        <filters>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
+            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
+            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_.*</filter>
+            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_.*</filter>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 68774 -->
+        <message>OV requires the plugin to throw when value of DEVICE_ID is unrecognized, but plugin does not throw</message>
+        <filters>
+            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithIncorrectKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
+            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithNoExistingKey.*SOME_DEVICE_ID.*</filter>
+            <filter>smoke_BehaviorTests.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 77755 -->
+        <message>OV requires the plugin to throw on network load when config file is incorrect, but plugin does not throw</message>
+        <filters>
+            <filter>.*smoke_Auto_BehaviorTests.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_config.*unknown_file_MULTI_DEVICE_PRIORITIES=(NPU_|NPU,CPU_).*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 77756 -->
+        <message>OV expects the plugin to not throw any exception on network load, but it actually throws</message>
+        <filters>
+            <filter>.*(smoke_Multi_Behavior|smoke_Auto_Behavior).*SetPropLoadNetWorkGetPropTests.*SetPropLoadNetWorkGetProperty.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 68776 -->
+        <message>Plugin can not perform SetConfig for value like: device=NPU config key=LOG_LEVEL value=0</message>
+        <filters>
+            <filter>smoke_BehaviorTests/DefaultValuesConfigTests.CanSetDefaultValueBackToPlugin.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 48480 -->
+        <message>Disabled with ticket number 48480</message>
+        <filters>
+            <filter>.*OVExecutableNetworkBaseTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 63708 -->
+        <message>Disabled with ticket number 63708</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 64490 -->
+        <message>Disabled with ticket number 64490</message>
+        <filters>
+            <filter>.*OVClassNetworkTestP.*SetAffinityWithConstantBranches.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 86380 -->
+        <message>The output tensor gets freed when the inference request structure's destructor is called. The issue is unrelated to the caching feature.</message>
+        <filters>
+            <filter>.*CacheTestBase.CompareWithRefImpl.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <message>Expected: SetConfig(configuration, target_device) throws an exception of type InferenceEngine::Exception. Throws nothing.</message>
+        <filters>
+            <!-- EISW 89274 -->
+            <filter>.*AutoBatch.*Behavior.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*AUTO_BATCH_TIMEOUT.*</filter>
+            <!-- EISW 89084 -->
+            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.SetConfigWithIncorrectKey.*AUTO_BATCH_TIMEOUT.*</filter>
+            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_BATCH_TIMEOUT.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>Dynamic I/O shapes are being used when running the tests. This feature is not yet supported by the NPU plugin.</message>
+        <filters>
+            <filter>.*SetPreProcessTo.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>This scenario became invalid upon refactoring the implementation as to use the 2.0 OV API.</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests/VersionTest.pluginCurrentVersionIsCorrect.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 102428 -->
+        <message>Tests throw errors as expected but drivers post-v.1657 will fail to catch them</message>
+        <filters>
+            <filter>.*FailGracefullyTest.*</filter>
+            <filter>.*QueryNetworkTestSuite3NPU.*</filter>
+        </filters>
+    </skip_config>
+<!-- Conditionally disabled test patterns -->
+    <skip_config>
+        <message>Tests are disabled for all devices except NPU3720</message>
+        <enable_rules>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <!-- EISW 49620 -->
+            <filter>.*NPU3720.*</filter>
+            <!-- EISW 84621 -->
+            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
+            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 70764 -->
+        <message>Disabled for when backend is empty (i.e., no device)</message>
+        <enable_rules>
+            <backend>empty</backend>
+        </enable_rules>
+        <filters>
+            <!-- Cannot run InferRequest tests without a device to infer to -->
+            <filter>.*InferRequest.*</filter>
+            <filter>.*OVInferRequest.*</filter>
+            <filter>.*OVInferenceChaining.*</filter>
+            <filter>.*ExecutableNetworkBaseTest.*</filter>
+            <filter>.*OVExecutableNetworkBaseTest.*</filter>
+            <filter>.*ExecNetSetPrecision.*</filter>
+            <filter>.*SetBlobTest.*</filter>
+            <filter>.*InferRequestCallbackTests.*</filter>
+            <filter>.*PreprocessingPrecisionConvertTest.*</filter>
+            <filter>.*SetPreProcessToInputInfo.*</filter>
+            <filter>.*InferRequestPreprocess.*</filter>
+            <filter>.*HoldersTestOnImportedNetwork.*</filter>
+            <filter>.*HoldersTest.Orders.*</filter>
+            <filter>.*HoldersTestImportNetwork.Orders.*</filter>
+            <!-- Cannot compile network without explicit specifying of the device in case of no devices -->
+            <filter>.*OVExecGraphImportExportTest.*</filter>
+            <filter>.*OVHoldersTest.*</filter>
+            <filter>.*OVClassExecutableNetworkGetMetricTest.*</filter>
+            <filter>.*OVClassExecutableNetworkGetConfigTest.*</filter>
+            <filter>.*OVClassNetworkTestP.*SetAffinityWithConstantBranches.*</filter>
+            <filter>.*OVClassNetworkTestP.*SetAffinityWithKSO.*</filter>
+            <filter>.*OVClassNetworkTestP.*LoadNetwork.*</filter>
+            <filter>.*FailGracefullyTest.*</filter>
+            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
+            <!-- Exception in case of network compilation without devices in system -->
+            <!-- [Track number: E#30824] -->
+            <filter>.*OVClassImportExportTestP.*</filter>
+            <filter>.*OVClassLoadNetworkTestNPU.*LoadNetwork.*</filter>
+            <!-- [Track number: E#84621] -->
+            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
+            <filter>.*QueryNetworkTestSuite.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 111510 -->
+        <message>Failing test for NPU device</message>
+        <filters>
+            <filter>.*OVClassImportExportTestP.*OVClassCompiledModelImportExportTestP.*ImportNetworkThrowWithDeviceName.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>These tests runs only on LevelZero backend</message>
+        <enable_rules>
+            <backend>!LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestRunTests.*</filter>
+            <filter>.*OVClassGetMetricAndPrintNoThrow.*</filter>
+            <filter>.*IEClassGetMetricAndPrintNoThrow.*</filter>
+            <filter>.*CompileModelLoadFromFileTestBase.*</filter>
+            <filter>.*CorrectConfigTests.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 85493 -->
+        <message>Runs only on NPU3720 with Level Zero enabled #85493</message>
+        <enable_rules>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestRunTests.MultipleExecutorStreamsTestsSyncInfers.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>Other devices than NPU doesn't allow to set NPU properties with OV1.0 and CACHE_DIR + MLIR is not supported</message>
+        <filters>
+            <filter>.*smoke_AutoBatch_BehaviorTests/CorrectConfigTests.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <message>OpenVINO issues when using caching mechanism</message>
+        <filters>
+            <!-- CVS 119359 -->
+            <filter>.*smoke_Auto_BehaviorTests_CachingSupportCase_NPU/CompileModelLoadFromFileTestBase.*</filter>
+            <!-- CVS 120240 -->
+            <filter>.*smoke_BehaviorTests_CachingSupportCase_NPU/CompileModelLoadFromFileTestBase.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 103391 -->
+        <message>IfTest segfaults npuFuncTest on Ubuntu</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+            <operating_system>linux</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_IfTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 111369 -->
+        <message>Tests fail with: ZE_RESULT_ERROR_DEVICE_LOST, code 0x70000001</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+            <operating_system>linux</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*OVInferRequestMultithreadingTests.canRun3SyncRequestsConsistently.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 81065 -->
+        <message>IMD/Simics do not support the tests</message>
+        <enable_rules>
+            <backend>IMD</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_ClassPluginProperties.*DEVICE_UUID.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 85488 -->
+        <message>Run long time on IMD/Simics</message>
+        <enable_rules>
+            <backend>IMD</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*PreprocessingPrecisionConvertTestNPU.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 83423 -->
+        <message>Tests enabled only for L0 NPU3720</message>
+        <enable_rules>
+            <backend>!LEVEL0</backend>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_VariableStateBasic.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 83708 -->
+        <message>MemoryLSTMCellTest failing with NOT_IMPLEMENTED</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_MemoryLSTMCellTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 83423 -->
+        <message>QueryNetwork is only supported by 3720 platform</message>
+        <enable_rules>
+            <backend>!LEVEL0</backend>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*QueryNetworkTestSuite.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>Some NPU Plugin metrics require single device to work in auto mode or set particular device</message>
+        <filters>
+            <filter>.*OVClassGetConfigTest.*GetConfigNoThrow.*</filter>
+            <filter>.*OVClassGetConfigTest.*GetConfigHeteroNoThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 111455 -->
+        <message>Failing properties tests for AUTO / MULTI</message>
+        <filters>
+            <filter>.*OVCheckSetSupportedRWMetricsPropsTests.ChangeCorrectProperties.*MULTI.*LOG_LEVEL.*</filter>
+            <filter>.*OVCheckSetSupportedRWMetricsPropsTests.ChangeCorrectProperties.*AUTO.*LOG_LEVEL.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 99817 -->
+        <message>Disabled tests for NPU3720</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestVariableStateTest.inferreq_smoke_VariableState_2infers.*</filter>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 114903 -->
+        <message>Tests fail when using latest OV commit from ww09</message>
+        <enable_rules>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_RandomUniform/RandomLayerTest_NPU3720.SW.*</filter>
+        </filters>
+    </skip_config>
+     <skip_config>
+        <!-- EISW ##### -->
+        <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
+        <filters>
+            <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>Fails with CID</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- CVS 128116 -->
+        <message>Unicode paths for ov::cache_dir are not correctly handled on Windows</message>
+        <enable_rules>
+            <operating_system>windows</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*CompiledKernelsCacheTest.*CanCreateCacheDirAndDumpBinariesUnicodePath.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 108600 -->
+        <message>Unsupported NPU properties</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*OVCheckMetricsPropsTests_ModelDependceProps.*</filter>
+            <filter>.*OVClassCompileModelAndCheckSecondaryPropertiesTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <message>Failing properties tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <!-- EISW 108600 -->
+            <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
+            <!-- EISW 133153 -->
+            <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 109040 -->
+        <message>Disabled all tests CompileForDifferentPlatformsTests with config NPU_COMPILER_TYPE_DRIVER</message>
+        <filters>
+            <filter>.*smoke_BehaviorTest/CompileForDifferentPlatformsTests.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>Fails with CID</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 114623 -->
+        <message>The private platform names cannot be identified via the \"ov::available_devices\" configuration.</message>
+        <enable_rules>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_BehaviorTests_OVClassSetDefaultDeviceIDPropTest/OVClassSetDefaultDeviceIDPropTest.SetDefaultDeviceIDNoThrow.*</filter>
+            <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceGetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
+            <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceTestSetConfig.SetConfigSpecificDeviceNoThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 114624 -->
+        <message>The tests are not actually running the compiler-in-driver module.</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests_OVCheckSetSupportedRWMetricsPropsTests.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 109040 -->
+        <message>Disabled tests for NPU3720</message>
+        <enable_rules>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke.*_BehaviorTests/OVInferRequestCheckTensorPrecision.*type=i16.*</filter>
+            <filter>.*smoke.*_BehaviorTests/OVInferRequestCheckTensorPrecision.*type=u16.*</filter>
+            <filter>.*smoke.*_BehaviorTests/OVInferRequestCheckTensorPrecision.*type=u64.*</filter>
+            <filter>.*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 112064 -->
+        <message>Failing core threading tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*CoreThreadingTest.smoke_QueryModel.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 108600 -->
+        <message>Failing properties tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
+            <!-- EISW 133153 -->
+            <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 117582 -->
+        <message>Failing core threading test with cache enabled</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*CoreThreadingTest.CoreThreadingTestsWithCacheEnabled.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 118331 -->
+        <message>platform and compiler_type are private</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestCallbackTests.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestCallbackTests.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestCallbackTestsNPU.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestCallbackTestsNPU.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestIOTensorTestNPU.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestIOTensorTest.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestMultithreadingTests.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestMultithreadingTestsNPU.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestPerfCountersExceptionTest.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestPerfCountersTest.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests/OVInferRequestWaitTests.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestMultithreadingTests.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestMultithreadingTestsNPU.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestPerfCountersExceptionTest.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestPerfCountersTest.*</filter>
+            <filter>.*smoke_Auto_BehaviorTests/OVInferRequestWaitTests.*</filter>
+            <filter>.*smoke_OVClassNetworkTestP/OVClassNetworkTestPNPU.*</filter>
+            <filter>.*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*</filter>
+            <filter>.*smoke_Hetero_BehaviorTests_VariableState/OVInferRequestVariableStateTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 125086 -->
+        <message>Failing tests after functional tests migration to OV</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*OVCompiledModelPropertiesDefaultSupportedTests.CanCompileWithDefaultValueFromPlugin.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 125086 -->
+        <message>Failing tests after functional tests migration to OV</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+            <operating_system>windows</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*OVInferRequestPerfCountersExceptionTest.perfCountWereNotEnabledExceptionTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 125086 -->
+        <message>Failing tests after functional tests migration to OV</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>3720</device>
+            <operating_system>linux</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*OVInferRequestMultithreadingTests.canRun3AsyncRequestsConsistently.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 118331 -->
+        <message>Private properties cannot be accessed by HETERO compiled model</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <filter>.*smoke_Hetero_BehaviorTests.*OVClassCompiledModelGetPropertyTest_MODEL_PRIORITY.*</filter>
+            <filter>.*smoke_Hetero_BehaviorTests.*OVClassCompiledModelGetPropertyTest_EXEC_DEVICES.*</filter>
+            <filter>.*smoke_Hetero_BehaviorTests.*OVCompileModelGetExecutionDeviceTests.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>NPU plugin doesn't support infer dynamic</message>
+        <filters>
+            <filter>.*OVInferRequestBatchedTests.SetInputTensors_Can_Infer_Dynamic.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 118381 -->
+        <message>Comparation is failed, SLT need to be updated.</message>
+        <filters>
+            <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=zeros.*</filter>
+            <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=border.*</filter>
+            <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=reflection.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 116575 -->
+        <message>NPU fails for `OVIterationChaining.Simple` tests</message>
+        <filters>
+            <filter>.*OVIterationChaining.Simple.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 116596 -->
+        <message>Missing model ops in profiling info</message>
+        <filters>
+            <filter>.*OVInferRequestPerfCountersTest.CheckOperationInProfilingInfo.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 118045 -->
+        <message>NPU needs to implement ROITensor logic in zero_infer_request</message>
+        <filters>
+            <filter>.*OVInferRequestInferenceTests.Inference_ROI_Tensor/roi_nchw.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 116761 -->
+        <message>OVClassQueryModel tests do not work with COMPILER_TYPE=DRIVER</message>
+        <filters>
+            <filter>.*OVClassQueryModelTest.QueryModelHETEROWithDeviceIDNoThrow.*</filter>
+            <filter>.*OVClassQueryModelTest.QueryModelWithBigDeviceIDThrows.*</filter>
+            <filter>.*OVClassQueryModelTest.QueryModelWithInvalidDeviceIDThrows.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 109040 -->
+        <message>CheckWrongGraphExtAndThrow tests do not work with COMPILER_TYPE=DRIVER</message>
+        <filters>
+            <filter>.*DriverCompilerAdapterExpectedThrowNPU.CheckWrongGraphExtAndThrow.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 109040 -->
+        <message>Skip tests that can not wrong when DRIVER is default compiler type</message>
+        <filters>
+            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
+            <filter>.*MatMulTransposeConcatTest.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW 121347 -->
+        <message>Error message for empty model from stream must be changed to have \"device xml header\"</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests/OVClassCompiledModelImportExportTestP.smoke_ImportNetworkThrowWithDeviceName.*</filter>
+            <filter>.*smoke_Hetero_BehaviorTests/OVClassCompiledModelImportExportTestP.smoke_ImportNetworkThrowWithDeviceName.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>NPU cannot set properties for compiled models</message>
+        <filters>
+            <filter>.*OVClassCompiledModelSetCorrectConfigTest.canSetConfig.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- CVS 139118 -->
+        <message>Failing runtime model tests</message>
+        <filters>
+            <filter>.*OVCompiledModelGraphUniqueNodeNamesTest.CheckUniqueNodeNames.*</filter>
+            <filter>.*OVExecGraphSerializationTest.ExecutionGraph.*</filter>
+        </filters>
+    </skip_config>
+    <skip_config>
+        <!-- EISW ##### -->
+        <message>get_runtime_model method is not supported on NPU</message>
+        <filters>
+            <filter>.*OVClassModelOptionalTestP.CompileModelCreateDefaultExecGraphResult.*</filter>
+        </filters>
+    </skip_config>
+</skip_configs>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -5,6 +5,7 @@ Example:
         <enable_rules>
             <backend>LEVEL0</backend>
             <backend>IMD</backend>
+            <backend></backend>  (special case for empty backend)
             <device>3720</device>
             <device>4000</device>
             <operating_system>windows</operating_system>
@@ -19,292 +20,10 @@ Example:
 -->
 <skip_configs>
     <skip_config>
-        <!-- EISW ##### -->
-        <message>Tests break due to starting infer on IA side</message>
-        <filters>
-            <filter>.*CorrectConfigAPITests.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW ##### -->
-        <message>ARM CPU Plugin is not available on Yocto</message>
-        <filters>
-            <filter>.*IEClassLoadNetworkTest.*HETERO.*</filter>
-            <filter>.*IEClassLoadNetworkTest.*MULTI.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 30810 -->
-        <message>Hetero plugin doesn't throw an exception in case of big device ID</message>
-        <filters>
-            <filter>.*OVClassLoadNetworkTestNPU.*LoadNetworkHETEROWithBigDeviceIDThrows.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 30815 -->
-        <message>NPU Plugin doesn't handle DEVICE_ID in QueryNetwork implementation</message>
-        <filters>
-            <filter>.*OVClassQueryNetworkTest.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 12774 -->
-        <message>Cannot detect npu platform when it's not passed; Skip tests on Yocto which passes device without platform</message>
-        <filters>
-            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithDeviceIDNoThrow.*</filter>
-            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithBigDeviceIDThrows.*</filter>
-            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithInvalidDeviceIDThrows.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 28335 -->
-        <message>Disabled test E#28335</message>
-        <filters>
-            <filter>.*smoke_LoadNetworkToDefaultDeviceNoThrow.*</filter>
-        </filters>
-    </skip_config>
-        <skip_config>
-        <!-- EISW 32241 -->
-        <message>Disabled test E#28335</message>
-        <filters>
-            <filter>.*LoadNetwork.*CheckDeviceInBlob.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 27343 -->
-        <message>double free detected</message>
-        <filters>
-            <filter>.*InferConfigInTests\\.CanInferWithConfig.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW ##### -->
-        <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
-        <filters>
-            <filter>.*checkGetExecGraphInfoIsNotNullptr.*</filter>
-            <filter>.*CanCreateTwoExeNetworksAndCheckFunction.*</filter>
-            <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
-            <filter>.*CheckExecGraphInfo.*</filter>
-            <filter>.*canLoadCorrectNetworkToGetExecutable.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 31074 -->
-        <message>Disabled test E#28335</message>
-        <filters>
-            <filter>.*checkInferTime.*</filter>
-            <filter>.*OVExecGraphImportExportTest.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 31074 -->
-        <message>Test uses legacy OpenVINO 1.0 API, no need to support it</message>
-        <filters>
-            <filter>.*ExecutableNetworkBaseTest.checkGetMetric.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 31074 -->
-        <message>SetConfig function is not implemented for ExecutableNetwork interface (implemented only for npu plugin)</message>
-        <filters>
-            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNet.*</filter>
-            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNetAndCheckConfigAndCheck.*</filter>
-            <filter>.*CanSetConfigToExecNet.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 30822 -->
-        <message>Exception 'Not implemented</message>
-        <filters>
-            <filter>.*OVClassNetworkTestP.*LoadNetworkCreateDefaultExecGraphResult.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW ##### -->
-        <message>This is openvino specific test</message>
-        <filters>
-            <filter>.*ExecutableNetworkBaseTest.canExport.*</filter>
-        </filters>
-    </skip_config>
-        <skip_config>
-        <!-- EISW ##### -->
-        <message>TensorIterator layer is not supported</message>
-        <filters>
-            <filter>.*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*</filter>
-            <filter>.*OVInferRequestDynamicTests.*</filter>
-            <filter>.*OVInferenceChaining.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 97469 -->
-        <message>Tests with unsupported precision</message>
-        <filters>
-            <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=bf16.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=f64.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=u1.*</filter>
-            <filter>.*InferRequestCheckTensorPrecision.*type=i64.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 70764 -->
-        <!-- Confusing rule, it means that the tests should not be skipped for NPU3720 -->
-        <message>Tests enabled only for L0 NPU3720</message>
-        <enable_rules>
-            <backend>!LEVEL0</backend>
-            <device>!3720</device>
-        </enable_rules>
-        <filters>
-            <filter>.*InferRequestCheckTensorPrecision.*</filter>
-            <filter>.*InferRequestIOTensorSetPrecisionTest.*</filter>
-            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
-            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 32075 -->
-        <message>Exception during loading to the device</message>
-        <filters>
-            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROwithMULTINoThrow.*</filter>
-            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkMULTIwithHETERONoThrow.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW ##### -->
-        <message>compiler: Unsupported arch kind: NPUX311X</message>
-        <filters>
-            <filter>.*CompilationForSpecificPlatform.*(3800|3900).*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 67749 -->
-        <message>Can't loadNetwork without cache for ReadConcatSplitAssign with precision f32</message>
-        <filters>
-            <filter>.*CachingSupportCase_NPU.*CompileModelCacheTestBase.*CompareWithRefImpl.*ReadConcatSplitAssign.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 99817 -->
-        <message>NPU Plugin currently fails to get a valid output in these test cases</message>
-        <filters>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
-            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
-            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_.*</filter>
-            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_.*</filter>
-            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 68774 -->
-        <message>OV requires the plugin to throw when value of DEVICE_ID is unrecognized, but plugin does not throw</message>
-        <filters>
-            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithIncorrectKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
-            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithNoExistingKey.*SOME_DEVICE_ID.*</filter>
-            <filter>smoke_BehaviorTests.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 77755 -->
-        <message>OV requires the plugin to throw on network load when config file is incorrect, but plugin does not throw</message>
-        <filters>
-            <filter>.*smoke_Auto_BehaviorTests.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_config.*unknown_file_MULTI_DEVICE_PRIORITIES=(NPU_|NPU,CPU_).*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 77756 -->
-        <message>OV expects the plugin to not throw any exception on network load, but it actually throws</message>
-        <filters>
-            <filter>.*(smoke_Multi_Behavior|smoke_Auto_Behavior).*SetPropLoadNetWorkGetPropTests.*SetPropLoadNetWorkGetProperty.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 68776 -->
-        <message>Plugin can not perform SetConfig for value like: device=NPU config key=LOG_LEVEL value=0</message>
-        <filters>
-            <filter>smoke_BehaviorTests/DefaultValuesConfigTests.CanSetDefaultValueBackToPlugin.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 48480 -->
-        <message>Disabled with ticket number 48480</message>
-        <filters>
-            <filter>.*OVExecutableNetworkBaseTest.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 63708 -->
-        <message>Disabled with ticket number 63708</message>
-        <filters>
-            <filter>.*smoke_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
-            <filter>.*smoke_Multi_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 64490 -->
-        <message>Disabled with ticket number 64490</message>
-        <filters>
-            <filter>.*OVClassNetworkTestP.*SetAffinityWithConstantBranches.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 86380 -->
-        <message>The output tensor gets freed when the inference request structure's destructor is called. The issue is unrelated to the caching feature.</message>
-        <filters>
-            <filter>.*CacheTestBase.CompareWithRefImpl.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <message>Expected: SetConfig(configuration, target_device) throws an exception of type InferenceEngine::Exception. Throws nothing.</message>
-        <filters>
-            <!-- EISW 89274 -->
-            <filter>.*AutoBatch.*Behavior.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*AUTO_BATCH_TIMEOUT.*</filter>
-            <!-- EISW 89084 -->
-            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.SetConfigWithIncorrectKey.*AUTO_BATCH_TIMEOUT.*</filter>
-            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_BATCH_TIMEOUT.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW ##### -->
-        <message>Dynamic I/O shapes are being used when running the tests. This feature is not yet supported by the NPU plugin.</message>
-        <filters>
-            <filter>.*SetPreProcessTo.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW ##### -->
-        <message>This scenario became invalid upon refactoring the implementation as to use the 2.0 OV API.</message>
-        <filters>
-            <filter>.*smoke_BehaviorTests/VersionTest.pluginCurrentVersionIsCorrect.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
-        <!-- EISW 102428 -->
-        <message>Tests throw errors as expected but drivers post-v.1657 will fail to catch them</message>
-        <filters>
-            <filter>.*FailGracefullyTest.*</filter>
-            <filter>.*QueryNetworkTestSuite3NPU.*</filter>
-        </filters>
-    </skip_config>
-<!-- Conditionally disabled test patterns -->
-    <skip_config>
-        <message>Tests are disabled for all devices except NPU3720</message>
-        <enable_rules>
-            <device>!3720</device>
-        </enable_rules>
-        <filters>
-            <!-- EISW 49620 -->
-            <filter>.*NPU3720.*</filter>
-            <!-- EISW 84621 -->
-            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
-            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
-        </filters>
-    </skip_config>
-    <skip_config>
         <!-- EISW 70764 -->
         <message>Disabled for when backend is empty (i.e., no device)</message>
         <enable_rules>
-            <backend></backend> <!-- special case for no device -->
+            <backend></backend> <!-- special case for empty backend -->
         </enable_rules>
         <filters>
             <!-- Cannot run InferRequest tests without a device to infer to -->
@@ -341,15 +60,331 @@ Example:
             <filter>.*QueryNetworkTestSuite.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW 111510 -->
+        <message>Tests break due to starting infer on IA side</message>
+        <filters>
+            <filter>.*CorrectConfigAPITests.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>ARM CPU Plugin is not available on Yocto</message>
+        <filters>
+            <filter>.*IEClassLoadNetworkTest.*HETERO.*</filter>
+            <filter>.*IEClassLoadNetworkTest.*MULTI.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 30810 -->
+    <skip_config>    
+        <message>Hetero plugin doesn't throw an exception in case of big device ID</message>
+        <filters>
+            <filter>.*OVClassLoadNetworkTestNPU.*LoadNetworkHETEROWithBigDeviceIDThrows.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 30815 -->
+    <skip_config>
+        <message>NPU Plugin doesn't handle DEVICE_ID in QueryNetwork implementation</message>
+        <filters>
+            <filter>.*OVClassQueryNetworkTest.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 12774 -->
+    <skip_config>
+        <message>Cannot detect npu platform when it's not passed; Skip tests on Yocto which passes device without platform</message>
+        <filters>
+            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithDeviceIDNoThrow.*</filter>
+            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithBigDeviceIDThrows.*</filter>
+            <filter>.*IEClassLoadNetworkTest.LoadNetworkWithInvalidDeviceIDThrows.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 28335 -->
+    <skip_config>
+        <message>Disabled test E#28335</message>
+        <filters>
+            <filter>.*smoke_LoadNetworkToDefaultDeviceNoThrow.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 32241 -->
+    <skip_config>
+        <message>Disabled test E#28335</message>
+        <filters>
+            <filter>.*LoadNetwork.*CheckDeviceInBlob.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 27343 -->
+    <skip_config>
+        <message>double free detected</message>
+        <filters>
+            <filter>.*InferConfigInTests\\.CanInferWithConfig.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
+        <filters>
+            <filter>.*checkGetExecGraphInfoIsNotNullptr.*</filter>
+            <filter>.*CanCreateTwoExeNetworksAndCheckFunction.*</filter>
+            <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
+            <filter>.*CheckExecGraphInfo.*</filter>
+            <filter>.*canLoadCorrectNetworkToGetExecutable.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 28335 -->
+    <skip_config>
+        <message>Disabled test E#28335</message>
+        <filters>
+            <filter>.*checkInferTime.*</filter>
+            <filter>.*OVExecGraphImportExportTest.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 31074 -->
+    <skip_config>
+        <message>Test uses legacy OpenVINO 1.0 API, no need to support it</message>
+        <filters>
+            <filter>.*ExecutableNetworkBaseTest.checkGetMetric.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 31074 -->
+    <skip_config>
+        <message>SetConfig function is not implemented for ExecutableNetwork interface (implemented only for npu plugin)</message>
+        <filters>
+            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNet.*</filter>
+            <filter>.*ExecutableNetworkBaseTest.canSetConfigToExecNetAndCheckConfigAndCheck.*</filter>
+            <filter>.*CanSetConfigToExecNet.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 30822 -->
+    <skip_config>
+        <message>Exception 'Not implemented</message>
+        <filters>
+            <filter>.*OVClassNetworkTestP.*LoadNetworkCreateDefaultExecGraphResult.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>This is openvino specific test</message>
+        <filters>
+            <filter>.*ExecutableNetworkBaseTest.canExport.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>TensorIterator layer is not supported</message>
+        <filters>
+            <filter>.*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*</filter>
+            <filter>.*OVInferRequestDynamicTests.*</filter>
+            <filter>.*OVInferenceChaining.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 97469 -->
+    <skip_config>
+        <message>Tests with unsupported precision</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=boolean.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=bf16.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=f64.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u1.*</filter>
+            <filter>.*InferRequestCheckTensorPrecision.*type=i64.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 70764 -->
+    <skip_config>
+        <message>Tests enabled only for L0 NPU3720</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*</filter>
+            <filter>.*InferRequestIOTensorSetPrecisionTest.*</filter>
+            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
+            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 32075 -->
+    <skip_config>
+        <message>Exception during loading to the device</message>
+        <filters>
+            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROwithMULTINoThrow.*</filter>
+            <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkMULTIwithHETERONoThrow.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>compiler: Unsupported arch kind: NPUX311X</message>
+        <filters>
+            <filter>.*CompilationForSpecificPlatform.*(3800|3900).*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 67749 -->
+    <skip_config>
+        <message>Can't loadNetwork without cache for ReadConcatSplitAssign with precision f32</message>
+        <filters>
+            <filter>.*CachingSupportCase_NPU.*CompileModelCacheTestBase.*CompareWithRefImpl.*ReadConcatSplitAssign.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 99817 -->
+    <skip_config>
+        <message>NPU Plugin currently fails to get a valid output in these test cases</message>
+        <filters>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
+            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
+            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_.*</filter>
+            <filter>.*OVInferRequestIOTensorTestNPU.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_.*</filter>
+            <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow/targetDevice=NPU3720_configItem=MULTI_DEVICE_PRIORITIES_NPU_.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 68774 -->
+    <skip_config>
+        <message>OV requires the plugin to throw when value of DEVICE_ID is unrecognized, but plugin does not throw</message>
+        <filters>
+            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithIncorrectKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
+            <filter>smoke_BehaviorTests.*IncorrectConfigTests.SetConfigWithNoExistingKey.*SOME_DEVICE_ID.*</filter>
+            <filter>smoke_BehaviorTests.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*(SOME_DEVICE_ID|DEVICE_UNKNOWN).*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 77755 -->
+    <skip_config>
+        <message>OV requires the plugin to throw on network load when config file is incorrect, but plugin does not throw</message>
+        <filters>
+            <filter>.*smoke_Auto_BehaviorTests.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_config.*unknown_file_MULTI_DEVICE_PRIORITIES=(NPU_|NPU,CPU_).*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 77756 -->
+    <skip_config>
+        <message>OV expects the plugin to not throw any exception on network load, but it actually throws</message>
+        <filters>
+            <filter>.*(smoke_Multi_Behavior|smoke_Auto_Behavior).*SetPropLoadNetWorkGetPropTests.*SetPropLoadNetWorkGetProperty.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 68776 -->
+    <skip_config>
+        <message>Plugin can not perform SetConfig for value like: device=NPU config key=LOG_LEVEL value=0</message>
+        <filters>
+            <filter>smoke_BehaviorTests/DefaultValuesConfigTests.CanSetDefaultValueBackToPlugin.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 48480 -->
+    <skip_config>
+        <message>Disabled with ticket number 48480</message>
+        <filters>
+            <filter>.*OVExecutableNetworkBaseTest.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 63708 -->
+    <skip_config>
+        <message>Disabled with ticket number 63708</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
+            <filter>.*smoke_Multi_BehaviorTests.*InferStaticNetworkSetInputTensor.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 64490 -->
+    <skip_config>
+        <message>Disabled with ticket number 64490</message>
+        <filters>
+            <filter>.*OVClassNetworkTestP.*SetAffinityWithConstantBranches.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 86380 -->
+    <skip_config>
+        <message>The output tensor gets freed when the inference request structure's destructor is called. The issue is unrelated to the caching feature.</message>
+        <filters>
+            <filter>.*CacheTestBase.CompareWithRefImpl.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>Expected: SetConfig(configuration, target_device) throws an exception of type InferenceEngine::Exception. Throws nothing.</message>
+        <filters>
+            <!-- EISW 89274 -->
+            <filter>.*AutoBatch.*Behavior.*IncorrectConfigAPITests.SetConfigWithNoExistingKey.*AUTO_BATCH_TIMEOUT.*</filter>
+            <!-- EISW 89084 -->
+            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.SetConfigWithIncorrectKey.*AUTO_BATCH_TIMEOUT.*</filter>
+            <filter>.*AutoBatch.*Behavior.*IncorrectConfigTests.CanNotLoadNetworkWithIncorrectConfig.*AUTO_BATCH_TIMEOUT.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>Dynamic I/O shapes are being used when running the tests. This feature is not yet supported by the NPU plugin.</message>
+        <filters>
+            <filter>.*SetPreProcessTo.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW ##### -->
+    <skip_config>
+        <message>This scenario became invalid upon refactoring the implementation as to use the 2.0 OV API.</message>
+        <filters>
+            <filter>.*smoke_BehaviorTests/VersionTest.pluginCurrentVersionIsCorrect.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 102428 -->
+    <skip_config>
+        <message>Tests throw errors as expected but drivers post-v.1657 will fail to catch them</message>
+        <filters>
+            <filter>.*FailGracefullyTest.*</filter>
+            <filter>.*QueryNetworkTestSuite3NPU.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>Tests are disabled for all devices except NPU3720</message>
+        <enable_rules>
+            <device>!3720</device>
+        </enable_rules>
+        <filters>
+            <!-- EISW 49620 -->
+            <filter>.*NPU3720.*</filter>
+            <!-- EISW 84621 -->
+            <filter>.*DriverCompilerAdapterDowngradeInterpolate11TestNPU.*</filter>
+            <filter>.*DriverCompilerAdapterInputsOutputsTestNPU.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 111510 -->
+    <skip_config>    
         <message>Failing test for NPU device</message>
         <filters>
             <filter>.*OVClassImportExportTestP.*OVClassCompiledModelImportExportTestP.*ImportNetworkThrowWithDeviceName.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>These tests runs only on LevelZero backend</message>
         <enable_rules>
             <backend>!LEVEL0</backend>
@@ -362,8 +397,9 @@ Example:
             <filter>.*CorrectConfigTests.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 85493 -->
     <skip_config>
-        <!-- EISW 85493 -->
         <message>Runs only on NPU3720 with Level Zero enabled #85493</message>
         <enable_rules>
             <device>!3720</device>
@@ -372,13 +408,15 @@ Example:
             <filter>.*InferRequestRunTests.MultipleExecutorStreamsTestsSyncInfers.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>Other devices than NPU doesn't allow to set NPU properties with OV1.0 and CACHE_DIR + MLIR is not supported</message>
         <filters>
             <filter>.*smoke_AutoBatch_BehaviorTests/CorrectConfigTests.*</filter>
         </filters>
     </skip_config>
+
     <skip_config>
         <message>OpenVINO issues when using caching mechanism</message>
         <filters>
@@ -388,8 +426,9 @@ Example:
             <filter>.*smoke_BehaviorTests_CachingSupportCase_NPU/CompileModelLoadFromFileTestBase.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 103391 -->
     <skip_config>
-        <!-- EISW 103391 -->
         <message>IfTest segfaults npuFuncTest on Ubuntu</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -400,8 +439,9 @@ Example:
             <filter>.*smoke_IfTest.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 111369 -->
     <skip_config>
-        <!-- EISW 111369 -->
         <message>Tests fail with: ZE_RESULT_ERROR_DEVICE_LOST, code 0x70000001</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -412,8 +452,9 @@ Example:
             <filter>.*OVInferRequestMultithreadingTests.canRun3SyncRequestsConsistently.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 81065 -->
     <skip_config>
-        <!-- EISW 81065 -->
         <message>IMD/Simics do not support the tests</message>
         <enable_rules>
             <backend>IMD</backend>
@@ -422,8 +463,9 @@ Example:
             <filter>.*smoke_ClassPluginProperties.*DEVICE_UUID.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 85488 -->
     <skip_config>
-        <!-- EISW 85488 -->
         <message>Run long time on IMD/Simics</message>
         <enable_rules>
             <backend>IMD</backend>
@@ -432,8 +474,9 @@ Example:
             <filter>.*PreprocessingPrecisionConvertTestNPU.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 83423 -->
     <skip_config>
-        <!-- EISW 83423 -->
         <message>Tests enabled only for L0 NPU3720</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -443,8 +486,9 @@ Example:
             <filter>.*smoke_VariableStateBasic.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 83708 -->
     <skip_config>
-        <!-- EISW 83708 -->
         <message>MemoryLSTMCellTest failing with NOT_IMPLEMENTED</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -453,8 +497,9 @@ Example:
             <filter>.*smoke_MemoryLSTMCellTest.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 83423 -->
     <skip_config>
-        <!-- EISW 83423 -->
         <message>QueryNetwork is only supported by 3720 platform</message>
         <enable_rules>
             <backend>!LEVEL0</backend>
@@ -464,24 +509,27 @@ Example:
             <filter>.*QueryNetworkTestSuite.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>Some NPU Plugin metrics require single device to work in auto mode or set particular device</message>
         <filters>
             <filter>.*OVClassGetConfigTest.*GetConfigNoThrow.*</filter>
             <filter>.*OVClassGetConfigTest.*GetConfigHeteroNoThrow.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 111455 -->
     <skip_config>
-        <!-- EISW 111455 -->
         <message>Failing properties tests for AUTO / MULTI</message>
         <filters>
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.ChangeCorrectProperties.*MULTI.*LOG_LEVEL.*</filter>
             <filter>.*OVCheckSetSupportedRWMetricsPropsTests.ChangeCorrectProperties.*AUTO.*LOG_LEVEL.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 99817 -->
     <skip_config>
-        <!-- EISW 99817 -->
         <message>Disabled tests for NPU3720</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -492,8 +540,9 @@ Example:
             <filter>.*OVInferRequestIOTensorTest.InferStaticNetworkSetChangedInputTensorThrow.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 114903 -->
     <skip_config>
-        <!-- EISW 114903 -->
         <message>Tests fail when using latest OV commit from ww09</message>
         <enable_rules>
             <device>3720</device>
@@ -502,22 +551,25 @@ Example:
             <filter>.*smoke_RandomUniform/RandomLayerTest_NPU3720.SW.*</filter>
         </filters>
     </skip_config>
-     <skip_config>
-        <!-- EISW ##### -->
+    
+    <!-- EISW ##### -->
+    <skip_config>
         <message>GetExecGraphInfo function is not implemented for NPU plugin</message>
         <filters>
             <filter>.*CanCreateTwoCompiledModelsAndCheckRuntimeModel.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>Fails with CID</message>
         <filters>
             <filter>.*smoke_BehaviorTests_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
         </filters>
     </skip_config>
+
+    <!-- CVS 128116 -->
     <skip_config>
-        <!-- CVS 128116 -->
         <message>Unicode paths for ov::cache_dir are not correctly handled on Windows</message>
         <enable_rules>
             <operating_system>windows</operating_system>
@@ -526,8 +578,9 @@ Example:
             <filter>.*CompiledKernelsCacheTest.*CanCreateCacheDirAndDumpBinariesUnicodePath.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 108600 -->
     <skip_config>
-        <!-- EISW 108600 -->
         <message>Unsupported NPU properties</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -537,6 +590,7 @@ Example:
             <filter>.*OVClassCompileModelAndCheckSecondaryPropertiesTest.*</filter>
         </filters>
     </skip_config>
+
     <skip_config>
         <message>Failing properties tests</message>
         <enable_rules>
@@ -549,22 +603,25 @@ Example:
             <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 109040 -->
     <skip_config>
-        <!-- EISW 109040 -->
         <message>Disabled all tests CompileForDifferentPlatformsTests with config NPU_COMPILER_TYPE_DRIVER</message>
         <filters>
             <filter>.*smoke_BehaviorTest/CompileForDifferentPlatformsTests.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>Fails with CID</message>
         <filters>
             <filter>.*smoke_BehaviorTests_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 114623 -->
     <skip_config>
-        <!-- EISW 114623 -->
         <message>The private platform names cannot be identified via the \"ov::available_devices\" configuration.</message>
         <enable_rules>
             <device>!3720</device>
@@ -575,15 +632,17 @@ Example:
             <filter>.*smoke_BehaviorTests_OVClassSpecificDeviceTest/OVSpecificDeviceTestSetConfig.SetConfigSpecificDeviceNoThrow.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 114624 -->
     <skip_config>
-        <!-- EISW 114624 -->
         <message>The tests are not actually running the compiler-in-driver module.</message>
         <filters>
             <filter>.*smoke_BehaviorTests_OVCheckSetSupportedRWMetricsPropsTests.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 109040 -->
     <skip_config>
-        <!-- EISW 109040 -->
         <message>Disabled tests for NPU3720</message>
         <enable_rules>
             <device>3720</device>
@@ -595,8 +654,9 @@ Example:
             <filter>.*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 112064 -->
     <skip_config>
-        <!-- EISW 112064 -->
         <message>Failing core threading tests</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -609,20 +669,22 @@ Example:
             <filter>.*CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput.*</filter>
         </filters>
     </skip_config>
+
     <skip_config>
-        <!-- EISW 108600 -->
         <message>Failing properties tests</message>
         <enable_rules>
             <backend>LEVEL0</backend>
         </enable_rules>
         <filters>
+            <!-- EISW 108600 -->
             <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
             <!-- EISW 133153 -->
             <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 117582 -->
     <skip_config>
-        <!-- EISW 117582 -->
         <message>Failing core threading test with cache enabled</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -631,8 +693,9 @@ Example:
             <filter>.*CoreThreadingTest.*CoreThreadingTestsWithCacheEnabled.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 118331 -->
     <skip_config>
-        <!-- EISW 118331 -->
         <message>platform and compiler_type are private</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -660,8 +723,9 @@ Example:
             <filter>.*smoke_Hetero_BehaviorTests_VariableState/OVInferRequestVariableStateTest.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 125086 -->
     <skip_config>
-        <!-- EISW 125086 -->
         <message>Failing tests after functional tests migration to OV</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -671,8 +735,9 @@ Example:
             <filter>.*OVCompiledModelPropertiesDefaultSupportedTests.CanCompileWithDefaultValueFromPlugin.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 125086 -->
     <skip_config>
-        <!-- EISW 125086 -->
         <message>Failing tests after functional tests migration to OV</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -683,8 +748,9 @@ Example:
             <filter>.*OVInferRequestPerfCountersExceptionTest.perfCountWereNotEnabledExceptionTest.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 125086 -->
     <skip_config>
-        <!-- EISW 125086 -->
         <message>Failing tests after functional tests migration to OV</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -695,8 +761,9 @@ Example:
             <filter>.*OVInferRequestMultithreadingTests.canRun3AsyncRequestsConsistently.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 118331 -->
     <skip_config>
-        <!-- EISW 118331 -->
         <message>Private properties cannot be accessed by HETERO compiled model</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -707,15 +774,17 @@ Example:
             <filter>.*smoke_Hetero_BehaviorTests.*OVCompileModelGetExecutionDeviceTests.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>NPU plugin doesn't support infer dynamic</message>
         <filters>
             <filter>.*OVInferRequestBatchedTests.SetInputTensors_Can_Infer_Dynamic.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 118381 -->
     <skip_config>
-        <!-- EISW 118381 -->
         <message>Comparation is failed, SLT need to be updated.</message>
         <filters>
             <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=zeros.*</filter>
@@ -723,29 +792,33 @@ Example:
             <filter>.*smoke.*GridSample_Tiling/GridSampleLayerTest.*align_corners=0.*Mode=nearest_padding_mode=reflection.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 116575 -->
     <skip_config>
-        <!-- EISW 116575 -->
         <message>NPU fails for `OVIterationChaining.Simple` tests</message>
         <filters>
             <filter>.*OVIterationChaining.Simple.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 116596 -->
     <skip_config>
-        <!-- EISW 116596 -->
         <message>Missing model ops in profiling info</message>
         <filters>
             <filter>.*OVInferRequestPerfCountersTest.CheckOperationInProfilingInfo.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 118045 -->
     <skip_config>
-        <!-- EISW 118045 -->
         <message>NPU needs to implement ROITensor logic in zero_infer_request</message>
         <filters>
             <filter>.*OVInferRequestInferenceTests.Inference_ROI_Tensor/roi_nchw.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 116761 -->
     <skip_config>
-        <!-- EISW 116761 -->
         <message>OVClassQueryModel tests do not work with COMPILER_TYPE=DRIVER</message>
         <filters>
             <filter>.*OVClassQueryModelTest.QueryModelHETEROWithDeviceIDNoThrow.*</filter>
@@ -753,46 +826,52 @@ Example:
             <filter>.*OVClassQueryModelTest.QueryModelWithInvalidDeviceIDThrows.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 109040 -->
     <skip_config>
-        <!-- EISW 109040 -->
         <message>CheckWrongGraphExtAndThrow tests do not work with COMPILER_TYPE=DRIVER</message>
         <filters>
             <filter>.*DriverCompilerAdapterExpectedThrowNPU.CheckWrongGraphExtAndThrow.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 109040 -->
     <skip_config>
-        <!-- EISW 109040 -->
         <message>Skip tests that can not wrong when DRIVER is default compiler type</message>
         <filters>
             <filter>.*OVClassLoadNetworkTestNPU.LoadNetworkHETEROWithDeviceIDNoThrow.*</filter>
             <filter>.*MatMulTransposeConcatTest.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW 121347 -->
     <skip_config>
-        <!-- EISW 121347 -->
         <message>Error message for empty model from stream must be changed to have \"device xml header\"</message>
         <filters>
             <filter>.*smoke_BehaviorTests/OVClassCompiledModelImportExportTestP.smoke_ImportNetworkThrowWithDeviceName.*</filter>
             <filter>.*smoke_Hetero_BehaviorTests/OVClassCompiledModelImportExportTestP.smoke_ImportNetworkThrowWithDeviceName.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>NPU cannot set properties for compiled models</message>
         <filters>
             <filter>.*OVClassCompiledModelSetCorrectConfigTest.canSetConfig.*</filter>
         </filters>
     </skip_config>
+
+    <!-- CVS 139118 -->
     <skip_config>
-        <!-- CVS 139118 -->
         <message>Failing runtime model tests</message>
         <filters>
             <filter>.*OVCompiledModelGraphUniqueNodeNamesTest.CheckUniqueNodeNames.*</filter>
             <filter>.*OVExecGraphSerializationTest.ExecutionGraph.*</filter>
         </filters>
     </skip_config>
+
+    <!-- EISW ##### -->
     <skip_config>
-        <!-- EISW ##### -->
         <message>get_runtime_model method is not supported on NPU</message>
         <filters>
             <filter>.*OVClassModelOptionalTestP.CompileModelCreateDefaultExecGraphResult.*</filter>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -189,24 +189,31 @@ bool isRuleInverted(std::string& rule) {
     return false;
 }
 
-bool categoryRuleEnabler(std::string category, std::vector<std::string> localSettings, pugi::xml_node& enableRules);
+bool categoryRuleEnabler(const std::string& category,
+                         const std::vector<std::string>& localSettings,
+                         const pugi::xml_node& enableRules);
 
-bool categoryRuleEnabler(std::string category, std::vector<std::string> localSettings, pugi::xml_node& enableRules) {
-    if (!enableRules.child(category.c_str()).empty()) {
-        FOREACH_CHILD (enableRule, enableRules, category.c_str()) {
-            auto categoryRule = enableRule.text().get();
+bool categoryRuleEnabler(const std::string& category,
+                         const std::vector<std::string>& localSettings,
+                         const pugi::xml_node& enableRules) {
+    if (enableRules.child(category.c_str()).empty()) {
+        return true;
+    }
 
-            std::string categoryRuleString(categoryRule);
-            bool invert = isRuleInverted(categoryRuleString);
-            for (auto& localSetting : localSettings) {
-                // Perform logical XOR to invert condition
-                if (!(categoryRuleString == localSetting) != !invert)
-                    return true;
+    FOREACH_CHILD (enableRule, enableRules, category.c_str()) {
+        auto categoryRule = enableRule.text().get();
+
+        std::string categoryRuleString(categoryRule);
+        bool invert = isRuleInverted(categoryRuleString);
+        for (auto& localSetting : localSettings) {
+            // Perform logical XOR to invert condition
+            if (!(categoryRuleString == localSetting) != !invert) {
+                return true;
             }
         }
-        return false;
     }
-    return true;
+
+    return false;
 }
 
 std::vector<std::string> disabledTestPatterns();
@@ -224,14 +231,16 @@ std::vector<std::string> disabledTestPatterns() {
 
         // Check if skip xml is set to be read
         const auto& filePath = ov::test::utils::NpuTestEnvConfig::getInstance().OV_NPU_TESTS_SKIP_CONFIG_FILE;
-        if (filePath.empty())
+        if (filePath.empty()) {
             _log.warning("OV_NPU_TESTS_SKIP_CONFIG_FILE not set");
-        else
+        } else {
             _log.info("Using %s as skip config", filePath.c_str());
+        }
 
         auto xmlResult = ov::util::pugixml::parse_xml(filePath.c_str());
-        if (!xmlResult.error_msg.empty() && !filePath.empty())
+        if (!xmlResult.error_msg.empty() && !filePath.empty()) {
             _log.error(xmlResult.error_msg.c_str());
+        }
 
         pugi::xml_document& xmlSkipConfig = *xmlResult.xml;
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -15,7 +15,6 @@
 #include "common_test_utils/common_utils.hpp"
 #include "functional_test_utils/ov_plugin_cache.hpp"
 #include "intel_npu/npu_private_properties.hpp"
-
 #include "openvino/util/xml_parse_utils.hpp"
 
 class BackendName {
@@ -97,12 +96,12 @@ private:
 
 class CurrentOS {
 public:
-CurrentOS() {
-    #ifdef WIN32
+    CurrentOS() {
+#ifdef WIN32
         _name = "windows";
-    #elif defined(__linux__)
+#elif defined(__linux__)
         _name = "linux";
-    #endif
+#endif
     }
 
     std::string getName() const {
@@ -119,7 +118,7 @@ CurrentOS() {
 
 private:
     std::string _name;
-};    
+};
 
 class SkipRegistry {
 public:
@@ -186,9 +185,9 @@ bool isRuleInverted(std::string& rule) {
     bool invertRule = false;
     auto pos = rule.find("!");
     if (pos != std::string::npos) {
-            invertRule = true;
-            // Extract negation character from rule string
-            rule.erase(pos, 1);
+        invertRule = true;
+        // Extract negation character from rule string
+        rule.erase(pos, 1);
     }
     return invertRule;
 }
@@ -196,8 +195,6 @@ bool isRuleInverted(std::string& rule) {
 std::vector<std::string> disabledTestPatterns();
 
 std::vector<std::string> disabledTestPatterns() {
-
-
     // Initialize skip registry
     static const auto skipRegistry = []() {
         SkipRegistry _skipRegistry;
@@ -211,14 +208,14 @@ std::vector<std::string> disabledTestPatterns() {
         // Check if skip xml is set to be read
         const auto& filePath = ov::test::utils::NpuTestEnvConfig::getInstance().OV_NPU_TESTS_SKIP_CONFIG_FILE;
         if (filePath.empty())
-           _log.warning ("[WARNING] OV_NPU_TESTS_SKIP_CONFIG_FILE not set");
+            _log.warning("[WARNING] OV_NPU_TESTS_SKIP_CONFIG_FILE not set");
         else
-            _log.info ("Using %s as skip config", filePath.c_str());
+            _log.info("Using %s as skip config", filePath.c_str());
 
         // Load the Skip config
         auto xmlResult = ov::util::pugixml::parse_xml(filePath.c_str());
         if (!xmlResult.error_msg.empty() && !filePath.empty())
-            _log.error (xmlResult.error_msg.c_str());
+            _log.error(xmlResult.error_msg.c_str());
 
         pugi::xml_document& xmlSkipConfig = *xmlResult.xml;
 
@@ -226,7 +223,7 @@ std::vector<std::string> disabledTestPatterns() {
         pugi::xml_node skipConfigsList = xmlSkipConfig.child("skip_configs");
 
         // Iterate through each skip rule
-        FOREACH_CHILD(skipConfigRule, skipConfigsList, "skip_config") {
+        FOREACH_CHILD (skipConfigRule, skipConfigsList, "skip_config") {
             // Extract skip message, it will get printed in the test logs
             auto skipMessageEntry = skipConfigRule.child("message").text().get();
 
@@ -238,15 +235,15 @@ std::vector<std::string> disabledTestPatterns() {
             if (!enableRules.empty()) {
                 bool backendRuleFlag = false;
                 if (!enableRules.child("backend").empty()) {
-                FOREACH_CHILD(enableRule, enableRules, "backend") {
-                    auto backendRule = enableRule.text().get();
+                    FOREACH_CHILD (enableRule, enableRules, "backend") {
+                        auto backendRule = enableRule.text().get();
 
-                    std::string backendRuleString(backendRule);
-                    bool invertRule = isRuleInverted(backendRuleString);
-                    // Perform logical XOR to invert condition
-                    if (!(backendRuleString == backendName.getName()) != !invertRule)
-                        backendRuleFlag = true;
-                }
+                        std::string backendRuleString(backendRule);
+                        bool invertRule = isRuleInverted(backendRuleString);
+                        // Perform logical XOR to invert condition
+                        if (!(backendRuleString == backendName.getName()) != !invertRule)
+                            backendRuleFlag = true;
+                    }
                 } else {
                     // Rule empty, default to true
                     backendRuleFlag = true;
@@ -254,17 +251,17 @@ std::vector<std::string> disabledTestPatterns() {
 
                 bool deviceRuleFlag = false;
                 if (!enableRules.child("device").empty()) {
-                FOREACH_CHILD(enableRule, enableRules, "device") {
-                    auto deviceRule = enableRule.text().get();
+                    FOREACH_CHILD (enableRule, enableRules, "device") {
+                        auto deviceRule = enableRule.text().get();
 
-                    std::string deviceRuleString(deviceRule);
-                    bool invertRule = isRuleInverted(deviceRuleString);
-                    for (auto& device : devices.getAvailableDevices()) {
-                    // Perform logical XOR to invert condition
-                    if (!(deviceRuleString == device) != !invertRule)
-                        deviceRuleFlag = true;
+                        std::string deviceRuleString(deviceRule);
+                        bool invertRule = isRuleInverted(deviceRuleString);
+                        for (auto& device : devices.getAvailableDevices()) {
+                            // Perform logical XOR to invert condition
+                            if (!(deviceRuleString == device) != !invertRule)
+                                deviceRuleFlag = true;
+                        }
                     }
-                }
                 } else {
                     // Rule empty, default to true
                     deviceRuleFlag = true;
@@ -272,12 +269,12 @@ std::vector<std::string> disabledTestPatterns() {
 
                 bool operatingSystemRuleFlag = false;
                 if (!enableRules.child("operating_system").empty()) {
-                FOREACH_CHILD(enableRule, enableRules, "operating_system") {
-                    auto operatingSystemRule = enableRule.text().get();
+                    FOREACH_CHILD (enableRule, enableRules, "operating_system") {
+                        auto operatingSystemRule = enableRule.text().get();
 
-                    if (operatingSystemRule == currentOS.getName())
-                        operatingSystemRuleFlag = true;
-                }
+                        if (operatingSystemRule == currentOS.getName())
+                            operatingSystemRuleFlag = true;
+                    }
                 } else {
                     // Rule empty, default to true
                     operatingSystemRuleFlag = true;
@@ -292,7 +289,7 @@ std::vector<std::string> disabledTestPatterns() {
 
             // Select individual filters and add them to the skipRegistry
             pugi::xml_node skipFiltersList = skipConfigRule.child("filters");
-            FOREACH_CHILD(skipFilter, skipFiltersList, "filter") {
+            FOREACH_CHILD (skipFilter, skipFiltersList, "filter") {
                 auto skipFilterEntry = skipFilter.text().get();
 
                 // Add skip to regoistry
@@ -302,9 +299,9 @@ std::vector<std::string> disabledTestPatterns() {
 
         // OV_NPU_TESTS_SKIP_CONFIG_FILE not present
         if (filePath.empty() || !xmlResult.error_msg.empty()) {
-        _log.warning ("[WARNING] Using legacy skip config");
+            _log.warning("[WARNING] Using legacy skip config");
 
-        // clang-format off
+            // clang-format off
 
         //
         //  Disabled test patterns

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -181,6 +181,8 @@ std::string getCurrentTestName() {
  * @param rule Input string
  * @return true if "!" is found
  */
+bool isRuleInverted(std::string& rule);
+
 bool isRuleInverted(std::string& rule) {
     bool invertRule = false;
     auto pos = rule.find("!");

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -16,6 +16,8 @@
 #include "functional_test_utils/ov_plugin_cache.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 
+#include "openvino/util/xml_parse_utils.hpp"
+
 class BackendName {
 public:
     BackendName() {
@@ -93,6 +95,32 @@ private:
     intel_npu::Logger _log = intel_npu::Logger("AvailableDevices", ov::log::Level::INFO);
 };
 
+class CurrentOS {
+    public:
+        CurrentOS() {
+    #ifdef WIN32
+            _name = "windows";
+    #elif defined(__linux__)
+            _name = "linux";
+    #endif
+        }
+    
+        std::string getName() const {
+            return _name;
+        }
+    
+        bool isLinux() const {
+            return _name == "linux";
+        }
+    
+        bool isWindows() const {
+            return _name == "windows";
+        }
+    
+    private:
+        std::string _name;
+        intel_npu::Logger _log = intel_npu::Logger("CurrentOS", ov::log::Level::INFO);
+    };    
 class SkipRegistry {
 public:
     void addPatterns(std::string&& comment, std::vector<std::string>&& patternsToSkip) {
@@ -147,6 +175,24 @@ std::string getCurrentTestName() {
     return currentTestName;
 }
 
+/** Checks if string containing rule has a "!" character
+ * If "!" is found a flag will be set and the rule will
+ * have the character erased to be used in further conditions
+ *
+ * @param rule Input string
+ * @return true if "!" is found
+ */
+bool isRuleInverted(std::string& rule) {
+    bool invertRule = false;
+    auto pos = rule.find("!");
+    if (pos != std::string::npos) {
+            invertRule = true;
+            // Extract negation character from rule string
+            rule.erase(pos, 1);
+    }
+    return invertRule;
+}
+
 std::vector<std::string> disabledTestPatterns();
 
 std::vector<std::string> disabledTestPatterns() {
@@ -156,6 +202,102 @@ std::vector<std::string> disabledTestPatterns() {
 
         const BackendName backendName;
         const AvailableDevices devices;
+        const CurrentOS currentOS;
+
+        // Check if skip xml is set to be read
+        const auto& filePath = ov::test::utils::NpuTestEnvConfig::getInstance().OV_NPU_TESTS_SKIP_CONFIG_FILE;
+        if (filePath.empty())
+            std::cout << "[WARNING] OV_NPU_TESTS_SKIP_CONFIG_FILE not set" << std::endl;
+
+        // Load the Skip config
+        auto xmlResult = ov::util::pugixml::parse_xml(filePath.c_str());
+        if (!xmlResult.error_msg.empty() && !filePath.empty()){
+            std::cout << "[ERROR]: " << xmlResult.error_msg.c_str() << std::endl;
+        }
+
+        pugi::xml_document& xmlSkipConfig = *xmlResult.xml;
+
+        // Select the parent node
+        pugi::xml_node skipConfigsList = xmlSkipConfig.child("skip_configs");
+
+        // Iterate through each skip rule
+        FOREACH_CHILD(skipConfigRule, skipConfigsList, "skip_config") {
+            // Extract skip message, it will get printed in the test logs
+            auto skipMessageEntry = skipConfigRule.child("message").text().get();
+
+            // Read enable/disable conditions:
+            // Multiple Backends, Devices, OSes can be selected
+            // If "!" is found, then rule is inverted
+            pugi::xml_node enableRules = skipConfigRule.child("enable_rules");
+            bool ruleFlag = false;
+            if (!enableRules.empty()) {
+                bool backendRuleFlag = false;
+                if (!enableRules.child("device").empty()) {
+                FOREACH_CHILD(enableRule, enableRules, "backend") {
+                    auto backendRule = enableRule.text().get();
+
+                    std::string backendRuleString(backendRule);
+                    bool invertRule = isRuleInverted(backendRuleString);
+                    // Perform logical XOR to invert condition
+                    if (!(backendRuleString == backendName.getName()) != !invertRule)
+                    backendRuleFlag = true;
+                }
+                } else {
+                    // Rule empty, default to true
+                    backendRuleFlag = true;
+                }
+
+                bool deviceRuleFlag = false;
+                if (!enableRules.child("device").empty()) {
+                FOREACH_CHILD(enableRule, enableRules, "device") {
+                    auto deviceRule = enableRule.text().get();
+
+                    std::string deviceRuleString(deviceRule);
+                    bool invertRule = isRuleInverted(deviceRuleString);
+                    for (auto& device : devices.getAvailableDevices()) {
+                    // Perform logical XOR to invert condition
+                    if (!(deviceRuleString == device) != !invertRule)
+                        deviceRuleFlag = true;
+                    }
+                }
+                } else {
+                    // Rule empty, default to true
+                    deviceRuleFlag = true;
+                }
+
+                bool operatingSystemRuleFlag = false;
+                if (!enableRules.child("operating_system").empty()) {
+                FOREACH_CHILD(enableRule, enableRules, "operating_system") {
+                    auto operatingSystemRule = enableRule.text().get();
+
+                    if (operatingSystemRule == currentOS.getName())
+                        operatingSystemRuleFlag = true;
+                }
+                } else {
+                    // Rule empty, default to true
+                    operatingSystemRuleFlag = true;
+                }
+
+                // Combine all rules
+                ruleFlag = backendRuleFlag && deviceRuleFlag && operatingSystemRuleFlag;
+            } else {
+                // All rules are empty, default to true
+                ruleFlag = true;
+            }
+
+            // Select individual filters and add them to the skipRegistry
+            pugi::xml_node skipFiltersList = skipConfigRule.child("filters");
+            FOREACH_CHILD(skipFilter, skipFiltersList, "filter") {
+                auto skipFilterEntry = skipFilter.text().get();
+
+                // Add skip to regoistry
+                _skipRegistry.addPatterns(ruleFlag, skipMessageEntry, {skipFilterEntry});
+            }
+        }
+
+        // OV_NPU_TESTS_SKIP_CONFIG_FILE not present
+        if (filePath.empty() || !xmlResult.error_msg.empty()) {
+        std::cout << "[WARNING] Using legacy skip config" << std::endl;
 
         // clang-format off
 
@@ -758,6 +900,8 @@ std::vector<std::string> disabledTestPatterns() {
                 ".*OVClassModelOptionalTestP.CompileModelCreateDefaultExecGraphResult.*",
         });
 
+        // OV_NPU_TESTS_SKIP_CONFIG_FILE not present
+        }
         return _skipRegistry;
     }();
     // clang-format on

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -294,11 +294,14 @@ std::vector<std::string> disabledTestPatterns() {
                     _skipRegistry.addPatterns(ruleFlag, skipMessageEntry, {skipFilterEntry});
                 }
             }
+            return _skipRegistry;
+
         } catch (const std::runtime_error& e) {
             // Fallback to legacy skips
             _log.warning(e.what());
+        }
 
-            // clang-format off
+        // clang-format off
 
         //
         //  Disabled test patterns
@@ -898,9 +901,6 @@ std::vector<std::string> disabledTestPatterns() {
         _skipRegistry.addPatterns("get_runtime_model method is not supported on NPU", {
                 ".*OVClassModelOptionalTestP.CompileModelCreateDefaultExecGraphResult.*",
         });
-
-        // catch () -> Fallback legacy skips
-        }
         return _skipRegistry;
     }();
     // clang-format on

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -188,10 +188,7 @@ bool isRuleInverted(std::string& rule) {
     if (pos != std::string::npos) {
         // Extract negation character from rule string
         rule.erase(pos, 1);
-        
         return true;
-        // Extract negation character from rule string
-        rule.erase(pos, 1);
     }
     return false;
 }

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -189,6 +189,24 @@ bool isRuleInverted(std::string& rule) {
     return false;
 }
 
+/** Reads multiple rules from specified categories:
+ *      - "Backend" rule category
+ *      - "Device" rule category
+ *      - "Operating System" rule category
+ *
+ *  When a rule is found it will get inverted if it starts with "!"
+ *  it will then be checked agains the current system config
+ *
+ *  If the rule is true,then the skip will be enabled and the test will not run.
+ *  If the rule is false, then the skip will be disabled and the test will run.
+ *
+ *  No rule means skip remains enabled
+ *
+ * @param category Input category that will be searched for rules
+ * @param localSettings Input current system setting, by category
+ * @param enableRules xml node to the category that will be checked and read
+ * @return true if a rule is found to match current system config
+ */
 bool categoryRuleEnabler(const std::string& category,
                          const std::vector<std::string>& localSettings,
                          const pugi::xml_node& enableRules);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -184,14 +184,16 @@ std::string getCurrentTestName() {
 bool isRuleInverted(std::string& rule);
 
 bool isRuleInverted(std::string& rule) {
-    bool invertRule = false;
     auto pos = rule.find("!");
     if (pos != std::string::npos) {
-        invertRule = true;
+        // Extract negation character from rule string
+        rule.erase(pos, 1);
+        
+        return true;
         // Extract negation character from rule string
         rule.erase(pos, 1);
     }
-    return invertRule;
+    return false;
 }
 
 std::vector<std::string> disabledTestPatterns();


### PR DESCRIPTION
### Details:
 - Adds a mechanism to load and parse an xml file containing all test skips
 - Defines skip enabling "rules": a user can select if a skip is applied depending on OS, Platform number or Backend type
 - Rules are optional. Users can negate a rule by using "!" and they can add as many rules as needed
 - Skip filters and rules are grouped in the following format:
```
<skip_config>
    <message> Provide reason why these tests are skipped </message>
    <enable_rules> <-- rules section starts here -->
        <backend>LEVEL0</backend>
        <backend>IMD</backend>
        <backend></backend>  (empty backend)
        <device>3720</device>
        <device>4000</device>
        <operating_system>windows</operating_system>
        <operating_system>linux</operating_system>
    </enable_rules>
    <filters> <-- skip filters section starts here -->
        <filter>skip this test 1</filter>
        <filter>skip this test 2</filter>
        <filter>skip this test 3</filter>
    </filters>
</skip_config>
```

Functionality is enabled by setting OV_NPU_TESTS_SKIP_CONFIG_FILE environment variable with the correct path, the file will be loaded and parsed.
However, if the path is left empty the application will use the legacy skip filters as configured in skip_tests_config.cpp

### Tickets:
 - EISW-142588
