### PR TITLE
Set allocated for empty constant byte to zero

### DIFF
--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -261,7 +261,8 @@ void Constant::allocate_buffer(bool memset_allocation) {
         constexpr uint8_t init_value = 0;
         m_data = std::make_shared<AlignedBuffer>(byte_size, host_alignment());
 
-        if (memset_allocation) {
+        // AlignedBuffer allocates 1 byte for empty constants, and we set it to zero
+        if (memset_allocation || m_data->size() != byte_size) {
             std::memset(m_data->get_ptr(), init_value, m_data->size());
         } else {
             set_unused_bits(m_data->get_ptr());

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -262,7 +262,7 @@ void Constant::allocate_buffer(bool memset_allocation) {
         m_data = std::make_shared<AlignedBuffer>(byte_size, host_alignment());
 
         // AlignedBuffer allocates 1 byte for empty constants, and we set it to zero
-        if (memset_allocation || m_data->size() != byte_size) {
+        if (memset_allocation || byte_size == 0) {
             std::memset(m_data->get_ptr(), init_value, m_data->size());
         } else {
             set_unused_bits(m_data->get_ptr());

--- a/src/core/tests/pass/serialization/const_compression.cpp
+++ b/src/core/tests/pass/serialization/const_compression.cpp
@@ -7,12 +7,12 @@
 #include <fstream>
 
 #include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/graph_comparator.hpp"
 #include "common_test_utils/test_common.hpp"
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/serialize.hpp"
-#include "transformations/common_optimizations/compress_float_constants.hpp"
-#include "common_test_utils/graph_comparator.hpp"
 #include "openvino/runtime/core.hpp"
+#include "transformations/common_optimizations/compress_float_constants.hpp"
 
 class SerializationConstantCompressionTest : public ov::test::TestsCommon {
 protected:
@@ -321,7 +321,7 @@ TEST_F(SerializationConstantCompressionTest, EmptyConstants) {
     auto B = ov::opset8::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
 
     auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
-    
+
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
 
     std::ifstream xml_1(m_out_xml_path_1, std::ios::binary);
@@ -344,7 +344,7 @@ TEST_F(SerializationConstantCompressionTest, EmptyAndNotEmptyConstantSameValues)
     auto B = ov::opset8::Constant::create(ov::element::i8, ov::Shape{1}, std::vector<int8_t>{0});
 
     auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
-    
+
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
 
     std::ifstream xml_1(m_out_xml_path_1, std::ios::binary);
@@ -367,7 +367,7 @@ TEST_F(SerializationConstantCompressionTest, EmptyAndNotEmptyConstantsDifferentV
     auto B = ov::opset8::Constant::create(ov::element::i8, ov::Shape{1}, std::vector<int8_t>{1});
 
     auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
-    
+
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
 
     std::ifstream xml_1(m_out_xml_path_1, std::ios::binary);

--- a/src/core/tests/pass/serialization/const_compression.cpp
+++ b/src/core/tests/pass/serialization/const_compression.cpp
@@ -11,6 +11,8 @@
 #include "openvino/opsets/opset8.hpp"
 #include "openvino/pass/serialize.hpp"
 #include "transformations/common_optimizations/compress_float_constants.hpp"
+#include "common_test_utils/graph_comparator.hpp"
+#include "openvino/runtime/core.hpp"
 
 class SerializationConstantCompressionTest : public ov::test::TestsCommon {
 protected:
@@ -311,4 +313,73 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsDifferentTypesI32
     std::ifstream bin_1(m_out_bin_path_1, std::ios::binary);
 
     ASSERT_EQ(file_size(bin_1), unique_const_count * ov::shape_size(shape) * sizeof(int32_t));
+}
+
+TEST_F(SerializationConstantCompressionTest, EmptyConstants) {
+    constexpr int unique_const_count = 1;
+    auto A = ov::opset8::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
+    auto B = ov::opset8::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
+
+    auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    
+    ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
+
+    std::ifstream xml_1(m_out_xml_path_1, std::ios::binary);
+    std::ifstream bin_1(m_out_bin_path_1, std::ios::binary);
+
+    ASSERT_EQ(file_size(bin_1), unique_const_count * sizeof(int8_t));
+
+    ov::Core core;
+    auto model_imported = core.read_model(m_out_xml_path_1, m_out_bin_path_1);
+
+    bool success;
+    std::string message;
+    std::tie(success, message) = compare_functions(model_initial, model_imported, true, true, false, true, true);
+    ASSERT_TRUE(success) << message;
+}
+
+TEST_F(SerializationConstantCompressionTest, EmptyAndNotEmptyConstantSameValues) {
+    constexpr int unique_const_count = 1;
+    auto A = ov::opset8::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
+    auto B = ov::opset8::Constant::create(ov::element::i8, ov::Shape{1}, std::vector<int8_t>{0});
+
+    auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    
+    ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
+
+    std::ifstream xml_1(m_out_xml_path_1, std::ios::binary);
+    std::ifstream bin_1(m_out_bin_path_1, std::ios::binary);
+
+    ASSERT_EQ(file_size(bin_1), unique_const_count * sizeof(int8_t));
+
+    ov::Core core;
+    auto model_imported = core.read_model(m_out_xml_path_1, m_out_bin_path_1);
+
+    bool success;
+    std::string message;
+    std::tie(success, message) = compare_functions(model_initial, model_imported, true, true, false, true, true);
+    ASSERT_TRUE(success) << message;
+}
+
+TEST_F(SerializationConstantCompressionTest, EmptyAndNotEmptyConstantsDifferentValues) {
+    constexpr int unique_const_count = 2;
+    auto A = ov::opset8::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
+    auto B = ov::opset8::Constant::create(ov::element::i8, ov::Shape{1}, std::vector<int8_t>{1});
+
+    auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    
+    ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
+
+    std::ifstream xml_1(m_out_xml_path_1, std::ios::binary);
+    std::ifstream bin_1(m_out_bin_path_1, std::ios::binary);
+
+    ASSERT_EQ(file_size(bin_1), unique_const_count * sizeof(int8_t));
+
+    ov::Core core;
+    auto model_imported = core.read_model(m_out_xml_path_1, m_out_bin_path_1);
+
+    bool success;
+    std::string message;
+    std::tie(success, message) = compare_functions(model_initial, model_imported, true, true, false, true, true);
+    ASSERT_TRUE(success) << message;
 }


### PR DESCRIPTION
### Details:
 - That is simplified fix for #29329, just to fix the particular issue with empty constant in PA transformation
 - Need to be reverted when #29329 is merged

### Tickets:
 - CVS-162291