### PR TITLE
[GPU] Use src buffer size for copy_to() call when called for two cldnn::memory objects

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -110,7 +110,7 @@ struct memory {
 
     virtual event::ptr copy_to(stream& stream, memory& other, bool blocking = true) const {
         const auto zero_offset = 0;
-        const auto data_size = other._bytes_count;
+        const auto data_size = _bytes_count;
         return copy_to(stream, other, zero_offset, zero_offset, data_size, blocking);
     }
 

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -488,3 +488,15 @@ INSTANTIATE_TEST_SUITE_P(mem_test,
                                                               mem_test_params{0, 79, 381},
                                                               mem_test_params{100, 79, 381}),
                                             ::testing::Values(false, true)));
+
+TEST(mem_test, copy_small_buf_to_large_with_out_of_bound_access) {
+    auto& ocl_engine = dynamic_cast<ocl::ocl_engine&>(get_test_engine());
+    auto& stream = get_test_stream();
+    auto small_buffer_size = 2048;
+    auto large_buffer_size = 3072;
+
+    auto small_buffer = ocl_engine.allocate_memory({{small_buffer_size}, data_types::u8, format::bfyx}, allocation_type::cl_mem, false);
+    auto large_buffer = ocl_engine.allocate_memory({{large_buffer_size}, data_types::u8, format::bfyx}, allocation_type::cl_mem, false);
+
+    OV_ASSERT_NO_THROW(small_buffer->copy_to(stream, *large_buffer, true));
+}


### PR DESCRIPTION
### Details:
 - Use src buffer size for copy_to() call when called for two cldnn::memory objects
 - Simplified backport of https://github.com/openvinotoolkit/openvino/pull/29534

### Tickets:
 - [CVS-164403](https://jira.devtools.intel.com/browse/CVS-164403)
