### PR TITLE
[core] OV model class clean-up

### DIFF
--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -332,24 +332,14 @@ public:
      *
      * @return constant reference to value from runtime info
      */
-    template <class T, class... Args, typename std::enable_if<!std::is_same<T, ov::Any>::value, bool>::type = true>
+    template <class T, class... Args>
     const T& get_rt_info(Args... args) const {
         const ov::Any& arg = get_rt_arg<Args...>(m_rt_info, args...);
-        return arg.as<T>();
-    }
-    /**
-     * @brief Returns a runtime attribute for the path, throws an ov::Exception if path doesn't exist
-     *
-     * @tparam T the type of returned value
-     * @tparam Args types of variadic arguments
-     * @param args path to the runtime attribute
-     *
-     * @return constant reference to value from runtime info
-     */
-    template <class T, class... Args, typename std::enable_if<std::is_same<T, ov::Any>::value, bool>::type = true>
-    const T& get_rt_info(Args... args) const {
-        const ov::Any& arg = get_rt_arg<Args...>(m_rt_info, args...);
-        return arg;
+        if constexpr (std::is_same_v<T, ov::Any>) {
+            return arg;
+        } else {
+            return arg.as<T>();
+        }
     }
 
     /**
@@ -360,24 +350,14 @@ public:
      *
      * @return constant reference to value from runtime info
      */
-    template <class T, typename std::enable_if<!std::is_same<T, ov::Any>::value, bool>::type = true>
+    template <class T>
     const T& get_rt_info(const std::vector<std::string>& args) const {
         const ov::Any& arg = get_rt_info(m_rt_info, args.cbegin(), args.cend());
-        return arg.as<T>();
-    }
-
-    /**
-     * @brief Returns a runtime attribute for the path, throws an ov::Exception if path doesn't exist
-     *
-     * @tparam T the type of returned value
-     * @param args vector with path to the runtime attribute
-     *
-     * @return constant reference to value from runtime info
-     */
-    template <class T, typename std::enable_if<std::is_same<T, ov::Any>::value, bool>::type = true>
-    const T& get_rt_info(const std::vector<std::string>& args) const {
-        const ov::Any& arg = get_rt_info(m_rt_info, args.cbegin(), args.cend());
-        return arg;
+        if constexpr (std::is_same_v<T, ov::Any>) {
+            return arg;
+        } else {
+            return arg.as<T>();
+        }
     }
 
     /**
@@ -452,20 +432,20 @@ private:
                      const std::vector<std::string>::const_iterator& end) const;
 
     // Checks rt attribute
-    template <class T,
-              typename std::enable_if<std::is_same<std::string, T>::value || std::is_same<T, const char*>::value ||
-                                          std::is_same<T, char*>::value,
-                                      bool>::type = true>
+    template <
+        class T,
+        std::enable_if_t<std::is_same_v<std::string, T> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>,
+                         bool> = true>
     bool has_rt_arg(const ov::AnyMap& rt_info, const T& name) const {
         return rt_info.find(name) != rt_info.end();
     }
 
     // Checks rt attribute
-    template <class T,
-              class... Args,
-              typename std::enable_if<std::is_same<std::string, T>::value || std::is_same<T, const char*>::value ||
-                                          std::is_same<T, char*>::value,
-                                      bool>::type = true>
+    template <
+        class T,
+        class... Args,
+        std::enable_if_t<std::is_same_v<std::string, T> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>,
+                         bool> = true>
     bool has_rt_arg(const ov::AnyMap& rt_info, const T& name, Args... args) const {
         bool has_attr = has_rt_arg(rt_info, name);
         if (!has_attr)
@@ -476,10 +456,10 @@ private:
     }
 
     // Allow to get constant attribute for variadic arguments
-    template <class T,
-              typename std::enable_if<std::is_same<std::string, T>::value || std::is_same<T, const char*>::value ||
-                                          std::is_same<T, char*>::value,
-                                      bool>::type = true>
+    template <
+        class T,
+        std::enable_if_t<std::is_same_v<std::string, T> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>,
+                         bool> = true>
     const ov::Any& get_rt_arg(const ov::AnyMap& rt_info, const T& name) const {
         OPENVINO_ASSERT(rt_info.find(name) != rt_info.end(),
                         "Cannot get runtime attribute. Path to runtime attribute is incorrect.");
@@ -487,11 +467,11 @@ private:
     }
 
     // Allow to get constant attribute for variadic arguments
-    template <class T,
-              class... Args,
-              typename std::enable_if<std::is_same<std::string, T>::value || std::is_same<T, const char*>::value ||
-                                          std::is_same<T, char*>::value,
-                                      bool>::type = true>
+    template <
+        class T,
+        class... Args,
+        std::enable_if_t<std::is_same_v<std::string, T> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>,
+                         bool> = true>
     const ov::Any& get_rt_arg(const ov::AnyMap& rt_info, const T& name, Args... args) const {
         const ov::Any& rt_attr = get_rt_arg<T>(rt_info, name);
         const ov::AnyMap& new_map = get_map_from_attr(rt_attr);
@@ -499,20 +479,20 @@ private:
     }
 
     // Allow to get attribute for variadic arguments
-    template <class T,
-              typename std::enable_if<std::is_same<std::string, T>::value || std::is_same<T, const char*>::value ||
-                                          std::is_same<T, char*>::value,
-                                      bool>::type = true>
+    template <
+        class T,
+        std::enable_if_t<std::is_same_v<std::string, T> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>,
+                         bool> = true>
     ov::Any& get_rt_arg(ov::AnyMap& rt_info, const T& name) {
         return get_attr(rt_info[name]);
     }
 
     // Allow to get attribute for variadic arguments
-    template <class T,
-              class... Args,
-              typename std::enable_if<std::is_same<std::string, T>::value || std::is_same<T, const char*>::value ||
-                                          std::is_same<T, char*>::value,
-                                      bool>::type = true>
+    template <
+        class T,
+        class... Args,
+        std::enable_if_t<std::is_same_v<std::string, T> || std::is_same_v<T, const char*> || std::is_same_v<T, char*>,
+                         bool> = true>
     ov::Any& get_rt_arg(ov::AnyMap& rt_info, const T& name, Args... args) {
         ov::Any& rt_attr = get_rt_arg<T>(rt_info, name);
         ov::AnyMap& new_map = get_map_from_attr(rt_attr);
@@ -539,7 +519,6 @@ private:
     static std::atomic<size_t> m_next_instance_id;
     std::string m_name;
     const std::string m_unique_name;
-    size_t m_placement{0};
     topological_sort_t m_topological_sorter;
 
     ov::ResultVector m_results;


### PR DESCRIPTION
### Details:
- Use new cpp features in template member functions
- Clean-up ov::Model ctors to re-use as much as possible (bin-size reduction)

### Tickets:
 - part of CVS-72662
