### PR TITLE
[Op][Transformations] Adjustment of internal GQA op shape infer and decomposition to Enable NPU

### DIFF
--- a/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
@@ -30,7 +30,7 @@ private:
     ov::OutputVector make_split(const ov::Output<ov::Node>& value, int64_t num_splits, int64_t axis);
     std::shared_ptr<ov::Node> rotaryEmbedding(ov::Output<ov::Node> input,
                                               ov::Output<ov::Node> past_seqlen,
-                                              std::shared_ptr<ov::Node> seqlen_k,
+                                              ov::Output<ov::Node> curr_seqlen_scalar,
                                               std::shared_ptr<ov::Node> cos_cache,
                                               std::shared_ptr<ov::Node> sin_cache,
                                               std::shared_ptr<ov::Node> dim_head_size,

--- a/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
@@ -24,6 +24,7 @@ public:
 
 private:
     ov::OutputVector decompose(std::shared_ptr<ov::op::internal::GroupQueryAttention> node);
+    std::shared_ptr<ov::Node> get_dimensions(const ov::Output<ov::Node>& node, const std::vector<int>& dims);
     std::shared_ptr<ov::Node> get_dimensions(const std::shared_ptr<op::v3::ShapeOf>& shape,
                                              const std::vector<int>& dims);
     std::shared_ptr<ov::Node> get_dimensions(const std::shared_ptr<ov::Node>& node, const std::vector<int>& dims);
@@ -31,8 +32,8 @@ private:
     std::shared_ptr<ov::Node> rotaryEmbedding(ov::Output<ov::Node> input,
                                               ov::Output<ov::Node> past_seqlen,
                                               ov::Output<ov::Node> curr_seqlen_scalar,
-                                              std::shared_ptr<ov::Node> cos_cache,
-                                              std::shared_ptr<ov::Node> sin_cache,
+                                              ov::Output<ov::Node> cos_cache,
+                                              ov::Output<ov::Node> sin_cache,
                                               std::shared_ptr<ov::Node> dim_head_size,
                                               bool interleaved);
 };

--- a/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
@@ -30,10 +30,7 @@ private:
     std::shared_ptr<ov::Node> get_dimensions(const std::shared_ptr<ov::Node>& node, const std::vector<int>& dims);
     ov::OutputVector make_split(const ov::Output<ov::Node>& value, int64_t num_splits, int64_t axis);
     std::shared_ptr<ov::Node> rotaryEmbedding(ov::Output<ov::Node> input,
-                                              ov::Output<ov::Node> past_seqlen,
-                                              ov::Output<ov::Node> curr_seqlen_scalar,
-                                              ov::Output<ov::Node> cos_cache,
-                                              ov::Output<ov::Node> sin_cache,
-                                              std::shared_ptr<ov::Node> dim_head_size,
+                                              ov::Output<ov::Node> cos,
+                                              ov::Output<ov::Node> sin,
                                               bool interleaved);
 };

--- a/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/group_query_attention_decomposition.hpp
@@ -24,7 +24,6 @@ public:
 
 private:
     ov::OutputVector decompose(std::shared_ptr<ov::op::internal::GroupQueryAttention> node);
-    std::shared_ptr<ov::Node> get_dimensions(const ov::Output<ov::Node>& node, const std::vector<int>& dims);
     std::shared_ptr<ov::Node> get_dimensions(const std::shared_ptr<op::v3::ShapeOf>& shape,
                                              const std::vector<int>& dims);
     std::shared_ptr<ov::Node> get_dimensions(const std::shared_ptr<ov::Node>& node, const std::vector<int>& dims);

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -104,7 +104,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
         Q = rotaryEmbedding(Q, cos, sin, rotary_interleaved);
         K = rotaryEmbedding(K, cos, sin, rotary_interleaved);
     }
-    const auto is_static_input = K.get_partial_shape().is_static();
+    const auto is_static_input = K.get_partial_shape().is_static() && past_key.get_partial_shape().is_static();
 
     auto construct_kv_cache = [&](const ov::Output<ov::Node>& past, const ov::Output<ov::Node>& current) {
         return register_new_node<v0::Concat>(ov::OutputVector{past, current}, 2);

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -110,6 +110,11 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
         return register_new_node<v0::Concat>(ov::OutputVector{past, current}, 2);
     };
     if (is_static_input) {
+        // Cache memory layout for static shapes:
+        // - Keys:    [0, ..., 0, past_key[0], ..., past_key[N-1], K[0], ..., K[M-1]]
+        // - Values:  [0, ..., 0, past_value[0], ..., past_value[N-1], V[0], ..., V[M-1]]
+        // Here, padding 0 are lay on front of the buffer.
+        //  M = current_seqlen, which is always 1 for the KV cache model.
         const auto current_kv_len_const = register_new_node(
             v0::Constant::create(ov::element::i64, ov::Shape{1}, {K.get_partial_shape()[2].get_length()}));
         const auto past_kv_len_const = register_new_node(

--- a/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/group_query_attention_decomposition.cpp
@@ -10,11 +10,13 @@
 #include "openvino/core/graph_util.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/op/gather.hpp"
 #include "openvino/op/greater.hpp"
+#include "openvino/op/greater_eq.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/range.hpp"
 #include "openvino/op/reshape.hpp"
@@ -59,6 +61,7 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     const auto scale = node->get_scale();
     const auto do_rotary = node->get_do_rotary();
     const auto rotary_interleaved = node->get_rotary_interleaved();
+    const auto is_static_input = node->get_is_static_input();
     // TODO: add softcap support
 
     auto Q = node->input_value(0);
@@ -70,15 +73,16 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     auto cos_cache = node->input_value(6);
     auto sin_cache = node->input_value(7);
 
-    // The length of all tokens (past + current) is `seqlens_k` + 1
+    // The length of all tokens (past + current) is `seqlens_k` + 1.
     // current = Q.shape[2], past = `seqlens_k` + 1 - current
 
     const auto T = Q.get_element_type();
     const auto q_shape = register_new_node<v3::ShapeOf>(Q);
-    const auto current_sequence_length = get_dimensions(q_shape, {2});
+    const auto current_seqlen = get_dimensions(q_shape, {2});
     const auto head_size_node = get_dimensions(q_shape, {3});
 
     auto zero = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {0}));
+    auto zero_without_shape = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{}, {0}));
     auto one = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {1}));
     auto one_without_shape = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{}, {1}));
     auto two = register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{1}, {2}));
@@ -87,18 +91,20 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
 
     // Only consider batch is 1
     auto seqlens_1d = register_new_node<v1::Reshape>(real_seqlens, one, false);
-    auto past_sequence_length = register_new_node<v1::Subtract>(seqlens_1d, current_sequence_length);
+    auto past_seqlen = register_new_node<v1::Subtract>(seqlens_1d, current_seqlen);
+    auto curr_seqlen_scalar = register_new_node<v1::Reshape>(current_seqlen, one_without_shape, false);
+
     if (do_rotary) {
         Q = rotaryEmbedding(Q,
-                            past_sequence_length,
-                            seqlens_1d,
+                            past_seqlen,
+                            curr_seqlen_scalar,
                             cos_cache.get_node_shared_ptr(),
                             sin_cache.get_node_shared_ptr(),
                             head_size_node,
                             rotary_interleaved);
         K = rotaryEmbedding(K,
-                            past_sequence_length,
-                            seqlens_1d,
+                            past_seqlen,
+                            curr_seqlen_scalar,
                             cos_cache.get_node_shared_ptr(),
                             sin_cache.get_node_shared_ptr(),
                             head_size_node,
@@ -106,15 +112,27 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     }
 
     auto construct_kv_cache = [&](const ov::Output<ov::Node>& past, const ov::Output<ov::Node>& current) {
-        auto past_datas = register_new_node<v8::Slice>(past, zero, past_sequence_length, one, two);
-        auto curr_datas = register_new_node<v8::Slice>(current, zero, current_sequence_length, one, two);
-        return register_new_node<v0::Concat>(ov::NodeVector{past_datas, curr_datas}, 2);
+        return register_new_node<v0::Concat>(ov::OutputVector{past, current}, 2);
     };
     K = construct_kv_cache(past_key, K);
     V = construct_kv_cache(past_value, V);
-    auto present_k = K;
-    auto present_v = V;
 
+    const auto concat_kv_len = get_dimensions(K.get_node_shared_ptr(), {2});
+    const auto concat_kv_len_scalar = register_new_node<v1::Reshape>(concat_kv_len, one_without_shape, false);
+
+    ov::Output<ov::Node> present_k;
+    ov::Output<ov::Node> present_v;
+    if (!is_static_input) {
+        present_k = K;
+        present_v = V;
+    } else {
+        const auto positions =
+            register_new_node<v4::Range>(one_without_shape, concat_kv_len_scalar, one_without_shape, ov::element::i64);
+        present_k = register_new_node<v8::Gather>(K, positions, two);
+        present_v = register_new_node<v8::Gather>(V, positions, two);
+    }
+
+    // Broadcast KV if grouped query attention
     const size_t kv_num_heads_factor = num_heads / kv_num_heads;
     if (kv_num_heads_factor > 1) {
         const auto kv_shape = register_new_node<v3::ShapeOf>(K);
@@ -132,18 +150,21 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
         V = register_new_node<v1::Reshape>(V, extended_kv_shape, false);
     }
 
-    // need to apply low-triangle mask to attention score.
-    // two steps, construct the total_sequence x total_sequence triangle, then slice the current length
-    auto seqlens_1d_scalar = register_new_node<v1::Reshape>(seqlens_1d, one_without_shape, false);
-    std::shared_ptr<ov::Node> mask_per_line_node =
-        register_new_node<v4::Range>(register_new_node(v0::Constant::create(ov::element::i64, ov::Shape{}, {0})),
-                                     seqlens_1d_scalar,
-                                     one_without_shape,
-                                     ov::element::i64);
-    auto hori_range = register_new_node<v0::Unsqueeze>(mask_per_line_node, zero);
-    auto vert_range = register_new_node<v0::Unsqueeze>(mask_per_line_node, one);
-    auto triu = register_new_node<v1::Greater>(hori_range, vert_range);
-    auto typed_zero = register_new_node(v0::Constant::create(T, ov::Shape{}, {0}));
+    // Make attention mask
+    std::shared_ptr<ov::Node> mask;
+
+    std::shared_ptr<ov::Node> hori_range =
+        register_new_node<v4::Range>(zero_without_shape, concat_kv_len_scalar, one_without_shape, ov::element::i64);
+    hori_range = register_new_node<v0::Unsqueeze>(hori_range, zero);
+
+    std::shared_ptr<ov::Node> vert_range =
+        register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
+    vert_range = register_new_node<v0::Unsqueeze>(vert_range, one);
+    const auto past_k_node_len = get_dimensions(past_key.get_node_shared_ptr(), {2});
+    vert_range = register_new_node<v1::Add>(vert_range, past_k_node_len);
+
+    const auto triu = register_new_node<v1::Greater>(hori_range, vert_range);
+    const auto typed_zero = register_new_node(v0::Constant::create(T, ov::Shape{}, {0}));
     // cf. make_attention_mask@src\plugins\intel_gpu\tests\common\subgraphs_builders.hpp
     std::shared_ptr<ov::Node> minus_inf = nullptr;
     if (T == ov::element::f32)
@@ -151,15 +172,22 @@ ov::OutputVector ov::pass::GroupQueryAttentionDecomposition::decompose(
     else if (T == ov::element::f16)
         minus_inf =
             register_new_node(v0::Constant::create(T, ov::Shape{}, {std::numeric_limits<ov::float16>::lowest()}));
-    auto atten_mask = register_new_node<v1::Select>(triu, minus_inf, typed_zero);
-    auto atten_mask_sliced = register_new_node<v8::Slice>(atten_mask, past_sequence_length, seqlens_1d, one, zero);
+    mask = register_new_node<v1::Select>(triu, minus_inf, typed_zero);
+
+    if (is_static_input) {
+        const auto padding_len = register_new_node<v1::Subtract>(concat_kv_len, seqlens_1d);
+        const auto padding_mask_vert_shape = register_new_node<v0::Concat>(ov::NodeVector{current_seqlen, one}, 0);
+        const auto padding_mask_vert = register_new_node<v3::Broadcast>(padding_len, padding_mask_vert_shape);
+        const auto padding_mask = register_new_node<v1::GreaterEqual>(hori_range, padding_mask_vert);
+        mask = register_new_node<v1::Select>(padding_mask, mask, minus_inf);
+    }
 
     std::shared_ptr<ov::Node> qga_output;
     if (scale != 0.0f) {
         auto scale_node = register_new_node(v0::Constant::create(T, Shape{}, {scale}));
-        qga_output = register_new_node<v13::ScaledDotProductAttention>(Q, K, V, atten_mask_sliced, scale_node, false);
+        qga_output = register_new_node<v13::ScaledDotProductAttention>(Q, K, V, mask, scale_node, false);
     } else {
-        qga_output = register_new_node<v13::ScaledDotProductAttention>(Q, K, V, atten_mask_sliced, false);
+        qga_output = register_new_node<v13::ScaledDotProductAttention>(Q, K, V, mask, false);
     }
 
     // transpose the result from (batch_size, num_heads, sequence_length, head_size)
@@ -201,7 +229,7 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::get_dimens
 std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::rotaryEmbedding(
     ov::Output<ov::Node> input,
     ov::Output<ov::Node> past_seqlen,
-    std::shared_ptr<ov::Node> seqlen_k,
+    ov::Output<ov::Node> curr_seqlen_scalar,
     std::shared_ptr<ov::Node> cos_cache,
     std::shared_ptr<ov::Node> sin_cache,
     std::shared_ptr<ov::Node> dim_head_size,
@@ -209,11 +237,14 @@ std::shared_ptr<ov::Node> ov::pass::GroupQueryAttentionDecomposition::rotaryEmbe
     using namespace ov::op;
     auto zero = v0::Constant::create(ov::element::i64, ov::Shape{1}, {0});
     auto one = v0::Constant::create(ov::element::i64, ov::Shape{1}, {1});
+    auto zero_without_shape = v0::Constant::create(ov::element::i64, ov::Shape{}, {0});
+    auto one_without_shape = v0::Constant::create(ov::element::i64, ov::Shape{}, {1});
 
-    auto slice_cache_dim_shape = seqlen_k;
-
-    auto cos = register_new_node<v8::Slice>(cos_cache, past_seqlen, slice_cache_dim_shape, one, zero);
-    auto sin = register_new_node<v8::Slice>(sin_cache, past_seqlen, slice_cache_dim_shape, one, zero);
+    ov::Output<ov::Node> position_ids =
+        register_new_node<v4::Range>(zero_without_shape, curr_seqlen_scalar, one_without_shape, ov::element::i64);
+    position_ids = register_new_node<v1::Add>(position_ids, past_seqlen);
+    auto cos = register_new_node<v8::Gather>(cos_cache, position_ids, zero);
+    auto sin = register_new_node<v8::Gather>(sin_cache, position_ids, zero);
 
     if (interleaved) {
         auto two = v0::Constant::create(ov::element::i64, ov::Shape{1}, {2});

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -38,6 +38,9 @@ public:
     bool get_rotary_interleaved() const {
         return m_rotary_interleaved;
     }
+    bool get_is_static_input() const {
+        return m_is_static_input;
+    }
 
 private:
     int64_t m_num_heads = 0;
@@ -45,6 +48,7 @@ private:
     float m_scale = 0;
     bool m_do_rotary = false;
     bool m_rotary_interleaved = false;
+    bool m_is_static_input = false;
 };
 
 }  // namespace ov::op::internal

--- a/src/core/dev_api/openvino/op/group_query_attention.hpp
+++ b/src/core/dev_api/openvino/op/group_query_attention.hpp
@@ -38,9 +38,6 @@ public:
     bool get_rotary_interleaved() const {
         return m_rotary_interleaved;
     }
-    bool get_is_static_input() const {
-        return m_is_static_input;
-    }
 
 private:
     int64_t m_num_heads = 0;
@@ -48,7 +45,6 @@ private:
     float m_scale = 0;
     bool m_do_rotary = false;
     bool m_rotary_interleaved = false;
-    bool m_is_static_input = false;
 };
 
 }  // namespace ov::op::internal

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -43,7 +43,7 @@ void GroupQueryAttention::validate_and_infer_types() {
     auto output_kv_len = past_sequence_len;
     if (past_sequence_len.is_dynamic() || sequence_len.is_dynamic()) {
         // For dynamic shapes, concatenate the past and current sequence lengths.
-        output_kv_len += sequence_len;   
+        output_kv_len += sequence_len;
     }
 
     const auto& element_type = get_input_element_type(0);

--- a/src/core/src/op/group_query_attention.cpp
+++ b/src/core/src/op/group_query_attention.cpp
@@ -40,15 +40,10 @@ void GroupQueryAttention::validate_and_infer_types() {
     const auto& head_size = q_shape[3];
     const auto& past_sequence_len = get_input_partial_shape(3)[2];
 
-    ov::Dimension output_kv_len;
-    if (past_sequence_len.is_static() && sequence_len.is_static()) {
-        // For static shapes, the output length is equal to the past sequence length.
-        // This is typically used in NPU cases.
-        output_kv_len = past_sequence_len;
-    } else {
+    auto output_kv_len = past_sequence_len;
+    if (past_sequence_len.is_dynamic() || sequence_len.is_dynamic()) {
         // For dynamic shapes, concatenate the past and current sequence lengths.
-        // This is commonly used in CPU and GPU cases.
-        output_kv_len = past_sequence_len + sequence_len;   
+        output_kv_len += sequence_len;   
     }
 
     const auto& element_type = get_input_element_type(0);


### PR DESCRIPTION
The KV cache handling logic differs between dynamic and static shapes.

In the case of dynamic shapes, the KV cache buffer only holds valid data. So it only needs a ConcatOP
For static shapes, the valid data is stored at the end of the buffer, with the beginning of the buffer being set to 0. So the ConcatOP will make the buffer greater than buffer size, it need slice the real size data.

The following scripts work for both CPU GPU (dynamic) and NPU (static)
```
import onnxruntime as rt
import os
import numpy as np
import time

import onnxruntime.tools.add_openvino_win_libs as utils
utils.add_openvino_libs_to_path()
from transformers import PreTrainedTokenizerFast

LOOP_TIME = 2
NUM_INFERENCE = 16 # how many 2nd token

def get_average_time(time_list):
    return (sum(time_list) - max(time_list) - min(time_list)) / (len(time_list) - 2)

GTA = False
test_phi3 = True
test_lama3 = False
is_npu = False

if test_phi3:
    gta_modelPath = os.path.join('C:\\', 'Users', 'gta', 'Downloads', 'Phi-3-mini-4k-instruct-onnx', 'model.onnx')
    if is_npu:
        gta_modelPath = os.path.join('C:\\', 'Users', 'gta', 'Downloads', 'Phi-3-mini-4k-instruct-onnx-rows-newalgo-int4', 'model.onnx')
    gta_tokenizerPath = os.path.join('C:\\', 'Users', 'gta', 'Downloads', 'Phi-3-mini-4k-instruct-onnx', 'tokenizer.json')
    server_modelPath = os.path.join('D:\\', 'models', 'llm', 'Phi-3-mini-4k-instruct-onnx', 'model.onnx')
    server_tokenizerPath = os.path.join('D:\\', 'models', 'llm', 'Phi-3-mini-4k-instruct-onnx', 'tokenizer.json')

if test_lama3:
    gta_modelPath = os.path.join('C:\\', 'Users', 'gta', 'Downloads', 'llama3.1-8B-instruct-onnx', 'model.onnx')
    gta_tokenizerPath = os.path.join('C:\\', 'Users', 'gta', 'Downloads', 'llama3.1-8B-instruct-onnx', 'tokenizer.json')
    server_modelPath = os.path.join('D:\\', 'models', 'llm', 'llama3.1-8B-instruct-onnx', 'model.onnx')
    server_tokenizerPath = os.path.join('D:\\', 'models', 'llm', 'llama3.1-8B-instruct-onnx', 'tokenizer.json')

if GTA:
    modelPath = gta_modelPath
    tokenizerPath = gta_tokenizerPath
else:
    modelPath = server_modelPath
    tokenizerPath = server_tokenizerPath

so = rt.SessionOptions()
# so.log_severity_level = 3
# so.enable_profiling = False

sess = rt.InferenceSession(modelPath, so, providers=['CPUExecutionProvider'])
#sess = rt.InferenceSession(modelPath, so, providers=['OpenVINOExecutionProvider'], provider_options=[{'device_type' : "CPU", 'cache_dir': "cpucache"}])
# sess = rt.InferenceSession(modelPath, so, providers=['OpenVINOExecutionProvider'], provider_options=[{'device_type' : "NPU", 'load_config':'{ "NPU": { "NPUW_CACHE_DIR": "ncache", "NPUW_DEVICES": "NPU", "NPU_USE_NPUW": "YES", "NPUW_DUMP_IO":"NO", "NPUW_FOLD": "YES", "NPUW_DUMP_SUBS": "NO", "NPUW_DQ": "YES", "NPUW_HOST_GATHER": "NO", "NPU_COMPILATION_MODE_PARAMS": "compute-layers-with-higher-precision=Sqrt,ReduceMean,Power,RMS" } }'}])
tokenizer = PreTrainedTokenizerFast(tokenizer_file=tokenizerPath)

outputs = sess.get_outputs()
output_names = list(map(lambda output: output.name, outputs))


def get_phi3_param():
    num_layers = 32
    batch_size = 1
    num_heads = 32
    sequence_length = 512
    hidden_size = 96
    return num_layers, batch_size, num_heads, sequence_length, hidden_size

def get_llama3_param():
    num_layers = 32
    batch_size = 1
    num_heads = 8
    sequence_length = 512
    hidden_size = 128
    return num_layers, batch_size, num_heads, sequence_length, hidden_size

if test_phi3:
    num_layers, batch_size, num_heads, sequence_length, hidden_size = get_phi3_param()

if test_lama3:
    num_layers, batch_size, num_heads, sequence_length, hidden_size = get_llama3_param()

def create_numpy_inputs(inputToken):
    tokenLen = len(inputToken)
    npinput_ids = np.array([inputToken], dtype=np.int64)
    if is_npu:
        npattention_mask = np.array([[1] * tokenLen + [0] * (sequence_length - tokenLen)], dtype=np.int64)
    else:
        npattention_mask = np.array([[1] * tokenLen], dtype=np.int64)
    return npinput_ids, npattention_mask

def init_npinput(inputToken):
    flattened_past_key_values = {}
    for index in range(num_layers):
        if is_npu:
            key_state = np.zeros((batch_size, num_heads, sequence_length - len(inputToken), hidden_size), dtype=np.float32)
            value_state = np.zeros((batch_size, num_heads, sequence_length - len(inputToken), hidden_size), dtype=np.float32)
        else:
            key_state = np.zeros((batch_size, num_heads, 0, hidden_size), dtype=np.float32)
            value_state = np.zeros((batch_size, num_heads, 0, hidden_size), dtype=np.float32)
        flattened_past_key_values[f'past_key_values.{index}.key'] = key_state
        flattened_past_key_values[f'past_key_values.{index}.value'] = value_state
    flattened_past_key_values['input_ids'], flattened_past_key_values['attention_mask'] = create_numpy_inputs(inputToken)
    return flattened_past_key_values


for loop_idx in range(LOOP_TIME):
    first_token_time_list = []
    secod_token_time_list = []
    print(f"start loop {loop_idx}")

    if test_phi3:
        input = """<|user|> 
The Sun is yellow because <|end|>
<|assistant|>
"""
    if test_lama3:
        input = """<|begin_of_text|><|user|>
The Sun is yellow because <|end|>
<|assistant|>
"""

    inputToken = tokenizer.encode(input)
    history_tokens = inputToken
    flattened_past_key_values = init_npinput(inputToken)
    lastTokenLen = len(inputToken)

    before = time.time()
    results = sess.run(output_names, flattened_past_key_values)
    after = time.time()
    first_token_time_list.append(int((after - before) * 1000))

    last_generated_token = np.argmax(results[0][-1, -1, :], axis=-1)
    print(last_generated_token ,end=' ')
    history_tokens.append(last_generated_token)
    for i in range(NUM_INFERENCE):
        # update kvcahe
        for index in range(len(output_names)):
            if not output_names[index].startswith('present'):
                continue
            outputname = output_names[index]
            inputname = outputname.replace('present', 'past_key_values')
            flattened_past_key_values[inputname] = results[index]

        # update input token
        flattened_past_key_values[f'input_ids'] = np.array([[last_generated_token]], dtype=np.int64)
        if is_npu:
            flattened_past_key_values[f'attention_mask'] = np.array([[1] * len(history_tokens) + [0] * (sequence_length - len(history_tokens))], dtype=np.int64)
        else:
            flattened_past_key_values[f'attention_mask'] = np.array([[1] * len(history_tokens)], dtype=np.int64)

        before = time.time()
        results = sess.run(output_names, flattened_past_key_values)
        after = time.time()
        secod_token_time_list.append(int((after - before) * 1000))

        last_generated_token = np.argmax(results[0][-1, -1, :], axis=-1)
        print(last_generated_token ,end=' ')
        history_tokens.append(last_generated_token)

    print(f"1st token times: {first_token_time_list}, avg {first_token_time_list[0]} ms")
    print(f"2nd token times: {secod_token_time_list}, avg {int(get_average_time(secod_token_time_list))} ms")

print(tokenizer.decode(history_tokens))
print(f"loop {LOOP_TIME} times finished")
```