### PR TITLE
[GPU] Allocate output mem using virtual memory in Windows even if physical memory is full

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_engine.cpp
@@ -165,7 +165,6 @@ bool ocl_engine::check_allocatable(const layout& layout, allocation_type type) {
         GPU_DEBUG_COUT << "[Warning] [GPU] Exceeded max size of memory allocation: " << "Required " << layout.bytes_count() << " bytes, already occupied : "
                        << used_mem << " bytes, but available memory size is " << get_max_memory_size() << " bytes" << std::endl;
         GPU_DEBUG_COUT << "Please note that performance might drop due to memory swap." << std::endl;
-        return false;
     }
 #endif
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -79,24 +79,24 @@ void set_arguments_impl(ocl_kernel_type& kernel,
         cl_int status = CL_INVALID_ARG_VALUE;
         switch (args[i].t) {
             case args_t::INPUT:
-                if (args[i].index < data.inputs.size() && data.inputs[args[i].index]) {
-                    status = set_kernel_arg(kernel, i, data.inputs[args[i].index]);
-                }
+                OPENVINO_ASSERT(args[i].index < data.inputs.size() && data.inputs[args[i].index],
+                               "The allocated input memory is necessary to set kernel arguments.");
+                status = set_kernel_arg(kernel, i, data.inputs[args[i].index]);
                 break;
             case args_t::INPUT_OF_FUSED_PRIMITIVE:
-                if (args[i].index < data.fused_op_inputs.size() && data.fused_op_inputs[args[i].index]) {
-                    status = set_kernel_arg(kernel, i, data.fused_op_inputs[args[i].index]);
-                }
+                OPENVINO_ASSERT(args[i].index < data.fused_op_inputs.size() && data.fused_op_inputs[args[i].index],
+                                "The allocated fused_op_input memory is necessary to set kernel arguments.");
+                status = set_kernel_arg(kernel, i, data.fused_op_inputs[args[i].index]);
                 break;
             case args_t::INTERNAL_BUFFER:
-                if (args[i].index < data.intermediates.size() && data.intermediates[args[i].index]) {
-                    status = set_kernel_arg(kernel, i, data.intermediates[args[i].index]);
-                }
+                OPENVINO_ASSERT(args[i].index < data.intermediates.size() && data.intermediates[args[i].index],
+                                "The allocated intermediate memory is necessary to set kernel arguments.");
+                status = set_kernel_arg(kernel, i, data.intermediates[args[i].index]);
                 break;
             case args_t::OUTPUT:
-                if (args[i].index < data.outputs.size() && data.outputs[args[i].index]) {
-                    status = set_kernel_arg(kernel, i, data.outputs[args[i].index]);
-                }
+                OPENVINO_ASSERT(args[i].index < data.outputs.size() && data.outputs[args[i].index],
+                                "The allocated output memory is necessary to set kernel arguments.");
+                status = set_kernel_arg(kernel, i, data.outputs[args[i].index]);
                 break;
             case args_t::WEIGHTS:
                 status = set_kernel_arg(kernel, i, data.weights);


### PR DESCRIPTION
### Details:
 - *primitive_inst tries to allocate output memory and it can alloc by using virtual memory even if physical memory is full on Windows. So the check_allocatable() func needs to return true.*
 - *...*

### Tickets:
 - *161457*
