### PR TITLE
[CPU] Provide an option to customize addr2line binary in JIT code disasm tool

### DIFF
--- a/src/plugins/intel_cpu/tools/dump_jit_disassm/README.md
+++ b/src/plugins/intel_cpu/tools/dump_jit_disassm/README.md
@@ -70,3 +70,4 @@ the final output looks like this:
 
  - In VSCode, if the final output is displayed in TERMINAL, you can click the `file:line_no` while holdding `Ctrl` key to directly navigate to coresponding source code.
 
+ - `llvm-addr2line` (`llvm-symbolizer`) may work significantly faster than default `addr2line`, consider using `addr2line` tool from LLVM toolchain if applicable. Customization is available using `--addr2line=<path-to-addr2line-tool>` flag.

--- a/src/plugins/intel_cpu/tools/dump_jit_disassm/__main__.py
+++ b/src/plugins/intel_cpu/tools/dump_jit_disassm/__main__.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 from colorama import Fore
 
-def addr2line(exefile, addrs):
-    proc = subprocess.Popen(["addr2line", "-C", "-e", exefile, "-f", "-s", "-p"],
+def addr2line(exefile, addrs, addr2line_path):
+    proc = subprocess.Popen([addr2line_path, "-C", "-e", exefile, "-f", "-s", "-p"],
                             stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
     line_info = {}
     for i, addr in enumerate(addrs):
@@ -24,6 +24,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=f"jit dump disassmbler")
     parser.add_argument("--filter", type=list, default=["xbyak.h","jit_generator.hpp","primitive.hpp","xbyak_mnemonic.h"])
     parser.add_argument("--maxcnt", type=int, help="Maximum number of entries from call stack to show", default=3)
+    parser.add_argument("--addr2line", type=str, help="path to addr2line tool", default="addr2line")
     parser.add_argument("trace", type=str)
     parser.add_argument("bin", type=str)
 
@@ -61,7 +62,7 @@ if __name__ == "__main__":
     print(f"extract debug info with addr2line...")
     traces={}
     for exefile, addrs in addr2check.items():
-        traces[exefile] = addr2line(exefile, addrs)
+        traces[exefile] = addr2line(exefile, addrs, args.addr2line)
 
     print("objdump...")
     disassemble = subprocess.check_output(f"objdump -D -b binary -mi386:x86-64 -M intel {args.bin}", shell=True, encoding="utf-8")


### PR DESCRIPTION
### Details:
In some cases using `llvm-addr2line` enables with dramatic tool performance improvement with the same output

This patch introduces an option to specify the path to desired `addr2line` tool binary (`addr2line` remains default)

```
$ time python ~/openvino/src/plugins/intel_cpu/tools/dump_jit_disassm/ dnnl_traces_cpu_jit_brgemm_kernel_t.5.txt dnnl_dump_cpu_jit_brgemm_kernel_t.5.bin

real    3m4.886s
user    3m3.696s
sys     0m1.172s
$ time python ~/openvino/src/plugins/intel_cpu/tools/dump_jit_disassm/ dnnl_traces_cpu_jit_brgemm_kernel_t.5.txt dnnl_dump_cpu_jit_brgemm_kernel_t.5.bin --addr2line=llvm-addr2line-15

real    0m0.938s
user    0m0.767s
sys     0m0.158s
```
Output after `addr2line` and `llvm-addr2line` execution remains the same

### Tickets:
 - N/A
