### PR TITLE
[CI] Limit wheel package version

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -12,7 +12,7 @@ build<1.3
 pygments>=2.8.1
 setuptools>=70.1,<76.1
 sympy>=1.10
-wheel>=0.38.1
+wheel>=0.38.1,<0.46.0
 patchelf<=0.17.2.1
 packaging>=22.0
 


### PR DESCRIPTION
### Details:
 - The new wheel version (0.46.0) throws an error: Failed to detect Python Tag via wheel.vendored.packaging.tags

### Tickets:
 - *ticket-id*
