### PR TITLE
[Protopipe] Fixed parse of 'metric' and 'random' entries when they are specified for all layers

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/README.md
+++ b/src/plugins/intel_npu/tools/protopipe/README.md
@@ -413,7 +413,7 @@ multi_inference:
   - network:
     - { name: A.xml, ip: FP16, input_data: A-inputs/, output_data: B-inputs/ }
       # overwrites global initializer for the model B.xml
-    - { name: B.xml, ip: FP16, input_data: B-inputs/, output_data: B-outptus/, random: { name: uniform, low: 0, high: 255.0 }
+    - { name: B.xml, ip: FP16, input_data: B-inputs/, output_data: B-outptus/, random: { dist: uniform, low: 0, high: 255.0 }}
 ```
 
 Run `Protopipe` in `reference` mode:

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -166,8 +166,13 @@ struct convert<std::map<K, V>> {
 template <typename T>
 struct convert<LayerVariantAttr<T>> {
     static bool decode(const Node& node, LayerVariantAttr<T>& layer_attr) {
+        // Note: "metric" and "random" entries in config are always presented
+        //       as maps.
+        //       To differ passed variants for them between "one value for all layers"
+        //       and "map of layers to values", it is needed to check that map of maps
+        //       is passed for them.
         if constexpr (std::is_same_v<IAccuracyMetric::Ptr, T> || std::is_same_v<IRandomGenerator::Ptr, T>) {
-            if (node.IsMap() && (node.begin() != node.end()) && node.begin()->second.IsMap()) {
+            if (node.IsMap() && (node.size() > 0) && node.begin()->second.IsMap()) {
                 layer_attr = node.as<std::map<std::string, T>>();
             } else {
                 layer_attr = node.as<T>();

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -166,10 +166,18 @@ struct convert<std::map<K, V>> {
 template <typename T>
 struct convert<LayerVariantAttr<T>> {
     static bool decode(const Node& node, LayerVariantAttr<T>& layer_attr) {
-        if (node.IsMap()) {
-            layer_attr = node.as<std::map<std::string, T>>();
+        if constexpr (std::is_same_v<IAccuracyMetric::Ptr, T> || std::is_same_v<IRandomGenerator::Ptr, T>) {
+            if (node.IsMap() && (node.begin() != node.end()) && node.begin()->second.IsMap()) {
+                layer_attr = node.as<std::map<std::string, T>>();
+            } else {
+                layer_attr = node.as<T>();
+            }
         } else {
-            layer_attr = node.as<T>();
+            if (node.IsMap()) {
+                layer_attr = node.as<std::map<std::string, T>>();
+            } else {
+                layer_attr = node.as<T>();
+            }
         }
         return true;
     }


### PR DESCRIPTION
### Details:
 - *Fixed parse of 'metric' and 'random' entries when they are specified for all layers*
 - *They are always presented as maps, so `convert<LayerVariantAttr<T>>` should be extended to check if they passed as maps of maps*

### Tickets:
 - *ticket-id*
