### PR TITLE
[CPU] Introduce ov::is_type_any_of for chaining ov::is_type calls

### DIFF
--- a/src/core/include/openvino/core/type.hpp
+++ b/src/core/include/openvino/core/type.hpp
@@ -101,6 +101,13 @@ is_type(Value value) {
     return value && value->get_type_info().is_castable(Type::get_type_info_static());
 }
 
+/// \brief Tests if value is a pointer/shared_ptr that can be statically cast to any of the specified types
+template <typename Type, typename... Types, typename Value>
+typename std::enable_if<(sizeof...(Types) > 0), bool>::type
+is_type(Value value) {
+    return is_type<Type>(value) || (is_type<Types>(value) || ...);
+}
+
 /// Casts a Value* to a Type* if it is of type Type, nullptr otherwise
 template <typename Type, typename Value>
 typename std::enable_if<std::is_convertible<decltype(static_cast<Type*>(std::declval<Value>())), Type*>::value,

--- a/src/core/include/openvino/core/type.hpp
+++ b/src/core/include/openvino/core/type.hpp
@@ -103,9 +103,8 @@ is_type(Value value) {
 
 /// \brief Tests if value is a pointer/shared_ptr that can be statically cast to any of the specified types
 template <typename Type, typename... Types, typename Value>
-typename std::enable_if<(sizeof...(Types) > 0), bool>::type
-is_type(Value value) {
-    return is_type<Type>(value) || (is_type<Types>(value) || ...);
+bool is_type_any_of(Value value) {
+    return is_type<Type>(value) || (is_type_any_of<Types>(value) || ...);
 }
 
 /// Casts a Value* to a Type* if it is of type Type, nullptr otherwise

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.cpp
@@ -172,7 +172,7 @@ void jit_kernel_emitter::emit_impl(const std::vector<size_t>& in, const std::vec
         auto expected_out_type = snippets::RegType::undefined;
         const auto& node = expression->get_node();
         // Note: currently only a few operations are allowed to have mixed in/out register types => skip validation here
-        if (!ov::is_type<snippets::op::LoopEnd>(node) && !ov::is_type<snippets::op::RegSpillBase>(node) &&
+        if (!ov::is_type_any_of<snippets::op::LoopEnd, snippets::op::RegSpillBase>(node) &&
             !std::dynamic_pointer_cast<jit_nop_emitter>(emitter)) {
             std::tie(expected_in_type, expected_out_type) = get_expected_reg_types(emitter);
         }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_kernel_emitter.cpp
@@ -125,7 +125,7 @@ void jit_kernel_emitter::emit_impl(const std::vector<size_t>& in, const std::vec
         const auto& node = expression->get_node();
         // Note: A few operations are allowed to have mixed register types on their inputs (or outputs) => skip
         // validation here
-        if (!ov::is_type<snippets::op::LoopEnd>(node) && !ov::is_type<snippets::op::RegSpillBase>(node) &&
+        if (!ov::is_type_any_of<snippets::op::LoopEnd, snippets::op::RegSpillBase>(node) &&
             !std::dynamic_pointer_cast<jit_nop_emitter>(emitter)) {
             std::tie(expected_in_type, expected_out_type) = get_expected_reg_types(emitter);
         }

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -226,7 +226,7 @@ private:
 
 bool Convolution::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (!ov::is_type<ov::op::v1::Convolution>(op) && !ov::is_type<ov::op::v1::GroupConvolution>(op)) {
+        if (!ov::is_type_any_of<ov::op::v1::Convolution, ov::op::v1::GroupConvolution>(op)) {
             errorMessage = "Only opset1 Convolution and GroupConvolution operations are supported";
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -27,10 +27,7 @@ bool DFT::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
             errorMessage = "Doesn't support op with dynamic shapes";
             return false;
         }
-        const auto interpDFT = ov::is_type<const op::v7::DFT>(op);
-        const auto interpIDFT = ov::is_type<const op::v7::IDFT>(op);
-
-        if (!interpDFT && !interpIDFT) {
+        if (!ov::is_type_any_of<const op::v7::DFT, const op::v7::IDFT>(op)) {
             errorMessage = "Only opset7 DFT/IDFT operation is supported";
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -78,9 +78,7 @@ ov::element::TypeVector FullyConnected::getSupportedCompressedActivationsTypes()
 bool FullyConnected::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                           std::string& errorMessage) noexcept {
     try {
-        if (!ov::is_type_any_of<const ov::op::internal::FullyConnected,
-                                const ov::op::internal::FullyConnectedQuantizedLegacy,
-                                const ov::op::internal::FullyConnectedCompressed>(op)) {
+        if (!ov::is_type<const ov::op::internal::FullyConnected>(op)) {
             return false;
         }
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -78,9 +78,9 @@ ov::element::TypeVector FullyConnected::getSupportedCompressedActivationsTypes()
 bool FullyConnected::isSupportedOperation(const std::shared_ptr<const ov::Node>& op,
                                           std::string& errorMessage) noexcept {
     try {
-        if (!ov::is_type<const ov::op::internal::FullyConnected>(op) &&
-            !ov::is_type<const ov::op::internal::FullyConnectedQuantizedLegacy>(op) &&
-            !ov::is_type<const ov::op::internal::FullyConnectedCompressed>(op)) {
+        if (!ov::is_type_any_of<const ov::op::internal::FullyConnected,
+                                const ov::op::internal::FullyConnectedQuantizedLegacy,
+                                const ov::op::internal::FullyConnectedCompressed>(op)) {
             return false;
         }
 

--- a/src/plugins/intel_cpu/src/nodes/pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/pooling.cpp
@@ -145,19 +145,21 @@ dnnl::pooling_forward::primitive_desc createDescriptorHelper(const dnnl::engine&
 
 bool Pooling::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (ov::is_type<const ov::op::v8::MaxPool>(op) || ov::is_type<const ov::op::v14::MaxPool>(op)) {
+        if (ov::is_type_any_of<const ov::op::v8::MaxPool, const ov::op::v14::MaxPool>(op)) {
             if (!op->get_output_target_inputs(1).empty()) {
                 errorMessage = "MaxPool from opset8 and opset14 is supported only with one output";
                 return false;
             }
-        } else if (!ov::is_type<const ov::op::v1::MaxPool>(op) && !ov::is_type<const ov::op::v8::MaxPool>(op) &&
-                   !ov::is_type<const ov::op::v14::MaxPool>(op) && !ov::is_type<const ov::op::v1::AvgPool>(op) &&
-                   !ov::is_type<const ov::op::v14::AvgPool>(op)) {
+        } else if (!ov::is_type_any_of<const ov::op::v1::MaxPool,
+                                       const ov::op::v8::MaxPool,
+                                       const ov::op::v14::MaxPool,
+                                       const ov::op::v1::AvgPool,
+                                       const ov::op::v14::AvgPool>(op)) {
             errorMessage = "Supported ops are MaxPool-1, MaxPool-8, MaxPool-14, AvgPool-1 and AvgPool-14";
             return false;
         }
 #if defined(OV_CPU_WITH_ACL)
-        if (ov::as_type_ptr<const ov::op::v8::MaxPool>(op) || ov::as_type_ptr<const ov::op::v14::MaxPool>(op)) {
+        if (ov::is_type_any_of<const ov::op::v8::MaxPool, const ov::op::v14::MaxPool>(op)) {
             if (ov::as_type_ptr<const ov::op::util::MaxPoolBase>(op)->get_kernel() != ov::Shape(2, 2)) {
                 errorMessage =
                     "Pooling indices returning source tensor coordinates is only supported for pool size 2x2";

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -20,8 +20,7 @@ namespace ov::intel_cpu::node {
 
 bool StridedSlice::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept {
     try {
-        if (!ov::is_type<ov::op::v1::StridedSlice>(op) && !ov::is_type<ov::op::v8::Slice>(op) &&
-            !ov::is_type<ov::op::v15::SliceScatter>(op)) {
+        if (!ov::is_type_any_of<ov::op::v1::StridedSlice, ov::op::v8::Slice, ov::op::v15::SliceScatter>(op)) {
             errorMessage = "Only StridedSlice from opset1, Slice from opset8 and SliceScatter from opset15 operations "
                            "are supported.";
             return false;

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -623,9 +623,9 @@ std::shared_ptr<IStaticShapeInfer> make_shape_inference(std::shared_ptr<ov::Node
         return shape_infer;
     } else if (ov::is_type<op::util::UnaryElementwiseArithmetic>(op)) {
         return std::make_shared<ShapeInferCopy>(std::move(op));
-    } else if (ov::is_type<op::util::BinaryElementwiseArithmetic>(op) ||
-               ov::is_type<op::util::BinaryElementwiseComparison>(op) ||
-               ov::is_type<op::util::BinaryElementwiseLogical>(op)) {
+    } else if (ov::is_type_any_of<op::util::BinaryElementwiseArithmetic,
+                                  op::util::BinaryElementwiseComparison,
+                                  op::util::BinaryElementwiseLogical>(op)) {
         return std::make_shared<ShapeInferEltwise>(std::move(op));
     } else {
         return std::make_shared<ShapeInferFallback>(std::move(op));

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/stateful_sdpa_fusion.cpp
@@ -177,8 +177,7 @@ StatefulSDPAFusion::StatefulSDPAFusion() {
                 // the second one leads to Assign, and this is checked later
                 // the third child is allowed to be a ShapeOf op only, thus one of them must be ShapeOf
                 if (!std::any_of(children.begin(), children.end(), [](const ov::Input<ov::Node>& child) {
-                        return ov::is_type<ov::op::v3::ShapeOf>(child.get_node()) ||
-                               ov::is_type<ov::op::v0::ShapeOf>(child.get_node());
+                        return ov::is_type_any_of<ov::op::v3::ShapeOf, ov::op::v0::ShapeOf>(child.get_node());
                     })) {
                     return false;
                 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -95,9 +95,8 @@ bool isSuitableBinaryConvolutionParent(const std::shared_ptr<const Node>& node) 
     return is_suitable_node && has_only_child;
 }
 bool isSuitableMiscParent(const std::shared_ptr<const Node>& node) {
-    const bool is_suitable_node = ov::is_type_any_of<ov::op::v0::NormalizeL2,
-                                                     ov::op::v1::ConvolutionBackpropData,
-                                                     ov::op::v1::GroupConvolutionBackpropData>(node);
+    const bool is_suitable_node =
+        ov::is_type_any_of<ov::op::v0::NormalizeL2, ov::op::util::ConvolutionBackPropBase>(node);
     // has a single output, connected to a single child
     const auto out = node->outputs();
     const bool has_only_child = (out.size() == 1) && (out[0].get_target_inputs().size() == 1);

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -72,14 +72,16 @@ bool isFullyConnected(const std::shared_ptr<const ov::Node>& node) {
 bool SupportsFusingWithConvolution_Simple(const std::shared_ptr<const Node>& node) {
     // Note: some other operations support this fusing (SoftPlus, Sqrt).
     // Skip them here, when they are supported by Snippets ARM. Ticket: 141170.
-    return ov::is_type<ov::op::v0::Abs>(node) || ov::is_type<ov::op::v0::Clamp>(node) ||
-           ov::is_type<ov::op::v0::Elu>(node) || ov::is_type<ov::op::v0::Relu>(node) ||
-           ov::is_type<ov::op::v0::Sigmoid>(node) || ov::is_type<ov::op::v0::Tanh>(node);
+    return ov::is_type_any_of<ov::op::v0::Abs,
+                              ov::op::v0::Clamp,
+                              ov::op::v0::Elu,
+                              ov::op::v0::Relu,
+                              ov::op::v0::Sigmoid,
+                              ov::op::v0::Tanh>(node);
 }
 // Convolution is a special case, since it supports peculiar fusings
 bool isSuitableConvolutionParent(const std::shared_ptr<const Node>& node) {
-    const bool is_suitable_node =
-        ov::is_type<ov::op::v1::Convolution>(node) || ov::is_type<ov::op::v1::GroupConvolution>(node);
+    const bool is_suitable_node = ov::is_type_any_of<ov::op::v1::Convolution, ov::op::v1::GroupConvolution>(node);
     // has a single output, connected to a single child
     const auto out = node->outputs();
     const bool has_only_child = (out.size() == 1) && (out[0].get_target_inputs().size() == 1);
@@ -93,9 +95,9 @@ bool isSuitableBinaryConvolutionParent(const std::shared_ptr<const Node>& node) 
     return is_suitable_node && has_only_child;
 }
 bool isSuitableMiscParent(const std::shared_ptr<const Node>& node) {
-    const bool is_suitable_node = ov::is_type<ov::op::v0::NormalizeL2>(node) ||
-                                  ov::is_type<ov::op::v1::ConvolutionBackpropData>(node) ||
-                                  ov::is_type<ov::op::v1::GroupConvolutionBackpropData>(node);
+    const bool is_suitable_node = ov::is_type_any_of<ov::op::v0::NormalizeL2,
+                                                     ov::op::v1::ConvolutionBackpropData,
+                                                     ov::op::v1::GroupConvolutionBackpropData>(node);
     // has a single output, connected to a single child
     const auto out = node->outputs();
     const bool has_only_child = (out.size() == 1) && (out[0].get_target_inputs().size() == 1);
@@ -126,8 +128,7 @@ bool isSuitableChildForFusingBias(const std::shared_ptr<const Node>& node, int f
     }
 
     auto is_suitable_parent = [](const std::shared_ptr<const Node>& node) {
-        return (ov::is_type<ov::op::v1::Convolution>(node) || ov::is_type<ov::op::v1::GroupConvolution>(node) ||
-                ov::is_type<ov::op::v0::MatMul>(node));
+        return (ov::is_type_any_of<ov::op::v1::Convolution, ov::op::v1::GroupConvolution, ov::op::v0::MatMul>(node));
     };
 
     for (const auto& in : node->inputs()) {
@@ -221,8 +222,7 @@ bool isSuitableConvert(const std::shared_ptr<const Node>& node) {
 }
 
 auto is_skipped_op(const std::shared_ptr<ov::Node>& op) -> bool {
-    return ov::is_type<ov::op::v0::Constant>(op) || ov::is_type<ov::op::v0::Parameter>(op) ||
-           ov::is_type<ov::op::v0::Result>(op);
+    return ov::is_type_any_of<ov::op::v0::Constant, ov::op::v0::Parameter, ov::op::v0::Result>(op);
 }
 
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/op/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/op/eltwise.cpp
@@ -26,8 +26,7 @@ namespace ov::intel_cpu::tpp::op {
 #define UNARY_AUX_METHODS(UNARY_OP) GENERAL_AUX_METHODS(UNARY_OP, UnaryEltwiseTPP, new_args.at(0))
 
 bool EltwiseTPP::is_supported(const std::shared_ptr<ov::Node>& node) {
-    return ov::is_type<ov::op::v1::Add>(node) || ov::is_type<ov::op::v1::Subtract>(node) ||
-           ov::is_type<ov::op::v1::Multiply>(node) || ov::is_type<ov::op::v1::Divide>(node);
+    return ov::is_type_any_of<ov::op::v1::Add, ov::op::v1::Subtract, ov::op::v1::Multiply, ov::op::v1::Divide>(node);
 }
 
 bool EltwiseTPP::visit_attributes(AttributeVisitor& visitor) {

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/fuse_tpp_to_equations.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/fuse_tpp_to_equations.cpp
@@ -27,10 +27,8 @@ bool FuseTPPToEquations::fuse_from_root(const NodePtr& root, const std::shared_p
     auto get_tpp_op = [](const NodePtr& n) {
         auto tpp = std::dynamic_pointer_cast<op::EltwiseTPP>(n);
         bool not_supported_op =
-            // ticket: 152532
-            ov::is_type<ov::snippets::op::ReduceBase>(n) ||
-            // ticket: 152510
-            ov::is_type<ov::op::v0::Relu>(n);
+            // tickets: 152532, 152510
+            ov::is_type_any_of<ov::snippets::op::ReduceBase, ov::op::v0::Relu>(n);
         return not_supported_op ? nullptr : tpp;
     };
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -244,7 +244,7 @@ bool Transformations::fuse_type_to_fq(const std::shared_ptr<ov::Node>& node, con
     auto consumers = node->output(0).get_target_inputs();
     for (auto& input : consumers) {
         const auto consumer = input.get_node();
-        if (ov::is_type<ov::op::v0::Result>(consumer) || ov::is_type<ov::op::v0::Convert>(consumer)) {
+        if (ov::is_type_any_of<ov::op::v0::Result, ov::op::v0::Convert>(consumer)) {
             continue;
         }
         auto convert_after = std::make_shared<opset4::Convert>(node, to);
@@ -1131,22 +1131,37 @@ void Transformations::MainSnippets(void) {
 
     auto is_supported_op = [](const std::shared_ptr<const ov::Node>& n) -> bool {
 #if defined(OPENVINO_ARCH_ARM64)
-        return (ov::is_type<ov::op::v0::Abs>(n) || ov::is_type<ov::op::v1::Add>(n) ||
-                ov::is_type<ov::op::v0::Clamp>(n) || ov::is_type<ov::op::v0::Ceiling>(n) ||
-                ov::is_type<ov::op::v0::Convert>(n) || ov::is_type<ov::op::v1::Divide>(n) ||
-                ov::is_type<ov::op::v0::Elu>(n) || ov::is_type<ov::op::v0::Exp>(n) ||
-                ov::is_type<ov::op::v1::Equal>(n) || ov::is_type<ov::op::v0::FakeQuantize>(n) ||
-                ov::is_type<ov::op::v0::Floor>(n) || ov::is_type<ov::op::v1::FloorMod>(n) ||
-                ov::is_type<ov::op::v0::Gelu>(n) || ov::is_type<ov::op::v7::Gelu>(n) ||
-                ov::is_type<ov::op::v1::Greater>(n) || ov::is_type<ov::op::v1::GreaterEqual>(n) ||
-                ov::is_type<ov::op::v4::HSwish>(n) || ov::is_type<ov::op::v1::LessEqual>(n) ||
-                ov::is_type<ov::op::v1::Maximum>(n) || ov::is_type<ov::op::v1::Minimum>(n) ||
-                ov::is_type<ov::op::v4::Mish>(n) || ov::is_type<ov::op::v1::Mod>(n) ||
-                ov::is_type<ov::op::v1::Multiply>(n) || ov::is_type<ov::op::v0::PRelu>(n) ||
-                ov::is_type<ov::op::v0::Relu>(n) || ov::is_type<ov::op::v5::Round>(n) ||
-                ov::is_type<ov::op::v0::Sigmoid>(n) || ov::is_type<ov::op::v0::Sqrt>(n) ||
-                ov::is_type<ov::op::v1::Subtract>(n) || ov::is_type<ov::op::v4::Swish>(n) ||
-                ov::is_type<ov::op::v0::Tanh>(n));
+        return (ov::is_type_any_of<ov::op::v0::Abs,
+                                   ov::op::v1::Add,
+                                   ov::op::v0::Clamp,
+                                   ov::op::v0::Ceiling,
+                                   ov::op::v0::Convert,
+                                   ov::op::v1::Divide,
+                                   ov::op::v0::Elu,
+                                   ov::op::v0::Exp,
+                                   ov::op::v1::Equal,
+                                   ov::op::v0::FakeQuantize,
+                                   ov::op::v0::Floor,
+                                   ov::op::v1::FloorMod,
+                                   ov::op::v0::Gelu,
+                                   ov::op::v7::Gelu,
+                                   ov::op::v1::Greater,
+                                   ov::op::v1::GreaterEqual,
+                                   ov::op::v4::HSwish,
+                                   ov::op::v1::LessEqual,
+                                   ov::op::v1::Maximum,
+                                   ov::op::v1::Minimum,
+                                   ov::op::v4::Mish,
+                                   ov::op::v1::Mod,
+                                   ov::op::v1::Multiply,
+                                   ov::op::v0::PRelu,
+                                   ov::op::v0::Relu,
+                                   ov::op::v5::Round,
+                                   ov::op::v0::Sigmoid,
+                                   ov::op::v0::Sqrt,
+                                   ov::op::v1::Subtract,
+                                   ov::op::v4::Swish,
+                                   ov::op::v0::Tanh>(n));
 #else
         // CPU Plugin support Swish in Subgraph via conversion to SwichCPU which assumes second input to be constant,
         // and CPU Plugin does not support Mish for x64
@@ -1158,10 +1173,14 @@ void Transformations::MainSnippets(void) {
         // todo: general tokenization flow is not currently supported for these operations.
         // they can be tokenized only as a part of complex patterns
         auto is_unsupported_by_common_tokenization = [](const std::shared_ptr<const ov::Node>& n) {
-            return (ov::is_type<const ov::op::v1::Softmax>(n) || ov::is_type<const ov::op::v8::Softmax>(n) ||
-                    ov::is_type<const ov::op::v0::MatMul>(n) || ov::is_type<const ov::op::v1::Transpose>(n) ||
-                    ov::is_type<const ov::op::v1::Broadcast>(n) || ov::is_type<const ov::op::v3::Broadcast>(n) ||
-                    ov::is_type<const ov::op::v1::ReduceMax>(n) || ov::is_type<const ov::op::v1::ReduceSum>(n));
+            return (ov::is_type_any_of<const ov::op::v1::Softmax,
+                                       const ov::op::v8::Softmax,
+                                       const ov::op::v0::MatMul,
+                                       const ov::op::v1::Transpose,
+                                       const ov::op::v1::Broadcast,
+                                       const ov::op::v3::Broadcast,
+                                       const ov::op::v1::ReduceMax,
+                                       const ov::op::v1::ReduceSum>(n));
         };
         return !is_unsupported(n) && !is_unsupported_by_common_tokenization(n);
 #endif
@@ -1189,8 +1208,10 @@ void Transformations::MainSnippets(void) {
 
             return supported_element_types.count(t.get_element_type()) != 0 ||
                    (is_input && t.get_element_type() == ov::element::i32 &&
-                    (ov::is_type<const opset1::Transpose>(n) || ov::is_type<const opset1::Broadcast>(n) ||
-                     ov::is_type<const opset1::ReduceMax>(n) || ov::is_type<const opset1::ReduceSum>(n)));
+                    (ov::is_type_any_of<const opset1::Transpose,
+                                        const opset1::Broadcast,
+                                        const opset1::ReduceMax,
+                                        const opset1::ReduceSum>(n)));
         };
 
         const auto& inputs = n->inputs();

--- a/src/plugins/intel_cpu/src/transformations/utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/utils.cpp
@@ -22,7 +22,7 @@ bool has_matmul_with_compressed_weights(const std::shared_ptr<const ov::Model>& 
     };
 
     for (const auto& op : model->get_ops()) {
-        if (!ov::is_type<ov::op::v0::MatMul>(op) && !ov::is_type<ov::op::internal::FullyConnected>(op)) {
+        if (!ov::is_type_any_of<ov::op::v0::MatMul, ov::op::internal::FullyConnected>(op)) {
             continue;
         }
 


### PR DESCRIPTION
### Details:
 - Add `ov::is_type_any_of` that chains `ov::is_type` calls for better code readability
 - Reuse new function for applicable cases in CPU plugin

### Tickets:
 - N/A
