### PR TITLE
[GPU] Release ov::Model from memory once it's no longer needed

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -162,6 +162,7 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer& ib,
         auto graph = n == 0 ? graph_base : std::make_shared<Graph>(graph_base, n);
         m_graphs.push_back(graph);
     }
+    m_config.set_property(ov::hint::model(nullptr));
 }
 
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {


### PR DESCRIPTION
### Details:

Clean build:
  | 1st run [MB] | 2nd run [MB]
-- | -- | --
WSS after pipeline creation | 2034 | **2729**
PWSS after pipeline creation | 1904 | 1719
WSS after pipe.generate() | 2078 | **2818**
PWSS after pipe.generate() | 1934 | 1784

After change:
  | 1st run [MB] | 2nd run [MB]
-- | -- | --
WSS after pipeline creation | 2033 | **2013**
PWSS after pipeline creation | 1904 | 1875
WSS after pipe.generate() | 2078 | **2056**
PWSS after pipe.generate() | 1948 | 1918

### Tickets:
 - CVS-164342
