### PR TITLE
[CPU] Remove code supporting only C++17 standard and older

### DIFF
--- a/src/plugins/intel_cpu/src/cache/multi_cache.h
+++ b/src/plugins/intel_cpu/src/cache/multi_cache.h
@@ -45,11 +45,7 @@ public:
      */
     template <typename KeyType,
               typename BuilderType,
-#if (defined(_MSVC_LANG) && (_MSVC_LANG > 201703L)) || (defined(__cplusplus) && (__cplusplus > 201703L))
               typename ValueType = std::invoke_result_t<BuilderType&, const KeyType&>>
-#else
-              typename ValueType = typename std::result_of<BuilderType&(const KeyType&)>::type>
-#endif
     typename CacheEntry<KeyType, ValueType>::ResultType getOrCreate(const KeyType& key, BuilderType builder) {
         auto entry = getEntry<KeyType, ValueType>();
         return entry->getOrCreate(key, std::move(builder));

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1373,15 +1373,9 @@ using UpdateNodes = UpdateNodesSeq;
 
 #if (OV_THREAD == OV_THREAD_TBB || OV_THREAD == OV_THREAD_TBB_AUTO || OV_THREAD == OV_THREAD_OMP)
 
-#    if (defined(_MSVC_LANG) && (_MSVC_LANG > 201703L)) || (defined(__cplusplus) && (__cplusplus > 201703L))
-#        define ov_memory_order_release std::memory_order_release
-#        define ov_memory_order_relaxed std::memory_order_relaxed
-#        define ov_memory_order_acquire std::memory_order_acquire
-#    else
-#        define ov_memory_order_release std::memory_order::memory_order_release
-#        define ov_memory_order_relaxed std::memory_order::memory_order_relaxed
-#        define ov_memory_order_acquire std::memory_order::memory_order_acquire
-#    endif
+#    define ov_memory_order_release std::memory_order_release
+#    define ov_memory_order_relaxed std::memory_order_relaxed
+#    define ov_memory_order_acquire std::memory_order_acquire
 
 class UpdateNodesBase {
 public:

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1373,10 +1373,6 @@ using UpdateNodes = UpdateNodesSeq;
 
 #if (OV_THREAD == OV_THREAD_TBB || OV_THREAD == OV_THREAD_TBB_AUTO || OV_THREAD == OV_THREAD_OMP)
 
-#    define ov_memory_order_release std::memory_order_release
-#    define ov_memory_order_relaxed std::memory_order_relaxed
-#    define ov_memory_order_acquire std::memory_order_acquire
-
 class UpdateNodesBase {
 public:
     explicit UpdateNodesBase(std::vector<NodePtr>& executableGraphNodes)
@@ -1388,21 +1384,21 @@ public:
                 if (node->isDynamicNode()) {
                     node->updateShapes();
                 }
-                m_prepareCounter.store(i, ov_memory_order_release);
+                m_prepareCounter.store(i, std::memory_order_release);
             }
         } catch (...) {
-            m_completion.store(true, ov_memory_order_relaxed);
+            m_completion.store(true, std::memory_order_relaxed);
             throw;
         }
-        m_prepareCounter.store(stop_indx, ov_memory_order_relaxed);
-        m_completion.store(true, ov_memory_order_release);
+        m_prepareCounter.store(stop_indx, std::memory_order_relaxed);
+        m_completion.store(true, std::memory_order_release);
     }
 
     void updateDynParams(size_t node_indx, size_t /*unused*/) {
         size_t local_counter = node_indx;
         while (true) {
-            const bool completion = m_completion.load(ov_memory_order_acquire);
-            const size_t prepareCounter = m_prepareCounter.load(ov_memory_order_relaxed);
+            const bool completion = m_completion.load(std::memory_order_acquire);
+            const size_t prepareCounter = m_prepareCounter.load(std::memory_order_relaxed);
             if (completion && local_counter == prepareCounter) {
                 break;
             }


### PR DESCRIPTION
### Details:
Remove old branches of code that depends on `__cplusplus` macro
 - `std::result_of` is deprecated in C++17 and removed in C++20
 - `std::memory_order_*` is directly accessible in the std namespace as enum fields as well. It is the correct way for both C++17 and C++20

### Tickets:
 - N/A
