### PR TITLE
Add support for bf16 random input filling in benchmark_app

### DIFF
--- a/samples/cpp/benchmark_app/inputs_filling.cpp
+++ b/samples/cpp/benchmark_app/inputs_filling.cpp
@@ -586,6 +586,8 @@ ov::Tensor get_random_tensor(const std::pair<std::string, benchmark_app::InputIn
         return create_tensor_random<double, double>(inputInfo.second);
     } else if (type == ov::element::f16) {
         return create_tensor_random<ov::float16, float>(inputInfo.second);
+    } else if (type == ov::element::bf16) {
+        return create_tensor_random<ov::bfloat16, float>(inputInfo.second);
     } else if (type == ov::element::i32) {
         return create_tensor_random<int32_t, int32_t>(inputInfo.second);
     } else if (type == ov::element::i64) {


### PR DESCRIPTION
### Details:
Support for random fill (`-i random`) for `bf16` type input tensors in the model.

### Tickets:
 - N/A
