### PR TITLE
[TESTS] Skip RMSNorm tests on older torch

### DIFF
--- a/tests/layer_tests/pytorch_tests/test_norm.py
+++ b/tests/layer_tests/pytorch_tests/test_norm.py
@@ -392,8 +392,8 @@ class TestRMSNorm(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_torch_export
-    @pytest.mark.skipif(version.parse(torch.__version__) < version.parse("2.3"),
-                        reason="Not supported in PyTorch versions earlier than 2.3.")
+    @pytest.mark.skipif(version.parse(torch.__version__) < version.parse("2.4"),
+                        reason="Not supported in PyTorch versions earlier than 2.4.")
     @pytest.mark.parametrize("normalized_shape", [[10,],
                                                   [10, 10],
                                                   [5, 10, 10]])

--- a/tests/layer_tests/pytorch_tests/test_norm.py
+++ b/tests/layer_tests/pytorch_tests/test_norm.py
@@ -6,6 +6,7 @@ import platform
 import numpy as np
 import pytest
 import torch
+from packaging import version
 
 from pytorch_layer_test_class import PytorchLayerTest
 
@@ -391,6 +392,8 @@ class TestRMSNorm(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_torch_export
+    @pytest.mark.skipif(version.parse(torch.__version__) < version.parse("2.3"),
+                        reason="Not supported in PyTorch versions earlier than 2.3.")
     @pytest.mark.parametrize("normalized_shape", [[10,],
                                                   [10, 10],
                                                   [5, 10, 10]])


### PR DESCRIPTION
### Details:
 - *Skip RMSNorm tests on older torch*

### Tickets:
 - *CVS-163922*
