### PR TITLE
[Snippets][CPU] Fixed and Improvements for PerfCounters

### DIFF
--- a/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
+++ b/src/common/snippets/src/lowered/pass/insert_perf_count.cpp
@@ -41,7 +41,11 @@ bool InsertPerfCount::run(LinearIR& linear_ir, lowered::LinearIR::constExprIt be
             const auto empty_inputs = std::vector<PortConnectorPtr>{};
             linear_ir.insert_node(perf_count_begin, empty_inputs, perf_count_begin_pos->get()->get_loop_ids(), false, perf_count_begin_pos);
 
-            const auto& perf_count_end = std::make_shared<snippets::op::PerfCountEnd>(perf_count_begin->output(0));
+            // Unique ConsoleDumper for each PerfCounter pair
+            std::vector<std::shared_ptr<snippets::utils::Dumper>> dumpers;
+            dumpers.push_back(std::make_shared<snippets::utils::ConsoleDumper>());
+
+            const auto& perf_count_end = std::make_shared<snippets::op::PerfCountEnd>(perf_count_begin->output(0), dumpers);
             perf_count_end->set_friendly_name(std::string("PerfCount_End_") + std::to_string(seq_number));
             // linear_ir.insert has insert before behavior, need to increment perf_count_end_pos
             linear_ir.insert_node(perf_count_end, empty_inputs, perf_count_end_pos->get()->get_loop_ids(), false, next(perf_count_end_pos));

--- a/src/common/snippets/src/op/perf_count.cpp
+++ b/src/common/snippets/src/op/perf_count.cpp
@@ -189,7 +189,7 @@ PerfCountEnd::~PerfCountEnd() {
 }
 
 std::shared_ptr<Node> PerfCountEnd::clone_with_new_inputs(const OutputVector& inputs) const {
-    return std::make_shared<PerfCountEnd>(inputs.at(0));
+    return std::make_shared<PerfCountEnd>(inputs.at(0), dumpers);
 }
 
 void PerfCountEnd::set_accumulated_time() {

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -486,7 +486,8 @@ void Subgraph::control_flow_transformations(size_t min_parallel_work_amount, siz
 
 #ifdef SNIPPETS_DEBUG_CAPS
     if (m_linear_ir->get_config().debug_config->perf_count_mode != DebugCapsConfig::PerfCountMode::Disabled) {
-        lowered::pass::InsertPerfCount perf_count_pass({});
+        const std::map<std::string, std::string> bound_names = {};
+        lowered::pass::InsertPerfCount perf_count_pass(bound_names);
         perf_count_pass.run(*m_linear_ir, m_linear_ir->cbegin(), m_linear_ir->cend());
     }
 #endif

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -285,9 +285,9 @@ intel_cpu::CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t ho
 
 #ifdef SNIPPETS_DEBUG_CAPS
     jitters[snippets::op::PerfCountBegin::get_type_info_static()] =
-        CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_chrono_start_emitter);
+        CREATE_SNIPPETS_EMITTER(ov::intel_cpu::jit_perf_count_chrono_start_emitter);
     jitters[snippets::op::PerfCountEnd::get_type_info_static()] =
-        CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_chrono_end_emitter);
+        CREATE_SNIPPETS_EMITTER(ov::intel_cpu::jit_perf_count_chrono_end_emitter);
     jitters[ov::intel_cpu::PerfCountRdtscBegin::get_type_info_static()] =
         CREATE_CPU_EMITTER(ov::intel_cpu::jit_perf_count_rdtsc_start_emitter);
     jitters[ov::intel_cpu::PerfCountRdtscEnd::get_type_info_static()] =

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_perf_count_chrono_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_perf_count_chrono_emitters.cpp
@@ -16,11 +16,12 @@ using namespace Xbyak::util;
 
 namespace ov::intel_cpu {
 
-jit_perf_count_chrono_start_emitter::jit_perf_count_chrono_start_emitter(dnnl::impl::cpu::x64::jit_generator* host,
-                                                                         dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                                                                         const std::shared_ptr<ov::Node>& n)
-    : jit_emitter(host, host_isa) {
-    m_start_node = ov::as_type_ptr<snippets::op::PerfCountBegin>(n);
+jit_perf_count_chrono_start_emitter::jit_perf_count_chrono_start_emitter(
+    dnnl::impl::cpu::x64::jit_generator* host,
+    dnnl::impl::cpu::x64::cpu_isa_t host_isa,
+    const ov::snippets::lowered::ExpressionPtr& expr)
+    : jit_binary_call_emitter(host, host_isa, expr->get_live_regs()) {
+    m_start_node = ov::as_type_ptr<snippets::op::PerfCountBegin>(expr->get_node());
 }
 
 size_t jit_perf_count_chrono_start_emitter::get_inputs_num() const {
@@ -33,15 +34,19 @@ void jit_perf_count_chrono_start_emitter::set_start_time(snippets::op::PerfCount
 
 void jit_perf_count_chrono_start_emitter::emit_impl(const std::vector<size_t>& in_idxs,
                                                     const std::vector<size_t>& out_idxs) const {
+    init_binary_call_regs(0, {});
+    const Xbyak::Reg64& aux_reg = get_call_address_reg();
+    const Xbyak::Reg64& callee_saved_reg = get_callee_saved_reg();
+
     EmitABIRegSpills spill(h);
-    spill.preamble();
+    spill.preamble(get_regs_to_spill());
 
     const auto& set_start_time_overload = static_cast<void (*)(snippets::op::PerfCountBegin*)>(set_start_time);
-    h->mov(h->rax, reinterpret_cast<size_t>(set_start_time_overload));
+    h->mov(aux_reg, reinterpret_cast<size_t>(set_start_time_overload));
     h->mov(abi_param1, reinterpret_cast<size_t>(m_start_node.get()));
 
-    spill.rsp_align(h->rbx.getIdx());
-    h->call(h->rax);
+    spill.rsp_align(callee_saved_reg.getIdx());
+    h->call(aux_reg);
     spill.rsp_restore();
 
     spill.postamble();
@@ -50,9 +55,9 @@ void jit_perf_count_chrono_start_emitter::emit_impl(const std::vector<size_t>& i
 ///////////////////jit_perf_count_chrono_end_emitter////////////////////////////////////
 jit_perf_count_chrono_end_emitter::jit_perf_count_chrono_end_emitter(dnnl::impl::cpu::x64::jit_generator* host,
                                                                      dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                                                                     const std::shared_ptr<ov::Node>& n)
-    : jit_emitter(host, host_isa) {
-    m_end_node = ov::as_type_ptr<snippets::op::PerfCountEnd>(n);
+                                                                     const ov::snippets::lowered::ExpressionPtr& expr)
+    : jit_binary_call_emitter(host, host_isa, expr->get_live_regs()) {
+    m_end_node = ov::as_type_ptr<snippets::op::PerfCountEnd>(expr->get_node());
 }
 
 size_t jit_perf_count_chrono_end_emitter::get_inputs_num() const {
@@ -65,16 +70,20 @@ void jit_perf_count_chrono_end_emitter::set_accumulated_time(snippets::op::PerfC
 
 void jit_perf_count_chrono_end_emitter::emit_impl(const std::vector<size_t>& in_idxs,
                                                   const std::vector<size_t>& out_idxs) const {
+    init_binary_call_regs(0, {});
+    const Xbyak::Reg64& aux_reg = get_call_address_reg();
+    const Xbyak::Reg64& callee_saved_reg = get_callee_saved_reg();
+
     EmitABIRegSpills spill(h);
-    spill.preamble();
+    spill.preamble(get_regs_to_spill());
 
     const auto& set_accumulated_time_overload =
         static_cast<void (*)(snippets::op::PerfCountEnd*)>(set_accumulated_time);
-    h->mov(h->rax, reinterpret_cast<size_t>(set_accumulated_time_overload));
+    h->mov(aux_reg, reinterpret_cast<size_t>(set_accumulated_time_overload));
     h->mov(abi_param1, reinterpret_cast<size_t>(m_end_node.get()));
 
-    spill.rsp_align(h->rbx.getIdx());
-    h->call(h->rax);
+    spill.rsp_align(callee_saved_reg.getIdx());
+    h->call(aux_reg);
     spill.rsp_restore();
 
     spill.postamble();

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_perf_count_chrono_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_perf_count_chrono_emitters.hpp
@@ -5,16 +5,16 @@
 
 #    pragma once
 
-#    include "emitters/plugin/x64/jit_emitter.hpp"
+#    include "jit_binary_call_emitter.hpp"
 #    include "snippets/op/perf_count.hpp"
 
 namespace ov::intel_cpu {
 
-class jit_perf_count_chrono_start_emitter : public jit_emitter {
+class jit_perf_count_chrono_start_emitter : public jit_binary_call_emitter {
 public:
     jit_perf_count_chrono_start_emitter(dnnl::impl::cpu::x64::jit_generator* host,
                                         dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                                        const std::shared_ptr<ov::Node>& n);
+                                        const ov::snippets::lowered::ExpressionPtr& expr);
     size_t get_inputs_num() const override;
 
 private:
@@ -24,11 +24,11 @@ private:
     std::shared_ptr<snippets::op::PerfCountBegin> m_start_node = nullptr;
 };
 
-class jit_perf_count_chrono_end_emitter : public jit_emitter {
+class jit_perf_count_chrono_end_emitter : public jit_binary_call_emitter {
 public:
     jit_perf_count_chrono_end_emitter(dnnl::impl::cpu::x64::jit_generator* host,
                                       dnnl::impl::cpu::x64::cpu_isa_t host_isa,
-                                      const std::shared_ptr<ov::Node>& n);
+                                      const ov::snippets::lowered::ExpressionPtr& expr);
     size_t get_inputs_num() const override;
 
 private:


### PR DESCRIPTION
### Details:
 - *Added missed dumping in `InsertPerfCount` and copy of dumpers in `PerfCountEnd::clone_with_new_inputs()`.*
 - *Added only live register spills in JIT emitters of perf counters to avoid extra overheads*

### Tickets:
 - *N/A*
