### PR TITLE
[CPU][DEBUG_CAPS] Create directory for input/output blobs automatically

### DIFF
--- a/src/plugins/intel_cpu/src/utils/node_dumper.h
+++ b/src/plugins/intel_cpu/src/utils/node_dumper.h
@@ -6,6 +6,7 @@
 #ifdef CPU_DEBUG_CAPS
 #    include <node.h>
 
+#    include "openvino/util/file_util.hpp"
 #    include "utils/debug_caps_config.h"
 
 namespace ov {
@@ -24,6 +25,7 @@ public:
         : node(_node),
           count(_count),
           config(_config) {
+        ov::util::create_directory_recursive(config.blobDumpDir);
         dumpInputBlobs(node, config, count);
     }
 


### PR DESCRIPTION
### Details:
 - Create directory specified in `OV_CPU_BLOB_DUMP_DIR` environment variable if blob dumping debug capability is enabled

### Tickets:
 - N/A
