### PR TITLE
[CLANG_FORMAT] Force west const

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -23,6 +23,7 @@ DerivePointerAlignment: false
 FixNamespaceComments: true
 IndentCaseLabels: false
 IndentPPDirectives: AfterHash
+QualifierAlignment: Left
 ForEachMacros:
   - foreach
   - FOREACH_CHILD

--- a/src/bindings/c/src/ov_common.cpp
+++ b/src/bindings/c/src/ov_common.cpp
@@ -7,7 +7,7 @@
  * @variable global value for error info.
  * Don't change its order.
  */
-char const* error_infos[] = {"success",
+const char* error_infos[] = {"success",
                              "general error",
                              "it's not implement",
                              "failed to network",

--- a/src/bindings/c/tests/ov_remote_context_test.cpp
+++ b/src/bindings/c/tests/ov_remote_context_test.cpp
@@ -47,11 +47,11 @@ protected:
         std::vector<cl_platform_id> platform_ids(n);
         err = clGetPlatformIDs(n, platform_ids.data(), NULL);
 
-        for (auto const& id : platform_ids) {
+        for (const auto& id : platform_ids) {
             cl::Platform platform = cl::Platform(id);
             std::vector<cl::Device> devices;
             platform.getDevices(CL_DEVICE_TYPE_GPU, &devices);
-            for (auto const& d : devices) {
+            for (const auto& d : devices) {
                 if (refVendorID == d.getInfo<CL_DEVICE_VENDOR_ID>()) {
                     cl_device = d;
                     cl_context = cl::Context(cl_device);

--- a/src/bindings/js/node/src/async_reader.cpp
+++ b/src/bindings/js/node/src/async_reader.cpp
@@ -22,7 +22,7 @@ void ReaderWorker::OnOK() {
     _deferred.Resolve(model);
 }
 
-void ReaderWorker::OnError(Napi::Error const& error) {
+void ReaderWorker::OnError(const Napi::Error& error) {
     _deferred.Reject(error.Value());
 }
 

--- a/src/common/conditional_compilation/include/openvino/cc/factory.h
+++ b/src/common/conditional_compilation/include/openvino/cc/factory.h
@@ -20,8 +20,8 @@ class Factory;
 
 template <typename Key, typename T, typename... Args>
 class Factory<Key, T(Args...)> {
-    Factory(Factory const&) = delete;
-    Factory& operator=(Factory const&) = delete;
+    Factory(const Factory&) = delete;
+    Factory& operator=(const Factory&) = delete;
 
 public:
     using builder_t = std::function<T(Args...)>;

--- a/src/common/conditional_compilation/include/openvino/cc/selective_build.h
+++ b/src/common/conditional_compilation/include/openvino/cc/selective_build.h
@@ -132,7 +132,7 @@ case_wrapper<C, T> make_case_wrapper(C&& val, const char* name) {
 }
 
 template <openvino::itt::domain_t (*domain)(), template <typename...> class Fn, typename Ctx, typename T, typename Case>
-bool match(char const* region, Ctx&& ctx, T&& val, Case&& cs) {
+bool match(const char* region, Ctx&& ctx, T&& val, Case&& cs) {
     const bool is_matched = val == cs.value;
     if (is_matched) {
         openvino::itt::ScopedTask<domain> task(openvino::itt::handle(std::string(region) + "$" + cs.name));
@@ -148,7 +148,7 @@ template <openvino::itt::domain_t (*domain)(),
           typename T,
           typename Case,
           typename... Cases>
-bool match(char const* region, Ctx&& ctx, T&& val, Case&& cs, Cases&&... cases) {
+bool match(const char* region, Ctx&& ctx, T&& val, Case&& cs, Cases&&... cases) {
     if (match<domain, Fn>(region, std::forward<Ctx>(ctx), std::forward<T>(val), std::forward<Case>(cs)))
         return true;
     return match<domain, Fn>(region, std::forward<Ctx>(ctx), std::forward<T>(val), std::forward<Cases>(cases)...);

--- a/src/common/itt/include/openvino/itt.hpp
+++ b/src/common/itt/include/openvino/itt.hpp
@@ -41,8 +41,8 @@ typedef struct handle_ {
  * @cond
  */
 namespace internal {
-domain_t domain(char const* name);
-handle_t handle(char const* name);
+domain_t domain(const char* name);
+handle_t handle(const char* name);
 void taskBegin(domain_t d, handle_t t);
 void taskEnd(domain_t d);
 void threadName(const char* name);
@@ -65,7 +65,7 @@ inline void threadName(const std::string& name) {
     internal::threadName(name.c_str());
 }
 
-inline handle_t handle(char const* name) {
+inline handle_t handle(const char* name) {
     return internal::handle(name);
 }
 
@@ -81,7 +81,7 @@ inline handle_t handle(const std::string& name) {
  * @param name [in] The annotation name
  */
 template <typename Tag>
-handle_t handle(char const* name) {
+handle_t handle(const char* name) {
     static auto h = internal::handle(name);
     return h;
 }

--- a/src/common/itt/src/itt.cpp
+++ b/src/common/itt/src/itt.cpp
@@ -24,11 +24,11 @@ static size_t callStackDepth() {
 
 static thread_local uint32_t call_stack_depth = 0;
 
-domain_t domain(char const* name) {
+domain_t domain(const char* name) {
     return reinterpret_cast<domain_t>(__itt_domain_create(name));
 }
 
-handle_t handle(char const* name) {
+handle_t handle(const char* name) {
     return reinterpret_cast<handle_t>(__itt_string_handle_create(name));
 }
 
@@ -51,11 +51,11 @@ void threadName(const char* name) {
 
 #else
 
-domain_t domain(char const*) {
+domain_t domain(const char*) {
     return nullptr;
 }
 
-handle_t handle(char const*) {
+handle_t handle(const char*) {
     return nullptr;
 }
 

--- a/src/common/util/include/openvino/util/common_util.hpp
+++ b/src/common/util/include/openvino/util/common_util.hpp
@@ -150,7 +150,7 @@ bool contains(const R& container, const V& value) {
  * @return result of multiplication
  */
 template <typename T, typename A>
-T product(std::vector<T, A> const& vec) {
+T product(const std::vector<T, A>& vec) {
     return vec.empty() ? T{0} : std::accumulate(vec.begin(), vec.end(), T{1}, std::multiplies<T>());
 }
 

--- a/src/core/reference/include/openvino/reference/autobroadcast_binop.hpp
+++ b/src/core/reference/include/openvino/reference/autobroadcast_binop.hpp
@@ -126,7 +126,7 @@ void numpy_broadcast_binop(const T* arg0,
     //                 [ 3, 2, 6]
     using namespace internal;
 
-    size_t const shape_rank = std::max(arg0_shape.size(), arg1_shape.size()) + 1;
+    const size_t shape_rank = std::max(arg0_shape.size(), arg1_shape.size()) + 1;
 
     // TODO: Use compiler-specific alloca() or variable-length array
     std::vector<size_t> tmp(shape_rank * 2);
@@ -137,16 +137,16 @@ void numpy_broadcast_binop(const T* arg0,
     row_major_strides(arg0_shape, strides0, shape_rank);
     row_major_strides(arg1_shape, strides1, shape_rank);
 
-    size_t const padding0 = shape_rank - arg0_shape.size();
-    size_t const padding1 = shape_rank - arg1_shape.size();
+    const size_t padding0 = shape_rank - arg0_shape.size();
+    const size_t padding1 = shape_rank - arg1_shape.size();
 
     Shape output_shape(shape_rank, 0);
 
     size_t axis = 0;
 
     for (size_t i = 0; i < shape_rank; ++i) {
-        auto const dim0 = value_with_padding_or(arg0_shape, padding0, i, 1);
-        auto const dim1 = value_with_padding_or(arg1_shape, padding1, i, 1);
+        const auto dim0 = value_with_padding_or(arg0_shape, padding0, i, 1);
+        const auto dim1 = value_with_padding_or(arg1_shape, padding1, i, 1);
 
         output_shape[i] = std::max(dim0, dim1);
 

--- a/src/core/reference/src/op/einsum.cpp
+++ b/src/core/reference/src/op/einsum.cpp
@@ -1040,7 +1040,7 @@ void einsum_impl(const ov::TensorVector& inputs, ov::TensorVector& outputs, cons
     fix_inputs_with_0d_ellipsis<T>(int_inputs, input_subscripts, output_subscript);
 
     // contract inputs by Einsum until just one is remained
-    for (auto const& inds_pair : einsum_path) {
+    for (const auto& inds_pair : einsum_path) {
         contract_two_inputs<T>(int_inputs, input_subscripts, output_subscript, inds_pair.first, inds_pair.second);
     }
 

--- a/src/core/reference/src/utils/coordinate_transform.cpp
+++ b/src/core/reference/src/utils/coordinate_transform.cpp
@@ -35,7 +35,7 @@ CoordinateIterator::CoordinateIterator(const Shape& target_shape, bool is_end)
       m_coordinate(target_shape.size(), 0) {
     // The case where we have a zero-length axis is a bit special, in that
     // the iterator always starts out of bounds.
-    bool const empty = std::find(target_shape.begin(), target_shape.end(), 0) != target_shape.end();
+    const bool empty = std::find(target_shape.begin(), target_shape.end(), 0) != target_shape.end();
 
     m_oob = is_end || empty;
 }

--- a/src/core/shape_inference/include/einsum_shape_inference.hpp
+++ b/src/core/shape_inference/include/einsum_shape_inference.hpp
@@ -49,7 +49,7 @@ std::vector<TRShape> shape_infer(const Einsum* op, const std::vector<T>& input_s
                 "corresponding input subscript.");
             std::unordered_map<std::string, TRShape> single_input_label_to_shape;
             for (size_t label_ind = 0, dim_ind = 0; label_ind < labels.size() && dim_ind < input_rank; ++label_ind) {
-                auto const& label = labels[label_ind];
+                const auto& label = labels[label_ind];
                 if (label.compare("...") == 0) {
                     size_t num_broadcasted_dims = input_rank - labels.size() + 1;
                     auto current_sub_pshape = T(std::vector<DimType>(pshape.begin() + dim_ind,
@@ -100,7 +100,7 @@ std::vector<TRShape> shape_infer(const Einsum* op, const std::vector<T>& input_s
                 // Shape has dynamic rank and ellipsis
                 return {pshape};
             }
-            for (auto const& label : labels) {
+            for (const auto& label : labels) {
                 if (label_to_shape.find(label) == label_to_shape.end()) {
                     label_to_shape[label] = ov::PartialShape{Dimension::dynamic()};
                 }
@@ -112,7 +112,7 @@ std::vector<TRShape> shape_infer(const Einsum* op, const std::vector<T>& input_s
     auto output_shapes = std::vector<TRShape>(1);
     auto& output_shape = output_shapes[0];
 
-    for (auto const& output_label : output_labels) {
+    for (const auto& output_label : output_labels) {
         if (output_label == "..." && label_to_shape.find(output_label) == label_to_shape.end()) {
             // Output labels may contain ellipsis that does not cover any dimensions.
             continue;

--- a/src/core/shape_inference/include/eye_shape_inference.hpp
+++ b/src/core/shape_inference/include/eye_shape_inference.hpp
@@ -27,7 +27,7 @@ void check_1D_or_scalar_shape(const ov::op::v9::Eye* op, const T& input_shape, c
 }  // namespace util
 
 namespace eye {
-constexpr std::array<char const*, 4> shape_names{"'num_rows'", "'num_columns'", "'diagonal_index'", "'batch_shape'"};
+constexpr std::array<const char*, 4> shape_names{"'num_rows'", "'num_columns'", "'diagonal_index'", "'batch_shape'"};
 }
 
 namespace v9 {

--- a/src/core/shape_inference/include/prior_box_shape_inference_util.hpp
+++ b/src/core/shape_inference/include/prior_box_shape_inference_util.hpp
@@ -12,7 +12,7 @@
 namespace ov {
 namespace op {
 namespace prior_box {
-constexpr std::array<char const*, 2> input_names{"output size", "image"};
+constexpr std::array<const char*, 2> input_names{"output size", "image"};
 
 namespace validate {
 inline std::vector<PartialShape> inputs_et(const Node* const op) {

--- a/src/core/shape_inference/include/slice_shape_inference.hpp
+++ b/src/core/shape_inference/include/slice_shape_inference.hpp
@@ -15,7 +15,7 @@ namespace op {
 
 namespace slice {
 
-constexpr std::array<char const*, 4> shape_names{"start", "stop", "step", "axes"};
+constexpr std::array<const char*, 4> shape_names{"start", "stop", "step", "axes"};
 
 struct AxesMap {
     bool is_valid{};               //!< Flag indicates current axes map has valid data (unique).

--- a/src/core/shape_inference/include/strided_slice_shape_inference.hpp
+++ b/src/core/shape_inference/include/strided_slice_shape_inference.hpp
@@ -20,7 +20,7 @@ std::vector<TRShape> shape_infer(const StridedSlice* op,
                                  const std::vector<T>& input_shapes,
                                  const ITensorAccessor& ta = make_tensor_accessor()) {
     using DimType = typename T::value_type;
-    static constexpr std::array<char const*, 3> shape_names{"Begin", "End", "Strides"};
+    static constexpr std::array<const char*, 3> shape_names{"Begin", "End", "Strides"};
 
     NODE_VALIDATION_CHECK(op, (input_shapes.size() == 3 || input_shapes.size() == 4));
 

--- a/src/core/src/op/batch_to_space.cpp
+++ b/src/core/src/op/batch_to_space.cpp
@@ -72,7 +72,7 @@ bool batch_to_space_evaluate(TensorVector& outputs, const TensorVector& inputs) 
 
     auto data_shape = in.get_shape();
 
-    auto const block_values_size = shape_size(inputs[1].get_shape());
+    const auto block_values_size = shape_size(inputs[1].get_shape());
 
     const auto* block_values = inputs[1].data<int64_t>();
     const auto* crops_begin_values = inputs[2].data<int64_t>();

--- a/src/core/src/op/einsum.cpp
+++ b/src/core/src/op/einsum.cpp
@@ -120,8 +120,8 @@ void op::v7::Einsum::parse_equation(const std::string& equation,
         // equation is in implicit mode so recover output subscript
         output_subscript = "";
         for (size_t ind = 0; ind < input_subscripts.size(); ++ind) {
-            auto const& input_subscript = input_subscripts[ind];
-            for (auto const& label : extract_labels(input_subscript)) {
+            const auto& input_subscript = input_subscripts[ind];
+            for (const auto& label : extract_labels(input_subscript)) {
                 if (label != ellipsis && (is_label_elsewhere(input_subscripts, label, {ind}) == false)) {
                     output_subscript += label;
                 }

--- a/src/core/src/pass/perf_counters.cpp
+++ b/src/core/src/pass/perf_counters.cpp
@@ -5,7 +5,7 @@
 
 namespace ov {
 namespace pass {
-openvino::itt::handle_t PerfCounters::operator[](ov::Node::type_info_t const& type_inf) {
+openvino::itt::handle_t PerfCounters::operator[](const ov::Node::type_info_t& type_inf) {
     std::lock_guard<std::mutex> guard(m_mutex);
     auto it = m_counters.find(&type_inf);
     if (it != m_counters.end())

--- a/src/core/src/pass/perf_counters.hpp
+++ b/src/core/src/pass/perf_counters.hpp
@@ -12,16 +12,16 @@
 namespace ov {
 namespace pass {
 class PerfCounters {
-    PerfCounters(PerfCounters const&) = delete;
-    PerfCounters& operator=(PerfCounters const&) = delete;
+    PerfCounters(const PerfCounters&) = delete;
+    PerfCounters& operator=(const PerfCounters&) = delete;
 
 public:
     PerfCounters() = default;
 
-    openvino::itt::handle_t operator[](ov::Node::type_info_t const& type_inf);
+    openvino::itt::handle_t operator[](const ov::Node::type_info_t& type_inf);
 
 private:
-    using key = ov::Node::type_info_t const*;
+    using key = const ov::Node::type_info_t*;
     using value = openvino::itt::handle_t;
     using counters_map = std::unordered_map<key, value>;
 

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -88,7 +88,7 @@ class ConstantWriter {
 public:
     using FilePosition = int64_t;
     using HashValue = size_t;
-    using ConstWritePositions = std::multimap<HashValue, std::pair<FilePosition, void const*>>;
+    using ConstWritePositions = std::multimap<HashValue, std::pair<FilePosition, const void*>>;
 
     ConstantWriter(std::ostream& bin_data, bool enable_compression = true)
         : m_binary_output(bin_data),
@@ -146,7 +146,7 @@ public:
             if (!ptr_is_temporary) {
                 // Since fp16_compressed data will be disposed at exit point and since we cannot reread it from the
                 // ostream, we store pointer to the original uncompressed blob.
-                m_hash_to_file_positions.insert({hash, {offset, static_cast<void const*>(ptr)}});
+                m_hash_to_file_positions.insert({hash, {offset, static_cast<const void*>(ptr)}});
             }
             if (m_write_hash_value) {
                 m_binary_output.write(reinterpret_cast<const char*>(&hash), sizeof(uint64_t));

--- a/src/core/tests/constant.cpp
+++ b/src/core/tests/constant.cpp
@@ -895,7 +895,7 @@ TEST(constant, uint2_string_broadcast) {
 }
 
 TEST(constant, uint2_vector_less_than_single_byte) {
-    auto const shape = Shape{3};
+    const auto shape = Shape{3};
     const auto input = std::vector<uint8_t>{2, 3, 1};
 
     op::v0::Constant c(element::u2, shape, input);
@@ -909,7 +909,7 @@ TEST(constant, uint2_vector_less_than_single_byte) {
 }
 
 TEST(constant, uint2_vector_bigger_than_single_byte) {
-    auto const shape = Shape{7};
+    const auto shape = Shape{7};
     const auto input = std::vector<uint8_t>{2, 3, 1, 0, 1, 2, 0};
 
     op::v0::Constant c(element::u2, shape, input);
@@ -1007,7 +1007,7 @@ TEST(constant, uint3_string_broadcast) {
 }
 
 TEST(constant, uint3_vector_less_than_one_storage_unit) {
-    auto const shape = Shape{3};
+    const auto shape = Shape{3};
     const auto input = std::vector<uint8_t>{5, 3, 1};
 
     op::v0::Constant c(element::u3, shape, input);
@@ -1023,7 +1023,7 @@ TEST(constant, uint3_vector_less_than_one_storage_unit) {
 }
 
 TEST(constant, uint3_vector_greater_than_one_storage_unit) {
-    auto const shape = Shape{10};
+    const auto shape = Shape{10};
     const auto input = std::vector<uint8_t>{2, 3, 1, 0, 4, 5, 6, 7, 5, 2};
 
     op::v0::Constant c(element::u3, shape, input);
@@ -1247,7 +1247,7 @@ TEST(constant, uint6_string_broadcast) {
 }
 
 TEST(constant, uint6_vector_less_than_one_storage_unit) {
-    auto const shape = Shape{3};
+    const auto shape = Shape{3};
     const auto input = std::vector<uint8_t>{5, 23, 1};
 
     op::v0::Constant c(element::u6, shape, input);
@@ -1263,7 +1263,7 @@ TEST(constant, uint6_vector_less_than_one_storage_unit) {
 }
 
 TEST(constant, uint6_vector_greater_than_one_storage_unit) {
-    auto const shape = Shape{6};
+    const auto shape = Shape{6};
     const auto input = std::vector<uint8_t>{25, 3, 1, 0, 45, 5};
 
     op::v0::Constant c(element::u6, shape, input);

--- a/src/frontends/ir/src/ir_deserializer.cpp
+++ b/src/frontends/ir/src/ir_deserializer.cpp
@@ -558,7 +558,7 @@ std::shared_ptr<ov::Model> ov::XmlDeserializer::parse_function(const pugi::xml_n
                 OPENVINO_THROW("Attempt to access node ", e.fromLayerId, " that not in graph.");
             }
             auto& p_output = params[e.fromLayerId].params;
-            size_t const realInputPortId = p.params.get_real_input_port_id(e.toPortId);
+            const size_t realInputPortId = p.params.get_real_input_port_id(e.toPortId);
             if (realInputPortId >= inputs.size())
                 OPENVINO_THROW(p.params.type,
                                " layer ",
@@ -911,7 +911,7 @@ std::shared_ptr<ov::Node> ov::XmlDeserializer::create_node(const std::vector<ov:
             }
         }
 
-        auto const& opset = opsetIt->second;
+        const auto& opset = opsetIt->second;
 
         ovNode = std::shared_ptr<ov::Node>(opset.create_insensitive(type_name));
         if (!ovNode) {

--- a/src/frontends/onnx/frontend/src/core/model.hpp
+++ b/src/frontends/onnx/frontend/src/core/model.hpp
@@ -103,7 +103,7 @@ public:
     std::int64_t get_opset_version(const std::string& domain) {
         try {
             return ov::frontend::onnx::get_opset_version(*this->m_model_proto, domain);
-        } catch (ov::Exception const&) {
+        } catch (const ov::Exception&) {
             return -1;
         }
     }

--- a/src/frontends/onnx/frontend/src/core/transform.cpp
+++ b/src/frontends/onnx/frontend/src/core/transform.cpp
@@ -27,7 +27,7 @@ namespace frontend {
 namespace onnx {
 namespace transform {
 namespace {
-TypeProto get_input_type(std::string const& name, GraphProto& graph) {
+TypeProto get_input_type(const std::string& name, GraphProto& graph) {
     for (const auto& input : graph.input()) {
         if (input.name() == name) {
             return input.type();

--- a/src/frontends/onnx/frontend/src/input_model.cpp
+++ b/src/frontends/onnx/frontend/src/input_model.cpp
@@ -397,7 +397,7 @@ void InputModel::remove_output(const ov::frontend::Place::Ptr& place) {
     if (find_output != output_names.end()) {
         outputs.erase(std::remove_if(outputs.begin(),
                                      outputs.end(),
-                                     [&place](ov::frontend::Place::Ptr const& output) {
+                                     [&place](const ov::frontend::Place::Ptr& output) {
                                          return output->is_equal(place);
                                      }),
                       outputs.end());

--- a/src/frontends/onnx/tests/onnx_import.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import.in.cpp
@@ -218,7 +218,7 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_unsupported_op) {
     try {
         convert_model("unsupported_op.onnx");
         FAIL() << "Expected ov::Exception";
-    } catch (ov::Exception const& err) {
+    } catch (const ov::Exception& err) {
         std::string what{err.what()};
         EXPECT_NE(what.find("OpenVINO does not support"), std::string::npos);
         EXPECT_NE(what.find("FakeOpName"), std::string::npos);

--- a/src/frontends/pytorch/src/op/log_softmax.cpp
+++ b/src/frontends/pytorch/src/op/log_softmax.cpp
@@ -25,7 +25,7 @@ OutputVector translate_log_softmax_common(const NodeContext& context, bool is_fx
     */
     num_inputs_check(context, 2, 3);
     auto input = context.get_input(0);
-    auto const dim = context.const_input<int64_t>(1);
+    const auto dim = context.const_input<int64_t>(1);
 
     if (!context.input_is_none(2) && !is_fx) {
         const auto elem_type = input.get_element_type();

--- a/src/frontends/tests/frontend/shared/src/op_fuzzy.cpp
+++ b/src/frontends/tests/frontend/shared/src/op_fuzzy.cpp
@@ -42,7 +42,7 @@ inline void addInputOutput(const cnpy::NpyArray& npy_array, ov::test::TestCase& 
         test_case.add_expected_output(npy_array.shape, data);
 }
 
-static bool ends_with(std::string const& value, std::string const& ending) {
+static bool ends_with(const std::string& value, const std::string& ending) {
     if (ending.size() > value.size())
         return false;
     return std::equal(ending.rbegin(), ending.rend(), value.rbegin());

--- a/src/inference/src/dev/threading/cpu_streams_executor.cpp
+++ b/src/inference/src/dev/threading/cpu_streams_executor.cpp
@@ -241,9 +241,9 @@ struct CPUStreamsExecutor::Impl {
         private:
             // disable all copy and move semantics, user only can use fetch()
             // to create a new instance with a shared count num;
-            ThreadTracker(ThreadTracker const&) = default;
+            ThreadTracker(const ThreadTracker&) = default;
             ThreadTracker(ThreadTracker&&) = delete;
-            ThreadTracker& operator=(ThreadTracker const&) = delete;
+            ThreadTracker& operator=(const ThreadTracker&) = delete;
             ThreadTracker& operator=(ThreadTracker&&) = delete;
             std::thread::id _id;
             std::shared_ptr<std::atomic_int> _count_ptr;

--- a/src/inference/tests/unit/query_model_test.cpp
+++ b/src/inference/tests/unit/query_model_test.cpp
@@ -65,7 +65,7 @@ public:
              const std::unordered_set<std::string>& expected,
              float query_model_ratio = 1.0f) {
         auto supported = ov::get_supported_nodes(m_function, transform, is_node_supported, query_model_ratio);
-        auto const is_in_expected = [&expected](const std::string& x) {
+        const auto is_in_expected = [&expected](const std::string& x) {
             return expected.find(x) != expected.end();
         };
         bool is_equal =

--- a/src/plugins/hetero/src/subgraph_collector.cpp
+++ b/src/plugins/hetero/src/subgraph_collector.cpp
@@ -643,7 +643,7 @@ ov::hetero::SubgraphsMappingInfo ov::hetero::mask_model_subgraphs_by_ops(std::sh
             ParameterVector subgraph_parameters{submodel->inputs().size()};
             OutputVector args{submodel->inputs().size()};
             for (size_t j = 0; j < submodel->inputs().size(); j++) {
-                auto const& input = submodel->input(j);
+                const auto& input = submodel->input(j);
                 subgraph_parameters[j] =
                     std::make_shared<ov::op::v0::Parameter>(input.get_element_type(), input.get_partial_shape());
                 supported_ops[subgraph_parameters[j]->get_friendly_name()] = subgraph._affinity;

--- a/src/plugins/intel_cpu/src/config.cpp
+++ b/src/plugins/intel_cpu/src/config.cpp
@@ -232,7 +232,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             }
         } else if (key == ov::hint::inference_precision.name()) {
             try {
-                auto const prec = val.as<ov::element::Type>();
+                const auto prec = val.as<ov::element::Type>();
                 inferencePrecisionSetExplicitly = true;
                 if (prec == ov::element::bf16) {
                     if (hasHardwareSupport(ov::element::bf16)) {
@@ -282,7 +282,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             }
         } else if (key == ov::intel_cpu::snippets_mode.name()) {
             try {
-                auto const mode = val.as<ov::intel_cpu::SnippetsMode>();
+                const auto mode = val.as<ov::intel_cpu::SnippetsMode>();
                 if (mode == ov::intel_cpu::SnippetsMode::ENABLE) {
                     snippetsMode = SnippetsMode::Enable;
                 } else if (mode == ov::intel_cpu::SnippetsMode::IGNORE_CALLBACK) {
@@ -312,7 +312,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
         } else if (key == ov::hint::kv_cache_precision.name()) {
             try {
                 kvCachePrecisionSetExplicitly = true;
-                auto const prec = val.as<ov::element::Type>();
+                const auto prec = val.as<ov::element::Type>();
                 if (one_of(prec, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8)) {
                     kvCachePrecision = prec;
                 } else {
@@ -328,7 +328,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
         } else if (key == ov::key_cache_precision.name()) {
             try {
                 keyCachePrecisionSetExplicitly = true;
-                auto const prec = val.as<ov::element::Type>();
+                const auto prec = val.as<ov::element::Type>();
                 if (one_of(prec, ov::element::f32, ov::element::f16, ov::element::bf16, ov::element::u8)) {
                     keyCachePrecision = prec;
                 } else {
@@ -344,7 +344,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
         } else if (key == ov::value_cache_precision.name()) {
             try {
                 valueCachePrecisionSetExplicitly = true;
-                auto const prec = val.as<ov::element::Type>();
+                const auto prec = val.as<ov::element::Type>();
                 if (one_of(prec,
                            ov::element::f32,
                            ov::element::f16,
@@ -364,7 +364,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             }
         } else if (key == ov::key_cache_group_size.name() || key == ov::value_cache_group_size.name()) {
             try {
-                auto const groupSize = val.as<uint64_t>();
+                const auto groupSize = val.as<uint64_t>();
                 if (key == ov::key_cache_group_size.name()) {
                     keyCacheGroupSizeSetExplicitly = true;
                     keyCacheGroupSize = groupSize;
@@ -381,7 +381,7 @@ void Config::readProperties(const ov::AnyMap& prop, const ModelType modelType) {
             }
         } else if (key == ov::intel_cpu::key_cache_quant_mode.name()) {
             try {
-                auto const mode = val.as<ov::intel_cpu::CacheQuantMode>();
+                const auto mode = val.as<ov::intel_cpu::CacheQuantMode>();
                 if (mode == ov::intel_cpu::CacheQuantMode::AUTO) {
                     keyCacheQuantMode = CacheQuantMode::AUTO;
                 } else if (mode == ov::intel_cpu::CacheQuantMode::BY_CHANNEL) {

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -183,7 +183,7 @@ public:
     struct Tag {};
 
     struct PerfCounters {
-        PerfCounters(std::string const& name)
+        PerfCounters(const std::string& name)
             : execute(openvino::itt::handle(name)),
               getSupportedDescriptors(openvino::itt::handle<Tag<Node, 0>>("Node::getSupportedDescriptors")),
               initSupportedPrimitiveDescriptors(

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -45,8 +45,8 @@ void convert_vec(jit_generator& gen, const RegExp& src, const RegExp& dst);
 
 template <>
 void convert_vec<ov::float16, float>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f16vec = gen.xmm3;
-    auto const& f32vec = gen.ymm4;
+    const auto& f16vec = gen.xmm3;
+    const auto& f32vec = gen.ymm4;
 
     gen.movdqu(f16vec, gen.xword[src]);
     gen.vcvtph2ps(f32vec, f16vec);
@@ -55,8 +55,8 @@ void convert_vec<ov::float16, float>(jit_generator& gen, const RegExp& src, cons
 
 template <>
 void convert_vec<float, ov::float16>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f16vec = gen.xmm3;
-    auto const& f32vec = gen.ymm4;
+    const auto& f16vec = gen.xmm3;
+    const auto& f32vec = gen.ymm4;
 
     gen.vmovups(f32vec, gen.yword[src]);
     gen.vcvtps2ph(f16vec, f32vec, 0);
@@ -203,8 +203,8 @@ private:
 
 template <>
 void convert_vec<float, ov::float8_e4m3>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f32vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f32vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<float, ov::float8_e4m3>&>(gen);
 
@@ -215,8 +215,8 @@ void convert_vec<float, ov::float8_e4m3>(jit_generator& gen, const RegExp& src, 
 
 template <>
 void convert_vec<ov::float8_e4m3, float>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f32vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f32vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float8_e4m3, float>&>(gen);
 
@@ -227,8 +227,8 @@ void convert_vec<ov::float8_e4m3, float>(jit_generator& gen, const RegExp& src, 
 
 template <>
 void convert_vec<ov::float16, ov::float8_e4m3>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.ymm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.ymm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float16, ov::float8_e4m3>&>(gen);
 
@@ -239,8 +239,8 @@ void convert_vec<ov::float16, ov::float8_e4m3>(jit_generator& gen, const RegExp&
 
 template <>
 void convert_vec<ov::float8_e4m3, ov::float16>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.ymm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.ymm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float8_e4m3, ov::float16>&>(gen);
 
@@ -251,8 +251,8 @@ void convert_vec<ov::float8_e4m3, ov::float16>(jit_generator& gen, const RegExp&
 
 template <>
 void convert_vec<ov::intel_cpu::bfloat16_t, ov::float8_e4m3>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::intel_cpu::bfloat16_t, ov::float8_e4m3>&>(gen);
 
@@ -264,9 +264,9 @@ void convert_vec<ov::intel_cpu::bfloat16_t, ov::float8_e4m3>(jit_generator& gen,
 
 template <>
 void convert_vec<ov::float8_e4m3, ov::intel_cpu::bfloat16_t>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.ymm4;
-    auto const& f32vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.ymm4;
+    const auto& f32vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float8_e4m3, ov::intel_cpu::bfloat16_t>&>(gen);
 
@@ -279,8 +279,8 @@ void convert_vec<ov::float8_e4m3, ov::intel_cpu::bfloat16_t>(jit_generator& gen,
 
 template <>
 void convert_vec<float, ov::float8_e5m2>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f32vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f32vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<float, ov::float8_e5m2>&>(gen);
 
@@ -291,8 +291,8 @@ void convert_vec<float, ov::float8_e5m2>(jit_generator& gen, const RegExp& src, 
 
 template <>
 void convert_vec<ov::float8_e5m2, float>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f32vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f32vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float8_e5m2, float>&>(gen);
 
@@ -303,8 +303,8 @@ void convert_vec<ov::float8_e5m2, float>(jit_generator& gen, const RegExp& src, 
 
 template <>
 void convert_vec<ov::float16, ov::float8_e5m2>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.ymm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.ymm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float16, ov::float8_e5m2>&>(gen);
 
@@ -315,8 +315,8 @@ void convert_vec<ov::float16, ov::float8_e5m2>(jit_generator& gen, const RegExp&
 
 template <>
 void convert_vec<ov::float8_e5m2, ov::float16>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.ymm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.ymm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float8_e5m2, ov::float16>&>(gen);
 
@@ -327,8 +327,8 @@ void convert_vec<ov::float8_e5m2, ov::float16>(jit_generator& gen, const RegExp&
 
 template <>
 void convert_vec<ov::intel_cpu::bfloat16_t, ov::float8_e5m2>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::intel_cpu::bfloat16_t, ov::float8_e5m2>&>(gen);
 
@@ -340,9 +340,9 @@ void convert_vec<ov::intel_cpu::bfloat16_t, ov::float8_e5m2>(jit_generator& gen,
 
 template <>
 void convert_vec<ov::float8_e5m2, ov::intel_cpu::bfloat16_t>(jit_generator& gen, const RegExp& src, const RegExp& dst) {
-    auto const& f8vec = gen.xmm3;
-    auto const& f16vec = gen.ymm4;
-    auto const& f32vec = gen.zmm4;
+    const auto& f8vec = gen.xmm3;
+    const auto& f16vec = gen.ymm4;
+    const auto& f32vec = gen.zmm4;
 
     auto& cvt = dynamic_cast<jit_convert_array<ov::float8_e5m2, ov::intel_cpu::bfloat16_t>&>(gen);
 

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -183,7 +183,7 @@ struct jit_has_subnormals : public jit_has_special_value_base {
     const int length = isa == sse41 ? 4 : 8;
 
     void generate() override final {
-        size_t const vlen = length;
+        const size_t vlen = length;
         const int sh_bits = std::ilogb(vlen);
 
         auto zero = rmm4;
@@ -257,7 +257,7 @@ struct jit_has_bf16_overflows : public jit_has_special_value_base {
     const int length = isa == sse41 ? 4 : 8;
 
     void generate() override final {
-        size_t const vlen = length;
+        const size_t vlen = length;
         const int sh_bits = std::ilogb(vlen);
 
         auto zero = rmm4;

--- a/src/plugins/intel_cpu/src/nodes/kernels/aarch64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/aarch64/jit_uni_eltwise_generic.cpp
@@ -29,7 +29,7 @@ void jit_uni_eltwise_generic<isa>::generate() {
     preamble();
 
     static const std::vector<element::Type> exec_precisions_priority = {element::f16, element::f32};
-    auto const exec_prc = eltwise_precision_helper::get_precision(jep_.inputs_number,
+    const auto exec_prc = eltwise_precision_helper::get_precision(jep_.inputs_number,
                                                                   jep_.src_prc,
                                                                   eltwise_data_,
                                                                   exec_precisions_priority);

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/softmax_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/softmax_kernel.hpp
@@ -241,7 +241,7 @@ inline void scale_add2_reduce_max(float* a,
         }
 
         if (has_causal_mask) {
-            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(causal_mask + i));
+            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(causal_mask + i));
             auto v_maski32 = _mm512_cvtepi8_epi32(v_maski8);
             auto kmask = _mm512_cmp_epi32_mask(v_maski32, v_zeroi32, _MM_CMPINT_NE);  // !=0
             kmask = _kxor_mask16(kmask, kmask_xor);                                   // reverse, mask at ==0
@@ -269,7 +269,7 @@ inline void scale_add2_reduce_max(float* a,
         }
 
         if (has_causal_mask) {
-            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(causal_mask + i));
+            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(causal_mask + i));
             auto v_maski32 = _mm512_cvtepi8_epi32(v_maski8);
             auto kmask = _mm512_cmp_epi32_mask(v_maski32, v_zeroi32, _MM_CMPINT_NE);  // !=0
             kmask = _kxor_mask16(kmask, kmask_xor);                                   // reverse, mask at ==0
@@ -342,7 +342,7 @@ inline void scale_add2_reduce_max(float* a,
         }
 
         if (has_causal_mask) {
-            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(causal_mask + i));
+            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(causal_mask + i));
             auto v_maski32 = _mm256_cvtepi8_epi32(v_maski8);
             v_maski32 = _mm256_cmpeq_epi32(v_maski32, v_zeroi32);                    // ==0
             v_maski32 = _mm256_xor_si256(v_maski32, v_mask_xor);                     // reverse, mask at ==0
@@ -371,7 +371,7 @@ inline void scale_add2_reduce_max(float* a,
         }
 
         if (has_causal_mask) {
-            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<__m128i const*>(causal_mask + i));
+            auto v_maski8 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(causal_mask + i));
             auto v_maski32 = _mm256_cvtepi8_epi32(v_maski8);
             v_maski32 = _mm256_cmpeq_epi32(v_maski32, v_zeroi32);                    // ==0
             v_maski32 = _mm256_xor_si256(v_maski32, v_mask_xor);                     // reverse, mask at ==0

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_uni_eltwise_generic.cpp
@@ -36,7 +36,7 @@ template <dnnl::impl::cpu::x64::cpu_isa_t isa>
 void jit_uni_eltwise_generic<isa>::generate() {
     static const std::vector<element::Type> exec_precisions_priority =
         {element::u8, element::i8, element::u16, element::i16, element::bf16, element::i32, element::f32};
-    auto const exec_prc = eltwise_precision_helper::get_precision(jep_.inputs_number,
+    const auto exec_prc = eltwise_precision_helper::get_precision(jep_.inputs_number,
                                                                   jep_.src_prc,
                                                                   eltwise_data_,
                                                                   exec_precisions_priority);

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -46,7 +46,7 @@ const std::vector<size_t> NCDHW_TO_NDHWC_LAYOUT_DIMENSIONS_ORDER = {0, 2, 3, 4, 
  * before copying.
  * @details This is meant as a replacement for the legacy "ie_memcpy" function coming from the OpenVINO API.
  */
-void checkedMemcpy(void* destination, size_t destinationSize, void const* source, size_t numberOfBytes) {
+void checkedMemcpy(void* destination, size_t destinationSize, const void* source, size_t numberOfBytes) {
     if (numberOfBytes == 0) {
         return;
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/partitioning.cpp
@@ -34,7 +34,7 @@ inline bool operator==(const std::reference_wrapper<Subgraph>& lhs, const std::r
 
 template <typename T2>
 struct std::hash<std::pair<ov::npuw::Subgraph::Ref, T2>> {
-    std::size_t operator()(std::pair<ov::npuw::Subgraph::Ref, T2> const& p) const noexcept {
+    std::size_t operator()(const std::pair<ov::npuw::Subgraph::Ref, T2>& p) const noexcept {
         ov::npuw::Subgraph& sg = p.first.get();
         std::size_t h1 = std::hash<void*>{}(&sg);
         std::size_t h2 = std::hash<T2>{}(p.second);

--- a/src/plugins/intel_npu/src/plugin/npuw/util_xarch.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/util_xarch.cpp
@@ -244,7 +244,7 @@ void ov::npuw::util::XARCH::unpack_i4i8(const ov::SoPtr<ov::ITensor>& from,
     // per every iteration, what translates to (from->size() / 64) iterations
 
     const std::size_t total = from->get_size();
-    int8_t const* pSrc = static_cast<int8_t*>(from->data());  // 2 x i4 elements
+    const int8_t* pSrc = static_cast<int8_t*>(from->data());  // 2 x i4 elements
     int8_t* pDst = static_cast<int8_t*>(to->data());          // 1 x i8 element
     size_t stride = 64;
 
@@ -325,7 +325,7 @@ void ov::npuw::util::XARCH::unpack_u4i8(const ov::SoPtr<ov::ITensor>& from,
     NPUW_ASSERT(to->is_continuous());
     NPUW_ASSERT(from->get_size() == to->get_size());
 
-    uint8_t const* pSrc = static_cast<uint8_t*>(from->data());  // 2 x u4 elements
+    const uint8_t* pSrc = static_cast<uint8_t*>(from->data());  // 2 x u4 elements
     int8_t* pDst = static_cast<int8_t*>(to->data());            // 1 x i8 element
 
     const std::size_t total = from->get_size();
@@ -351,7 +351,7 @@ void ov::npuw::util::XARCH::unpack_i4f16(const ov::SoPtr<ov::ITensor>& from,
     // per every iteration, what translates to (from->size() / 64) iterations
 
     std::size_t total = to->get_size();
-    int8_t const* pSrc = static_cast<int8_t*>(from->data());  // 2 x i4  elements
+    const int8_t* pSrc = static_cast<int8_t*>(from->data());  // 2 x i4  elements
     int16_t* pDst = static_cast<int16_t*>(to->data());        // 1 x f16 element
     // bool tailOnly = total < 64;
 
@@ -743,7 +743,7 @@ void ov::npuw::util::XARCH::unpack_u4f16(const ov::SoPtr<ov::ITensor>& from,
     // per every iteration, what translates to (from->size() / 64) iterations
 
     const std::size_t total = to->get_size();
-    int8_t const* pSrc = static_cast<int8_t*>(from->data());  // 2 x i4  elements
+    const int8_t* pSrc = static_cast<int8_t*>(from->data());  // 2 x i4  elements
     int16_t* pDst = static_cast<int16_t*>(to->data());        // 1 x f16 element
 
     for (std::size_t index = 0; index < total; index += 64) {
@@ -1265,7 +1265,7 @@ void ov::npuw::util::XARCH::unpack_u4f32(const ov::SoPtr<ov::ITensor>& from,
     NPUW_ASSERT(to->is_continuous());
     NPUW_ASSERT(from->get_size() == to->get_size());
 
-    uint8_t const* pSrc = static_cast<uint8_t*>(from->data());  // 2 x u4 elements
+    const uint8_t* pSrc = static_cast<uint8_t*>(from->data());  // 2 x u4 elements
     float* pDst = static_cast<float*>(to->data());              // 1 x f32 element
 
     const std::size_t total = from->get_size();
@@ -1289,7 +1289,7 @@ void ov::npuw::util::XARCH::unpack_i8f16(const ov::SoPtr<ov::ITensor>& from,
     constexpr std::size_t VECSIZE = 8;
 
     const std::size_t total = from->get_size();
-    int8_t const* pSrc = from->data<int8_t>();
+    const int8_t* pSrc = from->data<int8_t>();
     int16_t* pDst = static_cast<int16_t*>(to->data());
 
     for (std::size_t index = 0; index < total; index += VECSIZE) {
@@ -1326,14 +1326,14 @@ void ov::npuw::util::XARCH::unpack_i8f16_scale(const ov::SoPtr<ov::ITensor>& fro
 
     const std::size_t total = from->get_size();
     const std::size_t stotal = scale->get_size();
-    int8_t const* pSrc = from->data<int8_t>();
-    int8_t const* pScl = static_cast<int8_t*>(scale->data());
+    const int8_t* pSrc = from->data<int8_t>();
+    const int8_t* pScl = static_cast<int8_t*>(scale->data());
     int16_t* pDst = static_cast<int16_t*>(to->data());
 
     for (std::size_t sindex = 0u; sindex < stotal; sindex++) {
         __m256 svec = avx2_load_scale(pScl, scale_elem_type);
         for (std::size_t index = 0u; index < (total / stotal); index += VECSIZE) {
-            __m128i const* pSrcV = reinterpret_cast<const __m128i*>(pSrc);
+            const __m128i* pSrcV = reinterpret_cast<const __m128i*>(pSrc);
             __m128i* pDstV = reinterpret_cast<__m128i*>(pDst);
             __m128i i8vec = _mm_loadl_epi64(pSrcV);      // load:    8 x i8  [ 64b of 128b]
             __m128i f16vec = avx2_i8tof16(i8vec, svec);  // convert & scale
@@ -1375,9 +1375,9 @@ void ov::npuw::util::XARCH::unpack_u8f16(const ov::SoPtr<ov::ITensor>& from,
 
     const std::size_t total = from->get_size();
     const std::size_t stotal = scale->get_size();
-    uint8_t const* pSrc = from->data<uint8_t>();
-    uint8_t const* pZrp = zerop->data<uint8_t>();
-    int8_t const* pScl = static_cast<int8_t*>(scale->data());
+    const uint8_t* pSrc = from->data<uint8_t>();
+    const uint8_t* pZrp = zerop->data<uint8_t>();
+    const int8_t* pScl = static_cast<int8_t*>(scale->data());
     int16_t* pDst = static_cast<int16_t*>(to->data());
 
     for (std::size_t sindex = 0u; sindex < stotal; sindex++) {
@@ -1386,7 +1386,7 @@ void ov::npuw::util::XARCH::unpack_u8f16(const ov::SoPtr<ov::ITensor>& from,
         __m256i u32zp = _mm256_cvtepu8_epi32(u8zp);  // i32 zero point
         __m256 f32zp = _mm256_cvtepi32_ps(u32zp);    // f32 zero point
         for (std::size_t index = 0u; index < (total / stotal); index += VECSIZE) {
-            __m128i const* pSrcV = reinterpret_cast<const __m128i*>(pSrc);
+            const __m128i* pSrcV = reinterpret_cast<const __m128i*>(pSrc);
             __m128i* pDstV = reinterpret_cast<__m128i*>(pDst);
             __m128i u8in = _mm_loadl_epi64(pSrcV);             // load:    8 x u8
             __m128i f16vec = avx2_u8tof16(u8in, f32zp, svec);  // convert & scale

--- a/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/weights_bank.cpp
@@ -21,8 +21,8 @@ public:
 
 private:
     BankManager() {}
-    BankManager(BankManager const&) = delete;
-    void operator=(BankManager const&) = delete;
+    BankManager(const BankManager&) = delete;
+    void operator=(const BankManager&) = delete;
 
 public:
     // Public API


### PR DESCRIPTION
It makes sense to have it alligned accross the whole product.
The change is not that big.
Also this helps clang-tidy to apply and format fixes in
consistent style