### PR TITLE
Fix(core): Resolve Segmentation Fault when Creating String Constants (Issue #23611)

### DIFF
--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -213,7 +213,7 @@ Constant::Constant(const Tensor& tensor)
 }
 
 Constant::Constant(const element::Type& type, const Shape& shape, const std::vector<std::string>& values)
-    : Constant(false, type, shape) {
+    : Constant(type == element::string, type, shape) {  // Set memset_allocation to true for string type to fix Issue #23611
     const auto this_shape_size = shape_size(m_shape);
     const auto values_size = values.size();
     const auto has_single_value = (values_size == 1);


### PR DESCRIPTION
Fixes a segmentation fault encountered when creating string type constants in OpenVINO.

**Problem:**

A segmentation fault occurs when attempting to create a constant tensor with string data type using the following Python code:

```python
import openvino.runtime.opset14 as ov
import numpy as np
str_const = ov.constant(np.array(['openvino'], dtype=str))
```

Root Cause Analysis:

The issue lies within the Constant constructor in src/core/src/op/constant.cpp. Specifically, the constructor chain for string constants includes:

Constant::Constant(const element::Type& type, const Shape& shape, const std::vector<std::string>& values)
    : Constant(false, type, shape) {
    // ...processing continues...
}


The problem is the passing of false for the memset_allocation parameter in the call to the base constructor. This flag determines how memory is initialized in the allocate_buffer function:

```C++

if (m_element_type == ov::element::string) {
    m_data = std::make_shared<StringAlignedBuffer>(num_elements, byte_size, host_alignment(), memset_allocation);
}
```

Subsequently, the constructor that handles raw data uses std::uninitialized_copy_n:

```C++

if (m_element_type == ov::element::string) {
    const auto src_strings = static_cast<const std::string*>(data);
    const auto dst_strings = static_cast<std::string*>(get_data_ptr_nc());
    std::uninitialized_copy_n(src_strings, num_elements, dst_strings);
}
```
std::uninitialized_copy_n expects the destination memory to be allocated but not initialized. When memset_allocation is false for string constants, the memory isn't properly prepared for string objects, leading to a segmentation fault when std::uninitialized_copy_n is called.

Solution:

This Pull Request modifies the Constant constructor for string types to ensure that memset_allocation is set to true. This will ensure that the memory allocated for string constants is properly initialized, resolving the segmentation fault.

Testing:

The fix has been tested by successfully creating string constants using the code snippet provided in the problem description. Further testing with various string lengths and multiple string elements has also been performed.

Issue Link:

This Pull Request addresses and resolves issue #23611.