### PR TITLE
[GPU] Separate input and weight rank check for reordered case in gemm

### DIFF
--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -179,10 +179,11 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
     auto input0_pshape = input_layouts[0].get_partial_shape();
     auto input1_pshape = input_layouts[1].get_partial_shape();
 
-    bool reordered = primitive->input_rank > 4 || primitive->weight_rank > 4;
+    bool input_reordered = primitive->input_rank > 4;
+    bool weight_reordered = primitive->weight_rank > 4;
     size_t output_rank = std::max(primitive->input_rank, primitive->weight_rank);
-    size_t input_rank = reordered ? output_rank : primitive->input_rank;
-    size_t weight_rank = reordered ? output_rank : primitive->weight_rank;
+    size_t input_rank = input_reordered ? output_rank : primitive->input_rank;
+    size_t weight_rank = weight_reordered ? output_rank : primitive->weight_rank;
 
     auto transposed_input0_pshape = get_transposed_input_shape(input0_pshape, input_rank, output_rank, primitive->transpose_input0, true);
     auto transposed_input1_pshape = get_transposed_input_shape(input1_pshape, weight_rank, output_rank, primitive->transpose_input1, false);

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -132,6 +132,9 @@ std::vector<layout> gemm_inst::calc_output_layouts(gemm_node const& node, const 
                                                                           prim->output_transpose_order);
 
     cldnn::format output_format = input0_layout.format;
+    // Format update for rank > 4 case
+    if (output_shapes[0].size() > output_format.dims_order().size())
+        output_format = cldnn::format::get_default_format(output_shapes[0].size());
     if (node.get_preferred_output_fmt() != format::any)
         output_format = node.get_preferred_output_fmt();
 
@@ -188,6 +191,9 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
     auto transposed_input1_pshape = get_transposed_input_shape(input1_pshape, weight_rank, output_rank, primitive->transpose_input1, false);
 
     std::vector<layout> layouts = input_layouts;
+    // Format update for rank > 4 case
+    if (layouts[0].format.dimension() < transposed_input0_pshape.size())
+        layouts[0].format = cldnn::format::get_default_format(transposed_input0_pshape.size());
     layouts[0].set_partial_shape(transposed_input0_pshape);
     layouts[1].set_partial_shape(transposed_input1_pshape);
 

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -179,11 +179,10 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
     auto input0_pshape = input_layouts[0].get_partial_shape();
     auto input1_pshape = input_layouts[1].get_partial_shape();
 
-    bool input_reordered = primitive->input_rank > 4;
-    bool weight_reordered = primitive->weight_rank > 4;
+    bool reordered = primitive->input_rank > 4 || primitive->weight_rank > 4;
     size_t output_rank = std::max(primitive->input_rank, primitive->weight_rank);
-    size_t input_rank = input_reordered ? output_rank : primitive->input_rank;
-    size_t weight_rank = weight_reordered ? output_rank : primitive->weight_rank;
+    size_t input_rank = (reordered && (input0_pshape.size() > primitive->input_rank))  ? output_rank : primitive->input_rank;
+    size_t weight_rank = (reordered && (input1_pshape.size() > primitive->weight_rank)) ? output_rank : primitive->weight_rank;
 
     auto transposed_input0_pshape = get_transposed_input_shape(input0_pshape, input_rank, output_rank, primitive->transpose_input0, true);
     auto transposed_input1_pshape = get_transposed_input_shape(input1_pshape, weight_rank, output_rank, primitive->transpose_input1, false);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gemm.cpp
@@ -275,7 +275,8 @@ public:
         const auto& primitive = impl_params.typed_desc<gemm>();
         auto updated_impl_params = canonicalize_fused_shapes(impl_params);
 
-        updated_impl_params.input_layouts = gemm_inst::transform_input_layouts(primitive, impl_params.input_layouts);
+        updated_impl_params.input_layouts = gemm_inst::transform_input_layouts(primitive, impl_params.input_layouts,
+                                                                               impl_params.get_program().is_new_shape_infer());
         updated_impl_params.output_layouts[0] = gemm_inst::transform_output_layout(primitive, updated_impl_params.input_layouts, impl_params.output_layouts[0]);
 
         for (auto& input_layout : updated_impl_params.input_layouts) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/gemm_onednn.cpp
@@ -84,7 +84,7 @@ protected:
         if (gemm_with_bias) {
             in_layouts.emplace_back(impl_params.get_input_layout(2));
         }
-        in_layouts = gemm_inst::transform_input_layouts(prim, in_layouts);
+        in_layouts = gemm_inst::transform_input_layouts(prim, in_layouts, impl_params.get_program().is_new_shape_infer());
         out_l = gemm_inst::transform_output_layout(prim, in_layouts, out_l);
 
         const auto& in0_l = in_layouts[0];

--- a/src/plugins/intel_gpu/src/graph/include/gemm_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/gemm_inst.h
@@ -34,7 +34,8 @@ public:
     static std::string to_string(gemm_node const& node);
 
     static std::vector<layout> transform_input_layouts(const std::shared_ptr<const gemm> primitive,
-                                                       const std::vector<layout>& input_layouts);
+                                                       const std::vector<layout>& input_layouts,
+                                                       const bool allow_new_shape_infer);
     static layout transform_output_layout(const std::shared_ptr<const gemm> primitive, const std::vector<layout>& input_layouts, const layout& output_layout);
 
     static bool is_fusable_permute_input_order_onednn(const std::vector<size_t>& permute_order, format& fmt) {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/matmul.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/matmul.cpp
@@ -575,7 +575,14 @@ const std::vector<ShapeRelatedParams> IS_Dynamic = {
             {{ {1, 5}, 12, -1, 4 }, {{ 1, 12, 16, 4 }, { 1, 12, 16, 4 }}}  // input 1
         },
         {false, false}
-    }
+    },
+    {
+        { //dynamic case description each pair per each input has {{dynamic shape}, {{static shape case1}, {static shape case2}, ...}
+            {{}, {{64, 64}}}, // input 0
+            {{-1, 128, 33, 64, 1}, {{1, 128, 33, 64, 1}}}  // input 1
+        },
+        {false, false}
+    },
 };
 
 const std::vector<ShapeRelatedParams> IS_Dynamic_nightly = {


### PR DESCRIPTION
### Details:
 - Separate input and weight rank check for reordered case in gemm to avoid exception from non reordered input (input0 in below layer)
![image](https://github.com/user-attachments/assets/283e7a7c-1bb2-42d7-a655-3dad6531850f)

 - convert_data_tensor() returns wrong data tensor when size of format.dims_order() is not same with shape.size(). So gemm need to set proper format for shape.size() in input/output layout.

### Tickets:
 - 163982
