### PR TITLE
Revert "License whitelist for dependency checker update"

### DIFF
--- a/.github/dependency_review.yml
+++ b/.github/dependency_review.yml
@@ -11,7 +11,6 @@ allow-licenses:
   - 'Python-2.0'
   - 'LGPL-3.0'
   - 'MPL-2.0'
-  - 'BSD-2-Clause AND BSD-3-Clause'
 fail-on-scopes:
   - 'runtime'
   - 'development'


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#29031 because it introduced sporadic failures (e.g.: https://github.com/openvinotoolkit/openvino/actions/runs/13432909164/job/37528579365?pr=29086) 

The licenses whitelist should not contain AND expressions (see https://github.com/actions/dependency-review-action/issues/842)