### PR TITLE
[SI] Removes unpredictable rt_info copying from partial value propagation

### DIFF
--- a/src/common/transformations/src/transformations/symbolic_transformations/dereshape_matmul.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/dereshape_matmul.cpp
@@ -113,6 +113,7 @@ ov::Output<ov::Node> get_target_shape_from_sources(const ov::Output<ov::Node>& b
         if (curr_is_const && next_is_const) {
             dims[curr_i] = nullptr;
             dims[curr_i + 1] = ov::op::util::make_try_fold<ov::op::v0::Concat>(ov::NodeVector{curr_node, next_node}, 0);
+            ov::copy_runtime_info(copy_rt_info_from, dims[curr_i + 1]);
         }
     }
     dims.erase(std::remove_if(dims.begin(),
@@ -327,7 +328,8 @@ ov::pass::DeReshapeMatMul::DeReshapeMatMul() {
             auto other_input_reshape =
                 op::util::make_try_fold<ov::op::v1::Reshape>(add_node->input_value(non_matmul_port), pattern, true);
             add_node->input(non_matmul_port).replace_source_output(other_input_reshape->output(0));
-            ov::copy_runtime_info({in_reshape_0, in_reshape_1}, {first_batch_dim, minus_one, other_input_reshape});
+            ov::copy_runtime_info({in_reshape_0, in_reshape_1},
+                                  {first_batch_dim, minus_one, other_input_reshape, pattern});
             add_node->validate_and_infer_types();
         }
         ov::replace_output_update_name(out_reshape->output(0), out_reshape->input_value(0));

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_slice.cpp
@@ -43,6 +43,7 @@ TSSliceForward::TSSliceForward() {
                                                            transpose_axis_order);
         const auto& indices = main_node->input_value(4);
         auto new_axis = std::make_shared<ov::op::v8::Gather>(data, indices, axis);
+        ov::copy_runtime_info(indices.get_node_shared_ptr(), new_axis);
 
         main_node->input(4).replace_source_output(new_axis);
 
@@ -96,6 +97,7 @@ TSSliceBackward::TSSliceBackward() {
                                                            reversed_transpose_order);
         const auto& indices = main_node->input_value(4);
         auto new_axis = std::make_shared<ov::op::v8::Gather>(data, indices, axis);
+        ov::copy_runtime_info(indices.get_node_shared_ptr(), new_axis);
         main_node->input(4).replace_source_output(new_axis);
 
         main_node->validate_and_infer_types();


### PR DESCRIPTION
### Details:
 - *Current rt_info propagation function doesn't do what it says it should do. And it works in a predictably bad manner.*

### Tickets:
 - *DeepSeek R1 related: CVS-162883,CVS-164161*
