### PR TITLE
[CPU] Apply 'bugprone-lambda-function-name' clang-tidy remarks

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -26,7 +26,6 @@
 # -bugprone-exception-escape. There are a lot of legacy code which does not handle exceptions properly and just catches them all. Major refactoring is required to correct this.
 # -bugprone-implicit-widening-of-multiplication-result
 # -bugprone-incorrect-roundings. There are explicit ways to perform rounding (i.e. std::floor(), std::round(), etc). Requires careful updates case by case
-# -bugprone-lambda-function-name. Used by generic debug caps macro
 # -bugprone-signed-char-misuse. The source code contains valid logic when pointer to the data is interpreted as int8_t (i.e. weights tensor)
 # -cppcoreguidelines-narrowing-conversions
 # -google-default-arguments,
@@ -59,7 +58,6 @@ Checks: >
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-incorrect-roundings,
-  -bugprone-lambda-function-name,
   -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
   -cppcoreguidelines-narrowing-conversions,

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -167,7 +167,7 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
 
 #    define DEBUG_LOG_EXT(name, ostream, prefix, ...)                                                              \
         do {                                                                                                       \
-            static DebugLogEnabled DEBUG_ENABLE_NAME(__FILE__, __func__, __LINE__, name);                          \
+            static DebugLogEnabled DEBUG_ENABLE_NAME(__FILE__, __PRETTY_FUNCTION__, __LINE__, name);               \
             if (DEBUG_ENABLE_NAME) {                                                                               \
                 ::std::stringstream ss___;                                                                         \
                 ov::intel_cpu::_write_all_to_stream(ss___, prefix, DEBUG_ENABLE_NAME.get_tag(), " ", __VA_ARGS__); \


### PR DESCRIPTION
### Details:
 - Fix "bugprone-lambda-function-name" remarks reported by clang-tidy:
   * Using `__PRETTY_FUNCTION__` instead of `__func__` macro simplifies debugging and shows the name of the outer function if this macro is called in the scope of lambda function
 - Enable "bugprone-lambda-function-name" clang-tidy checks on CI by default

### Tickets:
 - *ticket-id*
