### PR TITLE
[CPU] Apply 'readability-braces-around-statements' clang-tidy remarks

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -67,7 +67,6 @@ Checks: >
   -google-explicit-constructor,
   -google-readability-casting,
   -google-readability-todo,
-  -readability-braces-around-statements,
   -modernize-avoid-c-arrays,
   -modernize-use-constraints,
   -modernize-use-std-numbers,
@@ -106,10 +105,10 @@ CheckOptions:
     value: "3"
   - key: modernize-use-override.AllowOverrideAndFinal
     value: true
+ # Unifies the usage of the statements
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: "1"
 ### To be considered to enable:
-#  # Unifies the usage of the statements
-#  - key: readability-braces-around-statements.ShortStatementLines
-#    value: "1"
 #  Reasonable way to enforce splitting complex code into simple functions
 #  - key: google-readability-function-size.StatementThreshold
 #    value: "800"

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -405,8 +405,9 @@ void jit_prelu_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const s
     VReg dst = VReg(out_vec_idxs[0]);
     FReg fzero = FReg(aux_fp_gpr_idxs[0]);
 
-    if (src0.getIdx() != dst.getIdx())
+    if (src0.getIdx() != dst.getIdx()) {
         h->vmv_v_v(dst, src0);
+    }
 
     h->fmv_w_x(fzero, zero);
     h->vmflt_vf(mask_vreg(), src0, fzero);
@@ -466,8 +467,9 @@ void jit_relu_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const st
         return;
     }
 
-    if (src.getIdx() != dst.getIdx())
+    if (src.getIdx() != dst.getIdx()) {
         h->vmv_v_v(dst, src);
+    }
 
     h->vmflt_vf(mask_vreg(), dst, fzero);
 
@@ -481,8 +483,9 @@ std::set<std::vector<element::Type>> jit_relu_emitter::get_supported_precisions(
 }
 
 void jit_relu_emitter::register_table_entries() {
-    if (alpha != 0)
+    if (alpha != 0) {
         push_arg_entry_of("alpha", dnnl::impl::float2int(alpha));
+    }
 }
 
 /// Power Static ///
@@ -497,8 +500,9 @@ size_t jit_power_static_emitter::get_inputs_num() const {
 }
 
 size_t jit_power_static_emitter::aux_gprs_count() const {
-    if ((power == 0) || is_scale_shift() || (!is_sqrt() && !is_int_pow()))
+    if ((power == 0) || is_scale_shift() || (!is_sqrt() && !is_int_pow())) {
         return 2;
+    }
     return 1;
 }
 
@@ -507,10 +511,12 @@ bool jit_power_static_emitter::is_lmul_supported() const {
 }
 
 size_t jit_power_static_emitter::aux_vecs_count() const {
-    if (is_scale_shift())
+    if (is_scale_shift()) {
         return 2;
-    if (is_int_pow())
+    }
+    if (is_int_pow()) {
         return 1;
+    }
     return 0;
 }
 
@@ -546,8 +552,9 @@ void jit_power_static_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, 
         h->vfmacc_vv(aux0, aux1, src);
         h->vmv_v_v(dst, aux0);
     } else {
-        if (src.getIdx() != dst.getIdx())
+        if (src.getIdx() != dst.getIdx()) {
             h->vmv_v_v(dst, src);
+        }
     }
 
     // for power `-0.5f` there is `vfrsqrt7_v` instruction with worse accuracy
@@ -625,10 +632,12 @@ void jit_power_static_emitter::register_table_entries() {
         push_arg_entry_of("scale", dnnl::impl::float2int(scale));
         push_arg_entry_of("shift", dnnl::impl::float2int(shift));
     }
-    if (power != 1.f)
+    if (power != 1.f) {
         push_arg_entry_of("power", dnnl::impl::float2int(power));
-    if (power < 0)
+    }
+    if (power < 0) {
         push_arg_entry_of("one", CONST_1_F);
+    }
 }
 
 /// Sigmoid ///

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_emitter.cpp
@@ -211,13 +211,17 @@ std::vector<size_t> get_caller_saved_gprs(const jit_generator* h, const std::vec
     gprs.reserve(count);
     for (size_t j = 0; j < count; ++j) {
         const int i = static_cast<int>(j);
-        if (std::find(exclude_gpr_regs.cbegin(), exclude_gpr_regs.cend(), i) != exclude_gpr_regs.cend())
+        if (std::find(exclude_gpr_regs.cbegin(), exclude_gpr_regs.cend(), i) != exclude_gpr_regs.cend()) {
             continue;
-        if (std::find_if(std::begin(h->abi_save_gpr_regs), std::end(h->abi_save_gpr_regs),
-                        [i](const Reg& r) { return r.getIdx() == i; }) != std::end(h->abi_save_gpr_regs))
+        }
+        if (std::find_if(std::begin(h->abi_save_gpr_regs), std::end(h->abi_save_gpr_regs), [i](const Reg& r) {
+                return r.getIdx() == i;
+            }) != std::end(h->abi_save_gpr_regs)) {
             continue;
-        if (i == zero.getIdx() || i == sp.getIdx() || i == gp.getIdx() || i == tp.getIdx())
+        }
+        if (i == zero.getIdx() || i == sp.getIdx() || i == gp.getIdx() || i == tp.getIdx()) {
             continue;
+        }
         gprs.push_back(i);
     }
     return gprs;
@@ -227,11 +231,14 @@ std::vector<size_t> get_caller_saved_fp_gprs(const jit_generator* h, const std::
     fp_gprs.reserve(count);
     for (size_t j = 0; j < count; ++j) {
         const int i = static_cast<int>(j);
-        if (std::find(exclude_fp_gpr_regs.cbegin(), exclude_fp_gpr_regs.cend(), i) != exclude_fp_gpr_regs.cend())
+        if (std::find(exclude_fp_gpr_regs.cbegin(), exclude_fp_gpr_regs.cend(), i) != exclude_fp_gpr_regs.cend()) {
             continue;
-        if (std::find_if(std::begin(h->abi_save_fp_gpr_regs), std::end(h->abi_save_fp_gpr_regs),
-                        [i](const FReg& r) { return r.getIdx() == i; }) != std::end(h->abi_save_fp_gpr_regs))
+        }
+        if (std::find_if(std::begin(h->abi_save_fp_gpr_regs), std::end(h->abi_save_fp_gpr_regs), [i](const FReg& r) {
+                return r.getIdx() == i;
+            }) != std::end(h->abi_save_fp_gpr_regs)) {
             continue;
+        }
         fp_gprs.push_back(i);
     }
     return fp_gprs;
@@ -241,8 +248,9 @@ std::vector<size_t> get_caller_saved_vec_gprs(const jit_generator* h, const std:
     vecs.reserve(count);
     for (size_t j = 0; j < count; ++j) {
         const int i = static_cast<int>(j);
-        if (std::find(exclude_vec_regs.cbegin(), exclude_vec_regs.cend(), i) != exclude_vec_regs.cend())
+        if (std::find(exclude_vec_regs.cbegin(), exclude_vec_regs.cend(), i) != exclude_vec_regs.cend()) {
             continue;
+        }
         vecs.push_back(i);
     }
     return vecs;

--- a/src/plugins/intel_cpu/src/emitters/tpp/common/kernel_executors/brgemm.cpp
+++ b/src/plugins/intel_cpu/src/emitters/tpp/common/kernel_executors/brgemm.cpp
@@ -94,8 +94,9 @@ std::shared_ptr<BrgemmTppCompiledKernel> BrgemmKernelExecutor::compile_kernel(co
     std::shared_ptr<BrgemmTppCompiledKernel> compiled_kernel = std::make_shared<BrgemmTppCompiledKernel>();
 
     // Brgemm is not executable - nothing to compile
-    if (config.is_empty())
+    if (config.is_empty()) {
         return compiled_kernel;
+    }
     // data is row major, but libxsmm gemm suppose column major. in0 and in1 are exchanged to avoid data repack(kernel
     // call args aligned).
     libxsmm_gemm_shape m_shape = libxsmm_create_gemm_shape(config.get_N(),
@@ -122,8 +123,9 @@ void BrgemmKernelExecutor::update_config(const ov::snippets::lowered::Expression
     std::tie(M, N, K, beta) = BrgemmKernelExecutorHelper::get_runtime_brgemm_params(expr, linear_ir);
     const auto& tpp_mod = std::dynamic_pointer_cast<tpp::modifier::TensorProcessingPrimitive>(expr->get_node());
     auto replace_full_dim = [](size_t dim, size_t replace_dim) {
-        if (ov::snippets::utils::is_full_dim_value(dim))
+        if (ov::snippets::utils::is_full_dim_value(dim)) {
             return replace_dim;
+        }
         return dim;
     };
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -107,8 +107,9 @@ void jit_uni_eltwise_generic<isa>::generate() {
 
     size_t min_src_size = jep.dst_size;
     for (size_t i = 0; i < jep.inputs_number; i++) {
-        if (jep.src_size[i] != 1)
+        if (jep.src_size[i] != 1) {
             min_src_size = std::min(min_src_size, jep.src_size[i]);
+        }
     }
 
     if (min_src_size == jep.dst_size) {
@@ -142,12 +143,14 @@ void jit_uni_eltwise_generic<isa>::generate() {
 
     if (min_src_size != jep.dst_size) {
         bool is_valid_configuration = true;
-        if (jep.dst_size % min_src_size != 0)
+        if (jep.dst_size % min_src_size != 0) {
             is_valid_configuration = false;
+        }
 
         for (size_t i = 0; i < jep.inputs_number; i++) {
-            if (jep.src_size[i] != 1 && jep.src_size[i] != min_src_size && jep.src_size[i] != jep.dst_size)
+            if (jep.src_size[i] != 1 && jep.src_size[i] != min_src_size && jep.src_size[i] != jep.dst_size) {
                 is_valid_configuration = false;
+            }
         }
 
         OPENVINO_ASSERT(is_valid_configuration, "Eltwise jitter has invalid configuration for Eltwise node");
@@ -209,8 +212,9 @@ void jit_uni_eltwise_generic<isa>::generate() {
 
 template <ov::intel_cpu::riscv64::cpu_isa_t isa>
 void jit_uni_eltwise_generic<isa>::update_vlen(const Xbyak_riscv::Reg& gpr_work_amount, Xbyak_riscv::SEW sew, Xbyak_riscv::LMUL lmul, bool force) {
-    if (!force && current_lmul == lmul && current_sew == sew)
+    if (!force && current_lmul == lmul && current_sew == sew) {
         return;
+    }
 
     vsetvli(reg_vlen, gpr_work_amount, sew, lmul);
     current_lmul = lmul;
@@ -299,10 +303,11 @@ void jit_uni_eltwise_generic<isa>::store_vector(const Xbyak_riscv::Reg& gpr_work
             const auto needed_lmul = float2lmul(lmul_c * lmul2float(exec_lmul));
             const auto needed_sew = bytes2sew(sew);
             update_vlen(gpr_work_amount, needed_sew, needed_lmul);
-            if (src_prc.is_signed())
+            if (src_prc.is_signed()) {
                 vnclip_wi(dst, src, 0);
-            else
+            } else {
                 vnclipu_wi(dst, src, 0);
+            }
         };
         vnclip(aux_vec(), dst_vec(), 0.5f, 2);
         vnclip(dst_vec(), aux_vec(), 0.25f, 1);
@@ -341,8 +346,9 @@ Xbyak_riscv::LMUL jit_uni_eltwise_generic<isa>::get_max_lmul(const ov::element::
     }
 
     // aux vec is needed for intermediate conversion in load/store
-    if (jep_.src_prc[input_count - 1].size() < exec_prc.size() || jep_.dst_prc.size() < exec_prc.size())
+    if (jep_.src_prc[input_count - 1].size() < exec_prc.size() || jep_.dst_prc.size() < exec_prc.size()) {
         max_aux_vec_count = std::max(max_aux_vec_count, 1lu);
+    }
 
     const auto needed_vec_count = input_count + output_count + max_aux_vec_count + 1; // 1 - mask vec register
     const auto mul = static_cast<size_t>(vec_count / needed_vec_count);

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
@@ -232,8 +232,9 @@ static void quant_u8_by_channel_kernel(const T* src,
             min = std::min(min, tmp);
         }
         float temp_scale = (max - min) / 255;
-        if (temp_scale == 0)
+        if (temp_scale == 0) {
             temp_scale = 0.0001f;
+        }
         float temp_zp = -min / temp_scale;
         scale[j] = temp_scale;
         zp[j] = temp_zp;
@@ -603,8 +604,9 @@ static void paged_attn_quant_mt(const ov::intel_cpu::PlainTensor& k_src,
     } else {
         parallel_for3d(B, L1, H, [&](size_t b, size_t m, size_t h) {
             auto slot = slot_mapping.ptr<int32_t>(b)[m];
-            if (slot < 0)
+            if (slot < 0) {
                 return;
+            }
             auto block_number = slot / block_size;
             auto block_offset = slot % block_size;
             // The layout for per token per head:

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -1516,10 +1516,11 @@ struct MHAHelper {
         auto want_score_stride = rnd_up(kv_len, _block_size);
         _new_score_stride = std::max(prev_score_stride, want_score_stride);
         // std::max(S, SV) here is to ensure by_channel quantize has enough buffer to use
-        if (_quant_key_bychannel)
+        if (_quant_key_bychannel) {
             _output.resize<float>({static_cast<size_t>(_nthr), _block_size, H, std::max(S, SV)});
-        else
+        } else {
             _output.resize<float>({static_cast<size_t>(_nthr), _block_size, H, SV});
+        }
 
         // TODO: kernel supports stride
         if (_qk_gemm.empty() || prev_score_stride < _new_score_stride) {
@@ -2517,19 +2518,21 @@ struct AttentionExecutor : public PagedAttentionExecutor {
         _helper._value_group_size = _helper._value_group_size ? _helper._value_group_size : SV;
 
         // check by_hidden_dims parameter of value cache
-        if (!value_group_num && v_cache.get_precision().is_integral())
+        if (!value_group_num && v_cache.get_precision().is_integral()) {
             OPENVINO_THROW("PagedAttn value cache gets wrong group_size, ",
                            _helper._value_group_size,
                            " should be smaller than hidden_dims");
+        }
         size_t S = 0;
         if (_helper._quant_key_bychannel) {
             S = k_cache.size(3);
         } else {
             // check by_hidden_dims parameter of key cache
-            if (!key_group_num && k_cache.get_precision().is_integral())
+            if (!key_group_num && k_cache.get_precision().is_integral()) {
                 OPENVINO_THROW("PagedAttn key cache gets wrong group_size, ",
                                _helper._key_group_size,
                                " should be smaller than hidden_dims");
+            }
             S = k_cache.size(3) - (k_cache.get_precision().is_real() ? 0 : key_params_size * key_group_num);
             _helper._key_group_size = _helper._key_group_size ? _helper._key_group_size : S;
         }

--- a/src/plugins/intel_cpu/src/transformations/tpp/common/pass/lowered/set_tpp_leading_dim.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/common/pass/lowered/set_tpp_leading_dim.cpp
@@ -37,8 +37,9 @@ bool has_directly_connected_buffer(const ExpressionPort& port, const snippets::l
             const auto& border_points = port.get_type() == ExpressionPort::Type::Input ? loop_info->get_input_ports()
                                                                                        : loop_info->get_output_ports();
             const auto& found = std::find_if(border_points.begin(), border_points.end(), pred);
-            if (found == border_points.end() || found->is_incremented())
+            if (found == border_points.end() || found->is_incremented()) {
                 return false;
+            }
         }
         return true;
     };


### PR DESCRIPTION
### Details:
 - Fix "readability-braces-around-statements" remarks reported by clang-tidy
 - Enable "readability-braces-around-statements" clang-tidy checks on CI by default
 - Configure "readability-braces-around-statements.ShortStatementLines" with the value "1" to enforce one-line statements be wrapped with curly braces

### Tickets:
 - N/A
