### PR TITLE
[CPU] Fix avx2 of int8 kvcache incorrect output for PagedAttention

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -329,7 +329,6 @@ static void attn_acc_value_block(float* out,
             auto attn_w_vec0 = _mm256_set1_ps(weight[0] * v_f0[0]);
             auto zp0 = _mm256_set1_ps(v_f0[1]);
             size_t i = 0;
-            v += 8;
             for (; i + vec_len_f32_avx2 <= group_size; i += vec_len_f32_avx2) {
                 auto v_out = mm256_uni_loadu_ps(out + dst_offset + i);
                 auto v0 = _mm256_sub_ps(_mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(


### PR DESCRIPTION
### Details:
 - *Fix avx2 of int8 kvcache incorrect output for PagedAttention*
 - *...*

### Tickets:
 - *[161786](https://jira.devtools.intel.com/browse/CVS-161786)*
