### PR TITLE
[CPU] limit QKVProjection to only work on large K dim case

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -443,6 +443,11 @@ bool QKVProjection::isSupportedOperation(const std::shared_ptr<const ov::Node>& 
                 return false;
             }
 
+            if (config.hidden_size < CACHE_BLK_K_SIZE * 8) {
+                errorMessage = "QKVProjection input channel size is too small";
+                return false;
+            }
+
             if (config.quantized && (fcDynamicQuantizationGroupSize < static_cast<uint64_t>(config.hidden_size))) {
                 errorMessage = "QKVProjection input channel only support per-token dynamic quantization";
                 return false;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/qkv_proj_fusion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/qkv_proj_fusion.cpp
@@ -116,17 +116,16 @@ TEST_P(QKVProjFusionTest, CompareWithRefs) {
 
 namespace {
 
-// the shape size is divided by a const to reduce test time
-static ov::test::InputShape ishape_llama2_7b{ov::PartialShape{-1, -1, 4096 / 4}, {ov::Shape{1, 8, 4096 / 4}, ov::Shape{5, 7, 4096 / 4}}};
-static ov::test::InputShape ishape_qwen2_7b{ov::test::InputShape{ov::PartialShape{-1, -1, 3584 / 2}, {ov::Shape{1, 8, 3584 / 2}, ov::Shape{5, 7, 3584 / 2}}}};
+static ov::test::InputShape ishape_llama2_7b{ov::PartialShape{-1, -1, 4096}, {ov::Shape{1, 8, 4096}, ov::Shape{5, 7, 4096}}};
+static ov::test::InputShape ishape_qwen2_7b{ov::test::InputShape{ov::PartialShape{-1, -1, 3584}, {ov::Shape{1, 8, 3584}, ov::Shape{5, 7, 3584}}}};
 
 const std::vector<QKVProjFusionParams> qkv_params = {
-    // Llama-7B with reduced size
-    {ishape_llama2_7b,  4096 / 4, 4096 / 4, 4096 / 4, 4096 / 4, false},
-    {ishape_llama2_7b,  4096 / 4, 4096 / 4, 4096 / 4, 4096 / 4, true},
+    // Llama-7B
+    {ishape_llama2_7b,  4096, 4096, 4096, 4096, false},
+    {ishape_llama2_7b,  4096, 4096, 4096, 4096, true},
     // Qwen2-7B: hidden_size_per_head:128, num_attention_heads:28, num_key_value_heads:4
-    {ishape_qwen2_7b, 3584 / 2, 128 * 28 / 2, 128 * 4 / 2, 128 * 4 / 2, false},
-    {ishape_qwen2_7b, 3584 / 2, 128 * 28 / 2, 128 * 4 / 2, 128 * 4 / 2, true},
+    {ishape_qwen2_7b, 3584, 128 * 28, 128 * 4, 128 * 4, false},
+    {ishape_qwen2_7b, 3584, 128 * 28, 128 * 4, 128 * 4, true},
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_QKVProjFusion,


### PR DESCRIPTION
### Details:
 - *the AMX optimization of QKVProjection Node is only efficient on large input channel cases(which was true for most LLM models), but on some recent models with small QKV input channel, it actually causes regression, we simply disable this node and fallback to normal FullyConnected*
 - *...*

### Tickets:
 - *CVS-157051*
