### PR TITLE
[GHA] W/a for code style pipelines cmake 4.0 

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -4,6 +4,7 @@ on:
   merge_group:
 
 env:
+  CMAKE_POLICY_VERSION_MINIMUM: '3.5' # w/a for cmake >= 4.0
   DOXY_VER: '1.9.6'
 
 concurrency:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -7,6 +7,9 @@ concurrency:
 
 permissions: read-all
 
+env:
+  CMAKE_POLICY_VERSION_MINIMUM: '3.5' # w/a for cmake >= 4.0
+
 jobs:
   clang-format:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Details:
 - Code style pipelines uses GHA runners with the latest cmake version 4.0

### Tickets:
 - *ticket-id*
