### PR TITLE
Fix ov_core_set_get_property_gpu tests, add config_file as supported property for GPU

### DIFF
--- a/src/bindings/c/include/openvino/c/ov_property.h
+++ b/src/bindings/c/include/openvino/c/ov_property.h
@@ -241,8 +241,8 @@ OPENVINO_C_VAR(const char*)
 ov_property_key_auto_batch_timeout;
 
 /**
- * @brief Read-write property
- * @ingroup ov_property_key_intel_gpu_config_file
+ * @brief Read-write property to configure config file for GPU
+ * @ingroup ov_property_c_api
  */
 OPENVINO_C_VAR(const char*)
 ov_property_key_intel_gpu_config_file;

--- a/src/bindings/c/include/openvino/c/ov_property.h
+++ b/src/bindings/c/include/openvino/c/ov_property.h
@@ -239,3 +239,10 @@ ov_property_key_enable_mmap;
  */
 OPENVINO_C_VAR(const char*)
 ov_property_key_auto_batch_timeout;
+
+/**
+ * @brief Read-write property
+ * @ingroup ov_property_key_intel_gpu_config_file
+ */
+OPENVINO_C_VAR(const char*)
+ov_property_key_intel_gpu_config_file;

--- a/src/bindings/c/tests/ov_core_test.cpp
+++ b/src/bindings/c/tests/ov_core_test.cpp
@@ -767,7 +767,7 @@ TEST_P(ov_core_test_gpu, ov_core_set_get_property_gpu) {
     OV_EXPECT_OK(ov_core_create(&core));
     EXPECT_NE(nullptr, core);
 
-    const char* key_config = "ov_property_key_intel_gpu_config_file";
+    const char* key_config = ov_property_key_intel_gpu_config_file;
 
     OV_EXPECT_OK(ov_core_set_property(core, device_name.c_str(), key_config, TEST_CUSTOM_OP_CONFIG_PATH));
 

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -610,6 +610,7 @@ std::vector<ov::PropertyName> Plugin::get_supported_properties() const {
         ov::PropertyName{ov::cache_encryption_callbacks.name(), PropertyMutability::WO},
         ov::PropertyName{ov::hint::kv_cache_precision.name(), PropertyMutability::RW},
         ov::PropertyName{ov::hint::model.name(), PropertyMutability::WO},
+        ov::PropertyName{ov::intel_gpu::config_file.name(), PropertyMutability::RW},
     };
 
     return supported_properties;


### PR DESCRIPTION
### Details:
 - Fix ov_core_set_get_property_gpu tests, add config_file as supported property for GPU

### Tickets:
 - CVS-166069
