### PR TITLE
[CPU][DEBUG_CAPS] Parse boolean flags properly

### DIFF
--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -38,7 +38,7 @@ Config::Config() {
  */
 void Config::applyDebugCapsProperties() {
     // always enable perf counters for verbose, performance summary and average counters
-    if (!debugCaps.verbose.empty() || !debugCaps.summaryPerf.empty() || !debugCaps.averageCountersPath.empty()) {
+    if (!debugCaps.verbose.empty() || debugCaps.summaryPerf || !debugCaps.averageCountersPath.empty()) {
         collectPerfCounters = true;
     }
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/utils/debug_caps_config.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/utils/debug_caps_config.cpp
@@ -5,19 +5,12 @@
 
 #    include "debug_caps_config.hpp"
 
+#    include "openvino/util/env_util.hpp"
+
 namespace ov::intel_cpu {
 
 void SnippetsDebugCapsConfig::readProperties() {
-    auto readEnv = [](const char* envVar) {
-        const char* env = std::getenv(envVar);
-        if (env && *env) {
-            return env;
-        }
-
-        return static_cast<const char*>(nullptr);
-    };
-
-    enable_segfault_detector = readEnv("OV_CPU_SNIPPETS_SEGFAULT_DETECTOR") ? true : false;
+    enable_segfault_detector = ov::util::getenv_bool("OV_CPU_SNIPPETS_SEGFAULT_DETECTOR");
 }
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -271,12 +271,7 @@ void serializeToCout(const Graph& graph) {
 }
 
 void summary_perf(const Graph& graph) {
-    if (!graph.getGraphContext()) {
-        return;
-    }
-    const std::string& summaryPerf = graph.getConfig().debugCaps.summaryPerf;
-
-    if (summaryPerf.empty() || !std::stoi(summaryPerf)) {
+    if (!graph.getGraphContext() || !graph.getConfig().debugCaps.summaryPerf) {
         return;
     }
 

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.cpp
@@ -7,6 +7,8 @@
 
 #    include <string>
 
+#    include "openvino/util/env_util.hpp"
+
 namespace ov::intel_cpu {
 
 void DebugCapsConfig::readProperties() {
@@ -69,7 +71,7 @@ void DebugCapsConfig::readProperties() {
         dumpIR.parseAndSet(envVarValue);
     }
 
-    if (auto envVarValue = readEnv("OV_CPU_SUMMARY_PERF")) {
+    if (auto envVarValue = ov::util::getenv_bool("OV_CPU_SUMMARY_PERF")) {
         summaryPerf = envVarValue;
     }
 

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.h
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.h
@@ -45,7 +45,7 @@ public:
     std::string blobDumpDir = "cpu_dump";
     FORMAT blobDumpFormat = FORMAT::TEXT;
     std::unordered_map<FILTER, std::string, EnumClassHash> blobDumpFilters;
-    std::string summaryPerf = "";
+    bool summaryPerf = false;
     std::string memoryStatisticsDumpPath;
 
     struct TransformationFilter {


### PR DESCRIPTION
### Details:
Fix `OV_CPU_SUMMARY_PERF` and `OV_CPU_SNIPPETS_SEGFAULT_DETECTOR` environment variables parsing reusing `ov::util::getenv_bool` function that handles bool flags properly (allowing standard values like "0", "false", "off" for `false` and "1", "true", "on" for `true`, etc.)

### Tickets:
 - N/A
