### PR TITLE
[Snippets][CPU]Process transposed_b=true of MatMuls via BrgemmCopyB

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
@@ -209,6 +209,9 @@ void BrgemmCopyBKernel::init_brgemm_copy_b_kernel(
     brgCopyKernelConf.has_zero_point_b = false;
     brgCopyKernelConf.src_zp_type = dnnl::impl::cpu::x64::none;
 
+    brgCopyKernelConf.apply_scales_in_buffer_b = false;
+    brgCopyKernelConf.with_wei_decompression = false;
+
     OV_CPU_JIT_EMITTER_ASSERT(matmul::create_brgemm_matmul_copy_b(kernel, &brgCopyKernelConf) == dnnl_success,
                               "cannot create kernel due to invalid params");
 }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
@@ -68,6 +68,13 @@ template <
 inline T compute_repacked_n_dim(T n, const ov::element::Type& precision) {
     return ov::snippets::utils::rnd_up(n, static_cast<T>(compute_inner_n_block(precision)));
 }
+
+/// \brief  Computes allocation shape for Buffer between BrgemmCopyB and Brgemm
+ov::snippets::VectorDims compute_buffer_b_allocation_shape(size_t K,
+                                                           size_t N,
+                                                           const ov::element::Type& prc,
+                                                           bool is_transposed);
+
 /**
  * @brief Retrieves the expression pointer for the brgemm_copy_b expression corresponding to the given BrgemmCPU
  * expression.

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/eliminate_brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/eliminate_brgemm_copy_b.cpp
@@ -31,13 +31,8 @@ pass::EliminateBrgemmCopyB::EliminateBrgemmCopyB() {
         const auto& in_desc = snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(copy_b_node->input(0));
         const auto& layout = in_desc->get_layout();
 
-        auto is_supported_layout = [](const std::vector<size_t>& layout) {
-            return layout.empty() || (layout.size() - 1 == layout.back());
-        };
-
         // TODO [157340]: support external repacking for copyB with compensations
-        if (!is_supported_layout(layout) || brgemm_utils::with_compensations(copy_b_node->get_type()) ||
-            transformation_callback(copy_b_node)) {
+        if (brgemm_utils::with_compensations(copy_b_node->get_type()) || transformation_callback(copy_b_node)) {
             return false;
         }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/expressions/brgemm_copy_b_buffer_expressions.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/expressions/brgemm_copy_b_buffer_expressions.cpp
@@ -43,23 +43,16 @@ void RepackedWeightsBufferExpression::init_allocation_size(
     const size_t k_blk = *++in_subtensor.rbegin();
 
     const auto& precision = get_node()->get_input_element_type(0);
-    // Repacking buffer shape is set in accordance to OneDNN requirements
-    const size_t N_dim = compute_repacked_n_dim(n_blk, precision);
-    if (!in_layout.empty() && in_layout.back() != in_layout.size() - 1) {
-        // In case of transpose, K dimension must be rounded-up to number of elems in vector register
-        // For the details, please see 'transpose16x8' and 'fixup16x16' implementations and usage in
-        // onednn/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
-        const auto elems_in_vec = brgemm_utils::get_elems_in_vec(precision);
-        m_allocation_size = snippets::utils::dynamic_safe_mul(N_dim, snippets::utils::rnd_up(k_blk, elems_in_vec));
-    } else {
-        // Low precision repacking writes the result by m_brgemmVNNIFactor * m_inner_n_block blocks
-        // despite the actual size of the input data. Because of that we have to round-up the allocation shape to always
-        // have enough memory allocated. For the details, please see 'copy_4x64' and 'copy_2x32' implementations and
-        // usage in onednn/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
-        const auto brgemmVNNIFactor = brgemm_utils::compute_vnni_factor(precision);
-        OPENVINO_ASSERT(brgemmVNNIFactor > 0, "brgemmVNNIFactor value must be positive.");
-        m_allocation_size = snippets::utils::dynamic_safe_mul(N_dim, snippets::utils::rnd_up(k_blk, brgemmVNNIFactor));
-    }
+    const auto buffer_b_shape =
+        brgemm_utils::repacking::compute_buffer_b_allocation_shape(k_blk,
+                                                                   n_blk,
+                                                                   precision,
+                                                                   BrgemmCopyB::is_transposed(in_layout));
+    OPENVINO_ASSERT(buffer_b_shape.size() == 3, "Unexpected buffer B shape rank");
+    m_allocation_size =
+        std::accumulate(buffer_b_shape.cbegin(), buffer_b_shape.cend(), size_t(1), [](size_t a, size_t b) {
+            return snippets::utils::dynamic_safe_mul(a, b);
+        });
 }
 
 CompensationsBufferExpression::CompensationsBufferExpression(

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
@@ -51,7 +51,9 @@ VectorDims BrgemmExternalRepackingAdjuster::get_blk_order(size_t shape_rank) {
     return order;
 }
 
-VectorDims BrgemmExternalRepackingAdjuster::get_blk_shape(const VectorDims& planar_shape, ov::element::Type prc, bool is_transposed) {
+VectorDims BrgemmExternalRepackingAdjuster::get_blk_shape(const VectorDims& planar_shape,
+                                                          ov::element::Type prc,
+                                                          bool is_transposed) {
     size_t block = 1;
     if (is_transposed) {
         // In case of transpose, K dimension must be rounded-up to number of elems in vector register

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.hpp
@@ -31,7 +31,7 @@ public:
 private:
     using RepackExecutorPtr = std::shared_ptr<BrgemmCopyBKernelExecutor>;
     static VectorDims get_blk_order(size_t shape_rank);
-    static VectorDims get_blk_shape(const VectorDims& planar_shape, ov::element::Type prc);
+    static VectorDims get_blk_shape(const VectorDims& planar_shape, ov::element::Type prc, bool is_transposed);
 
     void update_kernel(const RepackExecutorPtr& executor,
                        const VectorDims& shape,

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1282,29 +1282,28 @@ void Transformations::MainSnippets(void) {
         // so we should extract transposes for the corresponding matmul nodes
 #if defined(SNIPPETS_LIBXSMM_TPP)
         // TPP doesn't support dynamic shapes -> there will be BrgemmCPU node
-        if (n->is_dynamic())
-            return true;
-        std::vector<std::vector<size_t>> layouts(3);
-        const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(n);
-        OPENVINO_ASSERT(matmul, "ExplicitTransposeMatMulInputs callback must be called for matmul node");
-        if (matmul->get_transpose_b()) {
-            std::vector<size_t> transposed_layout(n->get_input_partial_shape(1).size());
-            std::iota(transposed_layout.begin(), transposed_layout.end(), 0);
-            std::swap(*transposed_layout.rbegin(), *(transposed_layout.rbegin() + 1));
-            layouts[1] = std::move(transposed_layout);
+        if (!n->is_dynamic()) {
+            std::vector<std::vector<size_t>> layouts(3);
+            const auto matmul = ov::as_type_ptr<const ov::op::v0::MatMul>(n);
+            OPENVINO_ASSERT(matmul, "ExplicitTransposeMatMulInputs callback must be called for matmul node");
+            if (matmul->get_transpose_b()) {
+                std::vector<size_t> transposed_layout(n->get_input_partial_shape(1).size());
+                std::iota(transposed_layout.begin(), transposed_layout.end(), 0);
+                std::swap(*transposed_layout.rbegin(), *(transposed_layout.rbegin() + 1));
+                layouts[1] = std::move(transposed_layout);
+            }
+            ov::element::TypeVector precisions;
+            auto push_precision = [&](const ov::element::Type& precision) {
+                if (config.inferencePrecision == ov::element::bf16 && precision == ov::element::f32)
+                    precisions.push_back(ov::element::bf16);
+                else
+                    precisions.push_back(precision);
+            };
+            push_precision(n->get_input_element_type(0));
+            push_precision(n->get_input_element_type(1));
+            push_precision(n->get_output_element_type(0));
+            return !ov::intel_cpu::tpp::pass::BrgemmToBrgemmTPP::is_supported_brgemm_configuration(layouts, precisions);
         }
-        ov::element::TypeVector precisions;
-        auto push_precision = [&](const ov::element::Type& precision) {
-            if (config.inferencePrecision == ov::element::bf16 && precision == ov::element::f32)
-                precisions.push_back(ov::element::bf16);
-            else
-                precisions.push_back(precision);
-        };
-        push_precision(n->get_input_element_type(0));
-        push_precision(n->get_input_element_type(1));
-        push_precision(n->get_output_element_type(0));
-        if (ov::intel_cpu::tpp::pass::BrgemmToBrgemmTPP::is_supported_brgemm_configuration(layouts, precisions))
-            return false;
 #endif
         return true;
     };

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1276,7 +1276,7 @@ void Transformations::MainSnippets(void) {
         },
         snippets::pass::TokenizeSnippets);
 
-    auto mm_supports_transpose_b = [this, ignoreCallback](const std::shared_ptr<const ov::Node>& n) {
+    auto mm_supports_transpose_b = [this](const std::shared_ptr<const ov::Node>& n) {
         MAYBE_UNUSED(config.inferencePrecision);
         // Note: BrgemmTPP doesn't support transposed KN natively
         // so we should extract transposes for the corresponding matmul nodes

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1278,9 +1278,6 @@ void Transformations::MainSnippets(void) {
 
     auto mm_supports_transpose_b = [this, ignoreCallback](const std::shared_ptr<const ov::Node>& n) {
         MAYBE_UNUSED(config.inferencePrecision);
-        if (!ignoreCallback) {
-            return false;
-        }
         // Note: BrgemmTPP doesn't support transposed KN natively
         // so we should extract transposes for the corresponding matmul nodes
 #if defined(SNIPPETS_LIBXSMM_TPP)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -271,8 +271,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_LoopForCommon/LoopLayerCPUTest.CompareWithRefs/Input0_IS=\[1..10.1.1..10\]_.*_Input1_IS=\[1..8.1.1..8\]_.*_Input2_IS=\[1..10.\?.1..10\]_TS=.*_types=0_0_1_trip_count_type=.*_trip_count=(1|5)_exec_cond=1_netType=i8.*)",
         // Issue: 142997
         R"(.*smoke_TestsROIAlign.*)",
-        // Issue: 148527
-        R"(.*Snippets.*MatMulTransposeB.*i8.*i8.*)",
         // Issue: 136881
         R"(.*smoke_CompareWithRefs_4D_BitwiseShift_overflow_i32_cast.*_eltwise_op_type=BitwiseLeft.*_model_type=.*(i16|u16).*)",
     };


### PR DESCRIPTION
### Details:
 - *Currently, if `MatMul` has `transposed_b=true`, this attribute is extracted from `MatMul` as the separate op `Transpose`. The PR enables the processing `transposed_b=true* via `BrgemmCopyB` to avoid extra ops in Graph`*
 - *Fixed seg fault in `i8i8 MatMuls` with `transposed_b=true` on platforms without AMX instructions (scenario with compensations) - there were not-initialized attributes in `brgemm_config` which were interpreted as `true` (incorrect behavior). The PR initializes them with `False` values*
 - *The performance results are attached to the ticket 161514*

### Tickets:
 - *161514*
 - *148527*

