### PR TITLE
[CPU][REFACTORING] Move post ops into primitive attributes

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -391,11 +391,9 @@ std::tuple<VecMemoryDescs, MemoryDescPtr> Convolution::initMemoryDescriptors(ov:
     return {srcDescs, dstDesc};
 }
 
-ExecutorFactoryPtr<ConvAttrs> Convolution::createExecutorFactory(const MemoryDescArgs& descs,
-                                                                 const ConvAttrs& attrs,
-                                                                 const PostOps& postOps) {
+ExecutorFactoryPtr<ConvAttrs> Convolution::createExecutorFactory(const MemoryDescArgs& descs, const ConvAttrs& attrs) {
     auto executionContext = std::make_shared<ExecutorContext>(context, getImplPriority(), privateWeightCache);
-    return std::make_shared<ExecutorFactory<ConvAttrs>>(attrs, postOps, executionContext, descs, memoryFormatFilter);
+    return std::make_shared<ExecutorFactory<ConvAttrs>>(attrs, executionContext, descs, memoryFormatFilter);
 }
 
 std::tuple<ov::element::Type, ov::element::Type> Convolution::getDstAndSumPrecision() {
@@ -466,7 +464,7 @@ void Convolution::initSupportedPrimitiveDescriptors() {
 
     const auto [dstType, sumType] = getDstAndSumPrecision();
 
-    m_postOps = getPostOps(fusedWith, sumType);
+    m_attrs.postOps = getPostOps(fusedWith, sumType);
 
     auto [srcDescs, dstDesc] = initMemoryDescriptors(dstType);
 
@@ -477,7 +475,7 @@ void Convolution::initSupportedPrimitiveDescriptors() {
         {ARG_DST, dstDesc},
     };
 
-    m_factory = createExecutorFactory(descs, m_attrs, m_postOps);
+    m_factory = createExecutorFactory(descs, m_attrs);
 
     const std::vector<MemoryDescArgs> nodeDescriptorsList = m_factory->getProperMemoryDescriptors(descs);
 
@@ -635,7 +633,8 @@ ExecutorPtr Convolution::createFallbackExecutor() {
         return fallbackExecutor;
     }
 
-    PostOps fallbackPostOps = m_postOps;
+    ConvAttrs fallbackAttrs = m_attrs;
+    PostOps& fallbackPostOps = fallbackAttrs.postOps;
     // remove sum post-op from fallback post-ops
     auto sumPostOp =
         std::find_if(fallbackPostOps.begin(), fallbackPostOps.end(), [](const std::shared_ptr<PostOp>& postOp) {
@@ -644,7 +643,8 @@ ExecutorPtr Convolution::createFallbackExecutor() {
 
     fallbackPostOps.erase(sumPostOp, fallbackPostOps.end());
 
-    CPU_NODE_ASSERT(fallbackPostOps.size() < m_postOps.size(), "Unexpected post-ops size after sum post-op removal");
+    CPU_NODE_ASSERT(fallbackPostOps.size() < m_attrs.postOps.size(),
+                    "Unexpected post-ops size after sum post-op removal");
 
     auto dstType = getOriginalInputPrecisionAtPort(0);
 
@@ -661,7 +661,7 @@ ExecutorPtr Convolution::createFallbackExecutor() {
         {ARG_DST, dstDesc},
     };
 
-    auto fallbackFactory = createExecutorFactory(descs, m_attrs, fallbackPostOps);
+    auto fallbackFactory = createExecutorFactory(descs, fallbackAttrs);
     fallbackExecutor = fallbackFactory->make(m_memory);
     return fallbackExecutor;
 }

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -82,9 +82,7 @@ private:
 
     std::tuple<ov::element::Type, ov::element::Type> getDstAndSumPrecision();
     std::tuple<VecMemoryDescs, MemoryDescPtr> initMemoryDescriptors(ov::element::Type dstType) const;
-    ExecutorFactoryPtr<ConvAttrs> createExecutorFactory(const MemoryDescArgs& descs,
-                                                        const ConvAttrs& attrs,
-                                                        const PostOps& postOps);
+    ExecutorFactoryPtr<ConvAttrs> createExecutorFactory(const MemoryDescArgs& descs, const ConvAttrs& attrs);
     ExecutorPtr createFallbackExecutor();
 
     void prepareParams() override;
@@ -108,7 +106,6 @@ private:
 
     std::unordered_map<size_t, size_t> m_atoi;  // memory argument id to input id
     ConvAttrs m_attrs;
-    PostOps m_postOps;
     MemoryArgs m_memory;
     ExecutorFactoryPtr<ConvAttrs> m_factory;
     ExecutorPtr m_executor = nullptr;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected.hpp
@@ -12,10 +12,7 @@ namespace ov::intel_cpu {
 
 class ACLFullyConnectedExecutor : public ACLCommonExecutor {
 public:
-    ACLFullyConnectedExecutor(const FCAttrs& attrs,
-                              const PostOps& postOps,
-                              const MemoryArgs& memory,
-                              const ExecutorContext::CPtr& context);
+    ACLFullyConnectedExecutor(const FCAttrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context);
 
     static bool supports(const FCConfig& config);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
@@ -207,7 +207,6 @@ MemoryPtr acl_fc_executor::prepareWeightMemory(const MemoryArgs& memory,
                                                const ExecutorContext::CPtr& context,
                                                const FCAttrs& attrs,
                                                ACLFCAttrs& aclfcAttrs,
-                                               const PostOps& postOps,
                                                arm_compute::WeightFormat& expectedWeightFormat,
                                                arm_compute::TensorInfo& weiTensorInfo) {
     MemoryArgs memoryArgs;
@@ -241,7 +240,7 @@ MemoryPtr acl_fc_executor::prepareWeightMemory(const MemoryArgs& memory,
     }
     // TODO: ACLWeightFormatGenerator should be replaced with Reorder executor
     // that calls ACL NEReorder + NETranspose or dnnl::reorder depending on backend availability
-    auto aclWeightsRepack = std::make_shared<acl_fc_executor::ACLWeightFormatGenerator>(attrs, postOps, memoryArgs);
+    auto aclWeightsRepack = std::make_shared<acl_fc_executor::ACLWeightFormatGenerator>(attrs, memoryArgs);
     bool isNeededReorder = aclWeightsRepack->update(memoryArgs);
     expectedWeightFormat =
         isNeededReorder ? aclWeightsRepack->getOptImplWeightFormat() : arm_compute::WeightFormat::UNSPECIFIED;
@@ -288,16 +287,15 @@ static void initFCAttrs(const FCAttrs& attrs,
                         ACLTensorAttrs& aclTensorAttrs,
                         ACLFCAttrs& aclfcAttrs,
                         const MemoryArgs& memory,
-                        arm_compute::FullyConnectedLayerInfo& fullyConnectedLayerInfo,
-                        const PostOps& postOps) {
+                        arm_compute::FullyConnectedLayerInfo& fullyConnectedLayerInfo) {
     aclTensorAttrs.hasLayoutTypeNHWC = memory.at(ARG_SRC)->getDescPtr()->hasLayoutType(LayoutType::nspc);
     fullyConnectedLayerInfo.weights_trained_layout = getAclDataLayoutByMemoryDesc(memory.at(ARG_WEI)->getDescPtr());
     aclfcAttrs.inputPrecision = memory.at(ARG_SRC)->getDescPtr()->getPrecision();
     fullyConnectedLayerInfo.transpose_weights = false;
     aclfcAttrs.weightsNonTransposed = attrs.weightsNonTransposed;
 
-    if (checkPostOps(postOps)) {
-        auto activation = std::dynamic_pointer_cast<ActivationPostOp>(postOps[0]);
+    if (checkPostOps(attrs.postOps)) {
+        auto activation = std::dynamic_pointer_cast<ActivationPostOp>(attrs.postOps[0]);
         fullyConnectedLayerInfo.activation_info = getActivationLayerInfo(convertToEltwiseAlgorithm(activation->type()),
                                                                          activation->alpha(),
                                                                          activation->beta(),
@@ -335,10 +333,8 @@ ACLFunction acl_fc_executor::ACLWeightsConverter::configureFunction(const ACLTen
     return neCast;
 }
 
-acl_fc_executor::ACLWeightFormatGenerator::ACLWeightFormatGenerator(const FCAttrs& attrs,
-                                                                    const PostOps& postOps,
-                                                                    const MemoryArgs& memory) {
-    initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, fullyConnectedLayerInfo, postOps);
+acl_fc_executor::ACLWeightFormatGenerator::ACLWeightFormatGenerator(const FCAttrs& attrs, const MemoryArgs& memory) {
+    initFCAttrs(attrs, aclTensorAttrs, aclfcAttrs, memory, fullyConnectedLayerInfo);
 }
 
 void acl_fc_executor::ACLWeightFormatGenerator::updateTensorsShapes(ACLShapes& aclMemoryShapes) {

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.hpp
@@ -48,7 +48,6 @@ MemoryPtr prepareWeightMemory(const MemoryArgs& memory,
                               const ExecutorContext::CPtr& context,
                               const FCAttrs& attrs,
                               ACLFCAttrs& aclfcAttrs,
-                              const PostOps& postOps,
                               arm_compute::WeightFormat& expectedWeightFormat,
                               arm_compute::TensorInfo& weiTensorInfo);
 
@@ -66,7 +65,7 @@ public:
 
 class ACLWeightFormatGenerator : public ACLCommonExecutor {
 public:
-    ACLWeightFormatGenerator(const FCAttrs& attrs, const PostOps& postOps, const MemoryArgs& memory);
+    ACLWeightFormatGenerator(const FCAttrs& attrs, const MemoryArgs& memory);
     void updateTensorsShapes(ACLShapes& aclMemoryShapes) override;
     arm_compute::Status validateTensorsInfo(const ACLInfos& aclMemoryInfos) override;
     ACLFunction configureFunction(const ACLTensors& aclMemoryTensors) override;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_lowp_fullyconnected.hpp
@@ -12,10 +12,7 @@ namespace ov::intel_cpu {
 
 class ACLLowpFullyConnectedExecutor : public ACLCommonExecutor {
 public:
-    ACLLowpFullyConnectedExecutor(const FCAttrs& attrs,
-                                  const PostOps& postOps,
-                                  const MemoryArgs& memory,
-                                  const ExecutorContext::CPtr& context);
+    ACLLowpFullyConnectedExecutor(const FCAttrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context);
 
     static bool supports(const FCConfig& config);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/convolution_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convolution_config.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "executor_config.hpp"
+#include "post_ops.hpp"
 
 namespace ov::intel_cpu {
 
@@ -30,6 +31,8 @@ struct ConvAttrs {
     bool nonConstantWeights;
     ZeroPointsType inputZeroPointsType;
     std::vector<float> dqScales;
+
+    PostOps postOps;
 };
 
 using ConvConfig = executor::Config<ConvAttrs>;

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
@@ -423,7 +423,6 @@ static primitive_desc createPrimitiveDesc(const dnnl::memory::desc& inputDesc,
 }
 
 static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& attrs,
-                                                            const PostOps& postOps,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context) {
     const auto& srcDesc = memory.at(ARG_SRC)->getDescPtr();
@@ -442,7 +441,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
 
     if (attrs.fcSemantic) {
         // use original post ops and zero points in case if used as FC executor
-        return {DnnlPostOpsComposer(postOps,
+        return {DnnlPostOpsComposer(attrs.postOps,
                                     context->getEngine(),
                                     outputDims,
                                     channelDimIdx,
@@ -456,7 +455,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
                     .compose()};
     }
 
-    DnnlPostOpsComposer legacyPostOpsLegacyZeroPoints(postOps,
+    DnnlPostOpsComposer legacyPostOpsLegacyZeroPoints(attrs.postOps,
                                                       context->getEngine(),
                                                       outputDims,
                                                       channelDimIdx,
@@ -495,7 +494,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
     }
 
     // @todo avoid extra step of creating config to get the brgconv availability
-    auto config = GraphEmitter<ConvAttrs>::createConfig(memory, attrs, postOps);
+    auto config = GraphEmitter<ConvAttrs>::createConfig(memory, attrs);
     if (!DnnlConvolutionPrimitive::isBrgConvAvailable(config)) {
         DEBUG_LOG("Brgconv is not available. Skip extra attribute");
         return {legacyCompose};
@@ -510,7 +509,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
 
     if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) &&
         attrs.inputZeroPointsType == ZeroPointsType::PerTensor) {
-        DnnlPostOpsComposer legacyPostOpsOriginalZeroPoints(postOps,
+        DnnlPostOpsComposer legacyPostOpsOriginalZeroPoints(attrs.postOps,
                                                             context->getEngine(),
                                                             outputDims,
                                                             channelDimIdx,
@@ -526,7 +525,7 @@ static std::vector<DnnlPrimitiveAttrs> createPrimitiveAttrs(const ConvAttrs& att
         return attributeVariants;
     }
 
-    DnnlPostOpsComposer originalPostOpsOriginalZeroPoints(postOps,
+    DnnlPostOpsComposer originalPostOpsOriginalZeroPoints(attrs.postOps,
                                                           context->getEngine(),
                                                           outputDims,
                                                           channelDimIdx,
@@ -669,7 +668,6 @@ static std::tuple<MemoryDescPtr, MemoryDescPtr> createDummySrcDstDescs(const Con
 }
 
 DnnlShapeAgnosticDataPtr DnnlConvolutionPrimitive::createShapeAgnosticData(const ConvAttrs& attrs,
-                                                                           const PostOps& postOps,
                                                                            const MemoryArgs& memory,
                                                                            const ExecutorContext::CPtr& context,
                                                                            const bool cacheWeights) {
@@ -700,7 +698,7 @@ DnnlShapeAgnosticDataPtr DnnlConvolutionPrimitive::createShapeAgnosticData(const
     const dnnl::memory::desc dstDnnlDesc = MemoryDescUtils::convertToDnnlMemoryDesc(dstDesc)->getDnnlDesc();
     const dnnl::memory::desc biaDnnlDesc = MemoryDescUtils::convertToDnnlMemoryDesc(biasDesc)->getDnnlDesc();
 
-    const auto primitiveAttributes = createPrimitiveAttrs(attrs, postOps, memory, context);
+    const auto primitiveAttributes = createPrimitiveAttrs(attrs, memory, context);
 
     std::vector<dnnl::primitive_attr> dnnlAttrVariants;
     dnnlAttrVariants.reserve(primitiveAttributes.size());
@@ -734,7 +732,6 @@ DnnlShapeAgnosticDataPtr DnnlConvolutionPrimitive::createShapeAgnosticData(const
 }
 
 DnnlShapeAgnosticDataPtr DnnlConvolutionPrimitive::createShapeAgnosticData(const FCAttrs& fcAttrs,
-                                                                           const PostOps& postOps,
                                                                            const MemoryArgs& memory,
                                                                            const ExecutorContext::CPtr& context,
                                                                            const bool cacheWeights) {
@@ -751,9 +748,13 @@ DnnlShapeAgnosticDataPtr DnnlConvolutionPrimitive::createShapeAgnosticData(const
                     fcAttrs.weightsNonTransposed,
                     false,
                     false,
-                    true};
+                    true,
+                    false,
+                    {},
+                    {},
+                    fcAttrs.postOps};
 
-    const auto postOpData = createPrimitiveAttrs(attrs, postOps, memory, context);
+    const auto postOpData = createPrimitiveAttrs(attrs, memory, context);
     OPENVINO_ASSERT(postOpData.size() == 1, "Single attribute variant is expected when used as FC executor");
 
     return std::make_shared<DnnlShapeAgnosticData>(postOpData.front());

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
@@ -91,14 +91,12 @@ public:
                                                             bool weightsNonTransposed);
 
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const ConvAttrs& attrs,
-                                                            const PostOps& postOps,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
                                                             const bool cacheWeights);
 
     // create shape agnostic data using FC attributes (1x1 Convolution as FC executor)
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& fcAttrs,
-                                                            const PostOps& postOps,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
                                                             const bool cacheWeights);

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
@@ -39,14 +39,13 @@ class DnnlExecutor : public Executor {
 public:
     using PrimitivePtr = std::shared_ptr<Primitive>;
     DnnlExecutor(const Attrs& attrs,
-                 const PostOps& postOps,
                  const MemoryArgs& memory,
                  ExecutorContext::CPtr context,
                  const bool cacheWeights,
                  const bool fc3Das2D = false)
         : m_attrs(attrs),
           m_context(std::move(context)),
-          m_shapeAgnosticData(Primitive::createShapeAgnosticData(m_attrs, postOps, memory, m_context, cacheWeights)),
+          m_shapeAgnosticData(Primitive::createShapeAgnosticData(m_attrs, memory, m_context, cacheWeights)),
           m_primArgs(m_shapeAgnosticData->m_primAttrs.dnnlArgs),
           m_fc3Das2D(fc3Das2D) {}
     bool update(const MemoryArgs& memory) override {

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.cpp
@@ -203,7 +203,6 @@ static bool useDynamicQuantizationImpl(size_t dqGroupSize,
 }
 
 static DnnlPrimitiveAttrs createPrimitiveAttrs(const FCAttrs& attrs,
-                                               const PostOps& postOps,
                                                const MemoryArgs& memory,
                                                const ExecutorContext::CPtr& context,
                                                bool useDynamicQuantization) {
@@ -218,7 +217,7 @@ static DnnlPrimitiveAttrs createPrimitiveAttrs(const FCAttrs& attrs,
         one_of(srcDesc->getPrecision(), ov::element::u8, ov::element::i8) && weiDesc->getPrecision() == ov::element::i8;
     auto outputDataType = DnnlExtensionUtils::ElementTypeToDataType(dstDesc->getPrecision());
 
-    DnnlPostOpsComposer dnnlpoc(postOps,
+    DnnlPostOpsComposer dnnlpoc(attrs.postOps,
                                 context->getEngine(),
                                 dims,
                                 dims.size() - 1,
@@ -386,7 +385,6 @@ static VectorDims makeDummyOutputDims(const VectorDims& inShape, const VectorDim
 }
 
 DnnlShapeAgnosticDataPtr DnnlFCPrimitive::createShapeAgnosticData(const FCAttrs& attrs,
-                                                                  const PostOps& postOps,
                                                                   const MemoryArgs& memory,
                                                                   const ExecutorContext::CPtr& context,
                                                                   const bool cacheWeights) {
@@ -402,7 +400,7 @@ DnnlShapeAgnosticDataPtr DnnlFCPrimitive::createShapeAgnosticData(const FCAttrs&
         useWeightsDecompression &&
         useDynamicQuantizationImpl(attrs.dynamicQuantizationGroupSize, srcDesc, weiDesc, memory);
 
-    const auto postOpData = createPrimitiveAttrs(attrs, postOps, memory, context, useDynamicQuantization);
+    const auto postOpData = createPrimitiveAttrs(attrs, memory, context, useDynamicQuantization);
 
     if (!cacheWeights) {
         return std::make_shared<DnnlShapeAgnosticData>(postOpData);

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
@@ -55,7 +55,6 @@ public:
     }
 
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& attrs,
-                                                            const PostOps& postOps,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
                                                             const bool cacheWeights);

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.cpp
@@ -280,7 +280,6 @@ bool DnnlMatMulPrimitive::useWeightsDecompressionImpl(const ov::element::Type in
 }
 
 DnnlShapeAgnosticDataPtr DnnlMatMulPrimitive::createShapeAgnosticData(const FCAttrs& attrs,
-                                                                      const PostOps& postOps,
                                                                       const MemoryArgs& memory,
                                                                       const ExecutorContext::CPtr& context,
                                                                       const bool cacheWeights) {
@@ -292,7 +291,7 @@ DnnlShapeAgnosticDataPtr DnnlMatMulPrimitive::createShapeAgnosticData(const FCAt
 
     const auto useWeightsDecompression = useWeightsDecompressionImpl(srcDesc->getPrecision(), weiDesc->getPrecision());
     const auto postOpData =
-        createPrimitiveAttrs(postOps, memory, context, useWeightsDecompression, attrs.weightsNonTransposed);
+        createPrimitiveAttrs(attrs.postOps, memory, context, useWeightsDecompression, attrs.weightsNonTransposed);
 
     if (!cacheWeights) {
         return std::make_shared<DnnlShapeAgnosticData>(postOpData);

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
@@ -55,7 +55,6 @@ public:
     static bool useWeightsDecompressionImpl(const ov::element::Type inputType, const ov::element::Type weightsType);
 
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& attrs,
-                                                            const PostOps& postOps,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
                                                             const bool cacheWeights);

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_config.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "memory_arguments.hpp"
-#include "post_ops.hpp"
 
 namespace ov::intel_cpu::executor {
 
@@ -13,7 +12,6 @@ template <typename Attrs>
 struct Config {
     MemoryDescArgs descs;
     Attrs attrs;
-    PostOps postOps;
 };
 
 }  // namespace ov::intel_cpu::executor

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
@@ -23,12 +23,9 @@ public:
 
     using RequiresFallbackPredicate =
         std::function<std::optional<executor::Config<Attrs>>(const executor::Config<Attrs>&)>;
-    using AcceptsShapePredicate =
-        std::function<bool(const Attrs& attrs, const PostOps& postOps, const MemoryArgs& memory)>;
-    using CreateFunction = std::function<ExecutorPtr(const Attrs& attrs,
-                                                     const PostOps& postOps,
-                                                     const MemoryArgs& memory,
-                                                     const ExecutorContext::CPtr& context)>;
+    using AcceptsShapePredicate = std::function<bool(const Attrs& attrs, const MemoryArgs& memory)>;
+    using CreateFunction =
+        std::function<ExecutorPtr(const Attrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context)>;
 
     ExecutorImplementation(const char* name,
                            const ExecutorType type,
@@ -82,22 +79,19 @@ public:
         return {};
     }
 
-    [[nodiscard]] bool acceptsShapes(const Attrs& attrs, const PostOps& postOps, const MemoryArgs& memory) const {
+    [[nodiscard]] bool acceptsShapes(const Attrs& attrs, const MemoryArgs& memory) const {
         if (m_acceptsShape) {
-            return m_acceptsShape(attrs, postOps, memory);
+            return m_acceptsShape(attrs, memory);
         }
 
         return false;
     }
 
-    ExecutorPtr create(const Attrs& attrs,
-                       const PostOps& postOps,
-                       const MemoryArgs& memory,
-                       const ExecutorContext::CPtr context) const {
+    ExecutorPtr create(const Attrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr context) const {
         DEBUG_LOG("Creating executor using implementation: ", m_name);
 
         if (m_create) {
-            return m_create(attrs, postOps, memory, context);
+            return m_create(attrs, memory, context);
         }
         return nullptr;
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/fullyconnected_config.hpp
@@ -4,10 +4,8 @@
 
 #pragma once
 
-#include <vector>
-
-#include "cpu_memory.h"
 #include "executor_config.hpp"
+#include "post_ops.hpp"
 
 namespace ov::intel_cpu {
 
@@ -22,6 +20,8 @@ struct FCAttrs {
     bool nonConstantWeights = false;
 
     ov::intel_cpu::Config::ModelType modelType = ov::intel_cpu::Config::ModelType::Unknown;
+
+    PostOps postOps;
 };
 
 using FCConfig = executor::Config<FCAttrs>;

--- a/src/plugins/intel_cpu/src/nodes/executors/graph_emitter.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/graph_emitter.hpp
@@ -24,14 +24,12 @@ public:
 
     GraphEmitter(const MemoryDescArgs& descs,
                  const Attrs& attrs,
-                 const PostOps& postOps,
                  [[maybe_unused]] const MemoryArgs& memory,
                  ExecutorContext::CPtr context,
                  const std::string& name,
                  ensureAttrsStrategy ensureAttrs = {})
         : descs(descs),
           attrs(attrs),
-          postOps(postOps),
           context(std::move(context)),
           name(name),
           ensureAttrs(std::move(ensureAttrs)) {
@@ -40,7 +38,6 @@ public:
 
     GraphEmitter& createGraph([[maybe_unused]] const MemoryDescArgs& descs,
                               [[maybe_unused]] const Attrs& attrs,
-                              [[maybe_unused]] const PostOps& postOps,
                               [[maybe_unused]] const ExecutorContext::CPtr& context) {
         OPENVINO_THROW("Not implemented yet!");
         return *this;
@@ -61,11 +58,6 @@ public:
         return *this;
     }
 
-    GraphEmitter& ensurePostOpsMatch() {
-        OPENVINO_THROW("Not implemented yet!");
-        return *this;
-    }
-
     GraphPtr emit() {
         OPENVINO_THROW("Not implemented yet!");
         return graph;
@@ -82,8 +74,8 @@ public:
         return memoryDescs;
     }
 
-    static executor::Config<Attrs> createConfig(const MemoryArgs& memory, const Attrs& attrs, const PostOps& postOps) {
-        return executor::Config<Attrs>{memoryDescsFromMemory(memory), attrs, postOps};
+    static executor::Config<Attrs> createConfig(const MemoryArgs& memory, const Attrs& attrs) {
+        return executor::Config<Attrs>{memoryDescsFromMemory(memory), attrs};
     }
 
     static ExecutorPtr fallback(const executor::Config<Attrs>& config,
@@ -98,14 +90,13 @@ public:
                   " new config:",
                   fallbackConfig);
 
-        GraphEmitter<Attrs> graphEmitter(config.descs, config.attrs, config.postOps, memory, context, name);
+        GraphEmitter<Attrs> graphEmitter(config.descs, config.attrs, memory, context, name);
 
         [[maybe_unused]] const auto& graphExecutor =
-            graphEmitter.createGraph(fallbackConfig.descs, fallbackConfig.attrs, fallbackConfig.postOps, context)
+            graphEmitter.createGraph(fallbackConfig.descs, fallbackConfig.attrs, context)
                 .ensureAttrsMatch()
                 .ensureSrcDescsMatch()
                 .ensureDstDescsMatch()
-                .ensurePostOpsMatch()
                 .emit();
 
         OPENVINO_THROW("Fallback logic is not implemented yet");  // return graphExecutor;
@@ -114,7 +105,6 @@ public:
 private:
     const MemoryDescArgs& descs;
     const Attrs& attrs;
-    const PostOps& postOps;
     const ExecutorContext::CPtr context;
     const std::string& name;
     const ensureAttrsStrategy ensureAttrs;

--- a/src/plugins/intel_cpu/src/nodes/executors/implementation_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/implementation_utils.hpp
@@ -90,7 +90,7 @@ size_t weiMemSize(const Config& config) {
 
 template <typename Config>
 size_t postOpsNumbers(const Config& config) {
-    return config.postOps.size();
+    return config.attrs.postOps.size();
 }
 
 template <typename Attrs>
@@ -109,20 +109,15 @@ struct SupportsAnyConfig {
 
 template <typename Attrs>
 struct AcceptsAnyShape {
-    bool operator()([[maybe_unused]] const Attrs& attrs,
-                    [[maybe_unused]] const PostOps& postOps,
-                    [[maybe_unused]] const MemoryArgs& memory) const {
+    bool operator()([[maybe_unused]] const Attrs& attrs, [[maybe_unused]] const MemoryArgs& memory) const {
         return true;
     }
 };
 
 template <typename Primitive, typename Attrs>
 struct CreateDefault {
-    ExecutorPtr operator()(const Attrs& attrs,
-                           const PostOps& postOps,
-                           const MemoryArgs& memory,
-                           const ExecutorContext::CPtr& context) const {
-        return std::make_shared<Primitive>(attrs, postOps, memory, context);
+    ExecutorPtr operator()(const Attrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context) const {
+        return std::make_shared<Primitive>(attrs, memory, context);
     }
 };
 
@@ -131,12 +126,8 @@ template <typename Primitive,
           typename ShapeAgnosticData = DnnlShapeAgnosticData,
           typename Instantiator = DefaultInstantiator<Primitive, Attrs, ShapeAgnosticData>>
 struct CreateDnnlDefault {
-    ExecutorPtr operator()(const Attrs& attrs,
-                           const PostOps& postOps,
-                           const MemoryArgs& memory,
-                           const ExecutorContext::CPtr& context) const {
+    ExecutorPtr operator()(const Attrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context) const {
         return std::make_shared<DnnlExecutor<Primitive, Attrs, DnnlShapeAgnosticData, Instantiator>>(attrs,
-                                                                                                     postOps,
                                                                                                      memory,
                                                                                                      context,
                                                                                                      false);
@@ -213,8 +204,7 @@ std::optional<executor::Config<Attrs>> requiresFallbackCommon(const executor::Co
 
     const auto optimalDescriptors = createOptimalDescriptors(config.descs, typeConfig, layoutConfig, notation);
 
-    return std::optional<executor::Config<Attrs>>(
-        executor::Config<Attrs>{optimalDescriptors, config.attrs, config.postOps});
+    return std::optional<executor::Config<Attrs>>(executor::Config<Attrs>{optimalDescriptors, config.attrs});
 }
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.cpp
@@ -36,7 +36,6 @@ bool MatMulKleidiAIExecutor::supports(const FCConfig& config) {
 }
 
 MatMulKleidiAIExecutor::MatMulKleidiAIExecutor(const FCAttrs& attrs,
-                                               const PostOps& postOps,
                                                const MemoryArgs& memory,
                                                const ExecutorContext::CPtr& context)
     : m_attrs(attrs),

--- a/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/kleidiai/kleidiai_mm.hpp
@@ -19,10 +19,7 @@ namespace intel_cpu {
 
 class MatMulKleidiAIExecutor : public Executor {
 public:
-    MatMulKleidiAIExecutor(const FCAttrs& attrs,
-                           const PostOps& postOps,
-                           const MemoryArgs& memory,
-                           const ExecutorContext::CPtr& context);
+    MatMulKleidiAIExecutor(const FCAttrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context);
 
     void execute(const MemoryArgs& memory) override;
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -66,7 +66,7 @@ static MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory,
 
 // @todo use VERIFY macro for the checks
 bool MlasGemmExecutor::supports(const FCConfig& config) {
-    if (!config.postOps.empty()) {
+    if (!config.attrs.postOps.empty()) {
         DEBUG_LOG("MlasGemmExecutor: PostOps are not supported");
         return false;
     }
@@ -95,10 +95,7 @@ bool MlasGemmExecutor::supports(const FCConfig& config) {
     return true;
 }
 
-MlasGemmExecutor::MlasGemmExecutor(const FCAttrs& attrs,
-                                   [[maybe_unused]] const PostOps& postOps,
-                                   const MemoryArgs& memory,
-                                   const ExecutorContext::CPtr& context)
+MlasGemmExecutor::MlasGemmExecutor(const FCAttrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context)
     : m_attrs(attrs),
       m_memoryArgs(memory),
       packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context, !attrs.weightsNonTransposed)),

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
@@ -15,10 +15,7 @@ namespace ov::intel_cpu {
 
 class MlasGemmExecutor : public Executor {
 public:
-    MlasGemmExecutor(const FCAttrs& attrs,
-                     const PostOps& postOps,
-                     const MemoryArgs& memory,
-                     const ExecutorContext::CPtr& context);
+    MlasGemmExecutor(const FCAttrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr& context);
 
     void execute(const MemoryArgs& memory) override;
 

--- a/src/plugins/intel_cpu/src/nodes/executors/printers.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/printers.cpp
@@ -10,7 +10,6 @@
 
 #    include "fullyconnected_config.hpp"
 #    include "nodes/executors/convolution_config.hpp"
-#    include "post_ops.hpp"
 
 namespace ov::intel_cpu {
 
@@ -21,11 +20,6 @@ std::ostream& operator<<(std::ostream& os, [[maybe_unused]] const FCAttrs& attrs
 
 std::ostream& operator<<(std::ostream& os, [[maybe_unused]] const ConvAttrs& attrs) {
     // @todo print Attrs
-    return os;
-}
-
-std::ostream& operator<<(std::ostream& os, [[maybe_unused]] const PostOps& postOps) {
-    // @todo print PostOps
     return os;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/printers.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/printers.hpp
@@ -22,7 +22,6 @@ struct ConvAttrs;
 
 std::ostream& operator<<(std::ostream& os, const FCAttrs& attrs);
 std::ostream& operator<<(std::ostream& os, const ConvAttrs& attrs);
-std::ostream& operator<<(std::ostream& os, const PostOps& postOps);
 
 template <typename Attrs>
 std::ostream& operator<<(std::ostream& os, const executor::Config<Attrs>& config) {
@@ -32,7 +31,6 @@ std::ostream& operator<<(std::ostream& os, const executor::Config<Attrs>& config
         os << "[" << id << "]" << *descPtr << ";";
     }
 
-    os << config.postOps;
     os << config.attrs;
 
     return os;

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
@@ -49,7 +49,7 @@ bool ShlFCExecutor::supports(const FCConfig& config) {
         return false;
     }
 
-    if (!config.postOps.empty()) {
+    if (!config.attrs.postOps.empty()) {
         DEBUG_LOG("ShlFCExecutor: PostOps are not supported");
         return false;
     }
@@ -82,7 +82,6 @@ bool ShlFCExecutor::supports(const FCConfig& config) {
 }
 
 ShlFCExecutor::ShlFCExecutor(const FCAttrs& attrs,
-                             const PostOps& postOps,
                              const MemoryArgs& memory,
                              const ExecutorContext::CPtr context)
     : packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context)) {

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.hpp
@@ -12,7 +12,6 @@ namespace ov::intel_cpu {
 class ShlFCExecutor : public Executor {
 public:
     ShlFCExecutor(const FCAttrs& attrs,
-                  const PostOps& postOps,
                   const MemoryArgs& memory,
                   const ExecutorContext::CPtr context);
 

--- a/src/plugins/intel_cpu/src/nodes/executors/variable_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/variable_executor.hpp
@@ -25,16 +25,13 @@ public:
 
     VariableExecutor(const MemoryArgs& memory,
                      Attrs attrs,
-                     PostOps postOps,
                      ExecutorContext::CPtr context,
                      std::vector<ExecutorImplementationRef> suitableImplementations)
         : m_attrs(std::move(attrs)),
-          m_postOps(std::move(postOps)),
           m_context(std::move(context)),
           m_suitableImplementations(std::move(suitableImplementations)),
           m_implementationRequiresFallback(
-              cacheFallbackStatus(m_suitableImplementations,
-                                  GraphEmitter<Attrs>::createConfig(memory, m_attrs, m_postOps))),
+              cacheFallbackStatus(m_suitableImplementations, GraphEmitter<Attrs>::createConfig(memory, m_attrs))),
           m_executors(m_suitableImplementations.size()) {
         const size_t implId = select(memory, 0);
         m_executors[implId] = create(implId, memory);
@@ -95,13 +92,12 @@ private:
 
         auto startIt = m_suitableImplementations.begin() + startIdx;
 
-        const auto selectedImplementation =
-            std::find_if(startIt,
-                         m_suitableImplementations.end(),
-                         [&memory, this](const ExecutorImplementationRef& implementation) {
-                             return implementation.get().shapeAgnostic() ||
-                                    implementation.get().acceptsShapes(m_attrs, m_postOps, memory);
-                         });
+        const auto selectedImplementation = std::find_if(
+            startIt,
+            m_suitableImplementations.end(),
+            [&memory, this](const ExecutorImplementationRef& implementation) {
+                return implementation.get().shapeAgnostic() || implementation.get().acceptsShapes(m_attrs, memory);
+            });
 
         OPENVINO_ASSERT(selectedImplementation != m_suitableImplementations.end(), "Failed to select an implemetation");
 
@@ -115,20 +111,19 @@ private:
             const auto& impl = m_suitableImplementations[implId].get();
 
             if (m_implementationRequiresFallback[implId]) {
-                auto config = GraphEmitter<Attrs>::createConfig(memory, m_attrs, m_postOps);
+                auto config = GraphEmitter<Attrs>::createConfig(memory, m_attrs);
                 if (auto fallbackConfig = impl.requiresFallback(config)) {
                     return GraphEmitter<Attrs>::fallback(config, *fallbackConfig, memory, m_context, impl.name());
                 }
             }
 
-            return impl.create(m_attrs, m_postOps, memory, m_context);
+            return impl.create(m_attrs, memory, m_context);
         };
 
         return createWithFallback(implId, memory);
     }
 
     Attrs m_attrs;
-    PostOps m_postOps;
     const ExecutorContext::CPtr m_context;
     std::vector<ExecutorImplementationRef> m_suitableImplementations;
     // stores fallback status to avoid performing the check for every make() call

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -520,7 +520,7 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     attrs.dynamicQuantizationGroupSize = context->getConfig().fcDynamicQuantizationGroupSize;
     attrs.modelType = context->getConfig().modelType;
 
-    postOps = getPostOps(fusedWith);
+    attrs.postOps = getPostOps(fusedWith);
 
     const auto& srcTypes = getOriginalInputPrecisions();
     auto dstTypes = getOriginalOutputPrecisions();
@@ -554,7 +554,7 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     };
 
     auto executionContext = std::make_shared<ExecutorContext>(context, getImplPriority(), privateWeightCache);
-    factory = std::make_shared<ExecutorFactory<FCAttrs>>(attrs, postOps, executionContext, descs);
+    factory = std::make_shared<ExecutorFactory<FCAttrs>>(attrs, executionContext, descs);
     const std::vector<MemoryDescArgs> nodeDescriptorsList = factory->getProperMemoryDescriptors(descs);
     const MemoryDescArgs& nodeDescriptors = nodeDescriptorsList.front();
 

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -120,7 +120,6 @@ private:
     void needSplitMemoryForTensorParallel();
 
     FCAttrs attrs;
-    PostOps postOps;
     MemoryArgs memory;
     ExecutorFactoryPtr<FCAttrs> factory;
     ExecutorPtr executor = nullptr;


### PR DESCRIPTION
Since not all the operations / primitives support post ops.
So, post ops should be just another attribute