### PR TITLE
[GHA] Update latest artifacts link from openvino builds only

### DIFF
--- a/.github/actions/store_artifacts/store_artifacts.py
+++ b/.github/actions/store_artifacts/store_artifacts.py
@@ -139,7 +139,7 @@ def main():
             file.write(workflow_link)
         store_checksums(workflow_link_file)
 
-    if not error_found:
+    if not error_found and os.getenv('GITHUB_REPOSITORY') == 'openvinotoolkit/openvino':
         latest_artifacts_for_branch = artifact_utils.get_latest_artifacts_link(storage_dir, args.storage_root,
                                                                                args.branch_name, args.event_name)
         # Overwrite path to "latest" built artifacts only if a given commit is the head of a given branch


### PR DESCRIPTION
Quick fix for latest links overwrites from tokenizers, e.g. https://github.com/openvinotoolkit/openvino.genai/actions/runs/13773578761/job/38517620256?pr=1880