### PR TITLE
[GPU] fix of memory statistic test

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
@@ -117,7 +117,7 @@ public:
 
     /// Returns statistics of GPU memory allocated by engine in current process for all allocation types.
     /// @note It contains information about current memory usage
-    std::map<std::string, uint64_t> get_memory_statistics();
+    std::map<std::string, uint64_t> get_memory_statistics() const;
 
     /// Adds @p bytes count to currently used memory size of the specified allocation @p type
     void add_memory_used(uint64_t bytes, allocation_type type);
@@ -175,7 +175,6 @@ protected:
     /// Create engine for given @p device and @p configuration
     engine(const device::ptr device);
     const device::ptr _device;
-    std::map<std::string, uint64_t> statistics;
 
     std::array<std::atomic<uint64_t>, static_cast<size_t>(allocation_type::max_value)> _memory_usage_data{};
     std::array<std::atomic<uint64_t>, static_cast<size_t>(allocation_type::max_value)> _peak_memory_usage_data{};

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/engine.hpp
@@ -117,7 +117,7 @@ public:
 
     /// Returns statistics of GPU memory allocated by engine in current process for all allocation types.
     /// @note It contains information about current memory usage
-    std::map<std::string, uint64_t> get_memory_statistics() const;
+    std::map<std::string, uint64_t> get_memory_statistics();
 
     /// Adds @p bytes count to currently used memory size of the specified allocation @p type
     void add_memory_used(uint64_t bytes, allocation_type type);
@@ -175,6 +175,7 @@ protected:
     /// Create engine for given @p device and @p configuration
     engine(const device::ptr device);
     const device::ptr _device;
+    std::map<std::string, uint64_t> statistics;
 
     std::array<std::atomic<uint64_t>, static_cast<size_t>(allocation_type::max_value)> _memory_usage_data{};
     std::array<std::atomic<uint64_t>, static_cast<size_t>(allocation_type::max_value)> _peak_memory_usage_data{};

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -211,7 +211,8 @@ uint64_t engine::get_used_device_memory(allocation_type type) const {
     return _memory_usage_data[static_cast<size_t>(type)].load();
 }
 
-std::map<std::string, uint64_t> engine::get_memory_statistics() {
+std::map<std::string, uint64_t> engine::get_memory_statistics() const {
+    std::map<std::string, uint64_t> statistics;
     const auto add_stat = [&](allocation_type type) {
         auto idx = static_cast<size_t>(type);
         auto value = _memory_usage_data[idx].load();

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -217,9 +217,7 @@ std::map<std::string, uint64_t> engine::get_memory_statistics() {
         auto value = _memory_usage_data[idx].load();
         std::ostringstream oss;
         oss << type;
-        if (value != 0 || statistics.count(oss.str())) {
-            statistics[oss.str()] = value;
-        }
+        statistics[oss.str()] = value;
     };
 
     add_stat(allocation_type::unknown);

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -211,14 +211,13 @@ uint64_t engine::get_used_device_memory(allocation_type type) const {
     return _memory_usage_data[static_cast<size_t>(type)].load();
 }
 
-std::map<std::string, uint64_t> engine::get_memory_statistics() const {
-    std::map<std::string, uint64_t> statistics;
+std::map<std::string, uint64_t> engine::get_memory_statistics() {
     const auto add_stat = [&](allocation_type type) {
         auto idx = static_cast<size_t>(type);
         auto value = _memory_usage_data[idx].load();
-        if (value != 0) {
-            std::ostringstream oss;
-            oss << type;
+        std::ostringstream oss;
+        oss << type;
+        if (value != 0 || statistics.count(oss.str())) {
             statistics[oss.str()] = value;
         }
     };

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -586,12 +586,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
     std::map<std::string, uint64_t> t5;
     OV_ASSERT_NO_THROW(t5 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
-    ASSERT_FALSE(t5.empty());
-    for (auto&& kv : t5) {
-        if (kv.first.find("_cur") != std::string::npos) {
-            ASSERT_EQ(kv.second, 0);
-        }
-    }
+    ASSERT_TRUE(t5.empty()); //in case of zero memory it is returned empty map
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::intel_gpu::memory_statistics);
 }

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -491,10 +491,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_DEFAULT, GetMetricAndPrintNoTh
 
     ASSERT_FALSE(p.empty());
     std::cout << "Memory Statistics: " << std::endl;
-    for (auto&& kv : p) {
-        ASSERT_NE(kv.second, 0);
-        std::cout << kv.first << ": " << kv.second << " bytes" << std::endl;
-    }
+    ASSERT_TRUE(std::any_of(p.begin(), p.end(), [](const auto& p){return !p.second;}));
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::intel_gpu::memory_statistics);
 }
@@ -515,9 +512,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTIPLE_NETWORKS, GetMetricAn
     OV_ASSERT_NO_THROW(t1 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t1.empty());
-    for (auto&& kv : t1) {
-        ASSERT_NE(kv.second, 0);
-    }
+    ASSERT_TRUE(std::any_of(t1.begin(), t1.end(), [](const auto& p){return !p.second;}));
 
     auto exec_net2 = ie.compile_model(simpleNetwork, target_device);
 
@@ -525,7 +520,6 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTIPLE_NETWORKS, GetMetricAn
 
     ASSERT_FALSE(t2.empty());
     for (auto&& kv : t2) {
-        ASSERT_NE(kv.second, 0);
         auto iter = t1.find(kv.first);
         if (iter != t1.end()) {
             ASSERT_EQ(kv.second, t1[kv.first] * 2);
@@ -546,7 +540,10 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
     std::map<std::string, uint64_t> t1;
 
     OV_ASSERT_NO_THROW(t1 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
-    ASSERT_TRUE(t1.empty());
+    ASSERT_FALSE(t1.empty());
+    for (const auto& kv : t1) {
+        ASSERT_EQ(kv.second, 0);
+    }
 
     {
         auto exec_net1 = ie.compile_model(simpleNetwork, target_device);
@@ -555,9 +552,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
         OV_ASSERT_NO_THROW(t2 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
         ASSERT_FALSE(t2.empty());
-        for (auto&& kv : t2) {
-            ASSERT_NE(kv.second, 0);
-        }
+        ASSERT_TRUE(std::any_of(t2.begin(), t2.end(), [](const auto& p){return !p.second;}));
         {
             auto exec_net2 = ie.compile_model(actualNetwork, target_device);
 
@@ -565,16 +560,13 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
             OV_ASSERT_NO_THROW(t3 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
             ASSERT_FALSE(t3.empty());
-            for (auto&& kv : t3) {
-                ASSERT_NE(kv.second, 0);
-            }
+            ASSERT_TRUE(std::any_of(t3.begin(), t3.end(), [](const auto& p){return !p.second;}));
         }
         std::map<std::string, uint64_t> t4;
         OV_ASSERT_NO_THROW(t4 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
         ASSERT_FALSE(t4.empty());
         for (auto&& kv : t4) {
-            ASSERT_NE(kv.second, 0);
             if (kv.first.find("_cur") != std::string::npos) {
                 auto iter = t2.find(kv.first);
                 if (iter != t2.end()) {
@@ -588,9 +580,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
 
     ASSERT_FALSE(t5.empty());
     for (auto&& kv : t5) {
-        if (kv.first.find("_cur") != std::string::npos) {
-            ASSERT_EQ(kv.second, 0);
-        }
+        ASSERT_EQ(kv.second, 0);
     }
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::intel_gpu::memory_statistics);
@@ -620,9 +610,7 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPri
     OV_ASSERT_NO_THROW(t1 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
     ASSERT_FALSE(t1.empty());
-    for (auto&& kv : t1) {
-        ASSERT_NE(kv.second, 0);
-    }
+    ASSERT_TRUE(std::any_of(t1.begin(), t1.end(), [](const auto& p){return !p.second;}));
 
     for (auto& thread : threads) {
         thread = std::thread([&]() {
@@ -641,7 +629,6 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_MULTI_THREADS, GetMetricAndPri
 
     ASSERT_FALSE(t2.empty());
     for (auto&& kv : t2) {
-        ASSERT_NE(kv.second, 0);
         auto iter = t1.find(kv.first);
         if (iter != t1.end()) {
             ASSERT_EQ(kv.second, t1[kv.first] * 3);

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -586,7 +586,12 @@ TEST_P(OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES, GetMetricAndPrin
     std::map<std::string, uint64_t> t5;
     OV_ASSERT_NO_THROW(t5 = ie.get_property(target_device, ov::intel_gpu::memory_statistics));
 
-    ASSERT_TRUE(t5.empty()); //in case of zero memory it is returned empty map
+    ASSERT_FALSE(t5.empty());
+    for (auto&& kv : t5) {
+        if (kv.first.find("_cur") != std::string::npos) {
+            ASSERT_EQ(kv.second, 0);
+        }
+    }
 
     OV_ASSERT_PROPERTY_SUPPORTED(ov::intel_gpu::memory_statistics);
 }


### PR DESCRIPTION
### Details:
 - due to https://github.com/openvinotoolkit/openvino/pull/25269 map is empty when memory is zero (no only before any allocation (as before) but now also after cleanup)
 - it fix gpu func test OVGetMetricPropsTest_GPU_MEMORY_STATISTICS_CHECK_VALUES.GetMetricAndPrintNoThrow

### Tickets:
 - part of 164932
