### PR TITLE
[Core][IR FE] Remove unnecessary ops.hpp usage from IR FE

### DIFF
--- a/src/core/dev_api/openvino/op/ops_decl.hpp
+++ b/src/core/dev_api/openvino/op/ops_decl.hpp
@@ -1,0 +1,291 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+namespace ov::op::v0 {
+class Abs;
+class Acos;
+class Asin;
+class Atan;
+class BatchNormInference;
+class CTCGreedyDecoder;
+class Ceiling;
+class Clamp;
+class Concat;
+class Constant;
+class Convert;
+class Cos;
+class Cosh;
+class CumSum;
+class DepthToSpace;
+class DetectionOutput;
+class Elu;
+class Erf;
+class Exp;
+class FakeQuantize;
+class Floor;
+class GRN;
+class Gelu;
+class HardSigmoid;
+class Interpolate;
+class LRN;
+class LSTMCell;
+class Log;
+class MVN;
+class MatMul;
+class Negative;
+class NormalizeL2;
+class PRelu;
+class PSROIPooling;
+class Parameter;
+class PriorBox;
+class PriorBoxClustered;
+class Proposal;
+class RNNCell;
+class ROIPooling;
+class Range;
+class RegionYolo;
+class Relu;
+class ReorgYolo;
+class Result;
+class ReverseSequence;
+class Selu;
+class ShapeOf;
+class ShuffleChannels;
+class Sigmoid;
+class Sign;
+class Sin;
+class Sinh;
+class SpaceToDepth;
+class Sqrt;
+class SquaredDifference;
+class Squeeze;
+class Tan;
+class Tanh;
+class TensorIterator;
+class Tile;
+class Unsqueeze;
+class Xor;
+}  // namespace ov::op::v0
+
+namespace ov::op::v1 {
+class Add;
+class AvgPool;
+class BatchToSpace;
+class BinaryConvolution;
+class Broadcast;
+class ConvertLike;
+class Convolution;
+class ConvolutionBackpropData;
+class DeformableConvolution;
+class DeformablePSROIPooling;
+class Divide;
+class Equal;
+class FloorMod;
+class Gather;
+class GatherTree;
+class Greater;
+class GreaterEqual;
+class GroupConvolution;
+class GroupConvolutionBackpropData;
+class Less;
+class LessEqual;
+class LogicalAnd;
+class LogicalNot;
+class LogicalOr;
+class LogicalXor;
+class MaxPool;
+class Maximum;
+class Minimum;
+class Mod;
+class Multiply;
+class NonMaxSuppression;
+class NotEqual;
+class OneHot;
+class Pad;
+class Power;
+class ReduceLogicalAnd;
+class ReduceLogicalOr;
+class ReduceMax;
+class ReduceMean;
+class ReduceMin;
+class ReduceProd;
+class ReduceSum;
+class Reshape;
+class Reverse;
+class Select;
+class Softmax;
+class SpaceToBatch;
+class Split;
+class StridedSlice;
+class Subtract;
+class TopK;
+class Transpose;
+class VariadicSplit;
+}  // namespace ov::op::v1
+
+namespace ov::op::v3 {
+class Acosh;
+class Asinh;
+class Assign;
+class Atanh;
+class Broadcast;
+class Bucketize;
+class EmbeddingBagOffsetsSum;
+class EmbeddingBagPackedSum;
+class EmbeddingSegmentsSum;
+class ExtractImagePatches;
+class GRUCell;
+class NonMaxSuppression;
+class NonZero;
+class ROIAlign;
+class ReadValue;
+class ScatterElementsUpdate;
+class ScatterNDUpdate;
+class ScatterUpdate;
+class ShapeOf;
+class TopK;
+}  // namespace ov::op::v3
+
+namespace ov::op::v4 {
+class CTCLoss;
+class HSwish;
+class Interpolate;
+class LSTMCell;
+class Mish;
+class NonMaxSuppression;
+class Proposal;
+class Range;
+class ReduceL1;
+class ReduceL2;
+class SoftPlus;
+class Swish;
+}  // namespace ov::op::v4
+
+namespace ov::op::v5 {
+class BatchNormInference;
+class GRUSequence;
+class GatherND;
+class HSigmoid;
+class LSTMSequence;
+class LogSoftmax;
+class Loop;
+class NonMaxSuppression;
+class RNNSequence;
+class Round;
+}  // namespace ov::op::v5
+
+namespace ov::op::v6 {
+class Assign;
+class CTCGreedyDecoderSeqLen;
+class ExperimentalDetectronDetectionOutput;
+class ExperimentalDetectronGenerateProposalsSingleImage;
+class ExperimentalDetectronPriorGridGenerator;
+class ExperimentalDetectronROIFeatureExtractor;
+class ExperimentalDetectronTopKROIs;
+class GatherElements;
+class MVN;
+class ReadValue;
+}  // namespace ov::op::v6
+
+namespace ov::op::v7 {
+class DFT;
+class Einsum;
+class Gather;
+class Gelu;
+class IDFT;
+class Roll;
+}  // namespace ov::op::v7
+
+namespace ov::op::v8 {
+class AdaptiveAvgPool;
+class AdaptiveMaxPool;
+class DeformableConvolution;
+class DetectionOutput;
+class Gather;
+class GatherND;
+class I420toBGR;
+class I420toRGB;
+class If;
+class MatrixNms;
+class MaxPool;
+class MulticlassNms;
+class NV12toBGR;
+class NV12toRGB;
+class PriorBox;
+class RandomUniform;
+class Slice;
+class Softmax;
+}  // namespace ov::op::v8
+
+namespace ov::op::v9 {
+class Eye;
+class GenerateProposals;
+class GridSample;
+class IRDFT;
+class MulticlassNms;
+class NonMaxSuppression;
+class RDFT;
+class ROIAlign;
+class SoftSign;
+}  // namespace ov::op::v9
+
+namespace ov::op::v10 {
+class IsFinite;
+class IsInf;
+class IsNaN;
+class Unique;
+}  // namespace ov::op::v10
+
+namespace ov::op::v11 {
+class Interpolate;
+class TopK;
+}  // namespace ov::op::v11
+
+namespace ov::op::v12 {
+class GroupNormalization;
+class Pad;
+class ScatterElementsUpdate;
+}  // namespace ov::op::v12
+
+namespace ov::op::v13 {
+class BitwiseAnd;
+class BitwiseNot;
+class BitwiseOr;
+class BitwiseXor;
+class FakeConvert;
+class Multinomial;
+class NMSRotated;
+class ScaledDotProductAttention;
+}  // namespace ov::op::v13
+
+namespace ov::op::v14 {
+class AvgPool;
+class ConvertPromoteTypes;
+class Inverse;
+class MaxPool;
+}  // namespace ov::op::v14
+
+namespace ov::op::v15 {
+class BitwiseLeftShift;
+class BitwiseRightShift;
+class Col2Im;
+class EmbeddingBagOffsets;
+class EmbeddingBagPacked;
+class ROIAlignRotated;
+class STFT;
+class ScatterNDUpdate;
+class SearchSorted;
+class SliceScatter;
+class Squeeze;
+class StringTensorPack;
+class StringTensorUnpack;
+}  // namespace ov::op::v15
+
+namespace ov::op::v16 {
+class ISTFT;
+class Identity;
+class SegmentMax;
+}  // namespace ov::op::v16

--- a/src/core/dev_api/openvino/opsets/opset10_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset10_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset10 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset10_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset10

--- a/src/core/dev_api/openvino/opsets/opset11_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset11_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset11 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset11_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset11

--- a/src/core/dev_api/openvino/opsets/opset12_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset12_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset12 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset12_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset12

--- a/src/core/dev_api/openvino/opsets/opset13_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset13_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset13 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset13_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset13

--- a/src/core/dev_api/openvino/opsets/opset14_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset14_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset14 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset14_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset14

--- a/src/core/dev_api/openvino/opsets/opset15_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset15_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset15 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset15_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset15

--- a/src/core/dev_api/openvino/opsets/opset16_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset16_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset16 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset16_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset16

--- a/src/core/dev_api/openvino/opsets/opset1_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset1_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset1 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset1_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset1

--- a/src/core/dev_api/openvino/opsets/opset2_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset2_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset2 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset2_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset2

--- a/src/core/dev_api/openvino/opsets/opset3_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset3_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset3 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset3_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset3

--- a/src/core/dev_api/openvino/opsets/opset4_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset4_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset4 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset4_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset4

--- a/src/core/dev_api/openvino/opsets/opset5_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset5_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset5 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset5_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset5

--- a/src/core/dev_api/openvino/opsets/opset6_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset6_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset6 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset6_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset6

--- a/src/core/dev_api/openvino/opsets/opset7_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset7_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset7 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset7_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset7

--- a/src/core/dev_api/openvino/opsets/opset8_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset8_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset8 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset8_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset8

--- a/src/core/dev_api/openvino/opsets/opset9_decl.hpp
+++ b/src/core/dev_api/openvino/opsets/opset9_decl.hpp
@@ -1,0 +1,13 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/op/ops_decl.hpp"
+
+namespace ov::opset9 {
+#define _OPENVINO_OP_REG(a, b) using b::a;
+#include "openvino/opsets/opset9_tbl.hpp"
+#undef _OPENVINO_OP_REG
+}  // namespace ov::opset9

--- a/src/frontends/ir/tests/frontend_test_basic.cpp
+++ b/src/frontends/ir/tests/frontend_test_basic.cpp
@@ -4,9 +4,13 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "frontend_test.hpp"
-#include "openvino/opsets/opset1.hpp"
-#include "openvino/opsets/opset3.hpp"
-#include "openvino/opsets/opset6.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/proposal.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/transpose.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset3_decl.hpp"
+#include "openvino/opsets/opset6_decl.hpp"
 #include "utils.hpp"
 
 class IRFrontendTests : public ::testing::Test, public IRFrontendTestsImpl {

--- a/src/frontends/ir/tests/frontend_test_mmap.cpp
+++ b/src/frontends/ir/tests/frontend_test_mmap.cpp
@@ -4,7 +4,8 @@
 
 #include "common_test_utils/file_utils.hpp"
 #include "frontend_test.hpp"
-#include "openvino/opsets/opset1.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
 
 #ifndef __APPLE__  // TODO: add getVmRSSInKB() for Apple platform
 

--- a/src/frontends/ir/tests/frontend_test_with_extensions.cpp
+++ b/src/frontends/ir/tests/frontend_test_with_extensions.cpp
@@ -4,7 +4,6 @@
 
 #include "frontend_test.hpp"
 #include "openvino/op/util/framework_node.hpp"
-#include "openvino/opsets/opset1.hpp"
 
 class IRFrontendExtensionTests : public ::testing::Test, public IRFrontendTestsImpl {
 protected:

--- a/src/frontends/ir/tests/partial_shape_deserialization.cpp
+++ b/src/frontends/ir/tests/partial_shape_deserialization.cpp
@@ -10,7 +10,8 @@
 #include "common_test_utils/graph_comparator.hpp"
 #include "openvino/core/preprocess/input_tensor_info.hpp"
 #include "openvino/frontend/manager.hpp"
-#include "openvino/opsets/opset8.hpp"
+#include "openvino/op/round.hpp"
+#include "openvino/opsets/opset8_decl.hpp"
 #include "openvino/runtime/core.hpp"
 
 class PartialShapeDeserialization : public testing::Test {

--- a/src/frontends/ir/tests/tensor_iterator_deserialization.cpp
+++ b/src/frontends/ir/tests/tensor_iterator_deserialization.cpp
@@ -3,8 +3,12 @@
 //
 
 #include "frontend_test.hpp"
-#include "openvino/opsets/opset1.hpp"
-#include "openvino/opsets/opset8.hpp"
+#include "openvino/op/tensor_iterator.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset3_decl.hpp"
+#include "openvino/opsets/opset4_decl.hpp"
+#include "openvino/opsets/opset5_decl.hpp"
+#include "openvino/opsets/opset8_decl.hpp"
 
 class IRFrontendTestsTensorIterator : public ::testing::Test, public IRFrontendTestsImpl {
 protected:

--- a/src/frontends/ir/tests/tensor_iterator_deserialization.cpp
+++ b/src/frontends/ir/tests/tensor_iterator_deserialization.cpp
@@ -5,9 +5,6 @@
 #include "frontend_test.hpp"
 #include "openvino/op/tensor_iterator.hpp"
 #include "openvino/opsets/opset1_decl.hpp"
-#include "openvino/opsets/opset3_decl.hpp"
-#include "openvino/opsets/opset4_decl.hpp"
-#include "openvino/opsets/opset5_decl.hpp"
 #include "openvino/opsets/opset8_decl.hpp"
 
 class IRFrontendTestsTensorIterator : public ::testing::Test, public IRFrontendTestsImpl {


### PR DESCRIPTION
### Details:
 - Introduced operators' forward declarations file.
 - Introduced opset declaration files. It allows using `opsetN::op` without including _heavy_ `opsetN.hpp` file, but related op `.hpp` and `opsetN_decl.hpp`.
 - Removed unnecessary include ops.hpp
 - Added missing includes

### Tickets:
 - CVS-166054
