### PR TITLE
[CPU] Fix qkv_proj infinite loop while allocating the workers

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -4,6 +4,7 @@
 
 #include "qkv_proj.h"
 
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -32,8 +33,9 @@ static std::vector<int> allocate_workers(const std::vector<int>& grouped_works, 
     auto n_groups = grouped_works.size();
     // allocate 1 worker for each group
     std::vector<int> g_workers(n_groups, 1);
-    auto left_workers = n_workers - n_groups;
-    while (left_workers > 0) {
+    size_t left_workers = n_workers - n_groups;
+
+    for (size_t i = 0; i < left_workers; i++) {
         // which group is working hardest?
         float hardest_works = 0;
         size_t hardest_group = 0;
@@ -45,7 +47,6 @@ static std::vector<int> allocate_workers(const std::vector<int>& grouped_works, 
             }
         }
         g_workers[hardest_group]++;
-        left_workers--;
     }
 
     return g_workers;


### PR DESCRIPTION
Previous implementation used size_t decrement with the check
'while(size_t > 0)'
which is always true