### PR TITLE
Update cache_manager.hpp

### DIFF
--- a/src/inference/src/cache_manager.hpp
+++ b/src/inference/src/cache_manager.hpp
@@ -129,7 +129,9 @@ private:
     void write_cache_entry(const std::string& id, StreamWriter writer) override {
         // Fix the bug caused by pugixml, which may return unexpected results if the locale is different from "C".
         ScopedLocale plocal_C(LC_ALL, "C");
-        std::ofstream stream(getBlobFile(id), std::ios_base::binary | std::ofstream::out);
+        // Storing the str::wstring return value of getBlobFile into a path variable to avoid argument type mismatch compilation error 
+        std::filesystem::path pth = getBlobFile(id);
+        std::ofstream stream(pth, std::ios_base::binary | std::ofstream::out);
         writer(stream);
     }
 


### PR DESCRIPTION
Resolving the compilation error in the constructor call of std::ofstream due to argument type mismatch in the method write_catch_entry

Issue:a compilation error while building the OpenVINO project, specifically in the cache_manager.hpp file. The error occurs when attempting to construct a std::ofstream object with a std::wstring argument without first calling .c_str().

The proposed solution/fix in the issue description itself for of using the method ".c_str()" for converting the output of "getBlobFile()" form std::wstring to cons char* (but actually for std::wstring the "c_str()" returns const wchar_t*) will work fine for windows as it handles the const wchar_t* by itself, but on other systems like linux (which use UTF-8, they have only const char* filenames) this may cause some issues.

So the solution I am proposing is that create a variable of std::filesystem::path and store the return value of getBlobFile() into that and later use that variable to pass the path into the std::ofstream constructor as argument.
