### PR TITLE
[PyOV] Fix deprecation warnings from numpy in tests

### DIFF
--- a/src/bindings/python/tests/test_runtime/test_async_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_async_infer_request.py
@@ -223,7 +223,7 @@ def test_array_like_input_async_infer_queue(device, share_inputs):
         def __init__(self, array) -> None:
             self.data = array
 
-        def __array__(self):
+        def __array__(self, dtype=None, copy=None):
             return self.data
 
     jobs = 8
@@ -364,7 +364,7 @@ def test_array_like_input_async(device, share_inputs):
         def __init__(self, array) -> None:
             self.data = array
 
-        def __array__(self):
+        def __array__(self, dtype=None, copy=None):
             return np.array(self.data)
 
     _, request, _, input_data = generate_abs_compiled_model_with_data(device, Type.f32, np.single)

--- a/src/bindings/python/tests/test_runtime/test_sync_infer_request.py
+++ b/src/bindings/python/tests/test_runtime/test_sync_infer_request.py
@@ -563,7 +563,7 @@ def test_array_like_input_request(device, share_inputs):
         def __init__(self, array) -> None:
             self.data = array
 
-        def __array__(self):
+        def __array__(self, dtype=None, copy=None):
             return np.array(self.data)
 
     _, request, _, input_data = generate_abs_compiled_model_with_data(device, Type.f32, np.single)

--- a/src/bindings/python/tests/test_utils/test_data_dispatch.py
+++ b/src/bindings/python/tests/test_utils/test_data_dispatch.py
@@ -195,7 +195,7 @@ class FakeTensor():
     def __init__(self, array):
         self.array = array
 
-    def __array__(self):
+    def __array__(self, dtype=None, copy=None):
         return self.array
 
 


### PR DESCRIPTION
### Details:
 - From https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword:
> For any __array__ method on a non-NumPy array-like object, dtype=None and copy=None keywords must be added to the signature - this will work with older NumPy versions as well


### Tickets:
 - *ticket-id*
