### PR TITLE
[TRANSFORMATIONS] Support AUGRUCell fusion differences in the DIEN_Alibaba model

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/augru_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/augru_cell_fusion.cpp
@@ -28,6 +28,10 @@ using namespace std;
 using namespace ov::element;
 using namespace ov::pass::pattern;
 
+// The parameters of the inner loop have different
+// shapes in the newer version of the model,
+// so we need to use Unsqueeze and Transpose to
+// obtain the shapes the transfomation expects.
 static std::shared_ptr<ov::Node> get_bias_add(std::shared_ptr<ov::Node> bias_add, ov::pass::NodeRegistry& rg) {
     auto input_source_1_ps = bias_add->input_value(1).get_partial_shape();
     if (input_source_1_ps.is_static() && input_source_1_ps.rank().get_length() == 1) {

--- a/src/common/transformations/src/transformations/common_optimizations/augru_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/augru_cell_fusion.cpp
@@ -16,9 +16,10 @@
 #include "openvino/op/sigmoid.hpp"
 #include "openvino/op/split.hpp"
 #include "openvino/op/squeeze.hpp"
-#include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/tanh.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/variadic_split.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "ov_ops/augru_cell.hpp"
@@ -26,6 +27,31 @@
 using namespace std;
 using namespace ov::element;
 using namespace ov::pass::pattern;
+
+static std::shared_ptr<ov::Node> get_bias_add(std::shared_ptr<ov::Node> bias_add, ov::pass::NodeRegistry& rg) {
+    auto input_source_1_ps = bias_add->input_value(1).get_partial_shape();
+    if (input_source_1_ps.is_static() && input_source_1_ps.rank().get_length() == 1) {
+        auto unsqueeze =
+            rg.make<ov::op::v0::Unsqueeze>(bias_add->input_value(1),
+                                           ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}));
+        bias_add->input(1).replace_source_output(unsqueeze);
+    }
+
+    return bias_add;
+}
+
+static std::shared_ptr<ov::Node> get_weights_matmul(std::shared_ptr<ov::Node> mat_mul, ov::pass::NodeRegistry& rg) {
+    if (auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(mat_mul)) {
+        if (!matmul->get_transpose_b()) {
+            auto transpose =
+                rg.make<ov::op::v1::Transpose>(matmul->input_value(1),
+                                               ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0}));
+            matmul->input(1).replace_source_output(transpose);
+        }
+    }
+
+    return mat_mul;
+}
 
 ov::pass::AUGRUCellFusion::AUGRUCellFusion() {
     MATCHER_SCOPE(AUGRUCellFusion);
@@ -76,25 +102,16 @@ ov::pass::AUGRUCellFusion::AUGRUCellFusion() {
 
         auto A = pattern_map.at(subtract_1)->input_value(1);
         // biases are required
-        auto bias_add_1 = pattern_map.at(add_1);
-        auto unsqueeze = rg.make<ov::op::v0::Unsqueeze>(bias_add_1->input_value(1), ov::op::v0::Constant::create(element::i32, Shape{}, {0}));
-        bias_add_1->input(1).replace_source_output(unsqueeze);
+        auto bias_add_1 = get_bias_add(pattern_map.at(add_1), rg);
         auto split_bias_r_z = rg.make<ov::op::v1::Split>(bias_add_1->input_value(1), axis_1, 2);
-        auto bias_add_2 = pattern_map.at(add_2);
-        auto unsqueeze2 = rg.make<ov::op::v0::Unsqueeze>(bias_add_2->input_value(1), ov::op::v0::Constant::create(element::i32, Shape{}, {0}));
-        bias_add_2->input(1).replace_source_output(unsqueeze2);
-
-        std::cout << "split_bias_r_z->output(1): " << split_bias_r_z->output(1) << std::endl;
-        std::cout << "split_bias_r_z->output(0): " << split_bias_r_z->output(0) << std::endl;
-        std::cout << "bias_add_2->input_value(1): " << bias_add_2->input_value(1) << std::endl;
+        auto bias_add_2 = get_bias_add(pattern_map.at(add_2), rg);
 
         auto B = rg.make<ov::op::v0::Concat>(
             OutputVector{split_bias_r_z->output(1), split_bias_r_z->output(0), bias_add_2->input_value(1)},
             1);
-        std::cout << "B: " << B << std::endl;
 
-        auto WRrz = pattern_map.at(matmul_1)->input_value(1);
-        auto WRh = pattern_map.at(matmul_2)->input_value(1);
+        auto WRrz = get_weights_matmul(pattern_map.at(matmul_1), rg)->input_value(1);
+        auto WRh = get_weights_matmul(pattern_map.at(matmul_2), rg)->input_value(1);
 
         auto split_lenghts = rg.make<ov::op::v0::Constant>(i64, Shape{2}, vector<int64_t>{input_size, hidden_size});
         auto split_WRrz = rg.make<ov::op::v1::VariadicSplit>(WRrz, axis_1, split_lenghts);

--- a/src/common/transformations/src/transformations/common_optimizations/augru_cell_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/augru_cell_fusion.cpp
@@ -51,7 +51,8 @@ static std::shared_ptr<ov::Node> get_bias_add(const std::shared_ptr<ov::Node>& b
 // newer version of the model it doesn't seem to be the case,
 // so we need to insert a Transpose operation to make it
 // compatible with the code of the transformation.
-static std::shared_ptr<ov::Node> get_weights_matmul(const std::shared_ptr<ov::Node>& mat_mul, ov::pass::NodeRegistry& rg) {
+static std::shared_ptr<ov::Node> get_weights_matmul(const std::shared_ptr<ov::Node>& mat_mul,
+                                                    ov::pass::NodeRegistry& rg) {
     if (auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(mat_mul)) {
         if (!matmul->get_transpose_b()) {
             auto transpose =

--- a/src/common/transformations/tests/common_optimizations/augru_cell_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/augru_cell_fusion.cpp
@@ -128,3 +128,87 @@ static const std::vector<AUGRUFusionParams> params = {
 
 INSTANTIATE_TEST_SUITE_P(AUGRUFusionTest, AUGRUFusionTest, ValuesIn(params));
 INSTANTIATE_TEST_SUITE_P(AUGRUFusionTestDyn, AUGRUFusionTestDyn, ValuesIn(params));
+
+TEST_F(TransformationTestsF, AUGRUFusionDiffParamShapes) {
+    size_t input_size = 36;
+    size_t hidden_size = 36;
+    size_t batch = -1;
+    {
+        auto X = make_shared<Parameter>(f32, Shape{batch, input_size});
+        auto H = make_shared<Parameter>(f32, Shape{batch, hidden_size});
+        auto WRrz = make_shared<Parameter>(f32, Shape{input_size + hidden_size, 2 * hidden_size});
+        auto Brz = make_shared<Parameter>(f32, Shape{2 * hidden_size});
+        auto WRh = make_shared<Parameter>(f32, Shape{input_size + hidden_size, hidden_size});
+        auto Bh = make_shared<Parameter>(f32, Shape{hidden_size});
+        auto A = make_shared<Parameter>(f32, Shape{batch, 1});
+        auto concat_1 = make_shared<Concat>(OutputVector{X, H}, 1);
+        auto matmul_1 = make_shared<MatMul>(concat_1, WRrz, false, false);
+        auto add_1 = make_shared<Add>(matmul_1, Brz);
+
+        auto sigmoid = make_shared<Sigmoid>(add_1);
+        auto axis_1 = make_shared<Constant>(i64, Shape{}, 1);
+        auto split = make_shared<Split>(sigmoid, axis_1, 2);
+
+        auto multiply_1 = make_shared<Multiply>(split, H);
+        auto concat_2 = make_shared<Concat>(OutputVector{X, multiply_1}, 1);
+        auto matmul_2 = make_shared<MatMul>(concat_2, WRh, false, false);
+        auto add_2 = make_shared<Add>(matmul_2, Bh);
+        auto tanh = make_shared<Tanh>(add_2);
+
+        auto one = make_shared<Constant>(f32, Shape{1}, 1);
+        auto subtract_1 = make_shared<Subtract>(one, A);
+        auto multiply_2 = make_shared<Multiply>(subtract_1, split->output(1));
+        auto subtract_2 = make_shared<Subtract>(one, multiply_2);
+        auto multiply_3 = make_shared<Multiply>(subtract_2, tanh);
+
+        auto multiply_4 = make_shared<Multiply>(multiply_2, H);
+        auto add = make_shared<Add>(multiply_4, multiply_3);
+        model = make_shared<Model>(OutputVector{add}, ParameterVector{X, H, WRrz, WRh, Brz, Bh, A});
+
+        manager.register_pass<ov::pass::AUGRUCellFusion>();
+        comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
+        comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+        comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
+    }
+    {
+        auto X = make_shared<Parameter>(f32, Shape{batch, input_size});
+        auto H = make_shared<Parameter>(f32, Shape{batch, hidden_size});
+        auto WRzr = make_shared<Parameter>(f32, Shape{input_size + hidden_size, 2 * hidden_size});
+        auto WRzr_transpose =
+            make_shared<ov::op::v1::Transpose>(WRzr,
+                                               ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0}));
+        auto Bzr = make_shared<Parameter>(f32, Shape{2 * hidden_size});
+        auto Bzr_unsqz =
+            make_shared<ov::op::v0::Unsqueeze>(Bzr, ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}));
+        auto WRh = make_shared<Parameter>(f32, Shape{input_size + hidden_size, hidden_size});
+        auto WRh_transpose =
+            make_shared<ov::op::v1::Transpose>(WRh,
+                                               ov::op::v0::Constant::create(ov::element::i32, ov::Shape{2}, {1, 0}));
+
+        auto Bh = make_shared<Parameter>(f32, Shape{hidden_size});
+        auto Bh_unsqz =
+            make_shared<ov::op::v0::Unsqueeze>(Bh, ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}));
+        auto A = make_shared<Parameter>(f32, Shape{batch, 1});
+
+        auto axis_0 = make_shared<Constant>(i64, Shape{}, 0);
+        auto axis_1 = make_shared<Constant>(i64, Shape{}, 1);
+        auto split_lenghts = make_shared<Constant>(i64, Shape{2}, vector<size_t>{input_size, hidden_size});
+        auto split_WRrz = make_shared<VariadicSplit>(WRzr_transpose, axis_1, split_lenghts);
+        auto split_W_r_z = make_shared<Split>(split_WRrz->output(0), axis_0, 2);
+        auto split_R_r_z = make_shared<Split>(split_WRrz->output(1), axis_0, 2);
+        auto split_WRh = make_shared<VariadicSplit>(WRh_transpose, axis_1, split_lenghts);
+        auto Wzrh =
+            make_shared<Concat>(OutputVector{split_W_r_z->output(1), split_W_r_z->output(0), split_WRh->output(0)}, 0);
+        auto Rzrh =
+            make_shared<Concat>(OutputVector{split_R_r_z->output(1), split_R_r_z->output(0), split_WRh->output(1)}, 0);
+
+        auto split_bias_r_z = make_shared<Split>(Bzr_unsqz, axis_1, 2);
+        auto B = make_shared<Concat>(OutputVector{split_bias_r_z->output(1), split_bias_r_z->output(0), Bh_unsqz}, 1);
+
+        auto squeeze_B = make_shared<Squeeze>(B, axis_0);
+        auto cell = make_shared<ov::op::internal::AUGRUCell>(X, H, Wzrh, Rzrh, squeeze_B, A, hidden_size);
+
+        ParameterVector params = {X, H, WRzr, WRh, Bzr, Bh, A};
+        model_ref = make_shared<Model>(OutputVector{cell}, params);
+    }
+}


### PR DESCRIPTION
### Details:
The DIEN_Alibaba  model now has different shapes for parameters of a Loop inputs preventing it from fusing a part of the graph into AUGRUCell. Add Transposes and Unsqueezes to obtain parameters in the expected shapes.

### Tickets:
 - [CVS-159221](https://jira.devtools.intel.com/browse/CVS-159221)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>
