### PR TITLE
[SubgraphBaseTest] Fix tensors of lower elements type sizes being casted to equivalent minimum sizes C++ types

### DIFF
--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -559,10 +559,11 @@ void compare(const ov::Tensor& expected,
     }
 
     // error is a place with whole data related to incorrect element in tensor
-    size_t shape_size_cnt = shape_size(expected_shape);
+    size_t shape_size_cnt =
+        shape_size(expected_shape) * expected.get_element_type().bitwidth() / ov::element::from<ExpectedT>().bitwidth();
     tensor_comparation::Error error(abs_threshold, rel_threshold, topk_threshold, mvn_threshold, shape_size_cnt);
-    const auto expected_data = expected.data<ExpectedT>();
-    const auto actual_data = actual.data<ActualT>();
+    const auto expected_data = static_cast<ExpectedT*>(expected.data(expected.get_element_type()));
+    const auto actual_data = static_cast<ActualT*>(actual.data(actual.get_element_type()));
     for (size_t i = 0; i < shape_size_cnt; ++i) {
         double expected_value = expected_data[i];
         double actual_value = actual_data[i];

--- a/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/ov_tensor_utils.cpp
@@ -559,8 +559,7 @@ void compare(const ov::Tensor& expected,
     }
 
     // error is a place with whole data related to incorrect element in tensor
-    size_t shape_size_cnt =
-        shape_size(expected_shape) * expected.get_element_type().bitwidth() / ov::element::from<ExpectedT>().bitwidth();
+    size_t shape_size_cnt = shape_size(expected_shape);
     tensor_comparation::Error error(abs_threshold, rel_threshold, topk_threshold, mvn_threshold, shape_size_cnt);
     const auto expected_data = static_cast<ExpectedT*>(expected.data(expected.get_element_type()));
     const auto actual_data = static_cast<ActualT*>(actual.data(actual.get_element_type()));


### PR DESCRIPTION
### Details:
 - *Fix error `Tensor data with element type i4, is not representable as pointer to i8`*

### Tickets:
 - *163362*
