### PR TITLE
Type to fuse map

### DIFF
--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -13,6 +13,7 @@
 #include "openvino/pass/constant_folding.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/reference/convert.hpp"
+#include "openvino/cc/factory.h"
 #include "ov_ops/rms.hpp"
 #include "ov_ops/type_relaxed.hpp"
 #include "transformations/fp16_compression/align_mixed_fp32_fp16_types.hpp"
@@ -25,6 +26,8 @@
 #include "transformations/utils/utils.hpp"
 
 using namespace ov;
+
+OPENVINO_CC_DOMAINS(type_to_fuse_map);
 
 bool fuse_type_to_parameter(const std::shared_ptr<ov::Node>& node,
                             const precisions_map& precisions,
@@ -430,57 +433,60 @@ bool ov::pass::ConvertPrecision::run_on_model(const std::shared_ptr<ov::Model>& 
     bool has_fp16_compression = m_precisions.count(element::f32) > 0 && m_precisions[element::f32] == element::f16;
 
     type_to_fuse_map type_to_fuse{
-        {ov::op::v0::Convert::get_type_info_static(), fuse_type_to_convert},
-        {ov::op::v3::ShapeOf::get_type_info_static(), fuse_type_to_shapeof},
+        {ov::op::v0::Convert::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_convert, type_to_fuse_map)},
+        {ov::op::v3::ShapeOf::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_shapeof, type_to_fuse_map)},
         {ov::op::v6::Assign::get_type_info_static(),
-         m_store_original_precision_as_rt_attribute ? store_original_type_as_attribute : wrap_into_original_type},
+         m_store_original_precision_as_rt_attribute
+             ? OPENVINO_CC_REGISTER(store_original_type_as_attribute, type_to_fuse_map)
+             : OPENVINO_CC_REGISTER(wrap_into_original_type, type_to_fuse_map)},
         {ov::op::v6::ReadValue::get_type_info_static(),
-         m_store_original_precision_as_rt_attribute ? store_original_type_as_attribute : wrap_into_original_type},
-        {ov::op::v3::NonMaxSuppression::get_type_info_static(), fuse_type_to_nms3},
-        {ov::op::v4::NonMaxSuppression::get_type_info_static(), fuse_type_to_nms4},
-        {ov::op::v5::NonMaxSuppression::get_type_info_static(), fuse_type_to_nms5},
-        {ov::op::v9::NonMaxSuppression::get_type_info_static(), fuse_type_to_nms9},
-        {op::v13::NMSRotated::get_type_info_static(), fuse_type_to_nms_rotated},
-        {ov::op::v8::MatrixNms::get_type_info_static(), fuse_type_to_matrix_nms},
-        {ov::op::v8::MulticlassNms::get_type_info_static(), fuse_type_to_multiclass_nms},
-        {ov::op::v9::MulticlassNms::get_type_info_static(), fuse_type_to_multiclass_nms},
-        {ov::op::v9::GenerateProposals::get_type_info_static(), fuse_type_to_generate_proposals},
-        {ov::op::v6::CTCGreedyDecoderSeqLen::get_type_info_static(), fuse_type_to_ctc_greedy_decoder_seq_len},
-        {ov::op::v1::TopK::get_type_info_static(), fuse_type_to_topk},
-        {ov::op::v3::TopK::get_type_info_static(), fuse_type_to_topk},
-        {ov::op::v11::TopK::get_type_info_static(), fuse_type_to_topk},
-        {ov::op::v8::MaxPool::get_type_info_static(), fuse_type_to_maxpool},
-        {ov::op::v14::MaxPool::get_type_info_static(), fuse_type_to_maxpool},
-        {ov::op::v3::NonZero::get_type_info_static(), fuse_type_to_nonzero},
-        {ov::op::v3::Bucketize::get_type_info_static(), fuse_type_to_bucketize},
-        {ov::op::v1::Equal::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v1::Equal>},
-        {ov::op::v1::NotEqual::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v1::NotEqual>},
-        {ov::op::v1::Greater::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v1::Greater>},
-        {ov::op::v1::GreaterEqual::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v1::GreaterEqual>},
-        {ov::op::v1::Less::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v1::Less>},
-        {ov::op::v1::LessEqual::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v1::LessEqual>},
-        {ov::op::v10::IsFinite::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v10::IsFinite>},
-        {ov::op::v10::IsNaN::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v10::IsNaN>},
-        {ov::op::v10::IsInf::get_type_info_static(), fuse_type_to_binary_comparision<ov::op::v10::IsInf>},
-        {ov::op::v1::LogicalAnd::get_type_info_static(), fuse_type_to_logical<ov::op::v1::LogicalAnd>},
-        {ov::op::v1::LogicalOr::get_type_info_static(), fuse_type_to_logical<ov::op::v1::LogicalOr>},
-        {ov::op::v1::LogicalXor::get_type_info_static(), fuse_type_to_logical<ov::op::v1::LogicalXor>},
-        {ov::op::v1::LogicalNot::get_type_info_static(), fuse_type_to_logical<ov::op::v1::LogicalNot>},
-        {ov::op::v0::Xor::get_type_info_static(), fuse_type_to_logical<ov::op::v0::Xor>},
-        {ov::op::v1::ReduceLogicalAnd::get_type_info_static(),
-         fuse_type_to_reduce_logical<ov::op::v1::ReduceLogicalAnd>},
-        {ov::op::v1::ReduceLogicalOr::get_type_info_static(), fuse_type_to_reduce_logical<ov::op::v1::ReduceLogicalOr>},
-        {ov::op::v0::ShapeOf::get_type_info_static(), fuse_type_to_shapeof_v0},
-        {ov::op::v4::Range::get_type_info_static(), fuse_type_to_range_v4},
-        {ov::op::v9::Eye::get_type_info_static(), fuse_type_to_eye_v9},
-        {ov::op::v10::Unique::get_type_info_static(), fuse_type_to_unique_v10},
-        {ov::op::v8::RandomUniform::get_type_info_static(), fuse_type_to_random_uniform_v8},
-        {ov::op::v13::Multinomial::get_type_info_static(), fuse_type_to_multinomial_v13},
-        {ov::op::v0::PriorBox::get_type_info_static(), fuse_type_to_prior_box<ov::op::v0::PriorBox>},
-        {ov::op::v8::PriorBox::get_type_info_static(), fuse_type_to_prior_box<ov::op::v8::PriorBox>},
-        {ov::op::v0::PriorBoxClustered::get_type_info_static(), fuse_type_to_prior_box<ov::op::v0::PriorBoxClustered>},
-        {ov::op::v15::SearchSorted::get_type_info_static(), fuse_type_to_search_sorted_v15},
-        {ov::op::internal::RMS::get_type_info_static(), fuse_type_to_rms}};
+         m_store_original_precision_as_rt_attribute
+             ? OPENVINO_CC_REGISTER(store_original_type_as_attribute, type_to_fuse_map)
+             : OPENVINO_CC_REGISTER(wrap_into_original_type, type_to_fuse_map)},
+        {ov::op::v3::NonMaxSuppression::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_nms3, type_to_fuse_map)},
+        {ov::op::v4::NonMaxSuppression::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_nms4, type_to_fuse_map)},
+        {ov::op::v5::NonMaxSuppression::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_nms5, type_to_fuse_map)},
+        {ov::op::v9::NonMaxSuppression::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_nms9, type_to_fuse_map)},
+        {op::v13::NMSRotated::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_nms_rotated, type_to_fuse_map)},
+        {ov::op::v8::MatrixNms::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_matrix_nms, type_to_fuse_map)},
+        {ov::op::v8::MulticlassNms::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_multiclass_nms, type_to_fuse_map)},
+        {ov::op::v9::MulticlassNms::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_multiclass_nms, type_to_fuse_map)},
+        {ov::op::v9::GenerateProposals::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_generate_proposals, type_to_fuse_map)},
+        {ov::op::v6::CTCGreedyDecoderSeqLen::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_ctc_greedy_decoder_seq_len, type_to_fuse_map)},
+        {ov::op::v1::TopK::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_topk, type_to_fuse_map)},
+        {ov::op::v3::TopK::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_topk, type_to_fuse_map)},
+        {ov::op::v11::TopK::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_topk, type_to_fuse_map)},
+        {ov::op::v8::MaxPool::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_maxpool, type_to_fuse_map)},
+        {ov::op::v14::MaxPool::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_maxpool, type_to_fuse_map)},
+        {ov::op::v3::NonZero::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_nonzero, type_to_fuse_map)},
+        {ov::op::v3::Bucketize::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_bucketize, type_to_fuse_map)},
+        {ov::op::v1::Equal::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v1::Equal>, type_to_fuse_map)},
+        {ov::op::v1::NotEqual::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v1::NotEqual>, type_to_fuse_map)},
+        {ov::op::v1::Greater::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v1::Greater>, type_to_fuse_map)},
+        {ov::op::v1::GreaterEqual::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v1::GreaterEqual>, type_to_fuse_map)},
+        {ov::op::v1::Less::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v1::Less>, type_to_fuse_map)},
+        {ov::op::v1::LessEqual::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v1::LessEqual>, type_to_fuse_map)},
+        {ov::op::v10::IsFinite::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v10::IsFinite>, type_to_fuse_map)},
+        {ov::op::v10::IsNaN::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v10::IsNaN>, type_to_fuse_map)},
+        {ov::op::v10::IsInf::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_binary_comparision<ov::op::v10::IsInf>, type_to_fuse_map)},
+        {ov::op::v1::LogicalAnd::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_logical<ov::op::v1::LogicalAnd>, type_to_fuse_map)},
+        {ov::op::v1::LogicalOr::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_logical<ov::op::v1::LogicalOr>, type_to_fuse_map)},
+        {ov::op::v1::LogicalXor::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_logical<ov::op::v1::LogicalXor>, type_to_fuse_map)},
+        {ov::op::v1::LogicalNot::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_logical<ov::op::v1::LogicalNot>, type_to_fuse_map)},
+        {ov::op::v0::Xor::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_logical<ov::op::v0::Xor>, type_to_fuse_map)},
+        {ov::op::v1::ReduceLogicalAnd::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_reduce_logical<ov::op::v1::ReduceLogicalAnd>, type_to_fuse_map)},
+        {ov::op::v1::ReduceLogicalOr::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_reduce_logical<ov::op::v1::ReduceLogicalOr>, type_to_fuse_map)},
+        {ov::op::v0::ShapeOf::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_shapeof_v0, type_to_fuse_map)},
+        {ov::op::v4::Range::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_range_v4, type_to_fuse_map)},
+        {ov::op::v9::Eye::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_eye_v9, type_to_fuse_map)},
+        {ov::op::v10::Unique::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_unique_v10, type_to_fuse_map)},
+        {ov::op::v8::RandomUniform::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_random_uniform_v8, type_to_fuse_map)},
+        {ov::op::v13::Multinomial::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_multinomial_v13, type_to_fuse_map)},
+        {ov::op::v0::PriorBox::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_prior_box<ov::op::v0::PriorBox>, type_to_fuse_map)},
+        {ov::op::v8::PriorBox::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_prior_box<ov::op::v8::PriorBox>, type_to_fuse_map)},
+        {ov::op::v0::PriorBoxClustered::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_prior_box<ov::op::v0::PriorBoxClustered>, type_to_fuse_map)},
+        {ov::op::v15::SearchSorted::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_search_sorted_v15, type_to_fuse_map)},
+        {ov::op::internal::RMS::get_type_info_static(), OPENVINO_CC_REGISTER(fuse_type_to_rms, type_to_fuse_map)}};
 
     for (const auto& it : m_additional_type_to_fuse_map) {
         type_to_fuse[it.first] = it.second;

--- a/src/frontends/pytorch/src/op/rad2deg.cpp
+++ b/src/frontends/pytorch/src/op/rad2deg.cpp
@@ -5,8 +5,8 @@
 #include <cmath>
 
 #include "openvino/frontend/pytorch/node_context.hpp"
-#include "openvino/op/multiply.hpp"
 #include "openvino/op/constant.hpp"
+#include "openvino/op/multiply.hpp"
 
 namespace ov {
 namespace frontend {
@@ -16,7 +16,7 @@ namespace op {
 OutputVector translate_rad2deg(const NodeContext& context) {
     // Ensure that the operation has exactly one input (the input tensor)
     num_inputs_check(context, 1, 1);
-    
+
     // Retrieve the input tensor
     auto input = context.get_input(0);
 
@@ -24,10 +24,10 @@ OutputVector translate_rad2deg(const NodeContext& context) {
     auto input_type = input.get_element_type();
 
     const double pi_val = std::atan(1.0) * 4;
-    
+
     // Create a constant node with the conversion factor (180 / π)
     auto conversion_factor = context.mark_node(ov::op::v0::Constant::create(input_type, Shape{}, {180.0 / pi_val}));
-    
+
     // Apply the multiplication operation to convert radians to degrees
     auto result = context.mark_node(std::make_shared<ov::op::v1::Multiply>(input, conversion_factor));
 

--- a/src/frontends/pytorch/src/op/rad2deg.cpp
+++ b/src/frontends/pytorch/src/op/rad2deg.cpp
@@ -7,6 +7,7 @@
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/multiply.hpp"
+#include "utils.hpp"
 
 namespace ov {
 namespace frontend {

--- a/src/frontends/pytorch/src/op/rad2deg.cpp
+++ b/src/frontends/pytorch/src/op/rad2deg.cpp
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include <cmath>
+
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/constant.hpp"
-#include <cmath>
 
 namespace ov {
 namespace frontend {

--- a/src/frontends/pytorch/src/op/rad2deg.cpp
+++ b/src/frontends/pytorch/src/op/rad2deg.cpp
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/constant.hpp"
+#include <cmath>  // Required for M_PI
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_rad2deg(const NodeContext& context) {
+    // Ensure that the operation has exactly one input (the input tensor)
+    num_inputs_check(context, 1, 1);
+    
+    // Retrieve the input tensor
+    auto input = context.get_input(0);
+    
+    // Create a constant node with the conversion factor (180 / π)
+    auto conversion_factor = context.mark_node(ov::op::v0::Constant::create(element::f32, Shape{}, {180.0 / M_PI}));
+    
+    // Apply the multiplication operation to convert radians to degrees
+    auto result = context.mark_node(std::make_shared<ov::op::v1::Multiply>(input, conversion_factor));
+
+    // Return the computed result as an OutputVector
+    return {result};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/rad2deg.cpp
+++ b/src/frontends/pytorch/src/op/rad2deg.cpp
@@ -5,11 +5,7 @@
 #include "openvino/frontend/pytorch/node_context.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/constant.hpp"
-#include <cmath>  // Required for M_PI
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+#include <cmath>
 
 namespace ov {
 namespace frontend {
@@ -22,9 +18,14 @@ OutputVector translate_rad2deg(const NodeContext& context) {
     
     // Retrieve the input tensor
     auto input = context.get_input(0);
+
+    // Get the input element type dynamically
+    auto input_type = input.get_element_type();
+
+    const double pi_val = std::atan(1.0) * 4;
     
     // Create a constant node with the conversion factor (180 / π)
-    auto conversion_factor = context.mark_node(ov::op::v0::Constant::create(element::f32, Shape{}, {180.0 / M_PI}));
+    auto conversion_factor = context.mark_node(ov::op::v0::Constant::create(input_type, Shape{}, {180.0 / pi_val}));
     
     // Apply the multiplication operation to convert radians to degrees
     auto result = context.mark_node(std::make_shared<ov::op::v1::Multiply>(input, conversion_factor));

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -19,7 +19,6 @@ namespace op {
 using namespace ov::frontend;
 
 // TorchScript translations
-OP_CONVERTER(translate_rad2deg);
 OP_CONVERTER(translate_adaptive_avg_pool3d);
 OP_CONVERTER(translate_adaptive_avg_pool2d);
 OP_CONVERTER(translate_adaptive_avg_pool1d);
@@ -197,6 +196,7 @@ OP_CONVERTER(translate_quantized_add_relu);
 OP_CONVERTER(translate_quantized_hardswish);
 OP_CONVERTER(translate_quantized_mul);
 OP_CONVERTER(translate_range_length);
+OP_CONVERTER(translate_rad2deg);
 OP_CONVERTER(translate_rand);
 OP_CONVERTER(translate_randn);
 OP_CONVERTER(translate_randint);
@@ -347,7 +347,6 @@ OP_CONVERTER(translate_linear_awq);
 // Supported ops for TorchScript
 const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
     return {
-        {"aten::rad2deg", op::translate_rad2deg},
         {"aten::__and__", op::translate_bitwise_and},
         {"aten::__iand__", op::inplace_op<op::translate_bitwise_and>},
         {"aten::__derive_index", op::translate_derive_index},
@@ -620,6 +619,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::prod", op::translate_prod},
         {"aten::quantize_per_channel", op::translate_quantize_per_channel},
         {"aten::quantize_per_tensor", op::translate_quantize_per_tensor},
+        {"aten::rad2deg", op::translate_rad2deg},
         {"aten::rand", op::translate_rand},
         {"aten::rand_like", op::translate_rand_like},
         {"aten::randint", op::translate_randint},

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -19,6 +19,7 @@ namespace op {
 using namespace ov::frontend;
 
 // TorchScript translations
+OP_CONVERTER(translate_rad2deg);
 OP_CONVERTER(translate_adaptive_avg_pool3d);
 OP_CONVERTER(translate_adaptive_avg_pool2d);
 OP_CONVERTER(translate_adaptive_avg_pool1d);
@@ -340,11 +341,13 @@ OP_CONVERTER(translate_conv1d_ext);
 OP_CONVERTER(translate_embedding_ext);
 OP_CONVERTER(translate_linear_awq);
 
+
 }  // namespace op
 
 // Supported ops for TorchScript
 const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
     return {
+        {"aten::rad2deg", op::translate_rad2deg},
         {"aten::__and__", op::translate_bitwise_and},
         {"aten::__iand__", op::inplace_op<op::translate_bitwise_and>},
         {"aten::__derive_index", op::translate_derive_index},

--- a/tests/layer_tests/pytorch_tests/test_rad2deg.py
+++ b/tests/layer_tests/pytorch_tests/test_rad2deg.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import numpy as np
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestRad2Deg(PytorchLayerTest):
+    def _prepare_input(self):
+        """
+        Generates random test inputs in radians.
+        """
+        return (np.random.uniform(-np.pi, np.pi, (5, 5)).astype(np.float32),)
+
+    def create_model(self):
+        """
+        Defines a PyTorch model that applies the radian-to-degree conversion.
+        """
+        class AtenRad2Deg(torch.nn.Module):
+            def forward(self, x):
+                return torch.rad2deg(x)
+
+        ref_net = None  # No reference model needed
+        return AtenRad2Deg(), ref_net, "aten::rad2deg"
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    def test_rad2deg(self, ie_device, precision, ir_version):
+        """
+        Executes the rad2deg test on different devices and precision levels.
+        """
+        self._test(*self.create_model(), ie_device, precision, ir_version)


### PR DESCRIPTION
### Details:
 
Hi @p-wysocki, @11happy ,

I hope you're all doing well! Here's an update on the progress and implementation details for the issue [#23069: Possible Conditional Compilation Optimization for type_to_fuse_map].

What has been done so far:
Integration of Conditional Compilation (CC):

I added support for Conditional Compilation to the type_to_fuse_map in the file convert_precision.cpp.
The macro OPENVINO_CC_REGISTER was used to register each operation in the type_to_fuse_map under the domain type_to_fuse_map, which was defined using OPENVINO_CC_DOMAINS.
Code Changes:

The type_to_fuse_map was updated to include OPENVINO_CC_REGISTER for all operations. For example:
The domain type_to_fuse_map was defined at the top of the file:
Validation of factory.h:

The file openvino/cc/factory.h provides the necessary infrastructure for Conditional Compilation, including the macros OPENVINO_CC_REGISTER and OPENVINO_CC_DOMAINS.
The include path #include "openvino/cc/factory.h" works correctly as long as the build system (CMake) is configured to include the directory src/common/conditional_compilation/include.

Once everything is validated, commit the changes and push them to the repository.
Key Points for Discussion:
Include Path:

The include path #include "openvino/cc/factory.h" works as long as the build system is configured correctly. If there are any issues, we can adjust the CMake configuration or use the full path.

### Tickets:
 - *https://github.com/openvinotoolkit/openvino/issues/23069*
