### PR TITLE
[SNIPPETS][ARM] Enable logical operations tokenization

### DIFF
--- a/src/common/snippets/src/pass/validate.cpp
+++ b/src/common/snippets/src/pass/validate.cpp
@@ -79,22 +79,32 @@ bool Validate::is_supported_transpose(const std::shared_ptr<const ov::Node>& nod
 }
 
 bool Validate::is_supported_op(const std::shared_ptr<const ov::Node>& node) {
+    if (ov::is_type<ov::op::v1::LogicalAnd>(node) ||
+        ov::is_type<ov::op::v1::LogicalOr>(node) ||
+        ov::is_type<ov::op::v1::LogicalXor>(node) ||
+        ov::is_type<ov::op::v1::LogicalNot>(node)) {
+        return true;
+    }
     return false;
 }
 
 bool Validate::run_on_model(const std::shared_ptr<ov::Model>& m) {
     RUN_ON_MODEL_SCOPE(Validate);
-    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::Validate")
+    OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::Validate");
 
     for (const auto& op : m->get_ordered_ops()) {
-        VALIDATE(op, ov::op::v0::Constant, is_supported_constant)
-        VALIDATE(op, ov::op::v0::Convert, is_supported_convert)
-        VALIDATE(op, ov::op::v0::MatMul, is_supported_matmul)
-        VALIDATE(op, ov::op::v1::Softmax, is_supported_softmax)
-        VALIDATE(op, ov::op::v8::Softmax, is_supported_softmax)
-        VALIDATE(op, ov::op::v0::FakeQuantize, is_supported_fq)
-        VALIDATE(op, ov::op::v1::Transpose, is_supported_transpose)
+        VALIDATE(op, ov::op::v0::Constant, is_supported_constant);
+        VALIDATE(op, ov::op::v0::Convert, is_supported_convert);
+        VALIDATE(op, ov::op::v0::MatMul, is_supported_matmul);
+        VALIDATE(op, ov::op::v1::Softmax, is_supported_softmax);
+        VALIDATE(op, ov::op::v8::Softmax, is_supported_softmax);
+        VALIDATE(op, ov::op::v0::FakeQuantize, is_supported_fq);
+        VALIDATE(op, ov::op::v1::Transpose, is_supported_transpose);
         VALIDATE(op, ov::op::v1::Reshape, is_supported_op);
+        VALIDATE(op, ov::op::v1::LogicalAnd, is_supported_op);
+        VALIDATE(op, ov::op::v1::LogicalOr, is_supported_op);
+        VALIDATE(op, ov::op::v1::LogicalXor, is_supported_op);
+        VALIDATE(op, ov::op::v1::LogicalNot, is_supported_op);
     }
     return true;
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/cpu_generator.cpp
@@ -187,6 +187,12 @@ CPUTargetMachine::CPUTargetMachine(dnnl::impl::cpu::aarch64::cpu_isa_t host_isa,
     jitters[op::v1::GreaterEqual::get_type_info_static()] = CREATE_CPU_EMITTER(jit_greater_equal_emitter);
     jitters[op::v1::LessEqual::get_type_info_static()] = CREATE_CPU_EMITTER(jit_less_equal_emitter);
 
+    // Logical ops
+    jitters[op::v1::LogicalAnd::get_type_info_static()] = CREATE_CPU_EMITTER(jit_logical_and_emitter);
+    jitters[op::v1::LogicalOr::get_type_info_static()] = CREATE_CPU_EMITTER(jit_logical_or_emitter);
+    jitters[op::v1::LogicalNot::get_type_info_static()] = CREATE_CPU_EMITTER(jit_logical_not_emitter);
+    jitters[op::v1::LogicalXor::get_type_info_static()] = CREATE_CPU_EMITTER(jit_logical_xor_emitter);
+
     // unary
     jitters[ov::op::v0::Abs::get_type_info_static()] = CREATE_CPU_EMITTER(jit_abs_emitter);
     jitters[ov::op::v0::Ceiling::get_type_info_static()] = CREATE_CPU_EMITTER(jit_ceiling_emitter);


### PR DESCRIPTION
### Details:
- Enable tokenization of logical operations (LogicalAnd, LogicalOr, LogicalXor, LogicalNot) in Snippets for AArch64 devices
- Register logical operations with corresponding JIT emitters in CPUTargetMachine
- Add support for logical operations in the Snippets pipeline for AArch64 devices

### Tickets:
- #28160