### PR TITLE
[RV64] Fixed LeakyRelu CPU tests

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -231,6 +231,7 @@ std::string ActivationLayerCPUTest::getPrimitiveType(const utils::ActivationType
         if ((activation_type == utils::ActivationTypes::Clamp) ||
             (activation_type == utils::ActivationTypes::Exp) ||
             (activation_type == utils::ActivationTypes::Negative) ||
+            (activation_type == utils::ActivationTypes::LeakyRelu) ||
             (activation_type == utils::ActivationTypes::Relu) ||
             (activation_type == utils::ActivationTypes::PReLu) ||
             (activation_type == utils::ActivationTypes::Sigmoid) )


### PR DESCRIPTION
### Details:
 - *The PR https://github.com/openvinotoolkit/openvino/pull/29564 added `LeakyRelu` op for testing. Since `LeakyRelu` is supported by JIT kernel on RV64, the CPU tests should return `jit` in such cases.*
```
qemu-riscv64 -cpu rv64,x-v=true,vext_spec=v1.0  ./bin/riscv64/Release/ov_cpu_func_tests_subset --gtest_filter='*LeakyRelu*' 
....
[==========] 252 tests from 5 test suites ran. (25422 ms total)
[  PASSED  ] 252 tests.
```

### Tickets:
 - *N/A*
