### PR TITLE
[SPEC] Update Einsum specification about broadcasting labels and ellipsis that does not cover any dimensions

### DIFF
--- a/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/matrix/einsum-7.rst
+++ b/docs/articles_en/documentation/openvino-ir-format/operation-sets/operation-specs/matrix/einsum-7.rst
@@ -26,7 +26,7 @@ where each label refers to a dimension of the corresponding operand. Labels are 
 Labels do not need to appear in a subscript in alphabetical order.
 The subscript for a scalar input is empty. The input subscripts are separated with a comma ``,``.
 The output subscript ``<subscript for output>`` represents a sequence of labels (alphabetic letters ``['A',...,'Z','a',...,'z']``).
-The length of an input subscript matches a rank of the input. The input subscript is empty for a scalar input.
+The amount of dimensions covered by input subscript matches a rank of the input. The input subscript is empty for a scalar input.
 
 *Einsum* operation on multiple inputs can be treated as several consecutive *Einsum* operations. In the first step, *Einsum* applies the first two inputs.
 In the second step, it operates on the result of the first step and the third input, and so forth.
@@ -45,7 +45,7 @@ where dimensions with labels ``b`` and ``d`` are reduced, and the transpose is a
 .. note::
 
    * *Einsum* operation can perform on a single operand. In this case, the operation can transpose the input and reduce its dimensions.
-   * Input ranks must be equal to the length of corresponding subscripts. Dimensions with the same corresponding labels in input subscripts must be equal in size.
+   * Input ranks must be equal to amount of dimensions covered by corresponding subscripts. Ellipses may cover 0 or multiple dimensions. Dimensions with the same corresponding labels in input subscripts need to be broadcastable to satisfy NymPy broadcasting rules available in :doc:`Broadcast Rules For Elementwise Operations <../../broadcast-rules>`.
    * A label can be repeated in the same input subscript, for example, ``equation`` equal to ``aac,abd,ddde``. In this case, the corresponding dimensions must match in size, and the operand is replaced by its diagonal along these dimensions. For example, *Einsum* operation on the single 3D tensor of shape ``[2, 4, 5, 4]`` with ``equation`` equal to ``ijkj->ij``.
    * The specification considers the primitive algorithm for *Einsum* operation for better understanding of the operation and does not recommend it for implementation.
    * The described algorithm can be improved by immediate dimension sum-reduction of the intermediate results if the corresponding labels are absent  in the input subscripts of subsequent inputs and the output subscript. It can significantly boost performance and reduce memory costs. In the considered example, after the first step you can reduce the dimension corresponding to the label ``d``.
@@ -111,7 +111,15 @@ Example 5 shows how *Einsum* transposes input tensor:
              [[3.0, 6.0, 9.0]]]
 
 
-In addition to an alphabetic label, ellipsis ``...`` can be used as a label in a subscript to cover broadcasted dimensions. Each input subscript can contain at most one ellipsis. For example, the ellipsis in input subscript ``a...bc`` for five rank tensor covers the second and third dimensions. In case input subscripts contain ellipsis for several operands, the dimensions covered by the ellipsis must be broadcastable to satisfy numpy broadcasting (or multidirectional broadcasting) rules available in :doc:`Broadcast Rules For Elementwise Operations <../../broadcast-rules>`. If at least one input subscript contains an ellipsis, the output subscript must always contain one ellipsis. For example, *Einsum* operation on two inputs of shapes ``[9, 1, 4, 3]`` and ``[3, 11, 7, 1]`` with ``equation="a...b,b...->a..."`` has ellipsis for both operands covering dimensions with sizes ``[1, 4]`` and ``[11, 7, 1]`` that are broadcasted to ``[11, 7, 4]``. The resulted shape of *Einsum* operation will be ``[9, 11, 7, 4]`` since the dimension labeled with ``a`` is left with broadcasted dimensions.
+In addition to an alphabetic label, ellipsis ``...`` can be used as a label in a subscript to cover optional broadcasted dimensions.
+Each input subscript can contain at most one ellipsis.
+For example, the ellipsis in input subscript ``a...bc`` for five rank tensor covers the second and third dimensions.
+Optional ellipses covering no dimensions are either ignored or broadcasted to dimensions of ellipsis of other operands if available. 
+In case input subscripts contain ellipsis for several operands, the dimensions covered by the ellipsis must be broadcastable to satisfy
+NymPy broadcasting (or multidirectional broadcasting) rules available in :doc:`Broadcast Rules For Elementwise Operations <../../broadcast-rules>`.
+For example, *Einsum* operation on two inputs of shapes ``[9, 1, 4, 3]`` and ``[3, 11, 7, 1]`` with ``equation="a...b,b...->a..."``
+has ellipsis for both operands covering dimensions with sizes ``[1, 4]`` and ``[11, 7, 1]`` that are broadcasted to ``[11, 7, 4]``.
+The resulted shape of *Einsum* operation will be ``[9, 11, 7, 4]`` since the dimension labeled with ``a`` is left with broadcasted dimensions.
 
 Example 6 shows how *Einsum* operates on the single input with an equation containing ellipsis:
 


### PR DESCRIPTION

### Details:
- *Adjust specification with changes in Einsum decomposition from PR https://github.com/openvinotoolkit/openvino/pull/28151:
  - *Change documentation about broadcasting labels*
  - *Add mention of empty ellipsis*

### Tickets:
 - *CVS-157227*
