### PR TITLE
[Core] Fix `WeightlessCacheAttribute` not being serialized

### DIFF
--- a/src/core/dev_api/openvino/core/rt_info/weightless_caching_attributes.hpp
+++ b/src/core/dev_api/openvino/core/rt_info/weightless_caching_attributes.hpp
@@ -35,6 +35,8 @@ public:
 
     bool is_copyable() const override;
 
+    bool visit_attributes(AttributeVisitor& visitor) override;
+
     size_t original_size;
     size_t bin_offset;
     ov::element::Type original_dtype;

--- a/src/core/src/op/util/weightless_caching_attributes.cpp
+++ b/src/core/src/op/util/weightless_caching_attributes.cpp
@@ -8,6 +8,13 @@ bool ov::WeightlessCacheAttribute::is_copyable() const {
     return false;
 }
 
+bool ov::WeightlessCacheAttribute::visit_attributes(AttributeVisitor& visitor) {
+    visitor.on_attribute("original_size", original_size);
+    visitor.on_attribute("bin_offset", bin_offset);
+    visitor.on_attribute("original_dtype", original_dtype);
+    return true;
+}
+
 OPENVINO_API void ov::copy_weightless_cache_attr(const std::shared_ptr<ov::Node>& from,
                                                  const std::shared_ptr<ov::Node>& to) {
     const auto& rt_info = from->get_rt_info();


### PR DESCRIPTION
### Details:
 - *`WeightlessCacheAttribute` was skipped from serializing due to `visit_attributes` method not implemented, falling back to 
base class's `RuntimeAttribute::visit_attributes` which always return false here: https://github.com/openvinotoolkit/openvino/blob/master/src/core/src/pass/serialize.cpp#L1076-L1077*

### Tickets:
 - *162538*
