### PR TITLE
[CORE] Make an additional conversion from std::string to std::wstring

### DIFF
--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -239,7 +239,11 @@ inline std::string from_file_path(const ov::util::Path& path) {
 
 // TODO: remove this function after all calls use Path
 inline FilePath to_file_path(const ov::util::Path& path) {
+#if defined(_WIN32) && defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT)
+    return ov::util::string_to_wstring(path.string());
+#else
     return path.native();
+#endif
 }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT


### PR DESCRIPTION
Make an additional conversion from std::string to std::wstring at uv::util::to_file_path function when OPENVINO_ENABLE_UNICODE_PATH_SUPPORT was set

Tickets:
[162461](https://jira.devtools.intel.com/browse/CVS-162461)
[146659](https://jira.devtools.intel.com/browse/CVS-146659)