### PR TITLE
[CPU][ARM] Fix RandomUniform TF node precision issue

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -24,6 +24,7 @@
 #include "openvino/op/mvn.hpp"
 #include "openvino/op/normalize_l2.hpp"
 #include "openvino/op/power.hpp"
+#include "openvino/op/random_uniform.hpp"
 #include "openvino/op/range.hpp"
 #include "openvino/op/reduce_max.hpp"
 #include "openvino/op/reduce_mean.hpp"
@@ -42,6 +43,7 @@
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/util/broadcast_base.hpp"
 #include "openvino/op/util/pad_base.hpp"
+#include "openvino/op/util/precision_sensitive_attribute.hpp"
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pattern/op/optional.hpp"
@@ -265,6 +267,33 @@ public:
         register_matcher(m, callback);
     }
 };
+
+class MarkRandomUniform : public pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("MarkRandomUniform");
+
+    MarkRandomUniform() {
+        MATCHER_SCOPE(MarkRandomUniform);
+        auto random_uniform_pattern = pattern::wrap_type<ov::op::v8::RandomUniform>();
+
+        matcher_pass_callback callback = [=](pattern::Matcher& m) {
+            const auto& node = m.get_match_root();
+            if (!node)
+                return false;
+
+            disable_fp16_compression(node);
+            for (const auto& output : node->outputs()) {
+                for (const auto& out_inputs : output.get_target_inputs()) {
+                    mark_as_precision_sensitive(out_inputs);
+                }
+            }
+            return true;
+        };
+        auto m = make_shared<pattern::Matcher>(random_uniform_pattern, matcher_name);
+        register_matcher(m, callback);
+    }
+};
+
 /* MarkExpInReduceOpPath marks path that goes into ReduceSum and ReduceMean.
  * Values that go from Exp to ReduceSum/ReduceMean are precision
  * sensitive and should be kept in f32 precision for mixed inference.
@@ -435,6 +464,7 @@ bool MarkSugraphsToKeepInMixedPrecision::run_on_model(const shared_ptr<ov::Model
     REGISTER_PASS(manager, ov::pass::MarkFloatingPointRange)
     REGISTER_PASS(manager, MarkDivWithEps)
     REGISTER_PASS(manager, MarkExpInReduceOpPath)
+    REGISTER_PASS(manager, MarkRandomUniform)
     REGISTER_PASS(manager, PropagateDownDisableSensitivityForQuantized)
 
     // both Up and Down propagations are needed.

--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -287,7 +287,7 @@ public:
                     mark_as_precision_sensitive(out_inputs);
                 }
             }
-            return true;
+            return false;
         };
         auto m = make_shared<pattern::Matcher>(random_uniform_pattern, matcher_name);
         register_matcher(m, callback);

--- a/src/common/transformations/tests/common_optimizations/align_mixed_fp32_fp16_types_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/align_mixed_fp32_fp16_types_test.cpp
@@ -190,8 +190,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_with_rand_uniform) {
         auto minval = Constant::create(element::f32, Shape{}, {1});
         auto maxval = Constant::create(element::f32, Shape{}, {10});
         auto rand_uniform = make_shared<RandomUniform>(out_shape, minval, maxval, element::f32);
-        auto rand_uniform_decompressed = make_shared<Convert>(rand_uniform, element::f32);
-        auto rand_uniform_add_factor = make_shared<Add>(rand_uniform_decompressed, factor_const_decompressed);
+        auto rand_uniform_add_factor = make_shared<Add>(rand_uniform, factor_const_decompressed);
 
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, rand_uniform_add_factor);
         auto convert_to_f16_1 = make_shared<Convert>(mul_1, element::f32);

--- a/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_RandomUniform.py
@@ -43,8 +43,6 @@ class TestRandomUniform(CommonTFLayerTest):
                             use_legacy_frontend):
         if dtype == np.float16 or dtype == np.float64:
             pytest.skip('156027: Incorrect specification of RandomUniform for float16 and float64 output type')
-        if platform.machine() in ["aarch64", "arm64", "ARM64"]:
-            pytest.skip("156055: accuracy error on ARM")
         if ie_device == 'GPU':
             pytest.skip('156056: Accuracy error on GPU')
         self._test(*self.create_tf_random_uniform_net(shape_value, shape_type, dtype, seed, seed2),


### PR DESCRIPTION
### Details:
 - Add flag that disables FP16 compression for `RandomUniform` node
 - Remove precision loss due to FP32->FP16->FP32 conversions

### Tickets:
 - 156055
