### PR TITLE
[GPU] Fix crash on set_output_memory due to shape difference b/w actual shape & user tensor 

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
+++ b/src/plugins/intel_gpu/src/plugin/sync_infer_request.cpp
@@ -960,7 +960,7 @@ std::vector<cldnn::event::ptr> SyncInferRequest::prepare_output(size_t output_id
     auto output_tensor = std::dynamic_pointer_cast<RemoteTensorImpl>(m_plugin_outputs.at(output_idx).ptr);
     auto output_memory = output_tensor->get_memory();
     GPU_DEBUG_TRACE_DETAIL << internal_name << " with index " << output_idx << " prepare output: " << output_memory->buffer_ptr() << std::endl;
-    return network->set_output_memory(internal_name, output_memory, is_remote_tensor_impl);
+    return network->set_output_memory(internal_name, output_memory, is_dynamic && (is_remote_tensor_impl || user_tensor));
 }
 
 void SyncInferRequest::init_mappings() {


### PR DESCRIPTION
### Details:
 -   https://github.com/openvinotoolkit/openvino/pull/29795 to release branch 
 - Allow different output mem size with actual node size when user tenso is set and the port is remote
 - Fix crash in the wwb vlm test for phi-3.5 vision model
### Tickets:
 - *ticket-id*
