### PR TITLE
Updated to set cacheContent.model only for OPTIMIZE_SIZE mode

### DIFF
--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -839,7 +839,10 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model(const std::shared_ptr<
     } else if (cacheManager && device_supports_model_caching(plugin, parsed._config) && !is_proxy_device(plugin)) {
         CacheContent cacheContent{cacheManager, parsed._core_config.get_enable_mmap()};
         cacheContent.blobId = ov::ModelCache::compute_hash(model, create_compile_config(plugin, parsed._config));
-        cacheContent.model = model;
+        if (parsed._config.find(ov::cache_mode.name()) != parsed._config.end() &&
+            parsed._config.at(ov::cache_mode.name()).as<ov::CacheMode>() == ov::CacheMode::OPTIMIZE_SIZE) {
+            cacheContent.model = model;
+        }
         std::unique_ptr<CacheGuardEntry> lock = cacheGuard.get_hash_lock(cacheContent.blobId);
         res = load_model_from_cache(cacheContent, plugin, parsed._config, ov::SoPtr<ov::IRemoteContext>{}, [&]() {
             return compile_model_and_cache(plugin,
@@ -877,7 +880,10 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::compile_model(const std::shared_ptr<
         CacheContent cacheContent{cacheManager, parsed._core_config.get_enable_mmap()};
         cacheContent.blobId = ov::ModelCache::compute_hash(model, create_compile_config(plugin, parsed._config));
         std::unique_ptr<CacheGuardEntry> lock = cacheGuard.get_hash_lock(cacheContent.blobId);
-        cacheContent.model = model;
+        if (parsed._config.find(ov::cache_mode.name()) != parsed._config.end() &&
+            parsed._config.at(ov::cache_mode.name()).as<ov::CacheMode>() == ov::CacheMode::OPTIMIZE_SIZE) {
+            cacheContent.model = model;
+        }
         res = load_model_from_cache(cacheContent, plugin, parsed._config, context, [&]() {
             return compile_model_and_cache(plugin, model, parsed._config, context, cacheContent);
         });


### PR DESCRIPTION
### Details:
 - Memory usage was increased due to having `ov::Model` ptr in the `OPTIMIZE_SPEED` mode.
 - This PR resolves this issue to have it only for the `OPTIMIZE_SIZE` mode.

### Tickets:
 - 164342
