### PR TITLE
[NPU] Linking libze_loader.so on Android

### DIFF
--- a/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_api.cpp
@@ -12,7 +12,7 @@ ZeroApi::ZeroApi() {
     const std::string baseName = "ze_loader";
     try {
         auto libpath = ov::util::make_plugin_library_name({}, baseName);
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(ANDROID)
         libpath = libpath + LIB_ZE_LOADER_SUFFIX;
 #endif
 


### PR DESCRIPTION
- Linking libze_loader.so instead of libze_loader.so.1 on Android

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
