### PR TITLE
Revert "[GPU] Enable fusing dynamic eltwise with gemm in onednn case"

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -1142,8 +1142,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 auto eltw_in_size = peer_node->get_output_layout();
                 if (eltw_in_size.is_dynamic()
                     // this whitelist condition is temporarily and to be relaxed soon.
-                    && !fused_node->is_type<fully_connected>()
-                    && !fused_node->is_type<gemm>())
+                    && !fused_node->is_type<fully_connected>())
                     return;
             }
             if (parent1.first->is_type<convolution>() && !conv_supports_fusings(parent1.first->as<convolution>()))

--- a/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/gemm_fusion_test.cpp
@@ -482,6 +482,13 @@ class gemm_2in_dynamic_add : public gemm_2in_add {};
 TEST_P(gemm_2in_dynamic_add, add) {
     auto p = GetParam();
 
+    if (engine.get_device_info().supports_immad) {
+        p.expected_fused_primitives++;
+        if (!p.kernel_name.empty()) {
+            p.expected_not_fused_primitives++;
+        }
+    }
+
     cfg_fused.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     cfg_not_fused.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
@@ -518,10 +525,13 @@ TEST_P(gemm_2in_dynamic_add, add) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, gemm_2in_dynamic_add, ::testing::ValuesIn(std::vector<gemm_test_params>{
-    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 4, "gemm_tiled_opt", broadcast_kinds::batch, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 5, "", broadcast_kinds::batch, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 5, "", broadcast_kinds::feature, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_2, 4, 5, "", broadcast_kinds::feature, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_2, 4, 5, "", broadcast_kinds::batch, eltwise_mode::sum },
+    // Reference graph can be fused because force_implementation leads to optimize_data = true;
     gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 4, "gemm_tiled_opt", broadcast_kinds::feature, eltwise_mode::sum },
-    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_2, 4, 4, "gemm_tiled_opt", broadcast_kinds::feature, eltwise_mode::sum },
-    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_2, 4, 4, "gemm_tiled_opt", broadcast_kinds::batch, eltwise_mode::sum },
+    gemm_test_params{ CASE_GEMM_2IN_FP16_3D_1, 4, 4, "gemm_tiled_opt", broadcast_kinds::batch, eltwise_mode::sum }
 }));
 
 class gemm_2in_act_scale_quantize_i8 : public GemmFusingTest {};


### PR DESCRIPTION
This reverts commit c202882011202b4731b0bb7254c18cececc071ba

### Details:
 - *Reverts due to perf regression*

### Tickets:
 - *[CVS-164331](https://jira.devtools.intel.com/browse/CVS-164331)*