### PR TITLE
[CPU][DEBUG_CAPS] Disable .bin file dump on exec graph serialization

### DIFF
--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -16,6 +16,7 @@
 #include "openvino/pass/serialize.hpp"
 #include "openvino/runtime/exec_model_info.hpp"
 #include "utils/debug_capabilities.h"
+#include "utils/platform.h"
 
 namespace ov::intel_cpu {
 
@@ -245,13 +246,8 @@ void serializeToXML(const Graph& graph, const std::string& path) {
     }
 
     std::string binPath;
-#    ifdef _WIN32
-    binPath = "NUL";
-#    else
-    binPath = "/dev/null";
-#    endif
     ov::pass::Manager manager;
-    manager.register_pass<ov::pass::Serialize>(path, binPath, ov::pass::Serialize::Version::IR_V10);
+    manager.register_pass<ov::pass::Serialize>(path, NULL_STREAM, ov::pass::Serialize::Version::IR_V10);
     manager.run_passes(graph.dump());
 }
 

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -245,6 +245,11 @@ void serializeToXML(const Graph& graph, const std::string& path) {
     }
 
     std::string binPath;
+#    ifdef _WIN32
+    binPath = "NUL";
+#    else
+    binPath = "/dev/null";
+#    endif
     ov::pass::Manager manager;
     manager.register_pass<ov::pass::Serialize>(path, binPath, ov::pass::Serialize::Version::IR_V10);
     manager.run_passes(graph.dump());

--- a/src/plugins/intel_cpu/src/utils/ngraph_transformation.hpp
+++ b/src/plugins/intel_cpu/src/utils/ngraph_transformation.hpp
@@ -10,6 +10,7 @@
 
 #    include "debug_caps_config.h"
 #    include "openvino/util/file_util.hpp"
+#    include "utils/platform.h"
 
 namespace ov {
 namespace intel_cpu {
@@ -76,9 +77,8 @@ private:
 
         if (config.dumpIR.format.filter[DebugCapsConfig::IrFormatFilter::Xml]) {
             std::string xmlFile(pathAndName + ".xml");
-            std::string binFile(NULL_STREAM);
 
-            serializer.register_pass<ov::pass::Serialize>(xmlFile, binFile);
+            serializer.register_pass<ov::pass::Serialize>(xmlFile, NULL_STREAM);
         }
 
         if (config.dumpIR.format.filter[DebugCapsConfig::IrFormatFilter::Svg]) {

--- a/src/plugins/intel_cpu/src/utils/ngraph_transformation.hpp
+++ b/src/plugins/intel_cpu/src/utils/ngraph_transformation.hpp
@@ -76,7 +76,7 @@ private:
 
         if (config.dumpIR.format.filter[DebugCapsConfig::IrFormatFilter::Xml]) {
             std::string xmlFile(pathAndName + ".xml");
-            std::string binFile("/dev/null");  // @todo make it crossplatform using dummy implementation of std::ostream
+            std::string binFile(NULL_STREAM);
 
             serializer.register_pass<ov::pass::Serialize>(xmlFile, binFile);
         }

--- a/src/plugins/intel_cpu/src/utils/platform.h
+++ b/src/plugins/intel_cpu/src/utils/platform.h
@@ -1,0 +1,10 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#ifdef _WIN32
+#    define NULL_STREAM "NUL"
+#else
+#    define NULL_STREAM "/dev/null"
+#endif


### PR DESCRIPTION
### Details:
Disable exec graph ".bin" file dump when execution graph is being dump. This file is redundant, because execution graph does not provide any binaries.

### Tickets:
 - N/A
