### PR TITLE
Remove not needed include ops.hpp from template plugin

### DIFF
--- a/src/plugins/template/backend/ops/abs.cpp
+++ b/src/plugins/template/backend/ops/abs.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/abs.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/abs.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Abs>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/adaptive_avg_pool.cpp
+++ b/src/plugins/template/backend/ops/adaptive_avg_pool.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/adaptive_avg_pool.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/adaptive_avg_pool.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v8::AdaptiveAvgPool>& op,

--- a/src/plugins/template/backend/ops/adaptive_max_pool.cpp
+++ b/src/plugins/template/backend/ops/adaptive_max_pool.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/adaptive_max_pool.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/adaptive_max_pool.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v8::AdaptiveMaxPool>& op,

--- a/src/plugins/template/backend/ops/assign.cpp
+++ b/src/plugins/template/backend/ops/assign.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/assign.hpp"
+
 #include "evaluate_node.hpp"
 
 bool evaluate(const std::shared_ptr<ov::op::v3::Assign>& op,

--- a/src/plugins/template/backend/ops/avg_pool.cpp
+++ b/src/plugins/template/backend/ops/avg_pool.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/avg_pool.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/avg_pool.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::AvgPool>& op,

--- a/src/plugins/template/backend/ops/batch_norm.cpp
+++ b/src/plugins/template/backend/ops/batch_norm.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/batch_norm.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/batch_norm.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::BatchNormInference>& op,

--- a/src/plugins/template/backend/ops/binary_convolution.cpp
+++ b/src/plugins/template/backend/ops/binary_convolution.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/binary_convolution.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/binary_convolution.hpp"
 
 namespace bin_conv_v1 {
 template <ov::element::Type_t t_in, ov::element::Type_t t_f>

--- a/src/plugins/template/backend/ops/bucketize.cpp
+++ b/src/plugins/template/backend/ops/bucketize.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/bucketize.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/bucketize.hpp"
 
 namespace bucketize_v3 {
 template <ov::element::Type_t t1, ov::element::Type_t t2, ov::element::Type_t t3>

--- a/src/plugins/template/backend/ops/ceiling.cpp
+++ b/src/plugins/template/backend/ops/ceiling.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/ceiling.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/ceiling.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Ceiling>& op,

--- a/src/plugins/template/backend/ops/convert.cpp
+++ b/src/plugins/template/backend/ops/convert.cpp
@@ -6,6 +6,8 @@
 
 #include "evaluate_node.hpp"
 #include "openvino/core/type/element_iterator.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/convert_like.hpp"
 
 namespace convert {
 template <ov::element::Type_t ti, ov::element::Type_t to>

--- a/src/plugins/template/backend/ops/convert_color_nv12.cpp
+++ b/src/plugins/template/backend/ops/convert_color_nv12.cpp
@@ -5,6 +5,10 @@
 #include "openvino/reference/convert_color_nv12.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/i420_to_bgr.hpp"
+#include "openvino/op/i420_to_rgb.hpp"
+#include "openvino/op/nv12_to_bgr.hpp"
+#include "openvino/op/nv12_to_rgb.hpp"
 
 template <ov::element::Type_t ET>
 inline bool evaluate(const std::shared_ptr<ov::op::v8::NV12toRGB>& op,

--- a/src/plugins/template/backend/ops/convolution.cpp
+++ b/src/plugins/template/backend/ops/convolution.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/convolution.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/convolution.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v1::Convolution>& op,

--- a/src/plugins/template/backend/ops/convolution_backprop_data.cpp
+++ b/src/plugins/template/backend/ops/convolution_backprop_data.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/convolution_backprop_data.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/convolution.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v1::ConvolutionBackpropData>& op,

--- a/src/plugins/template/backend/ops/ctc_greedy_decoder.cpp
+++ b/src/plugins/template/backend/ops/ctc_greedy_decoder.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/ctc_greedy_decoder.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/ctc_greedy_decoder.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::CTCGreedyDecoder>& op,

--- a/src/plugins/template/backend/ops/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/template/backend/ops/ctc_greedy_decoder_seq_len.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/ctc_greedy_decoder_seq_len.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/ctc_greedy_decoder_seq_len.hpp"
 
 namespace ctc_greedy_decoder_v6 {
 template <ov::element::Type_t T1, ov::element::Type_t T2, ov::element::Type_t TOUT>

--- a/src/plugins/template/backend/ops/ctc_loss.cpp
+++ b/src/plugins/template/backend/ops/ctc_loss.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/ctc_loss.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/ctc_loss.hpp"
 
 namespace ctc_loss_v4 {
 template <

--- a/src/plugins/template/backend/ops/cum_sum.cpp
+++ b/src/plugins/template/backend/ops/cum_sum.cpp
@@ -5,6 +5,8 @@
 // clang-format off
 #include "evaluate_node.hpp"
 #include "openvino/reference/cum_sum.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/cum_sum.hpp"
 // clang-format on
 
 namespace cum_sum_v0 {

--- a/src/plugins/template/backend/ops/deformable_convolution.cpp
+++ b/src/plugins/template/backend/ops/deformable_convolution.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/deformable_convolution.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/deformable_convolution.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v8::DeformableConvolution>& op,

--- a/src/plugins/template/backend/ops/deformable_psroi_pooling.cpp
+++ b/src/plugins/template/backend/ops/deformable_psroi_pooling.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/deformable_psroi_pooling.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/deformable_psroi_pooling.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::DeformablePSROIPooling>& op,

--- a/src/plugins/template/backend/ops/detection_output.cpp
+++ b/src/plugins/template/backend/ops/detection_output.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/detection_output.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::DetectionOutput>& op,

--- a/src/plugins/template/backend/ops/divide.cpp
+++ b/src/plugins/template/backend/ops/divide.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/divide.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/divide.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::Divide>& op,

--- a/src/plugins/template/backend/ops/einsum.cpp
+++ b/src/plugins/template/backend/ops/einsum.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/einsum.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/einsum.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v7::Einsum>& op,

--- a/src/plugins/template/backend/ops/elu.cpp
+++ b/src/plugins/template/backend/ops/elu.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/elu.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/elu.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Elu>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/embedding_bag_offsets.cpp
+++ b/src/plugins/template/backend/ops/embedding_bag_offsets.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/embedding_bag_offsets.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/embeddingbag_offsets.hpp"
 
 namespace embedding_bag_offsets_v15 {
 template <ov::element::Type_t t1, ov::element::Type_t t2>

--- a/src/plugins/template/backend/ops/embedding_bag_offsets_sum.cpp
+++ b/src/plugins/template/backend/ops/embedding_bag_offsets_sum.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/embeddingbag_offsets_sum.hpp"
 #include "openvino/reference/embedding_bag_offsets.hpp"
 
 namespace embedding_bag_offsets_sum_v3 {

--- a/src/plugins/template/backend/ops/embedding_bag_packed.cpp
+++ b/src/plugins/template/backend/ops/embedding_bag_packed.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/embedding_bag_packed.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/embeddingbag_packed.hpp"
 
 namespace embedding_bag_packed_v15 {
 template <ov::element::Type_t t1, ov::element::Type_t t2>

--- a/src/plugins/template/backend/ops/embedding_bag_packed_sum.cpp
+++ b/src/plugins/template/backend/ops/embedding_bag_packed_sum.cpp
@@ -3,6 +3,8 @@
 //
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/embeddingbag_packedsum.hpp"
 #include "openvino/reference/embedding_bag_packed.hpp"
 
 namespace embedding_bag_packed_sum_v3 {

--- a/src/plugins/template/backend/ops/embedding_segments_sum.cpp
+++ b/src/plugins/template/backend/ops/embedding_segments_sum.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/embedding_segments_sum.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/embedding_segments_sum.hpp"
 
 namespace embedding_offsets_sum_v3 {
 template <ov::element::Type_t t1, ov::element::Type_t t2>

--- a/src/plugins/template/backend/ops/equal.cpp
+++ b/src/plugins/template/backend/ops/equal.cpp
@@ -6,6 +6,8 @@
 
 #include "evaluate_node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/equal.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v1::Equal>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/evaluate_node.hpp
+++ b/src/plugins/template/backend/ops/evaluate_node.hpp
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "openvino/core/except.hpp"
-#include "openvino/op/ops.hpp"
+#include "openvino/core/type/element_type.hpp"
+#include "openvino/op/select.hpp"
+#include "openvino/op/util/binary_elementwise_comparison.hpp"
 #include "openvino/runtime/tensor.hpp"
 
 template <ov::element::Type_t ET>

--- a/src/plugins/template/backend/ops/exp.cpp
+++ b/src/plugins/template/backend/ops/exp.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/exp.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/exp.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Exp>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/experimental_detectron_prior_grid_generator.cpp
+++ b/src/plugins/template/backend/ops/experimental_detectron_prior_grid_generator.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/experimental_detectron_prior_grid_generator.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/experimental_detectron_prior_grid_generator.hpp"
 
 namespace experimental_prior_grid {
 struct InfoForEDPriorGrid {

--- a/src/plugins/template/backend/ops/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/template/backend/ops/experimental_detectron_topk_rois.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/experimental_detectron_topk_rois.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/experimental_detectron_topkrois.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v6::ExperimentalDetectronTopKROIs>& op,

--- a/src/plugins/template/backend/ops/extract_image_patches.cpp
+++ b/src/plugins/template/backend/ops/extract_image_patches.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/extract_image_patches.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v3::ExtractImagePatches>& op,

--- a/src/plugins/template/backend/ops/fft.cpp
+++ b/src/plugins/template/backend/ops/fft.cpp
@@ -6,6 +6,8 @@
 
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
+#include "openvino/op/dft.hpp"
+#include "openvino/op/idft.hpp"
 
 namespace fft_v7 {
 struct InfoForFFT7 {

--- a/src/plugins/template/backend/ops/gather.cpp
+++ b/src/plugins/template/backend/ops/gather.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/gather.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/gather.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v8::Gather>& op,

--- a/src/plugins/template/backend/ops/gather_elements.cpp
+++ b/src/plugins/template/backend/ops/gather_elements.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/gather_elements.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/gather_elements.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v6::GatherElements>& op,

--- a/src/plugins/template/backend/ops/gather_nd.cpp
+++ b/src/plugins/template/backend/ops/gather_nd.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/gather_nd.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/gather_nd.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v5::GatherND>& op,

--- a/src/plugins/template/backend/ops/gather_tree.cpp
+++ b/src/plugins/template/backend/ops/gather_tree.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/gather_tree.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/gather_tree.hpp"
 
 bool evaluate(const std::shared_ptr<ov::op::v1::GatherTree>& op,
               ov::TensorVector& outputs,

--- a/src/plugins/template/backend/ops/gelu.cpp
+++ b/src/plugins/template/backend/ops/gelu.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/gelu.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Gelu>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/greater.cpp
+++ b/src/plugins/template/backend/ops/greater.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/greater.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/greater.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v1::Greater>& op,

--- a/src/plugins/template/backend/ops/grid_sample.cpp
+++ b/src/plugins/template/backend/ops/grid_sample.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/grid_sample.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t DATA_ET>
 bool evaluate(const std::shared_ptr<ov::op::v9::GridSample>& op,

--- a/src/plugins/template/backend/ops/grn.cpp
+++ b/src/plugins/template/backend/ops/grn.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/grn.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/grn.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v0::GRN>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/group_convolution.cpp
+++ b/src/plugins/template/backend/ops/group_convolution.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/group_convolution.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/group_conv.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v1::GroupConvolution>& op,

--- a/src/plugins/template/backend/ops/group_convolution_backprop_data.cpp
+++ b/src/plugins/template/backend/ops/group_convolution_backprop_data.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/group_convolution_backprop_data.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/group_conv.hpp"
 
 template <ov::element::Type_t T>
 bool evaluate(const std::shared_ptr<ov::op::v1::GroupConvolutionBackpropData>& op,

--- a/src/plugins/template/backend/ops/group_normalization.cpp
+++ b/src/plugins/template/backend/ops/group_normalization.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/group_normalization.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 #include "openvino/op/group_normalization.hpp"
 
 using namespace ov;

--- a/src/plugins/template/backend/ops/gru_cell.cpp
+++ b/src/plugins/template/backend/ops/gru_cell.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/gru_cell.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/gru_cell.hpp"
 #include "ov_ops/augru_cell.hpp"
 
 template <ov::element::Type_t ET>

--- a/src/plugins/template/backend/ops/hard_sigmoid.cpp
+++ b/src/plugins/template/backend/ops/hard_sigmoid.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/hard_sigmoid.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/hard_sigmoid.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::HardSigmoid>& op,

--- a/src/plugins/template/backend/ops/identity.cpp
+++ b/src/plugins/template/backend/ops/identity.cpp
@@ -6,6 +6,7 @@
 
 #include "evaluate_node.hpp"
 #include "openvino/core/type/element_iterator.hpp"
+#include "openvino/op/identity.hpp"
 
 template <>
 bool evaluate_node<ov::op::v16::Identity>(std::shared_ptr<ov::Node> node,

--- a/src/plugins/template/backend/ops/if.cpp
+++ b/src/plugins/template/backend/ops/if.cpp
@@ -7,6 +7,8 @@
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
 #include "openvino/core/shape_util.hpp"
+#include "openvino/op/if.hpp"
+#include "openvino/op/util/op_types.hpp"
 
 namespace if_op {
 bool call(ov::TensorVector& func_outputs,

--- a/src/plugins/template/backend/ops/irdft.cpp
+++ b/src/plugins/template/backend/ops/irdft.cpp
@@ -6,6 +6,7 @@
 
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
+#include "openvino/op/irdft.hpp"
 #include "openvino/reference/fft.hpp"
 
 namespace irfft_v9 {

--- a/src/plugins/template/backend/ops/is_finite.cpp
+++ b/src/plugins/template/backend/ops/is_finite.cpp
@@ -6,6 +6,8 @@
 
 #include "evaluate_node.hpp"
 #include "openvino/core/type/element_type.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/is_finite.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v10::IsFinite>& op,

--- a/src/plugins/template/backend/ops/is_inf.cpp
+++ b/src/plugins/template/backend/ops/is_inf.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/is_inf.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v10::IsInf>& op,

--- a/src/plugins/template/backend/ops/is_nan.cpp
+++ b/src/plugins/template/backend/ops/is_nan.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/is_nan.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/is_nan.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v10::IsNaN>& op,

--- a/src/plugins/template/backend/ops/log.cpp
+++ b/src/plugins/template/backend/ops/log.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/log.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/log.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Log>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/log_softmax.cpp
+++ b/src/plugins/template/backend/ops/log_softmax.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/log_softmax.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/log_softmax.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v5::LogSoftmax>& op,

--- a/src/plugins/template/backend/ops/lrn.cpp
+++ b/src/plugins/template/backend/ops/lrn.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/lrn.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/lrn.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::LRN>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/lstm_cell.cpp
+++ b/src/plugins/template/backend/ops/lstm_cell.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/lstm_cell.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v4::LSTMCell>& op,

--- a/src/plugins/template/backend/ops/mod.cpp
+++ b/src/plugins/template/backend/ops/mod.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/mod.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/mod.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::Mod>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/multiply.cpp
+++ b/src/plugins/template/backend/ops/multiply.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/multiply.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/multiply.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::Multiply>& op,

--- a/src/plugins/template/backend/ops/mvn.cpp
+++ b/src/plugins/template/backend/ops/mvn.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/mvn.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::MVN>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/non_max_suppression.cpp
+++ b/src/plugins/template/backend/ops/non_max_suppression.cpp
@@ -6,6 +6,7 @@
 
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
+#include "openvino/op/non_max_suppression.hpp"
 #include "openvino/runtime/tensor.hpp"
 
 namespace nms_v9 {

--- a/src/plugins/template/backend/ops/normalize_l2.cpp
+++ b/src/plugins/template/backend/ops/normalize_l2.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/normalize_l2.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/normalize_l2.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::NormalizeL2>& op,

--- a/src/plugins/template/backend/ops/ops_evaluates.hpp
+++ b/src/plugins/template/backend/ops/ops_evaluates.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "evaluate_node.hpp"
+#include "openvino/op/ops.hpp"
 #include "openvino/op/rms_norm.hpp"
 #include "ov_ops/augru_cell.hpp"
 #include "ov_ops/augru_sequence.hpp"

--- a/src/plugins/template/backend/ops/pad.cpp
+++ b/src/plugins/template/backend/ops/pad.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/pad.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/pad.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::Pad>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/prelu.cpp
+++ b/src/plugins/template/backend/ops/prelu.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/prelu.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/prelu.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::PRelu>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/proposal.cpp
+++ b/src/plugins/template/backend/ops/proposal.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/proposal.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Proposal>& op,

--- a/src/plugins/template/backend/ops/psroi_pooling.cpp
+++ b/src/plugins/template/backend/ops/psroi_pooling.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/psroi_pooling.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/psroi_pooling.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::PSROIPooling>& op,

--- a/src/plugins/template/backend/ops/rdft.cpp
+++ b/src/plugins/template/backend/ops/rdft.cpp
@@ -6,6 +6,7 @@
 
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
+#include "openvino/op/rdft.hpp"
 #include "openvino/reference/fft.hpp"
 #include "openvino/runtime/tensor.hpp"
 

--- a/src/plugins/template/backend/ops/read_value.cpp
+++ b/src/plugins/template/backend/ops/read_value.cpp
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/read_value.hpp"
+
 #include "evaluate_node.hpp"
+#include "openvino/op/read_value.hpp"
 
 bool evaluate(const std::shared_ptr<ov::op::v3::ReadValue>& op,
               ov::TensorVector& outputs,

--- a/src/plugins/template/backend/ops/reduce_mean.cpp
+++ b/src/plugins/template/backend/ops/reduce_mean.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/reduce_mean.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/reduce_mean.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v1::ReduceMean>& op,

--- a/src/plugins/template/backend/ops/region_yolo.cpp
+++ b/src/plugins/template/backend/ops/region_yolo.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/region_yolo.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/region_yolo.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::RegionYolo>& op,

--- a/src/plugins/template/backend/ops/relu.cpp
+++ b/src/plugins/template/backend/ops/relu.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/relu.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/relu.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Relu>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/reorg_yolo.cpp
+++ b/src/plugins/template/backend/ops/reorg_yolo.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/reorg_yolo.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/reorg_yolo.hpp"
 
 bool evaluate(const std::shared_ptr<ov::op::v0::ReorgYolo>& op,
               ov::TensorVector& outputs,

--- a/src/plugins/template/backend/ops/reverse_sequence.cpp
+++ b/src/plugins/template/backend/ops/reverse_sequence.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/reverse_sequence.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/reverse_sequence.hpp"
 
 namespace reverse_sequence_v0 {
 template <ov::element::Type_t t1, ov::element::Type_t t2>

--- a/src/plugins/template/backend/ops/rnn_cell.cpp
+++ b/src/plugins/template/backend/ops/rnn_cell.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/rnn_cell.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/rnn_cell.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::RNNCell>& op,

--- a/src/plugins/template/backend/ops/roi_align.cpp
+++ b/src/plugins/template/backend/ops/roi_align.cpp
@@ -6,6 +6,7 @@
 
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v9::ROIAlign>& op,

--- a/src/plugins/template/backend/ops/roi_align_rotated.cpp
+++ b/src/plugins/template/backend/ops/roi_align_rotated.cpp
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "openvino/op/roi_align_rotated.hpp"
+
 #include "evaluate_node.hpp"
 #include "evaluates_map.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 #include "openvino/op/roi_align.hpp"
+#include "openvino/op/roi_align_rotated.hpp"
 #include "openvino/reference/roi_align.hpp"
 
 template <ov::element::Type_t ET>

--- a/src/plugins/template/backend/ops/roi_pooling.cpp
+++ b/src/plugins/template/backend/ops/roi_pooling.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/roi_pooling.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/roi_pooling.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::ROIPooling>& op,

--- a/src/plugins/template/backend/ops/roll.cpp
+++ b/src/plugins/template/backend/ops/roll.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/roll.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/roll.hpp"
 
 bool evaluate(const std::shared_ptr<ov::op::v7::Roll>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {
     const auto& shiftType = inputs[1].get_element_type();

--- a/src/plugins/template/backend/ops/scatter_nd_update.cpp
+++ b/src/plugins/template/backend/ops/scatter_nd_update.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/scatter_nd_update.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v3::ScatterNDUpdate>& op,

--- a/src/plugins/template/backend/ops/search_sorted.cpp
+++ b/src/plugins/template/backend/ops/search_sorted.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/search_sorted.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/search_sorted.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v15::SearchSorted>& op,

--- a/src/plugins/template/backend/ops/selu.cpp
+++ b/src/plugins/template/backend/ops/selu.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/selu.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/selu.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Selu>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/sequences.cpp
+++ b/src/plugins/template/backend/ops/sequences.cpp
@@ -6,6 +6,10 @@
 #include "evaluate_node.hpp"
 #include "ov_ops/augru_sequence.hpp"
 #include "openvino/reference/sequences.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/gru_sequence.hpp"
+#include "openvino/op/lstm_sequence.hpp"
+#include "openvino/op/rnn_sequence.hpp"
 // clang-format on
 
 namespace rnn_seq_v5 {

--- a/src/plugins/template/backend/ops/sigmoid.cpp
+++ b/src/plugins/template/backend/ops/sigmoid.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/sigmoid.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/sigmoid.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Sigmoid>& op,

--- a/src/plugins/template/backend/ops/sign.cpp
+++ b/src/plugins/template/backend/ops/sign.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/sign.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/sign.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Sign>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/softsign.cpp
+++ b/src/plugins/template/backend/ops/softsign.cpp
@@ -5,6 +5,7 @@
 #include "openvino/reference/softsign.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/softsign.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v9::SoftSign>& op,

--- a/src/plugins/template/backend/ops/squared_difference.cpp
+++ b/src/plugins/template/backend/ops/squared_difference.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/squared_difference.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/squared_difference.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::SquaredDifference>& op,

--- a/src/plugins/template/backend/ops/tanh.cpp
+++ b/src/plugins/template/backend/ops/tanh.cpp
@@ -5,6 +5,8 @@
 #include "openvino/reference/tanh.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/core/type/element_type_traits.hpp"
+#include "openvino/op/tanh.hpp"
 
 template <ov::element::Type_t ET>
 bool evaluate(const std::shared_ptr<ov::op::v0::Tanh>& op, ov::TensorVector& outputs, const ov::TensorVector& inputs) {

--- a/src/plugins/template/backend/ops/tensor_iterator.cpp
+++ b/src/plugins/template/backend/ops/tensor_iterator.cpp
@@ -6,6 +6,7 @@
 
 #include "backend.hpp"
 #include "evaluate_node.hpp"
+#include "openvino/op/tensor_iterator.hpp"
 
 namespace ti_v0 {
 ov::reference::custom_evaluate_function evaluate =

--- a/src/plugins/template/backend/ops/unique.cpp
+++ b/src/plugins/template/backend/ops/unique.cpp
@@ -5,6 +5,9 @@
 #include "openvino/reference/unique.hpp"
 
 #include "evaluate_node.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/unique.hpp"
+#include "openvino/op/util/op_types.hpp"
 
 template <typename Data_t, typename Index_t, typename Count_t>
 void execute_unique(ov::TensorVector& outputs,


### PR DESCRIPTION
### Details:
 - Removed unnecessary include ops.hpp
 - Added missing includes

### Tickets:
 - CVS-165533
