### PR TITLE
Add aten::poisson translation

### DIFF
--- a/src/frontends/pytorch/src/op/poisson.cpp
+++ b/src/frontends/pytorch/src/op/poisson.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/op/constant.hpp"
+#include "pt_framework_node.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_poisson(const NodeContext& context) {
+    
+    num_inputs_check(context, 1, 2);
+    auto rates = context.get_input(0);
+    
+    if (!context.input_is_none(1)) {
+        PYTORCH_OP_CONVERSION_CHECK(false, "aten::poisson conversion with generator is not supported");
+    }
+
+    auto fw_node = std::make_shared<PtFrameworkNode>(context.get_decoder(), OutputVector{rates}, 1);
+    fw_node->set_output_type(0, rates.get_element_type(), rates.get_partial_shape());
+    auto res = context.mark_node(fw_node);
+    return {res};
+}
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov 

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -218,6 +218,7 @@ OP_CONVERTER(translate_remainder);
 OP_CONVERTER(translate_repeat_interleave);
 OP_CONVERTER(translate_reshape);
 OP_CONVERTER(translate_reshape_as);
+OP_CONVERTER(translate_poisson);
 OP_CONVERTER(translate_rms_norm);
 OP_CONVERTER(translate_rnn);
 OP_CONVERTER(translate_roi_align);
@@ -657,6 +658,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_ts() {
         {"aten::repeat_interleave", op::translate_repeat_interleave},
         {"aten::reshape", op::translate_reshape},
         {"aten::reshape_as", op::translate_reshape_as},
+        {"aten::poisson", op::translate_poisson},
         // TO DO: enable behaviour for resolve_conj and resolve_neg complex tensors,
         // when complex dtype will be supported
         // for real dtypes, these operations return input tensor without changes and can be skipped


### PR DESCRIPTION
Fixes: #29709 

**Details about PR**

- Added translation for the aten::poisson operation using PtFrameworkNode.
- Created a new file src/frontends/pytorch/src/op/poisson.cpp for the translation logic.
- Registered the aten::poisson translator in src/frontends/pytorch/src/op_table.cpp
