### PR TITLE
[intel-npu] compilerSupportVersion for NPU_TILES

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -1014,7 +1014,7 @@ struct DPU_GROUPS final : OptionBase<DPU_GROUPS, int64_t> {
 };
 
 //
-// SELECTED_TILES
+// TILES
 //
 
 struct TILES final : OptionBase<TILES, int64_t> {
@@ -1036,6 +1036,10 @@ struct TILES final : OptionBase<TILES, int64_t> {
 
     static bool isPublic() {
         return true;
+    }
+
+    static uint32_t compilerSupportVersion() {
+        return ONEAPI_MAKE_VERSION(5, 4);
     }
 
     static ov::PropertyMutability mutability() {


### PR DESCRIPTION
### Details:
 - Adding compiler support version for NPU_TILES (it was formerly renamed to NPU_DPU_GROUPS regardless to version) for legacy support

### Tickets:
 - *ticket-id*
