### PR TITLE
[GPU] Set dimension with min value for dynamic when creating tensor

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/common_utils.hpp
@@ -107,7 +107,7 @@ inline std::vector<cldnn::optional_data_type> get_output_data_types(const std::s
 inline ov::Shape get_tensor_shape(const ov::PartialShape& pshape) {
     ov::Shape res(pshape.size());
     for (size_t i = 0; i < pshape.size(); i++) {
-        res[i] = pshape[i].is_dynamic() ? 0 : pshape[i].get_length();
+        res[i] = pshape[i].is_dynamic() ? pshape[i].get_min_length() : pshape[i].get_length();
     }
 
     return res;


### PR DESCRIPTION
### Details:
 - Set dimension with min value for dynamic when creating tensor.
 - This solves an issue where there is an incompatibility between user tensor and port shape for dynamic shape.

### Tickets:
 - 139452
