### PR TITLE
[intel-npu] Increasing qdq_optimization's compiler support version

### DIFF
--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -552,8 +552,8 @@ std::string DriverCompilerAdapter::serializeConfig(const Config& config,
         content = std::regex_replace(content, std::regex(dqstr.str()), "");
     }
 
-    // QDQ_OPTIMIZATION is not supported in versions < 7.5 - need to remove it
-    if ((compilerVersion.major < 7) || (compilerVersion.major == 7 && compilerVersion.minor < 5)) {
+    // QDQ_OPTIMIZATION is not supported in versions < 7.20 - need to remove it
+    if ((compilerVersion.major < 7) || (compilerVersion.major == 7 && compilerVersion.minor < 20)) {
         std::ostringstream qdqstr;
         qdqstr << ov::intel_npu::qdq_optimization.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
                << VALUE_DELIMITER;

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -628,7 +628,7 @@ void Plugin::reset_compiler_dependent_properties() const {
     // NPU_QDQ_OPTIMIZATION
     // unpublish if compiler version requirement is not met
     if (_properties.find(ov::intel_npu::qdq_optimization.name()) != _properties.end()) {
-        if (active_compiler_version >= ICOMPILER_MAKE_VERSION(7, 5)) {
+        if (active_compiler_version >= ICOMPILER_MAKE_VERSION(7, 20)) {
             std::get<0>(_properties[ov::intel_npu::qdq_optimization.name()]) = true;  /// mark supported
         } else {
             std::get<0>(_properties[ov::intel_npu::qdq_optimization.name()]) = false;  // mark unsupported


### PR DESCRIPTION
### Details:
- Increasing npu compiler support version for NPU_QDQ_OPTIMIZATION property to 7.20
 - mirror of releases/2025/1 PR: https://github.com/openvinotoolkit/openvino/pull/29551

### Tickets:
 - *ticket-id*
