### PR TITLE
[CPU] Remove redundant NOLINT comments

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -82,6 +82,8 @@ CheckOptions:
     value: google
   - key: modernize-use-auto.MinTypeNameLength
     value: "3"
+  - key: modernize-use-override.AllowOverrideAndFinal
+    value: true
 ### To be considered to enable:
 #  # Unifies the usage of the statements
 #  - key: readability-braces-around-statements.ShortStatementLines

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_kernel_executor_table.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_kernel_executor_table.hpp
@@ -16,7 +16,7 @@ public:
         : snippets::KernelExecutor<Conf, KernelType>(std::move(c)),
           m_kernel_cache(std::move(kernel_cache)) {}
 
-    void update_kernel(const Conf& config, std::shared_ptr<KernelType>& kernel) const override final {  // NOLINT
+    void update_kernel(const Conf& config, std::shared_ptr<KernelType>& kernel) const override final {
         const auto& cache = m_kernel_cache.lock();
         OPENVINO_ASSERT(cache, "Invalid kernel cache pointer in CPUKernelExecutor::update_kernel()");
         const auto& lookup_result = cache->getOrCreate(Key(config), [this](const Key& k) {

--- a/src/plugins/intel_cpu/src/memory_state.h
+++ b/src/plugins/intel_cpu/src/memory_state.h
@@ -30,11 +30,11 @@ public:
     VariableStateBase(const std::string& name, MemoryDescPtr external_desc);
 
     // ov::IVariableState
-    void set_state(const ov::SoPtr<ov::ITensor>& state) override final;  // NOLINT
+    void set_state(const ov::SoPtr<ov::ITensor>& state) override final;
     ov::SoPtr<ov::ITensor> get_state() const override;
-    void reset() override final;                 // NOLINT
-    bool is_reset_state() const override final;  // NOLINT
-    void commit() override final;                // NOLINT
+    void reset() override final;
+    bool is_reset_state() const override final;
+    void commit() override final;
 
 protected:
     virtual MemoryPtr internal_state_mem() const = 0;

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -182,7 +182,7 @@ struct jit_has_subnormals : public jit_has_special_value_base {
     const Vmm rmm6 = Vmm(6);
     const int length = isa == sse41 ? 4 : 8;
 
-    void generate() override final {  // NOLINT
+    void generate() override final {
         size_t const vlen = length;
         const int sh_bits = std::ilogb(vlen);
 
@@ -256,7 +256,7 @@ struct jit_has_bf16_overflows : public jit_has_special_value_base {
     const Vmm rmm6 = Vmm(6);
     const int length = isa == sse41 ? 4 : 8;
 
-    void generate() override final {  // NOLINT
+    void generate() override final {
         size_t const vlen = length;
         const int sh_bits = std::ilogb(vlen);
 
@@ -596,21 +596,20 @@ Input::Input(const MemoryDescPtr& memDesc,
              const std::string& type,
              const GraphContext::CPtr& context)
     : Input(memDesc->getShape(), memDesc->getPrecision(), name, type, context) {
-    extMemDesc = memDesc;  // NOLINT(cppcoreguidelines-prefer-member-initializer) fixed in clang-tidy-18
+    extMemDesc = memDesc;
 }
 
 Input::Input(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context, const InputConfig& config)
     : Input(op, context) {
-    extMemDesc = config.desc;      // NOLINT(cppcoreguidelines-prefer-member-initializer) fixed in clang-tidy-18
-    m_isInPlace = config.inPlace;  // NOLINT(cppcoreguidelines-prefer-member-initializer) fixed in clang-tidy-18
+    extMemDesc = config.desc;
+    m_isInPlace = config.inPlace;
 }
 
 Input::Input(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context, const OutputConfig& config)
     : Input(op, context) {
-    extMemDesc = config.desc;         // NOLINT(cppcoreguidelines-prefer-member-initializer) fixed in clang-tidy-18
-    m_useParentMemoryDescForOutput =  // NOLINT(cppcoreguidelines-prefer-member-initializer)
-        config.useParentMemoryDescForOutput;
-    m_isInPlace = config.inPlace;  // NOLINT(cppcoreguidelines-prefer-member-initializer) fixed in clang-tidy-18
+    extMemDesc = config.desc;
+    m_useParentMemoryDescForOutput = config.useParentMemoryDescForOutput;
+    m_isInPlace = config.inPlace;
 }
 
 MemoryCPtr Input::getMemoryPtr() const {

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -62,11 +62,11 @@ public:
         return getType() == Type::MemoryOutput;
     }
 
-    void execute(const dnnl::stream& strm) override final;             // NOLINT
-    void executeDynamicImpl(const dnnl::stream& strm) override final;  // NOLINT
+    void execute(const dnnl::stream& strm) override final;
+    void executeDynamicImpl(const dnnl::stream& strm) override final;
 
-    bool isExecutable() const override final;  // NOLINT
-    bool neverExecute() const override final;  // NOLINT
+    bool isExecutable() const override final;
+    bool neverExecute() const override final;
 
     void registerInputNode(MemoryInputBase* node);
     void deregisterSibling(MemoryInputBase* node);
@@ -141,22 +141,22 @@ public:
 
     void initSupportedPrimitiveDescriptors() override;
 
-    void execute(const dnnl::stream& strm) override final;             // NOLINT
-    void executeDynamicImpl(const dnnl::stream& strm) override final;  // NOLINT
+    void execute(const dnnl::stream& strm) override final;
+    void executeDynamicImpl(const dnnl::stream& strm) override final;
     bool needShapeInfer() const override {
         return false;
     }
     bool needPrepareParams() const override {
         return false;
     }
-    bool neverExecute() const override final;  // NOLINT
-    bool isExecutable() const override final;  // NOLINT
+    bool neverExecute() const override final;
+    bool isExecutable() const override final;
 
     void registerOutputNode(MemoryOutputBase* node);
     void deregisterSibling(MemoryOutputBase* node);
 
     MemoryOutputBase& getOutputNode();
-    void assignState(MemStatePtr newState) override final;  // NOLINT
+    void assignState(MemStatePtr newState) override final;
 
 protected:
     MemoryInputBase(const std::string& id,

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
@@ -65,10 +65,10 @@ public:
  */
 class ShapeInferEmptyPads : public IShapeInfer {
 public:
-    const ov::CoordinateDiff& get_pads_begin() override final {  // NOLINT
+    const ov::CoordinateDiff& get_pads_begin() override final {
         return m_emptyVec;
     }
-    const ov::CoordinateDiff& get_pads_end() override final {  // NOLINT
+    const ov::CoordinateDiff& get_pads_end() override final {
         return m_emptyVec;
     }
 


### PR DESCRIPTION
### Details:
 - allow using "override" and "final" keywords at the same time in clang-tidy checks
 - remove NOLINTs that can be avoided

### Tickets:
 - N/A
