### PR TITLE
Adding new test case for outputShape

### DIFF
--- a/src/plugins/template/tests/functional/op_reference/group_convolution_backprop.cpp
+++ b/src/plugins/template/tests/functional/op_reference/group_convolution_backprop.cpp
@@ -487,6 +487,18 @@ std::vector<GroupConvolutionBackpropDataOutShapeParams> generateGroupConvolution
                                                    {1, 1},
                                                    {2},
                                                    {1, 14}),
+        // Adding new test case when output shape is non empty
+        GroupConvolutionBackpropDataOutShapeParams(Shape{1, 2, 2, 2},
+                                                   Shape{2, 1, 1, 2, 2},
+                                                   Shape{1, 2, 3, 3},
+                                                   IN_ET,
+                                                   std::vector<T>{1, 2, 3, 4, 5, 6, 7, 8},
+                                                   std::vector<T>{1, 0, 0, 1, 1, 0, 0, 1},
+                                                   std::vector<T>{1, 2, 3, 4, 5, 6, 7, 8, 9},
+                                                   {1, 1},
+                                                   {1, 1},
+                                                   {2},
+                                                   {1, 3}),
     };
     return groupConvolutionBackpropDataOutShapeParams;
 }


### PR DESCRIPTION
### Details:
 - This test case ensures that the GroupConvolutionBackpropData  operation correctly handles scenarios where the outputShape is explicitly specified and not empty, addressing the issue mentioned.

### Issue:
 - [*ticket-id*](https://github.com/openvinotoolkit/openvino/issues/24254)
