### PR TITLE
Fix mem_peak_usage on macos

### DIFF
--- a/tests/samples_tests/smoke_tests/test_benchmark_app.py
+++ b/tests/samples_tests/smoke_tests/test_benchmark_app.py
@@ -12,6 +12,7 @@
 """
 import json
 import os
+import platform
 import numpy as np
 import pathlib
 import pytest
@@ -63,7 +64,8 @@ def verify(sample_language, device, api=None, nireq=None, shape=None, data_shape
     assert 'FPS' in output
 
     # No Windows support due to the lack of the ‘psutil’ module in the CI infrastructure
-    if os.name == "posix":
+    # No Macos support due to no /proc/self/status file
+    if platform.system() == "Linux":
         assert 'Compile model ram used' in output
 
     if tmp_path:

--- a/tools/benchmark_tool/openvino/tools/benchmark/main.py
+++ b/tools/benchmark_tool/openvino/tools/benchmark/main.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import platform
 from datetime import datetime
 
 from openvino import Dimension, properties
@@ -23,7 +24,7 @@ from openvino.tools.benchmark.utils.statistics_report import StatisticsReport, J
     averageCntReport, detailedCntReport
 
 def get_peak_memory_usage():    
-    if os.name == "posix":
+    if platform.system() == "Linux":
         with open("/proc/self/status", "r") as f:
             for line in f:
                 if line.startswith("VmPeak:"):
@@ -31,6 +32,7 @@ def get_peak_memory_usage():
         raise RuntimeError("VmPeak attribute not found. Unable to determine peak memory usage.")
     
     # No Windows support due to the lack of the ‘psutil’ module in the CI infrastructure
+    # No Macos support due to no /proc/self/status file
     return None
 
 def log_memory_usage(logger, start_mem_usage, end_mem_usage, action_name):


### PR DESCRIPTION
The description of the PR and the fix for python are taken here:
https://github.com/openvinotoolkit/openvino/pull/29238

Faulty PR: https://github.com/openvinotoolkit/openvino/pull/28931

### Details:
 - macos samples tests are failing after https://github.com/openvinotoolkit/openvino/pull/28931 was merged (there is no "/proc/self/status" on macos)

Example failed jobs:
 - https://github.com/openvinotoolkit/openvino/actions/runs/13620712150/job/38072447907
 - https://github.com/openvinotoolkit/openvino/actions/runs/13620737535/job/38071526701

### Tickets:
 - CVS-163441