### PR TITLE
Fix issue in EliminateConcatStridedSlice with compilation problem

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -671,18 +671,17 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 ov::as_type_ptr<ov::op::v0::Concat>(slice_node->get_users()[0])->get_axis() == concat_axis) {
                 auto next_concat = ov::as_type_ptr<ov::op::v0::Concat>(slice_node->get_users()[0]);
                 auto next_concat_inputs = next_concat->input_values();
-                std::vector<std::shared_ptr<Node>> new_next_concat_inputs{};
+                ov::OutputVector new_next_concat_inputs{};
                 for (const auto& t : next_concat_inputs) {
                     if (t.get_node_shared_ptr() == slice_node) {
                         for (const auto& need_insert : new_concat_in_nodes) {
                             new_next_concat_inputs.push_back(need_insert);
                         }
-                        continue;
+                    } else {
+                        new_next_concat_inputs.push_back(t);
                     }
-                    new_next_concat_inputs.push_back(t.get_node_shared_ptr());
                 }
-                auto new_next_concat_node =
-                    next_concat->clone_with_new_inputs(ov::as_output_vector(new_next_concat_inputs));
+                auto new_next_concat_node = next_concat->clone_with_new_inputs(new_next_concat_inputs);
                 replace_output_update_name(next_concat, new_next_concat_node);
             } else {
                 std::vector<std::shared_ptr<Node>> new_slice_in_nodes{};

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -606,6 +606,7 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
         }
 
         node_index_info_map mismatch_slices{};
+        bool model_changed = false;
         for (const auto& [slice_node, slice_begin, slice_end] : slice_out_index_in_concat) {
             bool matched = false;
             for (const auto& [concat_input_node, concat_input_begin, concat_input_end] : in_index_in_concat) {
@@ -613,6 +614,7 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                     auto slice_outputs = slice_node->outputs();
                     for (auto& slice_output : slice_outputs) {
                         replace_output_update_name(slice_output, concat_input_node);
+                        model_changed = true;
                     }
                     matched = true;
                     break;
@@ -622,10 +624,10 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 mismatch_slices.push_back(std::make_tuple(slice_node, slice_begin, slice_end));
         }
         if (mismatch_slices.empty())
-            return true;
+            return model_changed;
 
         if (mismatch_slices.size() == slice_out_index_in_concat.size())
-            return false;
+            return model_changed;
 
         int64_t new_start_value{std::numeric_limits<int64_t>::max()};
         int64_t new_end_value{0};

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -584,8 +584,8 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 if (end_constant_node == nullptr)
                     return false;
                 auto end_values = end_constant_node->cast_vector<int64_t>();
-                if (end_values[concat_axis] > concat->get_shape()[concat_axis])
-                    end_values[concat_axis] = concat->get_shape()[concat_axis];
+                if (end_values[concat_axis] > static_cast<int64_t>(concat->get_shape()[concat_axis]))
+                    end_values[concat_axis] = static_cast<int64_t>(concat->get_shape()[concat_axis]);
 
                 slice_out_index_in_concat.push_back(
                     std::make_tuple(strided_slice_node, begin_values[concat_axis], end_values[concat_axis] - 1));

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -1598,6 +1598,52 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSlice) {
     }
 }
 
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceAll) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto concat = make_shared<ov::op::v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto begin_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
+        auto end_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 1});
+        auto strided_slice1 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const1,
+                                                                         end_const1,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(strided_slice1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto begin_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 1});
+        auto end_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 2});
+        auto strided_slice2 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const2,
+                                                                         end_const2,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto relu2 = std::make_shared<op::v0::Relu>(strided_slice2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 1});
+        auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 1});
+
+        auto relu1 = std::make_shared<op::v0::Relu>(param1);
+        auto result1 = std::make_shared<op::v0::Result>(relu1);
+
+        auto relu2 = std::make_shared<op::v0::Relu>(param2);
+        auto result2 = std::make_shared<op::v0::Result>(relu2);
+
+        model_ref = std::make_shared<ov::Model>(ResultVector{result1, result2}, ParameterVector{param1, param2});
+    }
+}
+
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcat) {
     {
         int64_t axis = 2;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -1617,7 +1617,7 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceAll) {
         auto result1 = std::make_shared<op::v0::Result>(relu1);
 
         auto begin_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 1});
-        auto end_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 2});
+        auto end_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 4});
         auto strided_slice2 = std::make_shared<ov::op::v1::StridedSlice>(concat,
                                                                          begin_const2,
                                                                          end_const2,
@@ -1683,6 +1683,66 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcat) {
         auto concat = make_shared<ov::op::v0::Concat>(ov::as_output_vector({relu, param2, param3}), axis);
         auto result = std::make_shared<op::v0::Result>(concat);
 
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+    }
+}
+
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatMismatch) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<ov::op::v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto begin_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
+        auto end_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 4});
+        auto strided_slice1 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const1,
+                                                                         end_const1,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+
+        auto begin_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
+        auto end_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 10});
+        auto strided_slice2 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const2,
+                                                                         end_const2,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto concat1 = make_shared<ov::op::v0::Concat>(ov::as_output_vector({relu, strided_slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 3});
+        auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 4});
+        auto param3 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 5});
+        auto concat = make_shared<ov::op::v0::Concat>(ov::as_output_vector({param1, param2, param3}), axis);
+
+        auto begin_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
+        auto end_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 4});
+        auto strided_slice1 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const1,
+                                                                         end_const1,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto relu = std::make_shared<op::v0::Relu>(strided_slice1);
+
+        auto begin_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
+        auto end_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 10});
+        auto strided_slice2 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const2,
+                                                                         end_const2,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto concat1 = make_shared<ov::op::v0::Concat>(ov::as_output_vector({relu, strided_slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
         model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2, param3});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -1747,6 +1747,57 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatMismatch) {
     }
 }
 
+TEST_F(TransformationTestsF, EliminateConcatStridedSliceTopKConcat) {
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 10, 3});
+        auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 10, 4});
+        auto concat = make_shared<ov::op::v0::Concat>(ov::as_output_vector({param1, param2}), axis);
+
+        auto begin_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 0});
+        auto end_const1 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
+        auto strided_slice1 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const1,
+                                                                         end_const1,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto topk = std::make_shared<ov::op::v1::TopK>(strided_slice1,
+                                                       ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {1}),
+                                                       axis,
+                                                       op::v1::TopK::Mode::MAX,
+                                                       op::v1::TopK::SortType::NONE);
+
+        auto begin_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 3});
+        auto end_const2 = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 0, 7});
+        auto strided_slice2 = std::make_shared<ov::op::v1::StridedSlice>(concat,
+                                                                         begin_const2,
+                                                                         end_const2,
+                                                                         std::vector<int64_t>{1, 1, 0},
+                                                                         std::vector<int64_t>{1, 1, 0});
+        auto topk_values = std::make_shared<ov::op::v0::Result>(topk->output(0));
+        auto concat1 = make_shared<ov::op::v0::Concat>(ov::as_output_vector({topk_values, strided_slice2}), axis);
+
+        auto result = std::make_shared<op::v0::Result>(concat1);
+        model = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2});
+        manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
+    }
+    {
+        int64_t axis = 2;
+        auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 10, 3});
+        auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 10, 4});
+        auto axis_const = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{}, axis);
+        auto topk = std::make_shared<ov::op::v1::TopK>(param1,
+                                                       ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {1}),
+                                                       axis,
+                                                       op::v1::TopK::Mode::MAX,
+                                                       op::v1::TopK::SortType::NONE);
+        auto topk_values = std::make_shared<ov::op::v0::Result>(topk->output(0));
+        auto concat = make_shared<ov::op::v0::Concat>(ov::as_output_vector({topk_values, param2}), axis);
+        auto result = std::make_shared<op::v0::Result>(concat);
+        model_ref = std::make_shared<ov::Model>(ResultVector{result}, ParameterVector{param1, param2});
+    }
+}
+
 TEST_F(TransformationTestsF, EliminateConcatStridedSliceConcatDiffAxis) {
     {
         int64_t axis = 2;

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -1630,7 +1630,6 @@ TEST_F(TransformationTestsF, EliminateConcatStridedSliceAll) {
         manager.register_pass<ov::pass::EliminateConcatStridedSlice>();
     }
     {
-        int64_t axis = 2;
         auto param1 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 1});
         auto param2 = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 10, 1});
 


### PR DESCRIPTION
### Details:
Fix errors 
 - 1) the concat & StridedSlice all can be eliminated;
 - 2) the inputs of concat have dim value = 1 in concat axis
 - 2) Fix the bug caused by EliminateConcatStridedSlice Pass which did not consider the Nodes which do not have default output index, such as TopK.

### Tickets:
 - CVS-165105
 - CVS-164371
 - CVS-165403