### PR TITLE
Allow to use weightless blob for already read ov::Model

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -777,6 +777,7 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model(const std::shared_ptr<
     if (cacheManager && device_supports_model_caching(plugin) && !is_proxy_device(plugin)) {
         CacheContent cacheContent{cacheManager, parsed._core_config.get_enable_mmap()};
         cacheContent.blobId = ov::ModelCache::compute_hash(model, create_compile_config(plugin, parsed._config));
+        cacheContent.model = model;
         std::unique_ptr<CacheGuardEntry> lock = cacheGuard.get_hash_lock(cacheContent.blobId);
         res = load_model_from_cache(cacheContent, plugin, parsed._config, ov::SoPtr<ov::IRemoteContext>{}, [&]() {
             return compile_model_and_cache(plugin,
@@ -811,6 +812,7 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model(const std::shared_ptr<
     if (cacheManager && device_supports_model_caching(plugin) && !is_proxy_device(plugin)) {
         CacheContent cacheContent{cacheManager, parsed._core_config.get_enable_mmap()};
         cacheContent.blobId = ov::ModelCache::compute_hash(model, create_compile_config(plugin, parsed._config));
+        cacheContent.model = model;
         std::unique_ptr<CacheGuardEntry> lock = cacheGuard.get_hash_lock(cacheContent.blobId);
         res = load_model_from_cache(cacheContent, plugin, parsed._config, context, [&]() {
             return compile_model_and_cache(plugin, model, parsed._config, context, cacheContent);
@@ -1473,14 +1475,15 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
                 update_config[ov::loaded_from_cache.name()] = true;
 
                 if (util::contains(plugin.get_property(ov::supported_properties), ov::weights_path)) {
-                    std::string weights_path = cacheContent.modelPath;
-                    auto pos = weights_path.rfind('.');
-                    if (pos != weights_path.npos && weights_path.substr(pos) == ".xml") {
-                        weights_path = weights_path.substr(0, pos);
-                        weights_path += ".bin";
+                    std::filesystem::path weights_path;
+                    if (cacheContent.model != nullptr && cacheContent.model->has_rt_info("__weights_path")) {
+                        weights_path = cacheContent.model->get_rt_info().at("__weights_path").as<std::string>();
+                    } else {
+                        weights_path = cacheContent.modelPath;
+                        weights_path.replace_extension(".bin");
                     }
                     if (ov::util::file_exists(weights_path)) {
-                        update_config[ov::weights_path.name()] = weights_path;
+                        update_config[ov::weights_path.name()] = weights_path.string();
                     }
                 }
                 if (model_buffer) {

--- a/src/inference/src/dev/core_impl.hpp
+++ b/src/inference/src/dev/core_impl.hpp
@@ -161,6 +161,7 @@ private:
         std::shared_ptr<ov::ICacheManager> cacheManager;
         std::string blobId = {};
         std::string modelPath = {};
+        std::shared_ptr<const ov::Model> model = nullptr;
         bool mmap_enabled = false;
     };
 


### PR DESCRIPTION
### Details:
 - Extending https://github.com/openvinotoolkit/openvino/pull/27407 to support `ov::Model` in addition to `models_path`