### PR TITLE
[GHA] Rename duplicated overall status check for dev RISCV pipeline

### DIFF
--- a/.github/workflows/linux_riscv_xuantie_dev_cpu.yml
+++ b/.github/workflows/linux_riscv_xuantie_dev_cpu.yml
@@ -244,7 +244,7 @@ jobs:
         timeout-minutes: ${{ inputs.testFilterType == 'SMOKE' && 125 || 25}}
 
   Overall_Status:
-    name: ci/gha_overall_status_linux_riscv
+    name: ci/gha_overall_status_linux_riscv_xuantie
     needs: [Smart_CI, Build, CPU_Functional_Tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes a mess with RISCV pipeline status. Will be non-required since this workflow contains paths filter.