### PR TITLE
[CI] [GHA] Provide paths to Dockerfiles to `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,7 +142,7 @@ updates:
   # Docker images
   - package-ecosystem: docker
     directories:
-      - "/.github/dockerfiles/**/*"
+      - "**/*"
     schedule:
       interval: "daily"
       time: "09:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -141,7 +141,8 @@ updates:
 
   # Docker images
   - package-ecosystem: docker
-    directory: "/"
+    directories:
+      - "/.github/dockerfiles/**/*"
     schedule:
       interval: "daily"
       time: "09:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,7 +142,7 @@ updates:
   # Docker images
   - package-ecosystem: docker
     directories:
-      - "/.github/dockerfiles/ov_build/**/*"
+      - "/.github/dockerfiles/**/*"
       - "/.github/dockerfiles/ov_test/**/*"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -142,7 +142,8 @@ updates:
   # Docker images
   - package-ecosystem: docker
     directories:
-      - "**/*"
+      - "/.github/dockerfiles/ov_build/**/*"
+      - "/.github/dockerfiles/ov_test/**/*"
     schedule:
       interval: "daily"
       time: "09:00"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -143,7 +143,6 @@ updates:
   - package-ecosystem: docker
     directories:
       - "/.github/dockerfiles/**/*"
-      - "/.github/dockerfiles/ov_test/**/*"
     schedule:
       interval: "daily"
       time: "09:00"


### PR DESCRIPTION
### Details:
 - `dependabot` supports listing several directories and using the wildcards: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
- I tried it in my fork, and it seems to be working