### PR TITLE
[Draft] [CPU] Enable conversion from f4e2m1 or f8e8m0 to f32

### DIFF
--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -228,7 +228,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::compile_model(const std::shared_ptr<
             ov::element::Type_t::i32,  ov::element::Type_t::u64,     ov::element::Type_t::i64,
             ov::element::Type_t::bf16, ov::element::Type_t::f16,     ov::element::Type_t::f32,
             ov::element::Type_t::f64,  ov::element::Type_t::boolean, ov::element::Type_t::string,
-            ov::element::Type_t::nf4,  ov::element::Type_t::dynamic};
+            ov::element::Type_t::nf4,  ov::element::Type_t::f4e2m1,  ov::element::Type_t::f8e8m0,
+            ov::element::Type_t::dynamic};
 
         if (!supported_precisions.count(input_precision)) {
             OPENVINO_THROW_NOT_IMPLEMENTED("CPU plugin: Input image format ",

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/conversion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/conversion.cpp
@@ -103,6 +103,7 @@ void ConvertCPULayerTest::SetUp() {
         primitive = getPrimitiveType();
 #if defined(OPENVINO_ARCH_ARM64)
     if (inPrc == ov::element::u4 || inPrc == ov::element::i4 ||
+        inPrc == ov::element::f4e2m1 || inPrc == ov::element::f8e8m0 ||
         inPrc == ov::element::f8e4m3 || inPrc == ov::element::f8e5m2 ||
         outPrc == ov::element::f8e4m3 || outPrc == ov::element::f8e5m2 ||
         outPrc == ov::element::nf4) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/conversion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/common/conversion.cpp
@@ -73,6 +73,24 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvertCPULayerTest_float_to_nf4, ConvertCPULayer
                                 ::testing::Values(CPUSpecificParams({nchw}, {nchw}, {}, {"ref"}))),
                         ConvertCPULayerTest::getTestCaseName);
 
+INSTANTIATE_TEST_SUITE_P(smoke_ConvertCPULayerTest_from_f4e2m1, ConvertCPULayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(inShapes_4D_dynamic()),
+                                ::testing::Values(ov::element::f4e2m1),
+                                ::testing::ValuesIn(float_precisions),
+                                ::testing::Values(ov::test::SpecialValue::none),
+                                ::testing::Values(CPUSpecificParams({nchw}, {nchw}, {}, {"ref"}))),
+                        ConvertCPULayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvertCPULayerTest_from_f8e8m0, ConvertCPULayerTest,
+                        ::testing::Combine(
+                                ::testing::ValuesIn(inShapes_4D_dynamic()),
+                                ::testing::Values(ov::element::f8e8m0),
+                                ::testing::ValuesIn(float_precisions),
+                                ::testing::Values(ov::test::SpecialValue::none),
+                                ::testing::Values(CPUSpecificParams({nchw}, {nchw}, {}, {"ref"}))),
+                        ConvertCPULayerTest::getTestCaseName);
+
 const std::vector<ov::element::Type> f8_precisions = {
     ov::element::f8e4m3,
     ov::element::f8e5m2,

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/type_ranges.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/type_ranges.hpp
@@ -18,7 +18,7 @@ namespace utils {
 static const std::vector<element::Type>& get_known_types() {
     static const auto known_types = [] {
         using namespace ov::element;
-        constexpr size_t enum_count = static_cast<std::underlying_type_t<Type_t>>(Type_t::f8e8m0) - 1;
+        constexpr size_t enum_count = static_cast<std::underlying_type_t<Type_t>>(Type_t::f8e8m0);
 
         std::vector<Type> types(enum_count);
         for (size_t idx = 1, i = 0; i < types.size(); ++idx, ++i) {


### PR DESCRIPTION
### Details:
 - *Enable conversion from f4e2m1 or f8e8m0 to f32 for CPU plugin.*

### Tickets:
 - *[CVS-164851](https://jira.devtools.intel.com/browse/CVS-164851)*
