### PR TITLE
[GPU] macro instead of function and bypass arg

### DIFF
--- a/src/plugins/intel_gpu/src/graph/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/CMakeLists.txt
@@ -34,7 +34,7 @@ set(COMMON_LINK_LIBRARIES openvino::shape_inference # for tensor accessor
 define_property(GLOBAL PROPERTY EXTRA_LINK_LIBRARIES_GLOBAL BRIEF_DOCS "All link libs" FULL_DOCS "Link libraries collection from all backends")
 set_property(GLOBAL PROPERTY EXTRA_LINK_LIBRARIES_GLOBAL "")
 
-function(ov_gpu_add_backend_target)
+macro(ov_gpu_add_backend_target)
     set(options
     )
     set(oneValueRequiredArgs
@@ -43,6 +43,7 @@ function(ov_gpu_add_backend_target)
     set(multiValueArgs
         INCLUDES                      # Extra include directories
         LINK_LIBRARIES                # Link libraries (in form of target name or file name)
+        BYPASS                        # All other args that must be passed as is to ov_add_target call
     )
     cmake_parse_arguments(ARG "${options}" "${oneValueRequiredArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -61,12 +62,13 @@ function(ov_gpu_add_backend_target)
 
     ov_add_target(
         NAME ${ARG_NAME}
+        ROOT ${CMAKE_CURRENT_SOURCE_DIR}
         TYPE OBJECT
         ADD_CPPLINT
         INCLUDES
             PRIVATE
                 ${TARGET_INCLUDES}
-        ${ARG_UNPARSED_ARGUMENTS}
+        ${ARG_BYPASS}
     )
 
     get_property(CURRENT_LIBS GLOBAL PROPERTY EXTRA_LINK_LIBRARIES_GLOBAL)
@@ -82,7 +84,7 @@ function(ov_gpu_add_backend_target)
         target_include_directories(${ARG_NAME} PRIVATE $<TARGET_PROPERTY:onednn_gpu_tgt,INTERFACE_SYSTEM_INCLUDE_DIRECTORIES>)
         add_dependencies(openvino_intel_gpu_${IMPL_TYPE}_obj onednn_gpu_tgt)
     endif()
-endfunction()
+endmacro()
 
 foreach(IMPL_TYPE IN LISTS AVAILABLE_IMPL_TYPES)
     add_subdirectory(impls/${IMPL_TYPE})

--- a/src/plugins/intel_gpu/src/graph/impls/cm/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/CMakeLists.txt
@@ -6,5 +6,4 @@ set(TARGET_NAME "openvino_intel_gpu_cm_obj")
 
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
-    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/plugins/intel_gpu/src/graph/impls/common/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/common/CMakeLists.txt
@@ -6,5 +6,4 @@ set(TARGET_NAME "openvino_intel_gpu_common_obj")
 
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
-    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/CMakeLists.txt
@@ -6,7 +6,6 @@ set(TARGET_NAME "openvino_intel_gpu_cpu_obj")
 
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
-    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
     LINK_LIBRARIES openvino::reference
 )
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/CMakeLists.txt
@@ -6,5 +6,4 @@ set(TARGET_NAME "openvino_intel_gpu_ocl_obj")
 
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
-    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/CMakeLists.txt
@@ -10,6 +10,5 @@ set(TARGET_NAME "openvino_intel_gpu_onednn_obj")
 
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
-    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
     LINK_LIBRARIES onednn_gpu_tgt
 )

--- a/src/plugins/intel_gpu/src/graph/impls/sycl/CMakeLists.txt
+++ b/src/plugins/intel_gpu/src/graph/impls/sycl/CMakeLists.txt
@@ -10,7 +10,6 @@ set(TARGET_NAME "openvino_intel_gpu_sycl_obj")
 
 ov_gpu_add_backend_target(
     NAME ${TARGET_NAME}
-    ROOT ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 add_sycl_to_target(TARGET ${TARGET_NAME})


### PR DESCRIPTION
### Details:
 - Use `macro` instead of `function` to omit ROOT argument setting for each backend
 - Added BYPASS argument which handles all args not processed by `ov_gpu_add_backend_target` to avoid any multi-value args parsing issues

