### PR TITLE
[CPU]Enable 4bit cache compression for pagedAttn

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -329,7 +329,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             try {
                 keyCachePrecisionSetExplicitly = true;
                 auto const prec = val.as<ov::element::Type>();
-                if (one_of(prec, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8)) {
+                if (one_of(prec, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8, ov::element::u4)) {
                     keyCachePrecision = prec;
                 } else {
                     OPENVINO_THROW("keyCachePrecision doesn't support value ", prec);

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -329,7 +329,12 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             try {
                 keyCachePrecisionSetExplicitly = true;
                 auto const prec = val.as<ov::element::Type>();
-                if (one_of(prec, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8, ov::element::u4)) {
+                if (one_of(prec,
+                           ov::element::f32,
+                           ov::element::f16,
+                           ov::element::bf16,
+                           ov::element::u8,
+                           ov::element::u4)) {
                     keyCachePrecision = prec;
                 } else {
                     OPENVINO_THROW("keyCachePrecision doesn't support value ", prec);
@@ -396,6 +401,25 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
                                val.as<ov::intel_cpu::CacheQuantMode>(),
                                " for property key ",
                                ov::intel_cpu::key_cache_quant_mode.name(),
+                               ". Expected only unsinged integer numbers");
+            }
+        } else if (key == ov::intel_cpu::value_cache_quant_mode.name()) {
+            try {
+                auto const mode = val.as<ov::intel_cpu::CacheQuantMode>();
+                if (mode == ov::intel_cpu::CacheQuantMode::AUTO) {
+                    valueCacheQuantMode = CacheQuantMode::AUTO;
+                } else if (mode == ov::intel_cpu::CacheQuantMode::BY_CHANNEL) {
+                    valueCacheQuantMode = CacheQuantMode::BY_CHANNEL;
+                } else if (mode == ov::intel_cpu::CacheQuantMode::BY_HIDDEN) {
+                    valueCacheQuantMode = CacheQuantMode::BY_HIDDEN;
+                } else {
+                    OPENVINO_THROW("invalid value");
+                }
+            } catch (ov::Exception&) {
+                OPENVINO_THROW("Wrong value ",
+                               val.as<ov::intel_cpu::CacheQuantMode>(),
+                               " for property key ",
+                               ov::intel_cpu::value_cache_quant_mode.name(),
                                ". Expected only unsinged integer numbers");
             }
         } else if (key == ov::cache_encryption_callbacks.name()) {

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -76,6 +76,7 @@ struct Config {
     size_t keyCacheGroupSize = 0ul;
     size_t valueCacheGroupSize = 0ul;
     CacheQuantMode keyCacheQuantMode = CacheQuantMode::AUTO;
+    CacheQuantMode valueCacheQuantMode = CacheQuantMode::AUTO;
     ov::threading::IStreamsExecutor::Config streamExecutorConfig;
     int streams = 1;
     bool streamsChanged = false;

--- a/src/plugins/intel_cpu/src/internal_properties.hpp
+++ b/src/plugins/intel_cpu/src/internal_properties.hpp
@@ -109,4 +109,12 @@ inline std::istream& operator>>(std::istream& is, CacheQuantMode& mode) {
  */
 static constexpr Property<CacheQuantMode, PropertyMutability::RW> key_cache_quant_mode{"KEY_CACHE_QUANT_MODE"};
 
+/**
+ * @brief Define cache quant mode.
+ * @param AUTO - default mode by primitive
+ * @param BY_CHANNEL - quant by channel
+ * @param BY_HIDDEN - quant by hidden
+ */
+static constexpr Property<CacheQuantMode, PropertyMutability::RW> value_cache_quant_mode{"VALUE_CACHE_QUANT_MODE"};
+
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
@@ -590,7 +590,6 @@ static void paged_attn_quant_mt(const ov::intel_cpu::PlainTensor& k_src,
                                 const size_t value_group_size) {
     size_t B = k_src.m_dims[0], H = k_src.m_dims[1], L1 = k_src.m_dims[2], S = k_src.m_dims[3];
     size_t block_size = quant_key_by_channel ? k_dst.m_dims[2] - 2 * sizeof(float) * get_sub_byte_multiplier(KEY_DST_PREC) : k_dst.m_dims[2];
-    printf("paged_attn_quant_mt| B %ld H %ld L1 %ld S %ld by_channel %ld past_lens %d block_size %ld\n", B, H, L1, S, quant_key_by_channel, past_lens.ptr<int32_t>()[0], block_size);
     if (quant_key_by_channel) {
         parallel_for2d(past_lens.size(0), H, [&](size_t sub_seq_id, size_t h) {
             // scale f32[S] zp f32[S] offset in bytes
@@ -656,26 +655,12 @@ static void paged_attn_quant_mt(const ov::intel_cpu::PlainTensor& k_src,
                                                                             S,
                                                                             p_scales,
                                                                             p_zps);
-                        // printf("before dequant prev_nums %ld\n", prev_nums);
-                        // for (size_t i = 0; i < prev_nums; i++) {
-                        //     for (size_t j = 0; j < S; j++) {
-                        //         printf("%f ", buffer[i * S + j]);
-                        //     }
-                        //     printf("\n");
-                        // }
                         cvt_copy(buffer + prev_nums * S,
                                  k_src.ptr<T>(b_in_tokens, h, m),
                                  valid_length,
                                  S,
                                  k_src.stride(0),
                                  S);
-                        // printf("after dequant prev_nums %ld\n", prev_nums + valid_length);
-                        // for (size_t i = 0; i < prev_nums; i++) {
-                        //     for (size_t j = 0; j < S; j++) {
-                        //         printf("%f ", buffer[i * S + j]);
-                        //     }
-                        //     printf("\n");
-                        // }
                         quantize_by_channel<float, KEY_DST_PREC>(buffer,
                                                                  p_k,
                                                                  prev_nums + valid_length,

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
@@ -294,7 +294,7 @@ static void quantize_by_channel(const T* src,
         for (size_t i = 0; i < seq_dim; ++i) {
             float tmp = src[i * src_stride + j];
             tmp = std::max(tmp / scale[j] + zp[j], 0.0f);
-            dst[i * dst_stride + j] = static_cast<uint8_t>(std::round(tmp / scale[j] + zp[j]));
+            dst[i * dst_stride + j] = static_cast<uint8_t>(std::round(tmp));
         }
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
@@ -811,7 +811,6 @@ void paged_attn_quantkv(const ov::intel_cpu::PlainTensor& k_src,
     if (v_dst.get_precision() == ov::element::u4) {
         dispatch |= 0x01;
     }
-    printf("paged_attn_quantkv|dispatch %d %x\n", dispatch, dispatch);
     if (k_src.get_precision() == ov::element::f32) {
         funcs_fp32[dispatch](k_src,
                              v_src,

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.hpp
@@ -36,6 +36,7 @@ void paged_attn_quantkv(const ov::intel_cpu::PlainTensor& k_src,
                         const ov::intel_cpu::PlainTensor& slot_mapping,
                         ov::intel_cpu::PlainTensor& temp_buffer,
                         const bool quant_key_by_channel,
+                        const bool quant_value_by_channel,
                         const size_t key_group_size,
                         const size_t value_group_size);
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant_kernel.hpp
@@ -20,10 +20,10 @@ namespace ov::Extensions::Cpu::XARCH {
 template <typename TDST,
           ov::element::Type_t SRC_PREC,
           typename std::enable_if<SRC_PREC == ov::element::u8, bool>::type = true>
-void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, float zp) {
+void attn_dequant_kernel(const void* src, TDST* dst, size_t n, float scale, float zp) {
     size_t i = 0;
     // loadu_si128/epi64 does not support const qualifier
-    auto* src_nc = const_cast<uint8_t*>(src);
+    uint8_t* src_nc = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src));
 #if defined(HAVE_AVX512F)
     auto v_zp = _mm512_set1_ps(zp);
     auto v_scale = _mm512_set1_ps(scale);
@@ -57,7 +57,7 @@ void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, f
 template <typename TDST,
           ov::element::Type_t SRC_PREC,
           typename std::enable_if<SRC_PREC == ov::element::u4, bool>::type = true>
-void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, float zp) {
+void attn_dequant_kernel(const void* src, TDST* dst, size_t n, float scale, float zp) {
     // 2 4bit data form a byte
     /* 0,1|2,3|4,5|6,7
           /      \
@@ -68,7 +68,7 @@ void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, f
        0,1,2,3,4,5,6,7
     */
     size_t i = 0;
-    auto* src_nc = const_cast<uint8_t*>(src);
+    uint8_t* src_nc = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src));
 #if defined(HAVE_AVX512F)
     auto v_scale = _mm512_set1_ps(scale);
     auto v_zp_scale = _mm512_set1_ps(zp * scale);
@@ -138,16 +138,16 @@ void attn_dequant_kernel(const uint8_t* src, TDST* dst, size_t n, float scale, f
     }
 }
 
-template <typename TDST>
-void attn_dequant_u8_by_channel_kernel(const uint8_t* src,
-                                       TDST* dst,
-                                       size_t seq_dim,
-                                       size_t hidden_dims,
-                                       size_t src_stride,
-                                       size_t dst_stride,
-                                       float* scale,
-                                       float* zp) {
-    uint8_t* src_nc = const_cast<uint8_t*>(src);
+template <typename TDST, ov::element::Type_t PREC, std::enable_if_t<PREC == ov::element::u8, bool> = true>
+void attn_dequant_by_channel_kernel(const void* src,
+                                    TDST* dst,
+                                    size_t seq_dim,
+                                    size_t hidden_dims,
+                                    size_t src_stride,
+                                    size_t dst_stride,
+                                    float* scale,
+                                    float* zp) {
+    uint8_t* src_nc = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src));
 
     for (size_t i = 0; i < seq_dim; ++i) {
         size_t j = 0;
@@ -178,6 +178,95 @@ void attn_dequant_u8_by_channel_kernel(const uint8_t* src,
             tmp = (tmp - zp[j]) * scale[j];
             dst[i * dst_stride + j] = tmp;
             j += 1;
+        }
+    }
+}
+
+template <typename TDST, ov::element::Type_t PREC, std::enable_if_t<PREC == ov::element::u4, bool> = true>
+void attn_dequant_by_channel_kernel(const void* src,
+                                    TDST* dst,
+                                    size_t seq_dim,
+                                    size_t hidden_dims,
+                                    size_t src_stride,
+                                    size_t dst_stride,
+                                    float* scale,
+                                    float* zp) {
+    uint8_t* src_nc = const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(src));
+    size_t j = 0;
+#if defined(HAVE_AVX512F)
+    for (; j + vec_len_f32_avx512 * 2 <= hidden_dims; j += vec_len_f32_avx512 * 2) {
+        auto v_scale0 = _mm512_loadu_ps(scale + j);
+        auto v_zp0 = _mm512_loadu_ps(zp + j);
+        auto v_scale1 = _mm512_loadu_ps(scale + j + vec_len_f32_avx512);
+        auto v_zp1 = _mm512_loadu_ps(zp + j + vec_len_f32_avx512);
+        for (size_t i = 0; i < seq_dim; i++) {
+            auto data = _mm_loadu_si128(reinterpret_cast<__m128i*>(src_nc + i * src_stride + j / 2));
+            auto v_i32 = _mm512_cvtepu8_epi32(data);
+
+            auto v_512_low_half = _mm512_srli_epi32(v_i32, 4);
+            auto v_f32_low_half = _mm512_cvtepi32_ps(v_512_low_half);
+
+            auto mask = _mm512_set1_epi32(0x0F);
+            auto v_512_high_half = _mm512_and_si512(v_i32, mask);
+            auto v_f32_high_half = _mm512_cvtepi32_ps(v_512_high_half);
+            // q * scale- zp * scale
+            // v_f32_low_half = _mm512_fmsub_ps(v_f32_low_half, v_scale, v_zp_scale);
+            // v_f32_high_half = _mm512_fmsub_ps(v_f32_high_half, v_scale, v_zp_scale);
+            __m512i idx1 = _mm512_set_epi32(23, 7, 22, 6, 21, 5, 20, 4, 19, 3, 18, 2, 17, 1, 16, 0);
+            __m512i idx2 = _mm512_set_epi32(31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8);
+            __m512 first_half = _mm512_permutex2var_ps(v_f32_low_half, idx1, v_f32_high_half);
+            __m512 second_half = _mm512_permutex2var_ps(v_f32_low_half, idx2, v_f32_high_half);
+            first_half = _mm512_sub_ps(first_half, v_zp0);
+            first_half = _mm512_mul_ps(first_half, v_scale0);
+            second_half = _mm512_sub_ps(second_half, v_zp1);
+            second_half = _mm512_mul_ps(second_half, v_scale1);
+            mm512_uni_storeu_ps(dst + i * dst_stride + j, first_half);
+            mm512_uni_storeu_ps(dst + i * dst_stride + j + vec_len_f32_avx512, second_half);
+        }
+    }
+#elif defined(HAVE_AVX2)
+    for (; j + vec_len_f32_avx2 * 2 <= hidden_dims; j += vec_len_f32_avx2 * 2) {
+        auto v_scale0 = _mm256_loadu_ps(scale + j);
+        auto v_zp0 = _mm256_loadu_ps(zp + j);
+        auto v_scale1 = _mm256_loadu_ps(scale + j + vec_len_f32_avx2);
+        auto v_zp1 = _mm256_loadu_ps(zp + j + vec_len_f32_avx2);
+        for (size_t i = 0; i < seq_dim; i++) {
+            auto data = _mm_loadl_epi64(reinterpret_cast<__m128i*>(src_nc + i * src_stride + j / 2));
+
+            auto v_i32 = _mm256_cvtepu8_epi32(data);
+            auto v_256_low_half = _mm256_srli_epi32(v_i32, 4);
+            auto v_f32_low_half = _mm256_cvtepi32_ps(v_256_low_half);
+
+            auto mask = _mm256_set1_epi32(0x0F);
+            auto v_256_high_half = _mm256_and_si256(v_i32, mask);
+            auto v_f32_high_half = _mm256_cvtepi32_ps(v_256_high_half);
+
+            // 0,2,4,6,8,10,12,14 | 1,3,5,7,9,11,13,15
+            //         _mm256_permute2f128_ps
+            // 0,2,4,6,1,3,5,7    | 8,10,12,14,9,11,13,15
+            //         _mm256_permutevar8x32_ps
+            // 0,1,2,3,4,5,6,7    | 8,9,10,11,12,13,14,15
+            __m256 first_half = _mm256_permute2f128_ps(v_f32_low_half, v_f32_high_half, 0x20);
+            auto idx1 = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
+            first_half = _mm256_permutevar8x32_ps(first_half, idx1);
+            __m256 second_half = _mm256_permute2f128_ps(v_f32_low_half, v_f32_high_half, 0x31);
+            second_half = _mm256_permutevar8x32_ps(second_half, idx1);
+            first_half = _mm256_sub_ps(first_half, v_zp0);
+            first_half = _mm256_mul_ps(first_half, v_scale0);
+            second_half = _mm256_sub_ps(second_half, v_zp1);
+            second_half = _mm256_mul_ps(second_half, v_scale1);
+            mm256_uni_storeu_ps(dst + i * dst_stride + j, first_half);
+            mm256_uni_storeu_ps(dst + i * dst_stride + j + vec_len_f32_avx2, second_half);
+        }
+    }
+#endif
+    for (; j < hidden_dims; j += 2) {
+        for (size_t i = 0; i < seq_dim; ++i) {
+            uint8_t data = src_nc[i * src_stride + j / 2];
+            float tmp0 = extract_half_byte(data, static_cast<bool>(j % 2));
+            float tmp1 = extract_half_byte(data, static_cast<bool>((j + 1) % 2));
+            dst[i * dst_stride + j] = (tmp0 - zp[j]) * scale[j];
+            dst[i * dst_stride + j + 1] = (tmp1 - zp[j + 1]) * scale[j + 1];
         }
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant_kernel.hpp
@@ -199,23 +199,9 @@ void attn_dequant_by_channel_kernel(const void* src,
         auto v_zp0 = _mm512_loadu_ps(zp + j);
         auto v_scale1 = _mm512_loadu_ps(scale + j + vec_len_f32_avx512);
         auto v_zp1 = _mm512_loadu_ps(zp + j + vec_len_f32_avx512);
+        __m512 first_half, second_half;
         for (size_t i = 0; i < seq_dim; i++) {
-            auto data = _mm_loadu_si128(reinterpret_cast<__m128i*>(src_nc + i * src_stride + j / 2));
-            auto v_i32 = _mm512_cvtepu8_epi32(data);
-
-            auto v_512_low_half = _mm512_srli_epi32(v_i32, 4);
-            auto v_f32_low_half = _mm512_cvtepi32_ps(v_512_low_half);
-
-            auto mask = _mm512_set1_epi32(0x0F);
-            auto v_512_high_half = _mm512_and_si512(v_i32, mask);
-            auto v_f32_high_half = _mm512_cvtepi32_ps(v_512_high_half);
-            // q * scale- zp * scale
-            // v_f32_low_half = _mm512_fmsub_ps(v_f32_low_half, v_scale, v_zp_scale);
-            // v_f32_high_half = _mm512_fmsub_ps(v_f32_high_half, v_scale, v_zp_scale);
-            __m512i idx1 = _mm512_set_epi32(23, 7, 22, 6, 21, 5, 20, 4, 19, 3, 18, 2, 17, 1, 16, 0);
-            __m512i idx2 = _mm512_set_epi32(31, 15, 30, 14, 29, 13, 28, 12, 27, 11, 26, 10, 25, 9, 24, 8);
-            __m512 first_half = _mm512_permutex2var_ps(v_f32_low_half, idx1, v_f32_high_half);
-            __m512 second_half = _mm512_permutex2var_ps(v_f32_low_half, idx2, v_f32_high_half);
+            mm512_loadu_u4_to_f32(src_nc + i * src_stride + j / 2, first_half, second_half);
             first_half = _mm512_sub_ps(first_half, v_zp0);
             first_half = _mm512_mul_ps(first_half, v_scale0);
             second_half = _mm512_sub_ps(second_half, v_zp1);
@@ -230,27 +216,9 @@ void attn_dequant_by_channel_kernel(const void* src,
         auto v_zp0 = _mm256_loadu_ps(zp + j);
         auto v_scale1 = _mm256_loadu_ps(scale + j + vec_len_f32_avx2);
         auto v_zp1 = _mm256_loadu_ps(zp + j + vec_len_f32_avx2);
+        __m256 first_half, second_half;
         for (size_t i = 0; i < seq_dim; i++) {
-            auto data = _mm_loadl_epi64(reinterpret_cast<__m128i*>(src_nc + i * src_stride + j / 2));
-
-            auto v_i32 = _mm256_cvtepu8_epi32(data);
-            auto v_256_low_half = _mm256_srli_epi32(v_i32, 4);
-            auto v_f32_low_half = _mm256_cvtepi32_ps(v_256_low_half);
-
-            auto mask = _mm256_set1_epi32(0x0F);
-            auto v_256_high_half = _mm256_and_si256(v_i32, mask);
-            auto v_f32_high_half = _mm256_cvtepi32_ps(v_256_high_half);
-
-            // 0,2,4,6,8,10,12,14 | 1,3,5,7,9,11,13,15
-            //         _mm256_permute2f128_ps
-            // 0,2,4,6,1,3,5,7    | 8,10,12,14,9,11,13,15
-            //         _mm256_permutevar8x32_ps
-            // 0,1,2,3,4,5,6,7    | 8,9,10,11,12,13,14,15
-            __m256 first_half = _mm256_permute2f128_ps(v_f32_low_half, v_f32_high_half, 0x20);
-            auto idx1 = _mm256_set_epi32(7, 3, 6, 2, 5, 1, 4, 0);
-            first_half = _mm256_permutevar8x32_ps(first_half, idx1);
-            __m256 second_half = _mm256_permute2f128_ps(v_f32_low_half, v_f32_high_half, 0x31);
-            second_half = _mm256_permutevar8x32_ps(second_half, idx1);
+            mm256_loadu_u4_to_f32(src_nc + i * src_stride + j / 2, first_half, second_half);
             first_half = _mm256_sub_ps(first_half, v_zp0);
             first_half = _mm256_mul_ps(first_half, v_scale0);
             second_half = _mm256_sub_ps(second_half, v_zp1);

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -3462,8 +3462,6 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                                          bool quant_key_bychannel,
                                                          bool quant_value_bychannel) {
     std::shared_ptr<PagedAttentionExecutor> executor;
-    std::cout << "make_pa_executor|" << data_type << "|" << key_cache_type << "|quant_key_bychannel|"
-              << quant_key_bychannel << std::endl;
 #if defined(OPENVINO_ARCH_X86_64)
     if (data_type == ov::element::bf16) {
 #    if defined(HAVE_AVX512F)
@@ -3505,7 +3503,11 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                " is not support");
             }
         } else {
-            OPENVINO_ASSERT(key_cache_type == ov::element::bf16, "expect kvcache type bf16, current: ", key_cache_type);
+            OPENVINO_ASSERT(key_cache_type == ov::element::bf16 && value_cache_type == ov::element::bf16,
+                            "expect kvcache type bf16, current: ",
+                            key_cache_type,
+                            " , ",
+                            value_cache_type);
             executor = std::make_shared<AttentionExecutor<ov::bfloat16, ov::element::bf16, ov::element::bf16>>();
         }
 #    else
@@ -3550,7 +3552,11 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                " is not support");
             }
         } else {
-            OPENVINO_ASSERT(key_cache_type == ov::element::f16, "expect kvcache type f16, current: ", key_cache_type);
+            OPENVINO_ASSERT(key_cache_type == ov::element::f16 && value_cache_type == ov::element::f16,
+                            "expect kvcache type f16, current: ",
+                            key_cache_type,
+                            " , ",
+                            value_cache_type);
             executor = std::make_shared<AttentionExecutor<ov::float16, ov::element::f16, ov::element::f16>>();
         }
 #    else
@@ -3594,13 +3600,20 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                " is not support");
             }
         } else if (key_cache_type == ov::element::f16) {
+            OPENVINO_ASSERT(value_cache_type == ov::element::f16,
+                            "expect value_cache_type type f16, current: ",
+                            value_cache_type);
             executor =
                 std::make_shared<AttentionExecutor<float, ov::element::f16, ov::element::f16>>(key_group_size,
                                                                                                value_group_size,
                                                                                                quant_key_bychannel,
                                                                                                quant_value_bychannel);
         } else {
-            OPENVINO_ASSERT(key_cache_type == ov::element::f32, "expect kvcache type f32, current: ", key_cache_type);
+            OPENVINO_ASSERT(key_cache_type == ov::element::f32 && value_cache_type == ov::element::f32,
+                            "expect kvcache type f32, current: ",
+                            key_cache_type,
+                            " , ",
+                            value_cache_type);
             executor =
                 std::make_shared<AttentionExecutor<float, ov::element::f32, ov::element::f32>>(key_group_size,
                                                                                                value_group_size,

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -3117,10 +3117,21 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
             }
 
         } else if (key_cache_type == ov::element::u4) {
-            executor = std::make_shared<AttentionExecutor<ov::bfloat16, ov::element::u4, ov::element::u8>>(
-                key_group_size,
-                value_group_size,
-                quant_key_bychannel);
+            if (value_cache_type == ov::element::u4) {
+                executor = std::make_shared<AttentionExecutor<ov::bfloat16, ov::element::u4, ov::element::u4>>(
+                    key_group_size,
+                    value_group_size,
+                    quant_key_bychannel);
+            } else if (value_cache_type == ov::element::u8) {
+                executor = std::make_shared<AttentionExecutor<ov::bfloat16, ov::element::u4, ov::element::u8>>(
+                    key_group_size,
+                    value_group_size,
+                    quant_key_bychannel);
+            } else {
+                OPENVINO_THROW("make_pa_executor: key_cache_type u4 with value_cache_type ",
+                               value_cache_type.to_string(),
+                               " is not support");
+            }
         } else {
             OPENVINO_ASSERT(key_cache_type == ov::element::bf16, "expect kvcache type bf16, current: ", key_cache_type);
             executor = std::make_shared<AttentionExecutor<ov::bfloat16, ov::element::bf16, ov::element::bf16>>();
@@ -3143,6 +3154,22 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                     quant_key_bychannel);
             } else {
                 OPENVINO_THROW("make_pa_executor: key_cache_type u8 with value_cache_type ",
+                               value_cache_type.to_string(),
+                               " is not support");
+            }
+        } else if (key_cache_type == ov::element::u4) {
+            if (value_cache_type == ov::element::u4) {
+                executor = std::make_shared<AttentionExecutor<ov::float16, ov::element::u4, ov::element::u4>>(
+                    key_group_size,
+                    value_group_size,
+                    quant_key_bychannel);
+            } else if (value_cache_type == ov::element::u8) {
+                executor = std::make_shared<AttentionExecutor<ov::float16, ov::element::u4, ov::element::u8>>(
+                    key_group_size,
+                    value_group_size,
+                    quant_key_bychannel);
+            } else {
+                OPENVINO_THROW("make_pa_executor: key_cache_type u4 with value_cache_type ",
                                value_cache_type.to_string(),
                                " is not support");
             }
@@ -3171,10 +3198,21 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                " is not support");
             }
         } else if (key_cache_type == ov::element::u4) {
-            executor =
-                std::make_shared<AttentionExecutor<float, ov::element::u4, ov::element::u8>>(key_group_size,
-                                                                                             value_group_size,
-                                                                                             quant_key_bychannel);
+            if (value_cache_type == ov::element::u4) {
+                executor =
+                    std::make_shared<AttentionExecutor<float, ov::element::u4, ov::element::u4>>(key_group_size,
+                                                                                                 value_group_size,
+                                                                                                 quant_key_bychannel);
+            } else if (value_cache_type == ov::element::u8) {
+                executor =
+                    std::make_shared<AttentionExecutor<float, ov::element::u4, ov::element::u8>>(key_group_size,
+                                                                                                 value_group_size,
+                                                                                                 quant_key_bychannel);
+            } else {
+                OPENVINO_THROW("make_pa_executor: key_cache_type u4 with value_cache_type ",
+                               value_cache_type.to_string(),
+                               " is not support");
+            }
         } else if (key_cache_type == ov::element::f16) {
             executor =
                 std::make_shared<AttentionExecutor<float, ov::element::f16, ov::element::f16>>(key_group_size,

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -3425,7 +3425,9 @@ struct AttentionExecutor : public PagedAttentionExecutor {
              output_score);
 
         if (rotated_block_indices) {
-            // TODO: implement u4
+            // Rotate kv cache currently doesn't support quantized cache.
+            // for u8 it only supports compilation but throws exception in the runtime
+            // TODO: implement u4/u8
             if constexpr (KEY_PREC != ov::element::u4)
                 rotate_kv_cache<typename ov::element_type_traits<KEY_PREC>::value_type>(
                     k_cache,

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -679,10 +679,10 @@ static void dot_product_block_quantized_by_channel(TA* a,
             auto va2 = mm256_uni_loadu_ps(a + i + vec_len_f32_avx2 * 2);
             auto va3 = mm256_uni_loadu_ps(a + i + vec_len_f32_avx2 * 3);
 
-            auto vb0_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + i));
-            auto vb1_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + i + vec_len_f32_avx2));
-            auto vb2_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + i + vec_len_f32_avx2 * 2));
-            auto vb3_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + i + vec_len_f32_avx2 * 3));
+            auto vb0_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + params_offset + i));
+            auto vb1_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + params_offset + i + vec_len_f32_avx2));
+            auto vb2_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + params_offset + i + vec_len_f32_avx2 * 2));
+            auto vb3_128 = _mm_loadl_epi64(reinterpret_cast<__m128i*>(b + params_offset + i + vec_len_f32_avx2 * 3));
 
             auto vb0_256 = _mm256_cvtepu8_epi32(vb0_128);
             auto vb1_256 = _mm256_cvtepu8_epi32(vb1_128);
@@ -812,7 +812,7 @@ static void dot_product_block_quantized_by_channel(TA* a,
         auto vsum0 = _mm256_set1_ps(0.0f);
         auto vsum1 = _mm256_set1_ps(0.0f);
         __m256 v256_b0, v256_b1;
-        for (; i + 2 * vec_len_f32_avx512 <= n; i += vec_len_f32_avx512 * 2) {
+        for (; i + 2 * vec_len_f32_avx2 <= n; i += vec_len_f32_avx2 * 2) {
             auto v0_zp = _mm256_loadu_ps(p_zps + i);
             auto v1_zp = _mm256_loadu_ps(p_zps + i + vec_len_f32_avx2);
             auto v0_scale = _mm256_loadu_ps(p_scales + i);

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.hpp
@@ -19,6 +19,7 @@ std::shared_ptr<PagedAttentionExecutor> make_pa_executor(ov::element::Type data_
                                                          ov::element::Type value_cache_type,
                                                          size_t key_group_size,
                                                          size_t value_group_size,
-                                                         bool quant_key_bychannel);
+                                                         bool quant_key_bychannel,
+                                                         bool quant_value_bychannel);
 
 }  // namespace ov::Extensions::Cpu::XARCH

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -258,7 +258,7 @@ bool PagedAttention::isSupportedOperation(const std::shared_ptr<const ov::Node>&
                    ov::element::f32,
                    ov::element::f16,
                    ov::element::bf16)) {
-            if (!one_of(kCachePrecision, ov::element::u8, ov::element::f16, ov::element::f32, ov::element::bf16)) {
+            if (!one_of(kCachePrecision, ov::element::u4, ov::element::u8, ov::element::f16, ov::element::f32, ov::element::bf16)) {
                 errorMessage = "PageAttn key value cache compression doesn't support key cache prec " +
                                kCachePrecision.to_string() + " value cache prec " + vCachePrecision.to_string();
                 return false;

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.cpp
@@ -150,12 +150,14 @@ void PagedAttention::initSupportedPrimitiveDescriptors() {
     supportedPrimitiveDescriptors.emplace_back(config, impl_desc_type::ref_any);
 }
 
-bool PagedAttention::isQuantByChannel(const Config::CacheQuantMode mode) noexcept {
+bool PagedAttention::isQuantByChannel(const Config::CacheQuantMode mode, const ov::element::Type precision) noexcept {
     // AUTO means select by primitive
     // for non-x86 platform, by-channel quantization is disabled
     // for x86 platform, by-channel quantization is disabled by default until further accuracy data collect
     bool byChannel = false;
-    if (mode == Config::CacheQuantMode::BY_CHANNEL) {
+    if (!precision.is_integral()) {
+        byChannel = false;
+    } else if (mode == Config::CacheQuantMode::BY_CHANNEL) {
         byChannel = true;
     } else if (mode == Config::CacheQuantMode::BY_HIDDEN) {
         byChannel = false;
@@ -179,7 +181,7 @@ void PagedAttention::createPrimitive() {
         auto vCachePrecision = getOriginalInputPrecisionAtPort(PagedAttentionExecutor::ID_VCACHE);
         const auto& cpuConfig = context->getConfig();
 
-        bool byChannel = isQuantByChannel(cpuConfig.keyCacheQuantMode);
+        bool byChannel = isQuantByChannel(cpuConfig.keyCacheQuantMode, cpuConfig.keyCachePrecision);
         return make_pa_executor(rtPrecision,
                                 kCachePrecision,
                                 vCachePrecision,

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.h
@@ -46,7 +46,7 @@ public:
     void createPrimitive() override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    static bool isQuantByChannel(const Config::CacheQuantMode mode) noexcept;
+    static bool isQuantByChannel(const Config::CacheQuantMode mode, const ov::element::Type precision) noexcept;
 
 private:
     ov::element::Type getRuntimePrecision() const override;

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -485,7 +485,11 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
                 head_size += sizeof(float) * 2 * group_num;
             }
         } else if (precision == ov::element::u4) {
-            head_size += sizeof(float) * 2 * group_num * 2;
+            if (bychannel) {
+                block_size += 2 * sizeof(float) * 2;
+            } else {
+                head_size += sizeof(float) * 2 * group_num * 2;
+            }
         }
     };
     CPU_REGISTER_PASS_COMMON(manager, ov::pass::ConvertPagedAttnInputs, cacheConfig, update_paged_attention_shape_func);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -468,9 +468,8 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     cacheConfig.keyCacheBlockSize = 32;
     cacheConfig.valueCacheBlockSize = 32;
 
-    bool byChannel = node::PagedAttention::isQuantByChannel(config.keyCacheQuantMode, config.keyCachePrecision);
-    cacheConfig.keyCacheQuantBychannel = byChannel;
-    cacheConfig.valueCacheQuantBychannel = false;
+    cacheConfig.keyCacheQuantBychannel = node::PagedAttention::isQuantByChannel(config.keyCacheQuantMode, config.keyCachePrecision);
+    cacheConfig.valueCacheQuantBychannel = node::PagedAttention::isQuantByChannel(config.valueCacheQuantMode, config.valueCachePrecision);
     cacheConfig.keyCacheDimOrder = {0, 1, 2, 3};
     cacheConfig.valueCacheDimOrder = {0, 1, 2, 3};
     auto update_paged_attention_shape_func = [](const ov::element::Type& precision,

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -468,7 +468,7 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     cacheConfig.keyCacheBlockSize = 32;
     cacheConfig.valueCacheBlockSize = 32;
 
-    bool byChannel = node::PagedAttention::isQuantByChannel(config.keyCacheQuantMode);
+    bool byChannel = node::PagedAttention::isQuantByChannel(config.keyCacheQuantMode, config.keyCachePrecision);
     cacheConfig.keyCacheQuantBychannel = byChannel;
     cacheConfig.valueCacheQuantBychannel = false;
     cacheConfig.keyCacheDimOrder = {0, 1, 2, 3};


### PR DESCRIPTION
### Details:
 - *Key cache of pagedAttn supports u4 by_channel/by_hidden compression*
 - *Value Cache of pagedAttn supports u4 by_channel/bu_hidden compression*
 - *Add cpu internal property VALUE_CACHE_QUANT_MODE to control value compression schema*

### Tickets:
 - *CVS-161864*
