### PR TITLE
[GPU] Improve micro_sdpa perf for PA case

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -145,14 +145,14 @@ sdpa_config_t xehpc_h256 = {16, 32, 32, 32, 8, 4, 8, 4};
 sdpa_config_t xehpc_h256_s64 = {16, 32, 32, 32, 8, 1, 8, 1};
 sdpa_config_t xehpc_h256_2nd = {16, 16, 16, 16, 16, 1, 16, 1};
 
-sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool quantized) {
+sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool quantized, bool is_pa) {
     if (head_size <= 32) {
         if (quantized && seq >= 128) {
             if (thin_q) return &xehpg_q_h32_2nd;
             return &xehpg_q_h32;
         }
         if (thin_q) return &xehpg_h32_2nd;
-        if (seq <= 0) return &xehpg_h32;
+        if (seq <= 0 && is_pa) return &xehpg_h32;
         if (seq <= 32) return &xehpg_h32_s32;
         if (seq <= 64) return &xehpg_h32_s64;
         if (seq <= 256) return &xehpg_h32_s256;
@@ -163,7 +163,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             return &xehpg_q_h64;
         }
         if (thin_q) return &xehpg_h64_2nd;
-        if (seq <= 0) return &xehpg_h64;
+        if (seq <= 0 && is_pa) return &xehpg_h64;
         if (seq <= 64) return &xehpg_h64_s64;
         if (seq <= 128) return &xehpg_h64_s128;
         return &xehpg_h64;
@@ -180,7 +180,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             if (seq <= 256) return &xehpg_h128_s256_2nd;
             return &xehpg_h128_2nd;
         }
-        if (seq <= 0) return &xehpg_h128;
+        if (seq <= 0 && is_pa) return &xehpg_h128;
         if (seq <= 32) return &xehpg_h128_s32;
         return &xehpg_h128;
     } else if (head_size <= 256) {
@@ -189,7 +189,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             if (seq <= 64) return &xehpg_h256_s64_2nd;
             return &xehpg_h256_2nd;
         }
-        if (seq <= 0) return &xehpg_h256;
+        if (seq <= 0 && is_pa) return &xehpg_h256;
         if (seq <= 32) return &xehpg_h256_s32;
         if (seq <= 128) return &xehpg_h256_s128;
         return &xehpg_h256;
@@ -197,10 +197,10 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
     return nullptr;
 }
 
-sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool quantized) {
+sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool quantized, bool is_pa) {
     if (head_size <= 32) {
         if (thin_q) return &xehpc_h32_2nd;
-        if (seq <= 0) return &xehpc_h32;
+        if (seq <= 0 && is_pa) return &xehpc_h32;
         if (seq <= 32) return &xehpc_h32_s32;
         return &xehpc_h32;
     } else if (head_size <= 64) {
@@ -209,7 +209,7 @@ sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
             return &xehpc_h64_2nd;
         }
         if (quantized && seq >= 256) return &xehpc_q_h64;
-        if (seq <= 0) return &xehpc_h64;
+        if (seq <= 0 && is_pa) return &xehpc_h64;
         if (seq <= 32) return &xehpc_h64_s32;
         if (seq <= 64) return &xehpc_h64_s64;
         return &xehpc_h64;
@@ -224,13 +224,13 @@ sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
             return &xehpc_q_h128;
         }
         if (thin_q) return &xehpc_h128_2nd;
-        if (seq <= 0) return &xehpc_h128;
+        if (seq <= 0 && is_pa) return &xehpc_h128;
         if (seq <= 32) return &xehpc_h128_s32;
         if (seq <= 64) return &xehpc_h128_s64;
         return &xehpc_h128;
     } else if (head_size <= 256) {
         if (thin_q) return &xehpc_h256_2nd;
-        if (seq <= 0) return &xehpc_h256;
+        if (seq <= 0 && is_pa) return &xehpc_h256;
         if (seq <= 64) return &xehpc_h256_s64;
         return &xehpc_h256;
     }
@@ -270,13 +270,13 @@ void SDPAKernelMicro::init_microkernels(const sdpa_params& params, micro::Packag
 
     switch (params.engineInfo.arch) {
         case gpu_arch::xe_hpg: {
-            config = choose_config_xehpg(static_cast<int32_t>(head_size), static_cast<int32_t>(n_keys.v), thin_q, is_quantized);
+            config = choose_config_xehpg(static_cast<int32_t>(head_size), static_cast<int32_t>(n_keys.v), thin_q, is_quantized, params.conf.is_paged_attention);
             break;
         }
         case gpu_arch::xe_hpc:
         case gpu_arch::xe2:
         case gpu_arch::xe3: {
-            config = choose_config_xehpc(static_cast<int32_t>(head_size), static_cast<int32_t>(n_keys.v), thin_q, is_quantized);
+            config = choose_config_xehpc(static_cast<int32_t>(head_size), static_cast<int32_t>(n_keys.v), thin_q, is_quantized, params.conf.is_paged_attention);
             break;
         }
         default: break;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -152,6 +152,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             return &xehpg_q_h32;
         }
         if (thin_q) return &xehpg_h32_2nd;
+        if (seq <= 0) return &xehpg_h32;
         if (seq <= 32) return &xehpg_h32_s32;
         if (seq <= 64) return &xehpg_h32_s64;
         if (seq <= 256) return &xehpg_h32_s256;
@@ -162,6 +163,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             return &xehpg_q_h64;
         }
         if (thin_q) return &xehpg_h64_2nd;
+        if (seq <= 0) return &xehpg_h64;
         if (seq <= 64) return &xehpg_h64_s64;
         if (seq <= 128) return &xehpg_h64_s128;
         return &xehpg_h64;
@@ -178,6 +180,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             if (seq <= 256) return &xehpg_h128_s256_2nd;
             return &xehpg_h128_2nd;
         }
+        if (seq <= 0) return &xehpg_h128;
         if (seq <= 32) return &xehpg_h128_s32;
         return &xehpg_h128;
     } else if (head_size <= 256) {
@@ -186,6 +189,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
             if (seq <= 64) return &xehpg_h256_s64_2nd;
             return &xehpg_h256_2nd;
         }
+        if (seq <= 0) return &xehpg_h256;
         if (seq <= 32) return &xehpg_h256_s32;
         if (seq <= 128) return &xehpg_h256_s128;
         return &xehpg_h256;
@@ -196,6 +200,7 @@ sdpa_config_t *choose_config_xehpg(int head_size, int seq, bool thin_q, bool qua
 sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool quantized) {
     if (head_size <= 32) {
         if (thin_q) return &xehpc_h32_2nd;
+        if (seq <= 0) return &xehpc_h32;
         if (seq <= 32) return &xehpc_h32_s32;
         return &xehpc_h32;
     } else if (head_size <= 64) {
@@ -204,6 +209,7 @@ sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
             return &xehpc_h64_2nd;
         }
         if (quantized && seq >= 256) return &xehpc_q_h64;
+        if (seq <= 0) return &xehpc_h64;
         if (seq <= 32) return &xehpc_h64_s32;
         if (seq <= 64) return &xehpc_h64_s64;
         return &xehpc_h64;
@@ -218,11 +224,13 @@ sdpa_config_t *choose_config_xehpc(int head_size, int seq, bool thin_q, bool qua
             return &xehpc_q_h128;
         }
         if (thin_q) return &xehpc_h128_2nd;
+        if (seq <= 0) return &xehpc_h128;
         if (seq <= 32) return &xehpc_h128_s32;
         if (seq <= 64) return &xehpc_h128_s64;
         return &xehpc_h128;
     } else if (head_size <= 256) {
         if (thin_q) return &xehpc_h256_2nd;
+        if (seq <= 0) return &xehpc_h256;
         if (seq <= 64) return &xehpc_h256_s64;
         return &xehpc_h256;
     }


### PR DESCRIPTION
### Details:
 - Use sdpa config for shape agnostic kernel assuming that the Seq len is > 64
 - Perf check done for BMG/LNL/DG2 
 - LNL:
![image](https://github.com/user-attachments/assets/4017d0b8-abca-4403-abfb-a35a0fdb0e26)
- DG2 
![image](https://github.com/user-attachments/assets/b236c65e-e901-411b-91a0-ff2235d3a4d8)
- BMG
![image](https://github.com/user-attachments/assets/4dd5851f-c674-4574-a72a-a72fc81a31f4)
- (Currently there is perf issue when attn_mask is used.
Since PA uses causal mask, there is no perf issue.
Once perf issue w.r.t the attn_mask is resolved, we can apply this change for non-PA case too)
### Tickets:
 -  CVS-163029
