### PR TITLE
[CPU][Snippets] Fixed build with CPU_DEBUG_CAPS=ON and SNIPPETS_DEBUG_CAPS=OFF

### DIFF
--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -68,16 +68,16 @@ private:
 #    define OP_EXTENSION_X64(x)
 #endif
 
-#if defined(CPU_DEBUG_CAPS)
-#    define OP_EXTENSION_DEBUG_CAPS(x) x,
+#if defined(SNIPPETS_DEBUG_CAPS)
+#    define OP_EXTENSION_SNIPPETS_DEBUG_CAPS(x) x,
 #else
-#    define OP_EXTENSION_DEBUG_CAPS(x)
+#    define OP_EXTENSION_SNIPPETS_DEBUG_CAPS(x)
 #endif
 
-#if defined(CPU_DEBUG_CAPS) && defined(OPENVINO_ARCH_X86_64)
-#    define OP_EXTENSION_DEBUG_CAPS_X64(x) x,
+#if defined(SNIPPETS_DEBUG_CAPS) && defined(OPENVINO_ARCH_X86_64)
+#    define OP_EXTENSION_SNIPPETS_DEBUG_CAPS_X64(x) x,
 #else
-#    define OP_EXTENSION_DEBUG_CAPS_X64(x)
+#    define OP_EXTENSION_SNIPPETS_DEBUG_CAPS_X64(x)
 #endif
 
 OPENVINO_CREATE_EXTENSIONS(std::vector<ov::Extension::Ptr>({
@@ -184,9 +184,9 @@ OPENVINO_CREATE_EXTENSIONS(std::vector<ov::Extension::Ptr>({
     std::make_shared<ov::OpExtension<ov::snippets::op::ReduceSum>>(),
     std::make_shared<ov::OpExtension<ov::snippets::op::Reshape>>(),
     // clang-format off
-    OP_EXTENSION_DEBUG_CAPS(std::make_shared<ov::OpExtension<ov::snippets::op::PerfCountBegin>>())
-    OP_EXTENSION_DEBUG_CAPS(std::make_shared<ov::OpExtension<ov::snippets::op::PerfCountEnd>>())
-    OP_EXTENSION_DEBUG_CAPS_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::PerfCountRdtscBegin>>())
-    OP_EXTENSION_DEBUG_CAPS_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::PerfCountRdtscEnd>>())
+    OP_EXTENSION_SNIPPETS_DEBUG_CAPS(std::make_shared<ov::OpExtension<ov::snippets::op::PerfCountBegin>>())
+    OP_EXTENSION_SNIPPETS_DEBUG_CAPS(std::make_shared<ov::OpExtension<ov::snippets::op::PerfCountEnd>>())
+    OP_EXTENSION_SNIPPETS_DEBUG_CAPS_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::PerfCountRdtscBegin>>())
+    OP_EXTENSION_SNIPPETS_DEBUG_CAPS_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::PerfCountRdtscEnd>>())
     // clang-format on
 }));


### PR DESCRIPTION
### Details:
 - *The PR https://github.com/openvinotoolkit/openvino/pull/29178 updated the file `extension.cpp` - debug-cap Snippets ops `PerfCount` are registered with `CPU_DEBUG_CAPS=ON` now. However, these ops are defined only when `SNIPPETS_DEBUG_CAPS=ON`. It means that if we try build the project with the keys `cmake .. CPU_DEBUG_CAPS=ON SNIPPETS_DEBUG_CAPS=OFF`, we will face with compilation problems. The current PR registers these ops only when `SNIPPETS_DEBUG_CAPS=ON` - returned the previous behavior.*

### Tickets:
 - *N/A*
