### PR TITLE
[GPU] Fix boundary case for fc_bf_tiled_forced_tile_b kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/fully_connected_gpu_bf_tiled_common.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/include/fully_connected_gpu_bf_tiled_common.cl
@@ -215,8 +215,13 @@ inline void (FUNC_NAME)(
                     #else
                         ACCUMULATOR_TYPE ds = d_scales[fi % DECOMPRESSION_SCALE_LENGTH];
                     #endif
+                    #if TILE_OFM > 1
                     ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi] * ds;
                     acc_tmp[bi][fi] = 0;
+                    #else
+                    acc[bi] += acc_tmp[bi] * ds;
+                    acc_tmp[bi] = 0;
+                    #endif
                 }
             }
 #endif
@@ -233,8 +238,13 @@ inline void (FUNC_NAME)(
                 #else
                     ACCUMULATOR_TYPE ds = d_scales[fi % DECOMPRESSION_SCALE_LENGTH];
                 #endif
+                #if TILE_OFM > 1
                 ((ACCUMULATOR_TYPE*)(&acc[bi]))[fi] += ((ACCUMULATOR_TYPE*)(&acc_tmp[bi]))[fi] * ds;
                 acc_tmp[bi][fi] = 0;
+                #else
+                acc[bi] += acc_tmp[bi] * ds;
+                acc_tmp[bi] = 0;
+                #endif
             }
         }
 #endif


### PR DESCRIPTION
### Details:
 - In the current `fc_bf_tiled_forced_tile_b` kernel, when `TILE_OFM=1`, `acc_tmp` becomes a one-dimensional array rather than two-dimensional array that process vector type, so issue may occur in the process of obtaining `acc` from `acc_tmp` and initializing `acc_tmp`
 - Fix this issued case for `fc_bf_tilied_forced_tile_b` kernel

### Tickets:
 - 162831
