### PR TITLE
[GPU] Extend OptimizeSubsequentReshapes pass to support any cases with a single dynamic dimension

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/optimize_subsequent_reshapes.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/optimize_subsequent_reshapes.cpp
@@ -18,7 +18,7 @@ OptimizeSubsequentReshapes::OptimizeSubsequentReshapes() {
     using namespace ov::pass::pattern;
     using ov::pass::pattern::op::Or;
 
-    auto dynamic_batch_only = [](Output<Node> output) {
+    auto single_dynamic_dim = [](Output<Node> output) {
         const auto& shape = output.get_partial_shape();
 
         if (shape.rank().is_dynamic())
@@ -27,23 +27,23 @@ OptimizeSubsequentReshapes::OptimizeSubsequentReshapes() {
         if (shape.size() <= 1)
             return false;
 
-        if (shape[0].is_static())
-            return false;
+        auto dynamic_dims = 0;
+        for (size_t i = 0; i < shape.size(); i++)
+            dynamic_dims += shape[i].is_dynamic() ? 1 : 0;
 
-        for (size_t i = 1; i < shape.size(); i++)
-            if (shape[i].is_dynamic())
-                return false;
+        if (dynamic_dims != 1)
+            return false;
 
         return true;
     };
 
-    auto first_reshape_data = any_input(dynamic_batch_only);
+    auto first_reshape_data = any_input(single_dynamic_dim);
     auto first_reshape_pattern = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
     auto first_reshape = wrap_type<ov::op::v1::Reshape>({ first_reshape_data, first_reshape_pattern },
-                                                        dynamic_batch_only && ov::pass::pattern::consumers_count(1));
+                                                        single_dynamic_dim && ov::pass::pattern::consumers_count(1));
 
     auto second_reshape_pattern = ov::pass::pattern::wrap_type<ov::op::v0::Constant>();
-    auto second_reshape = wrap_type<ov::op::v1::Reshape>({ first_reshape, second_reshape_pattern }, dynamic_batch_only);
+    auto second_reshape = wrap_type<ov::op::v1::Reshape>({ first_reshape, second_reshape_pattern }, single_dynamic_dim);
 
     ov::matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();
@@ -74,14 +74,14 @@ OptimizeSubsequentReshapes::OptimizeSubsequentReshapes() {
         std::vector<int32_t> new_pattern;
         for (auto& dim : second_reshape_ps) {
             if (dim.is_dynamic()) {
-                new_pattern.push_back(0);
+                new_pattern.push_back(-1);
             } else {
                 new_pattern.push_back(dim.get_length());
             }
         }
 
         auto new_pattern_const = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{new_pattern.size()}, new_pattern);
-        auto new_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape_node->input(0).get_source_output(), new_pattern_const, true);
+        auto new_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape_node->input(0).get_source_output(), new_pattern_const, false);
         new_reshape->set_friendly_name(second_reshape_node->get_friendly_name());
 
         ov::replace_node(second_reshape_node, new_reshape);


### PR DESCRIPTION
### Details:
 - Extend OptimizeSubsequentReshapes pass to support any cases with a single dynamic dimension. This allows to optimize two subsequent Reshape nodes and propagate properly dynamic padding, preventing explicit Reshape execution (and runtime static kernel compilation) and improving performance. This change fixes chatglm-3 model performance for CB pipeline 

### Tickets:
 - [CVS-162284](https://jira.devtools.intel.com/browse/CVS-162284)