### PR TITLE
[GPU] Fix dynamic onednn convolution format selection for VLMs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -931,7 +931,7 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
         return format::bfyx;
     }
 
-    if (node.is_dynamic() && use_onednn_impls && onednn_valid_post_ops && 
+    if (node.is_dynamic() && use_onednn_impls && onednn_valid_post_ops &&
         output_layout.get_partial_shape().size() == 4 && !i8_u8_input && !node.has_padded_dependency() &&
         input_layout.get_partial_shape()[1].is_static() && output_layout.get_partial_shape()[1].is_static()) {
         bool correct_data_type = ((input_layout.data_type == data_types::f16 || input_layout.data_type == data_types::f32) &&

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -931,6 +931,30 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
         return format::bfyx;
     }
 
+    if (node.is_dynamic() && use_onednn_impls && onednn_valid_post_ops && 
+        output_layout.get_partial_shape().size() == 4 && !i8_u8_input && !node.has_padded_dependency() &&
+        input_layout.get_partial_shape()[1].is_static() && output_layout.get_partial_shape()[1].is_static()) {
+        bool correct_data_type = ((input_layout.data_type == data_types::f16 || input_layout.data_type == data_types::f32) &&
+                                  (weights_layout.data_type == input_layout.data_type));
+        const int32_t feature_block_size = 16;
+        auto input_pshape = input_layout.get_partial_shape();
+        auto output_phshape = output_layout.get_partial_shape();
+        bool correct_in_out_feature = (input_pshape[1].get_length() >= feature_block_size && output_phshape[1].get_length() >= feature_block_size);
+        int32_t in_features_per_group = input_pshape[1].get_length() / prim->groups;
+        int32_t out_features_per_group = output_phshape[1].get_length() / prim->groups;
+        bool depthwise = prim->groups == static_cast<uint32_t>(input_pshape[1].get_length());
+        bool grouped = ((feature_block_size % out_features_per_group == 0) &&
+                        (feature_block_size % in_features_per_group == 0) &&
+                        (feature_block_size / out_features_per_group > 1) &&
+                        (feature_block_size / in_features_per_group > 1) &&
+                        (out_features_per_group != 1) &&
+                        (in_features_per_group != 1)) ||
+                       ((out_features_per_group % feature_block_size == 0 || feature_block_size % out_features_per_group == 0) &&
+                        (in_features_per_group % feature_block_size == 0));
+        if (correct_data_type && !correct_in_out_feature && !depthwise && !grouped)
+            return format::bfyx;
+    }
+
     if (input_layout.is_dynamic() || output_layout.is_dynamic()) {
         if (input_layout.get_partial_shape().size() <= 4)
             expected_format = format::b_fs_yx_fsv16;


### PR DESCRIPTION
### Details:
 - For dynamic model, the preferred format for `convolution` is selected to "b_fs_yx_fsv16" unconditionally. But the input channel is small (e.g. IC=3), the input tag of onednn conv is selected as blocked format w/ b16, which causes unnecessary computation cost.
 - Update format selection logic to select planar format in this case based on the maximum obtainable shape or attribute information.

### Tickets:
 - 162854
