### PR TITLE
[intel-npu] Increasing qdq optimization support version to 7.20

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -1301,7 +1301,7 @@ struct QDQ_OPTIMIZATION final : OptionBase<QDQ_OPTIMIZATION, bool> {
     }
 
     static uint32_t compilerSupportVersion() {
-        return ONEAPI_MAKE_VERSION(7, 5);
+        return ONEAPI_MAKE_VERSION(7, 20);
     }
 };
 


### PR DESCRIPTION
### Details:
 - Increasing compiler support version of NPU_QDQ_OPTIMIZATION property to 7.20
 - This was already merged once in https://github.com/openvinotoolkit/openvino/pull/29581 but accidentally removed in https://github.com/openvinotoolkit/openvino/pull/27955

### Tickets:
 - *ticket-id*
