### PR TITLE
[TRANSFORMATIONS] Fix implicit conversion of ov::Node with multiple outputs to ov::Output

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/gelu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/gelu_fusion.cpp
@@ -45,7 +45,7 @@ Predicate check_value(float ref, float eps = std::numeric_limits<float>::epsilon
 
 bool gelu_replacer(ov::pass::pattern::Matcher& m, const std::shared_ptr<ov::Node>& pattern_input_to_relu) {
     ov::pass::NodeRegistry rg;
-    auto pattern_to_output = m.get_pattern_map();
+    auto pattern_to_output = m.get_pattern_value_map();
     auto x_output = pattern_to_output.at(pattern_input_to_relu);
 
     auto gelu = rg.make<ov::op::v7::Gelu>(x_output);

--- a/src/common/transformations/tests/common_optimizations/gelu_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/gelu_fusion.cpp
@@ -290,7 +290,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternVariadicSplitAsInput) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, 512});
         auto axis = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{});
-        auto split_lengths= std::make_shared<ov::op::v0::Constant>(element::i64, Shape{2});
+        auto split_lengths = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{2});
         auto var_split = std::make_shared<ov::op::v1::VariadicSplit>(data, axis, split_lengths);
 
         auto div_const = ov::op::v0::Constant::create(element::f32, Shape{1}, {1.4142});
@@ -310,7 +310,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternVariadicSplitAsInput) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, PartialShape{-1, -1, 512});
         auto axis = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{});
-        auto split_lengths= std::make_shared<ov::op::v0::Constant>(element::i64, Shape{2});
+        auto split_lengths = std::make_shared<ov::op::v0::Constant>(element::i64, Shape{2});
         auto var_split = std::make_shared<ov::op::v1::VariadicSplit>(data, axis, split_lengths);
 
         auto gelu = std::make_shared<ov::op::v7::Gelu>(var_split->output(1));


### PR DESCRIPTION
### Details:
In the GeluFusionWithErfTwo transformation "input" may appear to be a VariadicSplit node with multiple outputs. Using the default output of the node is incorrect and leads to an exception if used as an input to another node because of an implicit conversion to ov::Output. Use the output of the VariadicSplit node explicitly to avoid the exception.

### Tickets:
- [CVS-164465](https://jira.devtools.intel.com/browse/CVS-164465)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
