### PR TITLE
[GPU] Use src buffer size for copy_to() call when called for two cldnn::memory objects

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -110,7 +110,7 @@ struct memory {
 
     virtual event::ptr copy_to(stream& stream, memory& other, bool blocking = true) const {
         const auto zero_offset = 0;
-        const auto data_size = other._bytes_count;
+        const auto data_size = _bytes_count;
         return copy_to(stream, other, zero_offset, zero_offset, data_size, blocking);
     }
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -11,6 +11,7 @@
 #include "crop_inst.h"
 #include "eltwise_inst.h"
 #include "gemm_inst.h"
+#include "assign_inst.h"
 #include "read_value_inst.h"
 #include "reshape_inst.h"
 #include "permute_inst.h"
@@ -475,6 +476,10 @@ bool crop_in_place_optimization::match(const program_node& node,
         if (user->is_type<concatenation>() && !user->is_output())
             return false;
         if (user->is_type<loop>() || user->is_type<non_max_suppression>())
+            return false;
+        // Read_value and assign don't handle data paddings internally, thus disable
+        // crop optimization for now
+        if (user->is_type<read_value>() || user->is_type<assign>())
             return false;
         // If the input tensor of convolution includes dynamic padding, there is an issue
         // where the total size of tensor is not properly calculated and becomes 0

--- a/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cpu/assign.cpp
@@ -54,7 +54,7 @@ struct assign_impl : public typed_primitive_impl<assign> {
 
         stream.wait_for_events(events);
 
-        const auto ev_set_memory = variable.get_memory()->copy_from(stream, instance.input_memory());
+        const auto ev_set_memory = variable.get_memory()->copy_from(stream, instance.input_memory(), 0, 0, variable.get_layout().bytes_count(), true);
         variable.set();
 
         return ev_set_memory;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -17,23 +17,6 @@
 #include <oneapi/dnnl/dnnl_ocl.hpp>
 #endif
 
-#define BOUNDARIES_CHECK(copy_type, src_size, src_offset, dst_size, dst_offset, copy_size)    \
-    OPENVINO_ASSERT(src_offset + copy_size <= src_size && dst_offset + copy_size <= dst_size, \
-                    "[GPU] Incorrect buffer sizes for ",                                      \
-                    copy_type,                                                                \
-                    " call. Parameters provided are"                                          \
-                    ": src_size=",                                                            \
-                    src_size,                                                                 \
-                    ", src_offset=",                                                          \
-                    src_offset,                                                               \
-                    ", dst_size=",                                                            \
-                    dst_size,                                                                 \
-                    ", dst_offset=",                                                          \
-                    dst_offset,                                                               \
-                    ", copy_size=",                                                           \
-                    copy_size,                                                                \
-                    ".");
-
 #define TRY_CATCH_CL_ERROR(...)               \
     try {                                     \
         __VA_ARGS__;                          \
@@ -43,6 +26,30 @@
 
 namespace cldnn {
 namespace ocl {
+
+static inline void check_boundaries(const std::string& func_str,
+                                    size_t src_size,
+                                    size_t src_offset,
+                                    size_t dst_size,
+                                    size_t dst_offset,
+                                    size_t copy_size) {
+    OPENVINO_ASSERT(src_offset + copy_size <= src_size && dst_offset + copy_size <= dst_size,
+                    "[GPU] Incorrect buffer sizes for ",
+                    func_str,
+                    " call. ",
+                    "Parameters provided are",
+                    ": src_size=",
+                    src_size,
+                    ", src_offset=",
+                    src_offset,
+                    ", dst_size=",
+                    dst_size,
+                    ", dst_offset=",
+                    dst_offset,
+                    ", copy_size=",
+                    copy_size,
+                    ".");
+}
 
 static inline cldnn::event::ptr create_event(stream& stream, size_t bytes_count, bool need_user_event) {
     if (bytes_count == 0) {
@@ -149,7 +156,7 @@ event::ptr gpu_buffer::copy_from(stream& stream, const void* data_ptr, size_t sr
     if (size == 0)
         return result_event;
 
-    BOUNDARIES_CHECK("gpu_buffer::copy_from(void*)", SIZE_MAX, src_offset, _bytes_count, dst_offset, size);
+    check_boundaries("gpu_buffer::copy_from(void*)", SIZE_MAX, src_offset, _bytes_count, dst_offset, size);
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -165,7 +172,7 @@ event::ptr gpu_buffer::copy_from(stream& stream, const memory& src_mem, size_t s
     if (size == 0)
         return result_event;
 
-    BOUNDARIES_CHECK("gpu_buffer::copy_from(memory&)", src_mem.size(), src_offset, _bytes_count, dst_offset, size);
+    check_boundaries("gpu_buffer::copy_from(memory&)", src_mem.size(), src_offset, _bytes_count, dst_offset, size);
 
     switch (src_mem.get_allocation_type()) {
         case allocation_type::usm_host:
@@ -201,7 +208,7 @@ event::ptr gpu_buffer::copy_to(stream& stream, void* data_ptr, size_t src_offset
     if (size == 0)
         return result_event;
 
-    BOUNDARIES_CHECK("gpu_buffer::copy_to(void*)", _bytes_count, src_offset, SIZE_MAX, dst_offset, size);
+    check_boundaries("gpu_buffer::copy_to(void*)", _bytes_count, src_offset, SIZE_MAX, dst_offset, size);
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -563,7 +570,7 @@ event::ptr gpu_usm::copy_from(stream& stream, const void* data_ptr, size_t src_o
     if (size == 0)
         return result_event;
 
-    BOUNDARIES_CHECK("gpu_usm::copy_from(void*)", SIZE_MAX, src_offset, _bytes_count, dst_offset, size);
+    check_boundaries("gpu_usm::copy_from(void*)", SIZE_MAX, src_offset, _bytes_count, dst_offset, size);
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -580,7 +587,7 @@ event::ptr gpu_usm::copy_from(stream& stream, const memory& src_mem, size_t src_
     if (size == 0)
         return result_event;
 
-    BOUNDARIES_CHECK("gpu_usm::copy_from(memory&)", src_mem.size(), src_offset, _bytes_count, dst_offset, size);
+    check_boundaries("gpu_usm::copy_from(memory&)", src_mem.size(), src_offset, _bytes_count, dst_offset, size);
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -613,7 +620,7 @@ event::ptr gpu_usm::copy_to(stream& stream, void* data_ptr, size_t src_offset, s
     if (size == 0)
         return result_event;
 
-    BOUNDARIES_CHECK("gpu_usm::copy_to(void*)", _bytes_count, src_offset, SIZE_MAX, dst_offset, size);
+    check_boundaries("gpu_usm::copy_to(void*)", _bytes_count, src_offset, SIZE_MAX, dst_offset, size);
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -701,5 +708,3 @@ ocl_surfaces_lock::ocl_surfaces_lock(std::vector<memory::ptr> mem, const stream&
 
 }  // namespace ocl
 }  // namespace cldnn
-
-#undef BOUNDARIES_CHECK

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -27,12 +27,12 @@
 namespace cldnn {
 namespace ocl {
 
-static inline void check_boundaries(const std::string& func_str,
-                                    size_t src_size,
+static inline void check_boundaries(size_t src_size,
                                     size_t src_offset,
                                     size_t dst_size,
                                     size_t dst_offset,
-                                    size_t copy_size) {
+                                    size_t copy_size,
+                                    const std::string& func_str = "") {
     OPENVINO_ASSERT(src_offset + copy_size <= src_size && dst_offset + copy_size <= dst_size,
                     "[GPU] Incorrect buffer sizes for ",
                     func_str,
@@ -156,7 +156,7 @@ event::ptr gpu_buffer::copy_from(stream& stream, const void* data_ptr, size_t sr
     if (size == 0)
         return result_event;
 
-    check_boundaries("gpu_buffer::copy_from(void*)", SIZE_MAX, src_offset, _bytes_count, dst_offset, size);
+    check_boundaries(SIZE_MAX, src_offset, _bytes_count, dst_offset, size, "gpu_buffer::copy_from(void*)");
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -172,7 +172,7 @@ event::ptr gpu_buffer::copy_from(stream& stream, const memory& src_mem, size_t s
     if (size == 0)
         return result_event;
 
-    check_boundaries("gpu_buffer::copy_from(memory&)", src_mem.size(), src_offset, _bytes_count, dst_offset, size);
+    check_boundaries(src_mem.size(), src_offset, _bytes_count, dst_offset, size, "gpu_buffer::copy_from(memory&)");
 
     switch (src_mem.get_allocation_type()) {
         case allocation_type::usm_host:
@@ -208,7 +208,7 @@ event::ptr gpu_buffer::copy_to(stream& stream, void* data_ptr, size_t src_offset
     if (size == 0)
         return result_event;
 
-    check_boundaries("gpu_buffer::copy_to(void*)", _bytes_count, src_offset, SIZE_MAX, dst_offset, size);
+    check_boundaries(_bytes_count, src_offset, SIZE_MAX, dst_offset, size, "gpu_buffer::copy_to(void*)");
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -570,7 +570,7 @@ event::ptr gpu_usm::copy_from(stream& stream, const void* data_ptr, size_t src_o
     if (size == 0)
         return result_event;
 
-    check_boundaries("gpu_usm::copy_from(void*)", SIZE_MAX, src_offset, _bytes_count, dst_offset, size);
+    check_boundaries(SIZE_MAX, src_offset, _bytes_count, dst_offset, size, "gpu_usm::copy_from(void*)");
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -587,7 +587,7 @@ event::ptr gpu_usm::copy_from(stream& stream, const memory& src_mem, size_t src_
     if (size == 0)
         return result_event;
 
-    check_boundaries("gpu_usm::copy_from(memory&)", src_mem.size(), src_offset, _bytes_count, dst_offset, size);
+    check_boundaries(src_mem.size(), src_offset, _bytes_count, dst_offset, size, "gpu_usm::copy_from(memory&)");
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();
@@ -620,7 +620,7 @@ event::ptr gpu_usm::copy_to(stream& stream, void* data_ptr, size_t src_offset, s
     if (size == 0)
         return result_event;
 
-    check_boundaries("gpu_usm::copy_to(void*)", _bytes_count, src_offset, SIZE_MAX, dst_offset, size);
+    check_boundaries(_bytes_count, src_offset, SIZE_MAX, dst_offset, size, "gpu_usm::copy_to(void*)");
 
     auto cl_stream = downcast<ocl_stream>(&stream);
     auto cl_event = blocking ? nullptr : &downcast<ocl_event>(result_event.get())->get();

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -489,7 +489,7 @@ INSTANTIATE_TEST_SUITE_P(mem_test,
                                                               mem_test_params{100, 79, 381}),
                                             ::testing::Values(false, true)));
 
-TEST(mem_test, copy_to_small_to_large) {
+TEST(mem_test, copy_small_buf_to_large_with_out_of_bound_access) {
     auto& ocl_engine = dynamic_cast<ocl::ocl_engine&>(get_test_engine());
     auto& stream = get_test_stream();
     auto small_buffer_size = 2048;

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -488,3 +488,15 @@ INSTANTIATE_TEST_SUITE_P(mem_test,
                                                               mem_test_params{0, 79, 381},
                                                               mem_test_params{100, 79, 381}),
                                             ::testing::Values(false, true)));
+
+TEST(mem_test, copy_to_small_to_large) {
+    auto& ocl_engine = dynamic_cast<ocl::ocl_engine&>(get_test_engine());
+    auto& stream = get_test_stream();
+    auto small_buffer_size = 2048;
+    auto large_buffer_size = 3072;
+
+    auto small_buffer = ocl_engine.allocate_memory({{small_buffer_size}, data_types::u8, format::bfyx}, allocation_type::cl_mem, false);
+    auto large_buffer = ocl_engine.allocate_memory({{large_buffer_size}, data_types::u8, format::bfyx}, allocation_type::cl_mem, false);
+
+    OV_ASSERT_NO_THROW(small_buffer->copy_to(stream, *large_buffer, true));
+}


### PR DESCRIPTION
### Details:
 - Use src buffer size for copy_to() call when called for two cldnn::memory objects

### Tickets:
 - [CVS-164403](https://jira.devtools.intel.com/browse/CVS-164403)
