### PR TITLE
[TFL FE]: fix uninitialized deprecated_builtin_code error

### DIFF
--- a/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.cpp
+++ b/src/frontends/tensorflow_lite/src/graph_iterator_flatbuffer.cpp
@@ -87,7 +87,11 @@ std::shared_ptr<DecoderBase> GraphIteratorFlatBuffer::get_decoder() const {
         auto op_codes = m_model->operator_codes();
         auto operator_code = (*op_codes)[node->opcode_index()];
         std::string type;
-        if (operator_code->deprecated_builtin_code() <
+        if (operator_code->deprecated_builtin_code() != operator_code->builtin_code()) {
+            // if the two enum values are different, take the non-zero one which means specified.
+            type = tflite::EnumNamesBuiltinOperator()[operator_code->deprecated_builtin_code() ? \
+               operator_code->deprecated_builtin_code() : operator_code->builtin_code()];
+        } else if (operator_code->deprecated_builtin_code() <
             tflite::BuiltinOperator::BuiltinOperator_PLACEHOLDER_FOR_GREATER_OP_CODES) {
             type = tflite::EnumNamesBuiltinOperator()[operator_code->deprecated_builtin_code()];
         } else {


### PR DESCRIPTION
This fixes #29666 

There could be uninitialized deprecated_builtin_code with value 0 while the builtin_code is actually set, adding check to avoid using the unintended value 0 when retrieving the operator type.

