### PR TITLE
Revert "[GPU] Enable fusing dynamic eltwise with gemm in onednn case"

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -1142,8 +1142,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 auto eltw_in_size = peer_node->get_output_layout();
                 if (eltw_in_size.is_dynamic()
                     // this whitelist condition is temporarily and to be relaxed soon.
-                    && !fused_node->is_type<fully_connected>()
-                    && !fused_node->is_type<gemm>())
+                    && !fused_node->is_type<fully_connected>())
                     return;
             }
             if (parent1.first->is_type<convolution>() && !conv_supports_fusings(parent1.first->as<convolution>()))

--- a/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
@@ -482,6 +482,9 @@ class gemm_2in_dynamic_add : public gemm_2in_add {};
 TEST_P(gemm_2in_dynamic_add, add) {
     auto p = GetParam();
 
+    if (engine.get_device_info().supports_immad)
+        p.expected_fused_primitives++;
+
     cfg_fused.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     cfg_not_fused.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 


### PR DESCRIPTION
This reverts commit c202882011202b4731b0bb7254c18cececc071ba

### Details:
 - *Reverts due to perf regression*

### Tickets:
 - *[CVS-164331](https://jira.devtools.intel.com/browse/CVS-164331)*
