### PR TITLE
[GPU] reorder_inputs fixed

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -2408,6 +2408,12 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_int8_scale_quantize_i8, ::testing::Va
 
 class conv_int8_scale_quantize_i8_conv_b_fs_yx_fsv4_int8 : public ConvFusingTest {};
 TEST_P(conv_int8_scale_quantize_i8_conv_b_fs_yx_fsv4_int8, basic) {
+    if (engine.get_device_info().supports_immad) {
+        std::cout << "[ SKIPPED ] The test is skipped (not targeting for onednn path)." << std::endl;
+        ASSERT_EQ(1, 1);
+        return;
+    }
+
     auto p = GetParam();
     create_topologies(
         input_layout("input", get_input_layout(p)),

--- a/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/add_onednn_optimization_attributes_test.cpp
@@ -65,9 +65,9 @@ TEST(add_onednn_optimization_attributes, sum_post_op_for_residual_connection) {
     if (!engine.get_device_info().supports_immad)
         return;
 
-    auto in_layout = layout{ov::PartialShape({1, 3, 32, 32}), data_types::f16, format::bfyx};
-    auto input = engine.allocate_memory(layout{ov::PartialShape({1, 3, 32, 32}), data_types::f16, format::bfyx});
-    auto weight = engine.allocate_memory(layout{ov::PartialShape({3, 3, 1, 1}), data_types::f16, format::bfyx});
+    auto in_layout = layout{ov::PartialShape({1, 16, 32, 32}), data_types::f16, format::bfyx};
+    auto input = engine.allocate_memory(layout{ov::PartialShape({1, 16, 32, 32}), data_types::f16, format::bfyx});
+    auto weight = engine.allocate_memory(layout{ov::PartialShape({16, 16, 1, 1}), data_types::f16, format::bfyx});
 
     topology topology;
     topology.add(input_layout("input", in_layout));

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -580,4 +580,41 @@ TEST(reorder_inputs, has_reshape_user) {
         ASSERT_EQ(static_cast<float>(ref_output[x]), output_ptr[x]);
     }
 }
+
+TEST(reorder_inputs, two_connections_with_different_format) {
+    // Topology:
+    // convolution(fsv16) ___ convolution
+    //                    \__ deformable_conv
+    //                     \_ reshape
+    // Purpose:
+    // When convolution has reshape as a user, its layout may be chosen in a confusing way from get_preferred_format.
+    // This test mimics the behavior.
+    //
+    // Expectation:
+    // Reorder should be added only to deformable_conv as deformable_conv supports bfyx only.
+
+    auto& engine = get_test_engine();
+    auto input = engine.allocate_memory({ data_types::f16, format::bfyx, { 1, 32, 128, 128 } });
+    auto weights = engine.allocate_memory({ data_types::f16, format::bfyx, { 32, 32, 1, 1 } });
+    auto trans = engine.allocate_memory({ data_types::f16, format::bfyx, { 1, 2, 128, 128 } });
+
+    topology topology;
+    topology.add(data("weights", weights));
+    topology.add(data("trans", trans));
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(convolution("conv1", input_info("input"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(convolution("conv2", input_info("conv1"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
+    topology.add(convolution("deform_conv", {input_info("conv1"), input_info("trans")}, "weights", "", true, 1, 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}));
+    topology.add(reshape("reshape", input_info("conv1"), tensor(2, 16, 128, 128), cldnn::reshape::reshape_mode::base));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    auto prog = program::build_program(engine, topology, config);
+
+    auto& node = prog->get_node("deform_conv");
+    ASSERT_NE(node.get_selected_impl(), nullptr);
+    auto kernel_name = node.get_selected_impl()->get_kernel_name();
+    ASSERT_EQ(kernel_name, "deformable_convolution_gpu_bfyx_opt");
+}
 #endif

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
@@ -409,6 +409,11 @@ TEST(depth_concatenate_f32_gpu, test06_padded_input) {
     //
     // *Convolution has input offset so it should be propagated, both back to reorders and to second concatenation.
     // As a result both concatenations should be optimized out and convolution should use optimized implementation.
+
+    if (engine.get_device_info().supports_immad) {
+        return;
+    }
+
     const int32_t input_f = 32;
     const int32_t output_f = 3 * input_f;
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
@@ -410,15 +410,14 @@ TEST(depth_concatenate_f32_gpu, test06_padded_input) {
     // *Convolution has input offset so it should be propagated, both back to reorders and to second concatenation.
     // As a result both concatenations should be optimized out and convolution should use optimized implementation.
 
-    if (engine.get_device_info().supports_immad) {
-        return;
-    }
-
     const int32_t input_f = 32;
     const int32_t output_f = 3 * input_f;
 
     tests::random_generator rg(GET_SUITE_NAME);
     auto& engine = get_test_engine();
+    if (engine.get_device_info().supports_immad) {
+        return;
+    }
     auto input1 = engine.allocate_memory({ data_types::f16, format::fs_b_yx_fsv32, {1, input_f, 1, 1} });
     auto input2 = engine.allocate_memory({ data_types::f16, format::fs_b_yx_fsv32, {1, input_f, 1, 1} });
 


### PR DESCRIPTION
### Details:
- get_target_output_format was checking wrong output port index
- insert_reorders_in_dir was skipping based on fmt_map. But fmt_map may not be up-to-date.
- It did not happen so far because it happens only when new_shape_infer is enabled and the node has reshape as a sibling.

### Tickets:
 - 163143
