### PR TITLE
[TRANSFORMATIONS] Fix implicit conversion of ov::Node with multiple outputs to ov::Output

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
@@ -160,7 +160,7 @@ IndirectSDPAOpt::IndirectSDPAOpt() {
         ov::replace_node(gather_node_1, gather_input_node_1);
 
         auto indirect_kv_cache_0 = std::make_shared<op::KVCache>(gather_input_node_0,
-                                                                 kv_cache_node_1->input(1).get_source_output(),
+                                                                 kv_cache_node_0->input(1).get_source_output(),
                                                                  beam_idx_node,
                                                                  kv_cache_node_0->get_variable(),
                                                                  kv_cache_node_0->get_concat_axis(),

--- a/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
@@ -160,7 +160,7 @@ IndirectSDPAOpt::IndirectSDPAOpt() {
         ov::replace_node(gather_node_1, gather_input_node_1);
 
         auto indirect_kv_cache_0 = std::make_shared<op::KVCache>(gather_input_node_0,
-                                                                 kv_cache_node_0->get_input_node_shared_ptr(1),
+                                                                 kv_cache_node_1->input(1).get_source_output(),
                                                                  beam_idx_node,
                                                                  kv_cache_node_0->get_variable(),
                                                                  kv_cache_node_0->get_concat_axis(),
@@ -168,7 +168,7 @@ IndirectSDPAOpt::IndirectSDPAOpt() {
                                                                  kv_cache_node_0->get_output_element_type(0));
 
         auto indirect_kv_cache_1 = std::make_shared<op::KVCache>(gather_input_node_1,
-                                                                 kv_cache_node_1->get_input_node_shared_ptr(1),
+                                                                 kv_cache_node_1->input(1).get_source_output(),
                                                                  beam_idx_node,
                                                                  kv_cache_node_1->get_variable(),
                                                                  kv_cache_node_1->get_concat_axis(),

--- a/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
@@ -160,7 +160,7 @@ IndirectSDPAOpt::IndirectSDPAOpt() {
         ov::replace_node(gather_node_1, gather_input_node_1);
 
         auto indirect_kv_cache_0 = std::make_shared<op::KVCache>(gather_input_node_0,
-                                                                 kv_cache_node_0->input(1).get_source_output(),
+                                                                 kv_cache_node_0->input_value(1),
                                                                  beam_idx_node,
                                                                  kv_cache_node_0->get_variable(),
                                                                  kv_cache_node_0->get_concat_axis(),
@@ -168,7 +168,7 @@ IndirectSDPAOpt::IndirectSDPAOpt() {
                                                                  kv_cache_node_0->get_output_element_type(0));
 
         auto indirect_kv_cache_1 = std::make_shared<op::KVCache>(gather_input_node_1,
-                                                                 kv_cache_node_1->input(1).get_source_output(),
+                                                                 kv_cache_node_1->input_value(1),
                                                                  beam_idx_node,
                                                                  kv_cache_node_1->get_variable(),
                                                                  kv_cache_node_1->get_concat_axis(),

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1144,6 +1144,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeSDPAFusion>();
 
         manager.register_pass<ov::pass::GLUFusion>();
+        manager.register_pass<ov::pass::VisualizeTree>("before_IndirectKVCache.svg");
         manager.register_pass<ov::intel_gpu::IndirectKVCache>();
 
         auto kv_cache_compression_dt = config.get_kv_cache_precision();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1144,7 +1144,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         manager.register_pass<ov::intel_gpu::UnsqueezeBroadcastReshapeSDPAFusion>();
 
         manager.register_pass<ov::pass::GLUFusion>();
-        manager.register_pass<ov::pass::VisualizeTree>("before_IndirectKVCache.svg");
         manager.register_pass<ov::intel_gpu::IndirectKVCache>();
 
         auto kv_cache_compression_dt = config.get_kv_cache_precision();


### PR DESCRIPTION
### Details:
In the IndirectSDPAOpt transformation, 1st input to the KVCache node may appear to be a
VariadicSplit node with multiple outputs. Using the default output of
the node is incorrect and leads to an exception if used as an input to
another node because of an implicit conversion to ov::Output. Use the
output of the VariadicSplit node explicitly to avoid the exception.

### Tickets:
- [CVS-163937](https://jira.devtools.intel.com/browse/CVS-163937)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>