### PR TITLE
[CPU][DEBUG_CAPS] Skip empty options in property groups

### DIFF
--- a/src/common/snippets/src/utils/debug_caps_config.cpp
+++ b/src/common/snippets/src/utils/debug_caps_config.cpp
@@ -40,6 +40,9 @@ void DebugCapsConfig::PropertyGroup::parseAndSet(const std::string& str) {
     };
 
     for (const auto& option : options) {
+        if (option.empty()) {
+            continue;
+        }
         const auto& parts = ov::util::split(option, '=');
         if (parts.size() > 2) {
             failed = true;

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.h
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.h
@@ -98,6 +98,9 @@ public:
             };
 
             for (const auto& option : options) {
+                if (option.empty()) {
+                    continue;
+                }
                 const auto& parts = ov::util::split(option, '=');
                 if (parts.size() > 2) {
                     failed = true;


### PR DESCRIPTION
### Details:
Fix parser failure on multiple spaces in debug caps env var options

### Tickets:
 - N/A