### PR TITLE
[TRANSFORMATIONS] Fix ConvertGatherToGatherCompressed to use Output explicitly instead of implicit conversion from Node

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/convert_gather_to_compressed.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_gather_to_compressed.cpp
@@ -89,8 +89,8 @@ ov::pass::ConvertGatherToGatherCompressed::ConvertGatherToGatherCompressed() {
         std::shared_ptr<ov::Node> gather_input_a =
             reshape_to_2d ? reshape_const_to_2d(pattern_map.at(dicts_m).get_node_shared_ptr())
                           : pattern_map.at(dicts_m).get_node_shared_ptr();
-        const auto& gather_input_b = gather_node->get_input_node_shared_ptr(1);
-        const auto& gather_input_c = gather_node->get_input_node_shared_ptr(2);
+        const auto& gather_input_b = gather_node->get_input_source_output(1);
+        const auto& gather_input_c = gather_node->get_input_source_output(2);
         const auto& scale = reshape_to_2d ? reshape_const_to_2d(pattern_map.at(mul_const_m).get_node_shared_ptr())
                                           : pattern_map.at(mul_const_m).get_node_shared_ptr();
         std::shared_ptr<ov::Node> optional_zero_point = nullptr;

--- a/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
@@ -18,6 +18,8 @@
 #include "openvino/op/transpose.hpp"
 #include "openvino/pass/manager.hpp"
 #include "ov_ops/gather_compressed.hpp"
+#include "openvino/op/topk.hpp"
+
 
 using namespace testing;
 using namespace ov::pass;
@@ -178,5 +180,38 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedFP16) {
                                                                                       zp_const);
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+    }
+}
+
+TEST_F(TransformationTestsF, ConvertGatherToCompressedMultiOutput) {
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
+
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{});
+        auto topk = std::make_shared<ov::op::v11::TopK>(input1, input2, 0, ov::op::v11::TopK::Mode::MAX, ov::op::v11::TopK::SortType::SORT_VALUES);
+
+        auto axis_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 16}, {1});
+        auto convert = std::make_shared<ov::op::v0::Convert>(weights_const, ov::element::f32);
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{32, 1}, {1});
+        auto scale = std::make_shared<ov::op::v1::Multiply>(convert, scale_const);
+        auto gather = std::make_shared<ov::op::v8::Gather>(scale, topk->output(1), axis_const);
+
+        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1, input2});
+        manager.register_pass<ConvertGatherToGatherCompressed>();
+    }
+    {
+        auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
+
+        auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{});
+        auto topk = std::make_shared<ov::op::v11::TopK>(input1, input2, 0, ov::op::v11::TopK::Mode::MAX, ov::op::v11::TopK::SortType::SORT_VALUES);
+
+        auto axis_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
+        auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 16}, {1});
+        auto scale_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{32, 1}, {1});
+        auto gather_compressed =
+                std::make_shared<ov::op::internal::GatherCompressed>(weights_const, topk->output(1), axis_const, 0, scale_const);
+
+        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1, input2});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
@@ -15,11 +15,10 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/result.hpp"
 #include "openvino/op/subtract.hpp"
+#include "openvino/op/topk.hpp"
 #include "openvino/op/transpose.hpp"
 #include "openvino/pass/manager.hpp"
 #include "ov_ops/gather_compressed.hpp"
-#include "openvino/op/topk.hpp"
-
 
 using namespace testing;
 using namespace ov::pass;
@@ -188,7 +187,11 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedMultiOutput) {
         auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
 
         auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{});
-        auto topk = std::make_shared<ov::op::v11::TopK>(input1, input2, 0, ov::op::v11::TopK::Mode::MAX, ov::op::v11::TopK::SortType::SORT_VALUES);
+        auto topk = std::make_shared<ov::op::v11::TopK>(input1,
+                                                        input2,
+                                                        0,
+                                                        ov::op::v11::TopK::Mode::MAX,
+                                                        ov::op::v11::TopK::SortType::SORT_VALUES);
 
         auto axis_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
         auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 16}, {1});
@@ -204,13 +207,20 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedMultiOutput) {
         auto input1 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::PartialShape{-1, 16});
 
         auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i32, ov::Shape{});
-        auto topk = std::make_shared<ov::op::v11::TopK>(input1, input2, 0, ov::op::v11::TopK::Mode::MAX, ov::op::v11::TopK::SortType::SORT_VALUES);
+        auto topk = std::make_shared<ov::op::v11::TopK>(input1,
+                                                        input2,
+                                                        0,
+                                                        ov::op::v11::TopK::Mode::MAX,
+                                                        ov::op::v11::TopK::SortType::SORT_VALUES);
 
         auto axis_const = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
         auto weights_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{32, 16}, {1});
         auto scale_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{32, 1}, {1});
-        auto gather_compressed =
-                std::make_shared<ov::op::internal::GatherCompressed>(weights_const, topk->output(1), axis_const, 0, scale_const);
+        auto gather_compressed = std::make_shared<ov::op::internal::GatherCompressed>(weights_const,
+                                                                                      topk->output(1),
+                                                                                      axis_const,
+                                                                                      0,
+                                                                                      scale_const);
 
         model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1, input2});
     }


### PR DESCRIPTION
### Details:
 - fix ConvertGatherToGatherCompressed to use Output explicitly instead of implicit conversion from Node
 - add unit test

### Tickets:
 - 159389
 - 138242
