### PR TITLE
Bump Cmake min version for npu tools & time tests

### DIFF
--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -6,7 +6,11 @@
 set(TARGET_NAME compile_tool)
 
 if (NOT DEFINED PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+    if(WIN32)
+        cmake_minimum_required(VERSION 3.16)
+    else()
+        cmake_minimum_required(VERSION 3.13)
+    endif()
     project(compile_tool_standalone)
     include("cmake/standalone.cmake")
     return()

--- a/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
@@ -6,7 +6,11 @@
 set(TARGET_NAME protopipe)
 
 if (NOT DEFINED PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+    if(WIN32)
+        cmake_minimum_required(VERSION 3.16)
+    else()
+        cmake_minimum_required(VERSION 3.13)
+    endif()
     project(protopipe_standalone)
     include("cmake/standalone.cmake")
     return()

--- a/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(TARGET_NAME protopipe)
 
 if (NOT DEFINED PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
     project(protopipe_standalone)
     include("cmake/standalone.cmake")
     return()

--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
@@ -6,7 +6,11 @@
 set(TARGET_NAME single-image-test)
 
 if (NOT DEFINED PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+    if(WIN32)
+        cmake_minimum_required(VERSION 3.16)
+    else()
+        cmake_minimum_required(VERSION 3.13)
+    endif()
     project(single-image-test_standalone)
     include("cmake/standalone.cmake")
     return()

--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(TARGET_NAME single-image-test)
 
 if (NOT DEFINED PROJECT_NAME)
-    cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
     project(single-image-test_standalone)
     include("cmake/standalone.cmake")
     return()

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_EXTENSIONS OFF)

--- a/tests/time_tests/CMakeLists.txt
+++ b/tests/time_tests/CMakeLists.txt
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.15)
+if(WIN32)
+    cmake_minimum_required(VERSION 3.16)
+else()
+    cmake_minimum_required(VERSION 3.13)
+endif()
 
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
### Details:
 - There is a customer's requirement to build NPU package with statically linked MS RT.
 - `CMAKE_MSVC_RUNTIME_LIBRARY` is supported since 3.15

### Tickets:
 - E-159926
