### PR TITLE
Add i8/u8 Evaluation Support For Comparison Ops

### DIFF
--- a/src/core/src/op/greater.cpp
+++ b/src/core/src/op/greater.cpp
@@ -57,7 +57,7 @@ bool Greater::evaluate(TensorVector& outputs, const TensorVector& inputs) const 
                                       this,
                                       outputs,
                                       inputs,
-                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64),
+                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64, i8, u8),
                                       greater::Evaluate,
                                       inputs[0].get_element_type(),
                                       inputs[0],
@@ -78,6 +78,8 @@ bool Greater::has_evaluate() const {
     case element::i64:
     case element::u32:
     case element::u64:
+    case element::i8:
+    case element::u8:
         return true;
     default:
         return false;

--- a/src/core/src/op/greater_eq.cpp
+++ b/src/core/src/op/greater_eq.cpp
@@ -57,7 +57,7 @@ bool GreaterEqual::evaluate(TensorVector& outputs, const TensorVector& inputs) c
                                       this,
                                       outputs,
                                       inputs,
-                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64),
+                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64, i8, u8),
                                       greater_equal::Evaluate,
                                       inputs[0].get_element_type(),
                                       inputs[0],
@@ -78,6 +78,8 @@ bool GreaterEqual::has_evaluate() const {
     case element::i64:
     case element::u32:
     case element::u64:
+    case element::i8:
+    case element::u8:
         return true;
     default:
         return false;

--- a/src/core/src/op/less.cpp
+++ b/src/core/src/op/less.cpp
@@ -56,7 +56,7 @@ bool Less::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
                                       this,
                                       outputs,
                                       inputs,
-                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64),
+                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64, i8, u8),
                                       less::Evaluate,
                                       inputs[0].get_element_type(),
                                       inputs[0],
@@ -77,6 +77,8 @@ bool Less::has_evaluate() const {
     case element::i64:
     case element::u32:
     case element::u64:
+    case element::i8:
+    case element::u8:
         return true;
     default:
         return false;

--- a/src/core/src/op/less_eq.cpp
+++ b/src/core/src/op/less_eq.cpp
@@ -57,7 +57,7 @@ bool LessEqual::evaluate(TensorVector& outputs, const TensorVector& inputs) cons
                                       this,
                                       outputs,
                                       inputs,
-                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64),
+                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64, i8, u8),
                                       less_equal::Evaluate,
                                       inputs[0].get_element_type(),
                                       inputs[0],
@@ -78,6 +78,8 @@ bool LessEqual::has_evaluate() const {
     case element::i64:
     case element::u32:
     case element::u64:
+    case element::i8:
+    case element::u8:
         return true;
     default:
         return false;

--- a/src/core/src/op/not_equal.cpp
+++ b/src/core/src/op/not_equal.cpp
@@ -55,7 +55,7 @@ bool NotEqual::evaluate(TensorVector& outputs, const TensorVector& inputs) const
                                       this,
                                       outputs,
                                       inputs,
-                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64),
+                                      OV_PP_ET_LIST(boolean, f32, i32, i64, u32, u64, i8, u8),
                                       not_equal::Evaluate,
                                       inputs[0].get_element_type(),
                                       inputs[0],
@@ -76,6 +76,8 @@ bool NotEqual::has_evaluate() const {
     case element::i64:
     case element::u32:
     case element::u64:
+    case element::i8:
+    case element::u8:
         return true;
     default:
         return false;


### PR DESCRIPTION
### Details:
 Add i8/u8 precision support in evaluation method for 6 comparison ops (Less/LessEqual/Equal/NotEqual/Greater/GreaterEqual)

### Tickets:
 - *E-161320*
