### PR TITLE
[NPU] Get same zero context for different CORE

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_backend.cpp
@@ -14,7 +14,7 @@ namespace intel_npu {
 ZeroEngineBackend::ZeroEngineBackend() : _logger("ZeroEngineBackend", Logger::global().level()) {
     _logger.debug("ZeroEngineBackend - initialize started");
 
-    _initStruct = std::make_shared<ZeroInitStructsHolder>();
+    _initStruct = ZeroInitStructsHolder::getInstance();
 
     auto device = std::make_shared<ZeroDevice>(_initStruct);
     _devices.emplace(std::make_pair(device->getName(), device));

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_init.hpp
@@ -73,6 +73,8 @@ public:
         return false;
     }
 
+    static const std::shared_ptr<ZeroInitStructsHolder>& getInstance();
+
 private:
     void initNpuDriver();
 

--- a/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
+++ b/src/plugins/intel_npu/src/utils/src/zero/zero_init.cpp
@@ -309,6 +309,11 @@ ZeroInitStructsHolder::ZeroInitStructsHolder()
     THROW_ON_FAIL_FOR_LEVELZERO("pfnDeviceGetGraphProperties", result);
 }
 
+const std::shared_ptr<ZeroInitStructsHolder>& ZeroInitStructsHolder::getInstance() {
+    static std::shared_ptr<ZeroInitStructsHolder> instance = std::make_shared<ZeroInitStructsHolder>();
+    return instance;
+}
+
 ZeroInitStructsHolder::~ZeroInitStructsHolder() {
     if (context) {
         log.debug("ZeroInitStructsHolder - performing zeContextDestroy");


### PR DESCRIPTION
### Details:
 - *Do not reinitialize driver and device for each ov::Core object*
