### PR TITLE
[GPU] Disable 2FCs+SwiGLU fusion for per-channel quantized models

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -197,7 +197,7 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
             auto wt_dt = fc_node.get_input_layout(1).data_type;
             if (!data_type_traits::is_i4_u4(wt_dt))
                 continue;
-            // TODO: For grouped decompression scale, 2FCs+SwiGLU fusion is disabled due to accuracy issue
+            // TODO: For per-channel quantized models(# of decompression scale groups = 1), 2FCs+SwiGLU fusion is disabled due to accuracy issue
             bool has_scale = !fc_node.get_primitive()->decompression_scale.empty();
             size_t offset = fc_node.get_primitive()->bias.empty() ? 2 : 3;
             if (has_scale &&

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -203,7 +203,7 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
             if (has_scale &&
                 fc_node.get_input_layout(1).is_static() &&
                 fc_node.get_input_layout(scale_idx).is_static() &&
-                fc_node.get_input_layout(1).batch() == fc_node.get_input_layout(scale_idx).get_linear_size())
+                fc_node.get_input_layout(1).batch() == static_cast<int>(fc_node.get_input_layout(scale_idx).get_linear_size()))
                 continue;
             if (swiglu_prim->glu_type != ov::op::internal::GLU::GluType::Swish ||
                !(swiglu_prim->axis == -1 || swiglu_prim->axis == static_cast<int64_t>(node->get_output_layout(0).get_partial_shape().size()) - 1))

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -199,10 +199,11 @@ void prepare_primitive_fusing::fuse_swiglu(program &p) {
                 continue;
             // TODO: For per-channel quantized models(# of decompression scale groups = 1), 2FCs+SwiGLU fusion is disabled due to accuracy issue
             bool has_scale = !fc_node.get_primitive()->decompression_scale.empty();
-            size_t offset = fc_node.get_primitive()->bias.empty() ? 2 : 3;
+            size_t scale_idx = fc_node.get_primitive()->bias.empty() ? 2 : 3;
             if (has_scale &&
-                fc_node.get_input_layout(offset).is_static() &&
-                fc_node.get_input_layout(offset).feature() == 1)
+                fc_node.get_input_layout(1).is_static() &&
+                fc_node.get_input_layout(scale_idx).is_static() &&
+                fc_node.get_input_layout(1).batch() == fc_node.get_input_layout(scale_idx).get_linear_size())
                 continue;
             if (swiglu_prim->glu_type != ov::op::internal::GLU::GluType::Swish ||
                !(swiglu_prim->axis == -1 || swiglu_prim->axis == static_cast<int64_t>(node->get_output_layout(0).get_partial_shape().size()) - 1))


### PR DESCRIPTION
### Details:
 - Currently for per-channel quantized models, FC(two FCs already fused)+SwiGLU fusion causes accuracy issue. 
 - 2FCs+SwiGLU fusion is disabled until `fully_connected_bf_tiled` opt kernel supports that case.

### Tickets:
 - 165528
