### PR TITLE
[GPU] Fix sdpa_micro to support scalar inputs for attn_mask and scale

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp
@@ -67,6 +67,9 @@ struct scaled_dot_product_attention : public primitive_base<scaled_dot_product_a
     std::vector<int64_t> input_v_transpose_order;
     std::vector<int64_t> output_transpose_order;
 
+    std::optional<float> attn_mask_val{};
+    std::optional<float> scale_val{};
+
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, is_causal);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -311,6 +311,9 @@ public:
         if (desc->scale_val.has_value()) {
             data_inputs_num--;
         }
+        if (desc->attn_mask_val.has_value()) {
+            data_inputs_num--;
+        }
 
         auto has_zp_input_buffers = desc->get_compression_zp_inputs_num() > 0;
         if (desc->is_kv_compressed) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -105,7 +105,7 @@ protected:
         auto inputs_num = instance.inputs_memory_count();
         if (instance.has_indirect_inputs() && stage == default_sdpa)
             inputs_num--;
-    
+
         const size_t attn_mask_idx = 3;
         const size_t scale_idx = 4;
         for (size_t i = 0; i < inputs_num; i++) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -100,12 +100,21 @@ protected:
 
     kernel_arguments_data get_arguments(const scaled_dot_product_attention_inst& instance, size_t stage) const override {
         kernel_arguments_data args;
+        const auto desc = instance.get_node().as<scaled_dot_product_attention>().get_primitive();
 
         auto inputs_num = instance.inputs_memory_count();
         if (instance.has_indirect_inputs() && stage == default_sdpa)
             inputs_num--;
-
+    
+        const size_t attn_mask_idx = 3;
+        const size_t scale_idx = 4;
         for (size_t i = 0; i < inputs_num; i++) {
+            if (i == attn_mask_idx && desc->attn_mask_val.has_value()) {
+                continue;
+            }
+            if (i == scale_idx && desc->scale_val.has_value()) {
+                continue;
+            }
             args.inputs.push_back(instance.input_memory_ptr(i));
         }
 
@@ -261,6 +270,20 @@ protected:
 
         config.is_causal = desc->is_causal;
 
+        if (desc->scale_val.has_value()) {
+            config.has_const_scale_val = true;
+            config.scale_val = desc->scale_val.value();
+        } else {
+            config.has_const_scale_val = false;
+        }
+
+        if (desc->attn_mask_val.has_value()) {
+            config.has_const_attn_mask_val = true;
+            config.attn_mask_val = desc->attn_mask_val.value();
+        } else {
+            config.has_const_attn_mask_val = false;
+        }
+
         if (desc->is_kv_compressed) {
             const auto& group_sizes = desc->quantization_attributes.group_sizes;
             const auto non_compressed_dims = std::count(group_sizes.begin(), group_sizes.end(), 1);
@@ -284,6 +307,10 @@ public:
         auto data_inputs_num = impl_param.input_layouts.size();
         if (has_indirect_inputs(impl_param))
             data_inputs_num--;
+
+        if (desc->scale_val.has_value()) {
+            data_inputs_num--;
+        }
 
         auto has_zp_input_buffers = desc->get_compression_zp_inputs_num() > 0;
         if (desc->is_kv_compressed) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_micro.cl
@@ -301,10 +301,24 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
         float iscale = native_recip(scale);
     #endif
 #else
+#ifdef STATIC_SCALE_VALUE
+    #if INVERT_SCALE
+    float iscale = convert_float(STATIC_SCALE_VALUE);
+    float scale = convert_float(STATIC_SCALE_VALUE_INV);
+    #else
+    float scale = convert_float(STATIC_SCALE_VALUE);
+    float iscale = convert_float(STATIC_SCALE_VALUE_INV);
+    #endif
+#else
     float iscale = sqrt(convert_float(HEAD_SIZE));
     float scale = native_recip(iscale);
 #endif
+#endif
     scale *= 1.442695f; // log2(e)
+
+#ifdef STATIC_SCALAR_ATTN_MASK_VALUE
+    float masked_scale = iscale * STATIC_SCALAR_ATTN_MASK_VALUE;
+#endif
 
 #ifdef PREFETCH_K0
     /* Prefetch first K tile. */
@@ -389,7 +403,15 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 
         /* Apply attention mask */
-#if WITH_ATTN_MASK
+#ifdef STATIC_SCALAR_ATTN_MASK_VALUE
+        const num_e = (ugemm_kq_c_type_block0 * ugemm_kq_c_type_block1) / SUBGROUP_SIZE;
+        #pragma unroll
+        for (int i = 0; i < sizeof(S_tile.x) / sizeof(S_tile.x[0]); i++) {
+                #pragma unroll
+                for (int j = 0; j < num_e; ++j)
+                    S_tile.x[i][j] = binary_add(S_tile.x[i][j], masked_scale);
+        }
+#elif WITH_ATTN_MASK
 #define unscale(x) ((x)*iscale)
         mask_tile_type_float mask_tile_float;
         tile_copy(mask_tile, mask_tile_float);
@@ -513,7 +535,7 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
                     LSC_LDCC_L1C_L3C);
         }
 #endif
-#if WITH_ATTN_MASK && defined(PREFETCH_MASK)
+#if WITH_ATTN_MASK && defined(PREFETCH_MASK) && !defined(STATIC_SCALAR_ATTN_MASK_VALUE)
         /* Prefetch next mask tile. */
         if (!last) {
             cooperative_prefetch_2d(msk + k0 + ugemm_kq_wg_tile_m + sg_i0_kq + (sg_j0_kq + wg_j0) * q,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
@@ -743,7 +743,11 @@ inline MASK_VECTOR_TYPE FUNC(load_attn_mask)(OPTIONAL_SHAPE_INFO_ARG
                                              ATTN_SCALE_BUFFER_ARG
                                              PA_BUFFERS_ARGS
                                              ) {
+#ifdef STATIC_SCALAR_ATTN_MASK_VALUE
+    MASK_VECTOR_TYPE mask_vec = STATIC_SCALAR_ATTN_MASK_VALUE;
+#else
     MASK_VECTOR_TYPE mask_vec = INPUT0_VAL_ZERO;
+#endif
 #if !IS_CAUSAL && HAS_ATTN_MASK_INPUT
     const uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0_idx, b1_idx, target_seq_idx, source_seq_idx);
     if (target_seq_idx >= (uint)TARGET_SEQ_LEN) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
@@ -420,6 +420,8 @@ KERNEL(sdpa_opt)(
 #elif !IS_CAUSAL && HAS_ATTN_MASK_INPUT
                         const uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0_idx, b1_idx, target_seq_idx + seq_idx, start_partition_idx + seq_len);
                         qk_val[seq_idx] += attn_mask[attn_mask_offset];
+#elif defined(STATIC_SCALAR_ATTN_MASK_VALUE)
+                        qk_val[seq_idx] += STATIC_SCALAR_ATTN_MASK_VALUE;
 #endif
 
                         // Update qk_max value
@@ -802,7 +804,7 @@ inline MASK_VECTOR_TYPE FUNC(load_attn_mask)(OPTIONAL_SHAPE_INFO_ARG
 #endif
 
     // Apply scale to attn_mask
-#if IS_CAUSAL || HAS_ATTN_MASK_INPUT
+#if IS_CAUSAL || HAS_ATTN_MASK_INPUT || defined(STATIC_SCALAR_ATTN_MASK_VALUE)
     mask_vec *= scale_val;
 #endif
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_ref.cl
@@ -156,6 +156,8 @@ KERNEL(sdpa_ref)(
 
 #if HAS_SCALE_INPUT
     const OUTPUT_TYPE scale_val = *scale;
+#elif defined(STATIC_SCALE_VALUE)
+    const OUTPUT_TYPE scale_val = STATIC_SCALE_VALUE;
 #else
     const OUTPUT_TYPE scale_val = OUTPUT_VAL_ONE / sqrt(TO_OUTPUT_TYPE(INPUT1_SIZE_X));
 #endif
@@ -220,6 +222,8 @@ KERNEL(sdpa_ref)(
 #elif !IS_CAUSAL && HAS_ATTN_MASK_INPUT
             uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0, b1, target_seq_idx, s);
             OUTPUT_TYPE attn_mask_val = attn_mask[attn_mask_offset];
+#elif defined(STATIC_SCALAR_ATTN_MASK_VALUE)
+            OUTPUT_TYPE attn_mask_val = TO_OUTPUT_TYPE(STATIC_SCALAR_ATTN_MASK_VALUE);
 #else
             OUTPUT_TYPE attn_mask_val = OUTPUT_VAL_ZERO;
 #endif

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.cpp
@@ -84,7 +84,7 @@ JitConstants SDPAKernelBase::GetJitConstants(const sdpa_params& params) const {
             jit.AddConstant(MakeJitConstant("HAS_ATTN_MASK_INPUT", 0));
             jit.AddConstant(MakeJitConstant("STATIC_SCALAR_ATTN_MASK_VALUE", params.conf.attn_mask_val));
         } else {
-            jit.AddConstant(MakeJitConstant("HAS_ATTN_MASK_INPUT", params.inputs.size() > 4));
+            jit.AddConstant(MakeJitConstant("HAS_ATTN_MASK_INPUT", params.inputs.size() > 3));
         }
     }
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.cpp
@@ -80,8 +80,12 @@ JitConstants SDPAKernelBase::GetJitConstants(const sdpa_params& params) const {
 
     jit.AddConstant(MakeJitConstant("IS_CAUSAL", params.conf.is_causal));
     if (!params.conf.is_paged_attention) {
-        jit.AddConstant(MakeJitConstant("HAS_ATTN_MASK_INPUT", params.inputs.size() > 3));
-        jit.AddConstant(MakeJitConstant("HAS_SCALE_INPUT", params.inputs.size() > 4));
+        if (params.conf.has_const_attn_mask_val) {
+            jit.AddConstant(MakeJitConstant("HAS_ATTN_MASK_INPUT", 0));
+            jit.AddConstant(MakeJitConstant("STATIC_SCALAR_ATTN_MASK_VALUE", params.conf.attn_mask_val));
+        } else {
+            jit.AddConstant(MakeJitConstant("HAS_ATTN_MASK_INPUT", params.inputs.size() > 4));
+        }
     }
 
     jit.AddConstant(MakeJitConstant("IS_KV_COMPRESSED", params.conf.is_kv_compressed));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_base.h
@@ -101,6 +101,8 @@ struct sdpa_configuration {
     int64_t paged_attention_max_len = 0;
     bool has_const_scale_val = false;
     float scale_val = 0.f;
+    bool has_const_attn_mask_val = false;
+    float attn_mask_val = 0.f;
     bool has_rotated_blocks = false;
 };
 

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -784,10 +784,12 @@ clKernelData SDPAKernelMicro::get_kernel_data(const sdpa_params& params, bool is
 
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 3}); // paged attention helper buffer
     } else {
-        if (params.inputs.size() >= 4 && !params.conf.has_const_attn_mask_val)
-            kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, 3}); // mask
-        if (params.inputs.size() >= 5 && !params.conf.has_const_scale_val)
-            kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, 4}); // Scale
+        uint32_t attn_mask_idx = 3;
+        uint32_t scale_idx = params.conf.has_const_attn_mask_val ? 3 : 4;
+        if (params.inputs.size() > attn_mask_idx && !params.conf.has_const_attn_mask_val)
+            kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, attn_mask_idx}); // mask
+        if (params.inputs.size() > scale_idx && !params.conf.has_const_scale_val)
+            kernel.params.arguments.push_back({ArgumentDescriptor::Types::INPUT, scale_idx}); // Scale
 
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::SCALAR, 0}); // D
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::SCALAR, 1}); // K

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -449,7 +449,6 @@ ParamsKey SDPAKernelMicro::GetSupportedKey() const {
 bool SDPAKernelMicro::Validate(const Params& p) const {
     if (!Parent::Validate(p))
         return false;
-
     const sdpa_params& params = static_cast<const sdpa_params&>(p);
 
     if (params.should_use_sdpa_opt)
@@ -483,7 +482,7 @@ bool SDPAKernelMicro::Validate(const Params& p) const {
         }
     }
 
-    const auto scale_idx = 4lu;
+    const auto scale_idx = params.conf.is_paged_attention || params.conf.has_const_attn_mask_val ? 4lu : 3lu;
     if (!params.conf.has_const_scale_val && params.inputs.size() > scale_idx && !params.inputs[scale_idx].is_dynamic() &&
         params.inputs[scale_idx].LogicalSize() == 1) {
         return false;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -477,7 +477,8 @@ bool SDPAKernelMicro::Validate(const Params& p) const {
     // TODO: To support sdpa_micro kernel with non-const scalar mask / scale inputs
     if (!params.conf.is_paged_attention) {
         const auto mask_idx = 3lu;
-        if (!params.conf.has_const_attn_mask_val && params.inputs.size() > mask_idx && !params.inputs[mask_idx].is_dynamic() && params.inputs[mask_idx].LogicalSize() == 1) {
+        if (!params.conf.has_const_attn_mask_val && params.inputs.size() > mask_idx && !params.inputs[mask_idx].is_dynamic() &&
+            params.inputs[mask_idx].LogicalSize() == 1) {
             return false;
         }
     }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_opt.cpp
@@ -201,10 +201,19 @@ JitConstants SDPAKernelOpt::GetJitConstants(const sdpa_params& params, size_t ke
         if (params.outputs.size() > 1) {
             jit.AddConstant(MakeJitConstant("PAGED_ATTENTION_SCORES_OUTPUT", 1));
         }
-    } else if (params.inputs.size() <= 4) {
-        jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE_INV", std::sqrt(static_cast<float>(params.conf.head_size))));
-        jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE", 1.0f / std::sqrt(static_cast<float>(params.conf.head_size))));
+    } else {
+        size_t scale_idx = params.conf.has_const_attn_mask_val ? 4 : 5;
+        if (params.inputs.size() > scale_idx) {
+            jit.AddConstant(MakeJitConstant("HAS_SCALE_INPUT", 1));
+        } else if (params.conf.has_const_scale_val) {
+            jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE", params.conf.scale_val));
+            jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE_INV", 1.0f / params.conf.scale_val));
+        } else {
+            jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE_INV", std::sqrt(static_cast<float>(params.conf.head_size))));
+            jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE", 1.0f / std::sqrt(static_cast<float>(params.conf.head_size))));
+        }
     }
+
 
     if (params.conf.is_paged_attention)
         jit.AddConstant(MakeJitConstant("IS_PAGED_ATTENTION", 1));

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_opt.cpp
@@ -202,7 +202,7 @@ JitConstants SDPAKernelOpt::GetJitConstants(const sdpa_params& params, size_t ke
             jit.AddConstant(MakeJitConstant("PAGED_ATTENTION_SCORES_OUTPUT", 1));
         }
     } else {
-        size_t scale_idx = params.conf.has_const_attn_mask_val ? 4 : 5;
+        size_t scale_idx = params.conf.has_const_attn_mask_val ? 3 : 4;
         if (params.inputs.size() > scale_idx) {
             jit.AddConstant(MakeJitConstant("HAS_SCALE_INPUT", 1));
         } else if (params.conf.has_const_scale_val) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_ref.cpp
@@ -41,6 +41,17 @@ JitConstants SDPAKernelRef::GetJitConstants(const sdpa_params& params) const {
     TransposedDimensionAccessHelperJit dims_q(params.inputs[0], params.input0_order);
     jit.AddConstant(MakeJitConstant("HEAD_SIZE", dims_q.x()));
 
+    size_t scale_idx = params.conf.has_const_attn_mask_val ? 3 : 4;
+    if (params.inputs.size() > scale_idx) {
+        jit.AddConstant(MakeJitConstant("HAS_SCALE_INPUT", 1));
+    } else if (params.conf.has_const_scale_val) {
+        jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE", params.conf.scale_val));
+        jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE_INV", 1.0f / params.conf.scale_val));
+    } else {
+        jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE_INV", std::sqrt(static_cast<float>(params.conf.head_size))));
+        jit.AddConstant(MakeJitConstant("STATIC_SCALE_VALUE", 1.0f / std::sqrt(static_cast<float>(params.conf.head_size))));
+    }
+
     return jit;
 }
 
@@ -101,7 +112,6 @@ KernelsData SDPAKernelRef::GetKernelsData(const Params& params) const {
     kd.internalBuffers.clear();
     kd.internalBuffers.push_back(prim_params.inputs[0].ElementSize());
     kd.internalBufferDataType = prim_params.inputs[0].GetDType();
-
     return { kd };
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
@@ -28,7 +28,7 @@ const size_t scale_idx = 4;
 
 static std::shared_ptr<ov::op::v0::Constant> GetScalarConstInput(const std::shared_ptr<ov::op::Op>& op, size_t idx) {
     std::shared_ptr<ov::op::v0::Constant> constOp = nullptr;
-    if (!op->get_input_partial_shape(idx).is_dynamic() && ov::shape_size(op->get_input_shape(idx)) == 1) {
+    if (op->get_input_size() > idx && !op->get_input_partial_shape(idx).is_dynamic() && ov::shape_size(op->get_input_shape(idx)) == 1) {
         constOp = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(idx));
     }
     return constOp;

--- a/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
@@ -7,6 +7,7 @@
 #include "intel_gpu/op/sdpa.hpp"
 #include "intel_gpu/op/indirect_sdpa.hpp"
 
+#include "openvino/op/constant.hpp"
 #include "openvino/op/scaled_dot_product_attention.hpp"
 
 #include "intel_gpu/primitives/scaled_dot_product_attention.hpp"
@@ -22,10 +23,25 @@ using IndirectSDPA = ov::intel_gpu::op::IndirectSDPA;
 
 namespace ov::intel_gpu {
 
+const size_t attn_mask_idx = 3;
+const size_t scale_idx = 4;
+
+static std::shared_ptr<ov::op::v0::Constant> GetScalarConstInput(const std::shared_ptr<ov::op::Op>& op, size_t idx) {
+    std::shared_ptr<ov::op::v0::Constant> constOp = nullptr;
+    if (!op->get_input_partial_shape(idx).is_dynamic() && ov::shape_size(op->get_input_shape(idx)) == 1) {
+        constOp = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(idx));
+    }
+    return constOp;
+}
+
 static void CreateScaledDotProductAttentionOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v13::ScaledDotProductAttention>& op) {
+    // if transpose fusion is disabled, this is used
     validate_inputs_count(op, {3, 4, 5});
     auto inputs = p.GetInputInfo(op);
     auto layerName = layer_type_name_ID(op);
+
+    auto scalar_scale = GetScalarConstInput(op, scale_idx);
+    auto scalar_attn_mask = GetScalarConstInput(op, attn_mask_idx);
 
     bool is_causal = op->get_causal();
     auto order = ov::op::internal::SDPA::default_order(op->get_output_partial_shape(0).size());
@@ -38,6 +54,14 @@ static void CreateScaledDotProductAttentionOp(ProgramBuilder& p, const std::shar
                                                          order,
                                                          order);
 
+    if (scalar_scale) {
+        sdpa_prim.scale_val = scalar_scale->cast_vector<float>()[0];
+    }
+
+    if (scalar_attn_mask) {
+        sdpa_prim.attn_mask_val = scalar_attn_mask->cast_vector<float>()[0];
+    }
+
     p.add_primitive(*op, sdpa_prim);
 }
 
@@ -46,8 +70,12 @@ static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::intern
     auto inputs = p.GetInputInfo(op);
     auto layerName = layer_type_name_ID(op);
 
+    auto scalar_scale = GetScalarConstInput(op, scale_idx);
+    auto scalar_attn_mask = GetScalarConstInput(op, attn_mask_idx);
+
     bool is_causal = op->get_causal();
     int64_t indirect_axis = -1;
+
     auto sdpa_prim = cldnn::scaled_dot_product_attention(layerName,
                                                          inputs,
                                                          is_causal,
@@ -56,6 +84,13 @@ static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::intern
                                                          op->get_input1_transpose_order(),
                                                          op->get_input2_transpose_order(),
                                                          op->get_output_transpose_order());
+    if (scalar_scale) {
+        sdpa_prim.scale_val = scalar_scale->cast_vector<float>()[0];
+    }
+
+    if (scalar_attn_mask) {
+        sdpa_prim.attn_mask_val = scalar_attn_mask->cast_vector<float>()[0];
+    }
 
     p.add_primitive(*op, sdpa_prim);
 }
@@ -63,6 +98,9 @@ static void CreateSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::intern
 static void CreateIndirectSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op::internal::IndirectSDPA>& op) {
     auto inputs = p.GetInputInfo(op);
     auto layerName = layer_type_name_ID(op);
+
+    auto scalar_scale = GetScalarConstInput(op, scale_idx);
+    auto scalar_attn_mask = GetScalarConstInput(op, attn_mask_idx);
 
     bool is_causal = op->get_causal();
     const auto compression_inputs = op->get_compression_inputs_num();
@@ -79,6 +117,13 @@ static void CreateIndirectSDPAOp(ProgramBuilder& p, const std::shared_ptr<ov::op
                                                          op->get_output_transpose_order(),
                                                          op->get_quantization_attrs(),
                                                          op->get_kv_compressed());
+    if (scalar_scale) {
+        sdpa_prim.scale_val = scalar_scale->cast_vector<float>()[0];
+    }
+
+    if (scalar_attn_mask) {
+        sdpa_prim.attn_mask_val = scalar_attn_mask->cast_vector<float>()[0];
+    }
 
     p.add_primitive(*op, sdpa_prim);
 }


### PR DESCRIPTION
### Details:
 - Previoulsy sdpa_micro was not supporting scalar value scale / attn_mask 
 - Fixed sdpa_micro to support scalar scale/attn_mask so that the VLM models such as llava-llama3 can use sdpa_micro for encoder 

### Tickets:
 - CVS-162856
