### PR TITLE
fix issue for tput hint with 1 thread only in 2025.1 branch

### DIFF
--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -346,7 +346,9 @@ std::vector<std::vector<int>> get_streams_info_table(
                 n_streams = input_infer_requests > 0 ? std::min(n_streams, input_infer_requests) : n_streams;
                 n_threads_per_stream = -1;
             } else {
-                auto model_threads = model_prefer_threads > n_threads ? n_threads / 2 : model_prefer_threads;
+                auto model_threads = n_threads == 1                     ? 1
+                                     : model_prefer_threads > n_threads ? n_threads / 2
+                                                                        : model_prefer_threads;
                 n_streams = ((n_threads + model_threads - 1) / model_threads);
                 if ((input_infer_requests > 0) && (n_streams > input_infer_requests)) {
                     n_streams = input_infer_requests;

--- a/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/streams_info/streams_info_table_test.cpp
@@ -1834,6 +1834,18 @@ StreamsCalculationTestCase _1sockets_mock_tput_4 = {
     {{4, MAIN_CORE_PROC, 2, 0, 0}},
 };
 
+StreamsCalculationTestCase _1sockets_mock_tput_5 = {
+    1,
+    false,
+    1,
+    2,
+    8,
+    "THROUGHPUT",
+    {},
+    {{16, 16, 0, 0, 0, 0}},
+    {{1, MAIN_CORE_PROC, 1, 0, 0}},
+};
+
 StreamsCalculationTestCase _2sockets_mock_latency_1 = {
     1,
     false,
@@ -2788,6 +2800,7 @@ INSTANTIATE_TEST_SUITE_P(StreamsInfoTable,
                                          _1sockets_mock_tput_2,
                                          _1sockets_mock_tput_3,
                                          _1sockets_mock_tput_4,
+                                         _1sockets_mock_tput_5,
                                          _2sockets_mock_latency_1,
                                          _2sockets_mock_latency_2,
                                          _2sockets_mock_latency_3,


### PR DESCRIPTION
### Details:
 - *fix issue for tput hint with 1 thread only in 2025.1 branch*

### Tickets:
 - *CVS-164466*
