### PR TITLE
Revert "[GHA] [CPU] Extend nightly scope for CPU func. tests"

### DIFF
--- a/.github/workflows/debian_10_arm.yml
+++ b/.github/workflows/debian_10_arm.yml
@@ -122,7 +122,6 @@ jobs:
       runner: 'aks-linux-16-cores-arm'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.debian_10_arm }}
       python-version: '3.7'
-      scope: ${{ github.event_name == 'workflow_dispatch' && 'nightly' || 'smoke' }}
 
   Overall_Status:
     name: ci/gha_overall_status_debian_10_arm

--- a/.github/workflows/job_cpu_functional_tests.yml
+++ b/.github/workflows/job_cpu_functional_tests.yml
@@ -16,11 +16,6 @@ on:
         description: 'Python version to setup. E.g., "3.11"'
         type: string
         required: true
-      scope:
-        description: 'Defines tests scope {nightly | smoke}'
-        type: string
-        required: false
-        default: 'smoke'
 
 permissions: read-all
 
@@ -40,7 +35,6 @@ jobs:
       INSTALL_TEST_DIR: ${{ github.workspace }}/install/tests
       PARALLEL_TEST_SCRIPT: ${{ github.workspace }}/install/tests/functional_test_utils/layer_tests_summary/run_parallel.py
       PARALLEL_TEST_CACHE: ${{ github.workspace }}/install/tests/test_cache.lst
-      GTEST_FILTER: ${{ inputs.scope == 'nightly' && '' || '--gtest_filter=smoke' }}
     steps:
       - name: Download OpenVINO package
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -112,8 +106,8 @@ jobs:
           # Needed as ze_loader.so is under INSTALL_TEST_DIR
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${INSTALL_TEST_DIR}
 
-          python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1 ${{ env.GTEST_FILTER }}
-        timeout-minutes: ${{ inputs.scope == 'nightly' && 125 || 25 }}
+          python3 ${PARALLEL_TEST_SCRIPT} -e ${INSTALL_TEST_DIR}/ov_cpu_func_tests -c ${PARALLEL_TEST_CACHE} -w ${INSTALL_TEST_DIR} -s suite -rf 0 -- --gtest_print_time=1 --gtest_filter=*smoke*
+        timeout-minutes: 25
 
       - name: Save tests execution time
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2

--- a/.github/workflows/linux_arm64.yml
+++ b/.github/workflows/linux_arm64.yml
@@ -223,7 +223,6 @@ jobs:
       runner: 'aks-linux-16-cores-arm'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_20_04_arm64 }}
       python-version: '3.11'
-      scope: ${{ github.event_name == 'workflow_dispatch' && 'nightly' || 'smoke' }}
 
   TensorFlow_Models_Tests:
     name: TensorFlow Models tests

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -416,7 +416,6 @@ jobs:
     with:
       runner: 'macos-13'
       python-version: '3.11'
-      scope: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)  && 'nightly' || 'smoke' }}
 
   upload_artifacts:
     name: Upload OpenVINO artifacts

--- a/.github/workflows/mac_arm64.yml
+++ b/.github/workflows/mac_arm64.yml
@@ -376,4 +376,3 @@ jobs:
     with:
       runner: 'macos-13-xlarge'
       python-version: '3.11'
-      scope: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)  && 'nightly' || 'smoke' }}

--- a/.github/workflows/ubuntu_22.yml
+++ b/.github/workflows/ubuntu_22.yml
@@ -362,7 +362,6 @@ jobs:
       runner: 'aks-linux-8-cores-32gb'
       image: ${{ fromJSON(needs.docker.outputs.images).ov_test.ubuntu_22_04_x64 }}
       python-version: '3.11'
-      scope: ${{ contains(fromJSON('["schedule", "workflow_dispatch"]'), github.event_name)  && 'nightly' || 'smoke' }}
 
   TensorFlow_Models_Tests_Precommit:
     name: TensorFlow Models tests

--- a/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/extension/extension.cpp
@@ -70,8 +70,7 @@ static std::string model_full_path(const char* path) {
                                      path);
 }
 
-TEST(DISABLED_Extension, XmlModelWithCustomAbs) {
-    // Issue: 163252
+TEST(Extension, XmlModelWithCustomAbs) {
     std::string model = R"V0G0N(
 <net name="Network" version="10">
     <layers>
@@ -193,8 +192,7 @@ TEST(Extension, smoke_XmlModelWithExtensionFromDSO) {
     infer_model(core, compiled_model, input_values, expected);
 }
 
-TEST(DISABLED_Extension, OnnxModelWithExtensionFromDSO) {
-    // Issue: 163252
+TEST(Extension, OnnxModelWithExtensionFromDSO) {
     std::vector<float> input_values{1, 2, 3, 4, 5, 6, 7, 8};
     std::vector<float> expected{1, 2, 3, 4, 5, 6, 7, 8};
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/cpu_reservation_test.cpp
@@ -23,10 +23,8 @@ using namespace testing;
 using Device = std::string;
 using Config = ov::AnyMap;
 using CpuReservationTest = ::testing::Test;
-// Issue: 163348
-using DISABLED_CpuReservationTest = ::testing::Test;
 
-TEST_F(DISABLED_CpuReservationTest, Mutiple_CompiledModel_Reservation) {
+TEST_F(CpuReservationTest, Mutiple_CompiledModel_Reservation) {
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);
@@ -62,7 +60,7 @@ TEST_F(DISABLED_CpuReservationTest, Mutiple_CompiledModel_Reservation) {
     }
 }
 
-TEST_F(DISABLED_CpuReservationTest, Cpu_Reservation_NoAvailableCores) {
+TEST_F(CpuReservationTest, Cpu_Reservation_NoAvailableCores) {
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);
@@ -79,7 +77,7 @@ TEST_F(DISABLED_CpuReservationTest, Cpu_Reservation_NoAvailableCores) {
 }
 
 #if defined(__linux__)
-TEST_F(DISABLED_CpuReservationTest, Cpu_Reservation_CpuPinning) {
+TEST_F(CpuReservationTest, Cpu_Reservation_CpuPinning) {
     std::vector<std::shared_ptr<ov::Model>> models;
     Config config = {ov::enable_profiling(true)};
     Device target_device(ov::test::utils::DEVICE_CPU);

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -279,49 +279,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_TestsROIAlign.*)",
         // Issue: 136881
         R"(.*smoke_CompareWithRefs_4D_BitwiseShift_overflow_i32_cast.*_eltwise_op_type=BitwiseLeft.*_model_type=.*(i16|u16).*)",
-        // Issue: 163083
-        // Issue: 163116
-        R"(.*RandomUniformLayerTestCPU.*OutPrc=bf16.*)",
-        // Issue: 163117
-        R"(.*InterpolateCubic_Layout_Test.*)",
-        // Issue: 163171
-        R"(.*CPUDetectionOutputDynamic3InLargeTensor.*)",
-        // Issue: 163168
-        R"(.*UniqueLayerTestCPU.*)",
-        // Issue: 163175
-        R"(.*GridSampleLayerTestCPU.*dataPrc=i8.*)",
-        R"(.*GridSampleLayerTestCPU.*dataPrc=bf16.*)",
-        // Issue: 163177
-        R"(.*NmsRotatedOpTest.*ScoreThr=0\.4.*)",
-        // Issue: 163222
-        R"(.*bf16.*LSTMSequenceCPUTest.*)",
-        // Issue: 163223
-        R"(.*bf16.*AUGRUSequenceCPUTest.*)",
-        // Issue: 163224
-        R"(.*bf16.*GRUSequenceCPUTest.*)",
-        // Issue: 163227
-        R"(.*QuantizedModelsTests\.MaxPoolFQ.*)",
-        R"(.*QuantizedModelsTests\.MaxPoolQDQ.*)",
-        // Issue: 163268
-        R"(.*QuantizedModelsTests\.ConvolutionQDQ.*)",
-        R"(.*QuantizedModelsTests\.ConvolutionFQ.*)",
-        // Issue: 163230
-        R"(.*ProposalLayerTest.*)",
-        // Issue: 163232
-        R"(.*FC_3D_BF16.*MatMulLayerCPUTest.*)",
-        // Issue: 163242
-        R"(.*bf16.*RNNSequenceCPUTest.*)",
-        // Issue: 163250
-        R"(.*OnnxModelWithExtensionFromDSO.*)",
-        // Issue: 163273
-        // todo: define correct area
-        R"(.*Deconv_2D_Planar_FP16.*DeconvolutionLayerCPUTest.*)",
-        // Issue: 163275
-        R"(.*NoReshapeAndReshapeDynamic.*CodegenGelu.*)",
-        // Issue: 163348
-        R"(.*CpuReservationTest.*Mutiple_CompiledModel_Reservation.*)",
-        // Issue: 163351
-        R"(.*CoreThreadingTestsWithIter.*nightly_AsyncInfer_ShareInput.*)",
     };
 
     // fp32 floor for bf16 models: conversion issue


### PR DESCRIPTION
Reverts openvinotoolkit/openvino#28751

After this PR was merged CPU Functional Tests job lasts for a few seconds because all the tests are filtered out