### PR TITLE
[CPU][GPU] Do not suppress virtual destructor related warnings

### DIFF
--- a/src/plugins/intel_cpu/CMakeLists.txt
+++ b/src/plugins/intel_cpu/CMakeLists.txt
@@ -17,13 +17,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     ov_add_compiler_flags(/wd4334)
     # oneDNN arm64: unary minus operator applied to unsigned type, result still unsigned
     ov_add_compiler_flags(/wd4146)
-elseif(OV_COMPILER_IS_CLANG)
-    # -Wno-delete-non-abstract-non-virtual-dtor is support > clang 9.0
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0)
-        ov_add_compiler_flags(-Wno-delete-non-abstract-non-virtual-dtor)
-    else()
-        ov_add_compiler_flags(-Wno-delete-non-virtual-dtor)
-    endif()
 elseif (OV_COMPILER_IS_INTEL_LLVM AND WIN32)
     ov_add_compiler_flags("/Wno-microsoft-include")
 endif()

--- a/src/plugins/intel_cpu/src/nodes/executors/deconv.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/deconv.hpp
@@ -53,7 +53,7 @@ using DeconvExecutorCPtr = std::shared_ptr<const DeconvExecutor>;
 
 class DeconvExecutorBuilder {
 public:
-    ~DeconvExecutorBuilder() = default;
+    virtual ~DeconvExecutorBuilder() = default;
     [[nodiscard]] virtual bool isSupported(const DeconvAttrs& convAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise.hpp
@@ -105,7 +105,7 @@ using EltwiseExecutorCPtr = std::shared_ptr<const EltwiseExecutor>;
 
 class EltwiseExecutorBuilder {
 public:
-    ~EltwiseExecutorBuilder() = default;
+    virtual ~EltwiseExecutorBuilder() = default;
     [[nodiscard]] virtual bool isSupported(const EltwiseAttrs& eltwiseAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -168,7 +168,7 @@ using InterpolateExecutorCPtr = std::shared_ptr<const InterpolateExecutor>;
 
 class InterpolateExecutorBuilder {
 public:
-    ~InterpolateExecutorBuilder() = default;
+    virtual ~InterpolateExecutorBuilder() = default;
     [[nodiscard]] virtual bool isSupported(const InterpolateAttrs& InterpolateAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;

--- a/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
@@ -53,7 +53,7 @@ using MVNExecutorCPtr = std::shared_ptr<const MVNExecutor>;
 
 class MVNExecutorBuilder {
 public:
-    ~MVNExecutorBuilder() = default;
+    virtual ~MVNExecutorBuilder() = default;
     [[nodiscard]] virtual bool isSupported(const MVNAttrs& mvnAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;

--- a/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
@@ -62,7 +62,7 @@ using PoolingExecutorCPtr = std::shared_ptr<const PoolingExecutor>;
 
 class PoolingExecutorBuilder {
 public:
-    ~PoolingExecutorBuilder() = default;
+    virtual ~PoolingExecutorBuilder() = default;
     [[nodiscard]] virtual bool isSupported(const PoolingAttrs& poolingAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;

--- a/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
@@ -42,7 +42,7 @@ using ReduceExecutorCPtr = std::shared_ptr<const ReduceExecutor>;
 
 class ReduceExecutorBuilder {
 public:
-    ~ReduceExecutorBuilder() = default;
+    virtual ~ReduceExecutorBuilder() = default;
     [[nodiscard]] virtual bool isSupported(const ReduceAttrs& reduceAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;

--- a/src/plugins/intel_gpu/CMakeLists.txt
+++ b/src/plugins/intel_gpu/CMakeLists.txt
@@ -30,15 +30,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     ov_add_compiler_flags(-Wno-strict-aliasing)
 endif()
 
-if(OV_COMPILER_IS_CLANG)
-    # -Wno-delete-non-abstract-non-virtual-dtor is support > clang 9.0
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 9.0)
-        ov_add_compiler_flags(-Wno-delete-non-abstract-non-virtual-dtor)
-    else()
-        ov_add_compiler_flags(-Wno-delete-non-virtual-dtor)
-    endif()
-endif()
-
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # 4267 4244 conversion from 'XXX' to 'YYY', possible loss of data
     ov_add_compiler_flags(/wd4244)


### PR DESCRIPTION
### Details:
- Do not suppress -Wdelete-non-abstract-non-virtual-dtor/-Wdelete-non-virtual-dtor warnings in CPU and GPU plugins
- Fix related issues in CPU plugin 

### Tickets:
 - N/A
