### PR TITLE
[CPU] Fix compilation issue for FullyConnected node

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/memory.cpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.cpp
@@ -671,11 +671,9 @@ void MemoryInput::initOptimalPrimitiveDescriptor() {
     selectedPd->setConfig(config);
 
     if (haveSubgraph()) {
-        // Adopt parent configuration, avoid to insert reorder before the MemoryInput.
         std::vector<Input::InputConfig> graphInputConfig;
-
-        for (size_t i = 0; i < getParentEdges().size(); i++) {
-            auto desc = getParentOutputMemDesc(getParentEdgeAt(i));
+        for (auto&& portConfig : config.inConfs) {
+            auto desc = portConfig.getMemDesc();
             graphInputConfig.emplace_back(node::Input::InputConfig{desc, true});
         }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/stateful_init_graph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/stateful_init_graph.cpp
@@ -4,6 +4,8 @@
 
 #include <shared_test_classes/base/ov_subgraph.hpp>
 
+#include <random>
+
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "utils/cpu_test_utils.hpp"
 
@@ -12,6 +14,18 @@ using namespace CPUTestUtils;
 using InitGraphStatefulModelTestParams = std::tuple<std::vector<InputShape>,  // input shapes
                                                     bool                      // ReadValue Assgin Direct pair or not
                                                     >;
+
+static std::shared_ptr<ov::op::v0::Constant> create_constant_node(const ov::element::Type& type,
+                                                                  const ov::Shape& shape,
+                                                                  std::mt19937& gen) {
+    size_t count = ov::shape_size(shape);
+    std::vector<float> values(count);
+    std::uniform_real_distribution<float> dis(0, 1);
+    for (auto& value : values)
+        value = dis(gen);
+    return ov::op::v0::Constant::create(type, shape, values);
+}
+
 class InitGraphStatefulModelBase : virtual public ov::test::SubgraphBaseTest,
                                    public testing::WithParamInterface<InitGraphStatefulModelTestParams>,
                                    public CPUTestsBase {
@@ -273,6 +287,134 @@ TEST_P(InitGraphStatefulDiffPrimitiveModel, CompareWithRefs) {
     run();
 }
 
+// ReadValueWithSubgraph connected with FakeConverts.
+// Note that the other parent branch is ommited for MatMul_2
+// and MatMul_3 to improve readability of the graph. They have
+// the same pattern as MatMul_1.
+//
+//                         Input
+//                           |
+//       Convert_1      Multiply_0
+//            |              |
+//      Multiply_1    FakeConvert_1
+//             \     /       |
+//            MatMul_1       |
+//                |          |
+//          ReadValue        |
+//          /     |          |
+//    Assign  FakeConvert_2  |
+//                |          |
+//              MatMul_2  MatMul_3
+//                   \     /
+//                     Add
+//                      |
+//                    Result
+//
+class InitGraphStatefulModelFakeConvert : public InitGraphStatefulModelBase {
+public:
+    void SetUp() override {
+        targetDevice = utils::DEVICE_CPU;
+
+        std::tie(inputShapes, directPair) = this->GetParam();
+
+#if defined(OPENVINO_ARCH_X86_64)
+        configuration.insert(ov::hint::inference_precision(ov::element::bf16));
+#endif
+
+        // Input
+        init_input_shapes(inputShapes);
+        ov::ParameterVector input_params;
+        for (auto&& shape : inputDynamicShapes) {
+            input_params.push_back(std::make_shared<ov::op::v0::Parameter>(netPrc, shape));
+        }
+
+        // Multiply_0
+        std::mt19937 gen(0);
+        const ov::Shape mul_shape = {targetStaticShapes[0][0][-1]};
+        const auto mul_0 = std::make_shared<ov::op::v1::Multiply>(input_params[0],
+            create_constant_node(netPrc, mul_shape, gen));
+
+        // FakeConvert_1
+        const ov::Shape scale_shape = {1}, shift_shape = {1};
+        const auto fake_convert_1 = std::make_shared<ov::op::v13::FakeConvert>(mul_0,
+            create_constant_node(netPrc, scale_shape, gen),
+            create_constant_node(netPrc, shift_shape, gen),
+            ov::element::f8e4m3);
+
+        // Convert_1
+        const ov::Shape convert_shape = {targetStaticShapes[0][0][-1], 1};
+        auto convert_1 = std::make_shared<ov::op::v0::Convert>(
+            create_constant_node(ov::element::f8e4m3, convert_shape, gen), netPrc);
+
+        // Multiply_1
+        const auto mul_1 = std::make_shared<ov::op::v1::Multiply>(convert_1,
+            create_constant_node(netPrc, mul_shape, gen));
+
+        // MatMul_1
+        auto matmul_1 = std::make_shared<ov::op::v0::MatMul>(fake_convert_1, mul_1);
+
+        // ReadValue
+        statePrc = ov::element::f32;
+        auto variable = std::make_shared<ov::op::util::Variable>(
+            ov::op::util::VariableInfo{inputDynamicShapes[0], statePrc, "var"});
+        auto readvalue = std::make_shared<ov::op::v6::ReadValue>(matmul_1, variable);
+
+        // FakeConvert_2
+        std::shared_ptr<ov::Node> fake_convert_2 = std::make_shared<ov::op::v13::FakeConvert>(readvalue,
+            create_constant_node(netPrc, scale_shape, gen),
+            create_constant_node(netPrc, shift_shape, gen),
+            ov::element::f8e4m3);
+
+        // Assign
+        auto assign = std::make_shared<ov::op::v6::Assign>(directPair ? readvalue : fake_convert_2, variable);
+
+        // Convert_2
+        auto convert_2 = std::make_shared<ov::op::v0::Convert>(
+            create_constant_node(ov::element::f8e4m3, convert_shape, gen), netPrc);
+
+        // Multiply_2
+        const auto mul_2 = std::make_shared<ov::op::v1::Multiply>(convert_2,
+            create_constant_node(netPrc, mul_shape, gen));
+
+        // MatMul_2
+        auto matmul_2 = std::make_shared<ov::op::v0::MatMul>(fake_convert_2, mul_2);
+
+        // Convert_3
+        auto convert_3 = std::make_shared<ov::op::v0::Convert>(
+            create_constant_node(ov::element::f8e4m3, convert_shape, gen), netPrc);
+
+        // Multiply_3
+        const auto mul_3 = std::make_shared<ov::op::v1::Multiply>(convert_3,
+            create_constant_node(netPrc, mul_shape, gen));
+
+        // MatMul_3
+        auto matmul_3 = std::make_shared<ov::op::v0::MatMul>(fake_convert_1, mul_3);
+
+        // Add
+        auto add = std::make_shared<ov::op::v1::Add>(matmul_2, matmul_3);
+
+        // Result
+        auto result = std::make_shared<ov::op::v0::Result>(add);
+
+        function = std::make_shared<ov::Model>(ov::ResultVector({result}), ov::SinkVector({assign}), input_params);
+    }
+
+    void check_init_graph_node() override {
+        CheckNumberOfNodesWithType(compiledModel, "FakeConvert", 0);
+    }
+
+    ov::Shape get_state_shape(size_t i) override {
+        return inputShapes[0].second[i];
+    }
+
+private:
+    bool directPair;
+};
+
+TEST_P(InitGraphStatefulModelFakeConvert, CompareWithRefs) {
+    run();
+}
+
 namespace {
 const std::vector<std::vector<InputShape>> inputShapes = {
     {
@@ -320,6 +462,26 @@ INSTANTIATE_TEST_SUITE_P(smoke_StatefulInitGraph,
                          InitGraphStatefulDiffPrimitiveModel,
                          testParamsDiffPrecision_smoke,
                          InitGraphStatefulDiffPrimitiveModel::getTestCaseName);
+
+const std::vector<std::vector<InputShape>> inputShapesFakeConvert = {
+    {
+        // Dynamic shape.
+        {{-1, -1}, {{1, 10}, {2, 10}}},
+    },
+    {
+        // Static shape.
+        {{2, 10}, {{2, 10}}},
+    }
+};
+
+const auto testParamsFakeConvert_smoke = ::testing::Combine(
+    ::testing::ValuesIn(inputShapesFakeConvert),
+    ::testing::ValuesIn(readValueAssginDirectPair));
+
+INSTANTIATE_TEST_SUITE_P(smoke_StatefulInitGraph,
+                         InitGraphStatefulModelFakeConvert,
+                         testParamsFakeConvert_smoke,
+                         InitGraphStatefulModelFakeConvert::getTestCaseName);
 
 }  // namespace
 


### PR DESCRIPTION
### Details:
 - *Revise MemoryInput node to use its own input config. Otherwise for infer_precision=bf16, the leading FullyConnected node in MemoryInput's subgraph could have unsupported data_precision f32, as in (data_precision, weight_precision, output_precision)=(f32, f32, bf16), because of precision dependencies during Graph::ResolveEdgeConflicts(), Graph::AllocatedReferencingEdges() etc.*
 - *A subgraph test case is added to reproduce this issue beforehand.*

### Tickets:
 - *[CVS-163281](https://jira.devtools.intel.com/browse/CVS-163281)*
