### PR TITLE
[GHA] disable mac in pre-commit

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -14,14 +14,14 @@ on:
      - '**/conformance/**'
    branches:
      - 'releases/**'
-  pull_request:
-   paths-ignore:
-     - '**/docs/**'
-     - 'docs/**'
-     - '**/**.md'
-     - '**.md'
-     - '**/layer_tests_summary/**'
-     - '**/conformance/**'
+  # pull_request:
+  #  paths-ignore:
+  #    - '**/docs/**'
+  #    - 'docs/**'
+  #    - '**/**.md'
+  #    - '**.md'
+  #    - '**/layer_tests_summary/**'
+  #    - '**/conformance/**'
 
 concurrency:
   # github.ref is not unique in post-commit


### PR DESCRIPTION
### Details:
 - Disabled mac pipeline in precommits, it was enabled for the test purposes in #29656 

### Tickets:
 - *ticket-id*
