### PR TITLE
[CPU][ARM] Disable ConvPoolRelu_i32_batch1 test on 32-bit system

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -613,6 +613,8 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(.*OVInferenceChaining.*StaticOutputToStaticInput.*)");
     retVector.emplace_back(R"(.*OVInferenceChainingStatic.*StaticOutputToStaticInput.*)");
     retVector.emplace_back(R"(.*ReduceCPULayerTest.*CompareWithRefs.*INFERENCE_PRECISION_HINT=f16.*)");
+    // Issue: 164799
+    retVector.emplace_back(R"(.*CompileModelCacheTestBase.*CompareWithRefImpl.*ConvPoolRelu_i32_batch1.*)");
 #endif
     if (!ov::with_cpu_x86_avx512_core_vnni() &&
         !ov::with_cpu_x86_avx2_vnni() &&


### PR DESCRIPTION
### Details:
Disable sporadically failing ConvPoolRelu_i32_batch1 on ARM 32 bit platforms

### Tickets:
 - 164799
