### PR TITLE
Remove OPENVINO_CPP_VER_AT_LEAST_17 macro usage

### DIFF
--- a/src/core/include/openvino/core/graph_util.hpp
+++ b/src/core/include/openvino/core/graph_util.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <deque>
+#include <filesystem>
 #include <functional>
 #include <list>
 #include <memory>
@@ -20,10 +21,6 @@
 #include "openvino/core/node.hpp"
 #include "openvino/op/parameter.hpp"
 #include "openvino/pass/serialize.hpp"
-
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
-#    include <filesystem>
-#endif
 
 namespace ov {
 
@@ -299,7 +296,6 @@ void serialize(const std::shared_ptr<const ov::Model>& m,
                const std::string& bin_path = "",
                ov::pass::Serialize::Version version = ov::pass::Serialize::Version::UNSPECIFIED);
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
 template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
 void serialize(const std::shared_ptr<const ov::Model>& m,
                const Path& xml_path,
@@ -307,7 +303,6 @@ void serialize(const std::shared_ptr<const ov::Model>& m,
                ov::pass::Serialize::Version version = ov::pass::Serialize::Version::UNSPECIFIED) {
     serialize(m, xml_path.string(), bin_path.string(), version);
 }
-#endif
 /// \}
 
 /// \brief Save given model into IR. Floating point weights are compressed to FP16 by default.
@@ -327,10 +322,8 @@ void save_model(const std::shared_ptr<const ov::Model>& model,
                 bool compress_to_fp16 = true);
 #endif
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
 template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
 void save_model(const std::shared_ptr<const ov::Model>& model, const Path& output_model, bool compress_to_fp16 = true) {
     save_model(model, output_model.string(), compress_to_fp16);
 }
-#endif
 }  // namespace ov

--- a/src/core/include/openvino/pass/serialize.hpp
+++ b/src/core/include/openvino/pass/serialize.hpp
@@ -4,16 +4,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <functional>
 #include <string>
 
 #include "openvino/core/model.hpp"
 #include "openvino/opsets/opset.hpp"
 #include "openvino/pass/pass.hpp"
-
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
-#    include <filesystem>
-#endif
 
 namespace ov {
 namespace pass {
@@ -39,12 +36,10 @@ public:
 
     Serialize(const std::string& xmlPath, const std::string& binPath, Version version = Version::UNSPECIFIED);
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     Serialize(const std::filesystem::path& xmlPath,
               const std::filesystem::path& binPath,
               Version version = Version::UNSPECIFIED)
         : Serialize(xmlPath.string(), binPath.string(), version) {}
-#endif
 
 private:
     std::ostream* m_xmlFile;

--- a/src/core/tests/file_util.cpp
+++ b/src/core/tests/file_util.cpp
@@ -281,7 +281,7 @@ TEST(file_util, path_cast_unicode) {
                 ov::util::Path(U"~/狗/ǡ୫ԩϗ/にほ/ąę/ど/௸ඊƷ/狗11.txt").generic_u8string());
     EXPECT_TRUE(std::u8string(u8"~/狗/ǡ୫ԩϗ/にほ/ąę/ど/௸ඊƷ/狗12.txt") ==
                 ov::util::Path(u8"~/狗/ǡ୫ԩϗ/にほ/ąę/ど/௸ඊƷ/狗12.txt").generic_u8string());
-#elif defined(OPENVINO_CPP_VER_AT_LEAST_17)
+#else
     EXPECT_EQ(std::string(u8"~/狗/ǡ୫ԩϗ/にほ/ąę/ど/௸ඊƷ/狗14.txt"),
               ov::util::Path(u"~/狗/ǡ୫ԩϗ/にほ/ąę/ど/௸ඊƷ/狗14.txt").generic_u8string());
     EXPECT_EQ(std::string(u8"~/狗/ǡ୫ԩϗ/にほ/ąę/ど/௸ඊƷ/狗15.txt"),

--- a/src/core/tests/frontend/frontend_manager.cpp
+++ b/src/core/tests/frontend/frontend_manager.cpp
@@ -480,7 +480,6 @@ TEST(FrontEndManagerTest, Exception_Safety_Input_Model_set_tensor_partial_value)
     CHECK_EXCEPTION_INPUT_MODEL(input_model->set_tensor_partial_value({}, {}, {}))
 }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
 
 TEST(FrontEndManagerTest, testFEMDestroy_InputModelHolderUsingPath) {
     InputModel::Ptr input_model;
@@ -504,4 +503,3 @@ TEST(FrontEndManagerTest, Exception_Safety_FrontEnd_Supported_By_Path) {
         fe->supported(std::filesystem::path("throw_now"));
     });
 }
-#endif

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -296,7 +296,6 @@ TEST_P(SerializationDeterministicityInputOutputTest, FromIrModel) {
     EXPECT_TRUE(files_equal(xml_2, xml_1));
 }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
 TEST_P(SerializationDeterministicityInputOutputTest, FromOvModelBybPath) {
     auto irVersion = GetParam();
 
@@ -335,7 +334,6 @@ TEST_P(SerializationDeterministicityInputOutputTest, FromOvModelBybPath) {
     std::ifstream xml_2(m_out_xml_path_2, std::ios::in | std::ios::binary);
     EXPECT_TRUE(files_equal(xml_1, xml_2));
 }
-#endif
 
 INSTANTIATE_TEST_SUITE_P(DeterministicityInputOutput,
                          SerializationDeterministicityInputOutputTest,

--- a/src/core/tests/pass/serialization/serialize.cpp
+++ b/src/core/tests/pass/serialization/serialize.cpp
@@ -74,7 +74,6 @@ TEST_P(SerializationTest, SaveModel) {
     });
 }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
 TEST_P(SerializationTest, CompareFunctionsByPath) {
     const auto out_xml_path = std::filesystem::path(m_out_xml_path);
     const auto out_bin_path = std::filesystem::path(m_out_bin_path);
@@ -89,7 +88,6 @@ TEST_P(SerializationTest, SaveModelByPath) {
         ov::save_model(m, out_xml_path, false);
     });
 }
-#endif
 
 INSTANTIATE_TEST_SUITE_P(
     IRSerialization,

--- a/src/frontends/common/include/openvino/frontend/frontend.hpp
+++ b/src/frontends/common/include/openvino/frontend/frontend.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -14,10 +15,6 @@
 #include "openvino/core/op_extension.hpp"
 #include "openvino/frontend/input_model.hpp"
 #include "openvino/frontend/visibility.hpp"
-
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
-#    include <filesystem>
-#endif
 
 namespace ov {
 namespace frontend {
@@ -54,12 +51,11 @@ public:
     /// \return true if model recognized, false - otherwise.
     template <typename... Types>
     inline bool supported(const Types&... vars) const {
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
         if constexpr ((std::is_same_v<std::filesystem::path, Types> || ...)) {
             return supported_impl({path_as_str_or_forward(vars)...});
-        } else
-#endif
+        } else {
             return supported_impl({ov::Any(vars)...});
+        }
     }
     inline bool supported(const ov::AnyVector& vars) const {
         return supported_impl(vars);
@@ -74,12 +70,11 @@ public:
     /// \return Loaded input model.
     template <typename... Types>
     inline InputModel::Ptr load(const Types&... vars) const {
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
         if constexpr ((std::is_same_v<std::filesystem::path, Types> || ...)) {
             return load_impl({path_as_str_or_forward(vars)...});
-        } else
-#endif
+        } else {
             return load_impl({ov::Any{vars}...});
+        }
     }
 
     inline InputModel::Ptr load(const ov::AnyVector& vars) const {
@@ -135,11 +130,9 @@ public:
     /// \{
     void add_extension(const std::string& library_path);
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     void add_extension(const std::filesystem::path& library_path) {
         add_extension(library_path.string());
     }
-#endif
     /// \}
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -185,7 +178,6 @@ private:
     static std::shared_ptr<ov::Model> create_copy(const std::shared_ptr<ov::Model>& ov_model,
                                                   const std::shared_ptr<void>& shared_object);
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class T>
     static constexpr auto path_as_str_or_forward(T&& p) {
         if constexpr (std::is_same_v<std::filesystem::path, std::decay_t<T>>) {
@@ -194,7 +186,6 @@ private:
             return std::forward<T>(p);
         }
     }
-#endif
 };
 
 template <>

--- a/src/frontends/tests/frontend/shared/src/conversion.cpp
+++ b/src/frontends/tests/frontend/shared/src/conversion.cpp
@@ -96,7 +96,6 @@ TEST_P(FrontEndConversionExtensionTest, TestConversionExtensionViaSO) {
     ASSERT_NE(model, nullptr);
 }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
 TEST_P(FrontEndConversionExtensionTest, TestConversionExtensionViaSOByPath) {
     auto frontend = m_param.m_frontend;
     const std::filesystem::path lib_path = get_lib_path("test_builtin_extensions");
@@ -108,4 +107,3 @@ TEST_P(FrontEndConversionExtensionTest, TestConversionExtensionViaSOByPath) {
     OV_ASSERT_NO_THROW(model = frontend->convert(input_model));
     ASSERT_NE(model, nullptr);
 }
-#endif

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include <filesystem>
 #include <istream>
 #include <map>
 #include <memory>
@@ -24,10 +25,6 @@
 #include "openvino/runtime/compiled_model.hpp"
 #include "openvino/runtime/remote_context.hpp"
 #include "openvino/runtime/tensor.hpp"
-
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
-#    include <filesystem>
-#endif
 
 namespace ov {
 
@@ -109,12 +106,10 @@ public:
                                           const std::string& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
         return read_model(model_path.string(), bin_path.string(), properties);
     }
-#endif
     /// @}
 
     /**
@@ -141,14 +136,12 @@ public:
         return read_model(model_path, bin_path, AnyMap{std::forward<Properties>(properties)...});
     }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path,
               class... Properties,
               std::enable_if_t<std::is_same_v<Path, std::filesystem::path> && (sizeof...(Properties) > 0)>* = nullptr>
     auto read_model(const Path& model_path, const Path& bin_path, Properties&&... properties) const {
         return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
     }
-#endif
     /// @}
 
     /**
@@ -250,12 +243,10 @@ public:
      */
     CompiledModel compile_model(const std::string& model_path, const AnyMap& properties = {});
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const AnyMap& properties = {}) const {
         return compile_model(model_path.string(), properties);
     }
-#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     CompiledModel compile_model(const std::wstring& model_path, const AnyMap& properties = {});
@@ -283,12 +274,10 @@ public:
         return compile_model(model_path, AnyMap{std::forward<Properties>(properties)...});
     }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, Properties&&... properties) {
         return compile_model(model_path.string(), std::forward<Properties>(properties)...);
     }
-#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     template <typename... Properties>
@@ -317,12 +306,10 @@ public:
                                 const std::string& device_name,
                                 const AnyMap& properties = {});
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, const AnyMap& properties = {}) {
         return compile_model(model_path.string(), device_name, properties);
     }
-#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     CompiledModel compile_model(const std::wstring& model_path,
@@ -353,12 +340,10 @@ public:
         return compile_model(model_path, device_name, AnyMap{std::forward<Properties>(properties)...});
     }
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, Properties&&... properties) {
         return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
     }
-#endif
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
     template <typename... Properties>
@@ -444,12 +429,10 @@ public:
      */
     void add_extension(const std::string& library_path);
 
-#ifdef OPENVINO_CPP_VER_AT_LEAST_17
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     void add_extension(const Path& model_path) {
         add_extension(model_path.string());
     }
-#endif
     /// @}
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -114,7 +114,6 @@ TEST_F(CoreBaseTest, LoadOVFolderOverCWPathPluginXML) {
 
 #endif
 
-#if defined(OPENVINO_CPP_VER_AT_LEAST_17) && defined(ENABLE_OV_IR_FRONTEND)
 namespace ov::test {
 TEST_F(CoreBaseTest, read_model_with_std_fs_path) {
     generate_test_model_files("test-model");
@@ -152,4 +151,3 @@ TEST_F(CoreBaseTest, compile_model_with_std_fs_path) {
     }
 }
 }  // namespace ov::test
-#endif

--- a/src/inference/tests/functional/ov_extension_test.cpp
+++ b/src/inference/tests/functional/ov_extension_test.cpp
@@ -82,12 +82,10 @@ public:
 };
 
 #if defined(ENABLE_OV_IR_FRONTEND)
-#    ifdef OPENVINO_CPP_VER_AT_LEAST_17
 TEST_F(OVExtensionTests, ReshapeIRWithNewExtensionsPathLib) {
     core.add_extension(std::filesystem::path(getOVExtensionPath()));
     test();
 }
-#    endif
 
 TEST_F(OVExtensionTests, ReshapeIRWithNewExtensionsLib) {
     core.add_extension(getOVExtensionPath());


### PR DESCRIPTION
### Details:
Clean up redundant macro after switch to C++17 standard by default

### Tickets:
 - N/A
