### PR TITLE
[GPU] Fix unit tests failing for BMG

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3544,7 +3544,7 @@ public:
 
         auto output = net.execute();
         auto out_mem = output.at("output").get_memory();
-        cldnn::mem_lock<OutputT> out_ptr(out_mem, get_test_stream());
+        mem_lock<OutputT, mem_lock_type::read> out_ptr(out_mem, get_test_stream());
 
         for (size_t bi = 0; bi < batch_num(); ++bi) {
             for (size_t fi = 0; fi < output_f(); ++fi) {
@@ -4425,7 +4425,7 @@ struct dynamic_fully_connected_gpu : ::testing::TestWithParam<fully_connected_dy
             ASSERT_EQ(out_l.spatial(0), 1);
             ASSERT_EQ(out_l.spatial(1), fc_3d ? output_f : 1);
 
-            cldnn::mem_lock<OutputT> output_ptr(output_prim_mem, get_test_stream());
+            mem_lock<OutputT, mem_lock_type::read> output_ptr(output_prim_mem, get_test_stream());
 
             auto ref_result = dynamic_fully_connected_reference_calc<OutputT>(batch_size,
                                                                               input_f,

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -2623,7 +2623,7 @@ public:
         }
         auto outputs = network->execute();
         auto output = outputs.at("reorder_bfyx").get_memory();
-        cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+        mem_lock<float, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         const float threshold_int8 = 1.f;
         const float threshold_fp16 = 1e-1;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -2872,7 +2872,7 @@ public:
         auto outputs = network->execute();
 
         auto output = outputs.at("gemm").get_memory();
-        cldnn::mem_lock<ov::float16> output_ptr(output, get_test_stream());
+        cldnn::mem_lock<ov::float16, mem_lock_type::read> output_ptr(output, get_test_stream());
 
         ASSERT_EQ(output_ptr.size(), (uint32_t)3);
         for (uint32_t i = 0; i < out_data.size(); ++i) {
@@ -3089,8 +3089,8 @@ public:
 
         auto ref_res = get_ref_results();
 
-        mem_lock<ov::float16> res_lock(res, get_test_stream());
-        mem_lock<ov::float16> res_ref_lock(ref_res, get_test_stream());
+        mem_lock<ov::float16, mem_lock_type::read> res_lock(res, get_test_stream());
+        mem_lock<ov::float16, mem_lock_type::read> res_ref_lock(ref_res, get_test_stream());
         for (size_t i = 0; i < res->count(); i++) {
             ASSERT_EQ(res_lock[i], res_ref_lock[i]) << i;
         }
@@ -3225,8 +3225,8 @@ public:
 
         auto ref_res = get_ref_results();
 
-        mem_lock<ov::float16> res_lock(res, get_test_stream());
-        mem_lock<ov::float16> res_ref_lock(ref_res, get_test_stream());
+        mem_lock<ov::float16, mem_lock_type::read> res_lock(res, get_test_stream());
+        mem_lock<ov::float16, mem_lock_type::read> res_ref_lock(ref_res, get_test_stream());
         for (size_t i = 0; i < res->count(); i++) {
             ASSERT_EQ(res_lock[i], res_ref_lock[i]) << i;
         }
@@ -3240,7 +3240,7 @@ public:
 
         auto res_onednn = engine.reinterpret_buffer(*output_mem_onednn, output_layout_onednn);
 
-        mem_lock<ov::float16> res_lock_onednn(res_onednn, get_test_stream());
+        mem_lock<ov::float16, mem_lock_type::read> res_lock_onednn(res_onednn, get_test_stream());
         for (size_t i = 0; i < res->count(); i++) {
             ASSERT_EQ(res_lock_onednn[i], res_ref_lock[i]) << i;
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -213,7 +213,7 @@ TEST(group_normalization, input_bfyx_output_fsv16) {
 
     auto outputs_g = network_g.execute();
     auto output_g = outputs_g.at("output").get_memory();
-    cldnn::mem_lock<float> output_mem_g(output_g, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_mem_g(output_g, get_test_stream());
 
     // Disable mem reuse to avoid wrong reuse due to not calculating of memory dependencies in the below model creation flow
     config.set_property(ov::intel_gpu::enable_memory_pool(false));
@@ -230,7 +230,7 @@ TEST(group_normalization, input_bfyx_output_fsv16) {
 
     auto outputs_t = network_t.execute();
     auto output_t = outputs_g.at("output").get_memory();
-    cldnn::mem_lock<float> output_mem_t(output_t, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_mem_t(output_t, get_test_stream());
 
     ASSERT_EQ(output_mem_g.size(), output_mem_t.size());
     ASSERT_EQ(outputs_g.begin()->first, outputs_t.begin()->first);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/paged_attention_gpu_test.cpp
@@ -644,7 +644,7 @@ private:
         OPENVINO_ASSERT(scores_output->count() == static_cast<size_t>(num_heads * num_queries * num_keys));
 
         std::vector<ov::float16> output_scores(num_keys, 0);
-        mem_lock<ov::float16> mem_ptr(scores_output, test_stream);
+        mem_lock<ov::float16, mem_lock_type::read> mem_ptr(scores_output, test_stream);
         for (int head_idx = 0; head_idx < num_heads; head_idx++) {
             for (int score_idx = 0; score_idx < num_keys; score_idx++) {
                 output_scores[score_idx] += mem_ptr[head_idx * num_queries * num_keys +
@@ -663,7 +663,7 @@ private:
         OPENVINO_ASSERT(data_output->count() == static_cast<size_t>(num_queries * num_heads * head_size));
 
         std::vector<ov::float16> output_data(data_output->count());
-        mem_lock<ov::float16> mem_ptr(data_output, test_stream);
+        mem_lock<ov::float16, mem_lock_type::read> mem_ptr(data_output, test_stream);
         for (size_t i = 0; i < data_output->count(); i++)
             output_data[i] = mem_ptr[i];
 
@@ -975,7 +975,7 @@ public:
     void compare(memory::ptr data_output_mem, memory::ptr scores_output_mem, std::pair<std::vector<ov::float16>, std::vector<ov::float16>> ref_data) {
         if (data_output_mem) {
             ASSERT_EQ(data_output_mem->count(), ref_data.first.size());
-            mem_lock<ov::float16> mem_ptr(data_output_mem, get_test_stream());
+            mem_lock<ov::float16, mem_lock_type::read> mem_ptr(data_output_mem, get_test_stream());
             for (size_t i = 0; i < data_output_mem->count(); i++) {
                 ASSERT_NEAR(mem_ptr[i], ref_data.first[i], tolerance);
             }
@@ -983,7 +983,7 @@ public:
 
         if (scores_output_mem) {
             ASSERT_EQ(scores_output_mem->count(), ref_data.second.size());
-            mem_lock<ov::float16> mem_ptr(scores_output_mem, get_test_stream());
+            mem_lock<ov::float16, mem_lock_type::read> mem_ptr(scores_output_mem, get_test_stream());
             for (size_t i = 0; i < scores_output_mem->count(); i++) {
                 ASSERT_NEAR(mem_ptr[i], ref_data.second[i], tolerance);
             }

--- a/src/plugins/intel_gpu/tests/unit/test_utils/network_test.h
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/network_test.h
@@ -104,7 +104,7 @@ struct reference_tensor_typed<T, 2> : reference_tensor {
     reference_tensor_typed(vector_type data) : reference(std::move(data)) {}
 
     void compare(cldnn::memory::ptr actual) override {
-        cldnn::mem_lock<T> ptr(actual, get_test_stream());
+        mem_lock<T, mem_lock_type::read> ptr(actual, get_test_stream());
         for (size_t bi = 0; bi < reference.size(); ++bi) {
             for (size_t fi = 0; fi < reference[0].size(); ++fi) {
                 auto coords = cldnn::tensor(cldnn::batch(bi), cldnn::feature(fi), cldnn::spatial(0, 0, 0, 0));

--- a/src/plugins/intel_gpu/tests/unit/test_utils/network_test.h
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/network_test.h
@@ -139,7 +139,7 @@ struct reference_tensor_typed<T, 4> : reference_tensor {
     using vector_type = VVVVF<T>;
     reference_tensor_typed(vector_type data) : reference(std::move(data)) {}
     void compare(cldnn::memory::ptr actual) override {
-        cldnn::mem_lock<T> ptr(actual, get_test_stream());
+        cldnn::mem_lock<T, mem_lock_type::read> ptr(actual, get_test_stream());
         for (size_t bi = 0; bi < reference.size(); ++bi) {
             for (size_t fi = 0; fi < reference[0].size(); ++fi) {
                 for (size_t yi = 0; yi < reference[0][0].size(); ++yi) {


### PR DESCRIPTION
### Details:
 - fix fails introduced by using device memory on output which can't do read-write lock
- fails introduced by 6db49399ba762c7b838c0ad07a6561c5e96fcac0
### Tickets:
 - 164934
