### PR TITLE
[GPU] Remove weightless cache checks during export

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -178,22 +178,13 @@ std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() co
 //     [ ov::Node::Input/ ov::Node::Output ]
 //     [ ov::intel_gpu::Graph ]
 void CompiledModel::export_model(std::ostream& model) const {
-    // If ov::CacheMode::OPTIMIZE_SIZE is set, do the export iff it's possible to do weightless caching
-    // which requires the weights_path or ov::Model ptr.
-    ov::CacheMode cache_mode = m_config.get_cache_mode();
-    std::string weights_path = m_config.get_weights_path();
-    auto model_ptr = m_config.get_model();
-    if (cache_mode == ov::CacheMode::OPTIMIZE_SIZE && !ov::util::validate_weights_path(weights_path) &&
-        model_ptr == nullptr) {
-        return;
-    }
-
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "CompiledModel::export_model");
     OPENVINO_ASSERT(!m_graphs.empty(), "[GPU] Model not loaded");
 
     const ov::EncryptionCallbacks encryption_callbacks = m_config.get_cache_encryption_callbacks();
 
     // Do not allow encryption for CacheMode::OPTIMIZE_SPEED - the cache size may cause severe memory penalty.
+    const ov::CacheMode cache_mode = m_config.get_cache_mode();
     const bool encryption_enabled = encryption_callbacks.encrypt && cache_mode == ov::CacheMode::OPTIMIZE_SIZE;
     std::unique_ptr<cldnn::BinaryOutputBuffer> ob_ptr =
         encryption_enabled

--- a/src/plugins/intel_gpu/tests/functional/behavior/model_cache.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/model_cache.cpp
@@ -31,7 +31,8 @@ namespace {
 enum class Import_API {
     IMPORT_EXPORT,
     COMPILE_FILEPATH,
-    COMPILE_MODEL
+    COMPILE_MODEL,
+    COMPILE_MODEL_WITH_MODEL_STR
 };
 
 std::string import_api_to_string(Import_API api) {
@@ -42,6 +43,8 @@ std::string import_api_to_string(Import_API api) {
         return "compile_filepath";
     case Import_API::COMPILE_MODEL:
         return "compile_model";
+    case Import_API::COMPILE_MODEL_WITH_MODEL_STR:
+        return "compile_model_with_model_str";
     default:
         return "";
     }
@@ -132,13 +135,19 @@ void CheckWeightlessCacheAccuracy::run() {
     } else if (import_api == Import_API::COMPILE_MODEL) {
         auto model = core->read_model(xml_path);
         compiled_model = core->compile_model(model, ov::test::utils::DEVICE_GPU, config);
+    } else if (import_api == Import_API::COMPILE_MODEL_WITH_MODEL_STR) {
+        std::ifstream model_s(xml_path);
+        std::string model_str((std::istreambuf_iterator<char>(model_s)), std::istreambuf_iterator<char>());
+        auto model_weight = ov::read_tensor_data(bin_path);
+        auto model = core->read_model(model_str, model_weight);
+        compiled_model = core->compile_model(model, ov::test::utils::DEVICE_GPU, config);
     } else {
         OPENVINO_THROW("Unknown import API");
     }
 
     auto get_cache_path = [&]() {
         std::string path;
-        if (import_api == Import_API::COMPILE_FILEPATH || import_api == Import_API::COMPILE_MODEL) {
+        if (import_api == Import_API::COMPILE_FILEPATH || import_api == Import_API::COMPILE_MODEL || import_api == Import_API::COMPILE_MODEL_WITH_MODEL_STR) {
             auto blobs = ov::test::utils::listFilesWithExt(cache_dir, "blob");
             EXPECT_EQ(blobs.size(), 1);
             path = blobs[0];
@@ -166,10 +175,18 @@ void CheckWeightlessCacheAccuracy::run() {
     } else if (import_api == Import_API::COMPILE_MODEL) {
         auto model = core->read_model(xml_path);
         imported_model = core->compile_model(model, ov::test::utils::DEVICE_GPU, config);
-    } else {
+    } else if (import_api == Import_API::COMPILE_MODEL_WITH_MODEL_STR) {
+        std::ifstream model_s(xml_path);
+        std::string model_str((std::istreambuf_iterator<char>(model_s)), std::istreambuf_iterator<char>());
+        auto model_weight = ov::read_tensor_data(bin_path);
+        auto model = core->read_model(model_str, model_weight);
+        imported_model = core->compile_model(model, ov::test::utils::DEVICE_GPU, config);
+    } else if (import_api == Import_API::IMPORT_EXPORT) {
         auto ifstr = std::ifstream(cache_path, std::ifstream::binary);
         imported_model = core->import_model(ifstr, ov::test::utils::DEVICE_GPU, config_with_weights_path);
         ifstr.close();
+    } else {
+        OPENVINO_THROW("Unknown import API");
     }
 
     auto second_cache_path = get_cache_path();
@@ -251,6 +268,7 @@ const std::vector<Import_API> import_api_types = {
     Import_API::IMPORT_EXPORT,
     Import_API::COMPILE_FILEPATH,
     Import_API::COMPILE_MODEL,
+    Import_API::COMPILE_MODEL_WITH_MODEL_STR,
 };
 
 const std::vector<ov::element::Type> inference_modes = {

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
@@ -1165,10 +1165,10 @@ TEST_P(OVCompiledModelBaseTest, compile_from_cached_weightless_blob_but_no_weigh
         EXPECT_FALSE(compiled_model.get_property(ov::loaded_from_cache));
     }
     {
-        // model not loaded from cache as no weights on path
+        // Model loaded from cache since weightless cache with ov::Model is supported.
         auto compiled_model = core->compile_model(model, target_device, configuration);
         ASSERT_TRUE(compiled_model);
-        EXPECT_FALSE(compiled_model.get_property(ov::loaded_from_cache));
+        EXPECT_TRUE(compiled_model.get_property(ov::loaded_from_cache));
     }
 
     std::error_code ec;

--- a/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/compiled_model/compiled_model_base.hpp
@@ -1168,7 +1168,11 @@ TEST_P(OVCompiledModelBaseTest, compile_from_cached_weightless_blob_but_no_weigh
         // Model loaded from cache since weightless cache with ov::Model is supported.
         auto compiled_model = core->compile_model(model, target_device, configuration);
         ASSERT_TRUE(compiled_model);
-        EXPECT_TRUE(compiled_model.get_property(ov::loaded_from_cache));
+        if (target_device == utils::DEVICE_GPU) {
+            EXPECT_TRUE(compiled_model.get_property(ov::loaded_from_cache));
+        } else {
+            EXPECT_FALSE(compiled_model.get_property(ov::loaded_from_cache));
+        }
     }
 
     std::error_code ec;


### PR DESCRIPTION
### Details:
 - There are some cases where weights_path doesn't exists and model_ptr is not propagated to CompiledModel::export_model().
 - Instead of fixing propagation I decided to remove the check during export because it's only relevant during the importing stage.
