### PR TITLE
EliminateAddZero

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/lin_op_sequence_fusion.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/lin_op_sequence_fusion.hpp
@@ -17,6 +17,7 @@ class TRANSFORMATIONS_API LinOpSequenceFusion;
 class TRANSFORMATIONS_API AddMultiplyFusion;
 class TRANSFORMATIONS_API AddAddFusion;
 class TRANSFORMATIONS_API MultiplyMultiplyFusion;
+class TRANSFORMATIONS_API EliminateAddZero;
 
 }  // namespace pass
 }  // namespace ov
@@ -39,6 +40,12 @@ public:
     MultiplyMultiplyFusion();
 };
 
+class ov::pass::EliminateAddZero : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("EliminateAddZero");
+    EliminateAddZero();
+};
+
 /**
  * @ingroup ov_transformation_common_api
  * @brief LinOpSequenceFusion transformation fuses linear operation sequence.
@@ -50,5 +57,6 @@ public:
         add_matcher<ov::pass::AddMultiplyFusion>();
         add_matcher<ov::pass::AddAddFusion>();
         add_matcher<ov::pass::MultiplyMultiplyFusion>();
+        add_matcher<ov::pass::EliminateAddZero>();
     }
 };

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -31,6 +31,7 @@
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
 #include "transformations/common_optimizations/fq_mul_fusion.hpp"
 #include "transformations/common_optimizations/fuse_rotary_positional_embeddings.hpp"
+#include "transformations/common_optimizations/lin_op_sequence_fusion.hpp"
 #include "transformations/common_optimizations/lora_subgraph_fusion.hpp"
 #include "transformations/common_optimizations/lstm_cell_fusion.hpp"
 #include "transformations/common_optimizations/mark_precision_sensitive_shapeof_subgraphs.hpp"
@@ -524,6 +525,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
 
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::EliminateConvert);
     CPU_REGISTER_PASS_COMMON(manager, SwapConvertTranspose);
+    CPU_REGISTER_PASS_COMMON(manager, ov::pass::LinOpSequenceFusion);
     CPU_REGISTER_PASS_X64(manager, ConvertToInteraction);
     CPU_REGISTER_PASS_X64(manager, ConvertInteractionInt8);
     CPU_REGISTER_PASS_ARM(manager, ConvertReduceNoKeepDims);


### PR DESCRIPTION
Changes:
- Add EliminateAddZero in LinOpSequenceFusion
- Add another run of LinOpSequenceFusion in CPU transformations pipeline after ConvertPrecision

Purpose:

Some LLM models generated by onnxruntime-genai has this pattern:
![image](https://github.com/user-attachments/assets/add14104-51f2-48b8-bbb1-dfa080ab519d)
The result of Sub will be converted to i32 and fed into GroupQueryAttention. This PR https://github.com/openvinotoolkit/openvino/pull/28163 decomposes GQA and introduces an Add that adds 1 back to the result.

With the changes in this PR, this add1 sub1 pattern which is repeated multiple times could be completely eliminated.

