### PR TITLE
[CPU] Apply 'readability-container-size-empty' clang-tidy remarks

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -46,6 +46,7 @@ Checks: >
   google-*,
   modernize-*,
   cppcoreguidelines-prefer-member-initializer,
+  readability-container-size-empty,
   readability-else-after-return,
   -bugprone-easily-swappable-parameters,
   -bugprone-exception-escape,

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -217,7 +217,7 @@ std::vector<std::vector<int>> get_streams_info_table(
             }
         }
         if (input_threads > 0) {
-            if (hint_model_distribution_policy.size() == 0) {
+            if (hint_model_distribution_policy.empty()) {
                 n_threads_per_stream = std::min(input_threads, proc_type_table[0][ALL_PROC]);
             } else {
                 for (auto& row : proc_socket_table) {

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.cpp
@@ -606,21 +606,21 @@ void DnnlPostOpsComposer::appendClip(const std::vector<float>& low, const std::v
     } else if (low.size() == 1) {
         OPENVINO_ASSERT(high.size() == OC);
         appendEltwise(dnnl::algorithm::eltwise_clip, low[0], std::numeric_limits<float>::max());
-        if (high.size() > 0) {
+        if (!high.empty()) {
             appendBinary(dnnl::algorithm::binary_min, high);
         }
     } else if (high.size() == 1) {
         OPENVINO_ASSERT(low.size() == OC);
         appendEltwise(dnnl::algorithm::eltwise_clip, -std::numeric_limits<float>::max(), high[0]);
-        if (low.size() > 0) {
+        if (!low.empty()) {
             appendBinary(dnnl::algorithm::binary_max, low);
         }
     } else {
-        if (low.size() > 0) {
+        if (!low.empty()) {
             OPENVINO_ASSERT(low.size() == OC);
             appendBinary(dnnl::algorithm::binary_max, low);
         }
-        if (high.size() > 0) {
+        if (!high.empty()) {
             OPENVINO_ASSERT(high.size() == OC);
             appendBinary(dnnl::algorithm::binary_min, high);
         }

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer_legacy.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer_legacy.cpp
@@ -246,21 +246,21 @@ void DnnlPostOpsComposerLegacy::appendClip(const std::vector<float>& low, const 
     } else if (low.size() == 1) {
         OPENVINO_ASSERT(high.size() == OC);
         appendEltwise(dnnl::algorithm::eltwise_clip, low[0], std::numeric_limits<float>::max());
-        if (high.size() > 0) {
+        if (!high.empty()) {
             appendBinary(dnnl::algorithm::binary_min, high);
         }
     } else if (high.size() == 1) {
         OPENVINO_ASSERT(low.size() == OC);
         appendEltwise(dnnl::algorithm::eltwise_clip, -std::numeric_limits<float>::max(), high[0]);
-        if (low.size() > 0) {
+        if (!low.empty()) {
             appendBinary(dnnl::algorithm::binary_max, low);
         }
     } else {
-        if (low.size() > 0) {
+        if (!low.empty()) {
             OPENVINO_ASSERT(low.size() == OC);
             appendBinary(dnnl::algorithm::binary_max, low);
         }
-        if (high.size() > 0) {
+        if (!high.empty()) {
             OPENVINO_ASSERT(high.size() == OC);
             appendBinary(dnnl::algorithm::binary_min, high);
         }

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -199,8 +199,8 @@ static inline bool isPhycicalMemCompatible(const MemoryDesc& lhsMemDesc, const M
 
     // this check needed to avoid inserting unnecessary reorders if the memory is used in place and the batch size is
     // equal to 1 in nodes like concate and split
-    size_t lhsSkipAxis = lhsBlockDims.size() > 0 && lhsBlockDims[0] == 1 ? 0 : Shape::UNDEFINED_DIM;
-    size_t rhsSkipAxis = rhsBlockDims.size() > 0 && rhsBlockDims[0] == 1 ? 0 : Shape::UNDEFINED_DIM;
+    size_t lhsSkipAxis = !lhsBlockDims.empty() && lhsBlockDims[0] == 1 ? 0 : Shape::UNDEFINED_DIM;
+    size_t rhsSkipAxis = !rhsBlockDims.empty() && rhsBlockDims[0] == 1 ? 0 : Shape::UNDEFINED_DIM;
 
     bool isDenseTensor = dimsEqualStrong(lhsStridesDefault, lhsBlockMemDesc->getStrides(), lhsSkipAxis) &&
                          dimsEqualStrong(rhsStridesDefault, rhsBlockMemDesc->getStrides(), rhsSkipAxis);

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp
@@ -180,7 +180,7 @@ void jit_emitter::emitter_preamble(const std::vector<size_t>& in_idxs,
         h->push(Reg64(preserved_gpr_idx));
     }
 
-    if (preserved_vec_idxs.size()) {
+    if (!preserved_vec_idxs.empty()) {
         h->sub(h->rsp, preserved_vec_idxs.size() * get_vec_length());
     }
 
@@ -200,7 +200,7 @@ void jit_emitter::emitter_postamble() const {
         pop_vec(preserved_vec_idxs[i], h->ptr[h->rsp + i * get_vec_length()]);
     }
 
-    if (preserved_vec_idxs.size()) {
+    if (!preserved_vec_idxs.empty()) {
         h->add(h->rsp, preserved_vec_idxs.size() * get_vec_length());
     }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.cpp
@@ -94,7 +94,7 @@ ov::snippets::lowered::ExpressionPtr jit_loop_end_emitter::get_loop_begin_expr(
 
 void jit_loop_end_emitter::validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     const auto io_size = num_inputs + num_outputs;
-    OV_CPU_JIT_EMITTER_ASSERT(out.size() == 0, "Invalid number of out arguments: expected ", 0, " got ", out.size());
+    OV_CPU_JIT_EMITTER_ASSERT(out.empty(), "Invalid number of out arguments: expected ", 0, " got ", out.size());
     OV_CPU_JIT_EMITTER_ASSERT(in.size() == io_size + 1,
                               "Invalid number of in arguments: expected ",
                               io_size + 1,

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.cpp
@@ -168,7 +168,7 @@ ov::snippets::lowered::ExpressionPtr jit_loop_end_emitter::get_loop_begin_expr(
 
 void jit_loop_end_emitter::validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const {
     const auto io_size = num_inputs + num_outputs;
-    OV_CPU_JIT_EMITTER_ASSERT(out.size() == 0, "Invalid number of out arguments: expected ", 0, " got ", out.size());
+    OV_CPU_JIT_EMITTER_ASSERT(out.empty(), "Invalid number of out arguments: expected ", 0, " got ", out.size());
     OV_CPU_JIT_EMITTER_ASSERT(in.size() == io_size + 1,
                               "Invalid number of in arguments: expected ",
                               io_size + 1,

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -1771,8 +1771,8 @@ void GraphOptimizer::FuseConvolutionSumAndConvolutionSumActivation(Graph& graph)
 
         lastNode->fuseInto(mergedConv);
 
-        if (mergedConv->fusedWith.size() > 0 && (mergedConv->fusedWith[0]->getType() == Type::Convolution ||
-                                                 mergedConv->fusedWith[0]->getType() == Type::BinaryConvolution)) {
+        if (!mergedConv->fusedWith.empty() && (mergedConv->fusedWith[0]->getType() == Type::Convolution ||
+                                               mergedConv->fusedWith[0]->getType() == Type::BinaryConvolution)) {
             // Merged with DW_conv. Shape may change
             mergedConv->inputShapes.push_back(mergedConv->fusedWith[0]->getOutputShapeAtPort(0));
         } else {

--- a/src/plugins/intel_cpu/src/infer_request.cpp
+++ b/src/plugins/intel_cpu/src/infer_request.cpp
@@ -88,7 +88,7 @@ void SyncInferRequest::infer() {
     }
 
     convert_batched_tensors();
-    if (m_batched_tensors.size() > 0) {
+    if (!m_batched_tensors.empty()) {
         // batched_tensors will be updated for each infer, external_ptr should be update together
         update_external_tensor_ptrs();
     }
@@ -349,8 +349,8 @@ void SyncInferRequest::set_tensor(const ov::Output<const ov::Node>& in_port, con
     // WA: legacy api create blob with ANY layout will not set BlockingDesc, which will lead to tensor.get_shape()
     // return empty shape but tensor.get_size() return correct value, and tensor.reshape() cannot update
     // BlockingDesc, so to construct new tensor with original tensor's data, which is only for ov legacy api usage.
-    if (in_port.get_partial_shape().is_static() && in_tensor->get_size() > 0 && in_tensor->get_shape().size() == 0 &&
-        in_tensor->get_size() == ov::shape_size(in_port.get_shape()) && in_port.get_shape().size() > 0) {
+    if (in_port.get_partial_shape().is_static() && in_tensor->get_size() > 0 && in_tensor->get_shape().empty() &&
+        in_tensor->get_size() == ov::shape_size(in_port.get_shape()) && !in_port.get_shape().empty()) {
         tensor = ov::make_tensor(in_tensor->get_element_type(), in_port.get_shape(), in_tensor->data());
     }
     auto port_found = find_port(in_port);
@@ -619,7 +619,7 @@ void SyncInferRequest::sub_streams_infer() {
 
     size_t requests_num = requests.size();
 
-    if (requests.size() > 0) {
+    if (!requests.empty()) {
         for (const auto& output : outputs) {
             auto tensor = requests[0]->get_tensor(output);
             set_tensor(output, tensor);

--- a/src/plugins/intel_cpu/src/nodes/broadcast.cpp
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.cpp
@@ -220,7 +220,7 @@ void Broadcast::plainExecute(const dnnl::stream& strm) {
     if (!dataSrcRank) {
         srcDims = VectorDims(1, 1);
     }
-    if (!srcStrides.size()) {
+    if (srcStrides.empty()) {
         srcStrides = VectorDims(1, 1);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/bucketize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.cpp
@@ -201,7 +201,7 @@ void Bucketize::prepareParams() {
 
     // update with_bins/num_values/num_bin_values
     auto input_tensor_dims = inputTensorMemPtr->getStaticDims();
-    if (input_tensor_dims.size() < 1) {
+    if (input_tensor_dims.empty()) {
         THROW_CPU_NODE_ERR("has incorrect dimensions of the input.");
     }
     auto input_bin_dims = inputBinsMemPtr->getStaticDims();

--- a/src/plugins/intel_cpu/src/nodes/concat.cpp
+++ b/src/plugins/intel_cpu/src/nodes/concat.cpp
@@ -84,7 +84,7 @@ void Concat::getSupportedDescriptors() {
                 break;
             }
         }
-        if (incorrectDims || firstParentDims.size() == 0) {
+        if (incorrectDims || firstParentDims.empty()) {
             THROW_CPU_NODE_ERR("has incorrect input dimensions");
         }
     }

--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -513,7 +513,7 @@ void DFT::updateTwiddlesFFT(size_t n_complex, bool inverse) {
     size_t numBlocks = 1;
 
     twiddlesFFT.reserve((n_complex - 1) * 2);
-    if (twiddlesFFT.size() == 0) {
+    if (twiddlesFFT.empty()) {
         twiddlesFFT.emplace_back(1.0f);   //  cos(0)
         twiddlesFFT.emplace_back(-0.0f);  // -sin(0)
     } else {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -1396,7 +1396,7 @@ bool Eltwise::isWithBroadcast() {
 }
 
 void Eltwise::getSupportedDescriptors() {
-    if (getParentEdges().size() < 1) {
+    if (getParentEdges().empty()) {
         THROW_CPU_NODE_ERR("Incorrect number of input edges");
     }
     if (getChildEdges().empty()) {

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -370,8 +370,8 @@ void Gather::prepareParams() {
     if (dataSrcRank <= 1 && dataMemPtr->getDesc().getPrecision() == ov::element::i32) {
         const auto& dataDims = dataMemPtr->getStaticDims();
         const auto& idxDims = idxMemPtr->getStaticDims();
-        if ((dataDims.size() == 0 || (dataDims.size() == 1 && dataDims[0] <= 64)) &&
-            (idxDims.size() == 0 || (idxDims.size() == 1 && idxDims[0] <= 64))) {
+        if ((dataDims.empty() || (dataDims.size() == 1 && dataDims[0] <= 64)) &&
+            (idxDims.empty() || (idxDims.size() == 1 && idxDims[0] <= 64))) {
             canOptimize1DCase = true;
             return;
         }
@@ -944,7 +944,7 @@ void Gather::exec1DCase() {
     const auto* pidx = idxMemPtr->getDataAs<int32_t>();
 
     const auto& idxDims = idxMemPtr->getStaticDims();
-    const auto idxCnt = (idxDims.size() == 0) ? 1 : idxDims[0];
+    const auto idxCnt = (idxDims.empty()) ? 1 : idxDims[0];
     auto axisDim = srcMemPtr->getStaticDims()[0];
     for (size_t i = 0; i < idxCnt; i++) {
         auto ii = pidx[i];

--- a/src/plugins/intel_cpu/src/nodes/grn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/grn.cpp
@@ -82,7 +82,7 @@ void GRN::prepareParams() {
         }
     }
 
-    if (dataDims.size() > 0) {
+    if (!dataDims.empty()) {
         N = static_cast<int>(dataDims[0]);
     }
     if (dataDims.size() > 1) {

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -511,7 +511,7 @@ void MultiClassNms::nmsWithEta(const float* boxes,
                 }
             }
             fb.reserve(sorted_boxes.size());
-            if (sorted_boxes.size() > 0) {
+            if (!sorted_boxes.empty()) {
                 auto adaptive_threshold = m_iouThreshold;
                 int max_out_box =
                     (static_cast<size_t>(m_nmsRealTopk) > sorted_boxes.size()) ? sorted_boxes.size() : m_nmsRealTopk;
@@ -626,7 +626,7 @@ void MultiClassNms::nmsWithoutEta(const float* boxes,
             }
 
             int io_selection_size = 0;
-            if (sorted_boxes.size() > 0) {
+            if (!sorted_boxes.empty()) {
                 parallel_sort(sorted_boxes.begin(),
                               sorted_boxes.end(),
                               [](const std::pair<float, int>& l, const std::pair<float, int>& r) {

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -44,7 +44,7 @@ void NonZero::getSupportedDescriptors() {
     if (getParentEdges().size() != 1) {
         THROW_CPU_NODE_ERR("has incorrect number of input edges: ", getParentEdges().size());
     }
-    if (!getChildEdges().size()) {
+    if (getChildEdges().empty()) {
         THROW_CPU_NODE_ERR("has incorrect number of output edges: ", getChildEdges().size());
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -285,7 +285,7 @@ bool RDFT::needShapeInfer() const {
 }
 
 bool RDFT::needPrepareParams() const {
-    return axesChanged() || signalSizesChanged() || twiddles.size() == 0;
+    return axesChanged() || signalSizesChanged() || twiddles.empty();
 }
 
 static void adjustInputSize(VectorDims& inputShape,

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -3746,7 +3746,7 @@ void Reduce::setJITBeyond5D() {
 std::vector<int> Reduce::update_src_dims() {
     std::vector<int> reduce_axes = raw_axes;
 
-    if (reduce_axes.size() < 1) {
+    if (reduce_axes.empty()) {
         return reduce_axes;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.cpp
@@ -65,7 +65,7 @@ void ReorgYolo::execute(const dnnl::stream& strm) {
     int IW = (inDims.size() > 3) ? inDims[3] : 1;
     int IH = (inDims.size() > 2) ? inDims[2] : 1;
     int IC = (inDims.size() > 1) ? inDims[1] : 1;
-    int B = (inDims.size() > 0) ? inDims[0] : 1;
+    int B = (!inDims.empty()) ? inDims[0] : 1;
 
     int ic_off = IC / (stride * stride);
     int ih_off = IH * stride;

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -861,7 +861,7 @@ void ScatterUpdate::execute(const dnnl::stream& strm) {
         auto updateDims = updateMemPtr->getStaticDims();
         if (updateDims.size() <= 1) {
             DEBUG_LOG(getName(), " exec1DCase");
-            auto updateCnt = (updateDims.size() == 0) ? 1 : updateDims[0];
+            auto updateCnt = (updateDims.empty()) ? 1 : updateDims[0];
             auto srcLength = srcMemPtr->getStaticDims()[0];
             auto* psrc = reinterpret_cast<int32_t*>(srcPtr);
             auto* pdst = reinterpret_cast<int32_t*>(dstPtr);

--- a/src/plugins/intel_cpu/src/nodes/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/softmax.cpp
@@ -76,7 +76,7 @@ SoftMax::SoftMax(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& 
 }
 
 void SoftMax::getSupportedDescriptors() {
-    if (descs.size()) {
+    if (!descs.empty()) {
         return;
     }
 
@@ -89,7 +89,7 @@ void SoftMax::getSupportedDescriptors() {
     if (getParentEdges().size() != 1) {
         THROW_CPU_NODE_ERR("Incorrect number of input edges");
     }
-    if (!getChildEdges().size()) {
+    if (getChildEdges().empty()) {
         THROW_CPU_NODE_ERR("Incorrect number of output edges");
     }
 

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -334,7 +334,7 @@ void Split::initOptimalPrimitiveDescriptor() {
 
     auto config = selected_pd->getConfig();
     canUseOptimizedNspc2Ncsp = false;
-    CPU_NODE_ASSERT(config.inConfs.size() > 0, "Incorrect number of input configurations");
+    CPU_NODE_ASSERT(!config.inConfs.empty(), "Incorrect number of input configurations");
     const auto inConfDesc = config.inConfs[0].getMemDesc();
     if (axis == 1 && one_of(inConfDesc->getShape().getRank(), 4u, 5u) && inConfDesc->hasLayoutType(LayoutType::nspc)) {
         canUseOptimizedNspc2Ncsp = true;

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -205,7 +205,7 @@ static Config::ModelType getModelType(const std::shared_ptr<const Model>& model)
         return Config::ModelType::CNN;
     }
 
-    if ((op::util::has_op_with_type<op::v13::ScaledDotProductAttention>(model) && model->get_variables().size() > 0) ||
+    if ((op::util::has_op_with_type<op::v13::ScaledDotProductAttention>(model) && !model->get_variables().empty()) ||
         op::util::has_op_with_type<ov::op::PagedAttentionExtension>(model)) {
         return Config::ModelType::LLM;
     }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/reshape.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/reshape.cpp
@@ -77,7 +77,7 @@ Result SqueezeShapeInfer::infer(const std::vector<std::reference_wrapper<const V
         const auto& memPtr = data_dependency.at(SQUEEZE_PATTERN);
         const auto data = memPtr->getData();
         const auto& dims = memPtr->getStaticDims();
-        if (dims.size() != 0) {
+        if (!dims.empty()) {
             const size_t outputPatternSize = std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>());
             std::vector<int64_t> outPattern = ov::get_raw_data_as<int64_t>(memPtr->getDesc().getPrecision(),
                                                                            data,

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -151,7 +151,7 @@ public:
 
     std::optional<std::vector<StaticShape>> infer(const std::vector<StaticShapeRef>& input_shapes,
                                                   const ov::ITensorAccessor&) override {
-        NODE_VALIDATION_CHECK(m_node.get(), input_shapes.size() > 0, "Incorrect number of input shapes");
+        NODE_VALIDATION_CHECK(m_node.get(), !input_shapes.empty(), "Incorrect number of input shapes");
         return {std::vector<StaticShape>{input_shapes[0]}};
     }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
@@ -59,7 +59,7 @@ ov::intel_cpu::MoveReadValueInputsToSubgraph::MoveReadValueInputsToSubgraph() {
             }
 
             // node is Output
-            if (node->get_output_target_inputs(0).size() == 0u) {
+            if (node->get_output_target_inputs(0).empty()) {
                 found_output = true;
                 return;
             }
@@ -122,7 +122,7 @@ ov::intel_cpu::MoveReadValueInputsToSubgraph::MoveReadValueInputsToSubgraph() {
         // Reverse DFS ReadValue, find all suitable nodes and move them to subgraph_nodes.
         reverse_dfs(readvalue->get_input_node_shared_ptr(0));
 
-        if (inputs.size() == 0 || subgraph_nodes.size() == 0) {
+        if (inputs.empty() || subgraph_nodes.empty()) {
             return false;
         }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/mha_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/mha_fusion.cpp
@@ -403,7 +403,7 @@ ov::intel_cpu::MHAQuantFusion::MHAQuantFusion() {
             ov::as_type_ptr<ov::opset1::FakeQuantize>(pattern_to_output.at(fakeQuantize0).get_node_shared_ptr());
         if (fq0_node) {
             fq0_scale = simplifyToScale(fq0_node);
-            if (!fq0_scale.size()) {
+            if (fq0_scale.empty()) {
                 return false;
             }
         }
@@ -453,7 +453,7 @@ ov::intel_cpu::MHAQuantFusion::MHAQuantFusion() {
             ov::as_type_ptr<ov::opset1::FakeQuantize>(pattern_to_output.at(fakeQuantize1).get_node_shared_ptr());
         if (fq1_node) {
             fq1_scale = simplifyToScale(fq1_node);
-            if (!fq1_scale.size()) {
+            if (fq1_scale.empty()) {
                 return false;
             }
         } else {
@@ -472,7 +472,7 @@ ov::intel_cpu::MHAQuantFusion::MHAQuantFusion() {
         if (auto fq_node =
                 ov::as_type_ptr<ov::opset1::FakeQuantize>(pattern_to_output.at(fakeQuantize2).get_node_shared_ptr())) {
             fq2_scale = simplifyToScale(fq_node);
-            if (!fq2_scale.size()) {
+            if (fq2_scale.empty()) {
                 return false;
             }
         }
@@ -623,7 +623,7 @@ ov::intel_cpu::MHAQuantFusion2::MHAQuantFusion2() {
             ov::as_type_ptr<ov::opset1::FakeQuantize>(pattern_to_output.at(fakeQuantize0).get_node_shared_ptr());
         if (fq0_node) {
             fq0_scale = simplifyToScale(fq0_node);
-            if (!fq0_scale.size()) {
+            if (fq0_scale.empty()) {
                 return false;
             }
         } else {
@@ -644,7 +644,7 @@ ov::intel_cpu::MHAQuantFusion2::MHAQuantFusion2() {
             if (auto fq_node = ov::as_type_ptr<ov::opset1::FakeQuantize>(
                     pattern_to_output.at(fakeQuantize1).get_node_shared_ptr())) {
                 fq1_scale = simplifyToScale(fq_node);
-                if (!fq1_scale.size()) {
+                if (fq1_scale.empty()) {
                     return false;
                 }
             }


### PR DESCRIPTION
### Details:
 - Fix "readability-container-size-empty" remarks reported by clang-tidy
 - Enable "readability-container-size-empty" clang-tidy checks on CI by default

### Tickets:
 - N/A
