### PR TITLE
[GPU] to use original dims for fc_onednn_impl

### DIFF
--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -66,14 +66,14 @@ format::type get_preferred_format(fully_connected_node const& node, const kernel
     }
 
     if (input_layout.data_type == data_types::f32 &&
-        (input_layout.format == format::bfyx || input_layout.format == format::bfzyx) &&
+        (input_layout.format == format::bfyx || input_layout.format == format::bfzyx || input_layout.format == format::bfwzyx) &&
         no_spatial_padding &&
         input_layout.batch() != 8)
         return input_layout.format;
 
     auto input_pitches = input_layout.get_pitches();
     if (input_layout.data_type == data_types::f16 &&
-        (input_layout.format == format::bfyx || input_layout.format == format::bfzyx) &&
+        (input_layout.format == format::bfyx || input_layout.format == format::bfzyx || input_layout.format == format::bfwzyx) &&
         no_spatial_padding &&
         input_pitches[0] % 2 == 0 &&
         input_layout.batch() != 16)
@@ -128,25 +128,28 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         weights_layout.set_partial_shape(reshape_to_2d(weights_pshape, feature));
     }
 
-    auto output_size = tensor();
-
-    // If immad is supported, spatial dimensions are reshaped to 2d in order to select oneDnn impl,
-    // because oneDnn doesn't support spatial dimensions for output.
     if (supports_immad) {
-        if (desc->input_size > 3) {
-            input_layout.set_partial_shape(reshape_to_2d(input_pshape, feature));
+        ov::PartialShape out_pshape = {input_layout.batch(), weights_layout.batch()};
+        if (desc->input_size == 3) {
+            out_pshape = {input_layout.batch(), input_layout.feature(), weights_layout.batch()};
+        } else if (desc->input_size == 4) {
+            out_pshape = {input_layout.batch(), input_layout.feature(), input_layout.spatial(1), weights_layout.batch()};
+        } else if (desc->input_size == 5) {
+            out_pshape = {input_layout.batch(), input_layout.feature(), input_layout.spatial(2), input_layout.spatial(1), weights_layout.batch()};
+        } else if (desc->input_size == 6) {
+            out_pshape = {input_layout.batch(), input_layout.feature(), input_layout.spatial(3),
+                          input_layout.spatial(2), input_layout.spatial(1), weights_layout.batch()};
         }
 
-        output_size = tensor(input_layout.batch(), weights_layout.batch(), 1, 1);
-        if (desc->input_size == 3) {
-            output_size = tensor(input_layout.batch(), input_layout.feature(), 1, weights_layout.batch());
-        }
+        format output_format = get_preferred_format(node, impl_param);
+
+        return layout(out_pshape, output_type, output_format);
     } else {
         if (desc->input_size > 5) {
             input_layout.set_partial_shape(reshape_to_2d(input_pshape, feature));
         }
 
-        output_size = tensor(input_layout.batch(), weights_layout.batch(), 1, 1);
+        auto output_size = tensor(input_layout.batch(), weights_layout.batch(), 1, 1);
         if (desc->input_size == 3) {
             output_size = tensor(input_layout.batch(), input_layout.feature(), 1, weights_layout.batch());
         } else if (desc->input_size == 4) {
@@ -154,11 +157,11 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         } else if (desc->input_size == 5) {
             output_size = tensor(input_layout.batch(), input_layout.feature(), weights_layout.batch(), input_layout.spatial(1), input_layout.spatial(2));
         }
+
+        format output_format = get_preferred_format(node, impl_param);
+
+        return layout(output_type, output_format, output_size);
     }
-
-    format output_format = get_preferred_format(node, impl_param);
-
-    return layout(output_type, output_format, output_size);
 }
 
 template<typename ShapeType>
@@ -246,10 +249,27 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
                 can_apply_fake_alignment = false;
                 break;
             }
+            auto fuse_op_input_shape = fused_op_input_layout.get_shape();
+
             // Check fused desc's input has full tensor, then do not fake alignment
-            if (orig_output_layout.get_shape() == fused_op_input_layout.get_shape()) {
+            if (orig_output_layout.get_shape() == fuse_op_input_shape) {
                 can_apply_fake_alignment = false;
                 break;
+            }
+
+            if (fuse_op_input_shape.size() > 2) {
+                auto fuse_op_batch_size = std::accumulate(fuse_op_input_shape.begin(),
+                                                          fuse_op_input_shape.end() - 1,
+                                                          size_t{1},
+                                                          std::multiplies<size_t>());
+                if (fuse_op_batch_size > 1) {
+                    GPU_DEBUG_TRACE_DETAIL << "unable to apply fake-alignment: "
+                                           << orig_impl_param.typed_desc<fully_connected>()->id
+                                           << " " << input_shape
+                                           << " + " << fuse_op_input_shape << std::endl;
+                    can_apply_fake_alignment = false;
+                    break;
+                }
             }
         }
     }

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -274,6 +274,11 @@ kernel_impl_params fully_connected_inst::get_fake_aligned_params(kernel_impl_par
         }
     }
 
+    auto prim = orig_impl_param.typed_desc<fully_connected>();
+    if (prim != nullptr && prim->weights_rank > 2) {
+        can_apply_fake_alignment = false;
+    }
+
     GPU_DEBUG_IF(orig_impl_param.get_program().get_config().get_disable_fake_alignment()) {
         can_apply_fake_alignment = false;
     }

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -130,9 +130,9 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
     }
 
     if (supports_immad) {
-        ov::PartialShape out_pshape = {input_layout.batch(), weights_layout.batch()};
+        ov::PartialShape out_pshape = {input_layout.batch(), weights_layout.batch(), 1, 1};
         if (desc->input_size == 3) {
-            out_pshape = {input_layout.batch(), input_layout.feature(), weights_layout.batch()};
+            out_pshape = {input_layout.batch(), input_layout.feature(), weights_layout.batch(), 1};
         } else if (desc->input_size == 4) {
             out_pshape = {input_layout.batch(), input_layout.feature(), input_layout.spatial(1), weights_layout.batch()};
         } else if (desc->input_size == 5) {

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -118,9 +118,10 @@ layout fully_connected_inst::calc_output_layout(fully_connected_node const& node
         return reshapeSize;
     };
 
-    int64_t feature = input_pshape[std::min(desc->input_size, static_cast<size_t>(4)) - 1].get_length();
+    size_t feature_idx = supports_immad ? desc->input_size : std::min(desc->input_size, static_cast<size_t>(4));
+    int64_t feature = input_pshape[feature_idx - 1].get_length();
 
-    if (desc->input_size == 3) {
+    if (desc->input_size == 3 && !supports_immad) {
         feature = std::max({input_layout.spatial(0), input_layout.spatial(1), input_layout.spatial(2)});
     }
 

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -66,7 +66,7 @@ format::type get_preferred_format(fully_connected_node const& node, const kernel
     }
 
     if (input_layout.data_type == data_types::f32 &&
-        (input_layout.format == format::bfyx || input_layout.format == format::bfzyx || input_layout.format == format::bfwzyx) &&
+        one_of<cldnn::format>(input_layout.format, {format::bfyx, format::bfzyx, format::bfwzyx}) &&
         no_spatial_padding &&
         input_layout.batch() != 8)
         return input_layout.format;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -472,7 +472,8 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
                                                                        desc->weights,
                                                                        bias_name,
                                                                        fc.get_output_layout().data_type,
-                                                                       desc->input_size);
+                                                                       desc->input_size,
+                                                                       desc->weights_rank);
 
             if (desc->compressed_weights) {
                 fc_with_bias_prim->compressed_weights = true;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -130,25 +130,71 @@ protected:
         get_matmul_primitive_descriptor(const kernel_impl_params& impl_params,
                                         cldnn::engine& engine,
                                         size_t prim_input_size,
+                                        size_t prim_weights_rank,
                                         bool has_bias,
                                         const dnnl::primitive_attr& attr = dnnl::primitive_attr()) {
         auto input_layout = impl_params.get_input_layout(0);
         auto weights_layout = impl_params.get_input_layout(1);
         auto output_layout = impl_params.get_output_layout();
 
-        transform_layouts(input_layout, weights_layout, output_layout, prim_input_size);
+        dnnl::memory::format_tag target_fmt;
+        dnnl::memory::format_tag weights_fmt;
 
-        auto input_md = onednn::layout_to_memory_desc(input_layout, dnnl::memory::format_tag::ab, false);
-        // TODO: should change format to any. May need a reorder.
-        auto weights_md = onednn::layout_to_memory_desc(weights_layout, dnnl::memory::format_tag::ba);
-        auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::ab, false);
+        if (prim_input_size == 3) {
+            target_fmt = dnnl::memory::format_tag::abc;
+            weights_fmt = dnnl::memory::format_tag::acb;
+        } else if (prim_input_size == 4) {
+            target_fmt = dnnl::memory::format_tag::abcd;
+            weights_fmt = dnnl::memory::format_tag::abdc;
+        } else if (prim_input_size == 5) {
+            target_fmt = dnnl::memory::format_tag::abcde;
+            weights_fmt = dnnl::memory::format_tag::abced;
+        } else if (prim_input_size == 6) {
+            target_fmt = dnnl::memory::format_tag::abcdef;
+            weights_fmt = dnnl::memory::format_tag::abcdfe;
+        } else {
+            target_fmt = dnnl::memory::format_tag::ab;
+            weights_fmt = dnnl::memory::format_tag::ba;
+        }
+
+        // Transform weights_layout according to input layout
+        {
+            ov::PartialShape new_weights_pshape;
+
+            for (size_t i = 0; i < (prim_input_size - prim_weights_rank); i++) {
+                new_weights_pshape.push_back(1);
+            }
+
+            for (size_t i = 0; i < prim_weights_rank; i++) {
+                new_weights_pshape.push_back(weights_layout.get_partial_shape()[i]);
+            }
+
+            weights_layout.set_partial_shape(new_weights_pshape);
+            weights_layout.format = input_layout.format;
+        }
+
+        dnnl::memory::desc input_md = onednn::layout_to_memory_desc(input_layout, target_fmt, false);
+        dnnl::memory::desc weights_md = onednn::layout_to_memory_desc(weights_layout, weights_fmt, false);
+        dnnl::memory::desc output_md = onednn::layout_to_memory_desc(output_layout, target_fmt, false);
 
         if (has_bias) {
-            dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::ab;
             auto bias_l = impl_params.get_input_layout(2);
-            if (bias_l.get_shape().size() == 1)
-                target_fmt = dnnl::memory::format_tag::ba;
-            auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), target_fmt, false);
+            auto bias_b_size = (bias_l.get_partial_shape().size() == 1) ? 1 : bias_l.batch();
+            auto bias_f_size = static_cast<int32_t>(bias_l.get_tensor().count()) / bias_b_size;
+
+            if (prim_input_size == 3) {
+                bias_l.set_partial_shape({ 1, bias_b_size, bias_f_size });
+            } else if (prim_input_size == 4) {
+                bias_l.set_partial_shape({ 1, 1, bias_b_size, bias_f_size });
+            } else if (prim_input_size == 5) {
+                bias_l.set_partial_shape({ 1, 1, 1, bias_b_size, bias_f_size });
+            } else if (prim_input_size == 6) {
+                bias_l.set_partial_shape({ 1, 1, 1, 1, bias_b_size, bias_f_size });
+            } else {
+                bias_l.set_partial_shape({ bias_b_size, bias_f_size });
+            }
+
+            auto bias_md = onednn::layout_to_memory_desc(bias_l, target_fmt, false);
             return std::make_shared<dnnl::matmul::primitive_desc>(
                 engine.get_onednn_engine(),
                 input_md,
@@ -174,9 +220,11 @@ public:
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ob.getKernelImplParams());
         auto prim = impl_params->typed_desc<fully_connected>();
         size_t input_size = prim->input_size;
+        size_t weigts_rank = prim->weights_rank;
         bool has_bias = !prim->bias.empty();
         bool is_compressed = prim->compressed_weights;
         ob << input_size;
+        ob << weigts_rank;
         ob << has_bias;
         ob << is_compressed;
         ob << prim->dynamic_quantized_activation;
@@ -204,11 +252,13 @@ public:
         parent::load(ib);
 
         size_t input_size = 2;
+        size_t weigts_rank = 2;
         bool has_bias = false;
         bool is_compressed = false;
         bool dynamic_quantized_activation;
         bool dynamic_quantized_activation_zp;
         ib >> input_size;
+        ib >> weigts_rank;
         ib >> has_bias;
         ib >> is_compressed;
         ib >> dynamic_quantized_activation;
@@ -265,7 +315,7 @@ public:
                 _attrs->set_zero_points(DNNL_ARG_SRC, GROUPED, dnnl::memory::dims{1, src_group_size}, dnnl::memory::data_type::u8);
         }
 
-        auto prim_desc = get_matmul_primitive_descriptor(*impl_params, ib.get_engine(), input_size, has_bias, *_attrs);
+        auto prim_desc = get_matmul_primitive_descriptor(*impl_params, ib.get_engine(), input_size, weigts_rank, has_bias, *_attrs);
         _pd = *prim_desc;
 
         std::vector<uint8_t> prim_cache;
@@ -298,18 +348,20 @@ public:
 
             auto weights_layout = impl_params.get_input_layout(1);
             is_four_bit_weight = weights_layout.data_type == data_types::u4 || weights_layout.data_type == data_types::i4;
+            auto shift_size = std::max<size_t>(prim->input_size - 2, 0);
             if (!prim->decompression_scale.empty()) {
                 auto decompression_scale_idx = ++idx;
-                ds_data_type = convert_data_type(arg.get_dependency(decompression_scale_idx).get_output_layout().data_type);
+                auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
+                ds_data_type = convert_data_type(scale_layout.data_type);
                 auto ifm = arg.get_dependency(1).get_output_layout().get_dim(1);
-                auto ngroups = arg.get_dependency(decompression_scale_idx).get_output_layout().get_dim(1);
+                auto ngroups = scale_layout.get_dim(1);
                 group_size = ifm / ngroups;
                 if (!is_four_bit_weight) {
                     // 8-bit quantized weight
-                    attr->set_scales(DNNL_ARG_WEIGHTS, PER_OC, dnnl::memory::dims{}, ds_data_type);
+                    attr->set_scales(DNNL_ARG_WEIGHTS, (PER_OC << shift_size), dnnl::memory::dims{}, ds_data_type);
                 } else {
                     // OneDNN does not support scalar zero-point for s4 and u8 type. Need to broadcast it.
-                    attr->set_scales(DNNL_ARG_WEIGHTS, GROUPED, {group_size, 1}, ds_data_type);
+                    attr->set_scales(DNNL_ARG_WEIGHTS, (GROUPED << shift_size), {group_size, 1}, ds_data_type);
                 }
             }
 
@@ -323,9 +375,9 @@ public:
                 } else {
                     auto ngroups = dzp_layout.get_dim(1);
                     if (ngroups == 1) {
-                        attr->set_zero_points(DNNL_ARG_WEIGHTS, PER_OC, dnnl::memory::dims{}, dzp_data_type);
+                        attr->set_zero_points(DNNL_ARG_WEIGHTS, (PER_OC << shift_size), dnnl::memory::dims{}, dzp_data_type);
                     } else {
-                        attr->set_zero_points(DNNL_ARG_WEIGHTS, GROUPED, {group_size, 1}, dzp_data_type);
+                        attr->set_zero_points(DNNL_ARG_WEIGHTS, (GROUPED << shift_size), {group_size, 1}, dzp_data_type);
                     }
                 }
             }
@@ -339,15 +391,15 @@ public:
                 int src_group_size = innermost_len / src_scale_ngroups;
 
                 auto act_scale_data_type = convert_data_type(impl_params.input_layouts[src_scale_idx].data_type);
-                attr->set_scales(DNNL_ARG_SRC, GROUPED, dnnl::memory::dims{1, src_group_size}, act_scale_data_type);
+                attr->set_scales(DNNL_ARG_SRC, (GROUPED << shift_size), dnnl::memory::dims{1, src_group_size}, act_scale_data_type);
 
                 if (prim->activation_zero_point.is_valid())
-                    attr->set_zero_points(DNNL_ARG_SRC, GROUPED, dnnl::memory::dims{1, src_group_size}, dnnl::memory::data_type::u8);
+                    attr->set_zero_points(DNNL_ARG_SRC, (GROUPED << shift_size), dnnl::memory::dims{1, src_group_size}, dnnl::memory::data_type::u8);
             }
 
 
             auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
-                                                             prim->input_size, !prim->bias.empty(), *attr);
+                                                             prim->input_size, prim->weights_rank, !prim->bias.empty(), *attr);
 
             auto prim_onednn = std::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
             prim_onednn->_ds_group_size = group_size;
@@ -356,7 +408,7 @@ public:
             return prim_onednn;
         } else {
             auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
-                                                             prim->input_size, !prim->bias.empty(), *attr);
+                                                             prim->input_size, prim->weights_rank, !prim->bias.empty(), *attr);
 
             return std::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -157,6 +157,14 @@ protected:
             weights_fmt = dnnl::memory::format_tag::ba;
         }
 
+        if (prim_input_size < 4) {
+            auto output_pshape = output_layout.get_partial_shape();
+            if (output_pshape.size() > prim_input_size) {
+                output_pshape.resize(prim_input_size);
+                output_layout.set_partial_shape(output_pshape);
+            }
+        }
+
         // Transform weights_layout according to input layout
         {
             ov::PartialShape new_weights_pshape;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -220,11 +220,11 @@ public:
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ob.getKernelImplParams());
         auto prim = impl_params->typed_desc<fully_connected>();
         size_t input_size = prim->input_size;
-        size_t weigts_rank = prim->weights_rank;
+        size_t weights_rank = prim->weights_rank;
         bool has_bias = !prim->bias.empty();
         bool is_compressed = prim->compressed_weights;
         ob << input_size;
-        ob << weigts_rank;
+        ob << weights_rank;
         ob << has_bias;
         ob << is_compressed;
         ob << prim->dynamic_quantized_activation;
@@ -252,13 +252,13 @@ public:
         parent::load(ib);
 
         size_t input_size = 2;
-        size_t weigts_rank = 2;
+        size_t weights_rank = 2;
         bool has_bias = false;
         bool is_compressed = false;
         bool dynamic_quantized_activation;
         bool dynamic_quantized_activation_zp;
         ib >> input_size;
-        ib >> weigts_rank;
+        ib >> weights_rank;
         ib >> has_bias;
         ib >> is_compressed;
         ib >> dynamic_quantized_activation;
@@ -315,7 +315,7 @@ public:
                 _attrs->set_zero_points(DNNL_ARG_SRC, GROUPED, dnnl::memory::dims{1, src_group_size}, dnnl::memory::data_type::u8);
         }
 
-        auto prim_desc = get_matmul_primitive_descriptor(*impl_params, ib.get_engine(), input_size, weigts_rank, has_bias, *_attrs);
+        auto prim_desc = get_matmul_primitive_descriptor(*impl_params, ib.get_engine(), input_size, weights_rank, has_bias, *_attrs);
         _pd = *prim_desc;
 
         std::vector<uint8_t> prim_cache;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
@@ -37,7 +37,10 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
         if (one_of(data_types::i64, {in0_dt, wei_dt}))
             return false;
 
-        if (!everyone_is(format::bfyx, in_layout.format, out_layout.format) && !everyone_is(format::any, in_layout.format, out_layout.format))
+        if (!everyone_is(format::bfyx, in_layout.format, out_layout.format) &&
+            !everyone_is(format::bfzyx, in_layout.format, out_layout.format) &&
+            !everyone_is(format::bfwzyx, in_layout.format, out_layout.format) &&
+            !everyone_is(format::any, in_layout.format, out_layout.format))
             return false;
 
         if (!is_supported_pad(in_layout) || !is_supported_pad(out_layout))
@@ -63,18 +66,6 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
                     (decompression_zp_dt != ov::element::Type_t::u8 && decompression_zp_dt != ov::element::Type_t::i8)) {
                     return false;
                 }
-            }
-        }
-
-        const auto& output_layout = fc_node.get_output_layout();
-        const auto& ps = output_layout.get_partial_shape();
-        size_t non_spatial_count = 2 + (fc_prim->input_size == 3 ? 1 : 0);
-        size_t rank = ps.size();
-
-        // OneDnn doesn't support spatial dimensions for output
-        for (auto i = non_spatial_count; i < rank; i++) {
-            if (ps[i].is_dynamic() || ps[i] != 1) {
-                return false;
             }
         }
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -274,6 +274,28 @@ dnnl::memory::desc layout_to_memory_desc(cldnn::layout l, dnnl::memory::format_t
         dims.push_back(l.batch());
         dims.push_back(l.feature());
         dims.push_back(l.spatial(1));
+    } else if (target_fmt == dnnl::memory::format_tag::acb) {
+        dims.push_back(l.batch());
+        dims.push_back(l.spatial(1));
+        dims.push_back(l.feature());
+    } else if (target_fmt == dnnl::memory::format_tag::abdc) {
+        dims.push_back(l.batch());
+        dims.push_back(l.feature());
+        dims.push_back(l.spatial(0));
+        dims.push_back(l.spatial(1));
+    } else if (target_fmt == dnnl::memory::format_tag::abced) {
+        dims.push_back(l.batch());
+        dims.push_back(l.feature());
+        dims.push_back(l.spatial(2));
+        dims.push_back(l.spatial(0));
+        dims.push_back(l.spatial(1));
+    } else if (target_fmt == dnnl::memory::format_tag::abcdfe) {
+        dims.push_back(l.batch());
+        dims.push_back(l.feature());
+        dims.push_back(l.spatial(3));
+        dims.push_back(l.spatial(2));
+        dims.push_back(l.spatial(0));
+        dims.push_back(l.spatial(1));
     } else if (target_fmt == dnnl::memory::format_tag::ba) {
         dims.push_back(l.feature());
         dims.push_back(l.get_tensor().count() / l.feature());

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1283,11 +1283,12 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                 expected = format::get_default_format(node.get_input_layout(0).get_rank());
                 node.set_preferred_input_fmt(0, expected);
             } else {
-                auto& fc_node = node.as<fully_connected>();
-                auto input_layout = fc_node.get_input_layout();
-                if (input_layout.format.dimension() > 4) {
-                    expected = format::bfyx;
-                    node.set_preferred_input_fmt(0, format::bfyx);
+                if (!use_onednn_impls) {
+                    auto& fc_node = node.as<fully_connected>();
+                    auto input_layout = fc_node.get_input_layout();
+                    if (input_layout.format.dimension() > 4) {
+                        expected = format::bfyx;
+                    }
                 }
             }
         }

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -1288,6 +1288,7 @@ format layout_optimizer::get_preferred_format(program_node& node) {
                     auto input_layout = fc_node.get_input_layout();
                     if (input_layout.format.dimension() > 4) {
                         expected = format::bfyx;
+                        node.set_preferred_input_fmt(0, format::bfyx);
                     }
                 }
             }

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2699,7 +2699,9 @@ bool primitive_inst::is_valid_fusion() const {
         }
     }
 
-    const auto& out_pshape = _impl_params->get_output_layout().get_partial_shape();
+    const auto& out_pshape = (_unfused_subgraph != nullptr && !get_flag(ExecutionFlags::SHAPE_CHANGED)) ?
+                            _unfused_subgraph->get_primitive(_node->id())->get_output_layout().get_partial_shape() :
+                            _impl_params->get_output_layout().get_partial_shape();
     for (auto& fd : fused_eltwise_prims) {
         auto outer_dep_idx = fd.outer_dep_start_idx;
         if (outer_dep_idx < 0) // no outer dep
@@ -2733,29 +2735,6 @@ bool primitive_inst::is_valid_fusion() const {
 
             if (gemm_dims[0] != data_dims[0] && gemm_dims[1] != 1)
                 return false;
-        } else if (_node->is_type<fully_connected>() && _node->get_preferred_impl_type() == impl_types::onednn) {
-            const auto& fc_layout = _impl_params->get_output_layout();
-            const auto& data_layout = outer_dep.first->_impl_params->get_output_layout();
-
-            const auto fc_dims = fc_layout.get_dims();
-            const auto data_dims = data_layout.get_dims();
-
-            auto same_spatial = [](layout a, layout b) {
-                if (a.get_spatial_rank() != b.get_spatial_rank())
-                    return false;
-                for (size_t i = 0; i < a.get_spatial_rank(); i++) {
-                    if (a.spatial(i) != b.spatial(i))
-                        return false;
-                }
-                return true;
-            };
-
-            if (!(fc_dims[0] == 1 || fc_dims[1] == 1) &&
-                !(data_dims[0] == 1 && data_dims[1] == 1) &&
-                !((data_dims[0] == 1 || data_dims[1] == 1) && same_spatial(fc_layout, data_layout)) &&
-                !(fc_layout.count() == data_layout.count())) {
-                return false;
-            }
         }
 #endif
 

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1566,69 +1566,36 @@ void program_node::create_onednn_primitive_attributes(
         } else if (desc.is_type<eltwise>()) {
             auto dep_idx = desc.outer_dep_start_idx;
             auto in = get_input_layout(dep_idx);
-            auto fc_needs_full_tensor = [&]() {
-                for (size_t i = 0; i < cldnn_post_ops.size(); i++) {
-                    auto& desc = cldnn_post_ops[i];
-                    if (desc.is_type<eltwise>()) {
-                        auto prim = this->as<fully_connected>().get_primitive();
-                        auto dep_idx = desc.outer_dep_start_idx;
-                        auto in = get_input_layout(dep_idx);
-                        if (prim->input_size == 3 && in.batch() > 1 && in.feature() > 1)
-                            return true;
-                    }
-                }
-                return false;
-            };
+
             auto set_binary_op = [&](dnnl::algorithm alg, onednn_post_op_type op_type) {
-                if (is_type<fully_connected>() || is_type<gemm>()) {
+                if (is_type<gemm>()) {
                     size_t rank = cldnn::format::dimension(in.format);
                     auto in_pshape = in.get_partial_shape();
                     auto out_pshape = get_output_layout().get_partial_shape();
-                    size_t ones_to_add = 0;
-
-                    if (is_type<fully_connected>()) {
-                        auto prim = this->as<fully_connected>().get_primitive();
-                        if (prim->input_size == in_pshape.size()) {
-                            if (prim->input_size >= 3 && !fc_needs_full_tensor()) {
-                                cldnn::onednn::combine_bf_with_first_spatial_dim(in);
-                                in_pshape = in.get_partial_shape();
-                            }
-                            ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
-                        } else {
-                            if (prim->input_size >= 3) {
-                                cldnn::onednn::combine_bf_with_first_spatial_dim(in);
-                                in_pshape = in.get_partial_shape();
-                                ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
-                            } else {
-                                ones_to_add = 2;
-                            }
-                        }
-                        if (ones_to_add > 0) {
-                            layout new_layout = in;
-                            ov::PartialShape new_input_pshape;
-                            auto last = in_pshape.begin() + in_pshape.size();
-                            if (in_pshape.size() > prim->input_size)
-                                last -= ones_to_add;
-                            std::vector<ov::Dimension> dims(in_pshape.begin(), last);
-                            new_input_pshape = ov::PartialShape(dims);
-                            new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
-                            new_layout.set_partial_shape(new_input_pshape);
-                            in = new_layout;
-                        }
-                    } else {
-                        ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
-                        if (ones_to_add > 0) {
-                            layout new_layout = in;
-                            ov::PartialShape new_input_pshape;
-                            std::vector<ov::Dimension> dims(in_pshape.begin(), in_pshape.begin() + in_pshape.size());
-                            new_input_pshape = ov::PartialShape(dims);
-                            new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
-                            new_layout.set_partial_shape(new_input_pshape);
-                            in = new_layout;
-                        }
+                    size_t ones_to_add = std::max(out_pshape.size(), static_cast<size_t>(rank)) - in_pshape.size();
+                    if (ones_to_add > 0) {
+                        layout new_layout = in;
+                        ov::PartialShape new_input_pshape;
+                        std::vector<ov::Dimension> dims(in_pshape.begin(), in_pshape.begin() + in_pshape.size());
+                        new_input_pshape = ov::PartialShape(dims);
+                        new_input_pshape.insert(new_input_pshape.begin(), ones_to_add, 1ul);
+                        new_layout.set_partial_shape(new_input_pshape);
+                        in = new_layout;
                     }
                     size_t in_batched_size = in.count() / (in.spatial(0) * in.spatial(1));
                     dnnl::memory::dims dims = onednn::convert_gemm_tensor(in.get_tensor(), rank, in_batched_size == 1);
+                    dnnl::memory::data_type dt = onednn::convert_data_type(in.data_type);
+                    dnnl::memory::format_tag fmt = onednn::convert_gemm_data_format(dims, in.format);
+                    post_ops.append_binary(alg, dnnl::memory::desc(dims, dt, fmt));
+                    update_onednn_post_op_list(op_type, dep_idx, fmt, false, dims, dt);
+                } else if (is_type<fully_connected>()) {
+                    auto input_size = this->as<fully_connected>().get_primitive()->input_size;
+
+                    dnnl::memory::dims dims;
+                    for (size_t i = 0; i < input_size; i++) {
+                        dims.push_back(in.get_dim(i));
+                    }
+
                     dnnl::memory::data_type dt = onednn::convert_data_type(in.data_type);
                     dnnl::memory::format_tag fmt = onednn::convert_gemm_data_format(dims, in.format);
                     post_ops.append_binary(alg, dnnl::memory::desc(dims, dt, fmt));

--- a/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fake_alignment/fc_fake_alignment_test.cpp
@@ -232,7 +232,7 @@ TEST_P(fully_connected_skip_fake_align_test, skip_fake_alignment_case) {
 
     topology.add(input_layout("weights", p.weight_layout));
     topology.add(fully_connected("fc_prim1", input_info("eltwise_add1"), "weights", "",
-                 cldnn::data_types::f32, p.input_layout.get_rank(), p.weight_layout.get_rank()));
+                 cldnn::data_types::f32, p.input_layout.get_partial_shape().size(), p.weight_layout.get_partial_shape().size()));
 
     topology.add(input_layout("bias",
                  layout{ov::PartialShape{1, 1, p.expected_output_layout_igpu.get_dims()[2]}, cldnn::data_types::f32, cldnn::format::bfyx}));

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -119,7 +119,12 @@ public:
     }
 
     layout get_per_channel_layout(fully_connected_test_params& p) {
-        return layout{ ov::PartialShape{1, p.out_shape[1]}, p.default_type, p.default_format };
+        ov::PartialShape pshape = {1, p.out_shape[1]};
+        if (p.out_shape.size() >= 3)
+            pshape.push_back(1);
+        if (p.out_shape.size() == 4)
+            pshape.push_back(1);
+        return layout{ pshape, p.default_type, p.default_format };
     }
 
     size_t get_output_dim_size(fully_connected_test_params& p) {
@@ -162,9 +167,9 @@ public:
 #define CASE_FC_FP32_1 { 1, 3 }, { 1, 4 }, { 4, 3 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP32_2 { 2, 3 }, { 2, 4 }, { 4, 3 }, data_types::f32, format::yxfb, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP32_3 { 2, 32 }, { 2, 16 }, { 16, 32 }, data_types::f32, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP32_3D_3 { 2, 32, 32 }, { 2, 32, 16 }, { 16, 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP32_3D_3 { 2, 32, 32 }, { 2, 32, 16 }, { 16, 32 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 
 #define DYN_CASE_FC_FP32_3D_1 { 5, 3, 3 }, { 5, 3, 5 }, { 5, 3 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
 #define DYN_CASE_FC_FP32_3D_2 { 2, 1, 1 }, { 2, 1, 32 }, { 32, 1 }, data_types::f32, format::bfyx, data_types::f32, format::oiyx, data_types::f32, format::bfyx
@@ -174,20 +179,20 @@ public:
 #define CASE_FC_U8S8_2 { 2, 3 }, { 2, 4 }, { 4, 3 }, data_types::u8, format::b_fs_yx_fsv4, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_U8S8_3 { 2, 32 }, { 2, 16 }, { 16, 32 }, data_types::u8, format::b_fs_yx_fsv4, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_U8S8_4 { 1, 3 }, { 1, 3 }, { 3, 3 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_U8S8_3D_1 { 2, 32, 3 }, { 2, 32, 16 }, { 16, 3, 1 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_U8S8_3D_2 { 1, 1, 3 }, { 1, 1, 32 }, { 32, 3, 1 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_U8S8_3D_3 { 2, 3, 1 }, { 2, 3, 15 }, { 15, 1, 1 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_U8S8_3D_4 { 1, 512, 1024 }, { 1, 384, 1024 }, { 1024, 1024, 1 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_U8S8_3D_1 { 2, 32, 3 }, { 2, 32, 16 }, { 16, 3 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_U8S8_3D_2 { 1, 1, 3 }, { 1, 1, 32 }, { 32, 3 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_U8S8_3D_3 { 2, 3, 1 }, { 2, 3, 15 }, { 15, 1 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_U8S8_3D_4 { 1, 512, 1024 }, { 1, 384, 1024 }, { 1024, 1024 }, data_types::u8, format::bfyx, data_types::i8, format::oiyx, data_types::f32, format::bfyx
 
 #define CASE_FC_FP16_1 { 1, 3 }, { 1, 4 }, { 4, 3 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP16_2 { 2, 3 }, { 2, 4 }, { 4, 3 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP16_3 { 2, 32 }, { 2, 16 }, { 16, 32 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
 #define CASE_FC_FP16_4 { 128, 76 }, { 128, 768 }, { 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP16_5 { 1, 128, 76 }, { 1, 128, 768 }, { 1, 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP16_6 { 2, 1, 76 }, { 2, 1, 768 }, { 768, 76, 1 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP16_7 { 2, 128, 76 }, { 2, 128, 768 }, { 768, 76, 1 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP16_3D_1 { 2, 32, 3 }, { 2, 32, 16 }, { 16, 3, 1 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
-#define CASE_FC_FP16_3D_2 { 1, 1, 3 }, { 1, 1, 32 }, { 32, 3, 1 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP16_5 { 1, 128, 76 }, { 1, 128, 768 }, { 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP16_6 { 2, 1, 76 }, { 2, 1, 768 }, { 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP16_7 { 2, 128, 76 }, { 2, 128, 768 }, { 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP16_3D_1 { 2, 32, 3 }, { 2, 32, 16 }, { 16, 3 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
+#define CASE_FC_FP16_3D_2 { 1, 1, 3 }, { 1, 1, 32 }, { 32, 3 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
 
 #define DYN_CASE_FC_FP16_5 { 1, 128, 76 }, { 1, 128, 768 }, { 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
 #define DYN_CASE_FC_FP16_6 { 2, 1, 76 }, { 2, 1, 768 }, { 768, 76 }, data_types::f16, format::bfyx, data_types::f16, format::oiyx, data_types::f32, format::bfyx
@@ -202,7 +207,7 @@ public:
 #define CASE_FC_FP16_INT4_COMP_2 { 2, 128 }, { 2, 128 }, { 128, 128 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
 
 #define CASE_FC_FP16_INT8_COMP_1 { 1, 128 }, { 1, 128 }, { 128, 128 }, data_types::f16, format::bfyx, data_types::u8, format::oiyx, data_types::f16, format::bfyx
-#define CASE_FC_FP16_3D_INT8_COMP_1 { 2, 32, 4 }, { 2, 32, 16 }, { 16, 4, 1 }, data_types::f16, format::bfyx, data_types::u8, format::oiyx, data_types::f16, format::bfyx
+#define CASE_FC_FP16_3D_INT8_COMP_1 { 2, 32, 4 }, { 2, 32, 16 }, { 16, 4 }, data_types::f16, format::bfyx, data_types::u8, format::oiyx, data_types::f16, format::bfyx
 
 #define CASE_FC_FP16_INT4_SWIGLU_1 { 1, 64 }, { 1, 64 }, { 64, 64 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
 #define CASE_FC_FP16_INT4_SWIGLU_2 { 1, 64}, { 1, 128 }, { 128, 64 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3334,6 +3334,8 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
             ASSERT_EQ(out_l.feature(), 3);
             ASSERT_EQ(out_l.spatial(0), 2);
             ASSERT_EQ(out_l.spatial(1), 1);
+            ASSERT_EQ(out_l.spatial(2), 1);
+            ASSERT_EQ(out_l.spatial(3), 2);
         } else {
             ASSERT_EQ(output_prim_mem->get_layout().batch(), 6);
             ASSERT_EQ(out_l.batch(), 6);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -417,7 +417,7 @@ TEST(fully_connected_gpu, no_biases_4d_input_immad) {
 
     //  Input  : 1x8x8x12
     //  Weights: 48x12x1x1
-    //  Output : 64x48x1x1
+    //  Output : 1x8x8x48
 
     const int32_t input_b = 1, input_f = 8, input_y = 8, input_x = 12,          // size of the whole input buffer
                   weight_b = 48, weight_f = 12, weight_y = 1, weight_x = 1;     // size of the whole weights buffer
@@ -449,10 +449,10 @@ TEST(fully_connected_gpu, no_biases_4d_input_immad) {
     ASSERT_TRUE(fc_impl->is_onednn());
 
     auto outputs = network.execute();
-    ASSERT_EQ(outputs.begin()->second.get_layout().batch(), input_f*input_y);
-    ASSERT_EQ(outputs.begin()->second.get_layout().feature(), weight_b);
-    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(1), weight_y);
-    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(0), weight_x);
+    ASSERT_EQ(outputs.begin()->second.get_layout().batch(), input_b);
+    ASSERT_EQ(outputs.begin()->second.get_layout().feature(), input_f);
+    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(1), input_y);
+    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(0), weight_b);
 }
 
 TEST(fully_connected_gpu, no_biases_5d_input) {
@@ -502,7 +502,7 @@ TEST(fully_connected_gpu, no_biases_5d_input_immad) {
 
     //  Input  : 1x8x8x8x12
     //  Weights: 48x12
-    //  Output : 512x48x1x1
+    //  Output : 1x8x8x8x48
 
     const int32_t input_b = 1, input_f = 8, input_z = 8, input_y = 8, input_x = 12, // size of the whole input buffer
                   weight_b = 48, weight_f = 12;                                     // size of the whole weights buffer
@@ -534,10 +534,11 @@ TEST(fully_connected_gpu, no_biases_5d_input_immad) {
     ASSERT_TRUE(fc_impl->is_onednn());
 
     auto outputs = network.execute();
-    ASSERT_EQ(outputs.begin()->second.get_layout().batch(), input_f*input_z*input_y);
-    ASSERT_EQ(outputs.begin()->second.get_layout().feature(), weight_b);
-    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(1), 1);
-    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(0), 1);
+    ASSERT_EQ(outputs.begin()->second.get_layout().batch(), input_b);
+    ASSERT_EQ(outputs.begin()->second.get_layout().feature(), input_f);
+    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(2), input_z);
+    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(1), input_y);
+    ASSERT_EQ(outputs.begin()->second.get_layout().spatial(0), weight_b);
 }
 
 TEST(fully_connected_gpu, xb_f32_batch_1) {
@@ -3327,11 +3328,19 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
         auto output_prim_mem = outputs.begin()->second.get_memory();
 
         auto out_l = network->get_output_layout(outputs.begin()->first);
-        ASSERT_EQ(output_prim_mem->get_layout().batch(), 6);
-        ASSERT_EQ(out_l.batch(), 6);
-        ASSERT_EQ(out_l.feature(), 2);
-        ASSERT_EQ(out_l.spatial(0), 1);
-        ASSERT_EQ(out_l.spatial(1), 1);
+        if (engine.get_device_info().supports_immad) {
+            ASSERT_EQ(output_prim_mem->get_layout().batch(), 1);
+            ASSERT_EQ(out_l.batch(), 1);
+            ASSERT_EQ(out_l.feature(), 3);
+            ASSERT_EQ(out_l.spatial(0), 2);
+            ASSERT_EQ(out_l.spatial(1), 1);
+        } else {
+            ASSERT_EQ(output_prim_mem->get_layout().batch(), 6);
+            ASSERT_EQ(out_l.batch(), 6);
+            ASSERT_EQ(out_l.feature(), 2);
+            ASSERT_EQ(out_l.spatial(0), 1);
+            ASSERT_EQ(out_l.spatial(1), 1);
+        }
 
         std::vector<float> expected_output = {
             0.75, -0.5, -0.75, -1, 1.25, -0.75, 1.75, -1, 0.75, -0.5, -1.25, -1.5
@@ -4807,7 +4816,7 @@ TEST(fully_connected_3d_onednn_gpu, compressed_int4_scale_static) {
 
     auto in_layout = layout{ {1, batch_num, ifm_num, 1}, data_types::f16, format::bfyx };
 
-    auto fc_prim = fully_connected("fc_prim", input_info("input"), "weights", "", "scale", "dcomp_zp", data_types::f16, 3, 4);
+    auto fc_prim = fully_connected("fc_prim", input_info("input"), "weights", "", "scale", "dcomp_zp", data_types::f16, 3, 2);
 
     fc_prim.decompression_zero_point_scalar = 8;
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -75,7 +75,7 @@ public:
             ASSERT_EQ(params_hash, 1095272671134235967UL);
         } else {
             ASSERT_EQ(primitive_hash, 9510988594087947885UL);
-            ASSERT_EQ(params_hash, 17622194704492960871UL);
+            ASSERT_EQ(params_hash, 12994953567935633205UL);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -75,7 +75,7 @@ public:
             ASSERT_EQ(params_hash, 1095272671134235967UL);
         } else {
             ASSERT_EQ(primitive_hash, 9510988594087947885UL);
-            ASSERT_EQ(params_hash, 12994953567935633205UL);
+            ASSERT_EQ(params_hash, 17622194704492960871UL);
         }
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/memory_test.cpp
@@ -623,7 +623,7 @@ public:
             // The 'grid_sample' layer should be dynamic, not 'shape agnostic kernel' and user of 'elt1'. This is a key condition of this test.
             grid_sample("grid_sample", { input_info("elt1"), input_info("input_dyn") }, attributes),
             data("fc_weights", fc_weights_data),
-            fully_connected("fc", input_info("grid_sample"), "fc_weights")
+            fully_connected("fc", input_info("grid_sample"), "fc_weights", "", 4, 4)
         };
 
         ExecutionConfig config = get_test_default_config(engine);


### PR DESCRIPTION
### Details:
 - This PR updates fc_onednn_impl to use original dims instead of squashing input layout to 2D.
 - It resolves layout mismatch problems between fc and post-ops.

### Tickets:
 - 164104, 164106
