### PR TITLE
[CPU][ARM] Change KleidiAI repo source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -89,4 +89,4 @@
 	url = https://github.com/openvinotoolkit/shl.git
 [submodule "src/plugins/intel_cpu/thirdparty/kleidiai"]
 	path = src/plugins/intel_cpu/thirdparty/kleidiai
-	url = https://git.gitlab.arm.com/kleidi/kleidiai.git
+	url = https://github.com/ARM-software/kleidiai.git


### PR DESCRIPTION
### Details:
 - ARM's gitlab is less stable than github, so it's more robust to fetch KleiaiAI from github

