### PR TITLE
Skip Constant data copy during partial value propagation

### DIFF
--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -660,13 +660,13 @@ bool Constant::has_evaluate() const {
 bool Constant::evaluate_lower(TensorVector& outputs) const {
     outputs.resize(1);
     outputs[0] = get_tensor_view();
-    return get_data_ptr();
+    return get_data_ptr() != nullptr;
 }
 
 bool Constant::evaluate_upper(TensorVector& outputs) const {
     outputs.resize(1);
     outputs[0] = get_tensor_view();
-    return get_data_ptr();
+    return get_data_ptr() != nullptr;
 }
 
 bool Constant::can_constant_fold(const OutputVector& input_values) const {

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -659,7 +659,7 @@ bool Constant::has_evaluate() const {
 
 bool Constant::evaluate_lower(TensorVector& outputs) const {
     if (!outputs.empty() && outputs[0].get_element_type() != m_element_type)
-        return evaluate(outputs, {}); // for TypeRelaxed<Constant>
+        return evaluate(outputs, {});  // for TypeRelaxed<Constant>
     outputs.resize(1);
     outputs[0] = get_tensor_view();
     return get_data_ptr() != nullptr;
@@ -667,7 +667,7 @@ bool Constant::evaluate_lower(TensorVector& outputs) const {
 
 bool Constant::evaluate_upper(TensorVector& outputs) const {
     if (!outputs.empty() && outputs[0].get_element_type() != m_element_type)
-        return evaluate(outputs, {}); // for TypeRelaxed<Constant>
+        return evaluate(outputs, {});  // for TypeRelaxed<Constant>
     outputs.resize(1);
     outputs[0] = get_tensor_view();
     return get_data_ptr() != nullptr;

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -658,10 +658,15 @@ bool Constant::has_evaluate() const {
 }
 
 bool Constant::evaluate_lower(TensorVector& outputs) const {
-    return evaluate(outputs, {});
+    outputs.resize(1);
+    outputs[0] = get_tensor_view();
+    return get_data_ptr();
 }
+
 bool Constant::evaluate_upper(TensorVector& outputs) const {
-    return evaluate(outputs, {});
+    outputs.resize(1);
+    outputs[0] = get_tensor_view();
+    return get_data_ptr();
 }
 
 bool Constant::can_constant_fold(const OutputVector& input_values) const {

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -658,12 +658,16 @@ bool Constant::has_evaluate() const {
 }
 
 bool Constant::evaluate_lower(TensorVector& outputs) const {
+    if (!outputs.empty() && outputs[0].get_element_type() != m_element_type)
+        return evaluate(outputs, {}); // for TypeRelaxed<Constant>
     outputs.resize(1);
     outputs[0] = get_tensor_view();
     return get_data_ptr() != nullptr;
 }
 
 bool Constant::evaluate_upper(TensorVector& outputs) const {
+    if (!outputs.empty() && outputs[0].get_element_type() != m_element_type)
+        return evaluate(outputs, {}); // for TypeRelaxed<Constant>
     outputs.resize(1);
     outputs[0] = get_tensor_view();
     return get_data_ptr() != nullptr;


### PR DESCRIPTION
### Details:
 - *Skip Constant data copy during partial value propagation*

### Tickets:
 - *DeepSeek R1 related: CVS-162883,CVS-164161*