### PR TITLE
[Draft] Fix excess rounding for f8e4m3 subnormal values

### DIFF
--- a/src/core/src/type/float8_e4m3.cpp
+++ b/src/core/src/type/float8_e4m3.cpp
@@ -85,14 +85,16 @@ uint8_t f16_to_f8e4m3_bits(const float16 value) {
         uint16_t fractional = (input & f16_m_mask) << (f16_e_size - f8e4m3_e_size);
 
         // for normalized values round apply rounding change f8 fractional and biased exponent
-        if ((fractional & round_half) == round_odd || (fractional & round_norm) != 0) {
-            fractional += round_even;
-            if (0 != (fractional & f8_e_mask)) {
-                fractional &= f8_e_mask;
-                ++f8_biased_exp;
+        if (f8_biased_exp >= 0) {
+            if ((fractional & round_half) == round_odd || (fractional & round_norm) != 0) {
+                fractional += round_even;
+                if (0 != (fractional & f8_e_mask)) {
+                    fractional &= f8_e_mask;
+                    ++f8_biased_exp;
+                }
             }
+            fractional &= f8_m_mask;
         }
-        fractional &= f8_m_mask;
 
         // set exponent and mantissa on f8 bits
         if (f8_biased_exp > f8e4m3_e_max) {

--- a/src/core/tests/float8_e4m3.cpp
+++ b/src/core/tests/float8_e4m3.cpp
@@ -156,6 +156,12 @@ TEST(F8E4M3Test, f8e4m3_num_limits_exp) {
     EXPECT_EQ(max_exp10, 2);
 }
 
+TEST(F8E4M3Test, f32_subnormal) {
+    const auto f8 = ov::float8_e4m3(0.0038014843f);
+
+    EXPECT_EQ(f8.to_bits(), 0x02);
+}
+
 TEST(F8E4M3Test, f32_gt_zero_le_f8_half_lowest_subnormal) {
     const auto f8 = ov::float8_e4m3(0.0009765625f);
 


### PR DESCRIPTION
### Details:
 - *Fix excess rounding for f8e4m3 subnormal values for https://github.com/openvinotoolkit/openvino/pull/28501. In function `f16_to_f8e4m3_bits`, rounding should be done only once for normal values as well as for subnormal values seperately.*
 - *Add a unit test to reproduce this issue beforehand.*

### Tickets:
 - *[CVS-164743](https://jira.devtools.intel.com/browse/CVS-164743)*
