### PR TITLE
[GPU] Update gemm_tiled_opt dynamic support

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/gemm_tiled_opt.cl
@@ -695,9 +695,11 @@ KERNEL(gemm_tiled_opt)(
 
 #if HAS_FUSED_OPS && FUSED_OPS_CAN_USE_PRELOAD
     #if IS_DYNAMIC
+    uint xs = b_raw_global_id;
     FUSED_OPS_PRELOAD_SCALAR;
     #else // IS_DYNAMIC
         #if TILE_N_NOT_DIVISIBLE || B_VEC_SIZE == 1
+    uint xs = b_raw_global_id;
     FUSED_OPS_PRELOAD_SCALAR;
         #else // TILE_N_NOT_DIVISIBLE
     FUSED_OPS_PRELOAD_VEC;
@@ -720,6 +722,8 @@ KERNEL(gemm_tiled_opt)(
             #if FUSED_OPS_CAN_USE_PRELOAD
             FUSED_OPS_CALC_SCALAR;
             #else // FUSED_OPS_CAN_USE_PRELOAD
+            ACCUMULATOR_TYPE dequantized_scalar = dequantized;
+            uint xs = b_raw_global_id;
             FUSED_OPS_SCALAR;
             #endif // FUSED_OPS_CAN_USE_PRELOAD
             OUTPUT_TYPE res = FUSED_OPS_RESULT_SCALAR;
@@ -741,7 +745,23 @@ KERNEL(gemm_tiled_opt)(
         #else // BIAS_TERM
         ACCUMULATOR_TYPE_VEC dequantized = (ACCUMULATOR_TYPE_VEC)(ALPHA) * c_tile[write_id];
         #endif // BIAS_TERM
+
         #if HAS_FUSED_OPS
+        #ifdef FUSE_SCALAR
+        OUTPUT_TYPE_VEC result;
+        unroll_for (uint n_elem = 0; n_elem < B_VEC_SIZE; ++n_elem) {
+            ACCUMULATOR_TYPE dequantized_scalar = dequantized[n_elem];
+            uint xs = b_raw_global_id + SIMD_WIDTH * n_elem;
+            FUSED_OPS_SCALAR;
+            result[n_elem] = FUSED_OPS_RESULT_SCALAR;
+        }
+
+        unroll_for (uint n_elem = 0; n_elem < B_VEC_SIZE; ++n_elem) {
+            if (b_raw_global_id + SIMD_WIDTH * n_elem < N) {
+                *(d_ptr_tmp + SIMD_WIDTH * n_elem * x_pitch) = result[n_elem];
+            }
+        }
+        #else // fuse vec
         FUSED_OPS_VEC;
         OUTPUT_TYPE_VEC result = FUSED_OPS_RESULT_VEC;
         unroll_for (uint n_elem = 0; n_elem < B_VEC_SIZE; ++n_elem) {
@@ -749,6 +769,7 @@ KERNEL(gemm_tiled_opt)(
                 *(d_ptr_tmp + SIMD_WIDTH * n_elem * x_pitch) = result[n_elem];
             }
         }
+        #endif // FUSE_SCALAR
         #else
         unroll_for (uint n_elem = 0; n_elem < B_VEC_SIZE; ++n_elem) {
             if (b_raw_global_id + SIMD_WIDTH * n_elem < N) {
@@ -770,6 +791,8 @@ KERNEL(gemm_tiled_opt)(
             #if FUSED_OPS_CAN_USE_PRELOAD
             FUSED_OPS_CALC_SCALAR;
             #else // FUSED_OPS_CAN_USE_PRELOAD
+            ACCUMULATOR_TYPE dequantized_scalar = dequantized;
+            const uint xs = b_raw_global_id;
             FUSED_OPS_SCALAR;
             #endif // FUSED_OPS_CAN_USE_PRELOAD
             OUTPUT_TYPE res = FUSED_OPS_RESULT_SCALAR;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp
@@ -328,6 +328,14 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
                 if ((vec_axis_dim == 1 && op.tensors[0].LogicalSize() != 1) && (params.inputs[1].X().v != vec_axis_dim)) {
                     vec_load_type = LoadType::LT_UNALIGNED;
                 }
+
+                // In case of a fused operation where input data has dynamic innermost dimension,
+                // we shouldn't use block reads, as the dynamic dimension may only have a single
+                // broadcastable value. Therefore, we should force scalar fusions (to read elements
+                // one by one using _SAFE index calculation) and apply them in the loop over vec_size
+                if (vec_axis_dim == 0) {
+                    jit.AddConstants({MakeJitConstant("FUSE_SCALAR", 1)});
+                }
             }
         }
         FusedOpsConfiguration conf_vec = { "_VEC", {"b", "f", "(y + write_id)", "x"},
@@ -339,8 +347,8 @@ JitConstants GemmKernelTiledOpt::GetJitConstants(const gemm_params& params) cons
                                            IndexType::TENSOR_COORD,
                                            Tensor::DataChannelName::X };
 
-        FusedOpsConfiguration conf_scalar = { "_SCALAR", {"b", "f", "(y + write_id)", "x"},
-                                               "dequantized",
+        FusedOpsConfiguration conf_scalar = { "_SCALAR", {"b", "f", "(y + write_id)", "xs"},
+                                               "dequantized_scalar",
                                                input_dt,
                                                1,
                                                LoadType::LT_UNALIGNED,

--- a/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
@@ -120,6 +120,7 @@ public:
 #define CASE_GEMM_2IN_FP16_4 { { 1, 2, 128, 64 }, { 1, 2, 64, 256 } }, { 1, 2, 128, 256 }, data_types::f16, data_types::f16, data_types::f16, format::bfyx, data_types::f16, format::bfyx
 #define CASE_GEMM_2IN_FP16_5 { { 2, 3, 2, 2 }, { 2, 3, 2, 2 } }, { 2, 3, 2, 2 }, data_types::f16, data_types::f16, data_types::f16, format::bfyx, data_types::f16, format::bfyx
 #define CASE_GEMM_2IN_FP16_3D_1 { { 16, 8, 64 }, { 16, 64, 8 }, { 16, 1, 8 } }, { 16, 8, 8 }, data_types::f16, data_types::f16, data_types::f16, format::bfyx, data_types::f16, format::bfyx
+#define CASE_GEMM_2IN_FP16_3D_2 { { 1, 8, 64 }, { 1, 64, 8 }, { 1, 1, 1 } }, { 1, 8, 8 }, data_types::f16, data_types::f16, data_types::f16, format::bfyx, data_types::f16, format::bfyx
 #define CASE_GEMM_2IN_FP16_5D_1 { { 2, 3, 5, 6, 4 }, { 2, 3, 5, 4, 6} }, { 2, 3, 5, 6, 6 }, data_types::f16, data_types::f16, data_types::f16, format::bfzyx, data_types::f16, format::bfzyx
 #define CASE_GEMM_2IN_FP16_6D_1 { { 2, 3, 2, 3, 5, 7 }, { 2, 3, 2, 3, 7, 5 } }, { 2, 3, 2, 3, 5, 5 }, data_types::f16, data_types::f16, data_types::f16, format::bfwzyx, data_types::f16, format::bfwzyx
 
@@ -461,7 +462,7 @@ TEST_P(gemm_2in_add, eltwise_postop_scalar_dynamic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, gemm_2in_add, ::testing::ValuesIn(std::vector<gemm_test_params>{
-    // gemm_test_params{ CASE_GEMM_2IN_FP16_3, 3, 4, "", broadcast_kinds::none, eltwise_mode::sum },    // TODO: check why failed in eltwise_postop_dynamic
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3, 3, 4, "", broadcast_kinds::none, eltwise_mode::sum },
     gemm_test_params{ CASE_GEMM_2IN_FP16_4, 3, 4, "", broadcast_kinds::none, eltwise_mode::sum },
     gemm_test_params{ CASE_GEMM_2IN_FP16_5, 3, 4, "", broadcast_kinds::batch, eltwise_mode::sum },
     gemm_test_params{ CASE_GEMM_2IN_FP16_5, 3, 4, "", broadcast_kinds::batch, eltwise_mode::prod },
@@ -519,6 +520,8 @@ TEST_P(gemm_2in_dynamic_add, add) {
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, gemm_2in_dynamic_add, ::testing::ValuesIn(std::vector<gemm_test_params>{
     gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 4, "gemm_tiled_opt", broadcast_kinds::batch, eltwise_mode::sum },
     gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 4, "gemm_tiled_opt", broadcast_kinds::feature, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_2, 4, 4, "gemm_tiled_opt", broadcast_kinds::feature, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_2, 4, 4, "gemm_tiled_opt", broadcast_kinds::batch, eltwise_mode::sum },
 }));
 
 class gemm_2in_act_scale_quantize_i8 : public GemmFusingTest {};


### PR DESCRIPTION
Revert some earlier PR 28252 and PR 28764.  These PR causing memory increase as well as 2X performance drop. 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       Instead to fix the issue primitive_inst, update gemm_kernel_tiled_opt kernel to convert to use fuse with scalar for innermost broadcasting.

Remove unit test from PR 28252 as that is not valid use case.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        

CVS-162230
