### PR TITLE
[GPU] Set CL_TARGET_OPENCL_VERSION=300 as default

### DIFF
--- a/src/plugins/intel_gpu/CMakeLists.txt
+++ b/src/plugins/intel_gpu/CMakeLists.txt
@@ -54,7 +54,8 @@ if(ENABLE_GPU_DEBUG_CAPS)
     add_definitions(-DENABLE_DEBUG_CAPS=1)
 endif()
 
-set(INTEL_GPU_TARGET_OCL_VERSION "200" CACHE STRING "Target version of OpenCL which should be used by GPU plugin")
+set(INTEL_GPU_TARGET_OCL_VERSION "300"
+  CACHE STRING "Target version of OpenCL which should be used by GPU plugin")
 
 add_definitions(-DCL_TARGET_OPENCL_VERSION=${INTEL_GPU_TARGET_OCL_VERSION})
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernel_base_opencl.cpp
@@ -177,7 +177,9 @@ std::shared_ptr<KernelString> KernelBaseOpenCL::GetKernelString(const std::strin
                 kernel_string->options += " -DOPT_HINTS_SUPPORTED=1";
         }
 
-#if CL_TARGET_OPENCL_VERSION >= 200
+#if CL_TARGET_OPENCL_VERSION >= 300
+        kernel_string->options += " -cl-std=CL3.0";
+#elif CL_TARGET_OPENCL_VERSION >= 200
         kernel_string->options += " -cl-std=CL2.0";
 #endif
 


### PR DESCRIPTION
... and pass `-cl-std=3.0` to OpenCL C compilation when CL_TARGET_OPENCL_VERSION >= 300. This enables running OpenVINO on PoCL without `POCL_IGNORE_CL_STD=1` environment variable (except perhaps for parts that use kernels from `src/plugins/intel_gpu/thirdparty/onednn_gpu` submodule).

