### PR TITLE
[Snippets] Fixed handling of `Parameters` with 1D shapes in `SplitDimensionM` pass

### DIFF
--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -82,9 +82,14 @@ private:
 
     void reshape_subgraph(const std::shared_ptr<op::Subgraph>& subgraph, const ov::Shape& shape, size_t batch_m_dim, size_t new_m_dim);
 
+    static size_t get_dim_M(const ov::Shape& shape) {
+        return *(shape.rbegin() + dim_M_index);
+    }
+
     size_t m_concurrency;
 
     static const size_t min_kernel_m;
+    static const size_t dim_M_index;
 };
 } // namespace pass
 } // namespace snippets

--- a/src/common/snippets/src/pass/split_dimension_m.cpp
+++ b/src/common/snippets/src/pass/split_dimension_m.cpp
@@ -111,6 +111,7 @@ std::vector<size_t> SplitDimensionM::get_updated_order(const std::vector<size_t>
 }
 
 ov::snippets::VectorDims SplitDimensionM::reshape_m_dim(ov::snippets::VectorDims shape, size_t m_index, size_t batch_m_dim, size_t new_m_dim) {
+    OPENVINO_ASSERT(m_index < shape.size(), "Incorrect M index: it should be less than target shape rank");
     if (shape[m_index] == 1)
         return unsqueeze_m_dim(std::move(shape), m_index);
     shape[m_index] = new_m_dim;
@@ -118,6 +119,7 @@ ov::snippets::VectorDims SplitDimensionM::reshape_m_dim(ov::snippets::VectorDims
     return shape;
 }
 ov::snippets::VectorDims SplitDimensionM::unsqueeze_m_dim(ov::snippets::VectorDims shape, size_t m_index) {
+    OPENVINO_ASSERT(m_index < shape.size(), "Incorrect M index: it should be less than target shape rank");
     shape.insert(shape.begin() + m_index, 1);
     return shape;
 }
@@ -217,7 +219,7 @@ void SplitDimensionM::reshape_subgraph(const std::shared_ptr<op::Subgraph>& subg
             return;
 
         const auto shape = param->get_partial_shape().get_shape();
-        // if Shape rank is less than index of dimension M, no need to reshape it.
+        // if the index of dimension M is equal or greater than Shape rank, no need to reshape it.
         if (shape.size() <= dim_M_index)
             return;
 

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -240,6 +240,16 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHASelect_SplitM) {
     run();
 }
 
+TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHASelect_SplitM_ScalarParams) {
+    const auto& f = MHASelectSplitMFunction(std::vector<PartialShape>{{8, 512, 18}, {8, 18, 64}, {1}, {64}, {8, 64, 512}},
+                                            std::vector<Shape>{{8, 2, 256, 18}, {8, 1, 18, 64}, {}, {},
+                                                               {8, 1, 64, 512}, {8, 512, 512}});
+    model = f.getOriginal();
+    model_ref = f.getReference();
+    config.set_concurrency(16);
+    run();
+}
+
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Reshape_extraction) {
     const auto& f = MHAWithExtractedReshapeFunction(std::vector<PartialShape>{{400, 196, 80},
                                                                               {400, 80, 196},

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -471,7 +471,10 @@ std::shared_ptr<ov::Model> MHASelectSplitMFunction::initReference() const {
     auto param2 = std::make_shared<ov::opset1::Parameter>(precision, input_shapes[4]);
     ov::ParameterVector ngraphParam = {param0, param1, addParam, selectParam, param2};
 
-    auto make_reshape = [](const std::shared_ptr<ov::Node>& node, const ov::Shape& new_shape) {
+    auto make_reshape = [](const std::shared_ptr<ov::Node>& node, const ov::Shape& new_shape) -> std::shared_ptr<ov::Node> {
+        if (new_shape.empty()) {
+            return node;
+        }
         auto shape_const = ov::op::v0::Constant::create(ov::element::i32, {new_shape.size()}, new_shape);
         return std::make_shared<ov::op::v1::Reshape>(node, shape_const, true);
     };


### PR DESCRIPTION
### Details:
 - *Fixed handling of `Parameters` with 1D shapes in `SplitDimensionM` pass. No need to insert `Reshape` op on input with 1D shape since `M` dimension has index `1` from the end.*

### Tickets:
 - *149846*
