### PR TITLE
[GPU] Expose USM memory as supported in device capabilities

### DIFF
--- a/src/bindings/python/src/openvino/_pyopenvino/properties/intel_gpu/__init__.pyi
+++ b/src/bindings/python/src/openvino/_pyopenvino/properties/intel_gpu/__init__.pyi
@@ -12,6 +12,7 @@ class CapabilityGPU:
     openvino.properties.intel_gpu.CapabilityGPU submodule that simulates ov::intel_gpu::capability
     """
     HW_MATMUL: typing.ClassVar[str] = 'GPU_HW_MATMUL'
+    USM_MEMORY: typing.ClassVar[str] = 'GPU_USM_MEMORY'
 class MemoryType:
     """
     openvino.properties.intel_gpu.MemoryType submodule that simulates ov::intel_gpu::memory_type

--- a/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
+++ b/src/bindings/python/src/pyopenvino/core/properties/properties.cpp
@@ -266,6 +266,7 @@ void regmodule_properties(py::module m) {
         "openvino.properties.intel_gpu.CapabilityGPU submodule that simulates ov::intel_gpu::capability");
 
     m_capability_gpu.attr("HW_MATMUL") = ov::intel_gpu::capability::HW_MATMUL;
+    m_capability_gpu.attr("USM_MEMORY") = ov::intel_gpu::capability::USM_MEMORY;
 
     // Submodule log
     py::module m_log = m_properties.def_submodule("log", "openvino.properties.log submodule that simulates ov::log");

--- a/src/bindings/python/tests/test_runtime/test_properties.py
+++ b/src/bindings/python/tests/test_runtime/test_properties.py
@@ -552,6 +552,7 @@ def test_properties_memory_type_gpu():
 
 def test_properties_capability_gpu():
     assert intel_gpu.CapabilityGPU.HW_MATMUL == "GPU_HW_MATMUL"
+    assert intel_gpu.CapabilityGPU.USM_MEMORY == "GPU_USM_MEMORY"
 
 
 def test_properties_hint_model():

--- a/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
+++ b/src/inference/include/openvino/runtime/intel_gpu/properties.hpp
@@ -164,6 +164,12 @@ namespace capability {
  */
 constexpr static const auto HW_MATMUL = "GPU_HW_MATMUL";
 
+/**
+ * @brief Device supports unified shared memory
+ * @ingroup ov_runtime_ocl_gpu_prop_cpp_api
+ */
+constexpr static const auto USM_MEMORY = "GPU_USM_MEMORY";
+
 }  // namespace capability
 }  // namespace intel_gpu
 }  // namespace ov

--- a/src/plugins/intel_gpu/docs/gpu_plugin_driver_troubleshooting.md
+++ b/src/plugins/intel_gpu/docs/gpu_plugin_driver_troubleshooting.md
@@ -68,7 +68,7 @@ With this option, you can check whether Intel XMX(Xe Matrix Extension) feature i
 ```
 $ ./hello_query_device.py
 ...
-[ INFO ]                OPTIMIZATION_CAPABILITIES: FP32, BIN, FP16, INT8, GPU_HW_MATMUL
+[ INFO ]                OPTIMIZATION_CAPABILITIES: FP32, BIN, FP16, INT8, GPU_HW_MATMUL, GPU_USM_MEMORY
 ```
 
 ## 8. If you have errors with OpenCL headers in application build

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -638,6 +638,8 @@ std::vector<std::string> Plugin::get_device_capabilities(const cldnn::device_inf
         capabilities.emplace_back(ov::device::capability::INT8);
     if (info.supports_immad)
         capabilities.emplace_back(ov::intel_gpu::capability::HW_MATMUL);
+    if (info.supports_usm)
+        capabilities.emplace_back(ov::intel_gpu::capability::USM_MEMORY);
     capabilities.emplace_back(ov::device::capability::EXPORT_IMPORT);
 
     return capabilities;


### PR DESCRIPTION
### Details:
 - Currently if the user does not provide shared object handle params for remote tensor creation, GPU plugin directly allocated remote tensor and since `ocl buffer` is selected as the default value for shared memory type
 - Expose `USM MEMORY` as supported in device capabilities(`OPTIMIZATION_CAPABILITIES`). And from the user side, check if `USM_MEMORY` is listed as supported, allocate remote tensor as usm memory type selected by the shared object handle params for further performance gain.

### Tickets:
 - 163996
