### PR TITLE
[C API] Implement `ov_tensor_set_string_data` c-api

### DIFF
--- a/src/bindings/c/docs/api_overview.md
+++ b/src/bindings/c/docs/api_overview.md
@@ -1108,6 +1108,14 @@ This struct provides an interface to infer requests of `ov_compiled_model_t` and
     - `data` - A point to host memory.
   -  Return value: Status code of the operation: OK(0) for success.
 
+- `ov_status_e ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, size_t array_size)`
+  - Description: Set string data for tensor
+  - Parameters:
+    - `tensor` - A point to ov_tensor_t
+    - `string_array` - String array
+    - `array_size` - Number of elements in string array
+  -  Return value: Status code of the operation: OK(0) for success.
+
 - `void ov_tensor_free(ov_tensor_t* tensor)`
   - Description: Free ov_tensor_t.
   - Parameters:

--- a/src/bindings/c/include/openvino/c/ov_tensor.h
+++ b/src/bindings/c/include/openvino/c/ov_tensor.h
@@ -85,7 +85,7 @@ ov_tensor_get_element_type(const ov_tensor_t* tensor, ov_element_type_e* type);
  * @param tensor A point to ov_tensor_t
  */
 OPENVINO_C_API(ov_status_e)
-ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, size_t array_size);
+ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, const size_t array_size);
 
 /**
  * @brief the total number of elements (a product of all the dims or 1 for scalar).

--- a/src/bindings/c/include/openvino/c/ov_tensor.h
+++ b/src/bindings/c/include/openvino/c/ov_tensor.h
@@ -78,6 +78,16 @@ OPENVINO_C_API(ov_status_e)
 ov_tensor_get_element_type(const ov_tensor_t* tensor, ov_element_type_e* type);
 
 /**
+ * @brief Set string data for tensor
+ * @ingroup ov_tensor_c_api
+ * @param string_array Array of strings
+ * @param array_size Size of the array
+ * @param tensor A point to ov_tensor_t
+ */
+OPENVINO_C_API(ov_status_e)
+ov_tensor_set_string(ov_tensor_t* tensor, const char** string_array, size_t array_size);
+
+/**
  * @brief the total number of elements (a product of all the dims or 1 for scalar).
  * @ingroup ov_tensor_c_api
  * @param elements_size number of elements

--- a/src/bindings/c/include/openvino/c/ov_tensor.h
+++ b/src/bindings/c/include/openvino/c/ov_tensor.h
@@ -85,7 +85,7 @@ ov_tensor_get_element_type(const ov_tensor_t* tensor, ov_element_type_e* type);
  * @param tensor A point to ov_tensor_t
  */
 OPENVINO_C_API(ov_status_e)
-ov_tensor_set_string(ov_tensor_t* tensor, const char** string_array, size_t array_size);
+ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, size_t array_size);
 
 /**
  * @brief the total number of elements (a product of all the dims or 1 for scalar).

--- a/src/bindings/c/src/ov_tensor.cpp
+++ b/src/bindings/c/src/ov_tensor.cpp
@@ -109,6 +109,30 @@ ov_status_e ov_tensor_get_shape(const ov_tensor_t* tensor, ov_shape_t* shape) {
     return ov_status_e::OK;
 }
 
+ov_status_e ov_tensor_set_string(ov_tensor_t* tensor, const char** string_array, size_t array_size) {
+    if (!tensor || !string_array || array_size == 0 || tensor->object->get_element_type() != ov::element::string ) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+    try {
+        if (tensor->object->get_element_type() != ov::element::string) {
+            return ov_status_e::INVALID_C_PARAM;
+        }
+        const size_t tensor_size = tensor->object->get_size();
+        if (tensor_size != array_size) {
+            return ov_status_e::INVALID_C_PARAM;
+        }
+        std::string* tensor_data = tensor->object->data<std::string>();
+        for (size_t i = 0; i < array_size; ++i) {
+            if (!string_array[i]) {
+                return ov_status_e::INVALID_C_PARAM;
+            }
+            tensor_data[i] = std::string(string_array[i]);
+        }
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
 ov_status_e ov_tensor_get_element_type(const ov_tensor_t* tensor, ov_element_type_e* type) {
     if (!tensor || !type) {
         return ov_status_e::INVALID_C_PARAM;

--- a/src/bindings/c/src/ov_tensor.cpp
+++ b/src/bindings/c/src/ov_tensor.cpp
@@ -109,8 +109,8 @@ ov_status_e ov_tensor_get_shape(const ov_tensor_t* tensor, ov_shape_t* shape) {
     return ov_status_e::OK;
 }
 
-ov_status_e ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, size_t array_size) {
-    if (!tensor || !string_array || array_size == 0 || tensor->object->get_element_type() != ov::element::string ||
+ov_status_e ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, const size_t array_size) {
+    if (!tensor || !string_array || tensor->object->get_element_type() != ov::element::string ||
         tensor->object->get_size() != array_size) {
         return ov_status_e::INVALID_C_PARAM;
     }

--- a/src/bindings/c/src/ov_tensor.cpp
+++ b/src/bindings/c/src/ov_tensor.cpp
@@ -109,25 +109,18 @@ ov_status_e ov_tensor_get_shape(const ov_tensor_t* tensor, ov_shape_t* shape) {
     return ov_status_e::OK;
 }
 
-ov_status_e ov_tensor_set_string(ov_tensor_t* tensor, const char** string_array, size_t array_size) {
-    if (!tensor || !string_array || array_size == 0 || tensor->object->get_element_type() != ov::element::string ) {
+ov_status_e ov_tensor_set_string_data(ov_tensor_t* tensor, const char** string_array, size_t array_size) {
+    if (!tensor || !string_array || array_size == 0 || tensor->object->get_element_type() != ov::element::string ||
+        tensor->object->get_size() != array_size) {
         return ov_status_e::INVALID_C_PARAM;
     }
     try {
-        if (tensor->object->get_element_type() != ov::element::string) {
-            return ov_status_e::INVALID_C_PARAM;
-        }
-        const size_t tensor_size = tensor->object->get_size();
-        if (tensor_size != array_size) {
-            return ov_status_e::INVALID_C_PARAM;
-        }
-        std::string* tensor_data = tensor->object->data<std::string>();
         for (size_t i = 0; i < array_size; ++i) {
             if (!string_array[i]) {
                 return ov_status_e::INVALID_C_PARAM;
             }
-            tensor_data[i] = std::string(string_array[i]);
         }
+        std::copy_n(string_array, array_size, tensor->object->data<std::string>());
     }
     CATCH_OV_EXCEPTIONS
     return ov_status_e::OK;

--- a/src/bindings/c/tests/ov_tensor_test.cpp
+++ b/src/bindings/c/tests/ov_tensor_test.cpp
@@ -81,7 +81,6 @@ protected:
         ov_tensor_free(tensor);
     }
 
-public:
     ov_shape_t shape;
     ov_tensor_t* tensor;
 };
@@ -161,6 +160,14 @@ TEST_P(ov_tensor_create_test, set_tensor_shape) {
 }
 
 TEST_F(ov_string_tensor_create_test, set_tensor_string) {
-    const char* string_array[4] = {"hello", "hi", "world", "yes"};
-    OV_EXPECT_OK(ov_tensor_set_string_data(tensor, string_array, 4));
+    const size_t number_of_strings = 4;
+    const char* string_array[number_of_strings] = {"hello", "hi", "world", ""};
+    OV_EXPECT_OK(ov_tensor_set_string_data(tensor, string_array, number_of_strings));
+    void* output_data = NULL;
+    ov_tensor_data(tensor, &output_data);
+    auto string_data = static_cast<std::string*>(output_data);
+    for (size_t i = 0; i < number_of_strings; ++i) {
+        const std::string& current_string = string_data[i];
+        EXPECT_EQ(current_string, std::string(string_array[i]));
+    }
 }

--- a/src/bindings/c/tests/ov_tensor_test.cpp
+++ b/src/bindings/c/tests/ov_tensor_test.cpp
@@ -67,6 +67,26 @@ public:
     ov_tensor_t* tensor;
 };
 
+class ov_string_tensor_create_test : public ::testing::TestWithParam<ov_element_type_e> {
+protected:
+    void SetUp() override {
+        tensor = nullptr;
+        int64_t dims[1] = {1};
+        ov_shape_create(1, dims, &shape);
+        OV_EXPECT_OK(ov_tensor_create(ov_element_type_e::STRING, shape, &tensor));
+        EXPECT_NE(nullptr, tensor);
+    }
+
+    void TearDown() override {
+        ov_shape_free(&shape);
+        ov_tensor_free(tensor);
+    }
+
+public:
+    ov_shape_t shape;
+    ov_tensor_t* tensor;
+};
+
 INSTANTIATE_TEST_SUITE_P(ov_tensor,
                          ov_tensor_create_test,
                          ::testing::Values(ov_element_type_e::BOOLEAN,
@@ -85,6 +105,10 @@ INSTANTIATE_TEST_SUITE_P(ov_tensor,
                                            ov_element_type_e::U16,
                                            ov_element_type_e::U32,
                                            ov_element_type_e::U64));
+
+INSTANTIATE_TEST_SUITE_P(ov_tensor,
+                         ov_string_tensor_create_test,
+                         ::testing::Values(ov_element_type_e::STRING));
 
 TEST_P(ov_tensor_create_test, get_tensor_element_type) {
     ov_element_type_e type = GetParam();
@@ -139,4 +163,15 @@ TEST_P(ov_tensor_create_test, set_tensor_shape) {
 
     ov_shape_free(&shape_update);
     ov_shape_free(&shape_res);
+}
+
+TEST_P(ov_string_tensor_create_test, set_tensor_string) {
+    const char* string_array[3] = {"hello", "hi", "world"};
+    size_t array_size = 3;
+    ov_shape_t shape;
+    int64_t dims[1] = {1};
+    ov_shape_create(3, dims, &shape);
+    OV_EXPECT_OK(ov_tensor_set_shape(tensor, shape));
+    OV_EXPECT_OK(ov_tensor_set_string(tensor, string_array, array_size));
+    
 }

--- a/src/bindings/c/tests/ov_tensor_test.cpp
+++ b/src/bindings/c/tests/ov_tensor_test.cpp
@@ -67,12 +67,11 @@ public:
     ov_tensor_t* tensor;
 };
 
-class ov_string_tensor_create_test : public ::testing::TestWithParam<ov_element_type_e> {
+class ov_string_tensor_create_test : public ::testing::Test {
 protected:
     void SetUp() override {
         tensor = nullptr;
-        int64_t dims[1] = {1};
-        ov_shape_create(1, dims, &shape);
+        setup_4d_shape(&shape, 4, 1, 1, 1);
         OV_EXPECT_OK(ov_tensor_create(ov_element_type_e::STRING, shape, &tensor));
         EXPECT_NE(nullptr, tensor);
     }
@@ -105,10 +104,6 @@ INSTANTIATE_TEST_SUITE_P(ov_tensor,
                                            ov_element_type_e::U16,
                                            ov_element_type_e::U32,
                                            ov_element_type_e::U64));
-
-INSTANTIATE_TEST_SUITE_P(ov_tensor,
-                         ov_string_tensor_create_test,
-                         ::testing::Values(ov_element_type_e::STRING));
 
 TEST_P(ov_tensor_create_test, get_tensor_element_type) {
     ov_element_type_e type = GetParam();
@@ -165,13 +160,7 @@ TEST_P(ov_tensor_create_test, set_tensor_shape) {
     ov_shape_free(&shape_res);
 }
 
-TEST_P(ov_string_tensor_create_test, set_tensor_string) {
-    const char* string_array[3] = {"hello", "hi", "world"};
-    size_t array_size = 3;
-    ov_shape_t shape;
-    int64_t dims[1] = {1};
-    ov_shape_create(3, dims, &shape);
-    OV_EXPECT_OK(ov_tensor_set_shape(tensor, shape));
-    OV_EXPECT_OK(ov_tensor_set_string(tensor, string_array, array_size));
-    
+TEST_F(ov_string_tensor_create_test, set_tensor_string) {
+    const char* string_array[4] = {"hello", "hi", "world", "yes"};
+    OV_EXPECT_OK(ov_tensor_set_string_data(tensor, string_array, 4));
 }


### PR DESCRIPTION
### Details:
Related to https://github.com/openvinotoolkit/openvino/issues/26906
This implements c-api for setting string tensor data for previously initialized string type tensor.
This API is needed since string data can't be set using existing `ov_tensor_data`
