### PR TITLE
[core] Use std::filesystem::path in ov::pass::Serialize

### DIFF
--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -137,6 +137,13 @@ bool is_absolute_file_path(const std::string& path);
  */
 void create_directory_recursive(const std::string& path);
 
+/**
+ * @brief Interface function to create directories recursively by given path
+ * @param path - path to file, can be relative to current working directory
+ * @throw runtime_error if any error occurred
+ */
+void create_directory_recursive(const std::filesystem::path& path);
+
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 /**
  * @brief Interface function to create directorty recursively by given path

--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -287,41 +287,21 @@ bool ov::util::is_absolute_file_path(const std::string& path) {
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 void ov::util::create_directory_recursive(const std::wstring& path) {
-    if (path.empty() || directory_exists(path)) {
-        return;
-    }
-
-    std::size_t pos = path.rfind(ov::util::FileTraits<wchar_t>::file_separator);
-    if (pos != std::wstring::npos) {
-        create_directory_recursive(path.substr(0, pos));
-    }
-
-    int err = wmakedir(path);
-    if (err != 0 && errno != EEXIST) {
-        std::stringstream ss;
-        // TODO: in case of exception it may be needed to remove all created sub-directories
-        ss << "Couldn't create directory [" << ov::util::wstring_to_string(path) << "], err=" << strerror(errno) << ")";
-        throw std::runtime_error(ss.str());
-    }
+    create_directory_recursive(std::filesystem::path{path});
 }
 #endif
 
 void ov::util::create_directory_recursive(const std::string& path) {
-    if (path.empty() || directory_exists(path)) {
-        return;
-    }
+    create_directory_recursive(std::filesystem::path{path});
+}
 
-    std::size_t pos = path.rfind(ov::util::FileTraits<char>::file_separator);
-    if (pos != std::string::npos) {
-        create_directory_recursive(path.substr(0, pos));
-    }
-
-    int err = makedir(path);
-    if (err != 0 && errno != EEXIST) {
-        std::stringstream ss;
-        // TODO: in case of exception it may be needed to remove all created sub-directories
-        ss << "Couldn't create directory [" << path << "], err=" << strerror(errno) << ")";
-        throw std::runtime_error(ss.str());
+void ov::util::create_directory_recursive(const std::filesystem::path& dir_path) {
+    if (!directory_exists(dir_path)) {
+        if (std::error_code ec; !std::filesystem::create_directories(dir_path, ec)) {
+            std::stringstream ss;
+            ss << "Couldn't create directory [" << dir_path.string() << "], err=" << ec.message() << ")";
+            throw std::runtime_error(ss.str());
+        }
     }
 }
 

--- a/src/core/include/openvino/pass/serialize.hpp
+++ b/src/core/include/openvino/pass/serialize.hpp
@@ -34,18 +34,15 @@ public:
 
     Serialize(std::ostream& xmlFile, std::ostream& binFile, Version version = Version::UNSPECIFIED);
 
-    Serialize(const std::string& xmlPath, const std::string& binPath, Version version = Version::UNSPECIFIED);
-
     Serialize(const std::filesystem::path& xmlPath,
               const std::filesystem::path& binPath,
-              Version version = Version::UNSPECIFIED)
-        : Serialize(xmlPath.string(), binPath.string(), version) {}
+              Version version = Version::UNSPECIFIED);
 
 private:
     std::ostream* m_xmlFile;
     std::ostream* m_binFile;
-    const std::string m_xmlPath;
-    const std::string m_binPath;
+    const std::filesystem::path m_xmlPath;
+    const std::filesystem::path m_binPath;
     const Version m_version;
     const std::map<std::string, ov::OpSet> m_custom_opsets;
 };

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1243,26 +1243,22 @@ void ngfunction_2_ir(pugi::xml_node& netXml,
     }
 }
 
-std::string valid_xml_path(const std::string& path) {
-    OPENVINO_ASSERT(path.length() > 4, "Path for xml file is too short: \"" + path + "\"");
-
-    const char* const extension = ".xml";
-    const bool has_xml_extension = path.rfind(extension) == path.size() - std::strlen(extension);
-    OPENVINO_ASSERT(has_xml_extension,
-                    "Path for xml file doesn't contains file name with 'xml' extension: \"" + path + "\"");
+const std::filesystem::path valid_xml_path(const std::filesystem::path& path) {
+    OPENVINO_ASSERT(path.extension() == ".xml",
+                    "Path for xml file doesn't contains file name with 'xml' extension: \"",
+                    path,
+                    "\"");
     return path;
 }
 
-std::string provide_bin_path(const std::string& xmlPath, const std::string& binPath) {
-    if (!binPath.empty()) {
-        return binPath;
+std::filesystem::path provide_bin_path(const std::filesystem::path& xml_path, const std::filesystem::path& bin_path) {
+    if (bin_path.empty()) {
+        auto path = xml_path;
+        path.replace_extension(".bin");
+        return path;
+    } else {
+        return bin_path;
     }
-    assert(xmlPath.size() > 4);  // should be check by valid_xml_path
-    std::string bestPath = xmlPath;
-    const char* const extension = "bin";
-    const auto ext_size = std::strlen(extension);
-    bestPath.replace(bestPath.size() - ext_size, ext_size, extension);
-    return bestPath;
 }
 
 void serializeFunc(std::ostream& xml_file,
@@ -1317,27 +1313,16 @@ bool pass::Serialize::run_on_model(const std::shared_ptr<ov::Model>& model) {
     if (m_xmlFile && m_binFile) {
         serializeFunc(*m_xmlFile, *m_binFile, model, m_version);
     } else {
-#if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-        const auto& xmlPath_ref = ov::util::string_to_wstring(m_xmlPath);
-        const auto& binPath_ref = ov::util::string_to_wstring(m_binPath);
-        std::string message_bin = "Can't open bin file.";
-        std::string message_xml = "Can't open xml file.";
-#else
-        const auto& xmlPath_ref = m_xmlPath;
-        const auto& binPath_ref = m_binPath;
-        std::string message_bin = "Can't open bin file: \"" + binPath_ref + "\"";
-        std::string message_xml = "Can't open xml file: \"" + xmlPath_ref + "\"";
-#endif
-        auto xmlDir = ov::util::get_directory(xmlPath_ref);
-        if (xmlDir != xmlPath_ref)
-            ov::util::create_directory_recursive(xmlDir);
+        if (const auto xml_dir = m_xmlPath.parent_path(); !xml_dir.empty()) {
+            ov::util::create_directory_recursive(xml_dir);
+        }
 
-        std::ofstream bin_file(binPath_ref, std::ios::out | std::ios::binary);
-        OPENVINO_ASSERT(bin_file, message_bin);
+        std::ofstream bin_file(m_binPath, std::ios::out | std::ios::binary);
+        OPENVINO_ASSERT(bin_file, "Can't open bin file: \"", m_binPath, "\"");
 
         // create xml file
-        std::ofstream xml_file(xmlPath_ref, std::ios::out);
-        OPENVINO_ASSERT(xml_file, message_xml);
+        std::ofstream xml_file(m_xmlPath, std::ios::out);
+        OPENVINO_ASSERT(xml_file, "Can't open xml file: \"", m_xmlPath, "\"");
 
         try {
             serializeFunc(xml_file, bin_file, model, m_version);
@@ -1347,8 +1332,8 @@ bool pass::Serialize::run_on_model(const std::shared_ptr<ov::Model>& model) {
             // hence we need to delete it here in case of failure
             xml_file.close();
             bin_file.close();
-            std::ignore = std::remove(m_xmlPath.c_str());
-            std::ignore = std::remove(m_binPath.c_str());
+            std::ignore = std::filesystem::remove(m_xmlPath);
+            std::ignore = std::filesystem::remove(m_binPath);
             throw;
         }
     }
@@ -1364,7 +1349,7 @@ pass::Serialize::Serialize(std::ostream& xmlFile, std::ostream& binFile, pass::S
       m_binPath{},
       m_version{version} {}
 
-pass::Serialize::Serialize(const std::string& xmlPath, const std::string& binPath, pass::Serialize::Version version)
+pass::Serialize::Serialize(const std::filesystem::path& xmlPath, const std::filesystem::path& binPath, Version version)
     : m_xmlFile{nullptr},
       m_binFile{nullptr},
       m_xmlPath{valid_xml_path(xmlPath)},

--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/include/utils/models.hpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/include/utils/models.hpp
@@ -20,7 +20,7 @@ inline std::string get_ref_path(const std::string& model_path) {
         return "";
     }
     if (!ov::util::directory_exists(conformance::refCachePath)) {
-        ov::util::create_directory_recursive(conformance::refCachePath);
+        ov::util::create_directory_recursive(std::filesystem::path{conformance::refCachePath});
     }
     std::string path_to_cache = conformance::refCachePath + std::string(ov::test::utils::FileSeparator);
     std::string ref_name = model_path.substr(model_path.rfind(ov::test::utils::FileSeparator) + 1);

--- a/src/tests/test_utils/functional_test_utils/src/summary/api_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/api_summary.cpp
@@ -152,7 +152,7 @@ void ApiSummary::saveReport() {
     filename += ov::test::utils::REPORT_EXTENSION;
 
     if (!ov::util::directory_exists(outputFolder)) {
-        ov::util::create_directory_recursive(outputFolder);
+        ov::util::create_directory_recursive(std::filesystem::path{outputFolder});
     }
 
     std::string outputFilePath = outputFolder + std::string(ov::test::utils::FileSeparator) + filename;

--- a/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/summary/op_summary.cpp
@@ -233,7 +233,7 @@ void OpSummary::saveReport() {
     filename += ov::test::utils::REPORT_EXTENSION;
 
     if (!ov::util::directory_exists(outputFolder)) {
-        ov::util::create_directory_recursive(outputFolder);
+        ov::util::create_directory_recursive(std::filesystem::path{outputFolder});
     }
 
     std::string outputFilePath = outputFolder + std::string(ov::test::utils::FileSeparator) + filename;


### PR DESCRIPTION
### Details:
 - Use `std::filessytem::path` in `ov::pass::Serialize` instead of string
 - Remove ctor with strings as `std::filesystem::path` should allow create this pass from strings without API break
 - Update `ov::util::create_directory_recursive` to use paths as base type.

### Tickets:
 - Part of CVS-146660