### PR TITLE
[Snippets] Fix register type assignment for pass through expressions

### DIFF
--- a/src/common/snippets/src/lowered/pass/init_live_ranges.cpp
+++ b/src/common/snippets/src/lowered/pass/init_live_ranges.cpp
@@ -38,17 +38,17 @@ bool InitLiveRanges::run(LinearIR& linear_ir) {
         std::set<Reg> live_regs;
 
         if (pass_through_expr(expr)) {
-            live_regs = std::prev(expr_it)->get()->get_live_regs();
-            if (expr_it != linear_ir.begin())
+            if (expr_it != linear_ir.begin()) {
+                live_regs = std::prev(expr_it)->get()->get_live_regs();
                 expr->set_live_regs(live_regs);
+            }
         } else {
             // Remove all regs that expired before start
             regs_to_expire.erase(regs_to_expire.begin(), regs_to_expire.lower_bound(start)); // remove all elements lower than start (not equal)
             for (const auto& time_reg : regs_to_expire)
                 live_regs.insert(time_reg.second.begin(), time_reg.second.end());
+            expr->set_live_regs(std::move(live_regs));
         }
-
-        expr->set_live_regs(std::move(live_regs));
 
         for (size_t i = 0; i < expr->get_output_count(); ++i) {
             const auto& out_pd = expr->get_output_port_descriptor(i);

--- a/src/common/snippets/src/lowered/pass/init_live_ranges.cpp
+++ b/src/common/snippets/src/lowered/pass/init_live_ranges.cpp
@@ -40,7 +40,7 @@ bool InitLiveRanges::run(LinearIR& linear_ir) {
         if (pass_through_expr(expr)) {
             if (expr_it != linear_ir.begin()) {
                 live_regs = std::prev(expr_it)->get()->get_live_regs();
-                expr->set_live_regs(live_regs);
+                expr->set_live_regs(std::move(live_regs));
             }
         } else {
             // Remove all regs that expired before start
@@ -50,6 +50,9 @@ bool InitLiveRanges::run(LinearIR& linear_ir) {
             expr->set_live_regs(std::move(live_regs));
         }
 
+        // Note that here we continue to process pass_through expressions to define register type if it was not defined
+        // in the parent expression (for example, in cases where there are no parent expression for passthrough
+        // expressions) and to propagate new registers to the consumers
         for (size_t i = 0; i < expr->get_output_count(); ++i) {
             const auto& out_pd = expr->get_output_port_descriptor(i);
             if (out_pd->get_reg().is_defined())


### PR DESCRIPTION
### Details:
Fix skipped register type assignment for  in `InitLiveRanges` pass for expressions that don't affect lifetime of registers (list is defined in `pass_through_expr` function of this pass)

### Tickets:
 - N/A
