### PR TITLE
Optimize redundant reorder-permute pattern

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/lstm_seq.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/lstm_seq.hpp
@@ -23,7 +23,7 @@ struct LSTMSeqImplementationManager : public ImplementationManager {
         for (size_t idx = 0; idx < node.get_dependencies().size(); idx++) {
             in_fmts[idx] = format::bfyx;
         }
-        out_fmts[0] = format::byfx;
+        out_fmts[0] = format::ybfx;
         for (size_t idx = 1; idx < node.get_outputs_count(); idx++) {
             out_fmts[idx] = format::bfyx;
         }


### PR DESCRIPTION
### Details:
 - *Optimize reorder and permute operation if the permute cancels changes made by the reorder*
 - *Change CM LSTM output format to ybfx as it only supports batch=1 and ybfx can be used in next LSTM layer input without reorder*