### PR TITLE
[CPU] reduce temporary weight memory of PA and SDPA

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -1502,8 +1502,6 @@ struct MHAHelper {
         auto want_score_stride = rnd_up(kv_len, _block_size);
         auto new_score_stride = std::max(prev_score_stride, want_score_stride);
         // resize temporary buffers, weight.size(3) will be aligned to block_size
-        std::cout << "_weight" << &_weight <<  " _nthr:" << _nthr << " H:" << H << " _block_size:" << _block_size
-                  << " _new_score_stride:" << new_score_stride << " SV:" << SV << std::endl;
         _weight.resize<float>({static_cast<size_t>(_nthr), H / Hk, _block_size, new_score_stride});
         // std::max(S, SV) here is to ensure by_channel quantize has enough buffer to use
         if (_quant_key_bychannel)

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -2266,7 +2266,7 @@ struct MHA {
                                attn_work_count * Hk <= 2 * _helper._nthr
                            ? false
                            : true;  // or less than 2 work items per thread, loop H
-        auto weight_h = loop_hk ? _helper._H / HK : 1;
+        auto weight_h = loop_hk ? _helper.H / Hk : 1;
         _helper.resize_temporary_weight_buffer(weight_h);
 
         parallel_for2d_dynamic(attn_work_count, loop_hk ? Hk : _helper.H, [&](size_t w, size_t hx) {

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -1502,6 +1502,8 @@ struct MHAHelper {
         auto want_score_stride = rnd_up(kv_len, _block_size);
         auto new_score_stride = std::max(prev_score_stride, want_score_stride);
         // resize temporary buffers, weight.size(3) will be aligned to block_size
+        std::cout << "_weight" << &_weight <<  " _nthr:" << _nthr << " H:" << H << " _block_size:" << _block_size
+                  << " _new_score_stride:" << new_score_stride << " SV:" << SV << std::endl;
         _weight.resize<float>({static_cast<size_t>(_nthr), H, _block_size, new_score_stride});
         // std::max(S, SV) here is to ensure by_channel quantize has enough buffer to use
         if (_quant_key_bychannel)

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -342,6 +342,9 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
         qk_scratch_b.resize<T>({B, Hk, qk_gemm_ptr->get_scratch_b_size() / data_size});
         wv_scratch_b.resize<T>({B, Hk, wv_gemm_ptr->get_scratch_b_size() / data_size});
         const size_t m_block_size = qk_gemm_ptr->get_mblk_size();
+
+        std::cout << "weight_score " << &weight_score << " SDPA m_threads_num:" << m_threads_num << " H:" << H << " m_block_size:" << m_block_size
+                  << " kv_len:" << kv_len << " B:" << B << " q_len:" << q_len << std::endl;
         weight_score.resize<float>({m_threads_num, H, m_block_size, kv_len});
         if (has_out_transpose) {
             fp32_out.resize<float>({B, q_len, H, head_size_v});

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -356,23 +356,10 @@ struct PlainTensor {
 #ifdef _WIN32
                 ptr = _aligned_malloc(capacity_new, 64);
 #else
-                size_t capacity_new_2n = 1;
-                while (capacity_new_2n < capacity_new) {
-                    capacity_new_2n *= 2;
-                }
-                capacity_new = capacity_new_2n;
-                //m_ptr.reset();
-                //malloc_trim(0);
-                std::cout << "capacity_new:" << capacity_new << std::endl;
                 int rc = ::posix_memalign(&ptr, 64, capacity_new);
                 if (rc) {
                     OPENVINO_ASSERT(false, "PlainTensor call posix_memalign failed: ", rc);
                 }
-                //ptr = ::aligned_alloc(64, capacity_new);
-                //if (ptr == nullptr) {
-                //    OPENVINO_ASSERT(false, "PlainTensor call aligned_alloc failed: ");
-                //}
-                memset(ptr, 0, capacity_new);
 #endif
                 m_ptr = std::shared_ptr<uint8_t>(static_cast<uint8_t*>(ptr), [](uint8_t* ptr) {
 #ifdef _WIN32

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -356,10 +356,23 @@ struct PlainTensor {
 #ifdef _WIN32
                 ptr = _aligned_malloc(capacity_new, 64);
 #else
+                size_t capacity_new_2n = 1;
+                while (capacity_new_2n < capacity_new) {
+                    capacity_new_2n *= 2;
+                }
+                capacity_new = capacity_new_2n;
+                //m_ptr.reset();
+                //malloc_trim(0);
+                std::cout << "capacity_new:" << capacity_new << std::endl;
                 int rc = ::posix_memalign(&ptr, 64, capacity_new);
                 if (rc) {
                     OPENVINO_ASSERT(false, "PlainTensor call posix_memalign failed: ", rc);
                 }
+                //ptr = ::aligned_alloc(64, capacity_new);
+                //if (ptr == nullptr) {
+                //    OPENVINO_ASSERT(false, "PlainTensor call aligned_alloc failed: ");
+                //}
+                memset(ptr, 0, capacity_new);
 #endif
                 m_ptr = std::shared_ptr<uint8_t>(static_cast<uint8_t*>(ptr), [](uint8_t* ptr) {
 #ifdef _WIN32


### PR DESCRIPTION
### Details:
 - *In the q @ k operation of PA and SDPA, need to use [q_len, s] @ [s, kv_len] =  [q_len, kv_len] memory to save the result. If there is multi batch size and multi heads, the memory shape is [B, H, q_len, kv_len], but in the implementation of CPU plugin, the operation will be split into multi tasks, every task only calculate a block size, so every task need memory [block_size, kv_len], the tasks will be scheduled to many different threads by tbb, so need to malloc [threads_num, block_size, kv_len] memory to save all the results. The temporary result will be used to do softmax operation and @ v in the same thread,  so it's safe to use [threads_num, block_size, kv_len] instead of [threads_num, H,  block_size, kv_len]*
 - *when loop_hk = true in PA, dim H became Hk, so the temporary weight memory shape became [threads_num, H / Hk,  block_size, kv_len]*
 - *about SDPA please refer to  https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html*

### Tickets:
 - *CVS-163700*
