### PR TITLE
[intel_npu] Compiled model destructor was not reseting pinned cores from CPU

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -46,6 +46,7 @@ CompiledModel::CompiledModel(const std::shared_ptr<const ov::Model>& model,
 
 CompiledModel::~CompiledModel() {
     _logger.debug("~CompiledModel()");
+    std::dynamic_pointer_cast<ov::threading::IStreamsExecutor>(get_task_executor())->cpu_reset();
 }
 
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {
@@ -128,11 +129,11 @@ void CompiledModel::configure_stream_executors() {
         task_executor = ov::threading::executor_manager()->get_executor("NPU");
     } else if (get_property(ov::hint::enable_cpu_pinning.name()).as<bool>()) {
         auto executor_config = ov::threading::IStreamsExecutor::Config{
-            "Intel NPU plugin executor",
-            get_plugin()->get_property(ov::num_streams.name(), {}).as<ov::streams::Num>(),
-            1,
-            ov::hint::SchedulingCoreType::PCORE_ONLY,
-            true};
+            /* name = */ "Intel NPU plugin executor",
+            /* streams = */ get_plugin()->get_property(ov::num_streams.name(), {}).as<ov::streams::Num>(),
+            /* threads_per_stream = */ 1,
+            /* thread_preferred_core_type = */ ov::hint::SchedulingCoreType::PCORE_ONLY,
+            /* cpu_reservation = */ true};
         task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(executor_config);
     } else {
         task_executor = std::make_shared<ov::threading::CPUStreamsExecutor>(


### PR DESCRIPTION
### Details:
 - *Add `cpu_reset` in `intel_npu::CompiledModel::dtor`*

### Tickets:
 - *E158043*
