### PR TITLE
[GPU] Fix wrong index order in Gather

### DIFF
--- a/src/plugins/intel_gpu/src/graph/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/gather.cpp
@@ -47,6 +47,7 @@ layout gather_inst::calc_output_layout(gather_node const& node, kernel_impl_para
         switch (input_layout.format) {
         case format::bfyx:
         case format::bfzyx:
+        case format::bfwzyx:
         case format::b_fs_zyx_fsv16:
         case format::b_fs_zyx_fsv32:
             output_format = format::get_default_format(dims_converted.size());

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.cpp
@@ -4,6 +4,7 @@
 
 #include "primitive_base.hpp"
 
+#include "gather.hpp"
 #include "gather_inst.h"
 #include "gather/gather_kernel_selector.h"
 #include "gather/gather_kernel_ref.h"
@@ -176,6 +177,11 @@ public:
         (_kernel_data.update_dispatch_data_func)(*_kernel_data.params, _kernel_data);
     }
 };
+
+std::unique_ptr<primitive_impl> GatherImplementationManager::create_impl(const program_node& node, const kernel_impl_params& params) const {
+    assert(node.is_type<gather>());
+    return typed_primitive_impl_ocl<gather>::create<gather_impl>(static_cast<const gather_node&>(node), params);
+}
 
 namespace detail {
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/gather.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/gather.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "registry/implementation_manager.hpp"
+#include "program_node.h"
+
+#include <memory>
+
+namespace cldnn {
+
+namespace ocl {
+
+struct GatherImplementationManager : public ImplementationManager {
+    OV_GPU_PRIMITIVE_IMPL("ocl::gather")
+    GatherImplementationManager(shape_types shape_type, ValidateFunc vf = nullptr) : ImplementationManager(impl_types::ocl, shape_type, vf) {}
+    std::unique_ptr<primitive_impl> create_impl(const program_node& node, const kernel_impl_params& params) const override;
+    in_out_fmts_t query_formats(const program_node& node) const override {
+        std::vector<format::type> in_fmts(node.get_dependencies().size(), format::any);
+        std::vector<format::type> out_fmts(node.get_outputs_count(), format::any);
+
+        for (size_t i = 0; i < node.get_dependencies().size(); i++) {
+            size_t in_rank = node.get_input_layout(i).get_rank();
+            in_fmts[i] = format::get_default_format(in_rank);
+        }
+        size_t out_rank = node.get_output_layout().get_rank();
+        out_fmts[0] = format::get_default_format(out_rank);
+
+        return {in_fmts, out_fmts};
+    }
+};
+
+} // namespace ocl
+} // namespace cldnn

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/register.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/register.cpp
@@ -31,7 +31,6 @@ void register_implementations() {
     REGISTER_OCL(experimental_detectron_topk_rois);
     REGISTER_OCL(eltwise);
     REGISTER_OCL(fully_connected);
-    REGISTER_OCL(gather);
     REGISTER_OCL(gather_elements);
     REGISTER_OCL(gemm);
     REGISTER_OCL(generate_proposals);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/register.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/register.hpp
@@ -26,7 +26,6 @@
 #include "intel_gpu/primitives/experimental_detectron_topk_rois.hpp"
 #include "intel_gpu/primitives/eye.hpp"
 #include "intel_gpu/primitives/fully_connected.hpp"
-#include "intel_gpu/primitives/gather.hpp"
 #include "intel_gpu/primitives/gather_elements.hpp"
 #include "intel_gpu/primitives/gather_tree.hpp"
 #include "intel_gpu/primitives/gemm.hpp"

--- a/src/plugins/intel_gpu/src/graph/registry/gather_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/gather_impls.cpp
@@ -7,14 +7,18 @@
 #include "intel_gpu/primitives/gather.hpp"
 #include "primitive_inst.h"
 
+#if OV_GPU_WITH_OCL
+    #include "impls/ocl/gather.hpp"
+#endif
+
 namespace ov::intel_gpu {
 
 using namespace cldnn;
 
 const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<gather>::get_implementations() {
     static const std::vector<std::shared_ptr<ImplementationManager>> impls = {
-        OV_GPU_GET_INSTANCE_OCL(gather, shape_types::static_shape, not_in_shape_flow())
-        OV_GPU_GET_INSTANCE_OCL(gather, shape_types::dynamic_shape, not_in_shape_flow())
+        OV_GPU_CREATE_INSTANCE_OCL(ocl::GatherImplementationManager, shape_types::static_shape, not_in_shape_flow())
+        OV_GPU_CREATE_INSTANCE_OCL(ocl::GatherImplementationManager, shape_types::dynamic_shape, not_in_shape_flow())
         OV_GPU_GET_INSTANCE_CPU(gather, shape_types::static_shape, in_shape_flow())
         OV_GPU_GET_INSTANCE_CPU(gather, shape_types::dynamic_shape, in_shape_flow())
     };

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/gather/gather_kernel_ref.cpp
@@ -155,19 +155,6 @@ static inline std::vector<std::string> GetOrder(size_t size) {
     return idx_order;
 }
 
-static inline std::vector<std::string> GetFinalIndexOrder(size_t size) {
-    std::vector<std::string> idx_order;
-
-    OPENVINO_ASSERT(size > 4, "[GPU] Only support 5 or 6 dimensions");
-
-    if (size == 5) {
-        idx_order = {"b", "f", "0", "z", "0"};
-    } else if (size == 6) {
-        idx_order = {"b", "f", "0", "w", "z", "0"};
-    }
-    return idx_order;
-}
-
 static std::string GetDictionaryIndexOrder(const gather_params& params, size_t axis) {
     auto idx_order = GetOrder(params.outputs[0].GetDims().size());
     auto input_axis_index_macro = "INPUT_AXIS_INDEX";


### PR DESCRIPTION
### Details:
There were two problems with gather :
1. Allowing unnecessary reorder
By the definition of gather, the input and output dimensions can be different. Forcing the input and output dimensions to match using reorder node will lead to unintended results. It needs to prevent the reorder by `GatherImplementationManager`.

2. Hard-coded index order for 5D, 6D
The hard-coded index order for 5D, 6D created by `GetFinalIndexOrder()` seems assuming the wrong indices (2nd input). see below the problematic case.
> Problematic case : `data.shape=[3,4,12,12,6,3]`, `indices.shape=[3,4,1,12,12,1]`, `batch_dims=4`, `axis=4`, `output.shape=[3,4,12,12,1,3]`  

Actually it must be `indices.shape=[3,4,12,12,1]`. But `indices.shape=[3,4,1,12,12,1]` was created due to the unnecessary reorder. According to the definition of gather, `indices.shape=[3,4,1,12,12,1]` cannot produce `output.shape=[3,4,12,12,1,3]`. But the incorrect index order created by `GetFinalIndexOrder()` gets produced that output shape with using the incorrect indices.shape. Therefore `GetFinalIndexOrder()` should not be used to remove hard-coded index order but generalize the way to create the correct index order by assuming the correct indices.shape.

### Tickets:
 - 164891
