### PR TITLE
[GPU] Fix clEnqueueCopyBuffer error in RemoteTensor use case

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -402,6 +402,8 @@ void SyncInferRequest::wait() {
                     need_reallocate = usm_host_tensor->get_impl()->get_original_memory()->size() < output_memory->size();
                 else if (!is_remote_tensor_impl && output_memory)
                     need_reallocate = output_tensor_wrapper.actual_size < output_memory->size();
+                else if (is_remote_tensor_impl && output_memory)
+                    need_reallocate = false;
 
                 if (need_reallocate) {
                     std::string internal_name = m_output_names_map.at(port_idx);


### PR DESCRIPTION
### Details:
 - Since PR(https://github.com/openvinotoolkit/openvino/pull/29061), even if the network is dynamic, if user tensor's shape is static, remote tensor can be set as plugin's output tensor, and output prim reuse remote tensor's memory
 - However, even though it is remote tensor use case, there is a possibility that the user output tensor will be reallocated to the predicted shape by shape predictor
 - Therefore this code block has been updated to not perform shape prediction in remote tensor use case

### Tickets:
 - 163470
