### PR TITLE
[C API] Implement `ov_core_add_extension` c-api

### DIFF
--- a/src/bindings/c/docs/api_overview.md
+++ b/src/bindings/c/docs/api_overview.md
@@ -631,6 +631,14 @@ This struct represents OpenVINO entity and allows you to manipulate with plugins
 
   - Return value: Status code of the operation: OK(0) for success.
 
+- `ov_status_e ov_core_add_extension(const ov_core_t* core, const char* library_path)`
+
+  - Description: Adds an extension to the core.
+  - Parameters:
+    - `core` - A pointer `ov_core_t` instance.
+    - `library_path` - Path to an extension.
+  - Return value: Status code of the operation: OK(0) for success.
+
 ## OV Model
 
 This struct contains the information about the model read from IR and allows you to manipulate with some model parameters such as layers affinity and output layers.

--- a/src/bindings/c/include/openvino/c/gpu/gpu_plugin_properties.h
+++ b/src/bindings/c/include/openvino/c/gpu/gpu_plugin_properties.h
@@ -59,3 +59,6 @@ OPENVINO_C_VAR(const char*) ov_property_key_intel_gpu_dev_object_handle;
 
 //!< Read-write property<uint32_t string>: video decoder surface plane in a shared memory blob parameter map.
 OPENVINO_C_VAR(const char*) ov_property_key_intel_gpu_va_plane;
+
+//!< Read-write property to pass config file.
+OPENVINO_C_VAR(const char*) ov_property_key_intel_gpu_config_file;

--- a/src/bindings/c/include/openvino/c/ov_core.h
+++ b/src/bindings/c/include/openvino/c/ov_core.h
@@ -237,6 +237,16 @@ ov_core_compile_model_from_file(const ov_core_t* core,
                                 ov_compiled_model_t** compiled_model,
                                 ...);
 
+/**
+ * @brief Adds an extension to the core.
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param path Path to the extension.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_add_extension(const ov_core_t* core, const char* path);
+
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 /**
  * @brief Reads a model and creates a compiled model from the IR/ONNX/PDPD file.

--- a/src/bindings/c/src/ov_core.cpp
+++ b/src/bindings/c/src/ov_core.cpp
@@ -204,6 +204,17 @@ ov_status_e ov_core_compile_model_from_file(const ov_core_t* core,
     return ov_status_e::OK;
 }
 
+ov_status_e ov_core_add_extension(const ov_core_t* core, const char* path) {
+    if (!core || !path) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        core->object->add_extension(path);
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
 ov_status_e ov_core_set_property(const ov_core_t* core, const char* device_name, ...) {
     if (!core) {
         return ov_status_e::INVALID_C_PARAM;

--- a/src/bindings/c/src/ov_property.cpp
+++ b/src/bindings/c/src/ov_property.cpp
@@ -36,6 +36,7 @@ const char* ov_property_key_hint_execution_mode = "EXECUTION_MODE_HINT";
 const char* ov_property_key_force_tbb_terminate = "FORCE_TBB_TERMINATE";
 const char* ov_property_key_enable_mmap = "ENABLE_MMAP";
 const char* ov_property_key_auto_batch_timeout = "AUTO_BATCH_TIMEOUT";
+const char* ov_property_key_intel_gpu_config_file = "CONFIG_FILE";
 
 // Write-only property key
 const char* ov_property_key_cache_encryption_callbacks = "CACHE_ENCRYPTION_CALLBACKS";

--- a/src/bindings/c/tests/CMakeLists.txt
+++ b/src/bindings/c/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TARGET_NAME "ov_capi_test")
 
 file(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/ov_*.cpp test_model_repo.cpp)
 file(GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+list(APPEND DEFINES TEST_CUSTOM_OP_CONFIG_PATH="${CMAKE_CURRENT_SOURCE_DIR}/../../../plugins/intel_gpu/tests/functional/custom_op/custom_op.xml")
 
 if(NOT TARGET OpenCL::OpenCL)
     list(FILTER SOURCES EXCLUDE REGEX ov_remote_context_test.cpp)
@@ -15,6 +16,8 @@ endif()
 add_executable(${TARGET_NAME} ${SOURCES} ${HEADERS})
 target_link_libraries(${TARGET_NAME} PRIVATE openvino_c openvino::util
     common_test_utils gtest_main)
+
+target_compile_definitions(${TARGET_NAME} PRIVATE ${DEFINES})
 
 target_include_directories(${TARGET_NAME} PUBLIC
     $<BUILD_INTERFACE:${OPENVINO_API_SOURCE_DIR}/include>)

--- a/src/bindings/c/tests/ov_core_test.cpp
+++ b/src/bindings/c/tests/ov_core_test.cpp
@@ -34,6 +34,35 @@ public:
     }
 };
 
+class ov_core_test_gpu : public ov_capi_test_base {
+public:
+    void SetUp() override {
+        core = nullptr;
+        OV_EXPECT_OK(ov_core_create(&core));
+        EXPECT_NE(nullptr, core);
+
+        // Check gpu plugin and hardware available.
+        bool gpu_device_available = false;
+        char* info = nullptr;
+        const char* key = ov_property_key_available_devices;
+        if (ov_core_get_property(core, "GPU", key, &info) == ov_status_e::OK) {
+            if (strlen(info) > 0) {
+                gpu_device_available = true;
+            }
+        }
+        ov_free(info);
+        if (!gpu_device_available) {
+            GTEST_SKIP();
+        }
+    }
+
+    void TearDown() override {
+        ov_core_free(core);
+    }
+
+    ov_core_t* core;
+};
+
 INSTANTIATE_TEST_SUITE_P(ov_core, ov_core_test, ::testing::Values("CPU"));
 
 TEST_P(ov_core_test, ov_core_create_with_config) {
@@ -123,6 +152,15 @@ TEST_P(ov_core_test, ov_core_compile_model) {
 
     ov_compiled_model_free(compiled_model);
     ov_model_free(model);
+    ov_core_free(core);
+}
+
+TEST_P(ov_core_test, ov_core_add_extension) {
+    ov_core_t* core = nullptr;
+    OV_EXPECT_OK(ov_core_create(&core));
+    EXPECT_NE(nullptr, core);
+
+    OV_EXPECT_OK(ov_core_add_extension(core, extension_file_path.c_str()));
     ov_core_free(core);
 }
 
@@ -720,6 +758,25 @@ TEST_P(ov_core_test, ov_core_compile_model_from_file_unicode) {
     ov_core_free(core);
 }
 #endif
+
+INSTANTIATE_TEST_SUITE_P(ov_core_gpu, ov_core_test_gpu, ::testing::Values("GPU"));
+
+TEST_P(ov_core_test_gpu, ov_core_set_get_property_gpu) {
+    auto device_name = GetParam();
+    ov_core_t* core = nullptr;
+    OV_EXPECT_OK(ov_core_create(&core));
+    EXPECT_NE(nullptr, core);
+
+    const char* key_config = "ov_property_key_intel_gpu_config_file";
+
+    OV_EXPECT_OK(ov_core_set_property(core, device_name.c_str(), key_config, TEST_CUSTOM_OP_CONFIG_PATH));
+
+    char* property_value_config = nullptr;
+    OV_EXPECT_OK(ov_core_get_property(core, device_name.c_str(), key_config, &property_value_config));
+    EXPECT_STREQ(TEST_CUSTOM_OP_CONFIG_PATH, property_value_config);
+
+    ov_core_free(core);
+}
 
 using ov_util_test = ov_core_test;
 INSTANTIATE_TEST_SUITE_P(ov_capi_test, ov_util_test, ::testing::Values("CPU"));

--- a/src/bindings/c/tests/ov_test.hpp
+++ b/src/bindings/c/tests/ov_test.hpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <openvino/util/file_util.hpp>
 
+#include "common_test_utils/file_utils.hpp"
 #include "openvino/c/openvino.h"
 #include "openvino/openvino.hpp"
 #include "test_model_repo.hpp"
@@ -31,6 +32,7 @@ public:
         TestDataHelpers::generate_test_model();
         xml_file_name = TestDataHelpers::get_model_xml_file_name();
         bin_file_name = TestDataHelpers::get_model_bin_file_name();
+        extension_file_path = get_extension_file_path();
     }
 
     void TearDown() override {
@@ -38,7 +40,11 @@ public:
     }
 
 public:
-    std::string xml_file_name, bin_file_name;
+    std::string xml_file_name, bin_file_name, extension_file_path;
+    inline std::string get_extension_file_path() {
+        return ov::util::make_plugin_library_name<char>(ov::test::utils::getExecutableDirectory(),
+                                                        std::string("openvino_template_extension") + OV_BUILD_POSTFIX);
+    }
 };
 
 inline size_t find_device(ov_available_devices_t avai_devices, const char* device_name) {


### PR DESCRIPTION
### Details:
This is to implement the c-api discussed in https://github.com/openvinotoolkit/openvino/issues/26645 and based on the previous PR (now closed) https://github.com/openvinotoolkit/openvino/pull/26670 which was failing some CI tests.

- Add `ov_core_add_extension`
- Update c-api tests
- Implemented CPU as well as GPU plugin's extension

Closes https://github.com/openvinotoolkit/openvino/issues/26645