### PR TITLE
[GPU] Fix incorrect key/value cache scale shape does not program correctly

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -328,6 +328,13 @@ public:
             params.inputs[i] = convert_data_tensor(impl_param.get_input_layout(i));
         }
 
+        if (desc->scale_val.has_value()) {
+            data_inputs_num++;
+        }
+        if (desc->attn_mask_val.has_value()) {
+            data_inputs_num++;
+        }
+
         params.conf = get_sdpa_configuration(impl_param);
 
         params.input0_order = desc->input_q_transpose_order;


### PR DESCRIPTION
Recent change to sdpa_micro to convert scalar buffer to scalar value has mismatch the key/value scale shape programming which use the wrong input index.

This affect qwen2-7 model that generate the garbage output.

### Tickets:
CVS-165877
