### PR TITLE
Limit parallel build jobs based on actual processor count for external projects

### DIFF
--- a/cmake/developer_package/cross_compile/native_compile.cmake
+++ b/cmake/developer_package/cross_compile/native_compile.cmake
@@ -3,6 +3,8 @@
 #
 
 include(ExternalProject)
+include(ProcessorCount)
+ProcessorCount(PROCESSOR_COUNT)
 
 #
 # ov_native_compile_external_project(
@@ -124,7 +126,7 @@ function(ov_native_compile_external_project)
             "${NATIVE_CMAKE_COMMAND}"
                 --build "${CMAKE_CURRENT_BINARY_DIR}/build"
                 --config Release
-                --parallel
+                --parallel ${PROCESSOR_COUNT}
                 -- ${ARG_NATIVE_TARGETS}
         # Test Step Options:
         TEST_EXCLUDE_FROM_MAIN ON


### PR DESCRIPTION
### Details:
Set explicit limitation for parallel jobs in `ov_native_compile_external_project` to the actual processors count retrieved from cmake.

Motivation of this change: `--parallel` without arguments may be interpreted as unlimited amount of threads. For example, it uses `make -j0` on ARM 32-bit build for `protobuf` library, as a result it overflows RAM and hangs the system.

### Tickets:
 - N/A
