### PR TITLE
[core] Make const ov::Model in hint::model property

### DIFF
--- a/src/inference/include/openvino/runtime/properties.hpp
+++ b/src/inference/include/openvino/runtime/properties.hpp
@@ -530,7 +530,7 @@ static constexpr Property<uint32_t> num_requests{"PERFORMANCE_HINT_NUM_REQUESTS"
  * ov::optimal_batch_size)
  * @ingroup ov_runtime_cpp_prop_api
  */
-static constexpr Property<std::shared_ptr<ov::Model>> model{"MODEL_PTR"};
+static constexpr Property<std::shared_ptr<const ov::Model>> model{"MODEL_PTR"};
 
 /**
  * @brief Special key for auto batching feature configuration. Enabled by default

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -251,7 +251,7 @@ ov::SoPtr<ov::ICompiledModel> import_compiled_model(const ov::Plugin& plugin,
         [&cfg, &plugin](const std::shared_ptr<const ov::Model>& model_ptr) {
             if (model_ptr != nullptr &&
                 ov::util::contains(plugin.get_property(ov::supported_properties), ov::hint::model)) {
-                cfg[ov::hint::model.name()] = std::const_pointer_cast<ov::Model>(model_ptr);
+                cfg[ov::hint::model.name()] = model_ptr;
             }
         },
         [&cfg, &plugin](const std::string& model_path) {
@@ -839,7 +839,7 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model(const std::shared_ptr<
     } else if (cacheManager && device_supports_model_caching(plugin, parsed._config) && !is_proxy_device(plugin)) {
         CacheContent cacheContent{cacheManager, parsed._core_config.get_enable_mmap()};
         cacheContent.blobId = ov::ModelCache::compute_hash(model, create_compile_config(plugin, parsed._config));
-        cacheContent.model = std::const_pointer_cast<ov::Model>(model);
+        cacheContent.model = model;
         std::unique_ptr<CacheGuardEntry> lock = cacheGuard.get_hash_lock(cacheContent.blobId);
         res = load_model_from_cache(cacheContent, plugin, parsed._config, ov::SoPtr<ov::IRemoteContext>{}, [&]() {
             return compile_model_and_cache(plugin,
@@ -877,7 +877,7 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model(const std::shared_ptr<
         CacheContent cacheContent{cacheManager, parsed._core_config.get_enable_mmap()};
         cacheContent.blobId = ov::ModelCache::compute_hash(model, create_compile_config(plugin, parsed._config));
         std::unique_ptr<CacheGuardEntry> lock = cacheGuard.get_hash_lock(cacheContent.blobId);
-        cacheContent.model = std::const_pointer_cast<ov::Model>(model);
+        cacheContent.model = model;
         res = load_model_from_cache(cacheContent, plugin, parsed._config, context, [&]() {
             return compile_model_and_cache(plugin, model, parsed._config, context, cacheContent);
         });

--- a/src/inference/src/dev/core_impl.hpp
+++ b/src/inference/src/dev/core_impl.hpp
@@ -161,7 +161,7 @@ private:
         std::shared_ptr<ov::ICacheManager> cacheManager;
         std::string blobId = {};
         std::string modelPath = {};
-        std::shared_ptr<ov::Model> model = nullptr;
+        std::shared_ptr<const ov::Model> model{};
         bool mmap_enabled = false;
     };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -24,7 +24,7 @@
 #include "primitive.hpp"
 #include "transformations/convert_precision.hpp"
 
-using weights_memory_ptr = std::variant<std::shared_ptr<ov::MappedMemory>, std::shared_ptr<ov::Model>>;
+using weights_memory_ptr = std::variant<std::shared_ptr<ov::MappedMemory>, std::shared_ptr<const ov::Model>>;
 using offset_const_map_t = std::map<size_t, std::shared_ptr<ov::op::v0::Constant>>;
 using shared_mapped_memory_ptr = std::shared_ptr<ov::SharedBuffer<std::shared_ptr<ov::MappedMemory>>>;
 using constant_memory_ptr = std::variant<shared_mapped_memory_ptr, std::shared_ptr<ov::op::v0::Constant>>;
@@ -53,7 +53,7 @@ namespace cldnn {
 
 class WeightsMemory {
 public:
-    WeightsMemory(std::shared_ptr<ov::Model> model) : weights_memory(model) {
+    WeightsMemory(std::shared_ptr<const ov::Model> model) : weights_memory(model) {
         fill_offset_to_constant_map(model);
     }
 
@@ -67,7 +67,7 @@ public:
                 original_size,
                 mapped_memory);
         } else {
-            auto model_ptr = std::get<std::shared_ptr<ov::Model>>(weights_memory);
+            auto model_ptr = std::get<std::shared_ptr<const ov::Model>>(weights_memory);
             auto const_it = offset_to_constant_map.find(bin_offset);
             if (const_it == offset_to_constant_map.end()) {
                 OPENVINO_THROW("Constant with bin_offset ", bin_offset, " not found in the model");
@@ -78,7 +78,7 @@ public:
     }
 
 private:
-    void fill_offset_to_constant_map(std::shared_ptr<ov::Model> model) {
+    void fill_offset_to_constant_map(std::shared_ptr<const ov::Model> model) {
         const auto& ops = model->get_ops();
         for (const auto& node : ops) {
             if (ov::op::util::is_constant(node)) {

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -693,10 +693,10 @@ uint32_t Plugin::get_max_batch_size(const ov::AnyMap& options) const {
         }
     }
 
-    std::shared_ptr<ov::Model> model;
+    std::shared_ptr<const ov::Model> model;
     auto model_param = options.find(ov::hint::model.name())->second;
-    if (model_param.is<std::shared_ptr<ov::Model>>()) {
-        model = model_param.as<std::shared_ptr<ov::Model>>();
+    if (model_param.is<std::shared_ptr<const ov::Model>>()) {
+        model = model_param.as<std::shared_ptr<const ov::Model>>();
     } else {
         OPENVINO_THROW("[GPU_MAX_BATCH_SIZE] ov::hint::model should be std::shared_ptr<ov::Model> type");
     }
@@ -808,9 +808,9 @@ uint32_t Plugin::get_optimal_batch_size(const ov::AnyMap& options) const {
         GPU_DEBUG_INFO << "[OPTIMAL_BATCH_SIZE] ov::hint::model is not set: return 1" << std::endl;
         return static_cast<uint32_t>(1);
     }
-    std::shared_ptr<ov::Model> model;
+    std::shared_ptr<const ov::Model> model;
     try {
-        model = model_param->second.as<std::shared_ptr<ov::Model>>();
+        model = model_param->second.as<std::shared_ptr<const ov::Model>>();
     } catch (...) {
         OPENVINO_THROW("[OPTIMAL_BATCH_SIZE] ov::hint::model should be std::shared_ptr<ov::Model> type");
     }


### PR DESCRIPTION
### Details:
 - The `ov::hint::model` stores shared pointer to constant `ov::Model`

### Tickets:
 - CVS-164473
