### PR TITLE
[GFI] Add an AI usage notice to GFI template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -62,7 +62,7 @@ body:
     attributes:
       label: AI notice - Important!
       description: |
-          We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.
+          We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. **Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project.** Please take the time to understand the changes you are proposing and their impact.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -61,7 +61,7 @@ body:
     id: ai_notice
     attributes:
       label: AI notice - Important!
-      description: |
+      value: |
           We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. **Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project.** Please take the time to understand the changes you are proposing and their impact.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -58,6 +58,15 @@ body:
       required: true
 
   - type: textarea
+    id: ai_notice
+    attributes:
+      label: AI notice - Important!
+      description: |
+          We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.
+    validations:
+      required: true
+
+  - type: textarea
     id: ticket
     attributes:
       label: Ticket


### PR DESCRIPTION
### Details:
 - AI generated, low-effort PRs are becoming a significant problem
 - A warning allows us to have more freedom in closing PRs which are clearly AI generated and don't show any improvement over the review process
 - Let's hope this helps a little :)

### Tickets:
 - N/A
