### PR TITLE
[GPU] skip onednn impl when transpose out has bxfy format 

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
@@ -62,6 +62,11 @@ struct GemmImplementationManager : public ImplementationManager {
             !one_of(out_layout.format.value, supported_formats))
             return false;
 
+        std::vector<size_t> out_transpose_order(std::begin(gemm_prim->output_transpose_order), std::end(gemm_prim->output_transpose_order));
+        if (out_transpose_order == format::traits(static_cast<format::type>(format::bxfy))._order) {
+            return false;
+        }
+
         bool f16f16_case = everyone_is(data_types::f16, in0_dt, in1_dt) && one_of(out_dt, {data_types::f16, data_types::f32, data_types::i8});
         bool u8s8_case = one_of(in0_dt, {data_types::i8, data_types::u8}) &&
                          one_of(in1_dt, {data_types::i8, data_types::u8}) &&

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Intel Corporation
+// Copyright (C) 2024-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -62,8 +62,10 @@ struct GemmImplementationManager : public ImplementationManager {
             !one_of(out_layout.format.value, supported_formats))
             return false;
 
+        //format bxfy not on whitelist for fusable_output_order_onednn in gemm_inst.h what makes assert error later
+        //skipped onednn implementation as ocl is faster
         std::vector<size_t> out_transpose_order(std::begin(gemm_prim->output_transpose_order), std::end(gemm_prim->output_transpose_order));
-        if (out_transpose_order == format::traits(static_cast<format::type>(format::bxfy))._order) {
+        if (out_transpose_order == format::traits(format::bxfy)._order) {
             return false;
         }
 


### PR DESCRIPTION
### Details:
 - skip because looks more optimal to run yolov12 on ocl
 - adbc transpose out format not fused to matmul in onednn src/plugins/intel_gpu/thirdparty/onednn_gpu/src/graph/backend/dnnl/passes/transform.cpp:3891 tells about it
 - without it assert fail on src\plugins\intel_gpu\src\graph\impls\onednn\gemm_onednn.cpp:202
### Tickets:
 - 163418
