### PR TITLE
[Py OV] Extend Node with binary operations in openvino namespace

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/node.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/node.cpp
@@ -21,6 +21,7 @@
 #include "pyopenvino/graph/node.hpp"
 #include "pyopenvino/graph/rt_map.hpp"
 #include "pyopenvino/utils/utils.hpp"
+#include "pyopenvino/core/common.hpp"
 
 class PyNode : public ov::Node {
 public:
@@ -44,8 +45,10 @@ void regclass_graph_Node(py::module m) {
     node.doc() = "openvino.Node wraps ov::Node";
     node.def(
         "__add__",
-        [](const std::shared_ptr<ov::Node>& a, const std::shared_ptr<ov::Node> b) {
-            return std::shared_ptr<ov::Node>(std::make_shared<ov::op::v1::Add>(a, b));
+        [](Common::NodeInput a, Common::NodeInput b) {
+            const auto left = Common::node_from_input_value(a);
+            const auto right = Common::node_from_input_value(b);
+            return std::shared_ptr<ov::Node>(std::make_shared<ov::op::v1::Add>(left, right));
         },
         py::is_operator());
     node.def(

--- a/src/bindings/python/src/pyopenvino/graph/node.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/node.cpp
@@ -45,7 +45,7 @@ void regclass_graph_Node(py::module m) {
     node.def(
         "__add__",
         [](const std::shared_ptr<ov::Node>& a, const std::shared_ptr<ov::Node> b) {
-            return std::make_shared<ov::op::v1::Add>(a, b);
+            return std::shared_ptr<ov::Node>(std::make_shared<ov::op::v1::Add>(a, b));
         },
         py::is_operator());
     node.def(


### PR DESCRIPTION
### Details:
 - Add std::variant `NodeInput` in _pyopenvino to mimic current [definition](https://github.com/openvinotoolkit/openvino/blob/df6161d052577625d8812837f1b13010fd76c5af/src/bindings/python/src/openvino/utils/types.py#L22)
 - Fix `_pyopenvino.Node.__add__`
 - *...*

### Tickets:
 - [CVS-159588](https://jira.devtools.intel.com/browse/CVS-159588)
