### PR TITLE
[CPU] Fix dynamic output memory reuse

### DIFF
--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1142,7 +1142,9 @@ void Graph::Allocate() {
     const auto& edges = allocationContext.edges;
     InitEdgeStatus(edges);
 
-    auto [solution, edgeClusters, m_outputNodesMemBlocks] =
+    MemoryControl::MemorySolution solution;
+    EdgeClusters edgeClusters;
+    std::tie(solution, edgeClusters, m_outputNodesMemBlocks) =
         SolveMemoryReuse(memoryControl, allocationContext, m_context, outputNodesMap);
 
     AllocateBaseEdges(edgeClusters, solution);


### PR DESCRIPTION
Regression introduced in scope of memory reuse for inner graphs

the same fix is done in scope of:
- https://github.com/openvinotoolkit/openvino/pull/28876

This PR is created just in case we will have to merge the fix without refactoring