### PR TITLE
[Py OV] Core().compile_model(tokenizer, "CPU") fails

### DIFF
--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -404,18 +404,16 @@ ov::AnyMap py_object_to_any_map(const py::object& py_obj) {
     return return_value;
 }
 
-template <typename... Args, std::size_t... I>
-std::tuple<Args...> tuple_from_py_tuple_impl(const py::tuple& py_tuple, std::index_sequence<I...>) {
-    return std::make_tuple(py_tuple[I].cast<Args>()...);
-}
-
 template <typename... Args>
 std::tuple<Args...> tuple_from_py_tuple(const py::tuple& py_tuple) {
     if (py_tuple.size() != sizeof...(Args)) {
         OPENVINO_THROW(false, "Size of py::tuple does not match size of std::tuple");
     }
-
-    return tuple_from_py_tuple_impl<Args...>(py_tuple, std::index_sequence_for<Args...>{});
+    auto tuple_from_py_tuple_impl = []<std::size_t... I>(const py::tuple& py_tuple,
+                                                         std::index_sequence<I...>) -> std::tuple<Args...> {
+        return std::make_tuple(py_tuple[I].cast<Args>()...);
+    };
+    return tuple_from_py_tuple_impl(py_tuple, std::index_sequence_for<Args...>{});
 }
 
 ov::Any py_object_to_any(const py::object& py_obj) {

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -411,7 +411,7 @@ std::tuple<Args...> tuple_from_py_tuple_impl(const py::tuple& py_tuple, std::ind
 
 template <typename... Args>
 std::tuple<Args...> tuple_from_py_tuple(const py::tuple& py_tuple) {
-    OPENVINO_ASSERT(py_tuple.size() != sizeof...(Args), "Size of py::tuple does not match size of std::tuple");
+    OPENVINO_ASSERT(py_tuple.size() == sizeof...(Args), "Size of py::tuple does not match size of std::tuple");
 
     return tuple_from_py_tuple_impl<Args...>(py_tuple, std::index_sequence_for<Args...>{});
 }

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -409,8 +409,8 @@ std::tuple<Args...> tuple_from_py_tuple(const py::tuple& py_tuple) {
     if (py_tuple.size() != sizeof...(Args)) {
         OPENVINO_THROW(false, "Size of py::tuple does not match size of std::tuple");
     }
-    auto tuple_from_py_tuple_impl = []<std::size_t... I>(const py::tuple& py_tuple,
-                                                         std::index_sequence<I...>) -> std::tuple<Args...> {
+    auto tuple_from_py_tuple_impl =
+        []<std::size_t... I>(const py::tuple& py_tuple, std::index_sequence<I...>)->std::tuple<Args...> {
         return std::make_tuple(py_tuple[I].cast<Args>()...);
     };
     return tuple_from_py_tuple_impl(py_tuple, std::index_sequence_for<Args...>{});

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -433,6 +433,15 @@ ov::Any py_object_to_any(const py::object& py_obj) {
         return py_obj.cast<int64_t>();
     } else if (py::isinstance<py::none>(py_obj)) {
         return {};
+    } else if (py::isinstance(py_obj, py::module_::import("enum").attr("Enum"))) {
+        const auto value = py::cast<py::object>(py_obj).attr("value");
+        if (py::isinstance<py::int_>(value)) {
+            return value.cast<int64_t>();
+        } else if (py::isinstance<py::str>(value)) {
+            return value.cast<std::string>();
+        } else {
+            OPENVINO_THROW("Unsupported enum type.");
+        }
     } else if (py::isinstance<py::list>(py_obj)) {
         auto _list = py_obj.cast<py::list>();
 

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -465,13 +465,13 @@ ov::Any py_object_to_any(const py::object& py_obj) {
             OPENVINO_ASSERT(false, "Unsupported attribute type.");
         }
     } else if (py::isinstance<py::tuple>(py_obj)) {
-        auto _tuple = py::cast<py::tuple>(py_obj);
+        const auto _tuple = py::cast<py::tuple>(py_obj);
         if (_tuple.size() == 2) {
             return tuple_from_py_tuple<unsigned int, unsigned int>(_tuple);
         } else if (_tuple.size() == 3) {
             return tuple_from_py_tuple<unsigned int, unsigned int, unsigned int>(_tuple);
         } else {
-            OPENVINO_ASSERT(false, "Unsupported tuple size");
+            OPENVINO_THROW("Unsupported tuple size");
         }
         // OV types
     } else if (py_object_is_any_map(py_obj)) {

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -404,16 +404,16 @@ ov::AnyMap py_object_to_any_map(const py::object& py_obj) {
     return return_value;
 }
 
+template <typename... Args, std::size_t... I>
+std::tuple<Args...> tuple_from_py_tuple_impl(const py::tuple& py_tuple, std::index_sequence<I...>) {
+    return std::make_tuple(py_tuple[I].cast<Args>()...);
+}
+
 template <typename... Args>
 std::tuple<Args...> tuple_from_py_tuple(const py::tuple& py_tuple) {
-    if (py_tuple.size() != sizeof...(Args)) {
-        OPENVINO_THROW(false, "Size of py::tuple does not match size of std::tuple");
-    }
-    auto tuple_from_py_tuple_impl =
-        []<std::size_t... I>(const py::tuple& py_tuple, std::index_sequence<I...>)->std::tuple<Args...> {
-        return std::make_tuple(py_tuple[I].cast<Args>()...);
-    };
-    return tuple_from_py_tuple_impl(py_tuple, std::index_sequence_for<Args...>{});
+    OPENVINO_ASSERT(py_tuple.size() != sizeof...(Args), "Size of py::tuple does not match size of std::tuple");
+
+    return tuple_from_py_tuple_impl<Args...>(py_tuple, std::index_sequence_for<Args...>{});
 }
 
 ov::Any py_object_to_any(const py::object& py_obj) {

--- a/src/bindings/python/src/pyopenvino/utils/utils.cpp
+++ b/src/bindings/python/src/pyopenvino/utils/utils.cpp
@@ -267,6 +267,10 @@ py::object from_ov_any(const ov::Any& any) {
         return py::cast(any.as<ov::frontend::type::PyNone>());
     } else if (any.is<ov::frontend::type::PyScalar>()) {
         return py::cast(any.as<ov::frontend::type::PyScalar>());
+        // Check for py::object of type enum.Enum
+    } else if (auto enum_ptr = any.as<std::shared_ptr<py::object>>();
+               enum_ptr && py::isinstance(*enum_ptr, py::module_::import("enum").attr("Enum"))) {
+        return *enum_ptr;
     } else {
         PyErr_SetString(PyExc_TypeError, "Failed to convert parameter to Python representation!");
         return py::cast<py::object>((PyObject*)NULL);
@@ -417,6 +421,8 @@ ov::Any py_object_to_any(const py::object& py_obj) {
         return py_obj.cast<double>();
     } else if (py::isinstance(py_obj, float_32_type)) {
         return py_obj.cast<float>();
+    } else if (py::isinstance(py_obj, py::module_::import("enum").attr("Enum"))) {
+        return std::make_shared<py::object>(std::move(py_obj));
     } else if (py::isinstance<py::int_>(py_obj)) {
         return py_obj.cast<int64_t>();
     } else if (py::isinstance<py::none>(py_obj)) {

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -25,6 +25,7 @@ from openvino import (
     get_batch,
     serialize,
     save_model,
+    OVAny,
 )
 from openvino import Output
 from openvino.op.util import VariableInfo, Variable
@@ -736,6 +737,21 @@ def test_serialize_complex_rt_info(request, tmp_path):
 
     os.remove(xml_path)
     os.remove(bin_path)
+
+
+def test_rt_info_gil():
+    model = generate_add_model()
+
+    from enum import Enum
+    class EnumInfo(Enum):
+        INFO_A: str = "info_a"
+
+    core = Core()
+    model.set_rt_info(EnumInfo.INFO_A, "EnumInfo")
+    core.compile_model(model, "CPU")
+    assert model.get_rt_info("EnumInfo").value == EnumInfo.INFO_A
+    assert type(model.get_rt_info("EnumInfo").value) == EnumInfo
+    assert type(model.get_rt_info("EnumInfo")) == OVAny
 
 
 def test_model_add_remove_result_parameter_sink():

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -743,7 +743,7 @@ def test_rt_info_gil():
     model = generate_add_model()
 
     from enum import Enum
-    
+
     class EnumInfo(Enum):
         INFO_A: str = "info_a"
 

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -738,6 +738,19 @@ def test_serialize_complex_rt_info(request, tmp_path):
     os.remove(bin_path)
 
 
+def test_rt_info_gil():
+    model = generate_add_model()
+
+    from enum import Enum
+    class EnumInfo(Enum):
+        INFO_A: str = "info_a"
+
+    core = Core()
+    model.set_rt_info(EnumInfo.INFO_A, "EnumInfo")
+    core.compile_model(model, "CPU")
+    assert model.get_rt_info("EnumInfo") == EnumInfo.INFO_A
+
+
 def test_model_add_remove_result_parameter_sink():
     param = ops.parameter(PartialShape([1]), dtype=np.float32, name="param")
     relu1 = ops.relu(param, name="relu1")

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -738,19 +738,6 @@ def test_serialize_complex_rt_info(request, tmp_path):
     os.remove(bin_path)
 
 
-def test_rt_info_gil():
-    model = generate_add_model()
-    from enum import Enum
-
-    class EnumInfo(Enum):
-        INFO_A: str = "info_a"
-
-    core = Core()
-    model.set_rt_info(EnumInfo.INFO_A, "EnumInfo")
-    core.compile_model(model, "CPU")
-    assert model.get_rt_info("EnumInfo") == EnumInfo.INFO_A
-
-
 def test_model_add_remove_result_parameter_sink():
     param = ops.parameter(PartialShape([1]), dtype=np.float32, name="param")
     relu1 = ops.relu(param, name="relu1")

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -743,6 +743,7 @@ def test_rt_info_gil():
     model = generate_add_model()
 
     from enum import Enum
+    
     class EnumInfo(Enum):
         INFO_A: str = "info_a"
 

--- a/src/bindings/python/tests/test_runtime/test_model.py
+++ b/src/bindings/python/tests/test_runtime/test_model.py
@@ -740,8 +740,8 @@ def test_serialize_complex_rt_info(request, tmp_path):
 
 def test_rt_info_gil():
     model = generate_add_model()
-
     from enum import Enum
+
     class EnumInfo(Enum):
         INFO_A: str = "info_a"
 


### PR DESCRIPTION
### Details:
 - Cause: `openvino_tokenizers` Python object  `constants.UTF8ReplaceMode`, which inherits from python `enum.Enum`, is set on C++ `openvino.Model` using `model.set_rt_info()`. It fails when GIL is released in `model.compile_model()`
	
 - Fix: Use `std::shared_ptr` to properly manage python object reference lifetime on C++ side.
 - Accordind to [docs](https://docs.python.org/3/library/enum.html#module-contents) `Enum` is "Base class for creating enumerated constants."
 - What may need discussion? 
   - <s>I added the fix to `py_object_to_any()`/`from_ov_any()` methods. Maybe it should be narrowed specifically to `model.set_rt_info()` and `model.get_rt_info()`</s>
   
	
To reproduce use openvino in Debug mode:
```python
model = generate_add_model()

from enum import Enum
class EnumInfo(Enum):
    INFO_A: str = "info_a"

core = Core()
model.set_rt_info(EnumInfo.INFO_A, "EnumInfo")
core.compile_model(model, "CPU")
assert model.get_rt_info("EnumInfo").value == EnumInfo.INFO_A
assert type(model.get_rt_info("EnumInfo").value) == EnumInfo
assert type(model.get_rt_info("EnumInfo")) == OVAny
```

### Tickets:
 - [CVS-163166](https://jira.devtools.intel.com/browse/CVS-163166)
