### PR TITLE
[NPUW][AUTO] Fix CACHE_DIR for NPUW

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1379,7 +1379,11 @@ bool ov::CoreImpl::device_supports_internal_property(const ov::Plugin& plugin, c
 }
 
 bool ov::CoreImpl::device_supports_model_caching(const ov::Plugin& plugin, const ov::AnyMap& arguments) const {
-    return plugin.supports_model_caching(arguments);
+    ov::AnyMap properties;
+    if (arguments.count(ov::device::priorities.name())) {
+        properties[ov::device::priorities.name()] = arguments.at(ov::device::priorities.name()).as<std::string>();
+    }
+    return plugin.supports_model_caching(properties);
 }
 
 bool ov::CoreImpl::device_supports_cache_dir(const ov::Plugin& plugin) const {


### PR DESCRIPTION
Issue was introduced in https://github.com/openvinotoolkit/openvino/pull/27691
As an extension to NPU plugin NPUW has internal properties which aren't registered by NPU plugin. In this case we cannot just pass all the config properties directly to the plugin by `supports_model_caching()` function.
