### PR TITLE
[CPU] Remove empty catch blocks in jit_kernel.h

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -22,7 +22,6 @@
 ### Checks that are turned off but better be enabled later:
 # -bugprone-narrowing-conversions
 # -bugprone-easily-swappable-parameters
-# -bugprone-empty-catch. Better to fix, potentially hides some errors.
 # -bugprone-exception-escape. There are a lot of legacy code which does not handle exceptions properly and just catches them all. Major refactoring is required to correct this.
 # -bugprone-implicit-widening-of-multiplication-result
 # -bugprone-incorrect-roundings. There are explicit ways to perform rounding (i.e. std::floor(), std::round(), etc). Requires careful updates case by case
@@ -49,7 +48,6 @@ Checks: >
   cppcoreguidelines-prefer-member-initializer,
   readability-else-after-return,
   -bugprone-easily-swappable-parameters,
-  -bugprone-empty-catch,
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-incorrect-roundings,

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
@@ -185,11 +185,8 @@ public:
     if_expression(const boolean_expression<T>& expr) : _expr(expr) {}
 
     ~if_expression() {
-        try {
-            if (!_is_exit_valid) {
-                _expr._kernel.assignL(_exit, _else);
-            }
-        } catch (...) {
+        if (!_is_exit_valid) {
+            _expr._kernel.assignL(_exit, _else);
         }
     }
 
@@ -862,10 +859,7 @@ namespace internal {
 template <typename Reg>
 shared_reg<Reg> make_shared(Reg& reg, jit_kernel& kernel) {
     std::shared_ptr<Reg> ptr(&reg, [&kernel](Reg* preg) {
-        try {
-            kernel.free(*preg);
-        } catch (...) {
-        }
+        kernel.free(*preg);
     });
     return ptr;
 }


### PR DESCRIPTION
### Details:
Remove bugprone suppression of any kinds of exceptions in `if_expression` destructor and `make_shared` call for registers in jit_kernel.h

### Tickets:
 - N/A
