### PR TITLE
[NPU] Return a dummy model in case of get_runtime_model method

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -129,6 +129,8 @@ std::shared_ptr<const ov::Model> CompiledModel::get_runtime_model() const {
         results.push_back(std::move(result));
     }
 
+    _logger.warning("Returning a dummy ov::Model object that contains only the given parameter and result nodes");
+
     return std::make_shared<ov::Model>(results, parameters);
 }
 

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -21,6 +21,12 @@
 #include "openvino/runtime/threading/executor_manager.hpp"
 #include "transformations/utils/utils.hpp"
 
+namespace {
+
+const std::vector<size_t> CONSTANT_NODE_DUMMY_SHAPE{1};
+
+}
+
 namespace intel_npu {
 
 using intel_npu::envVarStrToBool;
@@ -81,7 +87,49 @@ void CompiledModel::export_model(std::ostream& stream) const {
 }
 
 std::shared_ptr<const ov::Model> CompiledModel::get_runtime_model() const {
-    OPENVINO_NOT_IMPLEMENTED;
+    ov::ParameterVector parameters;
+    ov::NodeVector results;
+
+    for (const IODescriptor& inputDescriptor : _graph->get_metadata().inputs) {
+        if (inputDescriptor.isStateInput || inputDescriptor.isStateOutput || inputDescriptor.isShapeTensor) {
+            continue;
+        }
+
+        std::shared_ptr<ov::op::v0::Parameter> parameter = std::make_shared<ov::op::v0::Parameter>(
+            inputDescriptor.precision,
+            inputDescriptor.shapeFromIRModel.has_value() ? *inputDescriptor.shapeFromIRModel
+                                                         : inputDescriptor.shapeFromCompiler);
+
+        parameter->set_friendly_name(inputDescriptor.nodeFriendlyName);
+        parameter->output(0).get_tensor().set_names(inputDescriptor.outputTensorNames);
+        parameters.push_back(std::move(parameter));
+    }
+
+    // The "result" nodes require a parent node in order to satisfy the API conventions. Additionally, a dummy shape for
+    // the "Constant" node was required since the specific constructor does not accept "ov::PartialShape" values (a
+    // constant can't have dynamic shape). The dummy tensor was also brought in order to register the correct,
+    // potentially dynamic, output shape.
+    for (const IODescriptor& outputDescriptor : _graph->get_metadata().outputs) {
+        if (outputDescriptor.isStateInput || outputDescriptor.isStateOutput || outputDescriptor.isShapeTensor) {
+            continue;
+        }
+
+        std::shared_ptr<ov::Node> constantDummy =
+            std::make_shared<ov::op::v0::Constant>(outputDescriptor.precision, CONSTANT_NODE_DUMMY_SHAPE);
+
+        const std::shared_ptr<ov::descriptor::Tensor>& tensorDummy = std::make_shared<ov::descriptor::Tensor>(
+            outputDescriptor.precision,
+            outputDescriptor.shapeFromIRModel.has_value() ? *outputDescriptor.shapeFromIRModel
+                                                          : outputDescriptor.shapeFromCompiler,
+            outputDescriptor.outputTensorNames);
+
+        std::shared_ptr<ov::Node> result = std::make_shared<ov::op::v0::Result>(constantDummy);
+        result->output(0).set_tensor_ptr(tensorDummy);
+        result->set_friendly_name(outputDescriptor.nodeFriendlyName);
+        results.push_back(std::move(result));
+    }
+
+    return std::make_shared<ov::Model>(results, parameters);
 }
 
 void CompiledModel::set_property(const ov::AnyMap& properties) {

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
@@ -17,6 +17,8 @@ const Params params[] = {
     std::tuple<Device, Config>{ov::test::utils::DEVICE_NPU,
                                {{ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)}}}};
 
+const Params params_cached[] = {std::tuple<Device, Config>{ov::test::utils::DEVICE_NPU, {}}};
+
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU,
@@ -26,10 +28,10 @@ INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
                          CoreThreadingTestsWithIter,
-                         testing::Combine(testing::ValuesIn(params), testing::Values(20), testing::Values(50)),
+                         testing::Combine(testing::ValuesIn(params), testing::Values(15), testing::Values(50)),
                          (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>));
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
                          CoreThreadingTestsWithCacheEnabled,
-                         testing::Combine(testing::ValuesIn(params), testing::Values(20), testing::Values(50)),
+                         testing::Combine(testing::ValuesIn(params), testing::Values(10), testing::Values(30)),
                          (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithCacheEnabled>));

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -870,14 +870,6 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- EISW ##### -->
-    <skip_config>
-        <message>get_runtime_model method is not supported on NPU</message>
-        <filters>
-            <filter>.*OVClassModelOptionalTestP.CompileModelCreateDefaultExecGraphResult.*</filter>
-        </filters>
-    </skip_config>
-
     <!-- CACHE_MODE is not supported on NPU, update test with correct property to make weightless compiled model -->
     <skip_config>
         <message>compiled_blob test use `CACHE_MOD` which is not supported on NPU</message>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -897,10 +897,6 @@ std::vector<std::string> disabledTestPatterns() {
                 ".*OVExecGraphSerializationTest.ExecutionGraph.*"
         });
 
-        // get_runtime_model method is not supported on NPU
-        _skipRegistry.addPatterns("get_runtime_model method is not supported on NPU", {
-                ".*OVClassModelOptionalTestP.CompileModelCreateDefaultExecGraphResult.*",
-        });
         // CACHE_MODE is not supported on NPU, update test with correct property to make weightless compiled model
         _skipRegistry.addPatterns("compiled_blob test use `CACHE_MOD` which is not supported on NPU", {
                 R"(.*OVCompiledModelBaseTest.*import_from_.*_blob.*)",


### PR DESCRIPTION
### Details:
 - *Fix conformance tests by returning a dummy model in case of get_runtime_model method*
 - *Reduce the number of iterations for core threading tests and change the config for caching*

### Tickets:
 - *CVS-161541*
