### PR TITLE
[GPU] Enable KV-cache compression in PagedAttention OCL kernel

### DIFF
--- a/src/common/transformations/include/transformations/common_optimizations/convert_pagedattn_inputs.hpp
+++ b/src/common/transformations/include/transformations/common_optimizations/convert_pagedattn_inputs.hpp
@@ -19,6 +19,8 @@ class TRANSFORMATIONS_API ConvertPagedAttnInputs;
 
 class ConvertPagedAttnInputs : public ov::pass::MatcherPass {
 public:
+    using UpdateShapeFunc = std::function<void(const ov::element::Type, const bool, const size_t, int64_t&, int64_t&)>;
+
     struct KVCacheConfig {
         ov::element::Type keyCachePrecision;
         ov::element::Type valueCachePrecision;
@@ -34,7 +36,7 @@ public:
     };
 
     OPENVINO_MATCHER_PASS_RTTI("ConvertPagedAttnInputs");
-    ConvertPagedAttnInputs(const KVCacheConfig& config);
+    ConvertPagedAttnInputs(const KVCacheConfig& config, UpdateShapeFunc update_shape_func);
 
     void setKVCacheConfig(const KVCacheConfig& config);
 
@@ -42,6 +44,7 @@ public:
 
 private:
     KVCacheConfig m_config;
+    UpdateShapeFunc m_update_shape_func;
 };
 
 }  // namespace pass

--- a/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_pagedattn_inputs.cpp
@@ -243,8 +243,23 @@ TEST_P(ConvertPagedAttnInputsTest, checkPrecisionAndShape) {
         cacheConfig.keyCacheGroupSize = keyCacheGroupSize;
         cacheConfig.valueCacheGroupSize = valueCacheGroupSize;
     }
+    auto update_paged_attention_shape_func = [](const ov::element::Type& precision,
+                                                const bool bychannel,
+                                                const size_t group_num,
+                                                int64_t& head_size,
+                                                int64_t& block_size) {
+        if (precision == ov::element::u8) {
+            if (bychannel) {
+                block_size += 2 * sizeof(float);
+            } else {
+                head_size += sizeof(float) * 2 * group_num;
+            }
+        } else if (precision == ov::element::u4) {
+            head_size += sizeof(float) * 2 * group_num * 2;
+        }
+    };
 
-    manager.register_pass<ov::pass::ConvertPagedAttnInputs>(cacheConfig);
+    manager.register_pass<ov::pass::ConvertPagedAttnInputs>(cacheConfig, update_paged_attention_shape_func);
     comparator.disable(FunctionsComparator::ACCURACY);
     comparator.disable(FunctionsComparator::RUNTIME_KEYS);
     disable_result_friendly_names_check();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/paged_attention.cpp
@@ -671,6 +671,11 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
             config.paged_attention_max_len = max_context_len_mem_lock[0];
         }
 
+        if (data_type_traits::is_i8_u8(impl_param.get_input_layout(3).data_type)) {
+            config.is_kv_compressed = true;
+            config.use_asymmetric_quantization = true;
+        }
+
         return config;
     }
 
@@ -693,6 +698,7 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         params.inputs[2] = rotation_trig_lut_tensor;
         params.outputs[0] = key_cache_tensor;
 
+        params.original_cache_dt = to_data_type(impl_param.get_input_layout(1).data_type);
         params.conf = get_sdpa_configuration(impl_param, is_dynamic);
 
         const auto& in_offsets_map = impl_param.in_port_to_shape_info_offset;
@@ -809,6 +815,11 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         }
 
         params.conf = get_sdpa_configuration(impl_param, is_dynamic);
+
+        // Currently, for the processing of the 1st token, plain SDPA kernels are used, which expect
+        // uncompressed plain QKV inputs. Therefore, set is_kv_compressed=false
+        params.conf.is_kv_compressed = false;
+        params.conf.use_asymmetric_quantization = false;
 
         const std::vector<int64_t> default_order = {0, 1, 2, 3};
         params.input0_order = default_order;
@@ -975,6 +986,7 @@ struct paged_attention_impl : multi_stage_primitive<paged_attention> {
         auto kv_cache_update_kernel_params = get_kv_cache_update_kernel_params(impl_param, stage, input_tensors, impl_param.is_dynamic());
         auto& kv_cache_update_kernel_selector = kv_cache_update_kernel_selector_t::Instance();
         kernels_data.push_back(kv_cache_update_kernel_selector.get_best_kernel(kv_cache_update_kernel_params));
+
         auto sdpa_kernel_params = get_sdpa_kernel_params(impl_param, stage, input_tensors, 0, impl_param.is_dynamic());
         auto& sdpa_kernel_selector = sdpa_kernel_selector_t::Instance();
         kernels_data.push_back(sdpa_kernel_selector.get_best_kernel(sdpa_kernel_params));

--- a/src/plugins/intel_gpu/src/graph/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/paged_attention.cpp
@@ -73,6 +73,8 @@ std::string paged_attention_inst::to_string(const paged_attention_node& node) {
     paged_attention_info.add("scale", desc->scale_val.value_or(1.0f));
     paged_attention_info.add("has_alibi", desc->has_alibi);
     paged_attention_info.add("has_rotated_blocks", desc->has_rotated_blocks);
+    paged_attention_info.add("key_cache_dt", node.get_input_layout(3).data_type);
+    paged_attention_info.add("value_cache_dt", node.get_input_layout(4).data_type);
     node_info->add("paged_attention primitive info", paged_attention_info);
     node_info->dump(primitive_description);
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
@@ -7,7 +7,7 @@
 #include "include/batch_headers/sub_group_block_write.cl"
 #include "include/batch_headers/sub_group_shuffle.cl"
 
-#define SUBGROUPS_PER_WG (HEAD_SIZE / SUBGROUP_SIZE)
+#define SUBGROUPS_PER_WG ((HEAD_SIZE / SUBGROUP_SIZE) * SG_SCALE_FACTOR)
 #define PAGED_ATTENTION_BLOCKS_PER_PARTITION (SEQ_LEN_PARTITION_SIZE / PAGED_ATTENTION_BLOCK_SIZE)
 
 #if HEAD_SIZE > 128
@@ -25,7 +25,7 @@
 #endif
 
 REQD_SUB_GROUP_SIZE(SUBGROUP_SIZE)
-__attribute__((reqd_work_group_size(1, 1, HEAD_SIZE)))
+__attribute__((reqd_work_group_size(1, 1, HEAD_SIZE * SG_SCALE_FACTOR)))
 KERNEL(pa_sdpa_opt)(
     OPTIONAL_SHAPE_INFO_ARG
     const __global INPUT0_TYPE* query,
@@ -75,10 +75,18 @@ KERNEL(pa_sdpa_opt)(
 
     const uint seq_idx = get_global_id(0);
     const uint head_num_idx = get_global_id(1);
-    const uint head_size_idx = get_global_id(2);
     const uint sglid = get_sub_group_local_id();
     const uint sgid = get_sub_group_id();
     const uint total_partitions_num = get_num_groups(2);
+    const uint lid = get_local_id(2);
+
+#if SG_SCALE_FACTOR == 2
+    const uint head_size_idx = lid % HEAD_SIZE;
+#elif SG_SCALE_FACTOR == 1
+    const uint head_size_idx = lid;
+#else
+    #error "pa_sdpa_opt.cl: Unsupported scale factor"
+#endif
 
     const uint batch_idx = seq_idx;
 
@@ -93,7 +101,6 @@ KERNEL(pa_sdpa_opt)(
 #endif
 
     const uint partition_idx = get_group_id(2);
-    const uint block_start_idx = partition_idx * SEQ_LEN_PARTITION_SIZE / PAGED_ATTENTION_BLOCK_SIZE;
 
     if (partition_idx * SEQ_LEN_PARTITION_SIZE >= seq_len) {
         return;
@@ -166,16 +173,33 @@ KERNEL(pa_sdpa_opt)(
 #else
             const uint head_idx = head_num_idx;
 #endif
-            const uint block_offset = block_indices[start_block_idx + block_num * SUBGROUPS_PER_WG] * HEAD_SIZE * KV_HEADS_NUM * SUBGROUP_SIZE + head_idx * HEAD_SIZE * SUBGROUP_SIZE;
+            const uint block_offset = block_indices[start_block_idx + block_num * SUBGROUPS_PER_WG] * ADJUSTED_HEAD_SIZE * KV_HEADS_NUM * SUBGROUP_SIZE + head_idx * ADJUSTED_HEAD_SIZE * SUBGROUP_SIZE;
 
             SOFTMAX_ACCUMULATOR_TYPE qk_acc = SOFTMAX_ACCUMULATOR_VAL_ZERO;
 
             #define KEY_VEC_SIZE SUBGROUP_SIZE
+            #define KEY_BLOCK MAKE_VECTOR_TYPE(INPUT1_TYPE, KEY_VEC_SIZE)
+#if IS_KV_COMPRESSED
+            const uint key_comp_offset = block_offset + HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+            INPUT0_TYPE* key_comp_ptr = key_cache + key_comp_offset;
+            INPUT0_TYPE comp_scale = key_comp_ptr[0 + sglid];
+            INPUT0_TYPE comp_zp = key_comp_ptr[PAGED_ATTENTION_BLOCK_SIZE + sglid];
+#endif
+
             unroll_for (uint qk_idx = 0; qk_idx < HEAD_SIZE / KEY_VEC_SIZE; qk_idx++) {
-                MAKE_VECTOR_TYPE(INPUT1_TYPE, KEY_VEC_SIZE) k_vals = 0;
+                #define KEY_BLOCK_UNCOMPRESSED MAKE_VECTOR_TYPE(INPUT0_TYPE, KEY_VEC_SIZE)
+                #define TO_KEY_BLOCK_UNCOMPRESSED_TYPE(val) CAT(convert_, KEY_BLOCK_UNCOMPRESSED)(val)
+
+                KEY_BLOCK k_vals_packed = 0;
                 unroll_for (uint i = 0; i < KEY_VEC_SIZE; i++) {
-                    k_vals[i] = BLOCK_READN(INPUT1_TYPE, 1, key_cache, block_offset + qk_idx * SUBGROUP_SIZE * KEY_VEC_SIZE + i * SUBGROUP_SIZE);
+                    k_vals_packed[i] = BLOCK_READN(INPUT1_TYPE, 1, key_cache, block_offset + qk_idx * SUBGROUP_SIZE * KEY_VEC_SIZE + i * SUBGROUP_SIZE);
                 }
+
+#if IS_KV_COMPRESSED
+                KEY_BLOCK_UNCOMPRESSED k_vals = (TO_KEY_BLOCK_UNCOMPRESSED_TYPE(k_vals_packed) - comp_zp) * comp_scale;
+#else
+                KEY_BLOCK k_vals = k_vals_packed;
+#endif
 
 #if STORE_QUERY_TO_SLM
                 INPUT0_TYPE q_val = slm_query[qk_idx * KEY_VEC_SIZE + sglid];
@@ -319,6 +343,15 @@ KERNEL(pa_sdpa_opt)(
         OUTPUT_TYPE acc = OUTPUT_VAL_ZERO;
 
         const uint partition_seq_len = min(seq_len - partition_idx * SEQ_LEN_PARTITION_SIZE, (uint)SEQ_LEN_PARTITION_SIZE);
+
+#if SG_SCALE_FACTOR > 1
+        const uint block_start_idx = (sgid / (SUBGROUPS_PER_WG / SG_SCALE_FACTOR)) * (SEQ_LEN_PARTITION_SIZE / SG_SCALE_FACTOR / SUBGROUP_SIZE);
+        const uint block_end_idx = min(block_start_idx + (SEQ_LEN_PARTITION_SIZE / SG_SCALE_FACTOR / SUBGROUP_SIZE), partition_seq_len / SUBGROUP_SIZE);
+#else
+        const uint block_start_idx = 0;
+        const uint block_end_idx = partition_seq_len / SUBGROUP_SIZE;
+#endif
+
         uint blocks_num_per_partition = min(total_blocks_num - partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION, (uint)PAGED_ATTENTION_BLOCKS_PER_PARTITION);
 
         uint leftovers = blocks_num_per_partition * PAGED_ATTENTION_BLOCK_SIZE - partition_seq_len;
@@ -329,19 +362,41 @@ KERNEL(pa_sdpa_opt)(
 
         const uint start_block_idx = block_indices_begins[subsequence_idx] + partition_idx * PAGED_ATTENTION_BLOCKS_PER_PARTITION;
 
-        for (uint block_num = 0; block_num < blocks_num_per_partition; block_num++) {
+        for (uint block_num = block_start_idx; block_num < block_end_idx; block_num++) {
 #ifdef BROADCAST_GROUP_SIZE
             const uint head_idx = head_num_idx / BROADCAST_GROUP_SIZE;
 #else
             const uint head_idx = head_num_idx;
 #endif
-            const uint block_offset = block_indices[start_block_idx + block_num] * KV_HEADS_NUM * HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + head_idx * HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + sgid * SUBGROUP_SIZE;
+            const uint block_offset = block_indices[start_block_idx + block_num] * KV_HEADS_NUM * ADJUSTED_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + head_idx * ADJUSTED_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+            const uint value_offset = block_offset + head_size_idx;
+
+#if IS_KV_COMPRESSED
+            const uint value_comp_offset = block_offset + HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+            INPUT0_TYPE* value_comp_ptr = value_cache + value_comp_offset;
+            INPUT0_TYPE comp_scale = value_comp_ptr[0 + sglid];
+            INPUT0_TYPE comp_zp = value_comp_ptr[PAGED_ATTENTION_BLOCK_SIZE + sglid];
+#endif
 
             #define VALUE_VEC_SIZE SUBGROUP_SIZE
-            MAKE_VECTOR_TYPE(INPUT2_TYPE, VALUE_VEC_SIZE) value_vals;
+            #define VALUE_UNCOMPRESSED INPUT0_TYPE
+            #define VALUE_BLOCK MAKE_VECTOR_TYPE(INPUT2_TYPE, VALUE_VEC_SIZE)
+            #define VALUE_BLOCK_UNCOMPRESSED MAKE_VECTOR_TYPE(INPUT0_TYPE, VALUE_VEC_SIZE)
+            #define TO_VALUE_UNCOMPRESSED_TYPE(val) CAT(convert_, VALUE_UNCOMPRESSED)(val)
+
+            VALUE_BLOCK v_vals_packed;
             unroll_for (uint i = 0; i < VALUE_VEC_SIZE; i++) {
-                value_vals[i] = BLOCK_READN(INPUT2_TYPE, 1, value_cache, block_offset + i * HEAD_SIZE);
+                v_vals_packed[i] = BLOCK_READN(INPUT2_TYPE, 1, value_cache, value_offset + i * HEAD_SIZE);
             }
+
+#if IS_KV_COMPRESSED
+            VALUE_BLOCK_UNCOMPRESSED value_vals;
+            unroll_for (uint i = 0; i < VALUE_VEC_SIZE; i++) {
+                value_vals[i] = (TO_VALUE_UNCOMPRESSED_TYPE(v_vals_packed[i]) - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+            }
+#else
+            VALUE_BLOCK value_vals = v_vals_packed;
+#endif
 
             OUTPUT_TYPE qk_val = slm_qk_vals[block_num * PAGED_ATTENTION_BLOCK_SIZE + sglid];
 
@@ -350,6 +405,10 @@ KERNEL(pa_sdpa_opt)(
             }
         }
 
+
+#if SG_SCALE_FACTOR > 1
+        if (sgid >= SUBGROUPS_PER_WG / SG_SCALE_FACTOR) {
+#endif
         if (leftovers != 0) {
 #ifdef BROADCAST_GROUP_SIZE
             const uint head_idx = head_num_idx / BROADCAST_GROUP_SIZE;
@@ -357,14 +416,57 @@ KERNEL(pa_sdpa_opt)(
             const uint head_idx = head_num_idx;
 #endif
             const uint last_block_idx = start_block_idx + blocks_num_per_partition;
-            const uint block_offset = block_indices[last_block_idx] * HEAD_SIZE * KV_HEADS_NUM * PAGED_ATTENTION_BLOCK_SIZE + head_idx * HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + sgid * SUBGROUP_SIZE;
+            const uint block_offset = block_indices[last_block_idx] * KV_HEADS_NUM * ADJUSTED_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE + head_idx * ADJUSTED_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+            const uint value_offset = block_offset + head_size_idx;
+
+#if IS_KV_COMPRESSED
+            const uint value_comp_offset = block_offset + HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+            INPUT0_TYPE* value_comp_ptr = value_cache + value_comp_offset;
+            INPUT0_TYPE comp_scale = value_comp_ptr[0 + sglid];
+            INPUT0_TYPE comp_zp = value_comp_ptr[PAGED_ATTENTION_BLOCK_SIZE + sglid];
+#endif
 
             OUTPUT_TYPE qk_val = slm_qk_vals[blocks_num_per_partition * PAGED_ATTENTION_BLOCK_SIZE + sglid];
             for (uint i = 0; i < leftovers; i++) {
-                INPUT2_TYPE value_val = BLOCK_READN(INPUT2_TYPE, 1, value_cache, block_offset + i * HEAD_SIZE);
+                INPUT2_TYPE value_packed = BLOCK_READN(INPUT2_TYPE, 1, value_cache, value_offset + i * HEAD_SIZE);
+#if IS_KV_COMPRESSED
+                #define VALUE_UNCOMPRESSED INPUT0_TYPE
+                #define TO_VALUE_UNCOMPRESSED_TYPE(val) CAT(convert_, VALUE_UNCOMPRESSED)(val)
+                VALUE_UNCOMPRESSED value_val = (TO_VALUE_UNCOMPRESSED_TYPE(value_packed) - sub_group_broadcast(comp_zp, i)) * sub_group_broadcast(comp_scale, i);
+#else
+                VALUE_UNCOMPRESSED value_val = value_packed;
+#endif
+
                 acc = mad(sub_group_broadcast(qk_val, i), value_val, acc);
             }
         }
+
+
+#if SG_SCALE_FACTOR > 1
+        }
+#endif
+
+#if SG_SCALE_FACTOR > 1
+        // Reuse slm_qk_vals SLM to sum-up results between two sets of subgroups
+        __local OUTPUT_TYPE* tmp_reduction_slm_mem = (__local OUTPUT_TYPE*)&slm_qk_vals[0];
+        if ((partition_seq_len > (SEQ_LEN_PARTITION_SIZE / SG_SCALE_FACTOR)) || (leftovers != 0)) {
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (sgid >= SUBGROUPS_PER_WG / SG_SCALE_FACTOR) {
+                tmp_reduction_slm_mem[head_size_idx] = acc;
+            }
+
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (sgid < SUBGROUPS_PER_WG / SG_SCALE_FACTOR) {
+                acc += tmp_reduction_slm_mem[head_size_idx];
+            }
+        }
+#endif
+
+#if SG_SCALE_FACTOR > 1
+        if (sgid < SUBGROUPS_PER_WG / SG_SCALE_FACTOR) {
+#endif
 
         if (seq_len > SEQ_LEN_PARTITION_SIZE) {
             const uint tmp_out_offset = seq_idx * (HEADS_NUM * HEAD_SIZE * total_partitions_num) +
@@ -383,6 +485,9 @@ KERNEL(pa_sdpa_opt)(
             output[output_offset] = acc;
         }
 
+#if SG_SCALE_FACTOR > 1
+        }
+#endif
     }
 }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/pa_kv_cache_rotate_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/pa_kv_cache_rotate_kernel_ref.h
@@ -12,7 +12,7 @@ namespace kernel_selector {
 struct kv_cache_rotate_params : base_params {
     kv_cache_rotate_params() : base_params(KernelType::PA_KV_CACHE_ROTATE) {}
 
-    bool is_prefill = false;
+    Datatype original_cache_dt;
     sdpa_configuration conf;
 };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -477,6 +477,10 @@ bool SDPAKernelMicro::Validate(const Params& p) const {
     if (params.conf.is_paged_attention && params.outputs.size() > 1)
         return false;
 
+    if (params.conf.is_paged_attention && params.conf.paged_attention_sliding_window != 0) {
+        return false;
+    }
+
     // Alibi is not supported
     if (params.conf.is_paged_attention && params.conf.has_alibi_input)
         return false;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -91,6 +91,7 @@
 #include "transformations/common_optimizations/broadcast_elementwise_fusion.hpp"
 #include "transformations/common_optimizations/broadcast_transition.hpp"
 #include "transformations/common_optimizations/common_optimizations.hpp"
+#include "transformations/common_optimizations/convert_pagedattn_inputs.hpp"
 #include "transformations/common_optimizations/convert_quantize_dequantize.hpp"
 #include "transformations/common_optimizations/group_normalization_fusion.hpp"
 #include "transformations/common_optimizations/lin_op_sequence_fusion.hpp"
@@ -457,6 +458,26 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                           store_original_precision_as_rt_attribute);
 
         manager.register_pass<ov::pass::CommonOptimizations>();
+
+        ov::pass::ConvertPagedAttnInputs::KVCacheConfig kv_cache_config;
+        kv_cache_config.keyCachePrecision = config.get_kv_cache_precision();
+        kv_cache_config.valueCachePrecision = config.get_kv_cache_precision();
+        kv_cache_config.inferencePrecision = infer_precision;
+        kv_cache_config.keyCacheBlockSize = 16;
+        kv_cache_config.valueCacheBlockSize = 16;
+        kv_cache_config.keyCacheDimOrder = {0, 1, 3, 2};
+        kv_cache_config.valueCacheDimOrder = {0, 1, 2, 3};
+        manager.register_pass<ov::pass::ConvertPagedAttnInputs>(kv_cache_config,
+            [&infer_precision](const ov::element::Type& precision,
+               const bool bychannel,
+               const size_t group_num,
+               int64_t& head_size,
+               int64_t& block_size) {
+                OPENVINO_ASSERT(!bychannel, "[GPU] Unsupported KV-cache quantization mode");
+                if (precision == ov::element::i8 || precision == ov::element::u8) {
+                    head_size += infer_precision.size() * 2 * group_num;
+                }
+            });
 
         pass_config->set_callback<ov::pass::ScaledDotProductAttentionDecomposition>([&](const std::shared_ptr<const ov::Node> node){
             if (!config.get_enable_sdpa_optimization())

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -69,6 +69,7 @@ struct PagedAttentionManager {
     int num_heads;
     int head_size;
     int block_size;
+    bool kv_cache_compression;
     CacheRotationDescriptor rotation_config;
     std::vector<SubsequenceDescriptor> subsequence_descs;
 
@@ -100,10 +101,12 @@ struct PagedAttentionManager {
                           int num_heads,
                           int head_size,
                           int block_size,
+                          bool kv_cache_compression,
                           CacheRotationDescriptor rotation_config)
         : num_heads(num_heads)
         , head_size(head_size)
         , block_size(block_size)
+        , kv_cache_compression(kv_cache_compression)
         , rotation_config(rotation_config)
         , subsequence_descs(subsequence_descs)
         , test_engine(engine)
@@ -150,7 +153,6 @@ struct PagedAttentionManager {
                 int start_block_idx = block_indices_begins[i];
                 for (int block_idx = 1; block_idx < past_len / block_size; block_idx++) {
                     if (block_idx % 2 != 0) {
-                        std::cout << "\tadd: " << start_block_idx + block_idx << "\n";
                         rotated_block_indices.push_back(start_block_idx + block_idx);
                     }
                 }
@@ -180,9 +182,16 @@ struct PagedAttentionManager {
     }
 
     memory::ptr get_key_cache_memory() {
+        auto key_cache_dt = data_types::f16;
+        auto adjusted_head_size = head_size;
+        if (kv_cache_compression) {
+            key_cache_dt = data_types::i8;
+            adjusted_head_size += 4;
+        }
+
         auto num_blocks = block_indices.back() + 1;
-        auto key_cache_shape = ov::PartialShape{ num_blocks, num_heads, head_size, block_size };
-        auto key_cache_layout = layout{ key_cache_shape, data_types::f16, format::bfyx };
+        auto key_cache_shape = ov::PartialShape{ num_blocks, num_heads, adjusted_head_size, block_size };
+        auto key_cache_layout = layout{ key_cache_shape, key_cache_dt, format::bfyx };
         auto memory = test_engine.allocate_memory(key_cache_layout);
 
         for (int i = 0; i < static_cast<int>(subsequence_descs.size()); i++) {
@@ -195,19 +204,45 @@ struct PagedAttentionManager {
                                                                      : block_size;
                     for (int token_idx = 0; token_idx < last_token_idx; token_idx++) {
                         for (int head_idx = 0; head_idx < num_heads; head_idx++) {
-                            for (int head_size_idx = 0; head_size_idx < head_size; head_size_idx++) {
+                            if (kv_cache_compression) {
                                 size_t input_token_offset = block_idx * block_size + token_idx;
                                 ov::float16* data_ptr = key_data[i].data() +
                                                         input_token_offset * num_heads * head_size +
-                                                        head_idx * head_size + head_size_idx;
+                                                        head_idx * head_size;
 
-                                // shape: [num_blocks, num_heads, head_size, block_size]
-                                size_t output_offset = (start_block_idx + block_idx) * num_heads * head_size * block_size +
-                                                       head_idx * head_size * block_size +
-                                                       head_size_idx * block_size +
-                                                       token_idx;
+                                // shape: [num_blocks, num_heads, adjusted_head_size, block_size]
+                                size_t output_block_offset = (start_block_idx + block_idx) * num_heads * adjusted_head_size * block_size +
+                                                             head_idx * adjusted_head_size * block_size;
 
-                                set_values(test_stream, memory, data_ptr, 1, output_offset);
+                                auto [quantized_data, scale, zp] = quantize_data(data_ptr, head_size);
+                                for (int head_size_idx = 0; head_size_idx < head_size; head_size_idx++) {
+                                    auto quantized_data_ptr = quantized_data.data() + head_size_idx;
+
+                                    size_t output_offset = output_block_offset +
+                                                           head_size_idx * block_size +
+                                                           token_idx;
+
+                                    set_values(test_stream, memory, quantized_data_ptr, 1, output_offset);
+                                }
+
+                                size_t comp_offset = (output_block_offset + head_size * block_size) / 2;
+                                set_values(test_stream, memory, &scale, 1, comp_offset + token_idx);
+                                set_values(test_stream, memory, &zp, 1, comp_offset + block_size + token_idx);
+                            } else {
+                                for (int head_size_idx = 0; head_size_idx < head_size; head_size_idx++) {
+                                    size_t input_token_offset = block_idx * block_size + token_idx;
+                                    ov::float16* data_ptr = key_data[i].data() +
+                                                            input_token_offset * num_heads * head_size +
+                                                            head_idx * head_size + head_size_idx;
+
+                                    // shape: [num_blocks, num_heads, head_size, block_size]
+                                    size_t output_offset = (start_block_idx + block_idx) * num_heads * head_size * block_size +
+                                                           head_idx * head_size * block_size +
+                                                           head_size_idx * block_size +
+                                                           token_idx;
+
+                                    set_values(test_stream, memory, data_ptr, 1, output_offset);
+                                }
                             }
                         }
                     }
@@ -219,9 +254,16 @@ struct PagedAttentionManager {
     }
 
     memory::ptr get_value_cache_memory() {
+        auto value_cache_dt = data_types::f16;
+        auto adjusted_head_size = head_size;
+        if (kv_cache_compression) {
+            value_cache_dt = data_types::i8;
+            adjusted_head_size += 4;
+        }
+
         auto num_blocks = block_indices.back() + 1;
-        auto value_cache_shape = ov::PartialShape{ num_blocks, num_heads, block_size, head_size };
-        auto value_cache_layout = layout{ value_cache_shape, data_types::f16, format::bfyx };
+        auto value_cache_shape = ov::PartialShape{ num_blocks, num_heads, block_size, adjusted_head_size };
+        auto value_cache_layout = layout{ value_cache_shape, value_cache_dt, format::bfyx };
         auto memory = test_engine.allocate_memory(value_cache_layout);
 
         for (int i = 0; i < static_cast<int>(subsequence_descs.size()); i++) {
@@ -238,13 +280,28 @@ struct PagedAttentionManager {
                             ov::float16* data_ptr = value_data[i].data() +
                                                     input_token_offset * num_heads * head_size +
                                                     head_idx * head_size;
+                            if (kv_cache_compression) {
+                                auto [quantized_data, scale, zp] = quantize_data(data_ptr, head_size);
+                                auto quantized_data_ptr = quantized_data.data();
 
-                            // shape: [num_blocks, num_heads, block_size, head_size]
-                            size_t output_offset = (start_block_idx + block_idx) * num_heads * block_size * head_size +
-                                                   head_idx * block_size * head_size +
-                                                   token_idx * head_size;
+                                // shape: [num_blocks, num_heads, block_size, adjusted_head_size]
+                                size_t output_block_offset = (start_block_idx + block_idx) * num_heads * block_size * adjusted_head_size +
+                                                             head_idx * block_size * adjusted_head_size;
+                                size_t output_offset = output_block_offset +
+                                                       token_idx * head_size;
+                                set_values(test_stream, memory, quantized_data_ptr, head_size, output_offset);
 
-                            set_values(test_stream, memory, data_ptr, head_size, output_offset);
+                                size_t comp_offset = (output_block_offset + head_size * block_size) / 2;
+                                set_values(test_stream, memory, &scale, 1, comp_offset + token_idx);
+                                set_values(test_stream, memory, &zp, 1, comp_offset + block_size + token_idx);
+                            } else {
+                                // shape: [num_blocks, num_heads, block_size, head_size]
+                                size_t output_offset = (start_block_idx + block_idx) * num_heads * block_size * head_size +
+                                                       head_idx * block_size * head_size +
+                                                       token_idx * head_size;
+
+                                set_values(test_stream, memory, data_ptr, head_size, output_offset);
+                            }
                         }
                     }
                 }
@@ -400,6 +457,46 @@ private:
         auto data = rg.generate_random_1d<ov::float16>(total_elements_num, -1, 1);
 
         return data;
+    }
+
+    static std::tuple<std::vector<int8_t>, ov::float16, ov::float16> quantize_data(ov::float16* data, size_t size) {
+        float min_value = std::numeric_limits<float>::max();
+        float max_value = std::numeric_limits<float>::lowest();
+
+        for (size_t i = 0; i < size; i++) {
+            min_value = std::min((float)(data[i]), min_value);
+            max_value = std::max((float)(data[i]), max_value);
+        }
+
+        float diff_value = 0.001;
+        if (max_value != min_value)
+            diff_value = max_value - min_value;
+
+        float scale = (std::numeric_limits<int8_t>::max() - std::numeric_limits<int8_t>::lowest()) / diff_value;
+        float zp = ((float)-min_value * scale) + std::numeric_limits<int8_t>::lowest();
+
+        std::vector<int8_t> quantized_data;
+        quantized_data.resize(size);
+
+        auto convert_char_rte = [](float val) {
+            float rounded = std::nearbyint(val);
+
+            if (rounded > 127.0f) {
+                return static_cast<int8_t>(127);
+            } else if (rounded < -128.0f) {
+                return static_cast<int8_t>(-128);
+            } else {
+                return static_cast<int8_t>(rounded);
+            }
+        };
+
+        for (size_t i = 0; i < size; i++) {
+            quantized_data[i] = convert_char_rte(data[i] * scale + zp);
+        }
+
+        scale = 1.0f / scale;
+
+        return std::make_tuple(quantized_data, scale, zp);
     }
 };
 
@@ -675,7 +772,18 @@ public:
     }
 
     void execute(T& p) {
-        PagedAttentionManager pam(rg, get_test_engine(), get_test_stream(), p.subsequences, p.num_heads, p.head_size, p.block_size, p.rotation_config);
+        PagedAttentionManager pam(rg,
+                                  get_test_engine(),
+                                  get_test_stream(),
+                                  p.subsequences,
+                                  p.num_heads,
+                                  p.head_size,
+                                  p.block_size,
+                                  p.kv_cache_compression,
+                                  p.rotation_config);
+
+        if (p.kv_cache_compression)
+            tolerance = 25e-3;
 
         auto query_mem = pam.get_query_memory();
         auto key_mem = pam.get_key_memory();
@@ -888,6 +996,7 @@ struct paged_attention_test_params {
     int num_heads;
     int head_size;
     int block_size;
+    bool kv_cache_compression;
     bool dynamic_paddings;
     bool scores_output;
     CacheRotationDescriptor rotation_config;
@@ -900,6 +1009,8 @@ TEST_P(paged_attention_test, basic) {
     execute(p);
 }
 
+const auto ENABLE_CACHE_COMPRESSION = true;
+const auto DISABLE_CACHE_COMPRESSION = false;
 const auto ENABLE_SCORES = true;
 const auto DISABLE_SCORES = false;
 const auto PER_BLOCK_ROTATION = CacheRotationDescriptor{ true, true };
@@ -910,30 +1021,41 @@ const auto DYNAMIC_INPUT_PAD = true;
 
 INSTANTIATE_TEST_SUITE_P(smoke_paged_attention, paged_attention_test, ::testing::ValuesIn(std::vector<paged_attention_test_params>{
     /* with scores output */
-    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token
-    paged_attention_test_params{ {{36, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token
-    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token long
-    paged_attention_test_params{ {{10, 0}, {30, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
-    paged_attention_test_params{ {{128, 0}, {256, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
-    paged_attention_test_params{ {{1, 10}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 2nd token
-    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 2nd token + 2nd token
-    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
+    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token
+    paged_attention_test_params{ {{36, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token
+    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token long
+    paged_attention_test_params{ {{10, 0}, {30, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
+    paged_attention_test_params{ {{128, 0}, {256, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
+    paged_attention_test_params{ {{1, 10}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 2nd token
+    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // 2nd token + 2nd token
+    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, DISABLE_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
     /* without scores output, dynamic input query paddings */
-    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token
-    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token long
-    paged_attention_test_params{ {{10, 0}, {81, 0}, {129, 0}}, 2, 64, 16, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
-    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 2nd token + 2nd token
-    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
+    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token
+    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token long
+    paged_attention_test_params{ {{10, 0}, {81, 0}, {129, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
+    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 2nd token + 2nd token
+    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
     /* with scores, per_block rotation */
-    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token
-    paged_attention_test_params{ {{36, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token
-    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token long
-    paged_attention_test_params{ {{10, 0}, {30, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token + 1st token
-    paged_attention_test_params{ {{128, 0}, {256, 0}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token + 1st token
-    paged_attention_test_params{ {{1, 10}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 2nd token
-    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 2nd token + 2nd token
-    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
+    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token
+    paged_attention_test_params{ {{36, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token
+    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token long
+    paged_attention_test_params{ {{10, 0}, {30, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token + 1st token
+    paged_attention_test_params{ {{128, 0}, {256, 0}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 1st token + 1st token
+    paged_attention_test_params{ {{1, 10}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 2nd token
+    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 2nd token + 2nd token
+    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
     /* with scores, per_token rotation */
-    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_TOKEN_ROTATION }, // 2nd token + 2nd token
-    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, STATIC_INPUT_PAD, ENABLE_SCORES, PER_TOKEN_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
+    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_TOKEN_ROTATION }, // 2nd token + 2nd token
+    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, DISABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_TOKEN_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
+    /* without scores output, dynamic input query paddings, KV-cache compression */
+    paged_attention_test_params{ {{10, 0}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token
+    paged_attention_test_params{ {{1024, 0}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token long
+    paged_attention_test_params{ {{10, 0}, {81, 0}, {129, 0}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 1st token + 1st token
+    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // 2nd token + 2nd token
+    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, DYNAMIC_INPUT_PAD, DISABLE_SCORES, DISABLE_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
+    /* with scores, per_block rotation, KV-cache compression */
+    paged_attention_test_params{ {{1, 34}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_BLOCK_ROTATION }, // 2nd token
+    /* with scores, per_token rotation, KV-cache compression */
+    paged_attention_test_params{ {{1, 34}, {1, 515}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_TOKEN_ROTATION }, // 2nd token + 2nd token
+    paged_attention_test_params{ {{1, 34}, {25, 0}, {10, 34}}, 2, 64, 16, ENABLE_CACHE_COMPRESSION, STATIC_INPUT_PAD, ENABLE_SCORES, PER_TOKEN_ROTATION }, // mixed: 2nd token + 1st token + part of 1st token
 }));


### PR DESCRIPTION
### Details:
 - Enabled INT8_ASYM KV-cache compression for PagedAttention
 - Improved `pa_sdpa_opt` kernel with `scale_factor` to increase bandwidth utilization for compressed KV-cache
 - Updated kv_cache_update kernel to perform data quantization
 - Updated kv_cache_rotate kernel to rotate compressed cache (performing: Dequantization -> Rotation -> Quantization)
 - Enabled ConvertPagedAttnInputs transformation pass to allow plugin to configure PA inputs directly
 - Added related PA unit tests
 - Minor fixes of sdpa_micro to reject the kernel in case of unsupported sliding windows
