### PR TITLE
[core] Deprecate ov::Model constructor from ov::NodeVector

### DIFF
--- a/src/bindings/python/src/pyopenvino/graph/model.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/model.cpp
@@ -185,24 +185,23 @@ void regclass_graph_Model(py::module m) {
                     :type name: str
                  )");
 
-    model.def(py::init([](const std::vector<std::shared_ptr<ov::Node>>& results,
-                          const ov::ParameterVector& parameters,
-                          const std::string& name) {
-                  return make_model_with_tensor_names(results, parameters, name);
-              }),
-              py::arg("results"),
-              py::arg("parameters"),
-              py::arg("name") = "",
-              R"(
-                    Create user-defined Model which is a representation of a model.
+    model.def(
+        py::init([](const ov::NodeVector& results, const ov::ParameterVector& parameters, const std::string& name) {
+            return make_model_with_tensor_names(ov::as_output_vector(results), parameters, name);
+        }),
+        py::arg("results"),
+        py::arg("parameters"),
+        py::arg("name") = "",
+        R"(
+            Create user-defined Model which is a representation of a model.
 
-                    :param results: List of Nodes to be used as results.
-                    :type results: List[openvino.Node]
-                    :param parameters: List of parameters.
-                    :type parameters:  List[op.Parameter]
-                    :param name: String to set as model's friendly name.
-                    :type name: str
-                 )");
+            :param results: List of Nodes to be used as results.
+            :type results: List[openvino.Node]
+            :param parameters: List of parameters.
+            :type parameters:  List[op.Parameter]
+            :param name: String to set as model's friendly name.
+            :type name: str
+           )");
 
     model.def(py::init([](const std::shared_ptr<ov::Node>& result,
                           const ov::ParameterVector& parameters,

--- a/src/bindings/python/src/pyopenvino/graph/model.cpp
+++ b/src/bindings/python/src/pyopenvino/graph/model.cpp
@@ -185,6 +185,24 @@ void regclass_graph_Model(py::module m) {
                     :type name: str
                  )");
 
+    model.def(py::init([](const ov::ResultVector& results, const ov::ParameterVector& params, const std::string& name) {
+                  auto model = make_model_with_tensor_names(results, params, name);
+                  return model;
+              }),
+              py::arg("results"),
+              py::arg("parameters"),
+              py::arg("name") = "",
+              R"(
+                    Create user-defined Model which is a representation of a model.
+
+                    :param results: List of results.
+                    :type results: List[op.Result]
+                    :param parameters: List of parameters.
+                    :type parameters: List[op.Parameter]
+                    :param name: String to set as model's friendly name.
+                    :type name: str
+                )");
+
     model.def(
         py::init([](const ov::NodeVector& results, const ov::ParameterVector& parameters, const std::string& name) {
             return make_model_with_tensor_names(ov::as_output_vector(results), parameters, name);

--- a/src/bindings/python/tests/mock/mock_py_frontend/src/mock_py_frontend.cpp
+++ b/src/bindings/python/tests/mock/mock_py_frontend/src/mock_py_frontend.cpp
@@ -386,7 +386,7 @@ bool FrontEndMockPy::supported_impl(const std::vector<ov::Any>& params) const {
 
 std::shared_ptr<ov::Model> FrontEndMockPy::convert(const InputModel::Ptr& model) const {
     m_stat.m_convert_model++;
-    return std::make_shared<ov::Model>(ov::NodeVector{}, ov::ParameterVector{});
+    return std::make_shared<ov::Model>(ov::OutputVector{}, ov::ParameterVector{});
 }
 
 void FrontEndMockPy::convert(const std::shared_ptr<ov::Model>& func) const {
@@ -395,12 +395,12 @@ void FrontEndMockPy::convert(const std::shared_ptr<ov::Model>& func) const {
 
 std::shared_ptr<ov::Model> FrontEndMockPy::convert_partially(const InputModel::Ptr& model) const {
     m_stat.m_convert_partially++;
-    return std::make_shared<ov::Model>(ov::NodeVector{}, ov::ParameterVector{});
+    return std::make_shared<ov::Model>(ov::OutputVector{}, ov::ParameterVector{});
 }
 
 std::shared_ptr<ov::Model> FrontEndMockPy::decode(const InputModel::Ptr& model) const {
     m_stat.m_decode++;
-    return std::make_shared<ov::Model>(ov::NodeVector{}, ov::ParameterVector{});
+    return std::make_shared<ov::Model>(ov::OutputVector{}, ov::ParameterVector{});
 }
 
 void FrontEndMockPy::normalize(const std::shared_ptr<ov::Model>& function) const {

--- a/src/common/snippets/tests/src/lowered/pass/buffer_allocation.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/buffer_allocation.cpp
@@ -141,4 +141,3 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_BufferAllocation_EltwiseOptimized, Eltwi
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov
-

--- a/src/common/snippets/tests/src/pass/movebroadcast.cpp
+++ b/src/common/snippets/tests/src/pass/movebroadcast.cpp
@@ -21,7 +21,7 @@ TEST_F(TransformationTestsF, InsertBroadcastMove) {
         auto data0 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 3});
         auto data1 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 1});
         auto add = std::make_shared<ov::op::v1::Add>(data0, data1);
-        model = std::make_shared<Model>(NodeVector{add}, ParameterVector{data0, data1});
+        model = std::make_shared<Model>(OutputVector{add}, ParameterVector{data0, data1});
 
         manager.register_pass<snippets::pass::InsertMoveBroadcast>();
     }
@@ -30,6 +30,6 @@ TEST_F(TransformationTestsF, InsertBroadcastMove) {
         auto data1 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 1});
         auto move1 = std::make_shared<snippets::isa::BroadcastMove>(data1, ov::Dimension{3});
         auto add = std::make_shared<ov::op::v1::Add>(data0, move1);
-        model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{data0, data1});
+        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{data0, data1});
     }
 }

--- a/src/common/snippets/tests/src/pass/softmax_reshape_elimination.cpp
+++ b/src/common/snippets/tests/src/pass/softmax_reshape_elimination.cpp
@@ -22,14 +22,14 @@ TEST_F(TransformationTestsF, SoftmaxV1ReshapeElimination) {
         auto softmax_v1 = std::make_shared<ov::op::v1::Softmax>(reshape0, 1);
         auto shape1 = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{3}, std::vector<int32_t>{2, 3, 240});
         auto reshape1 = std::make_shared<ov::op::v1::Reshape>(softmax_v1, shape1, false);
-        model = std::make_shared<Model>(NodeVector{reshape1}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape1}, ParameterVector{data});
 
         manager.register_pass<snippets::pass::SoftmaxReshapeElimination>();
     }
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 3, 240});
         auto softmax_v1 = std::make_shared<ov::op::v1::Softmax>(data, 2);
-        model_ref = std::make_shared<Model>(NodeVector{softmax_v1}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{softmax_v1}, ParameterVector{data});
     }
 }
 
@@ -41,14 +41,14 @@ TEST_F(TransformationTestsF, SoftmaxV8ReshapeElimination) {
         auto softmax_v1 = std::make_shared<ov::op::v8::Softmax>(reshape0, -1);
         auto shape1 = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{1, 2, 340, 240});
         auto reshape1 = std::make_shared<ov::op::v1::Reshape>(softmax_v1, shape1, false);
-        model = std::make_shared<Model>(NodeVector{reshape1}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape1}, ParameterVector{data});
 
         manager.register_pass<snippets::pass::SoftmaxReshapeElimination>();
     }
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 340, 240});
         auto softmax_v1 = std::make_shared<ov::op::v8::Softmax>(data, 3);
-        model_ref = std::make_shared<Model>(NodeVector{softmax_v1}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{softmax_v1}, ParameterVector{data});
     }
 }
 
@@ -60,7 +60,7 @@ TEST_F(TransformationTestsF, SoftmaxReshapeElimination_IncorrectReshape) {
         auto softmax_v1 = std::make_shared<ov::op::v8::Softmax>(reshape0, -1);
         auto shape1 = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{1, 2, 340, 240});
         auto reshape1 = std::make_shared<ov::op::v1::Reshape>(softmax_v1, shape1, false);
-        model = std::make_shared<Model>(NodeVector{reshape1}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape1}, ParameterVector{data});
 
         manager.register_pass<snippets::pass::SoftmaxReshapeElimination>();
     }
@@ -74,13 +74,13 @@ TEST_F(TransformationTestsF, SoftmaxV8ReshapeElimination_DynamicBatch) {
         auto softmax_v1 = std::make_shared<ov::op::v8::Softmax>(reshape0, -1);
         auto shape1 = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{4}, std::vector<int32_t>{-1, 2, 340, 240});
         auto reshape1 = std::make_shared<ov::op::v1::Reshape>(softmax_v1, shape1, false);
-        model = std::make_shared<Model>(NodeVector{reshape1}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape1}, ParameterVector{data});
 
         manager.register_pass<snippets::pass::SoftmaxReshapeElimination>();
     }
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, ov::PartialShape{-1, 2, 340, 240});
         auto softmax_v1 = std::make_shared<ov::op::v8::Softmax>(data, 3);
-        model_ref = std::make_shared<Model>(NodeVector{softmax_v1}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{softmax_v1}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/add_fake_quantize_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/add_fake_quantize_fusion.cpp
@@ -32,7 +32,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusion) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
     }
     {
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusion) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionWithConvolutionAndScalarConsta
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data, filter});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data, filter});
         manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
     }
     {
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionWithConvolutionAndScalarConsta
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(conv, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data, filter});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data, filter});
     }
 }
 
@@ -96,7 +96,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionConstantOnFirstInput) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
     }
     {
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionConstantOnFirstInput) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -121,7 +121,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionConstantWithEqualValues) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
     }
     {
@@ -131,7 +131,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionConstantWithEqualValues) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -146,7 +146,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionReshape) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
     }
     {
@@ -156,7 +156,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionReshape) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -171,7 +171,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionWithPerChannelConstant) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
     }
     {
@@ -181,7 +181,7 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionWithPerChannelConstant) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -195,7 +195,7 @@ TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionNotAConstant) {
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data, add_2nd_input});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data, add_2nd_input});
     manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
 }
 
@@ -216,7 +216,7 @@ TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionWithConvolutionAndNonS
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data, filter});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data, filter});
     manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
 }
 
@@ -230,7 +230,7 @@ TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionLowPrecision) {
     auto output_low = opset5::Constant::create(element::f16, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f16, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     model_ref = model->clone();
     manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
 }
@@ -245,7 +245,7 @@ TEST_F(TransformationTestsF, NegativeAddFakeQuantizeFusionWithNonPerChannelConst
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
 }
 
@@ -258,6 +258,6 @@ TEST_F(TransformationTestsF, AddFakeQuantizeFusionWithBroadcastingConstant) {
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(add, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     manager.register_pass<ov::pass::AddFakeQuantizeFusion>();
 }

--- a/src/common/transformations/tests/common_optimizations/align_eltwise_input_ranks.cpp
+++ b/src/common/transformations/tests/common_optimizations/align_eltwise_input_ranks.cpp
@@ -37,7 +37,7 @@ TEST_P(AlignEltwiseInputRanksTestP, FusionTest) {
         auto low = op::v0::Constant::create(element::f32, const_shape, {0});
         auto high = op::v0::Constant::create(element::f32, const_shape, {20});
         auto fq = std::make_shared<opset8::FakeQuantize>(add, low, high, low, high, 256);
-        model = std::make_shared<Model>(NodeVector{less, logical_or, fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{less, logical_or, fq}, ParameterVector{data});
 
         manager.register_pass<ov::pass::AlignEltwiseInputRanks>();
     }
@@ -58,7 +58,7 @@ TEST_P(AlignEltwiseInputRanksTestP, FusionTest) {
         auto low = op::v0::Constant::create(element::f32, expected_const_shape, {0});
         auto high = op::v0::Constant::create(element::f32, expected_const_shape, {20});
         auto fq = std::make_shared<opset8::FakeQuantize>(add, low, high, low, high, 256);
-        model_ref = std::make_shared<Model>(NodeVector{less, logical_or, fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{less, logical_or, fq}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }

--- a/src/common/transformations/tests/common_optimizations/align_mixed_fp32_fp16_types_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/align_mixed_fp32_fp16_types_test.cpp
@@ -30,7 +30,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_1) {
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_1) {
         auto convert_to_f16_1 = make_shared<Convert>(mul_1, element::f32);
         auto matmul_1 = make_shared<MatMul>(convert_to_f16_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_2) {
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -98,7 +98,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_2) {
         auto convert_to_f16_1 = make_shared<Convert>(mul_1, element::f32);
         auto matmul_1 = make_shared<MatMul>(convert_to_f16_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -118,7 +118,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_3) {
         auto mul_1 = make_shared<Multiply>(add_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -143,7 +143,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_3) {
         auto convert_to_f16_1 = make_shared<Convert>(mul_1, element::f32);
         auto matmul_1 = make_shared<MatMul>(convert_to_f16_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -167,7 +167,7 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_with_rand_uniform) {
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, rand_uniform_add_factor);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -197,6 +197,6 @@ TEST_F(TransformationTestsF, align_mixed_fp16_fp32_with_rand_uniform) {
         auto convert_to_f16_1 = make_shared<Convert>(mul_1, element::f32);
         auto matmul_1 = make_shared<MatMul>(convert_to_f16_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/batch_to_space_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/batch_to_space_fusion.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, BatchToSpaceFusionTranspose) {
                                                    std::vector<int64_t>{0, 0, 0, 0});
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice, op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
         manager.register_pass<ov::pass::BatchToSpaceFusion>();
     }
 
@@ -49,7 +49,7 @@ TEST_F(TransformationTestsF, BatchToSpaceFusionTranspose) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 2, 2}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 2, 1}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 2, 1, 14}));
-        model_ref = std::make_shared<Model>(NodeVector{batch_to_space}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{batch_to_space}, ParameterVector{data});
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, BatchToSpaceFusionReshape) {
             std::make_shared<opset6::Reshape>(slice,
                                               op::v0::Constant::create(element::i64, Shape{4}, {1, 2, 4, 14}),
                                               false);
-        model = std::make_shared<Model>(NodeVector{reshape_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape_after}, ParameterVector{data});
         manager.register_pass<ov::pass::BatchToSpaceFusion>();
     }
 
@@ -83,7 +83,7 @@ TEST_F(TransformationTestsF, BatchToSpaceFusionReshape) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 2, 2}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 3, 0}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 1, 2}));
-        model_ref = std::make_shared<Model>(NodeVector{batch_to_space}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{batch_to_space}, ParameterVector{data});
     }
 }
 
@@ -104,7 +104,7 @@ TEST_F(TransformationTestsF, NegativeBatchToSpaceFusionInvalidTransposePerm) {
                                                    std::vector<int64_t>{0, 0, 0, 0});
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice, op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
         manager.register_pass<ov::pass::BatchToSpaceFusion>();
     }
 
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, NegativeBatchToSpaceFusionInvalidTransposePerm) {
                                                    std::vector<int64_t>{0, 0, 0, 0});
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice, op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
     }
 }
 
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, NegativeBatchToSpaceFusionInvalidMode) {
                                                    std::vector<int64_t>{0, 0, 0, 0});
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice, op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
         manager.register_pass<ov::pass::BatchToSpaceFusion>();
     }
 
@@ -165,7 +165,7 @@ TEST_F(TransformationTestsF, NegativeBatchToSpaceFusionInvalidMode) {
                                                    std::vector<int64_t>{0, 0, 0, 0});
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice, op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
     }
 }
 
@@ -188,7 +188,7 @@ TEST_F(TransformationTestsF, NegativeBatchToSpaceFusionInvalidRank) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice,
                                                 op::v0::Constant::create(element::i64, Shape{5}, {1, 0, 2, 3, 4}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
         manager.register_pass<ov::pass::BatchToSpaceFusion>();
     }
     {
@@ -209,7 +209,7 @@ TEST_F(TransformationTestsF, NegativeBatchToSpaceFusionInvalidRank) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(slice,
                                                 op::v0::Constant::create(element::i64, Shape{5}, {1, 0, 2, 3, 4}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
         manager.register_pass<ov::pass::BatchToSpaceFusion>();
     }
 }

--- a/src/common/transformations/tests/common_optimizations/binarize_weights.cpp
+++ b/src/common/transformations/tests/common_optimizations/binarize_weights.cpp
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, BinarizeWeightsActivationsOutputLowZero) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
         manager.register_pass<ov::pass::BinarizeWeights>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -73,7 +73,7 @@ TEST_F(TransformationTestsF, BinarizeWeightsActivationsOutputLowZero) {
         auto mul2 =
             std::make_shared<opset5::Multiply>(mul, opset5::Constant::create(element::f32, Shape{1, 1, 1}, {0.2f}));
 
-        model_ref = std::make_shared<Model>(NodeVector{mul2}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{mul2}, ParameterVector{data});
     }
 }
 
@@ -104,7 +104,7 @@ TEST_F(TransformationTestsF, BinarizeWeightsActivationsOutputLowNegative) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
         manager.register_pass<ov::pass::BinarizeWeights>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -129,7 +129,7 @@ TEST_F(TransformationTestsF, BinarizeWeightsActivationsOutputLowNegative) {
         auto mul2 =
             std::make_shared<opset5::Multiply>(mul, opset5::Constant::create(element::f32, Shape{1, 1, 1}, {0.2f}));
 
-        model_ref = std::make_shared<Model>(NodeVector{mul2}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{mul2}, ParameterVector{data});
     }
 }
 
@@ -160,7 +160,7 @@ TEST_F(TransformationTestsF, NegativeBinarizeWeightsInvalidLevels) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
         manager.register_pass<ov::pass::BinarizeWeights>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -191,7 +191,7 @@ TEST_F(TransformationTestsF, NegativeBinarizeWeightsInvalidLevels) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 }
 
@@ -222,7 +222,7 @@ TEST_F(TransformationTestsF, NegativeBinarizeWeightsInvalidActivationsOutputLowH
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
         manager.register_pass<ov::pass::BinarizeWeights>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -253,7 +253,7 @@ TEST_F(TransformationTestsF, NegativeBinarizeWeightsInvalidActivationsOutputLowH
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 }
 
@@ -284,7 +284,7 @@ TEST_F(TransformationTestsF, NegativeBinarizeWeightsInvalidOutputLowHigh) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
         manager.register_pass<ov::pass::BinarizeWeights>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -315,6 +315,6 @@ TEST_F(TransformationTestsF, NegativeBinarizeWeightsInvalidOutputLowHigh) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/broadcast_elementwise_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/broadcast_elementwise_fusion_test.cpp
@@ -53,7 +53,7 @@ public:
         auto input_shape_node = opset5::Constant::create(element::i64, Shape{broadcast_shape.size()}, broadcast_shape);
         auto broadcast = std::make_shared<opset5::Broadcast>(input2, input_shape_node);
         auto elementwise = std::make_shared<opset5::Multiply>(input1, broadcast);
-        return std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input1, input2});
+        return std::make_shared<ov::Model>(OutputVector{elementwise}, ParameterVector{input1, input2});
     }
 
     std::shared_ptr<Model> get_reference(const InputShape& input_shape, const InputShape& broadcast_output_shape) {
@@ -61,7 +61,7 @@ public:
         auto ref_input2 = std::make_shared<opset5::Parameter>(element::f32, broadcast_output_shape);
         auto ref_elementwise = std::make_shared<opset5::Multiply>(ref_input1, ref_input2);
 
-        return std::make_shared<ov::Model>(NodeVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
+        return std::make_shared<ov::Model>(OutputVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
     }
 };
 
@@ -88,7 +88,7 @@ public:
         auto input_shape_node = opset5::Constant::create(element::i64, Shape{broadcast_shape.size()}, broadcast_shape);
         auto broadcast = std::make_shared<opset5::Broadcast>(input2, input_shape_node);
         auto elementwise = std::make_shared<opset5::Multiply>(broadcast, input1);
-        return std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input1, input2});
+        return std::make_shared<ov::Model>(OutputVector{elementwise}, ParameterVector{input1, input2});
     }
 
     std::shared_ptr<Model> get_reference(const InputShape& input_shape, const InputShape& broadcast_output_shape) {
@@ -96,7 +96,7 @@ public:
         auto ref_input2 = std::make_shared<opset5::Parameter>(element::f32, broadcast_output_shape);
         auto ref_elementwise = std::make_shared<opset5::Multiply>(ref_input2, ref_input1);
 
-        return std::make_shared<ov::Model>(NodeVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
+        return std::make_shared<ov::Model>(OutputVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
     }
 };
 
@@ -122,7 +122,7 @@ public:
         auto input_shape_node = opset5::Constant::create(element::i64, Shape{broadcast_shape.size()}, broadcast_shape);
         auto broadcast = std::make_shared<opset5::Broadcast>(input2, input_shape_node);
         auto elementwise = std::make_shared<opset5::Multiply>(input1, broadcast);
-        return std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input1, input2});
+        return std::make_shared<ov::Model>(OutputVector{elementwise}, ParameterVector{input1, input2});
     }
 
     std::shared_ptr<Model> get_reference(const InputShape& input_shape,
@@ -135,7 +135,7 @@ public:
         auto ref_broadcast = std::make_shared<opset5::Broadcast>(ref_input2, ref_input_shape_node);
         auto ref_elementwise = std::make_shared<opset5::Multiply>(ref_input1, ref_broadcast);
 
-        return std::make_shared<ov::Model>(NodeVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
+        return std::make_shared<ov::Model>(OutputVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
     }
 };
 
@@ -164,7 +164,8 @@ public:
             std::make_shared<opset5::Parameter>(element::i64, Shape{(size_t)(broadcast_shape.rank().get_length())});
         auto broadcast = std::make_shared<opset5::Broadcast>(input2, input_shape_node);
         auto elementwise = std::make_shared<opset5::Multiply>(input1, broadcast);
-        return std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input1, input2, input_shape_node});
+        return std::make_shared<ov::Model>(OutputVector{elementwise},
+                                           ParameterVector{input1, input2, input_shape_node});
     }
 
     std::shared_ptr<Model> get_reference(const InputShape& input_shape, const InputShape& broadcast_output_shape) {
@@ -172,7 +173,7 @@ public:
         auto ref_input2 = std::make_shared<opset5::Parameter>(element::f32, broadcast_output_shape);
         auto ref_elementwise = std::make_shared<opset5::Multiply>(ref_input1, ref_input2);
 
-        return std::make_shared<ov::Model>(NodeVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
+        return std::make_shared<ov::Model>(OutputVector{ref_elementwise}, ParameterVector{ref_input1, ref_input2});
     }
 };
 
@@ -200,7 +201,8 @@ public:
             std::make_shared<opset5::Parameter>(element::i64, Shape{(size_t)(broadcast_shape.rank().get_length())});
         auto broadcast = std::make_shared<opset5::Broadcast>(input2, input_shape_node);
         auto elementwise = std::make_shared<opset5::Multiply>(input1, broadcast);
-        return std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input1, input2, input_shape_node});
+        return std::make_shared<ov::Model>(OutputVector{elementwise},
+                                           ParameterVector{input1, input2, input_shape_node});
     }
 
     std::shared_ptr<Model> get_reference(const InputShape& input_shape,
@@ -213,7 +215,7 @@ public:
         auto ref_broadcast = std::make_shared<opset5::Broadcast>(ref_input2, ref_input_shape_node);
         auto ref_elementwise = std::make_shared<opset5::Multiply>(ref_input1, ref_broadcast);
 
-        return std::make_shared<ov::Model>(NodeVector{ref_elementwise},
+        return std::make_shared<ov::Model>(OutputVector{ref_elementwise},
                                            ParameterVector{ref_input1, ref_input2, ref_input_shape_node});
     }
 };
@@ -288,7 +290,7 @@ TEST_F(TransformationTestsF, BroadcastElementwiseFusionWithShapeOf) {
         auto shape_of = std::make_shared<opset5::ShapeOf>(input);
         auto broadcast = std::make_shared<opset5::Broadcast>(input, shape_of);
         auto elementwise = std::make_shared<opset5::Multiply>(input, broadcast);
-        model = std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{elementwise}, ParameterVector{input});
 
         manager.register_pass<ov::pass::BroadcastElementwiseFusion>();
     }
@@ -296,7 +298,7 @@ TEST_F(TransformationTestsF, BroadcastElementwiseFusionWithShapeOf) {
     {
         auto input = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 3});
         auto elementwise = std::make_shared<opset5::Multiply>(input, input);
-        model_ref = std::make_shared<ov::Model>(NodeVector{elementwise}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{elementwise}, ParameterVector{input});
     }
 }
 
@@ -306,7 +308,7 @@ TEST_F(TransformationTestsF, BroadcastElementwiseFusionWithShapeOfNeg) {
         auto shape_of = std::make_shared<opset5::ShapeOf>(input);
         auto broadcast = std::make_shared<opset5::Broadcast>(input, shape_of);
         auto elementwise = std::make_shared<opset5::Multiply>(input, broadcast);
-        model = std::make_shared<ov::Model>(NodeVector{elementwise, broadcast}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{elementwise, broadcast}, ParameterVector{input});
 
         manager.register_pass<ov::pass::BroadcastElementwiseFusion>();
     }
@@ -319,7 +321,7 @@ TEST_F(TransformationTestsF, BroadcastElementwiseFusionDynShapesDifferentRanks) 
         auto constant = opset5::Constant::create(ov::element::f32, {}, {1.f});
         auto broadcast = std::make_shared<opset5::Broadcast>(constant, target_shape);
         auto elementwise = std::make_shared<opset5::Add>(input, broadcast);
-        model = std::make_shared<ov::Model>(ov::NodeVector{elementwise}, ov::ParameterVector{input, target_shape});
+        model = std::make_shared<ov::Model>(ov::OutputVector{elementwise}, ov::ParameterVector{input, target_shape});
 
         manager.register_pass<ov::pass::BroadcastElementwiseFusion>();
     }

--- a/src/common/transformations/tests/common_optimizations/clamp_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/clamp_fusion.cpp
@@ -28,7 +28,7 @@ TEST_F(TransformationTestsF, ClampFusion) {
         auto max_const = opset5::Constant::create(element::f32, Shape{1}, {5});
         auto max = std::make_shared<opset5::Maximum>(data, min_const);
         auto min = std::make_shared<opset5::Minimum>(max, max_const);
-        model = std::make_shared<Model>(NodeVector{min}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{min}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ClampFusion>();
     }
@@ -36,7 +36,7 @@ TEST_F(TransformationTestsF, ClampFusion) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
-        model_ref = std::make_shared<Model>(NodeVector{clamp}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{clamp}, ParameterVector{data});
     }
 }
 
@@ -47,7 +47,7 @@ TEST_F(TransformationTestsF, ClampFusionScalars) {
         auto max_const = opset5::Constant::create(element::f32, Shape{}, {5});
         auto max = std::make_shared<opset5::Maximum>(data, min_const);
         auto min = std::make_shared<opset5::Minimum>(max, max_const);
-        model = std::make_shared<Model>(NodeVector{min}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{min}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ClampFusion>();
     }
@@ -55,7 +55,7 @@ TEST_F(TransformationTestsF, ClampFusionScalars) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
-        model_ref = std::make_shared<Model>(NodeVector{clamp}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{clamp}, ParameterVector{data});
     }
 }
 
@@ -66,7 +66,7 @@ TEST_F(TransformationTestsF, ClampFusionNonConstMin) {
         auto max_const = opset5::Constant::create(element::f32, Shape{}, {5});
         auto max = std::make_shared<opset5::Maximum>(data, min_val);
         auto min = std::make_shared<opset5::Minimum>(max, max_const);
-        model = std::make_shared<Model>(NodeVector{min}, ParameterVector{data, min_val});
+        model = std::make_shared<Model>(OutputVector{min}, ParameterVector{data, min_val});
 
         manager.register_pass<ov::pass::ClampFusion>();
     }
@@ -77,7 +77,7 @@ TEST_F(TransformationTestsF, ClampFusionNonConstMin) {
         auto max_const = opset5::Constant::create(element::f32, Shape{}, {5});
         auto max = std::make_shared<opset5::Maximum>(data, min_val);
         auto min = std::make_shared<opset5::Minimum>(max, max_const);
-        model_ref = std::make_shared<Model>(NodeVector{min}, ParameterVector{data, min_val});
+        model_ref = std::make_shared<Model>(OutputVector{min}, ParameterVector{data, min_val});
     }
 }
 
@@ -89,7 +89,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMax) {
         auto min = std::make_shared<opset5::Minimum>(data, max_const);
         auto max = std::make_shared<opset5::Maximum>(min, min_const);
 
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ClampFusion>();
     }
@@ -97,7 +97,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMax) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
-        model_ref = std::make_shared<Model>(NodeVector{clamp}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{clamp}, ParameterVector{data});
     }
 }
 
@@ -108,7 +108,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMaxScalars) {
         auto max_const = opset5::Constant::create(element::f32, Shape{}, {5});
         auto min = std::make_shared<opset5::Minimum>(data, max_const);
         auto max = std::make_shared<opset5::Maximum>(min, min_const);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ClampFusion>();
     }
@@ -116,7 +116,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMaxScalars) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto clamp = std::make_shared<opset5::Clamp>(data, 0.1, 5);
-        model_ref = std::make_shared<Model>(NodeVector{clamp}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{clamp}, ParameterVector{data});
     }
 }
 
@@ -127,7 +127,7 @@ TEST_F(TransformationTestsF, ClampFusionMinMaxNonConstMax) {
         auto max_const = opset5::Constant::create(element::f32, Shape{}, {5});
         auto min = std::make_shared<opset5::Minimum>(data, max_const);
         auto max = std::make_shared<opset5::Maximum>(min, max_val);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data, max_val});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data, max_val});
 
         manager.register_pass<ov::pass::ClampFusion>();
     }
@@ -138,6 +138,6 @@ TEST_F(TransformationTestsF, ClampFusionMinMaxNonConstMax) {
         auto max_const = opset5::Constant::create(element::f32, Shape{}, {5});
         auto min = std::make_shared<opset5::Minimum>(data, max_const);
         auto max = std::make_shared<opset5::Maximum>(min, min_val);
-        model_ref = std::make_shared<Model>(NodeVector{max}, ParameterVector{data, min_val});
+        model_ref = std::make_shared<Model>(OutputVector{max}, ParameterVector{data, min_val});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/compress_float_constants_test.cpp
@@ -59,7 +59,7 @@ TEST_F(TransformationTestsF, CompressConstants_f32) {
                                                                 axes_node,
                                                                 interpolate4_attr);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{resize}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{resize}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -104,7 +104,7 @@ TEST_F(TransformationTestsF, CompressConstants_f32) {
                                                                 axes_node,
                                                                 interpolate4_attr);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{resize}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{resize}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -150,13 +150,13 @@ TEST_F(TransformationTestsF, CompressConstants_f32_If) {
                                                                 interpolate4_attr);
         auto then_op_result = std::make_shared<ov::op::v0::Result>(resize);
         auto body_then_function =
-            std::make_shared<ov::Model>(ov::NodeVector{then_op_result}, ov::ParameterVector{input_then});
+            std::make_shared<ov::Model>(ov::OutputVector{then_op_result}, ov::ParameterVector{input_then});
 
         // create else body
         auto input_else = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
         auto else_op_result = std::make_shared<ov::op::v0::Result>(input_else);
         auto body_else_function =
-            std::make_shared<ov::Model>(ov::NodeVector{else_op_result}, ov::ParameterVector{input_else});
+            std::make_shared<ov::Model>(ov::OutputVector{else_op_result}, ov::ParameterVector{input_else});
 
         // create main graph
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
@@ -168,7 +168,7 @@ TEST_F(TransformationTestsF, CompressConstants_f32_If) {
         if_op->set_output(then_op_result, else_op_result);
         auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
-        model = std::make_shared<ov::Model>(NodeVector{if_result}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{if_result}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -215,13 +215,13 @@ TEST_F(TransformationTestsF, CompressConstants_f32_If) {
                                                                 interpolate4_attr);
         auto then_op_result = std::make_shared<ov::op::v0::Result>(resize);
         auto body_then_function =
-            std::make_shared<ov::Model>(ov::NodeVector{then_op_result}, ov::ParameterVector{input_then});
+            std::make_shared<ov::Model>(ov::OutputVector{then_op_result}, ov::ParameterVector{input_then});
 
         // create else body
         auto input_else = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
         auto else_op_result = std::make_shared<ov::op::v0::Result>(input_else);
         auto body_else_function =
-            std::make_shared<ov::Model>(ov::NodeVector{else_op_result}, ov::ParameterVector{input_else});
+            std::make_shared<ov::Model>(ov::OutputVector{else_op_result}, ov::ParameterVector{input_else});
 
         // create main graph
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
@@ -233,7 +233,7 @@ TEST_F(TransformationTestsF, CompressConstants_f32_If) {
         if_op->set_output(then_op_result, else_op_result);
         auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{if_result}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{if_result}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -251,7 +251,7 @@ TEST_F(TransformationTestsF, CompressConstants_f64) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -270,7 +270,7 @@ TEST_F(TransformationTestsF, CompressConstants_f64) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -300,7 +300,7 @@ TEST_F(TransformationTestsF, CompressConstants_keep_in_f32_small_eps_out_of_rang
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -330,7 +330,7 @@ TEST_F(TransformationTestsF, CompressConstants_keep_in_f32_small_eps_out_of_rang
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -362,7 +362,7 @@ TEST_F(TransformationTestsF, CompressConstants_keep_in_f32_max_out_of_range_val)
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -390,7 +390,7 @@ TEST_F(TransformationTestsF, CompressConstants_keep_in_f32_max_out_of_range_val)
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -413,7 +413,7 @@ TEST_F(TransformationTestsF, CompressConstants_compress_to_f16_max_out_of_range_
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -432,7 +432,7 @@ TEST_F(TransformationTestsF, CompressConstants_compress_to_f16_max_out_of_range_
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -453,7 +453,7 @@ TEST_F(TransformationTestsF, CompressConstants_not_keep_in_f32_when_zeros) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -472,7 +472,7 @@ TEST_F(TransformationTestsF, CompressConstants_not_keep_in_f32_when_zeros) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -493,7 +493,7 @@ TEST_F(TransformationTestsF, CompressConstants_compress_to_f16_denormal_vals) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkPrecisionSensitiveConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -512,7 +512,7 @@ TEST_F(TransformationTestsF, CompressConstants_compress_to_f16_denormal_vals) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -532,7 +532,7 @@ TEST_F(TransformationTestsF, KeepFWPrecisionForFP16Constants_test_1) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkCompressedFloatConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -552,7 +552,7 @@ TEST_F(TransformationTestsF, KeepFWPrecisionForFP16Constants_test_1) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -572,7 +572,7 @@ TEST_F(TransformationTestsF, KeepFWPrecisionForBF16Constants_test_1) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkCompressedFloatConstants>();
         manager.register_pass<ov::pass::CompressFloatConstants>();
@@ -592,7 +592,7 @@ TEST_F(TransformationTestsF, KeepFWPrecisionForBF16Constants_test_1) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -611,14 +611,14 @@ auto build_model_DetectFakeQuantize = [](const TestParams&) -> std::shared_ptr<o
     auto output_low = ov::op::v0::Constant::create(element::u8, Shape{}, {1});
     auto output_high = ov::op::v0::Constant::create(element::u8, Shape{}, {2});
     auto fq = std::make_shared<ov::op::v0::FakeQuantize>(input, input_low, input_high, output_low, output_high, 1);
-    return std::make_shared<ov::Model>(ov::NodeVector{fq}, ov::ParameterVector{input});
+    return std::make_shared<ov::Model>(ov::OutputVector{fq}, ov::ParameterVector{input});
 };
 
 auto build_model_DetectFakeConvert = [](const TestParams&) -> std::shared_ptr<ov::Model> {
     auto input = std::make_shared<op::v0::Parameter>(element::f32, Shape{1, 2, 3});
     auto scale = ov::op::v0::Constant::create(element::f32, Shape{}, {1});
     auto convert = std::make_shared<ov::op::v13::FakeConvert>(input, scale);
-    return std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input});
+    return std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input});
 };
 
 auto build_model_DetectCompressedWeights = [](const TestParams& params) -> std::shared_ptr<ov::Model> {
@@ -638,7 +638,7 @@ auto build_model_DetectCompressedWeights = [](const TestParams& params) -> std::
     auto multiply = std::make_shared<ov::op::v1::Multiply>(tail_node, multiply_const);
 
     auto out_multiply = std::make_shared<ov::op::v1::Multiply>(input, multiply);
-    return std::make_shared<ov::Model>(ov::NodeVector{out_multiply}, ov::ParameterVector{input});
+    return std::make_shared<ov::Model>(ov::OutputVector{out_multiply}, ov::ParameterVector{input});
 };
 
 using ModelFactoryFunc = std::function<std::shared_ptr<Model>(const TestParams&)>;

--- a/src/common/transformations/tests/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/concat_reduce_fusion.cpp
@@ -45,14 +45,14 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionDynamicShape) {
             std::make_shared<ov::op::v1::ReduceMax>(concat,
                                                     ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        model = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
         auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto maximum = std::make_shared<ov::op::v1::Maximum>(left_input, right_input);
-        model_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -77,7 +77,7 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionKeepDimsDynamicShape) {
                                                     ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}),
                                                     true);
 
-        model = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
@@ -91,7 +91,7 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionKeepDimsDynamicShape) {
             std::make_shared<ov::op::v0::Unsqueeze>(right_input,
                                                     ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
         auto maximum = std::make_shared<ov::op::v1::Maximum>(left_unsqueeze, right_unsqueeze);
-        model_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -115,14 +115,14 @@ TEST_F(TransformationTestsF, ConcatReduceMaxFusionDynamicRank) {
             std::make_shared<ov::op::v1::ReduceMax>(concat,
                                                     ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        model = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
         auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto maximum = std::make_shared<ov::op::v1::Maximum>(left_input, right_input);
-        model_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -146,14 +146,14 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicShape) {
             std::make_shared<ov::op::v1::ReduceMin>(concat,
                                                     ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        model = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
         auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto maximum = std::make_shared<ov::op::v1::Minimum>(left_input, right_input);
-        model_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -177,14 +177,14 @@ TEST_F(TransformationTestsF, ConcatReduceMinFusionDynamicRank) {
             std::make_shared<ov::op::v1::ReduceMin>(concat,
                                                     ov::op::v0::Constant::create(element::i64, Shape{}, {reduce_axis}));
 
-        model = std::make_shared<Model>(NodeVector{reduce_max}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{reduce_max}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
         auto left_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto right_input = std::make_shared<ov::op::v0::Parameter>(element::f32, shape);
         auto maximum = std::make_shared<ov::op::v1::Minimum>(left_input, right_input);
-        model_ref = std::make_shared<Model>(NodeVector{maximum}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{maximum}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -206,7 +206,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseStaticShape) {
         auto squeeze =
             std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        model = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::PullSqueezeThroughEltwise>();
     }
     {
@@ -229,7 +229,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseStaticShape) {
 
         auto add = std::make_shared<ov::op::v1::Add>(left_squeeze, right_squeeze);
 
-        model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -251,7 +251,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationStaticSh
         auto squeeze =
             std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        model = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
@@ -260,7 +260,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationStaticSh
 
         auto add = std::make_shared<ov::op::v1::Add>(left_input, right_input);
 
-        model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -282,7 +282,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicS
         auto squeeze =
             std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        model = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
@@ -291,7 +291,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicS
 
         auto add = std::make_shared<ov::op::v1::Add>(left_input, right_input);
 
-        model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{left_input, right_input});
     }
 }
 
@@ -313,7 +313,7 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicR
         auto squeeze =
             std::make_shared<ov::op::v0::Squeeze>(add, ov::op::v0::Constant::create(element::i64, Shape{}, {0}));
 
-        model = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{left_input, right_input});
+        model = std::make_shared<Model>(OutputVector{squeeze}, ParameterVector{left_input, right_input});
         manager.register_pass<ov::pass::ConcatReduceFusion>();
     }
     {
@@ -322,6 +322,6 @@ TEST_F(TransformationTestsF, PullSqueezeThroughEltwiseSqueezeEliminationDynamicR
 
         auto add = std::make_shared<ov::op::v1::Add>(left_input, right_input);
 
-        model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{left_input, right_input});
+        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{left_input, right_input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/conv_to_binary_conv.cpp
+++ b/src/common/transformations/tests/common_optimizations/conv_to_binary_conv.cpp
@@ -40,7 +40,7 @@ TEST(TransformationTests, ConvToBinaryConvOutputLowZeroOutputHighOne) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -73,7 +73,7 @@ TEST(TransformationTests, ConvToBinaryConvOutputLowZeroOutputHighOne) {
         auto add = std::make_shared<opset5::Add>(conv, opset5::Constant::create(element::f32, Shape{1, 1, 1}, {0.7f}));
         auto mul = std::make_shared<opset5::Multiply>(add, opset5::Constant::create(element::f32, Shape{}, {0.2f}));
 
-        f_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -99,7 +99,7 @@ TEST(TransformationTests, ConvToBinaryConvOutputLowMinusOneOutputHighOne) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -130,7 +130,7 @@ TEST(TransformationTests, ConvToBinaryConvOutputLowMinusOneOutputHighOne) {
                                                         0.0f,
                                                         op::PadType::EXPLICIT);
 
-        f_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -156,7 +156,7 @@ TEST(TransformationTests, NegativeConvToBinaryConvInvalidWeights) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -183,7 +183,7 @@ TEST(TransformationTests, NegativeConvToBinaryConvInvalidWeights) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -209,7 +209,7 @@ TEST(TransformationTests, NegativeConvToBinaryConvInvalidLevels) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -236,7 +236,7 @@ TEST(TransformationTests, NegativeConvToBinaryConvInvalidLevels) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -262,7 +262,7 @@ TEST(TransformationTests, NegativeConvToBinaryConvOutputLowHigh) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -289,7 +289,7 @@ TEST(TransformationTests, NegativeConvToBinaryConvOutputLowHigh) {
                                                           Strides{1, 1},
                                                           op::PadType::EXPLICIT);
 
-        f_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/common_optimizations/convert_compression_only_to_legacy_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_compression_only_to_legacy_test.cpp
@@ -36,7 +36,7 @@ TEST(TransformationTests, ConvertCompressionOnlyToLegacy) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -58,7 +58,7 @@ TEST(TransformationTests, ConvertCompressionOnlyToLegacy) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
 
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref, true);
@@ -80,7 +80,7 @@ TEST(TransformationTests, ConvertCompressionOnlyToLegacyNoConvertion) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
 
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -102,7 +102,7 @@ TEST(TransformationTests, ConvertCompressionOnlyToLegacyNoConvertion) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
 
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref, true);

--- a/src/common/transformations/tests/common_optimizations/convert_convertlike.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_convertlike.cpp
@@ -27,7 +27,7 @@ TEST(TransformationTests, ConvertConvertLike) {
         auto like = opset8::Constant::create(element::i32, Shape{1}, {1});
         auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
 
-        f = std::make_shared<ov::Model>(NodeVector{cvtlike}, ParameterVector{data});
+        f = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -40,7 +40,7 @@ TEST(TransformationTests, ConvertConvertLike) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
         auto cvt = std::make_shared<opset8::Convert>(data, element::i32);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{cvt}, ParameterVector{data});
+        f_ref = std::make_shared<ov::Model>(OutputVector{cvt}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -56,7 +56,7 @@ TEST(TransformationTests, ConvertConvertLike2) {
         auto like = std::make_shared<opset8::Add>(data2, constant);
         auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
 
-        f = std::make_shared<ov::Model>(NodeVector{cvtlike}, ParameterVector{data, data2});
+        f = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, data2});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -69,7 +69,7 @@ TEST(TransformationTests, ConvertConvertLike2) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{3, 1, 2});
         auto cvt = std::make_shared<opset8::Convert>(data, element::i8);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{cvt}, ParameterVector{data});
+        f_ref = std::make_shared<ov::Model>(OutputVector{cvt}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -83,7 +83,7 @@ TEST(TransformationTests, ConvertConvertLike_Negative) {
         auto like = std::make_shared<opset8::Parameter>(element::dynamic, Shape{1});
         auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
 
-        f = std::make_shared<ov::Model>(NodeVector{cvtlike}, ParameterVector{data, like});
+        f = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, like});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -97,7 +97,7 @@ TEST(TransformationTests, ConvertConvertLike_Negative) {
         auto like = std::make_shared<opset8::Parameter>(element::dynamic, Shape{1});
         auto cvtlike = std::make_shared<opset8::ConvertLike>(data, like);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{cvtlike}, ParameterVector{data, like});
+        f_ref = std::make_shared<ov::Model>(OutputVector{cvtlike}, ParameterVector{data, like});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/common_optimizations/convert_divide.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_divide.cpp
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, ConvertDivide) {
         auto divide_constant = opset1::Constant::create(element::f32, Shape{1}, {1.5});
         auto divide = std::make_shared<opset1::Divide>(data, divide_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertDivide>();
     }
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, ConvertDivide) {
         auto divide_constant = opset1::Constant::create(element::f32, Shape{1}, {1. / 1.5});
         auto mul = std::make_shared<opset1::Multiply>(data, divide_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, ConvertDivideInverse) {
         auto divide_constant = opset1::Constant::create(element::f32, Shape{1}, {1});
         auto divide = std::make_shared<opset1::Divide>(divide_constant, data);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertDivide>();
     }
@@ -60,7 +60,7 @@ TEST_F(TransformationTestsF, ConvertDivideInverse) {
         auto constant = opset1::Constant::create(element::f32, Shape{}, {-1.0});
         auto pow = std::make_shared<opset1::Power>(data, constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{pow}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{pow}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, ConvertDivideNegative) {
         auto divide_constant = opset1::Constant::create(element::i32, Shape{1}, {2});
         auto divide = std::make_shared<opset1::Divide>(data, divide_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertDivide>();
     }
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, ConvertDivideNegative) {
         auto divide_constant = opset1::Constant::create(element::i32, Shape{1}, {2});
         auto divide = std::make_shared<opset1::Divide>(data, divide_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -92,7 +92,7 @@ TEST_F(TransformationTestsF, ConvertDivideScalar) {
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{});
         auto divide = std::make_shared<opset1::Divide>(data1, data2);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data1, data2});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
 
         OPENVINO_ASSERT(divide->get_output_partial_shape(0).rank().get_length() == 0);
 
@@ -105,7 +105,7 @@ TEST_F(TransformationTestsF, ConvertDivideScalar) {
         auto pow = std::make_shared<opset1::Power>(pow_input, opset1::Constant::create(element::f32, Shape{}, {-1}));
         auto mul = std::make_shared<opset1::Multiply>(data, pow);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data, pow_input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data, pow_input});
 
         OPENVINO_ASSERT(mul->get_output_partial_shape(0).rank().get_length() == 0);
     }
@@ -118,7 +118,7 @@ TEST_F(TransformationTestsF, ConvertDivideWithConstantPositive) {
         auto divide_constant = opset1::Constant::create(element::f32, Shape{}, {1.5});
         auto divide = std::make_shared<opset1::Divide>(data, divide_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertDivideWithConstant>();
     }
 
@@ -127,7 +127,7 @@ TEST_F(TransformationTestsF, ConvertDivideWithConstantPositive) {
         auto divide_constant = opset1::Constant::create(element::f32, Shape{}, {1. / 1.5});
         auto mul = std::make_shared<opset1::Multiply>(data, divide_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -138,7 +138,7 @@ TEST_F(TransformationTestsF, ConvertDivideWithConstantNegative) {
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{});
         auto divide = std::make_shared<opset1::Divide>(data1, data2);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data1, data2});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
         manager.register_pass<ov::pass::ConvertDivideWithConstant>();
     }
 
@@ -147,7 +147,7 @@ TEST_F(TransformationTestsF, ConvertDivideWithConstantNegative) {
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{});
         auto divide = std::make_shared<opset1::Divide>(data1, data2);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data1, data2});
+        model_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, ConvertDivideFP16ShapeOfSubgraphNegative) {
 
         auto interpolate = std::make_shared<opset1::Interpolate>(data, convert_after, interp_attr);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MarkDividesInShapeSubgraphs>();
         manager.register_pass<ov::pass::ConvertDivide>();
@@ -195,13 +195,13 @@ TEST_F(TransformationTestsF, ConvertDivide_If) {
         auto interpolate = std::make_shared<opset1::Interpolate>(data, convert_after, interp_attr);
         auto then_op_result = std::make_shared<opset1::Result>(interpolate);
 
-        auto body_then_function = std::make_shared<ov::Model>(NodeVector{then_op_result}, ParameterVector{data});
+        auto body_then_function = std::make_shared<ov::Model>(OutputVector{then_op_result}, ParameterVector{data});
 
         // create else body
         auto input_else = std::make_shared<ov::opset8::Parameter>(ov::element::f16, ov::Shape{1, 3, 22, 22});
         auto else_op_result = std::make_shared<opset1::Result>(input_else);
         auto body_else_function =
-            std::make_shared<ov::Model>(ov::NodeVector{else_op_result}, ov::ParameterVector{input_else});
+            std::make_shared<ov::Model>(ov::OutputVector{else_op_result}, ov::ParameterVector{input_else});
 
         // create main graph
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f16, ov::Shape{1, 3, 22, 22});
@@ -213,7 +213,7 @@ TEST_F(TransformationTestsF, ConvertDivide_If) {
         if_op->set_output(then_op_result, else_op_result);
         auto if_result = std::make_shared<opset1::Result>(if_op);
 
-        model = std::make_shared<ov::Model>(NodeVector{if_result}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{if_result}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MarkDividesInShapeSubgraphs>();
         auto decomp = manager.register_pass<pass::GraphRewrite>();
@@ -252,7 +252,7 @@ TEST_F(TransformationTestsF, ConvertDivideFP16ShapeOfSubgraphNegative2) {
 
         // "add" node specially set as a first output, so MarkDividesInShapeSubgraphs will start graph traversal from
         // it and after all nodes above are visited it will start traverse from "interpolate"
-        model = std::make_shared<ov::Model>(NodeVector{add, interpolate}, ParameterVector{data, data2});
+        model = std::make_shared<ov::Model>(OutputVector{add, interpolate}, ParameterVector{data, data2});
 
         manager.register_pass<ov::pass::MarkDividesInShapeSubgraphs>();
         manager.register_pass<ov::pass::ConvertDivide>();
@@ -277,7 +277,7 @@ TEST_F(TransformationTestsF, ConvertDivideFP32ShapeOfSubgraphNegative) {
 
         auto interpolate = std::make_shared<opset1::Interpolate>(data, convert_after, interp_attr);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MarkDividesInShapeSubgraphs>();
         manager.register_pass<ov::pass::ConvertDivide>();

--- a/src/common/transformations/tests/common_optimizations/convert_nms_gather_path_to_unsigned_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_nms_gather_path_to_unsigned_test.cpp
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, test_convert_to_unsigned_nms_gather_1) {
                                                   squeeze_node,
                                                   opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-        model = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+        model = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNmsGatherPathToUnsigned>();
     }
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, test_convert_to_unsigned_nms_gather_1) {
         auto gather =
             make_shared<opset8::Gather>(reshape_node, convert, opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-        model_ref = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+        model_ref = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
     }
 }
 
@@ -103,7 +103,7 @@ TEST_F(TransformationTestsF, test_convert_to_unsigned_nms_gather_2) {
         auto gather =
             make_shared<opset8::Gather>(reshape_node, convert, opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-        model = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+        model = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNmsGatherPathToUnsigned>();
     }
@@ -132,7 +132,7 @@ TEST_F(TransformationTestsF, test_convert_to_unsigned_nms_gather_2) {
         auto gather =
             make_shared<opset8::Gather>(reshape_node, convert, opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-        model_ref = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+        model_ref = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
     }
 }
 
@@ -158,7 +158,7 @@ TEST_F(TransformationTestsF, test_convert_to_unsigned_nms_gather_with_onnx_slice
         auto gather =
             make_shared<opset8::Gather>(reshape_node, convert, opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-        model = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+        model = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNmsGatherPathToUnsigned>();
     }
@@ -182,7 +182,7 @@ TEST_F(TransformationTestsF, test_convert_to_unsigned_nms_gather_with_onnx_slice
         auto gather =
             make_shared<opset8::Gather>(reshape_node, convert, opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-        model_ref = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+        model_ref = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
     }
 }
 
@@ -196,7 +196,7 @@ TEST(TransformationTests, test_convert_to_unsigned_nms_gather_3) {
                                               opset8::Constant::create(element::i32, Shape{1}, {2}),
                                               opset8::Constant::create(element::i32, Shape{1}, {0}));
 
-    shared_ptr<Model> f = make_shared<Model>(NodeVector{gather}, ParameterVector{boxes, scores});
+    shared_ptr<Model> f = make_shared<Model>(OutputVector{gather}, ParameterVector{boxes, scores});
 
     pass::Manager manager;
     manager.register_pass<ov::pass::InitNodeInfo>();
@@ -230,13 +230,13 @@ TEST(TransformationTests, test_convert_to_unsigned_nms_gather_with_if_condition)
     auto slice = make_shared<opset8::Slice>(input_then, start, stop, step);
 
     auto then_op_result = make_shared<op::v0::Result>(slice);
-    auto body_then_function = make_shared<Model>(NodeVector{then_op_result}, ParameterVector{input_then});
+    auto body_then_function = make_shared<Model>(OutputVector{then_op_result}, ParameterVector{input_then});
 
     auto input_else = make_shared<opset8::Parameter>(element::i32, PartialShape{-1, 1});
     auto reshape =
         make_shared<opset8::Reshape>(input_else, opset8::Constant::create(element::i32, Shape{1}, {-1}), true);
     auto else_op_result = make_shared<op::v0::Result>(reshape);
-    auto body_else_function = make_shared<Model>(NodeVector{else_op_result}, ParameterVector{input_else});
+    auto body_else_function = make_shared<Model>(OutputVector{else_op_result}, ParameterVector{input_else});
 
     if_op->set_then_body(body_then_function);
     if_op->set_else_body(body_else_function);
@@ -254,7 +254,7 @@ TEST(TransformationTests, test_convert_to_unsigned_nms_gather_with_if_condition)
     auto axis = opset8::Constant::create(element::i32, Shape{1}, {0});
     auto target_gather = make_shared<opset8::Gather>(data, ss_node, axis);
 
-    shared_ptr<Model> f = make_shared<Model>(NodeVector{target_gather}, ParameterVector{boxes, scores, data});
+    shared_ptr<Model> f = make_shared<Model>(OutputVector{target_gather}, ParameterVector{boxes, scores, data});
 
     pass::Manager manager;
     manager.register_pass<pass::InitNodeInfo>();

--- a/src/common/transformations/tests/common_optimizations/convert_quantize_dequantize.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_quantize_dequantize.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<Model> create_q_dq_function(const Shape& data_shape,
     auto scale = opset1::Constant::create(element::f32, scale_shape, scale_values);
     auto mul = std::make_shared<opset1::Multiply>(sub, scale);
 
-    return std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+    return std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 }
 
 template <typename LowPrecision, typename T>
@@ -95,7 +95,7 @@ void positive_test(const Shape& data_shape,
         auto output_high =
             opset1::Constant::create(element::f32, Shape{}, {(out_high - zero_point_values[0]) * scale_values[0]});
         auto fq = std::make_shared<opset1::FakeQuantize>(data, input_low, input_high, output_low, output_high, levels);
-        f_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/common_optimizations/convert_u4_weights_zero_point_to_scalar.cpp
+++ b/src/common/transformations/tests/common_optimizations/convert_u4_weights_zero_point_to_scalar.cpp
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsFloatZeroPointToScalar) {
         auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point);
         auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-        model = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
         manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
     }
     {
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsFloatZeroPointToScalar) {
         auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point);
         auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-        model_ref = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::ACCURACY);
     comparator.enable(FunctionsComparator::CONST_VALUES);
@@ -59,7 +59,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsU4ZeroPointToScalar) {
         auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
         auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-        model = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
         manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
     }
     {
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsU4ZeroPointToScalar) {
         auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
         auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-        model_ref = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::ACCURACY);
     comparator.enable(FunctionsComparator::CONST_VALUES);
@@ -89,7 +89,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsFloatZeroPointToScalarWeightsWithBi
         auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point);
         auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-        model = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
         manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
     }
     {
@@ -100,7 +100,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsFloatZeroPointToScalarWeightsWithBi
         auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point);
         auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-        model_ref = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::ACCURACY);
     comparator.enable(FunctionsComparator::CONST_VALUES);
@@ -120,7 +120,7 @@ TEST_F(TransformationTestsF, FuseU4WeightsAndZeroPointNotScalarLikeZP) {
     auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
     auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
     auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-    model = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+    model = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
     manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
 }
 
@@ -136,7 +136,7 @@ TEST_F(TransformationTestsF, FuseU4WeightsAndZeroPointNotU4Weights) {
     auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
     auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
     auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-    model = std::make_shared<Model>(NodeVector{multiply}, ParameterVector{});
+    model = std::make_shared<Model>(OutputVector{multiply}, ParameterVector{});
     manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
 }
 
@@ -152,7 +152,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsFloatZeroPointToScalarAdditionalZPC
     auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point);
     auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
     auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-    model = std::make_shared<Model>(NodeVector{multiply, zero_point_consumer}, ParameterVector{});
+    model = std::make_shared<Model>(OutputVector{multiply, zero_point_consumer}, ParameterVector{});
     manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
 }
 
@@ -169,7 +169,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsU4ZeroPointToScalarAdditionalZPCons
     auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
     auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
     auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-    model = std::make_shared<Model>(NodeVector{multiply, zero_point_consumer}, ParameterVector{});
+    model = std::make_shared<Model>(OutputVector{multiply, zero_point_consumer}, ParameterVector{});
     manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
 }
 
@@ -186,7 +186,7 @@ TEST_F(TransformationTestsF, ConvertU4WeightsU4ZeroPointToScalarAdditionalZPConv
     auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
     auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
     auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-    model = std::make_shared<Model>(NodeVector{multiply, zero_point_convert_consumer}, ParameterVector{});
+    model = std::make_shared<Model>(OutputVector{multiply, zero_point_convert_consumer}, ParameterVector{});
     manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
 }
 
@@ -203,6 +203,6 @@ TEST_F(TransformationTestsF, ConvertU4WeightsU4ZeroPointToScalarZPWithBiggerRank
     auto subtract = std::make_shared<ov::op::v1::Subtract>(convert, zero_point_convert);
     auto scale = ov::op::v0::Constant::create(decompression_precision, decompression_shape, {3.f});
     auto multiply = std::make_shared<ov::op::v1::Multiply>(subtract, scale);
-    model = std::make_shared<Model>(NodeVector{multiply, zero_point_convert_consumer}, ParameterVector{});
+    model = std::make_shared<Model>(OutputVector{multiply, zero_point_convert_consumer}, ParameterVector{});
     manager.register_pass<ov::pass::ConvertU4WeightsZeroPointToScalar>();
 }

--- a/src/common/transformations/tests/common_optimizations/depth_to_space_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/depth_to_space_fusion_test.cpp
@@ -32,7 +32,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionDepthFirst) {
         auto permute = std::make_shared<opset3::Transpose>(reshape_before, permutation);
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, shape_reshape_after, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input0});
 
         auto callback = [](const std::shared_ptr<const Node>& node) -> bool {
             return ov::as_type_ptr<const opset3::DepthToSpace>(node) != nullptr;
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionDepthFirst) {
         auto input0 = std::make_shared<opset3::Parameter>(element::f32, Shape{1, 128, 720, 480});
         auto depth_to_space =
             std::make_shared<opset3::DepthToSpace>(input0, opset3::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST, 2);
-        model_ref = std::make_shared<ov::Model>(NodeVector{depth_to_space}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{depth_to_space}, ParameterVector{input0});
     }
 }
 
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionDepthFirstDynamicBatch) {
         auto permute = std::make_shared<opset3::Transpose>(reshape_before, permutation);
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, shape_reshape_after, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input});
 
         auto callback = [](const std::shared_ptr<const Node>& node) -> bool {
             return ov::as_type_ptr<const opset3::DepthToSpace>(node) != nullptr;
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionDepthFirstDynamicBatch) {
         auto input = std::make_shared<opset3::Parameter>(element::f32, input_pshape);
         auto depth_to_space =
             std::make_shared<opset3::DepthToSpace>(input, opset3::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST, 2);
-        model_ref = std::make_shared<ov::Model>(NodeVector{depth_to_space}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{depth_to_space}, ParameterVector{input});
     }
 }
 
@@ -96,7 +96,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionBlockFirst) {
         auto permute = std::make_shared<opset3::Transpose>(reshape_before, permutation);
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, shape_reshape_after, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input0});
 
         auto callback = [](const std::shared_ptr<const Node>& node) -> bool {
             return ov::as_type_ptr<const opset3::DepthToSpace>(node) != nullptr;
@@ -112,7 +112,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionBlockFirst) {
         auto input0 = std::make_shared<opset3::Parameter>(element::f32, Shape{1, 128, 720, 480});
         auto depth_to_space =
             std::make_shared<opset3::DepthToSpace>(input0, opset3::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST, 2);
-        model_ref = std::make_shared<ov::Model>(NodeVector{depth_to_space}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{depth_to_space}, ParameterVector{input0});
     }
 }
 
@@ -128,7 +128,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionBlockFirstDynamicBatch) {
         auto permute = std::make_shared<opset3::Transpose>(reshape_before, permutation);
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, shape_reshape_after, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input});
 
         auto callback = [](const std::shared_ptr<const Node>& node) -> bool {
             return ov::as_type_ptr<const opset3::DepthToSpace>(node) != nullptr;
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionBlockFirstDynamicBatch) {
         auto input = std::make_shared<opset3::Parameter>(element::f32, input_pshape);
         auto depth_to_space =
             std::make_shared<opset3::DepthToSpace>(input, opset3::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST, 2);
-        model_ref = std::make_shared<ov::Model>(NodeVector{depth_to_space}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{depth_to_space}, ParameterVector{input});
     }
 }
 
@@ -160,7 +160,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionDynamicShape) {
         auto permute = std::make_shared<opset3::Transpose>(reshape_before, permutation);
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, shape_reshape_after, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input0, shape_reshape_before});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input0, shape_reshape_before});
 
         auto callback = [](const std::shared_ptr<const Node>& node) -> bool {
             return ov::as_type_ptr<const opset3::DepthToSpace>(node) != nullptr;
@@ -183,7 +183,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionDynamicShape) {
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, shape_reshape_after, false);
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input0, shape_reshape_before});
+            std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input0, shape_reshape_before});
     }
 }
 
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionSeveralConsumers) {
         // additional consumer
         auto additional_consumer = std::make_shared<opset3::Result>(reshape_before);
 
-        model = std::make_shared<ov::Model>(NodeVector{result, additional_consumer}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{result, additional_consumer}, ParameterVector{input0});
         auto callback = [](const std::shared_ptr<const Node>& node) -> bool {
             return ov::as_type_ptr<const opset3::DepthToSpace>(node) != nullptr;
         };
@@ -227,6 +227,6 @@ TEST_F(TransformationTestsF, DepthToSpaceFusionSeveralConsumers) {
         // additional consumer
         auto additional_consumer = std::make_shared<opset3::Result>(reshape_before);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{result, additional_consumer}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{result, additional_consumer}, ParameterVector{input0});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/dilated_convolution_converter.cpp
+++ b/src/common/transformations/tests/common_optimizations/dilated_convolution_converter.cpp
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, DilatedConvolutionConverter) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 2, 2}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 1, 1}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 1, 1}));
-        model = std::make_shared<Model>(NodeVector{batch_to_space}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{batch_to_space}, ParameterVector{data, filters});
 
         manager.register_pass<ov::pass::DilatedConvolutionConverter>();
     }
@@ -55,7 +55,7 @@ TEST_F(TransformationTestsF, DilatedConvolutionConverter) {
                                                           CoordinateDiff{1, 1},
                                                           Strides{2, 2},
                                                           op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -82,7 +82,7 @@ TEST_F(TransformationTestsF, NegativeDilatedConvolutionConverterPadsLessThanCrop
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 2, 2}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 0, 0}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{batch_to_space}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{batch_to_space}, ParameterVector{data, filters});
 
         manager.register_pass<ov::pass::DilatedConvolutionConverter>();
     }
@@ -108,7 +108,7 @@ TEST_F(TransformationTestsF, NegativeDilatedConvolutionConverterNonZeroPadsForNC
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 2, 2}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 0, 0}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 1, 1}));
-        model = std::make_shared<Model>(NodeVector{batch_to_space}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{batch_to_space}, ParameterVector{data, filters});
 
         manager.register_pass<ov::pass::DilatedConvolutionConverter>();
     }
@@ -134,7 +134,7 @@ TEST_F(TransformationTestsF, DilatedGroupConvolutionConverter) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 2, 2}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 1, 1}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {0, 0, 1, 1}));
-        model = std::make_shared<Model>(NodeVector{batch_to_space}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{batch_to_space}, ParameterVector{data, filters});
 
         manager.register_pass<ov::pass::DilatedConvolutionConverter>();
     }
@@ -148,7 +148,7 @@ TEST_F(TransformationTestsF, DilatedGroupConvolutionConverter) {
                                                                CoordinateDiff{1, 1},
                                                                Strides{2, 2},
                                                                op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);

--- a/src/common/transformations/tests/common_optimizations/dimension_tracking.cpp
+++ b/src/common/transformations/tests/common_optimizations/dimension_tracking.cpp
@@ -77,7 +77,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_Transpose_and_Convolution) {
                                                                  ov::CoordinateDiff{0, 0},
                                                                  ov::Strides{1, 1});
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -112,7 +112,7 @@ TEST(TransformationTests, AutoBatch_LabelPropagation_Convolution_Reshape) {
         std::make_shared<ov::opset1::Reshape>(conv,
                                               ov::opset1::Constant::create(ov::element::i64, {3}, {-1, 4, 6}),
                                               false);
-    const auto& model = std::make_shared<ov::Model>(ov::NodeVector{reshape}, ov::ParameterVector{data});
+    const auto& model = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -138,7 +138,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_SingleMultiply) {
     const auto& constant = std::make_shared<ov::opset1::Constant>(ov::element::f32, ov::Shape{1, 4, 1, 1});
     const auto& mul = std::make_shared<ov::opset1::Multiply>(data, constant);
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -168,7 +168,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_Two_Outputs) {
                                                                  ov::CoordinateDiff{0, 0},
                                                                  ov::Strides{1, 1});
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{conv, transpose}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{conv, transpose}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -198,7 +198,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_TwoOutputsReversed) {
         std::make_shared<ov::opset1::Constant>(ov::element::i64, ov::Shape{4}, std::vector<int64_t>{1, 0, 2, 3});
     const auto& transpose = std::make_shared<ov::opset1::Transpose>(data, order);
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{transpose, conv}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{transpose, conv}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -232,7 +232,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_IndependentBranchesConcated) {
 
     const auto& concat = std::make_shared<ov::opset1::Concat>(ov::NodeVector{conv, mul_1}, 1);
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -265,7 +265,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_TwoConvNetwork) {
                                                                    ov::CoordinateDiff{0, 0},
                                                                    ov::Strides{1, 1});
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{conv_0, conv_1}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{conv_0, conv_1}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();
@@ -293,7 +293,7 @@ TEST(TransformationTests, AutoBatch_FindBatch_NegativeTracking) {
     const auto& pattern = ov::op::v0::Constant::create(ov::element::i64, {1}, std::vector<int64_t>{-1});
     const auto& reshape = std::make_shared<ov::opset1::Reshape>(conv_0, pattern, false);
 
-    const auto& f = std::make_shared<ov::Model>(ov::NodeVector{reshape}, ov::ParameterVector{data});
+    const auto& f = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{data});
 
     ov::pass::Manager m;
     m.register_pass<ov::pass::InitNodeInfo>();

--- a/src/common/transformations/tests/common_optimizations/disable_shapeof_constant_folding_tests.cpp
+++ b/src/common/transformations/tests/common_optimizations/disable_shapeof_constant_folding_tests.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, DisableShapeOfConstantFolding) {
         auto shape_of = std::make_shared<opset6::ShapeOf>(data);
         auto abs = std::make_shared<opset6::Abs>(shape_of);
         auto reshape = std::make_shared<opset6::Reshape>(data, abs, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::DisableShapeOfConstantFolding>();
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -35,7 +35,7 @@ TEST_F(TransformationTestsF, DisableShapeOfConstantFolding) {
         auto shape_of = std::make_shared<opset6::ShapeOf>(data);
         auto abs = std::make_shared<opset6::Abs>(shape_of);
         auto reshape = std::make_shared<opset6::Reshape>(data, abs, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -47,7 +47,7 @@ TEST_F(TransformationTestsF, ShapeOfShapeOfConstantFolding) {
         auto reshape = std::make_shared<opset6::Reshape>(data, shape_of, false);
         auto rank = std::make_shared<opset6::ShapeOf>(shape_of);
         auto mul = std::make_shared<opset6::Multiply>(reshape, rank);
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::DisableShapeOfConstantFolding>();
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -58,6 +58,6 @@ TEST_F(TransformationTestsF, ShapeOfShapeOfConstantFolding) {
         auto shape_of = std::make_shared<opset6::ShapeOf>(data);
         auto reshape = std::make_shared<opset6::Reshape>(data, shape_of, false);
         auto mul = std::make_shared<opset6::Multiply>(reshape, opset6::Constant::create(element::i64, Shape{1}, {4}));
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/divide_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/divide_fusion.cpp
@@ -28,7 +28,7 @@ TEST(TransformationTests, DivideFusion) {
         auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
         auto mul = std::make_shared<opset1::Multiply>(data1, pow);
 
-        f = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data1, data2});
+        f = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -42,7 +42,7 @@ TEST(TransformationTests, DivideFusion) {
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
         auto divide = std::make_shared<opset1::Divide>(data1, data2);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data1, data2});
+        f_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
     }
 
     const auto res = FunctionsComparator::with_default()
@@ -61,7 +61,7 @@ TEST(TransformationTests, DivideFusionNegative) {
         auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
         auto mul = std::make_shared<opset1::Multiply>(data1, pow);
 
-        f = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data1, data2});
+        f = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -77,7 +77,7 @@ TEST(TransformationTests, DivideFusionNegative) {
         auto pow = std::make_shared<opset1::Power>(data2, pow_constant);
         auto mul = std::make_shared<opset1::Multiply>(data1, pow);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data1, data2});
+        f_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data1, data2});
     }
 
     const auto res = FunctionsComparator::with_default()

--- a/src/common/transformations/tests/common_optimizations/dropout_with_random_uniform_replacer_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/dropout_with_random_uniform_replacer_test.cpp
@@ -28,7 +28,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerCase1) {
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerCase1) {
         auto add = std::make_shared<opset8::Add>(broadcast, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -56,7 +56,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerCase2) {
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -70,7 +70,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerCase2) {
         auto add = std::make_shared<opset8::Add>(broadcast, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerWithConvert) {
         auto add = std::make_shared<opset8::Add>(convert, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -100,7 +100,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerWithConvert) {
         auto add = std::make_shared<opset8::Add>(convert, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -114,7 +114,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerAddConstNegative) {
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -128,7 +128,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerAddConstNegative) {
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerNonFloatRUNegative)
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -156,7 +156,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerNonFloatRUNegative)
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerInvalidMinNegative)
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -184,7 +184,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerInvalidMinNegative)
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -198,7 +198,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerInvalidMaxNegative)
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -212,7 +212,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerInvalidMaxNegative)
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }
 
@@ -226,7 +226,7 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerInvalidAddConstRank
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
 
         manager.register_pass<ov::pass::DropoutWithRandomUniformReplacer>();
     }
@@ -240,6 +240,6 @@ TEST_F(TransformationTestsF, DropoutWithRandomUniformReplacerInvalidAddConstRank
         auto add = std::make_shared<opset8::Add>(ru, add_const);
         auto floor = std::make_shared<opset8::Floor>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{floor}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{floor}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/eliminate_split_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/eliminate_split_test.cpp
@@ -22,7 +22,7 @@ TEST_F(TransformationTestsF, EliminateSplit) {
         auto axis_const = opset8::Constant::create(element::i64, Shape{}, {2});
         auto split = std::make_shared<opset8::Split>(mul, axis_const, 1);
         auto res = std::make_shared<opset8::Result>(split);
-        model = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{input});
 
         manager.register_pass<ov::pass::EliminateSplit>();
     }
@@ -31,7 +31,7 @@ TEST_F(TransformationTestsF, EliminateSplit) {
         auto mul_constant = opset8::Constant::create(element::f32, Shape{1}, {89.2});
         auto mul = std::make_shared<opset8::Multiply>(input, mul_constant);
         auto res = std::make_shared<opset8::Result>(mul);
-        model_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{input});
     }
 }
 
@@ -45,7 +45,7 @@ TEST_F(TransformationTestsF, EliminateSplitNegative) {
         auto res1 = std::make_shared<opset8::Result>(split->output(0));
         auto res2 = std::make_shared<opset8::Result>(split->output(1));
         auto res3 = std::make_shared<opset8::Result>(split->output(2));
-        model = std::make_shared<ov::Model>(NodeVector{res1, res2, res3}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{res1, res2, res3}, ParameterVector{input});
 
         manager.register_pass<ov::pass::EliminateSplit>();
     }
@@ -65,7 +65,7 @@ TEST_F(TransformationTestsF, EliminateSequenceOfSplits) {
         auto res1 = std::make_shared<opset8::Result>(true_split->output(0));
         auto res2 = std::make_shared<opset8::Result>(true_split->output(1));
         auto res3 = std::make_shared<opset8::Result>(true_split->output(2));
-        model = std::make_shared<ov::Model>(NodeVector{res1, res2, res3}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{res1, res2, res3}, ParameterVector{input});
 
         manager.register_pass<ov::pass::EliminateSplit>();
     }
@@ -77,6 +77,6 @@ TEST_F(TransformationTestsF, EliminateSequenceOfSplits) {
         auto res1 = std::make_shared<opset8::Result>(split->output(0));
         auto res2 = std::make_shared<opset8::Result>(split->output(1));
         auto res3 = std::make_shared<opset8::Result>(split->output(2));
-        model_ref = std::make_shared<ov::Model>(NodeVector{res1, res2, res3}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{res1, res2, res3}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/eliminate_unsqueeze_gather.cpp
+++ b/src/common/transformations/tests/common_optimizations/eliminate_unsqueeze_gather.cpp
@@ -48,13 +48,13 @@ protected:
                                                          v0::Constant::create(element::i64, Shape{1}, {0}),
                                                          v0::Constant::create(element::i64, Shape{1}, {axis}));
         const auto relu = std::make_shared<v0::Relu>(gather);
-        return std::make_shared<Model>(NodeVector{relu}, ParameterVector{parameter}, "Actual");
+        return std::make_shared<Model>(OutputVector{relu}, ParameterVector{parameter}, "Actual");
     }
 
     static std::shared_ptr<Model> reference(const TensorShape& inShape, const TensorType& inType) {
         const auto parameter = std::make_shared<v0::Parameter>(inType, inShape);
         const auto relu = std::make_shared<v0::Relu>(parameter);
-        return std::make_shared<Model>(NodeVector{relu}, ParameterVector{parameter}, "Reference");
+        return std::make_shared<Model>(OutputVector{relu}, ParameterVector{parameter}, "Reference");
     }
 };
 

--- a/src/common/transformations/tests/common_optimizations/flush_fp32_subnormals_to_zero_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/flush_fp32_subnormals_to_zero_test.cpp
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_max_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -70,7 +70,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_max_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -100,7 +100,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_min_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -118,7 +118,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_min_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -148,7 +148,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_arbitrary_subnorm) 
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -166,7 +166,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_arbitrary_subnorm) 
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -196,7 +196,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_max_neg_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -214,7 +214,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_max_neg_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -244,7 +244,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_min_neg_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -262,7 +262,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_min_neg_subnorm) {
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -292,7 +292,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_arbitrary_neg_subno
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -310,7 +310,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_arbitrary_neg_subno
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -341,7 +341,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_arbitrary_norm) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         manager.register_pass<pass::FlushFP32SubnormalsToZero>();
     }
@@ -370,7 +370,7 @@ TEST_F(TransformationTestsF, test_flush_fp32_subnorm_to_zero_arbitrary_norm) {
                                                   CoordinateDiff{0, 0},
                                                   Strides{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }

--- a/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/tests/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -113,7 +113,7 @@ static std::shared_ptr<ov::Model> buildROPE_Llama2(const size_t batch,
     auto mul_Multiply_463 = makeOP<ov::opset1::Multiply>({cat_Concat, cos_sin[1]}, {{"auto_broadcast", "numpy"}});
     auto add_Add = makeOP<ov::opset1::Add>({mul_Multiply, mul_Multiply_463}, {{"auto_broadcast", "numpy"}});
 
-    return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, parameters);
+    return std::make_shared<ov::Model>(ov::OutputVector{add_Add}, parameters);
 }
 
 TEST_F(TransformationTestsF, ConvertToROPE_LLama2_no_gather) {
@@ -146,7 +146,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LLama2_no_gather) {
                                                        {"config.rotary_ndims", static_cast<int>(ndims)},
                                                        {"config.gather_position_arg_id", 0}});
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{add_Add},
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{add_Add},
                                                 ov::ParameterVector{hidden_states, param_cos, param_sin});
     }
 }
@@ -183,7 +183,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_LLama2_with_gather) {
                                                        {"config.rotary_ndims", static_cast<int>(ndims)},
                                                        {"config.gather_position_arg_id", 3}});
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{add_Add},
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{add_Add},
                                                 ov::ParameterVector{hidden_states, seq_len, gather_id});
     }
 }
@@ -288,7 +288,7 @@ static std::shared_ptr<ov::Model> buildROPE_GPTNEOX(const int batch,
                                           {"ellipsis_mask", {}}});
     auto cat_Concat_458 = makeOP<ov::opset1::Concat>({add_Add, slice_Slice_357}, {{"axis", -1}});
 
-    return std::make_shared<ov::Model>(ov::NodeVector{cat_Concat_458}, parameters);
+    return std::make_shared<ov::Model>(ov::OutputVector{cat_Concat_458}, parameters);
 }
 
 TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_no_gather) {
@@ -322,7 +322,8 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_no_gather) {
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
                                                     {"config.gather_position_arg_id", 0}});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, param_cos, param_sin});
+        model_ref =
+            std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, param_cos, param_sin});
     }
 }
 
@@ -359,7 +360,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTNEOX_with_gather) {
                                                     {"config.rotary_ndims", rotary_ndims},
                                                     {"config.gather_position_arg_id", 3}});
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, gather_idx, batch_limit});
+            std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, gather_idx, batch_limit});
     }
 }
 
@@ -454,7 +455,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ) {
                                               {"ellipsis_mask", {}}});
         auto cat_Concat_826 = makeOP<ov::opset1::Concat>({add_Add_819, slice_Slice_582}, {{"axis", -1}});
         auto permute_Transpose_828 = makeOP<ov::opset1::Transpose>({cat_Concat_826, {0, 2, 1, 3}});
-        model = std::make_shared<ov::Model>(ov::NodeVector{permute_Transpose_828},
+        model = std::make_shared<ov::Model>(ov::OutputVector{permute_Transpose_828},
                                             ov::ParameterVector{input, gather_sin_cos});
     }
     manager.register_pass<ov::pass::RoPEFusion>();
@@ -475,7 +476,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ) {
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
                                                     {"config.gather_position_arg_id", 0}});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, cos_sin});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, cos_sin});
     }
 }
 
@@ -562,7 +563,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML) {
                                               {"ellipsis_mask", {}}});
         auto aten_cat_Concat_425 =
             makeOP<ov::opset1::Concat>({aten_flatten_Reshape_421, aten_slice_Slice_363}, {{"axis", -1}});
-        model = std::make_shared<ov::Model>(ov::NodeVector{aten_cat_Concat_425},
+        model = std::make_shared<ov::Model>(ov::OutputVector{aten_cat_Concat_425},
                                             ov::ParameterVector{input, seq_length, cos_sin_cache});
     }
     manager.register_pass<ov::pass::RoPEFusion>();
@@ -586,7 +587,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML) {
                                                     {"config.head_size", ndims},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, seq_length, cos_sin_cache});
+            std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, seq_length, cos_sin_cache});
     }
 }
 
@@ -641,7 +642,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML_Slice) {
             makeOP<opset1::Reshape>({stack, {0, 0, num_heads, rotary_ndims}}, {{"special_zero", true}});
         auto cat_Concat = makeOP<opset1::Concat>({flatten_Reshape, VariadicSplit_20795->output(1)}, {{"axis", -1}});
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{cat_Concat},
+        model = std::make_shared<ov::Model>(ov::OutputVector{cat_Concat},
                                             ov::ParameterVector{input, seq_length, cos_sin_cache});
     }
     manager.register_pass<ov::pass::RoPEFusion>();
@@ -665,7 +666,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML_Slice) {
                                                     {"config.head_size", ndims},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, seq_length, cos_sin_cache});
+            std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, seq_length, cos_sin_cache});
     }
 }
 
@@ -726,8 +727,8 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_Slice) {
         auto cat_Concat = makeOP<opset1::Concat>({add_Add, VariadicSplit_39740->output(1)}, {{"axis", -1}});
         auto permute_Transpose = makeOP<opset1::Transpose>({cat_Concat, {0, 2, 1, 3}});
 
-        model =
-            std::make_shared<ov::Model>(ov::NodeVector{permute_Transpose}, ov::ParameterVector{input, gather_sin_cos});
+        model = std::make_shared<ov::Model>(ov::OutputVector{permute_Transpose},
+                                            ov::ParameterVector{input, gather_sin_cos});
     }
     manager.register_pass<ov::pass::RoPEFusion>();
     {
@@ -747,7 +748,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_Slice) {
                                                     {"config.head_size", 0},
                                                     {"config.rotary_ndims", rotary_ndims},
                                                     {"config.gather_position_arg_id", 0}});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, cos_sin});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, cos_sin});
     }
 }
 
@@ -840,7 +841,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML_2d_rope) {
              {"shrink_axis_mask", {}},
              {"ellipsis_mask", {}}});
         auto cat_Concat_425 = makeOP<ov::opset1::Concat>({flatten_Reshape_421, slice_Slice_363}, {{"axis", -1}});
-        model = std::make_shared<ov::Model>(ov::NodeVector{cat_Concat_425},
+        model = std::make_shared<ov::Model>(ov::OutputVector{cat_Concat_425},
                                             ov::ParameterVector{input, cos_sin_cache, position_ids});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
@@ -863,8 +864,8 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML_2d_rope) {
                                                     {"config.head_cnt", num_heads},
                                                     {"config.head_size", ndims},
                                                     {"config.gather_position_arg_id", 0}});
-        model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, cos_sin_cache, position_ids});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope},
+                                                ov::ParameterVector{input, cos_sin_cache, position_ids});
     }
 }
 
@@ -949,7 +950,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML_nano_2d_rope) {
         auto stack_401 = makeOP<ov::opset1::Concat>({Unsqueeze_62716, Unsqueeze_62717}, {{"axis", -1}});
         auto flatten_Reshape_421 =
             makeOP<ov::opset1::Reshape>({stack_401, {0, num_heads, 0, rotary_ndims}}, {{"special_zero", true}});
-        model = std::make_shared<ov::Model>(ov::NodeVector{flatten_Reshape_421},
+        model = std::make_shared<ov::Model>(ov::OutputVector{flatten_Reshape_421},
                                             ov::ParameterVector{input, cos_sin_cache, position_ids});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
@@ -972,8 +973,8 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGML_nano_2d_rope) {
                                                     {"config.head_cnt", num_heads},
                                                     {"config.head_size", ndims},
                                                     {"config.gather_position_arg_id", 0}});
-        model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, cos_sin_cache, position_ids});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope},
+                                                ov::ParameterVector{input, cos_sin_cache, position_ids});
     }
 }
 
@@ -1006,7 +1007,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul) {
         auto y2 = std::make_shared<ov::op::v1::Multiply>(x3, t_sin);
         auto y = std::make_shared<ov::op::v1::Add>(y1, y2);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{y}, ov::ParameterVector{x, t_cos, t_sin});
+        model = std::make_shared<ov::Model>(ov::OutputVector{y}, ov::ParameterVector{x, t_cos, t_sin});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
     {
@@ -1020,7 +1021,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul) {
         config.head_cnt = num_heads;
         config.head_size = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
     comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
@@ -1060,7 +1061,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_squeeze_mul_unsqueeze) {
         auto y2 = std::make_shared<ov::op::v1::Multiply>(x3, t_sin);
         auto y = std::make_shared<ov::op::v1::Add>(y1, y2);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{y}, ov::ParameterVector{x, t_cos, t_sin});
+        model = std::make_shared<ov::Model>(ov::OutputVector{y}, ov::ParameterVector{x, t_cos, t_sin});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
     {
@@ -1074,7 +1075,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_squeeze_mul_unsqueeze) {
         config.head_cnt = num_heads;
         config.head_size = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
     comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
@@ -1114,7 +1115,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul_squeeze_unsqueeze) {
         auto y2 = std::make_shared<ov::op::v1::Multiply>(x3, t_sin);
         auto y = std::make_shared<ov::op::v1::Add>(y1, y2);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{y}, ov::ParameterVector{x, t_cos, t_sin});
+        model = std::make_shared<ov::Model>(ov::OutputVector{y}, ov::ParameterVector{x, t_cos, t_sin});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
     {
@@ -1128,7 +1129,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Flux_mul_squeeze_unsqueeze) {
         config.head_cnt = num_heads;
         config.head_size = ndims;
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{x, t_cos, t_sin}, config);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{x, t_cos, t_sin});
     }
     comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
@@ -1192,7 +1193,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM3_PagedAttention) {
         auto aten_cat_Concat_55 =
             makeOP<opset1::Concat>({aten_flatten_Reshape_55, VariadicSplit_29663->output(1)}, {{"axis", -1}});
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{aten_cat_Concat_55}, ov::ParameterVector{input, cos_sin});
+        model = std::make_shared<ov::Model>(ov::OutputVector{aten_cat_Concat_55}, ov::ParameterVector{input, cos_sin});
     }
     manager.register_pass<ov::pass::RoPEFusion>(false);
     {
@@ -1214,7 +1215,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM3_PagedAttention) {
                                                     {"config.head_cnt", num_heads},
                                                     {"config.head_size", ndims},
                                                     {"config.gather_position_arg_id", 0}});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, gather_cos_sin});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, gather_cos_sin});
     }
 }
 
@@ -1269,7 +1270,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Qwen_PagedAttention) {
         auto cat_Concat_2 = makeOP<opset1::Concat>({ListUnpack_Squeeze_0_1, ListUnpack_Squeeze_1}, {{"axis", -1}});
         auto mul_Multiply_3 = makeOP<opset1::Multiply>({cat_Concat_2, Reshape_27408}, {{"auto_broadcast", "numpy"}});
         auto add_Add_1 = makeOP<opset1::Add>({mul_Multiply_2, mul_Multiply_3}, {{"auto_broadcast", "numpy"}});
-        model = std::make_shared<ov::Model>(ov::NodeVector{add_Add_1}, ov::ParameterVector{position_ids, qkv});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add_Add_1}, ov::ParameterVector{position_ids, qkv});
     }
 
     manager.register_pass<ov::pass::RoPEFusion>(false);
@@ -1294,7 +1295,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_Qwen_PagedAttention) {
                                                     {"config.head_cnt", 32},
                                                     {"config.head_size", 128},
                                                     {"config.gather_position_arg_id", 3}});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, position_ids});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, position_ids});
     }
 }
 
@@ -1354,7 +1355,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_PagedAttention) {
             makeOP<opset1::Add>({aten_mul_Multiply, aten_mul_Multiply_1}, {{"auto_broadcast", "numpy"}});
         auto aten_cat_Concat_1 = makeOP<opset1::Concat>({aten_add_Add, VariadicSplit_32371->output(1)}, {{"axis", -1}});
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{aten_cat_Concat_1},
+        model = std::make_shared<ov::Model>(ov::OutputVector{aten_cat_Concat_1},
                                             ov::ParameterVector{input, aten_gather_GatherElements});
     }
     manager.register_pass<ov::pass::RoPEFusion>(false);
@@ -1377,7 +1378,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_GPTJ_PagedAttention) {
                                                     {"config.head_size", 0},
                                                     {"config.gather_position_arg_id", 0}});
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, aten_gather_GatherElements});
+            std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, aten_gather_GatherElements});
     }
 }
 
@@ -1429,7 +1430,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention) {
         auto aten_cat_Concat =
             makeOP<ov::opset1::Concat>({aten_flatten_Reshape, VariadicSplit_41226->output(1)}, {{"axis", -1}});
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{aten_cat_Concat}, ov::ParameterVector{input, input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{aten_cat_Concat}, ov::ParameterVector{input, input1});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
     {
@@ -1450,7 +1451,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention) {
                                                     {"config.head_size", 128},
                                                     {"config.gather_position_arg_id", 0}});
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, input1});
     }
 }
 
@@ -1514,7 +1515,7 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention_GPU) {
                                           {"ellipsis_mask", {}}});
         auto aten_cat_Concat = makeOP<opset1::Concat>({aten_flatten_Reshape, aten_slice_Slice_3}, {{"axis", -1}});
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{aten_cat_Concat}, ov::ParameterVector{input0, input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{aten_cat_Concat}, ov::ParameterVector{input0, input1});
     }
     manager.register_pass<ov::pass::RoPEFusion>(true);
     {
@@ -1535,6 +1536,6 @@ TEST_F(TransformationTestsF, ConvertToROPE_chatGLM4_PagedAttention_GPU) {
                                                     {"config.head_size", 128},
                                                     {"config.gather_position_arg_id", 0}});
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rope}, ov::ParameterVector{input, input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, input1});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/fused_names_cleanup.cpp
+++ b/src/common/transformations/tests/common_optimizations/fused_names_cleanup.cpp
@@ -27,7 +27,7 @@ TEST(TransformationTests, FusedNamesCleanup) {
         auto add2_const = opset9::Constant::create(element::f32, Shape{1}, {2.0});
         auto add1 = std::make_shared<opset9::Add>(add1_const, add2_const);
         auto add2 = std::make_shared<opset9::Add>(data, add1);
-        model = std::make_shared<Model>(NodeVector{add2}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{add2}, ParameterVector{data});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -44,7 +44,7 @@ TEST(TransformationTests, FusedNamesCleanup) {
 
         auto add_const = opset9::Constant::create(element::f32, Shape{1}, {3.0});
         auto add = std::make_shared<opset9::Add>(data, add_const);
-        model_ref = std::make_shared<Model>(NodeVector{add}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{data});
     }
     const FunctionsComparator func_comparator =
         FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);

--- a/src/common/transformations/tests/common_optimizations/gelu_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/gelu_fusion.cpp
@@ -60,7 +60,7 @@ TEST_P(GeluTestsP, GeluFusionPatternOne) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(data, mul_const);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, add);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfOne>();
     }
@@ -68,7 +68,7 @@ TEST_P(GeluTestsP, GeluFusionPatternOne) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -84,7 +84,7 @@ TEST_P(GeluTestsP, GeluFusionPatternOneF16) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(data, mul_const);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, add);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfOne>();
     }
@@ -92,7 +92,7 @@ TEST_P(GeluTestsP, GeluFusionPatternOneF16) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -108,7 +108,7 @@ TEST_P(GeluTestsP, GeluFusionPatternTwo) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(data, add);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, mul_const);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfTwo>();
     }
@@ -116,7 +116,7 @@ TEST_P(GeluTestsP, GeluFusionPatternTwo) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -132,7 +132,7 @@ TEST_P(GeluTestsP, GeluFusionPatternTwoF16) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(data, add);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, mul_const);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfTwo>();
     }
@@ -140,7 +140,7 @@ TEST_P(GeluTestsP, GeluFusionPatternTwoF16) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -156,7 +156,7 @@ TEST_P(GeluTestsP, GeluFusionPatternThree) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(add, mul_const);
         auto mul = std::make_shared<ov::op::v1::Multiply>(data, mul_first);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfThree>();
     }
@@ -164,7 +164,7 @@ TEST_P(GeluTestsP, GeluFusionPatternThree) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -180,7 +180,7 @@ TEST_P(GeluTestsP, GeluFusionPatternThreeF16) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(add, mul_const);
         auto mul = std::make_shared<ov::op::v1::Multiply>(data, mul_first);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfThree>();
     }
@@ -188,7 +188,7 @@ TEST_P(GeluTestsP, GeluFusionPatternThreeF16) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -206,7 +206,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternFour) {
         auto add = std::make_shared<ov::op::v1::Add>(mul2, add_const);
         auto mul3 = std::make_shared<ov::op::v1::Multiply>(data, add);
 
-        model = std::make_shared<Model>(NodeVector{mul3}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul3}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfFour>();
     }
@@ -214,7 +214,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternFour) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -232,7 +232,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternFourF16) {
         auto add = std::make_shared<ov::op::v1::Add>(mul2, add_const);
         auto mul3 = std::make_shared<ov::op::v1::Multiply>(data, add);
 
-        model = std::make_shared<Model>(NodeVector{mul3}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul3}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfFour>();
     }
@@ -240,7 +240,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternFourF16) {
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f16, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -258,8 +258,8 @@ TEST_F(TransformationTestsF, GeluFusionPatternIncorrectDivConstValue) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(data, add);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, mul_const);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfTwo>();
     }
@@ -279,8 +279,8 @@ TEST_F(TransformationTestsF, GeluFusionPatternTooShortDivConstValue) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(data, add);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, mul_const);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfTwo>();
     }
@@ -303,7 +303,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternVariadicSplitAsInput) {
         auto mul_first = std::make_shared<ov::op::v1::Multiply>(var_split->output(1), add);
         auto mul = std::make_shared<ov::op::v1::Multiply>(mul_first, mul_const);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::GeluFusionWithErfTwo>();
     }
@@ -314,7 +314,7 @@ TEST_F(TransformationTestsF, GeluFusionPatternVariadicSplitAsInput) {
         auto var_split = std::make_shared<ov::op::v1::VariadicSplit>(data, axis, split_lengths);
 
         auto gelu = std::make_shared<ov::op::v7::Gelu>(var_split->output(1));
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -344,14 +344,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_equal_const_values) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -378,7 +378,7 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_params_no_conversion) {
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
         model = std::make_shared<Model>(
-            NodeVector{mul_3},
+            OutputVector{mul_3},
             ParameterVector{input, pow_param, mul_0_param, mul_1_param, add_1_param, mul_2_param});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
@@ -411,14 +411,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_pow_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -449,14 +449,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_pow_value_2) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(add_1, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -486,7 +486,7 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_wrong_pow_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 }
@@ -517,14 +517,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_mul_0_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -554,7 +554,7 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_wrong_mul_0_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 }
@@ -583,14 +583,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_mul_1_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -620,7 +620,7 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_wrong_mul_1_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 }
@@ -652,14 +652,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_add_1_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -689,7 +689,7 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_wrong_add_1_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 }
@@ -721,14 +721,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_mul_2_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -758,7 +758,7 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_wrong_mul_2_value) {
 
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
 
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanh>();
     }
 }
@@ -791,7 +791,7 @@ TEST_F(TransformationTestsF, FoldGeluOperation) {
         auto mul6 = std::make_shared<ov::op::v1::Multiply>(add2, mul5);
 
         auto result = std::make_shared<ov::op::v0::Result>(mul6);
-        model = std::make_shared<Model>(NodeVector{result}, ParameterVector{param});
+        model = std::make_shared<Model>(OutputVector{result}, ParameterVector{param});
 
         manager.register_pass<ov::pass::GeluFusionWithTanhNoPower>();
     }
@@ -800,7 +800,7 @@ TEST_F(TransformationTestsF, FoldGeluOperation) {
         auto param = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1006, 2, 100, 3, 4096});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(param, ov::op::GeluApproximationMode::TANH);
         auto result = std::make_shared<ov::op::v0::Result>(gelu);
-        model_ref = std::make_shared<Model>(NodeVector{result}, ParameterVector{param});
+        model_ref = std::make_shared<Model>(OutputVector{result}, ParameterVector{param});
     }
 }
 
@@ -824,14 +824,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_no_pow2_value1) {
         auto mul_2_constant = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{1}, std::vector<float>{0.5f});
         auto mul_2 = std::make_shared<ov::op::v1::Multiply>(add_1, mul_2_constant);
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(input, mul_2);
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanhNoPower2>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -855,14 +855,14 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_no_pow2_value2) {
         auto mul_2_constant = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{1}, std::vector<float>{0.5f});
         auto mul_2 = std::make_shared<ov::op::v1::Multiply>(input, mul_2_constant);
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(add_1, mul_2);
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanhNoPower2>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }
 
@@ -886,13 +886,13 @@ TEST_F(TransformationTestsF, GeluFusionTanhWithTanh_epsilon_no_pow2_value3) {
         auto mul_2 = std::make_shared<ov::op::v1::Multiply>(input, add_1);
         auto mul_3_constant = std::make_shared<ov::op::v0::Constant>(element::f32, Shape{1}, std::vector<float>{0.5f});
         auto mul_3 = std::make_shared<ov::op::v1::Multiply>(mul_2, mul_3_constant);
-        model = std::make_shared<Model>(NodeVector{mul_3}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{mul_3}, ParameterVector{input});
         manager.register_pass<ov::pass::GeluFusionWithTanhNoPower2>();
     }
 
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto gelu = std::make_shared<ov::op::v7::Gelu>(data, op::GeluApproximationMode::TANH);
-        model_ref = std::make_shared<Model>(NodeVector{gelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gelu}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/glu_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/glu_fusion_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, GLUFusionTest1) {
         auto swish = std::make_shared<ov::op::v4::Swish>(variadic_split->output(0));
         auto mul = std::make_shared<ov::op::v1::Multiply>(swish, variadic_split->output(1));
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
         manager.register_pass<GLUFusion>();
     }
     {
@@ -47,7 +47,7 @@ TEST_F(TransformationTestsF, GLUFusionTest1) {
                                                               0,
                                                               ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{swiglu}, ov::ParameterVector{input});
     }
 }
 
@@ -60,7 +60,7 @@ TEST_F(TransformationTestsF, GLUFusionTest2) {
         auto swish = std::make_shared<ov::op::v4::Swish>(variadic_split->output(0));
         auto mul = std::make_shared<ov::op::v1::Multiply>(swish, variadic_split->output(1));
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
         manager.register_pass<GLUFusion>();
     }
 }
@@ -74,7 +74,7 @@ TEST_F(TransformationTestsF, GLUFusionTest3) {
         auto swish = std::make_shared<ov::op::v4::Swish>(variadic_split->output(0));
         auto mul = std::make_shared<ov::op::v1::Multiply>(swish, variadic_split->output(1));
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
         manager.register_pass<GLUFusion>();
     }
     {
@@ -88,7 +88,7 @@ TEST_F(TransformationTestsF, GLUFusionTest3) {
                                                               0,
                                                               ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{swiglu}, ov::ParameterVector{input});
     }
 }
 
@@ -101,7 +101,7 @@ TEST_F(TransformationTestsF, GLUFusionTest3ReverseOrder) {
         auto swish = std::make_shared<ov::op::v4::Swish>(variadic_split->output(0));
         auto mul = std::make_shared<ov::op::v1::Multiply>(variadic_split->output(1), swish);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
         manager.register_pass<GLUFusion>();
     }
     {
@@ -115,7 +115,7 @@ TEST_F(TransformationTestsF, GLUFusionTest3ReverseOrder) {
                                                               0,
                                                               ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{swiglu}, ov::ParameterVector{input});
     }
 }
 
@@ -128,7 +128,7 @@ TEST_F(TransformationTestsF, GLUFusionTest4) {
         auto swish = std::make_shared<ov::op::v4::Swish>(variadic_split->output(0));
         auto mul = std::make_shared<ov::op::v1::Multiply>(swish, variadic_split->output(0));
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
         manager.register_pass<GLUFusion>();
     }
 }
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, GeGLUFusionTest1) {
         auto gelu = std::make_shared<ov::op::v7::Gelu>(variadic_split->output(1));
         auto mul = std::make_shared<ov::op::v1::Multiply>(variadic_split->output(0), gelu);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
         manager.register_pass<GLUFusion>();
     }
     {
@@ -156,6 +156,6 @@ TEST_F(TransformationTestsF, GeGLUFusionTest1) {
                                                               1,
                                                               ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{swiglu}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{swiglu}, ov::ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/group_normalization_fusion_tests.cpp
+++ b/src/common/transformations/tests/common_optimizations/group_normalization_fusion_tests.cpp
@@ -176,7 +176,7 @@ protected:
                                                                         num_groups,
                                                                         epsilon);
 
-        return std::make_shared<Model>(NodeVector{group_norm}, ParameterVector{input});
+        return std::make_shared<Model>(OutputVector{group_norm}, ParameterVector{input});
     }
 };
 

--- a/src/common/transformations/tests/common_optimizations/hsigmoid_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/hsigmoid_fusion_test.cpp
@@ -30,7 +30,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluDivF16) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {6.0});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluDivF16) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
     }
 }
 
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluDivF32) {
         auto div_constant = opset7::Constant::create(element::f32, Shape{}, {6.0});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -63,7 +63,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluDivF32) {
         auto input = std::make_shared<opset7::Parameter>(element::f32, Shape{});
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
     }
 }
 
@@ -78,7 +78,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluMul) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.1666666716});
         auto mul_second = std::make_shared<opset7::Multiply>(min, mul_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -87,7 +87,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluMul) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
     }
 }
 
@@ -103,7 +103,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithoutRelu) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {6.0});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -112,7 +112,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithoutRelu) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
     }
 }
 
@@ -125,7 +125,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampMul) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {1.0 / 6.0});
         auto mul_first = std::make_shared<opset7::Multiply>(clamp, mul_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_first}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_first}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -134,7 +134,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampMul) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
     }
 }
 
@@ -147,7 +147,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampDiv) {
         auto div_constant = ov::op::v0::Constant::create(element::f16, Shape{}, {6.0});
         auto div = std::make_shared<ov::op::v1::Divide>(clamp, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -156,7 +156,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampDiv) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
     }
 }
 
@@ -171,7 +171,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluMulWrongConstValue) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.167});
         auto mul_second = std::make_shared<opset7::Multiply>(min, mul_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -186,7 +186,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluMulWrongConstValue) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.167});
         auto mul_second = std::make_shared<opset7::Multiply>(min, mul_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
     }
 }
 
@@ -201,7 +201,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluDivWrongConstValue) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {0.0});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -216,7 +216,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithReluDivWrongConstValue) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {0.0});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
     }
 }
 
@@ -232,7 +232,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithoutReluWrongConstValue) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {6.002});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -248,7 +248,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithoutReluWrongConstValue) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {6.002});
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
     }
 }
 
@@ -261,7 +261,7 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampWrongConstValue) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.98 / 6.15});
         auto mul_first = std::make_shared<opset7::Multiply>(clamp, mul_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_first}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_first}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidFusion>();
     }
@@ -274,6 +274,6 @@ TEST_F(TransformationTestsF, HSigmoidFusionWithClampWrongConstValue) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.98 / 6.15});
         auto mul_first = std::make_shared<opset7::Multiply>(clamp, mul_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul_first}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul_first}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/hswish_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/hswish_fusion_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluDivF16) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {6.0});
         auto div = std::make_shared<opset7::Divide>(mul, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishFusion>();
     }
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluDivF16) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -58,7 +58,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluDivF32) {
         auto div_constant = opset7::Constant::create(element::f32, Shape{}, {6.0});
         auto div = std::make_shared<opset7::Divide>(mul, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishFusion>();
     }
@@ -67,7 +67,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluDivF32) {
         auto input = std::make_shared<opset7::Parameter>(element::f32, Shape{});
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -83,7 +83,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluMul) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.1666666716});
         auto mul_second = std::make_shared<opset7::Multiply>(mul_first, mul_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishFusion>();
     }
@@ -92,7 +92,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluMul) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -109,7 +109,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithoutRelu) {
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
         auto mul = std::make_shared<opset7::Multiply>(input, div);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSigmoidFusion>();
@@ -120,7 +120,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithoutRelu) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -134,7 +134,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampMul) {
         auto mul_first = std::make_shared<opset7::Multiply>(clamp, mul_constant);
         auto mul_second = std::make_shared<opset7::Multiply>(input, mul_first);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSigmoidFusion>();
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampMul) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -159,7 +159,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampDiv) {
         auto div = std::make_shared<opset7::Divide>(clamp, div_constant);
         auto mul = std::make_shared<opset7::Multiply>(input, div);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSigmoidFusion>();
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampDiv) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -186,7 +186,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluMulWrongConstValue) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.167});
         auto mul_second = std::make_shared<opset7::Multiply>(mul_first, mul_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishFusion>();
     }
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluMulWrongConstValue) {
         auto mul_constant = opset7::Constant::create(element::f16, Shape{}, {0.167});
         auto mul_second = std::make_shared<opset7::Multiply>(mul_first, mul_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
     }
 }
 
@@ -218,7 +218,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluDivWrongConstValue) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {0.1});
         auto div = std::make_shared<opset7::Divide>(mul, div_constant);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishFusion>();
     }
@@ -234,7 +234,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithReluDivWrongConstValue) {
         auto div_constant = opset7::Constant::create(element::f16, Shape{}, {0.0});
         auto div = std::make_shared<opset7::Divide>(mul, div_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
     }
 }
 
@@ -251,7 +251,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithoutReluWrongConstValue) {
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
         auto mul = std::make_shared<opset7::Multiply>(input, div);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSigmoidFusion>();
@@ -270,7 +270,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithoutReluWrongConstValue) {
         auto div = std::make_shared<opset7::Divide>(min, div_constant);
         auto mul = std::make_shared<opset7::Multiply>(input, div);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 }
 
@@ -284,7 +284,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampWrongConstValue) {
         auto mul_first = std::make_shared<opset7::Multiply>(clamp, mul_constant);
         auto mul_second = std::make_shared<opset7::Multiply>(input, mul_first);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSigmoidFusion>();
@@ -300,7 +300,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampWrongConstValue) {
         auto mul_first = std::make_shared<opset7::Multiply>(clamp, mul_constant);
         auto mul_second = std::make_shared<opset7::Multiply>(input, mul_first);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
     }
 }
 
@@ -310,7 +310,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithHSigmoidMul) {
         auto hsigmoid = std::make_shared<opset7::HSigmoid>(input);
         auto mul = std::make_shared<opset7::Multiply>(input, hsigmoid);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishFusion>();
     }
@@ -319,7 +319,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithHSigmoidMul) {
         auto input = std::make_shared<opset7::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset7::HSwish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
     }
 }
 
@@ -331,7 +331,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClamp) {
         auto clamp = std::make_shared<opset7::Clamp>(add, 0.0f, 6.0f);
         auto mul = std::make_shared<opset7::Multiply>(input, clamp);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSwishFusion>();
@@ -343,7 +343,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClamp) {
         auto mul_const = opset7::Constant::create(element::f16, Shape{}, {6.0});
         auto mul = std::make_shared<opset7::Multiply>(hswish, mul_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 }
 
@@ -355,7 +355,7 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampWithWrongConstant) {
         auto clamp = std::make_shared<opset7::Clamp>(add, 0.11f, 6.32f);
         auto mul = std::make_shared<opset7::Multiply>(input, clamp);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         auto gr = manager.register_pass<pass::GraphRewrite>();
         gr->add_matcher<ov::pass::HSwishFusion>();
@@ -368,6 +368,6 @@ TEST_F(TransformationTestsF, HSwishFusionWithClampWithWrongConstant) {
         auto clamp = std::make_shared<opset7::Clamp>(add, 0.11f, 6.32f);
         auto mul = std::make_shared<opset7::Multiply>(input, clamp);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/interpolate_sequence_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/interpolate_sequence_fusion_test.cpp
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion4D1) {
                                                                      snd_axis_node,
                                                                      attributes[1]);
 
-        model = std::make_shared<ov::Model>(NodeVector{snd_interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{snd_interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::InterpolateSequenceFusion>();
     }
     {
@@ -92,7 +92,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion4D1) {
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axes_node, ref_attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -161,7 +161,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion4D2) {
                                                                        third_axis_node,
                                                                        attributes[2]);
 
-        model = std::make_shared<ov::Model>(NodeVector{third_interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{third_interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::InterpolateSequenceFusion>();
     }
     {
@@ -192,7 +192,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion4D2) {
                                                                  snd_scales_node,
                                                                  snd_axis_node,
                                                                  ref_attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -243,7 +243,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion4D3) {
                                                                      snd_axis_node,
                                                                      attributes[1]);
 
-        model = std::make_shared<ov::Model>(NodeVector{snd_interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{snd_interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::InterpolateSequenceFusion>();
     }
     {
@@ -260,7 +260,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion4D3) {
         auto div_node = std::make_shared<opset8::Divide>(sizes_cast, cast_shape_to_float);
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, div_node, axes_node, ref_attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -329,7 +329,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion5D1) {
                                                                        third_axis_node,
                                                                        attributes[2]);
 
-        model = std::make_shared<ov::Model>(NodeVector{third_interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{third_interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::InterpolateSequenceFusion>();
     }
     {
@@ -350,7 +350,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion5D1) {
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axes_node, ref_attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -419,7 +419,7 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion5D2) {
                                                                        third_axis_node,
                                                                        attributes[2]);
 
-        model = std::make_shared<ov::Model>(NodeVector{third_interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{third_interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::InterpolateSequenceFusion>();
     }
     {
@@ -436,6 +436,6 @@ TEST_F(TransformationTestsF, InterpolateSequenceFusion5D2) {
         auto div_node = std::make_shared<opset8::Divide>(sizes_cast, cast_shape_to_float);
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, div_node, axes_node, ref_attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/keep_constants_precision_and_add_converts_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/keep_constants_precision_and_add_converts_test.cpp
@@ -23,7 +23,7 @@ TEST_F(TransformationTestsF, KeepConstantsPrecisionAndAddConvertsTestBase) {
         auto weights = Constant::create(element::f32, Shape{1, 2, 2}, {1});
         auto matmul = std::make_shared<MatMul>(input, weights);
 
-        model = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{input});
 
         manager.register_pass<pass::KeepConstantsPrecisionAndAddConverts>();
         manager.get_pass_config()->set_callback<pass::KeepConstantsPrecisionAndAddConverts>(
@@ -46,7 +46,7 @@ TEST_F(TransformationTestsF, KeepConstantsPrecisionAndAddConvertsTestBase) {
         auto convert_weights = std::make_shared<Convert>(weights, element::f16);
         auto matmul = std::make_shared<MatMul>(input, convert_weights);
 
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{input});
     }
 }
 
@@ -58,7 +58,7 @@ TEST_F(TransformationTestsF, KeepConstantsPrecisionAndAddConvertsTestWithCompres
         mark_as_decompression(convert_weights);
         auto matmul = std::make_shared<MatMul>(input, convert_weights);
 
-        model = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{input});
 
         manager.register_pass<pass::KeepConstantsPrecisionAndAddConverts>();
         manager.get_pass_config()->set_callback<pass::KeepConstantsPrecisionAndAddConverts>(
@@ -81,6 +81,6 @@ TEST_F(TransformationTestsF, KeepConstantsPrecisionAndAddConvertsTestWithCompres
         auto convert_weights = std::make_shared<Convert>(weights, element::f16);
         auto matmul = std::make_shared<MatMul>(input, convert_weights);
 
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/leaky_relu_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/leaky_relu_fusion.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionConstant) {
         auto alpha = opset8::Constant::create(element::f32, Shape{1}, {0.1});
         auto multiply = std::make_shared<opset8::Multiply>(data, alpha);
         auto max = std::make_shared<opset8::Maximum>(data, multiply);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data});
 
         manager.register_pass<ov::pass::LeakyReluFusion>();
     }
@@ -36,7 +36,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionConstant) {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto alpha = opset8::Constant::create(element::f32, Shape{1}, {0.1});
         auto leaky_relu = std::make_shared<opset8::PRelu>(data, alpha);
-        model_ref = std::make_shared<Model>(NodeVector{leaky_relu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{leaky_relu}, ParameterVector{data});
     }
 }
 
@@ -46,7 +46,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionConstantGreaterThanOne) {
         auto alpha = opset8::Constant::create(element::f32, Shape{1}, {1.1});
         auto multiply = std::make_shared<opset8::Multiply>(data, alpha);
         auto max = std::make_shared<opset8::Maximum>(data, multiply);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data});
 
         manager.register_pass<ov::pass::LeakyReluFusion>();
     }
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionConstantAlphaOnFirstInput) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{2, 2});
         auto multiply = std::make_shared<opset8::Multiply>(alpha, data);
         auto max = std::make_shared<opset8::Maximum>(multiply, data);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data});
 
         manager.register_pass<ov::pass::LeakyReluFusion>();
     }
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionConstantAlphaOnFirstInput) {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto alpha = opset8::Constant::create(element::f32, Shape{1}, {0.1});
         auto leaky_relu = std::make_shared<opset8::PRelu>(data, alpha);
-        model_ref = std::make_shared<Model>(NodeVector{leaky_relu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{leaky_relu}, ParameterVector{data});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionScalar) {
         auto alpha = opset8::Constant::create(element::f32, Shape{}, {0.1});
         auto multiply = std::make_shared<opset8::Multiply>(data, alpha);
         auto max = std::make_shared<opset8::Maximum>(data, multiply);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data});
 
         manager.register_pass<ov::pass::LeakyReluFusion>();
     }
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionScalar) {
         auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 2});
         auto alpha = opset8::Constant::create(element::f32, Shape{}, {0.1});
         auto leaky_relu = std::make_shared<opset8::PRelu>(data, alpha);
-        model_ref = std::make_shared<Model>(NodeVector{leaky_relu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{leaky_relu}, ParameterVector{data});
     }
 }
 
@@ -104,7 +104,7 @@ TEST_F(TransformationTestsF, LeakyReluFusionParameter) {
         auto alpha = std::make_shared<opset8::Parameter>(element::f32, Shape{});
         auto multiply = std::make_shared<opset8::Multiply>(data, alpha);
         auto max = std::make_shared<opset8::Maximum>(data, multiply);
-        model = std::make_shared<Model>(NodeVector{max}, ParameterVector{data, alpha});
+        model = std::make_shared<Model>(OutputVector{max}, ParameterVector{data, alpha});
 
         manager.register_pass<ov::pass::LeakyReluFusion>();
     }

--- a/src/common/transformations/tests/common_optimizations/lin_op_sequence_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/lin_op_sequence_fusion_test.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, MulAddMulAddFusion) {
         auto mul2 = std::make_shared<opset3::Multiply>(add1, mul2_const);
         auto add2 = std::make_shared<opset3::Add>(mul2, add2_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{add2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add2}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, MulAddMulAddFusion) {
         auto mul1 = std::make_shared<opset3::Multiply>(input, mul1_const);
         auto add1 = std::make_shared<opset3::Add>(mul1, add1_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add1}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add1}, ParameterVector{input});
     }
 }
 
@@ -65,7 +65,7 @@ TEST_F(TransformationTestsF, MulMulMulFusion) {
         auto mul2 = std::make_shared<opset3::Multiply>(mul1, mul2_const);
         auto mul3 = std::make_shared<opset3::Multiply>(mul2, mul3_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul2}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 
@@ -75,7 +75,7 @@ TEST_F(TransformationTestsF, MulMulMulFusion) {
 
         auto mul1 = std::make_shared<opset3::Multiply>(input, mul1_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul1}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul1}, ParameterVector{input});
     }
 }
 
@@ -90,7 +90,7 @@ TEST_F(TransformationTestsF, MulMulMulFusion_f64) {
         auto mul2 = std::make_shared<opset3::Multiply>(mul1, mul2_const);
         auto mul3 = std::make_shared<opset3::Multiply>(mul2, mul3_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul2}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 
@@ -100,7 +100,7 @@ TEST_F(TransformationTestsF, MulMulMulFusion_f64) {
 
         auto mul1 = std::make_shared<opset3::Multiply>(input, mul1_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul1}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul1}, ParameterVector{input});
     }
 }
 
@@ -116,7 +116,7 @@ TEST_F(TransformationTestsF, MulMulMulFusion_not_supported_type) {
         auto mul2 = std::make_shared<opset3::Multiply>(mul1, mul2_const);
         auto mul3 = std::make_shared<opset3::Multiply>(mul2, mul3_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul2}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 }
@@ -132,7 +132,7 @@ TEST_F(TransformationTestsF, AddAddAddFusion) {
         auto add2 = std::make_shared<opset3::Add>(add1, add2_const);
         auto add3 = std::make_shared<opset3::Add>(add2, add3_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{add3}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add3}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, AddAddAddFusion) {
 
         auto add1 = std::make_shared<opset3::Add>(input, add1_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add1}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add1}, ParameterVector{input});
     }
 }
 
@@ -159,7 +159,7 @@ TEST_F(TransformationTestsF, MulAddAddMulFusion) {
         auto add2 = std::make_shared<opset3::Add>(add1, add2_const);
         auto mul2 = std::make_shared<opset3::Multiply>(add2, mul2_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul2}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 
@@ -171,7 +171,7 @@ TEST_F(TransformationTestsF, MulAddAddMulFusion) {
         auto mul1 = std::make_shared<opset3::Multiply>(input, mul1_const);
         auto add1 = std::make_shared<opset3::Add>(mul1, add1_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add1}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add1}, ParameterVector{input});
     }
 }
 
@@ -186,7 +186,7 @@ TEST_F(TransformationTestsF, AddAddAddFusionF64) {
         auto add2 = std::make_shared<opset3::Add>(add1, add2_const);
         auto add3 = std::make_shared<opset3::Add>(add2, add3_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{add3}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add3}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
     {
@@ -201,7 +201,7 @@ TEST_F(TransformationTestsF, AddAddAddFusionF64) {
 
         auto add3 = std::make_shared<opset3::Add>(add2, add3_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add3}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add3}, ParameterVector{input});
     }
 }
 
@@ -213,7 +213,7 @@ TEST_F(TransformationTestsF, MulAddAddMulFusionF64) {
         auto mul1_const = opset3::Constant::create(element::f64, Shape{128, 1}, {2});
         auto mul1 = std::make_shared<opset3::Multiply>(add1, mul1_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul1}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul1}, ParameterVector{input});
         manager.register_pass<ov::pass::LinOpSequenceFusion>();
     }
 
@@ -225,6 +225,6 @@ TEST_F(TransformationTestsF, MulAddAddMulFusionF64) {
         auto mul1 = std::make_shared<opset3::Multiply>(input, mul1_const);
         auto add1 = std::make_shared<opset3::Add>(mul1, add1_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add1}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add1}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/low_latency_v2_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/low_latency_v2_test.cpp
@@ -94,7 +94,7 @@ TEST(TransformationTests, LowLatency2_LSTM) {
 
         auto res_ti_1 = std::make_shared<Result>(tensor_iterator->output(1));
         auto res_ti_2 = std::make_shared<Result>(tensor_iterator->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
+        f = std::make_shared<Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -180,7 +180,7 @@ TEST(TransformationTests, LowLatency2_GRU) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 0);
 
         auto res_ti_1 = std::make_shared<Result>(tensor_iterator->output(1));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -261,7 +261,7 @@ TEST(TransformationTests, LowLatency2_RNN) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 0);
 
         auto res_ti_1 = std::make_shared<Result>(tensor_iterator->output(1));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -333,7 +333,7 @@ TEST(TransformationTests, LowLatency2_LSTMReshape) {
 
         auto res_ti_1 = std::make_shared<Result>(tensor_iterator->output(1));
         auto res_ti_2 = std::make_shared<Result>(tensor_iterator->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, H, C});
+        f = std::make_shared<Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, H, C});
 
         // Reshape
         // change the number of iteration of TI. 2 -> 1
@@ -424,7 +424,7 @@ TEST(TransformationTests, LowLatency2_LSTM_Loop) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
+        f = std::make_shared<Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -503,7 +503,7 @@ TEST(TransformationTests, LowLatency2_LSTM_several_iterations) {
 
         auto res_ti_1 = std::make_shared<Result>(tensor_iterator->output(1));
         auto res_ti_2 = std::make_shared<Result>(tensor_iterator->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, H, C});
+        f = std::make_shared<Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, H, C});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -612,7 +612,7 @@ TEST(TransformationTests, LowLatency2_LSTM_Loop_Reshape) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
+        f = std::make_shared<Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
 
         // Reshape
         // change the number of iteration of Loop. 10 -> 1
@@ -699,7 +699,7 @@ TEST(TransformationTests, LowLatency2_LSTM_Loop_several_iterations) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
+        f = std::make_shared<Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, H_init, C_init});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();

--- a/src/common/transformations/tests/common_optimizations/lstm_cell_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/lstm_cell_fusion.cpp
@@ -68,7 +68,7 @@ TEST_P(LSTMCellFusionTestSuite, SubgraphFusedToLSTMCell) {
         auto Ht = std::make_shared<op::v1::Multiply>(std::make_shared<op::v0::Tanh>(Ct), ot);
         auto C_abs = std::make_shared<op::v0::Abs>(Ct);
         auto H_abs = std::make_shared<op::v0::Abs>(Ht);
-        model = std::make_shared<Model>(NodeVector{H_abs, C_abs}, ParameterVector{X, H, C});
+        model = std::make_shared<Model>(OutputVector{H_abs, C_abs}, ParameterVector{X, H, C});
         manager.register_pass<ov::pass::LSTMCellFusion>();
     }
 
@@ -102,7 +102,7 @@ TEST_P(LSTMCellFusionTestSuite, SubgraphFusedToLSTMCell) {
                                                             std::vector<std::string>{"sigmoid", "tanh", "tanh"});
         auto C_abs = std::make_shared<op::v0::Abs>(lstm_cell->output(1));
         auto H_abs = std::make_shared<op::v0::Abs>(lstm_cell->output(0));
-        model_ref = std::make_shared<Model>(NodeVector{H_abs, C_abs}, ParameterVector{X, H, C});
+        model_ref = std::make_shared<Model>(OutputVector{H_abs, C_abs}, ParameterVector{X, H, C});
         manager.register_pass<ov::pass::LSTMCellFusion>();
     }
 
@@ -247,7 +247,7 @@ TEST_P(LSTMCellFusionWithSplitWeights, SubgraphFusedToLSTMCell) {
         auto c_neg = std::make_shared<op::v0::Negative>(ct);
         auto h_abs = std::make_shared<op::v0::Abs>(ht);
 
-        model = std::make_shared<Model>(NodeVector{h_abs, c_neg}, ParameterVector{x, h, c});
+        model = std::make_shared<Model>(OutputVector{h_abs, c_neg}, ParameterVector{x, h, c});
         manager.register_pass<ov::pass::LSTMCellFusion>();
     }
 
@@ -279,7 +279,7 @@ TEST_P(LSTMCellFusionWithSplitWeights, SubgraphFusedToLSTMCell) {
         auto c_neg = std::make_shared<op::v0::Negative>(lstm_cell->output(1));
         auto h_abs = std::make_shared<op::v0::Abs>(lstm_cell->output(0));
 
-        model_ref = std::make_shared<Model>(NodeVector{h_abs, c_neg}, ParameterVector{x, h, c});
+        model_ref = std::make_shared<Model>(OutputVector{h_abs, c_neg}, ParameterVector{x, h, c});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/mark_precision_sensitive_shapeof_subgraphs_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_precision_sensitive_shapeof_subgraphs_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_trivial_case) {
         auto input_2 = std::make_shared<opset10::Parameter>(element::f32, Shape{1, 3, 720, 1280});
         auto new_shape = std::make_shared<opset10::ShapeOf>(input_2);
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkPrecisionSensitiveShapeOfSubgraphs>();
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_trivial_case) {
         auto input_2 = std::make_shared<opset10::Parameter>(element::f32, Shape{1, 3, 720, 1280});
         auto new_shape = std::make_shared<opset10::ShapeOf>(input_2);
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_whole_shape_subgraph_is_ma
         auto new_shape = std::make_shared<opset10::Convert>(div, element::i64);
 
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkPrecisionSensitiveShapeOfSubgraphs>();
@@ -75,7 +75,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_whole_shape_subgraph_is_ma
         disable_fp16_compression(const_denominator);
         disable_fp16_compression(div);
         disable_fp16_compression(new_shape);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -100,7 +100,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_whole_shape_subgraph_is_ma
         std::vector<int64_t> end_mask = {0, 0, 0, 0};
         auto slice = std::make_shared<opset10::StridedSlice>(input_1, begin, concat_with_ends, begin_mask, end_mask);
         auto result = std::make_shared<opset10::Result>(slice);
-        model = std::make_shared<Model>(NodeVector{result}, ParameterVector{input_1});
+        model = std::make_shared<Model>(OutputVector{result}, ParameterVector{input_1});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkPrecisionSensitiveShapeOfSubgraphs>();
@@ -134,7 +134,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_whole_shape_subgraph_is_ma
         disable_fp16_compression(new_dim_size);
         disable_fp16_compression(const_ends);
         disable_fp16_compression(concat_with_ends);
-        model_ref = std::make_shared<Model>(NodeVector{result}, ParameterVector{input_1});
+        model_ref = std::make_shared<Model>(OutputVector{result}, ParameterVector{input_1});
     }
 }
 
@@ -175,7 +175,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_whole_shape_subgraph_is_ma
         auto add_1 = std::make_shared<opset10::Add>(input_1, const_4);
         auto result_1 = std::make_shared<opset10::Result>(add_1);
         auto result_2 = std::make_shared<opset10::Result>(interpolate);
-        model = std::make_shared<Model>(NodeVector{result_1, result_2}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{result_1, result_2}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkPrecisionSensitiveShapeOfSubgraphs>();
@@ -229,7 +229,7 @@ TEST_F(TransformationTestsF, MarkEntireShapeSubgraphs_whole_shape_subgraph_is_ma
         disable_fp16_compression(mul_1);
         disable_fp16_compression(convert_3);
 
-        model_ref = std::make_shared<Model>(NodeVector{result_1, result_2}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{result_1, result_2}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -245,7 +245,7 @@ TEST_F(TransformationTestsF, MarkConstantsInShapeSubgraphs_only_consts_marked_1)
         auto new_shape = std::make_shared<opset10::Convert>(div, element::i64);
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkPrecisionSensitiveConstants>();
@@ -264,7 +264,7 @@ TEST_F(TransformationTestsF, MarkConstantsInShapeSubgraphs_only_consts_marked_1)
 
         disable_fp16_compression(const_denominator);
 
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
     }
 }
 
@@ -290,7 +290,7 @@ TEST_F(TransformationTestsF, MarkConstantsInShapeSubgraphs_only_consts_marked_2)
         std::vector<int64_t> end_mask = {0, 0, 0, 0};
         auto slice = std::make_shared<opset10::StridedSlice>(input_1, begin, concat_with_ends, begin_mask, end_mask);
         auto result = std::make_shared<opset10::Result>(slice);
-        model = std::make_shared<Model>(NodeVector{result}, ParameterVector{input_1});
+        model = std::make_shared<Model>(OutputVector{result}, ParameterVector{input_1});
 
         pass::Manager manager;
         manager.register_pass<pass::MarkPrecisionSensitiveConstants>();
@@ -319,6 +319,6 @@ TEST_F(TransformationTestsF, MarkConstantsInShapeSubgraphs_only_consts_marked_2)
 
         disable_fp16_compression(const_denominator);
         disable_fp16_compression(const_ends);
-        model_ref = std::make_shared<Model>(NodeVector{result}, ParameterVector{input_1});
+        model_ref = std::make_shared<Model>(OutputVector{result}, ParameterVector{input_1});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -31,7 +31,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_1) {
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -56,7 +56,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_1) {
         disable_fp16_compression(factor_const);
         disable_fp16_compression(factor_const_decompressed);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator =
@@ -83,7 +83,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_with_reducemean) {
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -108,7 +108,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_with_reducemean) {
         disable_fp16_compression(factor_const);
         disable_fp16_compression(factor_const_decompressed);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator =
@@ -136,7 +136,7 @@ TEST(TransformationTests, MarkSugraphsToKeepInMixedPrecision_reducesum_without_e
     auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
     auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-    model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+    model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -170,7 +170,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_2) {
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -199,7 +199,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_2) {
         disable_fp16_compression(factor_const);
         disable_fp16_compression(factor_const_decompressed);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator =
@@ -230,7 +230,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_3) {
         auto mul_1 = make_shared<Multiply>(add_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -260,7 +260,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_3) {
         disable_fp16_compression(factor_const);
         disable_fp16_compression(factor_const_decompressed);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator =
@@ -321,7 +321,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_7) {
         auto div_1 = make_shared<Divide>(reduce_sum_4, add_1);
         auto matmul_1 = make_shared<MatMul>(div_1, input_4, false, true);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -402,7 +402,7 @@ TEST(TransformationTests, keep_precission_sensitive_fp32_7) {
         disable_fp16_compression(const_unsqueeze_2);
         disable_fp16_compression(const_unsqueeze_3);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
     }
 
     const FunctionsComparator func_comparator =
@@ -425,7 +425,7 @@ TEST(TransformationTests, DivisionByZeroMinimalPattern) {
         auto eps_const = Constant::create(element::f32, Shape{1}, {eps_value});
         auto add = std::make_shared<Add>(input_2, eps_const);
         auto divide = std::make_shared<Divide>(input_1, add);
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -441,7 +441,7 @@ TEST(TransformationTests, DivisionByZeroMinimalPattern) {
         disable_fp16_compression(eps_const);
         disable_fp16_compression(add);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator =
@@ -466,7 +466,7 @@ TEST(TransformationTests, DivisionByZeroEpsWithConvert) {
 
         auto add = std::make_shared<Add>(input_2, convert_eps);
         auto divide = std::make_shared<Divide>(input_1, add);
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -484,7 +484,7 @@ TEST(TransformationTests, DivisionByZeroEpsWithConvert) {
         disable_fp16_compression(convert_eps);
         disable_fp16_compression(add);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator =
@@ -509,7 +509,7 @@ TEST(TransformationTests, PowWithNegativeExponent) {
         auto pow = std::make_shared<Power>(add, pow_exp_const);
         auto mul = std::make_shared<Multiply>(input_1, pow);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -531,7 +531,7 @@ TEST(TransformationTests, PowWithNegativeExponent) {
         disable_fp16_compression(pow);
         disable_fp16_compression(mul);
 
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
     }
     const FunctionsComparator func_comparator =
         FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);
@@ -555,7 +555,7 @@ TEST(TransformationTests, PowWithPositiveExponent) {
     auto pow = std::make_shared<Power>(add, pow_exp_const);
     auto mul = std::make_shared<Multiply>(input_1, pow);
 
-    model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+    model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -581,7 +581,7 @@ TEST(TransformationTests, DivisionByZeroMinimalPatternUnchanged) {
     auto add = std::make_shared<Add>(input_2, eps_const);
     auto divide = std::make_shared<Divide>(input_1, add);
 
-    model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+    model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -611,7 +611,7 @@ TEST(TransformationTests, DivisionByZeroInL2NormWithSqrtAndWithMax) {
         auto sqrt = std::make_shared<Sqrt>(max);
         auto divide = std::make_shared<Divide>(input, sqrt);
 
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -637,7 +637,7 @@ TEST(TransformationTests, DivisionByZeroInL2NormWithSqrtAndWithMax) {
         disable_fp16_compression(sqrt);
         disable_fp16_compression(divide);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
     }
     const FunctionsComparator func_comparator =
         FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);
@@ -664,7 +664,7 @@ TEST(TransformationTests, DivisionByZeroMaxAndEpsWithConvert) {
         auto sqrt = std::make_shared<Sqrt>(max);
         auto divide = std::make_shared<Divide>(input, sqrt);
 
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -692,7 +692,7 @@ TEST(TransformationTests, DivisionByZeroMaxAndEpsWithConvert) {
         disable_fp16_compression(sqrt);
         disable_fp16_compression(divide);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
     }
     const FunctionsComparator func_comparator =
         FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);
@@ -718,7 +718,7 @@ TEST(TransformationTests, DivisionByZeroInL2NormWithSqrtAndWithAdd) {
         auto sqrt = std::make_shared<Sqrt>(add);
         auto divide = std::make_shared<Divide>(input, sqrt);
 
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -744,7 +744,7 @@ TEST(TransformationTests, DivisionByZeroInL2NormWithSqrtAndWithAdd) {
         disable_fp16_compression(add);
         disable_fp16_compression(divide);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
     }
     const FunctionsComparator func_comparator =
         FunctionsComparator::with_default().enable(FunctionsComparator::RUNTIME_KEYS);
@@ -770,7 +770,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_with_reducesum) 
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -788,7 +788,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_with_reducesum) 
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
         disable_fp16_compression(exp_1);
         disable_fp16_compression(mul_1);
         disable_fp16_compression(reduce_sum_1);
@@ -820,7 +820,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_with_reducemean)
         auto mul_1 = make_shared<Multiply>(reduce_mean_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -838,7 +838,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_with_reducemean)
         auto mul_1 = make_shared<Multiply>(reduce_mean_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
         disable_fp16_compression(exp_1);
         disable_fp16_compression(mul_1);
         disable_fp16_compression(reduce_mean_1);
@@ -869,7 +869,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_reducesum_withou
     auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
     auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-    model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+    model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -902,7 +902,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_reducesum_exp_th
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -923,7 +923,7 @@ TEST(TransformationTests, MarkReduceOpExpToKeepInMixedPrecision_reducesum_exp_th
         auto mul_1 = make_shared<Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<MatMul>(mul_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
         disable_fp16_compression(exp_1);
         disable_fp16_compression(mul_1);
         disable_fp16_compression(reduce_sum_1);
@@ -953,7 +953,7 @@ TEST(TransformationTests, MarkDivWithEps) {
         auto add = std::make_shared<Add>(input_2, eps_const);
         auto divide = std::make_shared<Divide>(input_1, add);
 
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
     }
@@ -968,7 +968,7 @@ TEST(TransformationTests, MarkDivWithEps) {
         disable_fp16_compression(add);
         disable_fp16_compression(eps_const);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
     }
     const auto fc = FunctionsComparator::with_default()
                         .enable(FunctionsComparator::PRECISIONS)
@@ -995,7 +995,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_PowWithNegativeEx
         auto pow = std::make_shared<Power>(add, pow_exp_const);
         auto mul = std::make_shared<Multiply>(input_1, pow);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
     }
@@ -1014,7 +1014,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_PowWithNegativeEx
         disable_fp16_compression(pow_exp_const);
         disable_fp16_compression(pow);
 
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
     }
     const auto fc = FunctionsComparator::with_default()
                         .enable(FunctionsComparator::PRECISIONS)
@@ -1041,7 +1041,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_PowWithPositiveEx
     auto pow = std::make_shared<Power>(add, pow_exp_const);
     auto mul = std::make_shared<Multiply>(input_1, pow);
 
-    model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+    model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -1070,7 +1070,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_MinimalPatternUnc
     auto add = std::make_shared<Add>(input_2, eps_const);
     auto divide = std::make_shared<Divide>(input_1, add);
 
-    model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+    model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -1111,7 +1111,7 @@ TEST(TransformationTests, MarkFloatingPointRange) {
         auto multiply_const = Constant::create(element::f32, Shape{}, {1.f});
         auto multiply = make_shared<Multiply>(convert, multiply_const);
 
-        model = make_shared<Model>(NodeVector{convert}, ParameterVector{end});
+        model = make_shared<Model>(OutputVector{convert}, ParameterVector{end});
 
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
@@ -1147,7 +1147,7 @@ TEST(TransformationTests, MarkFloatingPointRange) {
         disable_fp16_compression(greater);
         disable_fp16_compression(convert);
 
-        model_ref = make_shared<Model>(NodeVector{convert}, ParameterVector{end});
+        model_ref = make_shared<Model>(OutputVector{convert}, ParameterVector{end});
     }
 
     const FunctionsComparator func_comparator =
@@ -1174,7 +1174,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_InL2NormWithSqrtA
         auto sqrt = std::make_shared<Sqrt>(max);
         auto divide = std::make_shared<Divide>(input, sqrt);
 
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
     }
@@ -1198,7 +1198,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_InL2NormWithSqrtA
         disable_fp16_compression(max);
         disable_fp16_compression(sqrt);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
     }
     const auto fc = FunctionsComparator::with_default()
                         .enable(FunctionsComparator::PRECISIONS)
@@ -1226,7 +1226,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_InL2NormWithSqrtA
         auto sqrt = std::make_shared<Sqrt>(add);
         auto divide = std::make_shared<Divide>(input, sqrt);
 
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
         manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
         manager.run_passes(model);
     }
@@ -1250,7 +1250,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_InL2NormWithSqrtA
         disable_fp16_compression(add);
         disable_fp16_compression(sqrt);
 
-        model_ref = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input});
     }
     const auto fc = FunctionsComparator::with_default()
                         .enable(FunctionsComparator::PRECISIONS)
@@ -1284,7 +1284,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_disable_for_quant
     auto fq_2 = make_shared<opset10::FakeQuantize>(reduce_sum_1, in_low, in_high, out_low, out_high, 256);
     auto matmul_1 = make_shared<opset10::MatMul>(fq_2, input_2);
 
-    model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+    model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();
@@ -1325,7 +1325,7 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_disable_for_quant
     auto fq_2 = make_shared<opset10::FakeQuantize>(reduce_sum_1, in_low, in_high, out_low, out_high, 256);
     auto matmul_1 = make_shared<opset10::MatMul>(fq_2, input_2);
 
-    model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+    model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     model_ref = model->clone();
 
     manager.register_pass<pass::MarkSugraphsToKeepInMixedPrecision>();

--- a/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/matmul_multiply_fusion.cpp
@@ -20,7 +20,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionConstantWeightsScalarConstant) 
         auto matmul = std::make_shared<opset8::MatMul>(data, weights);
         auto mul_const = opset8::Constant::create(element::f32, Shape{}, {2});
         auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     }
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionConstantWeightsScalarConstant) 
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{4, 3});
         auto weights = opset8::Constant::create(element::f32, Shape{3, 2}, {2, 4, 6, 8, 10, 12});
         auto matmul = std::make_shared<opset8::MatMul>(data, weights);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionConstantWeightsNonScalarConstan
         auto matmul = std::make_shared<opset8::MatMul>(data, weights);
         auto mul_const = opset8::Constant::create(element::f32, Shape{1, 1, 1, 2}, {2, 3});
         auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     }
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionConstantWeightsNonScalarConstan
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 2, 4, 3});
         auto weights = opset8::Constant::create(element::f32, Shape{1, 1, 3, 2}, {2, 6, 6, 12, 10, 18});
         auto matmul = std::make_shared<opset8::MatMul>(data, weights);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionConstantTransposedWeightsNonSca
         auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, true);
         auto mul_const = opset8::Constant::create(element::f32, Shape{1, 1, 1, 2}, {2, 3});
         auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     }
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionConstantTransposedWeightsNonSca
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 2, 4, 3});
         auto weights = opset8::Constant::create(element::f32, Shape{1, 1, 2, 3}, {2, 4, 6, 12, 15, 18});
         auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, true);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -83,7 +83,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionNonConstantTransposedWeightsNon
         auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, true);
         auto mul_const = opset8::Constant::create(element::f32, Shape{1, 2}, {4, 5});
         auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data, weights});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data, weights});
 
         manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     }
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionNonConstantTransposedWeightsNon
         auto mul_const = opset8::Constant::create(element::f32, Shape{2, 1}, {4, 5});
         auto mul = std::make_shared<opset8::Multiply>(weights, mul_const);
         auto matmul = std::make_shared<opset8::MatMul>(data, mul, false, true);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data, weights});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data, weights});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, MatMulMultiplyFusionNonSingleConsumer) {
     auto mul_const = opset8::Constant::create(element::f32, Shape{1, 2}, {4, 5});
     auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
     auto add = std::make_shared<opset8::Add>(matmul, mul);
-    model = std::make_shared<Model>(NodeVector{add}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{add}, ParameterVector{data});
 
     manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -132,7 +132,7 @@ TEST_P(MatMulMultiplyFusionDynamicShapes, FusionTest) {
         auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, transpose_b);
         auto mul_const = opset8::Constant::create(element::f32, const_shape, {4});
         auto mul = std::make_shared<opset8::Multiply>(matmul, mul_const);
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     }
@@ -141,7 +141,7 @@ TEST_P(MatMulMultiplyFusionDynamicShapes, FusionTest) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, input_shape);
         auto weights = opset8::Constant::create(element::f32, new_weights_shape, {8});
         auto matmul = std::make_shared<opset8::MatMul>(data, weights, false, transpose_b);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }

--- a/src/common/transformations/tests/common_optimizations/mish_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mish_fusion_test.cpp
@@ -31,7 +31,7 @@ TEST_F(TransformationTestsF, MishFusing) {
         auto tanh = std::make_shared<opset4::Tanh>(log);
         auto mul = std::make_shared<opset4::Multiply>(input0, tanh);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input0});
 
         manager.register_pass<ov::pass::MishFusion>();
     }
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, MishFusing) {
         auto data = std::make_shared<opset4::Parameter>(element::f32, Shape{3, 1, 2});
         auto mish = std::make_shared<opset4::Mish>(data);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mish}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mish}, ParameterVector{data});
     }
 }
 
@@ -51,7 +51,7 @@ TEST_F(TransformationTestsF, MishWithSoftPlusFusing) {
         auto tanh = std::make_shared<opset4::Tanh>(softplus);
         auto mul = std::make_shared<opset4::Multiply>(input0, tanh);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input0});
 
         manager.register_pass<ov::pass::SoftPlusToMishFusion>();
     }
@@ -60,6 +60,6 @@ TEST_F(TransformationTestsF, MishWithSoftPlusFusing) {
         auto data = std::make_shared<opset4::Parameter>(element::f32, Shape{3, 1, 2});
         auto mish = std::make_shared<opset4::Mish>(data);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mish}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mish}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/tests/common_optimizations/moc_transformations.cpp
@@ -26,7 +26,7 @@ TEST(TransformationTests, TestModelTensorsConsistencyUseShapesTrue) {
     auto add2 = std::make_shared<opset12::Add>(add1, const2);
     auto add3 = std::make_shared<opset12::Add>(add2, const3);
 
-    auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
+    auto model = std::make_shared<Model>(OutputVector{add3}, ParameterVector{input});
     ov::pass::Manager m;
     m.register_pass<ov::pass::MOCTransformations>(true);
     m.run_passes(model);
@@ -47,7 +47,7 @@ TEST(TransformationTests, MOCConvertElimination) {
     auto convert_fp32 = std::make_shared<opset12::Convert>(const_val, element::f32);
     auto mul = std::make_shared<opset12::MatMul>(add1, convert_fp32);
 
-    auto model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input});
+    auto model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input});
     ov::pass::Manager m;
     m.register_pass<ov::pass::MOCTransformations>(false);
     m.run_passes(model);
@@ -64,7 +64,7 @@ TEST(TransformationTests, TestModelTensorsConsistencyUseShapesFalse) {
     auto add2 = std::make_shared<opset12::Add>(add1, const2);
     auto add3 = std::make_shared<opset12::Add>(add2, const3);
 
-    auto model = std::make_shared<Model>(NodeVector{add3}, ParameterVector{input});
+    auto model = std::make_shared<Model>(OutputVector{add3}, ParameterVector{input});
     ov::pass::Manager m;
     m.register_pass<ov::pass::MOCTransformations>(false);
     m.run_passes(model);

--- a/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/move_eltwise_up_data_movement_test.cpp
@@ -34,7 +34,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwise) {
 
         auto sigmoid = std::make_shared<ov::opset8::Sigmoid>(unsqueeze);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{sigmoid}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{sigmoid}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -49,7 +49,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwise) {
         auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
     }
 }
 
@@ -67,7 +67,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TypeRelaxedEltwise) {
         auto mul_const = ov::opset8::Constant::create(ov::element::f32, {}, {2.f});
         auto multiply = std::make_shared<ov::op::TypeRelaxed<ov::opset8::Multiply>>(transpose, mul_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{multiply}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{multiply}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -81,7 +81,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TypeRelaxedEltwise) {
             ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ov::opset8::Transpose>(multiply, transpose_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{transpose}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{transpose}, ov::ParameterVector{input});
     }
 }
 
@@ -106,7 +106,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, EltwiseSequence) {
 
         auto sigmoid = std::make_shared<ov::opset8::Sigmoid>(unsqueeze);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{sigmoid}, ov::ParameterVector{input_left, input_right});
+        model = std::make_shared<ov::Model>(ov::OutputVector{sigmoid}, ov::ParameterVector{input_left, input_right});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -127,7 +127,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, EltwiseSequence) {
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input_left, input_right});
+            std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input_left, input_right});
     }
 }
 
@@ -152,7 +152,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, DataMovementTwoConsumers) {
 
     auto relu = std::make_shared<ov::opset8::Relu>(transpose);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{sigmoid, relu}, ov::ParameterVector{input_left, input_right});
+    model = std::make_shared<ov::Model>(ov::OutputVector{sigmoid, relu}, ov::ParameterVector{input_left, input_right});
     manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
 }
 
@@ -176,7 +176,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithScalarOnSecondBra
                                               ov::opset8::Constant::create(ov::element::f32, {}, {scalar_value}));
 
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
@@ -192,7 +192,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithScalarOnSecondBra
         auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(transpose, unsqueeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
     }
 }
 
@@ -212,7 +212,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleEltwiseWith5ScalarOnSecondBranch) 
             ov::opset8::Constant::create(ov::element::f32, {1, 1, 1, 1, 1}, {scalar_value}));
 
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::opset8::Parameter>(ov::element::f32, shape);
@@ -224,7 +224,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleEltwiseWith5ScalarOnSecondBranch) 
         auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(add, unsqueeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
     }
 }
 
@@ -244,7 +244,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleBinaryEltwiseWithNotScalarOnSecond
     auto add_scalar = ov::opset8::Constant::create(ov::element::f32, {1, 1, 1, 3}, {0.5, 0.2, 0.3});
     auto add = std::make_shared<ov::opset8::Add>(unsqueeze, add_scalar);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+    model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
 }
 
@@ -259,7 +259,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicShape) {
 
         auto sigmoid = std::make_shared<ov::opset8::Sigmoid>(unsqueeze);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{sigmoid}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{sigmoid}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
 
@@ -271,7 +271,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicShape) {
         auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(sigmoid, unsqueeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
     }
 }
 
@@ -285,7 +285,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, SingleUnaryEltwiseDynamicRank) {
     auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {unsqueeze_axis});
     auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(input, unsqueeze_const);
     auto sigmoid = std::make_shared<ov::opset8::Sigmoid>(unsqueeze);
-    model = std::make_shared<ov::Model>(ov::NodeVector{sigmoid}, ov::ParameterVector{input});
+    model = std::make_shared<ov::Model>(ov::OutputVector{sigmoid}, ov::ParameterVector{input});
     manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
 }
 
@@ -306,7 +306,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantize) {
             ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
             255);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{fakequantize}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -323,7 +323,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantize) {
             ov::opset8::Constant::create(ov::element::i64, ov::Shape{input_order.size()}, input_order);
         auto transpose = std::make_shared<ov::opset8::Transpose>(fakequantize, transpose_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{transpose}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{transpose}, ov::ParameterVector{input});
     }
 }
 
@@ -345,7 +345,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, TransposeFakeQuantizePerChannel) {
             ov::opset8::Constant::create(ov::element::f32, ov::Shape{}, {127}),
             255);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{fakequantize}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{fakequantize}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
 }
@@ -361,7 +361,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseUnsqueeze) {
         auto per_channel_const = ov::opset8::Constant::create(ov::element::f32, {1, 20, 1, 1}, {0.5});
         auto add = std::make_shared<ov::opset8::Add>(unsqueeze, per_channel_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -373,7 +373,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseUnsqueeze) {
         auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{2}, {2, 3});  // {10, 20, 1, 1}
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(add, unsqueeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
     }
 }
 
@@ -388,7 +388,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseUnsqueezeReverseInOrder
         auto per_channel_const = ov::opset8::Constant::create(ov::element::f32, {1, 20, 1, 1}, {0.5});
         auto add = std::make_shared<ov::opset8::Add>(per_channel_const, unsqueeze);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -400,7 +400,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseUnsqueezeReverseInOrder
         auto unsqueeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{2}, {2, 3});  // {10, 20, 1, 1}
         auto unsqueeze = std::make_shared<ov::opset8::Unsqueeze>(add, unsqueeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{unsqueeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{unsqueeze}, ov::ParameterVector{input});
     }
 }
 
@@ -415,7 +415,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseSqueeze) {
         auto per_channel_const = ov::opset8::Constant::create(ov::element::f32, {10, 1, 1}, {0.5});
         auto add = std::make_shared<ov::opset8::Add>(squeeze, per_channel_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -427,7 +427,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseSqueeze) {
         auto squeeze_const = ov::opset8::Constant::create(ov::element::i64, ov::Shape{}, {2});  // {10, 20, 1}
         auto squeeze = std::make_shared<ov::op::v0::Squeeze>(add, squeeze_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{squeeze}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{input});
     }
 }
 
@@ -442,7 +442,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseSqueezeIllegal_1) {
     auto per_channel_const = ov::opset8::Constant::create(ov::element::f32, {1, 1, 20}, {0.5});
     auto add = std::make_shared<ov::opset8::Add>(squeeze, per_channel_const);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+    model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
 }
 
@@ -462,7 +462,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelEltwiseSqueezeIllegal_2) {
 
     auto add3 = std::make_shared<ov::opset8::Add>(add1, add2);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{add3}, ov::ParameterVector{input});
+    model = std::make_shared<ov::Model>(ov::OutputVector{add3}, ov::ParameterVector{input});
     manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
 }
 
@@ -479,7 +479,7 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapeMultiply) {
         auto per_channel_const = ov::opset8::Constant::create(ov::element::f32, {1, 3, 1, 1}, {0.5});
         auto multiply = std::make_shared<ov::op::v1::Multiply>(reshape, per_channel_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{multiply}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{multiply}, ov::ParameterVector{input});
         manager.register_pass<ov::pass::MoveEltwiseUpThroughDataMov>();
     }
     {
@@ -492,6 +492,6 @@ TEST_F(MoveEltwiseUpThroughDataMovTest, PerChannelReshapeMultiply) {
             std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{target_shape.size()}, target_shape);
         auto reshape = std::make_shared<ov::op::v1::Reshape>(multiply, reshape_constant, false);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{reshape}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/mul_fake_quantize_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/mul_fake_quantize_fusion.cpp
@@ -32,7 +32,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionPositiveConstant) {
         auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {0, 0, 0});
         auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
     }
     {
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionPositiveConstant) {
         auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {0, 0, 0});
         auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -57,7 +57,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionConstantOnFirstInput) {
         auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {0, 0, 0});
         auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
     }
     {
@@ -67,7 +67,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionConstantOnFirstInput) {
         auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {0, 0, 0});
         auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -82,7 +82,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionReshape) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
     }
     {
@@ -92,7 +92,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionReshape) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -107,7 +107,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionConstantNonScalarWithEqualValu
         auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-10, -10, -10});
         auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
     }
     {
@@ -117,7 +117,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionConstantNonScalarWithEqualValu
         auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-10, -10, -10});
         auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -132,7 +132,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionWithPerChannelConstant) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
     }
     {
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionWithPerChannelConstant) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -156,7 +156,7 @@ TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionNotAConstant) {
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data, mul_2nd_input});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data, mul_2nd_input});
     manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
 }
 
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionLowPrecision) {
     auto output_low = opset5::Constant::create(element::f16, Shape{1, 3, 1, 1}, {0, 0, 0});
     auto output_high = opset5::Constant::create(element::f16, Shape{1}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     model_ref = model->clone();
     manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
 }
@@ -185,7 +185,7 @@ TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionConstantAllNegative) {
     auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-10, -10, -10});
     auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     model_ref = model->clone();
     manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
 }
@@ -200,7 +200,7 @@ TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionConstantSomeNegative) 
     auto output_low = opset5::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-10, -10, -10});
     auto output_high = opset5::Constant::create(element::f32, Shape{1}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 20);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     model_ref = model->clone();
     manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
 }
@@ -215,7 +215,7 @@ TEST_F(TransformationTestsF, NegativeMulFakeQuantizeFusionWithNonPerChannelConst
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
 }
 
@@ -228,6 +228,6 @@ TEST_F(TransformationTestsF, MulFakeQuantizeFusionWithBroadcastingConstant) {
     auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
     auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
     auto fq = std::make_shared<opset5::FakeQuantize>(mul, input_low, input_high, output_low, output_high, 11);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     manager.register_pass<ov::pass::MulFakeQuantizeFusion>();
 }

--- a/src/common/transformations/tests/common_optimizations/mvn_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mvn_fusion_test.cpp
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, MVNFusionTestOutside) {
         auto power_div = std::make_shared<opset6::Power>(add_eps, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, MVNFusionTestOutside) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, MVNFusionTestReuseSub) {
         auto power_div = std::make_shared<opset6::Power>(add_eps, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -82,7 +82,7 @@ TEST_F(TransformationTestsF, MVNFusionTestReuseSub) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -105,7 +105,7 @@ TEST_F(TransformationTestsF, MVNFusionTestWithConvert) {
         auto power_div = std::make_shared<opset6::Power>(add_eps, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -115,7 +115,7 @@ TEST_F(TransformationTestsF, MVNFusionTestWithConvert) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -136,7 +136,7 @@ TEST_F(TransformationTestsF, MVNFusionTestSqrt) {
         auto power_div = std::make_shared<opset6::Power>(add_eps, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -146,7 +146,7 @@ TEST_F(TransformationTestsF, MVNFusionTestSqrt) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -166,7 +166,7 @@ TEST_F(TransformationTestsF, MVNFusionTestAltDiv) {
         auto add_eps = std::make_shared<opset6::Add>(power_sqrt, eps);
         auto div = std::make_shared<opset6::Divide>(sub1, add_eps);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -176,7 +176,7 @@ TEST_F(TransformationTestsF, MVNFusionTestAltDiv) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -201,7 +201,7 @@ TEST_F(TransformationTestsF, MVNFusionTestInsideSqrt) {
         auto power_div = std::make_shared<opset6::Power>(power_sqrt, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -211,7 +211,7 @@ TEST_F(TransformationTestsF, MVNFusionTestInsideSqrt) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -233,7 +233,7 @@ TEST_F(TransformationTestsF, MVNFusionTestReuseSubInsideSqrt) {
         auto power_div = std::make_shared<opset6::Power>(power_sqrt, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -243,7 +243,7 @@ TEST_F(TransformationTestsF, MVNFusionTestReuseSubInsideSqrt) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -266,7 +266,7 @@ TEST_F(TransformationTestsF, MVNFusionTestWithConvertInsideSqrt) {
         auto power_div = std::make_shared<opset6::Power>(power_sqrt, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -276,7 +276,7 @@ TEST_F(TransformationTestsF, MVNFusionTestWithConvertInsideSqrt) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -297,7 +297,7 @@ TEST_F(TransformationTestsF, MVNFusionTestSqrtInsideSqrt) {
         auto power_div = std::make_shared<opset6::Power>(power_sqrt, const_neg_1);
         auto div = std::make_shared<opset6::Multiply>(sub1, power_div);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -307,7 +307,7 @@ TEST_F(TransformationTestsF, MVNFusionTestSqrtInsideSqrt) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -327,7 +327,7 @@ TEST_F(TransformationTestsF, MVNFusionTestAltDivInsideSqrt) {
         auto power_sqrt = std::make_shared<opset6::Power>(add_eps, const_0_5);
         auto div = std::make_shared<opset6::Divide>(sub1, power_sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -337,7 +337,7 @@ TEST_F(TransformationTestsF, MVNFusionTestAltDivInsideSqrt) {
         auto axes = opset6::Constant::create(element::i32, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<opset6::MVN>(input, axes, true, 1e-9f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{input});
     }
 }
 
@@ -361,7 +361,7 @@ TEST_F(TransformationTestsF, MVNFusionTestWithParametersInside) {
         auto sub = std::make_shared<opset6::Subtract>(beta, mul2);
         auto add = std::make_shared<opset6::Add>(mul1, sub);
 
-        model = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input});
 
         manager.register_pass<ov::pass::MVNFusion>();
     }
@@ -375,6 +375,6 @@ TEST_F(TransformationTestsF, MVNFusionTestWithParametersInside) {
         auto beta = opset6::Constant::create(element::f32, Shape{}, {-1});
         auto add = std::make_shared<opset6::Add>(mul_gamma, beta);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/nearest_neighbor_upsampling_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/nearest_neighbor_upsampling_fusion_test.cpp
@@ -68,7 +68,7 @@ TEST_F(TransformationTestsF, NearestNeighborUpsamplingFusionSpatial2D1) {
         const auto mul = std::make_shared<opset8::Multiply>(reshape_1, mul_const);
 
         auto reshape_2 = std::make_shared<opset8::Reshape>(mul, concat_2, true);
-        model = std::make_shared<ov::Model>(NodeVector{reshape_2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_2}, ParameterVector{input});
         manager.register_pass<ov::pass::NearestNeighborUpsamplingFusion>();
     }
     {
@@ -88,7 +88,7 @@ TEST_F(TransformationTestsF, NearestNeighborUpsamplingFusionSpatial2D1) {
         auto scales_node = opset8::Constant::create(element::f32, {scales_as_floats.size()}, scales_as_floats);
         auto axes_node = opset8::Constant::create(element::i64, {2}, std::vector<int64_t>{1, 2});
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axes_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -140,7 +140,7 @@ TEST_F(TransformationTestsF, NearestNeighborUpsamplingFusionSpatial3D1) {
         const auto mul = std::make_shared<opset8::Multiply>(reshape_1, mul_const);
 
         auto reshape_2 = std::make_shared<opset8::Reshape>(mul, concat_2, true);
-        model = std::make_shared<ov::Model>(NodeVector{reshape_2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{reshape_2}, ParameterVector{input});
         manager.register_pass<ov::pass::NearestNeighborUpsamplingFusion>();
     }
     {
@@ -160,6 +160,6 @@ TEST_F(TransformationTestsF, NearestNeighborUpsamplingFusionSpatial3D1) {
         auto scales_node = opset8::Constant::create(element::f32, {scales_as_floats.size()}, scales_as_floats);
         auto axes_node = opset8::Constant::create(element::i64, {3}, std::vector<int64_t>{1, 2, 3});
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axes_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/ngraph_fq_transpose_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/ngraph_fq_transpose_test.cpp
@@ -37,7 +37,7 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
         auto fq = std::make_shared<ov::op::v0::FakeQuantize>(data, input_low, input_high, output_low, output_high, 1);
         auto transpose = std::make_shared<ov::op::v1::Transpose>(fq, transpose_order);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{transpose}, ParameterVector{});
+        model = std::make_shared<ov::Model>(ov::OutputVector{transpose}, ParameterVector{});
 
         manager.register_pass<ov::pass::PullTransposeThroughFQUp>();
         manager.register_pass<ov::pass::InjectionPass>([](std::shared_ptr<ov::Model> f) {
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, FQTransposeTest1) {
 
         auto fq = std::make_shared<ov::op::v0::FakeQuantize>(data, input_low, input_high, output_low, output_high, 1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fq}, ParameterVector{});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fq}, ParameterVector{});
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, FQTransposeNegativeCase) {
             std::make_shared<ov::op::v0::FakeQuantize>(sigmoid, input_low, input_high, output_low, output_high, 1);
         auto transpose = std::make_shared<ov::op::v1::Transpose>(fq, transpose_order);
 
-        return std::make_shared<ov::Model>(ov::NodeVector{transpose}, ParameterVector{data});
+        return std::make_shared<ov::Model>(ov::OutputVector{transpose}, ParameterVector{data});
     };
     model = create_graph();
 

--- a/src/common/transformations/tests/common_optimizations/nonzero_horizontal_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/nonzero_horizontal_fusion_test.cpp
@@ -22,7 +22,7 @@ struct NonZeroHorizontalFusionBuilder {
 
     std::shared_ptr<ov::Model> getOriginal() {
         const auto input = std::make_shared<ov::opset10::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        ov::NodeVector results;
+        ov::OutputVector results;
         for (size_t i = 0; i < branch_props.size(); ++i) {
             std::shared_ptr<ov::Node> nonzero;
             switch (branch_props[i]) {
@@ -48,7 +48,7 @@ struct NonZeroHorizontalFusionBuilder {
 
         std::shared_ptr<ov::Node> i32_node;
         std::shared_ptr<ov::Node> i64_node;
-        ov::NodeVector results;
+        ov::OutputVector results;
         for (size_t i = 0; i < branch_props.size(); ++i) {
             std::shared_ptr<ov::Node> nonzero;
             if (branch_props[i] == NonZeroType::I32) {

--- a/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/tests/common_optimizations/nop_elimination.cpp
@@ -100,7 +100,7 @@ TEST(nop_elimination, reshape_elimination_v1) {
         auto reshape_v1_org = std::make_shared<op::v1::Reshape>(arg, pattern_org, zero);
         auto reshape_v1 = std::make_shared<op::v1::Reshape>(reshape_v1_org, pattern, zero);
         auto abs = std::make_shared<op::v0::Abs>(reshape_v1);
-        return std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
+        return std::make_shared<ov::Model>(OutputVector{abs}, ParameterVector{arg});
     };
 
     auto func = generate_func(false);
@@ -124,7 +124,7 @@ TEST(nop_elimination, reshape_v1_1D) {
         const auto abs = make_shared<op::v0::Abs>(input);
         const auto req_shape = op::v0::Constant::create(element::i64, Shape{1}, {requested_dim});
         const auto reshape = make_shared<op::v1::Reshape>(abs, req_shape, false);
-        return make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        return make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     };
     // clang-format off
     vector<shared_ptr<ov::Model>> models{
@@ -160,7 +160,7 @@ TEST(nop_elimination, squeeze_reshape_elimination_check_info) {
 
         auto abs = std::make_shared<ov::op::v0::Abs>(reshape);
 
-        f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(OutputVector{abs}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -195,7 +195,7 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination) {
 
         auto abs = std::make_shared<ov::op::v0::Abs>(unsqueeze);
 
-        f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(OutputVector{abs}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -224,7 +224,7 @@ TEST(nop_elimination, squeeze_unsqueeze_elimination_dynamic_without_squeeze_axis
         auto unsqueeze = std::make_shared<ov::op::v0::Unsqueeze>(squeeze, unsqueeze_axes);
         unsqueeze->set_friendly_name("unsqueeze");
 
-        f = std::make_shared<ov::Model>(NodeVector{unsqueeze}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(OutputVector{unsqueeze}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -245,7 +245,7 @@ TEST_F(TransformationTestsF, reshape_reshape_elimination_v1_dynamic) {
 
         auto add_param = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 4096}));
         auto add = std::make_shared<op::v1::Add>(bottom_reshape, add_param);
-        model = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input, add_param});
+        model = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input, add_param});
     }
     {
         auto input = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 32, 1, 128}));
@@ -255,7 +255,7 @@ TEST_F(TransformationTestsF, reshape_reshape_elimination_v1_dynamic) {
 
         auto add_param = make_shared<op::v0::Parameter>(element::f32, PartialShape({-1, 4096}));
         auto add = std::make_shared<op::v1::Add>(bottom_reshape, add_param);
-        model_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input, add_param});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input, add_param});
     }
 
     manager.register_pass<ov::pass::NopElimination>();
@@ -270,7 +270,7 @@ TEST(nop_elimination, reshape_elimination_v1_dynamic_negative) {
     auto pattern = make_shared<op::v0::Parameter>(element::i64, PartialShape::dynamic(1));
     auto reshape_v1 = std::make_shared<op::v1::Reshape>(arg, pattern, false);
     auto abs = std::make_shared<op::v0::Abs>(reshape_v1);
-    auto f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg, pattern});
+    auto f = std::make_shared<ov::Model>(OutputVector{abs}, ParameterVector{arg, pattern});
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::NopElimination>();
     pass_manager.run_passes(f);
@@ -284,7 +284,7 @@ TEST(nop_elimination, reshape_arithmetical_reduce_elimination_dynamic) {
     auto pattern = op::v0::Constant::create(element::i64, Shape{4}, {0, 96, 1, 1});
     auto reshape_v1 = std::make_shared<op::v1::Reshape>(reduce, pattern, true);
     auto abs = std::make_shared<op::v0::Abs>(reshape_v1);
-    auto f = std::make_shared<ov::Model>(NodeVector{abs}, ParameterVector{arg});
+    auto f = std::make_shared<ov::Model>(OutputVector{abs}, ParameterVector{arg});
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::NopElimination>(false);
     pass_manager.run_passes(f);
@@ -298,7 +298,7 @@ TEST(nop_elimination, reshape_logical_reduce_elimination_dynamic) {
     auto pattern = op::v0::Constant::create(element::i64, Shape{4}, {0, 96, 1, 1});
     auto reshape_v1 = std::make_shared<op::v1::Reshape>(reduce, pattern, true);
     auto nz = std::make_shared<op::v3::NonZero>(reshape_v1);
-    auto f = std::make_shared<ov::Model>(NodeVector{nz}, ParameterVector{arg});
+    auto f = std::make_shared<ov::Model>(OutputVector{nz}, ParameterVector{arg});
     pass::Manager pass_manager;
     pass_manager.register_pass<ov::pass::NopElimination>(false);
     pass_manager.run_passes(f);
@@ -321,7 +321,7 @@ TEST(nop_elimination, reshape_elimination_v1_check_consumer_count) {
         auto relu = std::make_shared<ov::op::v0::Relu>(reshape_1);
         relu->set_friendly_name("relu");
 
-        f = std::make_shared<ov::Model>(NodeVector{reshape_2, relu}, ParameterVector{arg});
+        f = std::make_shared<ov::Model>(OutputVector{reshape_2, relu}, ParameterVector{arg});
     }
 
     pass::Manager pass_manager;
@@ -1405,7 +1405,7 @@ TEST(nop_elimination, gather_to_squeeze) {
         auto indices = op::v0::Constant::create(element::i64, Shape{}, vector<int64_t>{0});
         auto axis = op::v0::Constant::create(element::i64, Shape{}, vector<int64_t>{gather_axis});
         auto gather = std::make_shared<op::v8::Gather>(arg, indices, axis);
-        return std::make_shared<ov::Model>(NodeVector{gather}, ParameterVector{arg});
+        return std::make_shared<ov::Model>(OutputVector{gather}, ParameterVector{arg});
     };
 
     auto func_axis_0 = generate_func(0);
@@ -1433,7 +1433,7 @@ TEST(nop_elimination, not_gather_to_squeeze_with_vector_indices) {
         auto indices = op::v0::Constant::create(element::i64, Shape{1, 1}, vector<int64_t>{0});
         auto axis = op::v0::Constant::create(element::i64, Shape{}, vector<int64_t>{gather_axis});
         auto gather = std::make_shared<op::v8::Gather>(arg, indices, axis);
-        return std::make_shared<ov::Model>(NodeVector{gather}, ParameterVector{arg});
+        return std::make_shared<ov::Model>(OutputVector{gather}, ParameterVector{arg});
     };
 
     auto func_axis_0 = generate_func(0);

--- a/src/common/transformations/tests/common_optimizations/normalize_l2_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/normalize_l2_fusion_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMax) {
         auto sqrt = std::make_shared<opset4::Sqrt>(max);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
 
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMax) {
         auto axes_const = opset4::Constant::create(element::i64, Shape{2}, {0, 1});
         auto normalize_l2 = std::make_shared<opset4::NormalizeL2>(input, axes_const, eps_value, op::EpsMode::MAX);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{normalize_l2}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{normalize_l2}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -61,7 +61,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxIncorrectExp) {
         auto sqrt = std::make_shared<opset4::Sqrt>(max);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
@@ -79,7 +79,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxIncorrectEpsValueShape) {
         auto sqrt = std::make_shared<opset4::Sqrt>(max);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
@@ -98,7 +98,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithAdd) {
         auto sqrt = std::make_shared<opset4::Sqrt>(add);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
@@ -108,7 +108,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithAdd) {
         auto axes_const = opset4::Constant::create(element::i64, Shape{2}, {0, 1});
         auto normalize_l2 = std::make_shared<opset4::NormalizeL2>(input, axes_const, eps_value, op::EpsMode::ADD);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{normalize_l2}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{normalize_l2}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -127,7 +127,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithAddIncorrectExp) {
         auto sqrt = std::make_shared<opset4::Sqrt>(add);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
 }
@@ -144,7 +144,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithAddIncorrectEpsValueShape) {
         auto sqrt = std::make_shared<opset4::Sqrt>(add);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
 }
@@ -163,7 +163,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxMul) {
         auto unsqrt = std::make_shared<opset8::Power>(max, power_const);
         auto mul = std::make_shared<opset4::Multiply>(input, unsqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
 
@@ -172,7 +172,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxMul) {
         auto axes_const = opset4::Constant::create(element::i64, Shape{2}, {0, 1});
         auto normalize_l2 = std::make_shared<opset4::NormalizeL2>(input, axes_const, eps_value, op::EpsMode::MAX);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{normalize_l2}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{normalize_l2}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -192,7 +192,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxMulIncorrectSecondExp) {
         auto unsqrt = std::make_shared<opset8::Power>(max, power_const);
         auto mul = std::make_shared<opset4::Multiply>(input, unsqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
@@ -214,7 +214,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxSqrtAsPower) {
         auto sqrt = std::make_shared<opset4::Power>(max, sqrt_exp);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }
 
@@ -223,7 +223,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxSqrtAsPower) {
         auto axes_const = opset4::Constant::create(element::i64, Shape{2}, {0, 1});
         auto normalize_l2 = std::make_shared<opset4::NormalizeL2>(input, axes_const, eps_value, op::EpsMode::MAX);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{normalize_l2}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{normalize_l2}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -243,7 +243,7 @@ TEST_F(TransformationTestsF, NormalizeL2FusionWithMaxSqrtAsPowerIncorrectPowerEx
         auto sqrt = std::make_shared<opset4::Power>(max, sqrt_exp);
         auto divide = std::make_shared<opset4::Divide>(input, sqrt);
 
-        model = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Fusion>();
     }

--- a/src/common/transformations/tests/common_optimizations/optimize_strided_slice_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/optimize_strided_slice_test.cpp
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, OptimizeSS_UselessDeletion_Negative1) {
 
         auto ss = std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -58,7 +58,7 @@ TEST_F(TransformationTestsF, OptimizeSS_UselessDeletion_Negative2) {
 
         auto ss = std::make_shared<opset1::StridedSlice>(relu, begin, end, stride, begin_mask, end_mask);
 
-        model = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -77,14 +77,14 @@ TEST_F(TransformationTestsF, OptimizeSS_UselessDeletion) {
 
         auto ss = std::make_shared<opset1::StridedSlice>(relu, begin, end, stride, begin_mask, end_mask);
 
-        model = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
     {
         auto data = std::make_shared<opset1::Parameter>(element::f32, Shape{5, 5, 5, 5});
         auto relu = std::make_shared<opset1::Relu>(data);
-        model_ref = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{data});
     }
 }
 
@@ -101,7 +101,7 @@ TEST_F(TransformationTestsF, OptimizeSS_SkipUselessDeletionRevertCase) {
         auto ss = std::make_shared<opset3::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
         auto relu = std::make_shared<opset3::Relu>(ss);
 
-        model = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{data});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -117,7 +117,7 @@ TEST_F(TransformationTestsF, OptimizeSS_SkipUselessDeletionRevertCase) {
         auto ss = std::make_shared<opset3::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
         auto relu = std::make_shared<opset3::Relu>(ss);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{data});
     }
 }
 
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Usefull_Test) {
 
         auto ss = std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -185,7 +185,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Usefull_Test) {
 
         auto ss = std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
     }
 }
 
@@ -209,7 +209,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Shared_Test) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss2}, 0);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -225,7 +225,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Shared_Test) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss1}, 0);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
     }
 }
 
@@ -254,7 +254,7 @@ TEST_F(TransformationTestsF, OptimizeSS_NotShared_Test) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss2}, 0);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -282,7 +282,7 @@ TEST_F(TransformationTestsF, OptimizeSS_NotShared_Test) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss2}, 0);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
     }
 }
 
@@ -306,7 +306,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Groupped_Test) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss2}, 1);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -320,7 +320,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Groupped_Test) {
         auto concat =
             std::make_shared<opset1::Concat>(OutputVector{variadic_split->output(0), variadic_split->output(1)}, 1);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
     }
 }
 
@@ -337,7 +337,7 @@ TEST_F(TransformationTestsF, OptimizeSS_UselessDeletion_use_shapes_false) {
 
         auto ss = std::make_shared<opset1::StridedSlice>(relu, begin, end, stride, begin_mask, end_mask);
 
-        model = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -364,7 +364,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Shared_Test_use_shapes_false) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss2}, 0);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -380,7 +380,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Shared_Test_use_shapes_false) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss1}, 0);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
     }
 }
 
@@ -404,7 +404,7 @@ TEST_F(TransformationTestsF, OptimizeSS_Groupped_Test_use_shapes_false) {
 
         auto concat = std::make_shared<opset1::Concat>(NodeVector{ss1, ss2}, 1);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{source});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{source});
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -420,7 +420,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_default_axes) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -435,7 +435,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_default_axes) {
 
         auto strided_slice = std::make_shared<opset8::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -452,7 +452,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_axes_const_sorted_full) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
     }
     {
@@ -466,7 +466,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_axes_const_sorted_full) {
 
         auto strided_slice = std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -483,7 +483,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_all_const) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -497,7 +497,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_all_const) {
         auto strided_slice =
             std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -514,13 +514,13 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_all_const_fold) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
     {
         auto sliced_const = opset8::Constant::create(element::f32, Shape{2}, {3, 4});
-        model_ref = std::make_shared<ov::Model>(NodeVector{sliced_const}, ParameterVector{});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sliced_const}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -537,7 +537,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_sorted_le
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -562,7 +562,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_sorted_le
         auto strided_slice =
             std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data, start, stop, step});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data, start, stop, step});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -579,7 +579,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_unsorted)
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -605,7 +605,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_unsorted)
         auto strided_slice =
             std::make_shared<opset8::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data, start, stop, step});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data, start, stop, step});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -622,7 +622,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_negative_
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -637,7 +637,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_axes_const_negative_
 
         auto strided_slice = std::make_shared<opset8::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data, begin, end, stride});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data, begin, end, stride});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -655,7 +655,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_dyn_shape_axes_const
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -682,7 +682,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_dyn_shape_axes_const
         auto strided_slice =
             std::make_shared<opset8::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data, start, stop, step});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data, start, stop, step});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -699,7 +699,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_static_shape_axes_co
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -725,7 +725,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_sss_params_static_shape_axes_co
         auto strided_slice =
             std::make_shared<opset8::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data, start, stop, step});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data, start, stop, step});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -742,7 +742,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_dyn_rank_axes_const_positive) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>();
     }
@@ -757,7 +757,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_dyn_rank_axes_const_positive) {
 
         auto strided_slice = std::make_shared<opset8::StridedSlice>(data, begin, end, stride, begin_mask, end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data, begin, end, stride});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data, begin, end, stride});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -774,7 +774,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_dyn_rank_axes_const_negative) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin, end, step});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin, end, step});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -792,7 +792,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_axes_param) {
 
         auto slice = std::make_shared<opset8::Slice>(data, begin, end, step, axes);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, axes});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, axes});
         manager.register_pass<ov::pass::StridedSliceOptimization>();
         manager.register_pass<pass::ConstantFolding>();
     }
@@ -816,7 +816,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_begin_param_shape_of_use_shapes
         auto axes = std::make_shared<opset8::Range>(zero_const, one_const, one_const, element::i64);
 
         auto slice = std::make_shared<opset8::Slice>(shape_of_data, begin, end, step, axes);
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin});
 
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>(true);
@@ -835,7 +835,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_begin_param_shape_of_use_shapes
         auto strided_slice =
             std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{begin});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{begin});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -858,7 +858,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_begin_param_shape_of_use_shapes
         auto axes = std::make_shared<opset8::Range>(zero_const, one_const, one_const, element::i64);
 
         auto slice = std::make_shared<opset8::Slice>(shape_of_data, begin, end, step, axes);
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data, begin});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data, begin});
 
         manager.register_pass<pass::ConstantFolding>();
         manager.register_pass<ov::pass::SliceToStridedSlice>(false);
@@ -878,7 +878,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_begin_param_shape_of_use_shapes
         auto strided_slice =
             std::make_shared<opset1::StridedSlice>(data, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{begin});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{begin});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -901,7 +901,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_const_fold_params_slice_shape_o
         auto axes = std::make_shared<opset8::Range>(zero_const, one_const, one_const, element::i64);
 
         auto slice = std::make_shared<opset8::Slice>(shape_of_data, begin, end, step, axes);
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data});
 
         manager.register_pass<pass::ConstantFolding>();
         manager.register_pass<ov::pass::StridedSliceOptimization>(true);
@@ -909,7 +909,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_const_fold_params_slice_shape_o
     }
     {
         auto sliced_const = opset8::Constant::create(element::i64, Shape{2}, {3, 4});
-        model_ref = std::make_shared<ov::Model>(NodeVector{sliced_const}, ParameterVector{});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sliced_const}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -932,7 +932,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_const_fold_params_slice_shape_o
         auto axes = std::make_shared<opset8::Range>(zero_const, one_const, one_const, element::i64);
 
         auto slice = std::make_shared<opset8::Slice>(shape_of_data, begin, end, step, axes);
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data});
 
         manager.register_pass<pass::ConstantFolding>();
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
@@ -940,7 +940,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_const_fold_params_slice_shape_o
     }
     {
         auto sliced_const = opset8::Constant::create(element::i64, Shape{2}, {3, 4});
-        model_ref = std::make_shared<ov::Model>(NodeVector{sliced_const}, ParameterVector{});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sliced_const}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -963,7 +963,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_slice_all_use_shapes_true) {
 
         auto slice = std::make_shared<opset8::Slice>(relu, begin, end, step);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data});
         manager.register_pass<ov::pass::SliceToStridedSlice>(true);
         manager.register_pass<ov::pass::StridedSliceOptimization>(true);
         manager.register_pass<pass::ConstantFolding>();
@@ -980,7 +980,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_slice_all_use_shapes_true) {
         auto strided_slice =
             std::make_shared<opset8::StridedSlice>(relu, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -1003,7 +1003,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_slice_all_use_shapes_false) {
 
         auto slice = std::make_shared<opset8::Slice>(relu, begin, end, step);
 
-        model = std::make_shared<ov::Model>(NodeVector{slice}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{slice}, ParameterVector{data});
         manager.register_pass<ov::pass::SliceToStridedSlice>(false);
         manager.register_pass<ov::pass::StridedSliceOptimization>(false);
         manager.register_pass<pass::ConstantFolding>();
@@ -1020,7 +1020,7 @@ TEST_F(TransformationTestsF, SliceToStridedSlice_slice_all_use_shapes_false) {
         auto strided_slice =
             std::make_shared<opset8::StridedSlice>(relu, begin, end, stride, begin_end_mask, begin_end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{strided_slice}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{strided_slice}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -1059,7 +1059,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplit) {
 
         auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{slice_0, slice_2, slice_1}, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
         manager.register_pass<ov::pass::GroupedSliceToVSplitOptimization>();
     }
     {
@@ -1070,7 +1070,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplit) {
 
         auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{vsplit[0], vsplit[2], vsplit[1]}, 1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
     }
 }
 
@@ -1112,7 +1112,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplitChained) {
                                                                             slice_2_1_0},
                                                            1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
         manager.register_pass<ov::pass::GroupedSliceToVSplitOptimization>();
     }
     {
@@ -1156,7 +1156,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplitChained) {
                                                                             slice_2_1_0},
                                                            1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
     }
 }
 
@@ -1178,7 +1178,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplitSameSourceDifferentAxis) {
 
         auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{concat_0, concat_1}, 0);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat_2}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat_2}, ov::ParameterVector{data});
         manager.register_pass<ov::pass::GroupedSliceToVSplitOptimization>();
     }
     {
@@ -1198,7 +1198,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplitSameSourceDifferentAxis) {
 
         auto concat_2 = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{concat_0, concat_1}, 0);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat_2}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat_2}, ov::ParameterVector{data});
     }
 }
 
@@ -1213,7 +1213,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplitNegativeStartStop) {
 
         auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{slice_0, slice_2, slice_1}, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
         manager.register_pass<ov::pass::GroupedSliceToVSplitOptimization>();
     }
     {
@@ -1224,7 +1224,7 @@ TEST_F(TransformationTestsF, GroupedSliceToVSplitNegativeStartStop) {
 
         auto concat = std::make_shared<ov::op::v0::Concat>(ov::OutputVector{vsplit[0], vsplit[2], vsplit[1]}, 1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{data});
     }
 }
 
@@ -1249,7 +1249,7 @@ TEST_F(TransformationTestsF, SliceSequenceToSingleSlice) {
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {10, 1, INT32_MAX}),
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {1, -1, 2}),
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 1, 3}));
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{slice}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{slice}, ov::ParameterVector{data});
     }
 }
 
@@ -1301,6 +1301,6 @@ TEST_F(TransformationTestsF, SliceSequenceToSingleSliceStartAsParameter) {
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {1, -1, 2}),
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 1, 3}));
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{slice}, ov::ParameterVector{data, start_0, start_1, start_2});
+            std::make_shared<ov::Model>(ov::OutputVector{slice}, ov::ParameterVector{data, start_0, start_1, start_2});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/pad_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/pad_fusion.cpp
@@ -132,7 +132,7 @@ TEST_BODY(PadElimination) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::EliminatePad>();
     }
     {
@@ -145,7 +145,7 @@ TEST_BODY(PadElimination) {
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1},
                                                   op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -163,7 +163,7 @@ TEST_BODY(NegativePadElimination) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::EliminatePad>();
     }
     // Reference function is equal to function
@@ -183,7 +183,7 @@ TEST_BODY(PadFusionAvgPoolExcludePad) {
                                                   Shape{4, 4},
                                                   true,
                                                   op::RoundingType::FLOOR);
-        model = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -196,7 +196,7 @@ TEST_BODY(PadFusionAvgPoolExcludePad) {
                                                   false,
                                                   op::RoundingType::FLOOR,
                                                   op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
     }
 }
 
@@ -214,7 +214,7 @@ TEST_BODY(NegativePadFusionAvgPoolExcludePad) {
                                                   Shape{4, 4},
                                                   true,
                                                   op::RoundingType::FLOOR);
-        model = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
         manager.register_pass<ov::pass::PadFusion>();
     }
     // Reference function is equal to function
@@ -234,7 +234,7 @@ TEST_BODY(PadFusionAvgPoolDontExcludePad) {
                                                   Shape{4, 4},
                                                   false,
                                                   op::RoundingType::FLOOR);
-        model = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -247,7 +247,7 @@ TEST_BODY(PadFusionAvgPoolDontExcludePad) {
                                                   false,
                                                   op::RoundingType::FLOOR,
                                                   op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
     }
 }
 
@@ -265,7 +265,7 @@ TEST_BODY(NegativePadFusionAvgPoolDontExcludePad) {
                                                   Shape{4, 4},
                                                   false,
                                                   op::RoundingType::FLOOR);
-        model = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
         manager.register_pass<ov::pass::PadFusion>();
     }
     // Reference function is equal to function
@@ -285,7 +285,7 @@ TEST_BODY(PadFusionConvolution) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -298,7 +298,7 @@ TEST_BODY(PadFusionConvolution) {
                                                   CoordinateDiff{3, 3},
                                                   Shape{1, 1},
                                                   op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -316,7 +316,7 @@ TEST_BODY(NegativePadFusionConvolution) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     // Reference function is equal to function
@@ -338,7 +338,7 @@ TEST_BODY(PadFusionConvolutionBackpropData) {
                                                               CoordinateDiff{3, 3},
                                                               Shape{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -351,7 +351,7 @@ TEST_BODY(PadFusionConvolutionBackpropData) {
                                                               CoordinateDiff{1, 1},
                                                               Shape{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -370,7 +370,7 @@ TEST_BODY(PadFusionGroupConvolution) {
                                                        CoordinateDiff{1, 1},
                                                        Shape{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -383,7 +383,7 @@ TEST_BODY(PadFusionGroupConvolution) {
                                                        CoordinateDiff{3, 3},
                                                        Shape{1, 1},
                                                        op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -402,7 +402,7 @@ TEST_BODY(NegativePadFusionGroupConvolution) {
                                                        CoordinateDiff{1, 1},
                                                        Shape{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     // Reference function is equal to function
@@ -422,7 +422,7 @@ TEST_BODY(PadFusionGroupConvolutionBackpropData) {
                                                                    CoordinateDiff{3, 2},
                                                                    CoordinateDiff{4, 3},
                                                                    Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -434,7 +434,7 @@ TEST_BODY(PadFusionGroupConvolutionBackpropData) {
                                                                    CoordinateDiff{2, 1},
                                                                    CoordinateDiff{1, 2},
                                                                    Shape{1, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -454,7 +454,7 @@ TEST_BODY(PadFusionAvgPoolNonConstPadValue) {
                                                   Shape{4, 4},
                                                   true,
                                                   op::RoundingType::FLOOR);
-        model = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -467,7 +467,7 @@ TEST_BODY(PadFusionAvgPoolNonConstPadValue) {
                                                   false,
                                                   op::RoundingType::FLOOR,
                                                   op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
     }
 }
 
@@ -487,7 +487,7 @@ TEST_BODY(PadFusionConvolutionNonConstPadValue) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -500,7 +500,7 @@ TEST_BODY(PadFusionConvolutionNonConstPadValue) {
                                                   CoordinateDiff{3, 3},
                                                   Shape{1, 1},
                                                   op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -522,7 +522,7 @@ TEST_BODY(PadFusionConvolutionBackpropDataNonConstPadValue) {
                                                               CoordinateDiff{3, 3},
                                                               Shape{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -535,7 +535,7 @@ TEST_BODY(PadFusionConvolutionBackpropDataNonConstPadValue) {
                                                               CoordinateDiff{1, 1},
                                                               Shape{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -556,7 +556,7 @@ TEST_BODY(PadFusionGroupConvolutionNonConstPadValue) {
                                                        CoordinateDiff{1, 1},
                                                        Shape{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -569,7 +569,7 @@ TEST_BODY(PadFusionGroupConvolutionNonConstPadValue) {
                                                        CoordinateDiff{3, 3},
                                                        Shape{1, 1},
                                                        op::PadType::EXPLICIT);
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -589,7 +589,7 @@ TEST_BODY(PadFusionGroupConvolutionBackpropDataNonConstPadValue) {
                                                                    CoordinateDiff{3, 2},
                                                                    CoordinateDiff{4, 3},
                                                                    Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -601,7 +601,7 @@ TEST_BODY(PadFusionGroupConvolutionBackpropDataNonConstPadValue) {
                                                                    CoordinateDiff{2, 1},
                                                                    CoordinateDiff{1, 2},
                                                                    Shape{1, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -619,7 +619,7 @@ TEST_BODY(NegativePadFusionNonConstantPadMode) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -634,7 +634,7 @@ TEST_BODY(NegativePadFusionNonConstantPadMode) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -653,7 +653,7 @@ TEST_BODY(NegativePadFusionNonZeroPadValue) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -669,7 +669,7 @@ TEST_BODY(NegativePadFusionNonZeroPadValue) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -688,7 +688,7 @@ TEST_BODY(NegativePadFusionPadForBatchSize) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -704,7 +704,7 @@ TEST_BODY(NegativePadFusionPadForBatchSize) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -722,7 +722,7 @@ TEST_BODY(NegativePadFusionAvgPoolExcludePadNonZeroPads) {
                                                   Shape{4, 4},
                                                   true,
                                                   op::RoundingType::FLOOR);
-        model = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -737,7 +737,7 @@ TEST_BODY(NegativePadFusionAvgPoolExcludePadNonZeroPads) {
                                                   Shape{4, 4},
                                                   true,
                                                   op::RoundingType::FLOOR);
-        model_ref = std::make_shared<Model>(NodeVector{avg_pool}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{avg_pool}, ParameterVector{data});
     }
 }
 
@@ -758,7 +758,7 @@ TEST_BODY(NegativePadFusionConvolutionBackpropDataTooSmallPad) {
                                                               CoordinateDiff{1, 1},
                                                               Shape{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     {
@@ -776,7 +776,7 @@ TEST_BODY(NegativePadFusionConvolutionBackpropDataTooSmallPad) {
                                                               CoordinateDiff{1, 1},
                                                               Shape{1, 1});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
     }
 }
 
@@ -794,7 +794,7 @@ TEST_BODY(NegativePadPreservation) {
                                                   CoordinateDiff{0, 0},
                                                   CoordinateDiff{1, 1},
                                                   Shape{1, 1});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data, filters});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data, filters});
         manager.register_pass<ov::pass::PadFusion>();
     }
     // Reference function is equal to function

--- a/src/common/transformations/tests/common_optimizations/preprocessing_fusion_tests.cpp
+++ b/src/common/transformations/tests/common_optimizations/preprocessing_fusion_tests.cpp
@@ -132,7 +132,7 @@ TEST_F(TransformationTestsF, RICFusionSimple) {
         auto relu = std::make_shared<Relu>(input);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -141,7 +141,7 @@ TEST_F(TransformationTestsF, RICFusionSimple) {
         auto input = create_param({1, 3, 64, 64});
         auto relu = std::make_shared<Relu>(input);
         auto conv = create_conv_with_gather(relu, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -171,7 +171,7 @@ TEST_F(TransformationTestsF, RICFusionHard) {
         auto conv = create_conv(gconv2, {6, 12, 3, 3});
         auto conv2 = create_conv(concat, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv, conv2}, ParameterVector{input, input2});
+        model = std::make_shared<Model>(OutputVector{conv, conv2}, ParameterVector{input, input2});
 
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
@@ -196,7 +196,7 @@ TEST_F(TransformationTestsF, RICFusionHard) {
         auto conv = create_conv_with_gather(gconv2, {6, 12, 3, 3}, {8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3});
         auto conv2 = create_conv_with_gather(input2, {6, 3, 3, 3}, {2, 1, 0});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv, conv2}, ParameterVector{input, input2});
+        model_ref = std::make_shared<Model>(OutputVector{conv, conv2}, ParameterVector{input, input2});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -229,7 +229,7 @@ TEST_F(TransformationTestsF, RICFusionHardNegativePad12) {
         auto conv = create_conv(gconv2, {6, 12, 3, 3});
         auto conv2 = create_conv(concat, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv, conv2}, ParameterVector{input, input2});
+        model = std::make_shared<Model>(OutputVector{conv, conv2}, ParameterVector{input, input2});
 
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
@@ -258,7 +258,7 @@ TEST_F(TransformationTestsF, RICFusionHardNegativePad12) {
         auto conv = create_conv_with_gather(gconv2, {6, 12, 3, 3}, {8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3});
         auto conv2 = create_conv_with_gather(input2, {6, 3, 3, 3}, {2, 1, 0});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv, conv2}, ParameterVector{input, input2});
+        model_ref = std::make_shared<Model>(OutputVector{conv, conv2}, ParameterVector{input, input2});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -272,7 +272,7 @@ TEST_F(TransformationTestsF, RICFusionDynamic) {
         auto relu = std::make_shared<Relu>(input);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -281,7 +281,7 @@ TEST_F(TransformationTestsF, RICFusionDynamic) {
         auto input = create_param({-1, -1, -1, -1});
         auto relu = std::make_shared<Relu>(input);
         auto conv = create_conv_with_gather(relu, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -294,7 +294,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise1) {
         auto add = std::make_shared<Add>(input, Constant::create(element::f32, Shape{3, 1, 1}, {0.1, 0.2, 0.3}));
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -304,7 +304,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise1) {
         auto gather = create_gather(Constant::create(element::f32, Shape{3, 1, 1}, {0.1, 0.2, 0.3}), {2, 1, 0}, 0);
         auto add = std::make_shared<Add>(input, ov::util::get_constant_from_source(gather));
         auto conv = create_conv_with_gather(add, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -318,7 +318,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise2) {
         auto add = std::make_shared<Add>(input, create_weights({1, 1, 1}));
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -327,7 +327,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise2) {
         auto input = create_param({1, 3, 64, 64});
         auto add = std::make_shared<Add>(input, create_weights({1, 1, 1}));
         auto conv = create_conv_with_gather(add, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -341,7 +341,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise3) {
         auto add = std::make_shared<Add>(input, Constant::create(element::f32, Shape{1}, {0.2}));
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -350,7 +350,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise3) {
         auto input = create_param({1, 3, 64, 64});
         auto add = std::make_shared<Add>(input, Constant::create(element::f32, Shape{1}, {0.2}));
         auto conv = create_conv_with_gather(add, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -364,7 +364,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise4) {
         auto add = std::make_shared<Add>(create_weights({3, 1, 1}), input);
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -374,7 +374,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise4) {
         auto gather = create_gather(create_weights({3, 1, 1}), {2, 1, 0}, 0);
         auto add = std::make_shared<Add>(ov::util::get_constant_from_source(gather), input);
         auto conv = create_conv_with_gather(add, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -388,7 +388,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise5) {
         auto add = std::make_shared<Add>(create_weights({1, 3, 1, 1}), input);
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -398,7 +398,7 @@ TEST_F(TransformationTestsF, RICFusionEltwise5) {
         auto gather = create_gather(create_weights({1, 3, 1, 1}), {2, 1, 0}, 1);
         auto add = std::make_shared<Add>(ov::util::get_constant_from_source(gather), input);
         auto conv = create_conv_with_gather(add, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -413,7 +413,7 @@ TEST_F(TransformationTestsF, RICFusionEltwiseNegative) {
         auto add = std::make_shared<Add>(input, input2);
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input, input2});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input, input2});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -426,7 +426,7 @@ TEST_F(TransformationTestsF, RICFusionEltwiseTwoRIC) {
         auto add = std::make_shared<Add>(input, input2);
         auto conv = create_conv(add, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input, input2});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input, input2});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}, {1, "NCHW"}});
     }
@@ -436,7 +436,7 @@ TEST_F(TransformationTestsF, RICFusionEltwiseTwoRIC) {
         auto add = std::make_shared<Add>(input, input2);
         auto conv = create_conv_with_gather(add, {6, 3, 3, 3}, {2, 1, 0});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input, input2});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input, input2});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
@@ -449,7 +449,7 @@ TEST_F(TransformationTestsF, RICFusionEltwiseNegative3) {
         auto add = std::make_shared<Add>(input, Constant::create(element::f32, {1, 1, 1, 1, 1}, {1.4}));
         auto shapeof = std::make_shared<ShapeOf>(add);
 
-        model = std::make_shared<Model>(NodeVector{shapeof}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{shapeof}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -462,7 +462,7 @@ TEST_F(TransformationTestsF, RICFusionGroupConv) {
         auto relu = std::make_shared<Relu>(gconv);
         auto conv = create_conv(relu, {3, 6, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -473,7 +473,7 @@ TEST_F(TransformationTestsF, RICFusionGroupConv) {
         // [0, 1]-[2, 3]-[4, 5] -> [4, 5]-[2, 3]-[0, 1]
         auto relu = std::make_shared<Relu>(gconv);
         auto conv = create_conv_with_gather(relu, {3, 6, 3, 3}, {4, 5, 2, 3, 0, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -488,7 +488,7 @@ TEST_F(TransformationTestsF, RICFusionGroupConvNegative) {
         auto relu = std::make_shared<Relu>(gconv);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -501,7 +501,7 @@ TEST_F(TransformationTestsF, RICFusionTranspose) {
         auto transpose = std::make_shared<Transpose>(add, Constant::create(element::i64, Shape{4}, {0, 3, 1, 2}));
         auto conv = create_conv(transpose, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NHWC"}});
     }
@@ -512,7 +512,7 @@ TEST_F(TransformationTestsF, RICFusionTranspose) {
         auto add = std::make_shared<Add>(input, ov::util::get_constant_from_source(gather));
         auto transpose = std::make_shared<Transpose>(add, Constant::create(element::i64, Shape{4}, {0, 3, 1, 2}));
         auto conv = create_conv_with_gather(transpose, {6, 3, 3, 3}, {2, 1, 0});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -526,7 +526,7 @@ TEST_F(TransformationTestsF, RICFusionFQOnTheWay) {
         auto fq = create_fq(input);
         auto conv = create_conv(fq, create_fq(create_weights({6, 3, 3, 3})));
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -537,7 +537,7 @@ TEST_F(TransformationTestsF, RICFusionFQOnTheWay) {
         auto weights = ov::util::get_constant_from_source(create_gather(create_weights({6, 3, 3, 3}), {2, 1, 0}, 1));
         auto conv = create_conv(fq, create_fq(weights));
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -558,7 +558,7 @@ TEST_F(TransformationTestsF, RICFusionFQOnTheWay2) {
                                                          255);
         auto conv = create_conv(fq, fq_weights);
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -576,7 +576,7 @@ TEST_F(TransformationTestsF, RICFusionFQOnTheWay2) {
             255);
         auto conv = create_conv(fq, fq_weights);
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -598,7 +598,7 @@ TEST_F(TransformationTestsF, RICFusionFQOnTheWay3) {
         auto gconv = create_group_conv(fq, fq_weights);
         auto conv = create_conv(gconv, {6, 3, 1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -617,7 +617,7 @@ TEST_F(TransformationTestsF, RICFusionFQOnTheWay3) {
         auto gconv = create_group_conv(fq, fq_weights);
         auto conv = create_conv_with_gather(gconv, {6, 3, 1, 1}, {2, 1, 0});
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -631,7 +631,7 @@ TEST_F(TransformationTestsF, RICFusionShapeOf) {
         auto relu = std::make_shared<Relu>(input);
         auto shape_of = std::make_shared<ShapeOf>(relu);
 
-        model = std::make_shared<Model>(NodeVector{shape_of}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{shape_of}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -641,7 +641,7 @@ TEST_F(TransformationTestsF, RICFusionShapeOf) {
         auto relu = std::make_shared<Relu>(input);
         auto shape_of = std::make_shared<ShapeOf>(relu);
 
-        model_ref = std::make_shared<Model>(NodeVector{shape_of}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{shape_of}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -655,7 +655,7 @@ TEST_F(TransformationTestsF, RICFusionGatherDetectionNegative) {
         auto relu = std::make_shared<Relu>(gather);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
 }
@@ -668,7 +668,7 @@ TEST_F(TransformationTestsF, RICFusionGatherDetectionNegative2) {
         auto relu = std::make_shared<Relu>(gather);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input, input2});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input, input2});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
 }
@@ -680,7 +680,7 @@ TEST_F(TransformationTestsF, RICFusionGatherDetectionNegative3) {
         auto relu = std::make_shared<Relu>(gather);
         auto conv = create_conv(relu, {6, 1, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
 }
@@ -692,7 +692,7 @@ TEST_F(TransformationTestsF, RICFusionGatherDetectionNegative4) {
         auto relu = std::make_shared<Relu>(gather);
         auto conv = create_conv(relu, {6, 2, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
 }
@@ -705,7 +705,7 @@ TEST_F(TransformationTestsF, RICFusionSplitConcatDetectionNegative) {
         auto relu = std::make_shared<Relu>(concat);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
 }
@@ -719,7 +719,7 @@ TEST_F(TransformationTestsF, RICFusionSplitConcatDetectionNegative2) {
         auto relu = std::make_shared<Relu>(concat);
         auto conv = create_conv(relu, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
 }
@@ -744,7 +744,7 @@ TEST_F(TransformationTestsF, FuseConvertLayout) {
         auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto relu = std::make_shared<ov::op::v0::Relu>(transpose);
 
-        model = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
 
         using namespace ov::preprocess;
         PrePostProcessor p(model);
@@ -760,7 +760,7 @@ TEST_F(TransformationTestsF, FuseConvertLayout) {
         auto convert = std::make_shared<ov::op::v0::Convert>(input, element::f32);
         auto relu = std::make_shared<ov::op::v0::Relu>(convert);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
     }
 }
 
@@ -771,7 +771,7 @@ TEST_F(TransformationTestsF, FuseScaleValue) {
         auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         using namespace ov::preprocess;
         PrePostProcessor p(model);
@@ -787,7 +787,7 @@ TEST_F(TransformationTestsF, FuseScaleValue) {
         auto order = ov::op::v0::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -800,7 +800,7 @@ TEST_F(TransformationTestsF, FuseScaleValues) {
         auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
         using namespace ov::preprocess;
         PrePostProcessor p(model);
@@ -816,7 +816,7 @@ TEST_F(TransformationTestsF, FuseScaleValues) {
         auto order = ov::op::v0::Constant::create(element::i64, Shape{4}, {0, 3, 1, 2});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(input, order);
         auto conv = create_conv(transpose, {6, 3, 3, 3});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -931,7 +931,7 @@ TEST_F(TransformationTestsF, RICFusionConvertMultiplyGroupConv) {
                                                                      op::PadType::EXPLICIT);
         auto relu = std::make_shared<Relu>(group_conv);
         auto conv = create_conv(relu, {6, 9, 3, 3});
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
@@ -959,7 +959,7 @@ TEST_F(TransformationTestsF, RICFusionConvertMultiplyGroupConv) {
                                                           ov::CoordinateDiff{0, 0},
                                                           ov::CoordinateDiff{0, 0},
                                                           ov::Strides{1, 1});
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
@@ -1130,7 +1130,7 @@ TEST_F(TransformationTestsF, RICFusionNegativeUnsupported) {
                                                           CoordinateDiff{0, 0},
                                                           Strides{1, 1});
 
-        model = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
         apply_reverse_input_channels(model, {{0, "NCHW"}});
         manager.register_pass<ov::pass::ReverseInputChannelsFusion>();
     }
@@ -1254,14 +1254,14 @@ TEST_F(TransformationTestsF, RICFusionTwoConvolutions) {
     {
         auto conv1 = create_conv(input, create_weights({3, 3, 1, 1}));
         auto conv2 = create_conv(conv1, create_weights({3, 3, 1, 1}));
-        model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
     }
     {
         auto conv1_with_gather = create_conv_with_gather(input, create_weights({3, 3, 1, 1}), {2, 1, 0});
         auto conv2 = create_conv(conv1_with_gather, create_weights({3, 3, 1, 1}));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }
@@ -1272,7 +1272,7 @@ TEST_F(TransformationTestsF, RICFusionTwoConvolutionsTheSameWeights) {
     {
         auto conv1 = create_conv(input, weights);
         auto conv2 = create_conv(conv1, weights);
-        model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
 
         // ReverseInputChannelsFusion is expected to be applied inside PrePostProcessing
         apply_reverse_input_channels(model, {{0, "NCHW"}});
@@ -1280,7 +1280,7 @@ TEST_F(TransformationTestsF, RICFusionTwoConvolutionsTheSameWeights) {
     {
         auto conv1_with_gather = create_conv_with_gather(input, weights, {2, 1, 0});
         auto conv2 = create_conv(conv1_with_gather, weights);
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
 }

--- a/src/common/transformations/tests/common_optimizations/pull_through_reduce_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/pull_through_reduce_test.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<Model> generate_unsqueeze_model(element::Type in_type,
     const auto reduce_axes_const = Constant::create(element::i64, Shape{reduce_axes.size()}, reduce_axes);
     const auto reduce_mean = std::make_shared<ReduceType>(unsqueeze, reduce_axes_const, keep_dims);
 
-    return std::make_shared<Model>(NodeVector{reduce_mean}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{reduce_mean}, ParameterVector{input});
 }
 
 template <typename ReduceType>
@@ -48,7 +48,7 @@ std::shared_ptr<Model> generate_unsqueeze_ref_model(element::Type in_type,
     const auto reduce_mean = std::make_shared<ReduceType>(input, reduce_axes_const, keep_dims);
     const auto unsqueeze = std::make_shared<Unsqueeze>(reduce_mean, unsqueeze_axes_const);
 
-    return std::make_shared<Model>(NodeVector{unsqueeze}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{unsqueeze}, ParameterVector{input});
 }
 
 template <typename ReduceType>
@@ -65,7 +65,7 @@ std::shared_ptr<Model> generate_reshape_model(element::Type in_type,
     const auto reduce_axes_const = Constant::create(element::i64, Shape{reduce_axes.size()}, reduce_axes);
     const auto reduce_mean = std::make_shared<ReduceType>(reshape, reduce_axes_const, keep_dims);
 
-    return std::make_shared<Model>(NodeVector{reduce_mean}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{reduce_mean}, ParameterVector{input});
 }
 
 template <typename ReduceType>
@@ -82,7 +82,7 @@ std::shared_ptr<Model> generate_reshape_ref_model(element::Type in_type,
         Constant::create(element::i64, Shape{reshape_target_shape.size()}, reshape_target_shape);
     const auto reshape = std::make_shared<Reshape>(reduce_mean, reshape_target_shape_const, reshape_special_zero);
 
-    return std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input});
 }
 }  // namespace
 
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, PullUnsqueezeThroughReduceSkipIfNotConstAxes) {
     const auto reduce_axes = Constant::create(element::i64, Shape{}, {2});
     const auto reduce_mean = std::make_shared<ReduceMean>(unsqueeze, reduce_axes);
 
-    model = std::make_shared<Model>(NodeVector{reduce_mean}, ParameterVector{input, unsqueeze_axes});
+    model = std::make_shared<Model>(OutputVector{reduce_mean}, ParameterVector{input, unsqueeze_axes});
     manager.register_pass<pass::PullUnsqueezeThroughReduce>();
 }
 
@@ -214,7 +214,7 @@ TEST_F(TransformationTestsF, PullUnsqueezeThroughReduceMeanSkipIfMoreThanOneUnsq
     const auto reduce_mean = std::make_shared<ReduceMean>(unsqueeze, reduce_axes);
     const auto add = std::make_shared<Add>(unsqueeze, Constant::create(element::f32, Shape{}, {1}));
 
-    model = std::make_shared<Model>(NodeVector{reduce_mean, add}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{reduce_mean, add}, ParameterVector{input});
     manager.register_pass<pass::PullUnsqueezeThroughReduce>();
 }
 
@@ -372,7 +372,7 @@ TEST_F(TransformationTestsF, PullReshapeThroughReduceSkipIfNonConstAxes) {
     const auto reduce_axes = std::make_shared<Parameter>(element::i64, PartialShape{});
     const auto reduce_mean = std::make_shared<ReduceMean>(reshape, reduce_axes);
 
-    model = std::make_shared<Model>(NodeVector{reduce_mean}, ParameterVector{input, reduce_axes});
+    model = std::make_shared<Model>(OutputVector{reduce_mean}, ParameterVector{input, reduce_axes});
     manager.register_pass<pass::PullReshapeThroughReduce>();
 }
 
@@ -383,7 +383,7 @@ TEST_F(TransformationTestsF, PullReshapeThroughReduceMeanSkipIfDynamicReshapeOut
     const auto reduce_axes = Constant::create(element::i64, Shape{}, {2});
     const auto reduce_mean = std::make_shared<ReduceMean>(reshape, reduce_axes);
 
-    model = std::make_shared<Model>(NodeVector{reduce_mean}, ParameterVector{input, target_shape});
+    model = std::make_shared<Model>(OutputVector{reduce_mean}, ParameterVector{input, target_shape});
     manager.register_pass<pass::PullReshapeThroughReduce>();
 }
 
@@ -395,6 +395,6 @@ TEST_F(TransformationTestsF, PullReshapeThroughReduceMeanSkipIfMoreThanOneReshap
     const auto reduce_mean = std::make_shared<ReduceMean>(reshape, reduce_axes);
     const auto add = std::make_shared<Add>(reshape, Constant::create(element::f32, Shape{}, {1}));
 
-    model = std::make_shared<Model>(NodeVector{reduce_mean, add}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{reduce_mean, add}, ParameterVector{input});
     manager.register_pass<pass::PullReshapeThroughReduce>();
 }

--- a/src/common/transformations/tests/common_optimizations/push_constant_to_subgraphs.cpp
+++ b/src/common/transformations/tests/common_optimizations/push_constant_to_subgraphs.cpp
@@ -22,7 +22,7 @@ TEST_F(TransformationTestsF, PushConstantToSubgraphLoop) {
             auto mul = std::make_shared<opset10::Multiply>(X, Y);
             auto add = std::make_shared<opset10::Add>(mul, Z);
             auto cond = opset10::Constant::create(element::boolean, Shape{}, {true});
-            loop_body = std::make_shared<Model>(NodeVector{add, cond}, ParameterVector{X, Y, Z});
+            loop_body = std::make_shared<Model>(OutputVector{add, cond}, ParameterVector{X, Y, Z});
         }
         auto loop = std::make_shared<opset10::Loop>(trip_count, term_cond);
         loop->set_function(loop_body);
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, PushConstantToSubgraphLoop) {
             auto mul = std::make_shared<opset10::Multiply>(X, Y);
             auto add = std::make_shared<opset10::Add>(mul, constant);
             auto cond = opset10::Constant::create(element::boolean, Shape{}, {true});
-            loop_body = std::make_shared<Model>(NodeVector{add, cond}, ParameterVector{X, Y});
+            loop_body = std::make_shared<Model>(OutputVector{add, cond}, ParameterVector{X, Y});
         }
         auto loop = std::make_shared<opset10::Loop>(trip_count, term_cond);
         loop->set_function(loop_body);
@@ -199,7 +199,7 @@ TEST_F(TransformationTestsF, PushConstantToSubgraphLoopMoreThan32Inputs) {
             }
             auto concat = std::make_shared<opset10::Concat>(concat_inputs, 1);
             auto cond = opset10::Constant::create(element::boolean, Shape{}, {true});
-            loop_body = std::make_shared<Model>(NodeVector{concat, cond}, params);
+            loop_body = std::make_shared<Model>(OutputVector{concat, cond}, params);
         }
         auto loop = std::make_shared<opset10::Loop>(trip_count, term_cond);
         loop->set_function(loop_body);
@@ -237,7 +237,7 @@ TEST_F(TransformationTestsF, PushConstantToSubgraphLoopMoreThan32Inputs) {
             }
             auto concat = std::make_shared<opset10::Concat>(concat_inputs, 1);
             auto cond = opset10::Constant::create(element::boolean, Shape{}, {true});
-            loop_body = std::make_shared<Model>(NodeVector{concat, cond}, ParameterVector{X});
+            loop_body = std::make_shared<Model>(OutputVector{concat, cond}, ParameterVector{X});
         }
         auto loop = std::make_shared<opset10::Loop>(trip_count, term_cond);
         loop->set_function(loop_body);

--- a/src/common/transformations/tests/common_optimizations/random_uniform_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/random_uniform_fusion_test.cpp
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, RandomUniformMulFusing) {
         auto mul_const = opset8::Constant::create(element::f32, Shape{1, 1, 1}, {30.0});
         auto mul = std::make_shared<opset8::Multiply>(ru, mul_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::RandomUniformFusion>();
     }
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, RandomUniformMulFusing) {
         auto max_const = opset8::Constant::create(element::f32, Shape{}, {30.0});
         auto ru = std::make_shared<opset8::RandomUniform>(input, min_const, max_const, element::f32, 100, 200);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{ru}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{ru}, ParameterVector{input});
     }
 }
 
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, RandomUniformAddFusing) {
         auto add_const = opset8::Constant::create(element::f32, Shape{1, 1, 1, 1}, {-10.0});
         auto add = std::make_shared<opset8::Add>(ru, add_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input});
 
         manager.register_pass<ov::pass::RandomUniformFusion>();
     }
@@ -65,7 +65,7 @@ TEST_F(TransformationTestsF, RandomUniformAddFusing) {
         auto ru_min_const = opset8::Constant::create(element::f32, Shape{}, {-10.0});
         auto ru = std::make_shared<opset8::RandomUniform>(input, ru_min_const, ru_max_const, element::f32, 100, 200);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{ru}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{ru}, ParameterVector{input});
     }
 }
 
@@ -80,7 +80,7 @@ TEST_F(TransformationTestsF, RandomUniformWithConvertMulFusing) {
         auto mul_const = opset8::Constant::create(element::f16, Shape{}, {30.0});
         auto mul = std::make_shared<opset8::Multiply>(conv, mul_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::RandomUniformFusion>();
     }
@@ -93,7 +93,7 @@ TEST_F(TransformationTestsF, RandomUniformWithConvertMulFusing) {
         auto ru = std::make_shared<opset8::RandomUniform>(input, min_const, max_const, element::f32, 100, 200);
         auto conv = std::make_shared<opset8::Convert>(ru, element::f16);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv}, ParameterVector{input});
     }
 }
 
@@ -108,7 +108,7 @@ TEST_F(TransformationTestsF, RandomUniformWithConvertAddFusing) {
         auto add_const = opset8::Constant::create(element::f16, Shape{}, {-10.0});
         auto add = std::make_shared<opset8::Add>(conv, add_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input});
 
         manager.register_pass<ov::pass::RandomUniformFusion>();
     }
@@ -121,7 +121,7 @@ TEST_F(TransformationTestsF, RandomUniformWithConvertAddFusing) {
         auto ru = std::make_shared<opset8::RandomUniform>(input, ru_min_const, ru_max_const, element::f32, 100, 200);
         auto conv = std::make_shared<opset8::Convert>(ru, element::f16);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv}, ParameterVector{input});
     }
 }
 
@@ -135,7 +135,7 @@ TEST_F(TransformationTestsF, RandomUniformFusingInvalidRUType) {
         auto mul_const = opset8::Constant::create(element::i32, Shape{}, {30});
         auto mul = std::make_shared<opset8::Multiply>(ru, mul_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::RandomUniformFusion>();
     }
@@ -149,7 +149,7 @@ TEST_F(TransformationTestsF, RandomUniformFusingInvalidRUType) {
         auto mul_const = opset8::Constant::create(element::i32, Shape{}, {30});
         auto mul = std::make_shared<opset8::Multiply>(ru, mul_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 }
 
@@ -163,7 +163,7 @@ TEST_F(TransformationTestsF, RandomUniformFusingInvalidConstShape) {
         auto mul_const = opset8::Constant::create(element::f32, Shape{3}, {30, 20, 15});
         auto mul = std::make_shared<opset8::Multiply>(ru, mul_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::RandomUniformFusion>();
     }
@@ -177,6 +177,6 @@ TEST_F(TransformationTestsF, RandomUniformFusingInvalidConstShape) {
         auto mul_const = opset8::Constant::create(element::f32, Shape{3}, {30, 20, 15});
         auto mul = std::make_shared<opset8::Multiply>(ru, mul_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/reduce_reshape_fusion_tests.cpp
+++ b/src/common/transformations/tests/common_optimizations/reduce_reshape_fusion_tests.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<Model> generate_model(element::Type in_type,
     const auto target_shape = Constant::create(element::i64, Shape{reshape_target_shape.size()}, reshape_target_shape);
     const auto reshape = std::make_shared<Reshape>(reduce_mean, target_shape, reshape_special_zero);
 
-    return std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input});
 }
 
 template <typename ReduceType>
@@ -46,7 +46,7 @@ std::shared_ptr<Model> generate_ref_model(element::Type in_type,
     const auto reduce_axes_const = Constant::create(element::i64, Shape{reduce_axes.size()}, reduce_axes);
     const auto reduce_mean = std::make_shared<ReduceType>(input, reduce_axes_const, true);
 
-    return std::make_shared<Model>(NodeVector{reduce_mean}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{reduce_mean}, ParameterVector{input});
 }
 }  // namespace
 
@@ -130,7 +130,7 @@ TEST_F(TransformationTestsF, ReduceMeanReshapeFusionSkipIfNonConstReduceAxes) {
     const auto target_shape = Constant::create(element::i64, Shape{3}, {5, 1, 15});
     const auto reshape = std::make_shared<Reshape>(reduce_mean, target_shape, false);
 
-    model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input, reduce_axes});
+    model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input, reduce_axes});
     manager.register_pass<pass::ReduceReshapeFusion>();
 }
 
@@ -141,7 +141,7 @@ TEST_F(TransformationTestsF, ReduceMeanReshapeFusionSkipIfNonConstReshapeTargetS
     const auto target_shape = std::make_shared<Parameter>(element::i64, PartialShape{3});
     const auto reshape = std::make_shared<Reshape>(reduce_mean, target_shape, false);
 
-    model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input, target_shape});
+    model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input, target_shape});
     manager.register_pass<pass::ReduceReshapeFusion>();
 }
 
@@ -153,7 +153,7 @@ TEST_F(TransformationTestsF, ReduceMeanReshapeFusionSkipIfMoreThanOneReduceConsu
     const auto target_shape = Constant::create(element::i64, Shape{2}, {1, 1});
     const auto reshape = std::make_shared<Reshape>(reduce_mean, target_shape, false);
 
-    model = std::make_shared<Model>(NodeVector{reshape, add}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{reshape, add}, ParameterVector{input});
     manager.register_pass<pass::ReduceReshapeFusion>();
 }
 
@@ -166,7 +166,7 @@ TEST(TransformationTests, ReduceMeanReshapeFusionAssertValidOutputShape) {
     const auto order = Constant::create(element::i64, Shape{4}, {0, 3, 1, 2});
     const auto transpose = make_shared<Transpose>(reshape, order);
 
-    auto model = make_shared<Model>(NodeVector{transpose}, ParameterVector{input});
+    auto model = make_shared<Model>(OutputVector{transpose}, ParameterVector{input});
 
     pass::Manager manager;
     manager.set_per_pass_validation(false);

--- a/src/common/transformations/tests/common_optimizations/relu_fake_quantize_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/relu_fake_quantize_fusion.cpp
@@ -30,7 +30,7 @@ TEST_F(TransformationTestsF, ReluFakeQuantizeFusion) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(relu, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::ReluFakeQuantizeFusion>();
     }
     {
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, ReluFakeQuantizeFusion) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(data, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }
 
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, ReluFakeQuantizeFusionNegativeInputLow) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(relu, input_low, input_high, output_low, output_high, 11);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
         manager.register_pass<ov::pass::ReluFakeQuantizeFusion>();
     }
     {
@@ -65,6 +65,6 @@ TEST_F(TransformationTestsF, ReluFakeQuantizeFusionNegativeInputLow) {
         auto output_low = opset5::Constant::create(element::f32, Shape{}, {0});
         auto output_high = opset5::Constant::create(element::f32, Shape{}, {10});
         auto fq = std::make_shared<opset5::FakeQuantize>(relu, input_low, input_high, output_low, output_high, 11);
-        model_ref = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/remove_concat_zero_dim_input_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/remove_concat_zero_dim_input_test.cpp
@@ -26,14 +26,14 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimInputStaticShape) {
         auto input2 = std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1, 0, 3});
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input3});
     }
 }
 
@@ -46,14 +46,14 @@ TEST_F(TransformationTestsF, DisableRemoveConcatZeroDimInputStaticShape) {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
         ov::pass::disable_remove_concat_zerodim_input(concat);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
     }
 }
 
@@ -66,14 +66,14 @@ TEST_F(TransformationTestsF, DisableRemoveConcatZeroDimInputPartiallyKnowShape) 
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
         ov::pass::disable_remove_concat_zerodim_input(concat);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
     }
 }
 
@@ -86,14 +86,14 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimInputSubgraph) {
         auto abs = std::make_shared<ov::opset8::Abs>(in_abs);
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, abs, input3}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input3, in_abs});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input3, in_abs});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input3});
     }
 }
 
@@ -108,14 +108,14 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimInputSubgraph2) {
         auto mul = std::make_shared<ov::opset8::Multiply>(in_mul, abs);
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{mul, input3}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input3, in_mul});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input3, in_mul});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input3});
     }
 }
 
@@ -130,13 +130,13 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimInputPartiallyKnowShape) {
             ov::PartialShape{0, ov::Dimension::dynamic(), ov::Dimension::dynamic()});
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input3});
     }
 }
 
@@ -148,14 +148,14 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimInputDynamicRank) {
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
     }
 }
 
@@ -171,14 +171,14 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimTwoInputs) {
             std::make_shared<ov::opset8::Parameter>(ov::element::f32, ov::PartialShape{1, ov::Dimension::dynamic(), 0});
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2, input3}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2, input3});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2, input3});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
 
     {
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1}, axis);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1});
     }
 }
 
@@ -190,7 +190,7 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimAllInputsEmpty) {
         int64_t axis = -1;
         auto concat = std::make_shared<ov::opset8::Concat>(ov::OutputVector{input1, input2}, axis);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{input1, input2});
 
         manager.register_pass<ov::pass::RemoveConcatZeroDimInput>();
     }
@@ -198,6 +198,6 @@ TEST_F(TransformationTestsF, RemoveConcatZeroDimAllInputsEmpty) {
     {
         auto concat =
             std::make_shared<ov::opset8::Constant>(ov::element::f32, ov::Shape{1, 0, 2}, std::vector<float>{});
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{concat}, ov::ParameterVector{});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/reshape_prelu_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/reshape_prelu_test.cpp
@@ -28,7 +28,7 @@ TEST(TransformationTests, ReshapePReluTest1) {
         auto slope = opset1::Constant::create(element::f32, Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -40,7 +40,7 @@ TEST(TransformationTests, ReshapePReluTest1) {
         auto slope = opset1::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -55,7 +55,7 @@ TEST(TransformationTests, ReshapePReluTest2) {
         auto slope = opset1::Constant::create(element::f32, Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -68,7 +68,7 @@ TEST(TransformationTests, ReshapePReluTest2) {
         auto slope = opset1::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -82,7 +82,7 @@ TEST(TransformationTests, ReshapePReluTest3) {
         auto slope = opset1::Constant::create(element::f32, Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -94,7 +94,7 @@ TEST(TransformationTests, ReshapePReluTest3) {
         auto slope = opset1::Constant::create(element::f32, Shape{1, 3, 1, 1}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -108,7 +108,7 @@ TEST(TransformationTests, ReshapePReluTest4) {
         auto slope = opset1::Constant::create(element::f32, Shape{}, {-2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         f_ref = f;
 
         pass::Manager m;
@@ -128,7 +128,7 @@ TEST(TransformationTests, ReshapePReluTest5) {
         auto slope = opset1::Constant::create(element::f32, Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         f_ref = f;
 
         pass::Manager m;
@@ -148,7 +148,7 @@ TEST(TransformationTests, ReshapePReluTest6) {
         auto slope = opset1::Constant::create(element::f32, Shape{4}, {-2.f, -1.f, -2.f, -1.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         f_ref = f;
 
         pass::Manager m;
@@ -172,7 +172,7 @@ TEST(TransformationTests, ReshapePReluTest7) {
             ov::op::TemporaryReplaceOutputType(input, element::f32).get(),
             ov::op::TemporaryReplaceOutputType(slope, element::f32).get());
 
-        f = std::make_shared<ov::Model>(NodeVector{relaxed_prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relaxed_prelu}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -188,7 +188,7 @@ TEST(TransformationTests, ReshapePReluTest7) {
             ov::op::TemporaryReplaceOutputType(input, element::f32).get(),
             ov::op::TemporaryReplaceOutputType(slope, element::f32).get());
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{relaxed_prelu}, ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(OutputVector{relaxed_prelu}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -202,7 +202,7 @@ TEST(TransformationTests, ReshapePReluTest8) {
         auto slope = opset1::Constant::create(element::f32, Shape{3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -214,7 +214,7 @@ TEST(TransformationTests, ReshapePReluTest8) {
         auto slope = opset1::Constant::create(element::f32, Shape{1, 3}, {-2.f, -1.f, -2.f});
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -228,7 +228,7 @@ TEST(TransformationTests, ReshapePReluTest9) {
         auto slope = std::make_shared<opset1::Parameter>(element::f32, PartialShape::dynamic(1));
         auto prelu = std::make_shared<opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input, slope});
+        f = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input, slope});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ReshapePRelu>();
@@ -244,7 +244,7 @@ TEST(TransformationTests, ReshapePReluTest9) {
         auto reshape = std::make_shared<opset1::Reshape>(slope, reshape_const, true);
         auto prelu = std::make_shared<opset1::PRelu>(input, reshape);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{prelu}, ParameterVector{input, slope});
+        f_ref = std::make_shared<ov::Model>(OutputVector{prelu}, ParameterVector{input, slope});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/rms_norm_decomposition_test.cpp
@@ -37,7 +37,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest1) {
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma, mul1);
         auto comp = std::make_shared<ov::opset10::Convert>(mul2, ov::element::f16);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{comp}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>();
     }
     {
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest1) {
                                                        {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
         auto rms = std::make_shared<ov::op::internal::RMS>(input, rms_const, 1e-5f, ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rms}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -74,7 +74,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest2) {
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma, mul1);
         auto comp = std::make_shared<ov::opset10::Convert>(mul2, ov::element::f16);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{comp}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>();
     }
     {
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest2) {
                                                        {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
         auto rms = std::make_shared<ov::op::internal::RMS>(input, rms_const, 1e-5f, ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rms}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -111,7 +111,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest3) {
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma, mul1);
         auto comp = std::make_shared<ov::opset10::Convert>(mul2, ov::element::f16);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{comp}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>();
     }
 }
@@ -135,7 +135,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest4) {
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma, mul1);
         auto comp = std::make_shared<ov::opset10::Convert>(mul2, ov::element::f16);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{comp}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>();
     }
 }
@@ -159,7 +159,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest5) {
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma, mul1);
         auto comp = std::make_shared<ov::opset10::Convert>(mul2, ov::element::f16);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{comp}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>();
     }
     {
@@ -169,7 +169,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest5) {
                                                        {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
         auto rms = std::make_shared<ov::op::internal::RMS>(input, rms_const, 1e-5f, ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rms}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
     }
 }
 
@@ -192,7 +192,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest6) {
                                                    {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma, mul1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul2}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>(false);
     }
     {
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest6) {
                                                        {0.029f, 0.014f, 0.003f, 0.013f, 0.015f, 0.009f});
         auto rms = std::make_shared<ov::op::internal::RMS>(input, rms_const, 1e-5f);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rms}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
     }
 }
 
@@ -228,7 +228,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest7) {
         auto gamma_convert = std::make_shared<ov::opset10::Convert>(gamma, ov::element::f32);
         auto mul2 = std::make_shared<ov::opset10::Multiply>(gamma_convert, mul1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{mul2}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input});
         manager.register_pass<RMSFusion>(false);
     }
     {
@@ -239,7 +239,7 @@ TEST_F(TransformationTestsF, RMSNormFusionTest7) {
         auto gamma_convert = std::make_shared<ov::opset10::Convert>(gamma, ov::element::f32);
         auto rms = std::make_shared<ov::op::internal::RMS>(input, gamma_convert, 1e-5f, ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{rms}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/sdpa_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/sdpa_fusion_test.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest1) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(qk, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 
@@ -47,7 +47,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest1) {
                                                                                    mask_const,
                                                                                    scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -68,7 +68,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest2) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(qk, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest2) {
                                                                                    mask_const,
                                                                                    scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -105,7 +105,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest3) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(qk, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 
@@ -118,7 +118,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest3) {
                                                                                    mask_const,
                                                                                    scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -138,7 +138,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest4) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(qk, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 
@@ -165,7 +165,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest5) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(mask_add, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value, mask});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value, mask});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 
@@ -173,7 +173,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest5) {
         const auto scale_const = ov::op::v0::Constant::create(element::f16, ov::Shape{}, std::vector<float>{1.0f});
         const auto sdpa =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, mask, scale_const, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value, mask});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value, mask});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -197,7 +197,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest6) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(mask_add, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value, mask});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value, mask});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 
@@ -205,7 +205,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest6) {
         const auto scale_const = ov::op::v0::Constant::create(element::f16, ov::Shape{}, std::vector<float>{1.0f});
         const auto sdpa =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, mask, scale_const, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value, mask});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value, mask});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -228,7 +228,7 @@ TEST_F(TransformationTestsF, SDPAFusionTest7) {
         const auto softmax = std::make_shared<ov::op::v8::Softmax>(qk, -1);
         const auto qkv = std::make_shared<ov::op::v0::MatMul>(softmax, value, false, false);
 
-        model = std::make_shared<ov::Model>(NodeVector{qkv}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{qkv}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAFusion>();
     }
 }

--- a/src/common/transformations/tests/common_optimizations/sdpa_scale_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/sdpa_scale_fusion_test.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest1) {
         const auto sdpa =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(q_scaled, k_scaled, v_scaled, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAScaleFusion>();
     }
 
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest1) {
                                                                                    new_mask_const,
                                                                                    new_scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -82,7 +82,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest2) {
                                                                                    sdpa_scale_const,
                                                                                    casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAScaleFusion>();
     }
 
@@ -95,7 +95,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest2) {
                                                                                    sdpa_mask_const,
                                                                                    new_scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest3) {
                                                                                    sdpa_scale_const,
                                                                                    casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAScaleFusion>();
     }
 
@@ -136,7 +136,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest3) {
                                                                                    sdpa_mask_const,
                                                                                    new_scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -167,7 +167,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest4) {
                                                                                    sdpa_scale_const,
                                                                                    casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
+        model = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
         manager.register_pass<ov::pass::SDPAScaleFusion>();
     }
 
@@ -179,7 +179,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest4) {
                                                                                    sdpa_mask_const,
                                                                                    new_scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -210,7 +210,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest5) {
                                                                                    sdpa_scale_const,
                                                                                    casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
+        model = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
         manager.register_pass<ov::pass::SDPAScaleFusion>();
     }
 
@@ -221,7 +221,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest5) {
                                                                                    sdpa_mask_const,
                                                                                    scale_dyn,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value, scale_dyn});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -249,7 +249,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest6) {
         const auto sdpa =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(q_scaled, k_scaled, v_scaled, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
         manager.register_pass<ov::pass::SDPAScaleFusion>();
     }
 
@@ -268,7 +268,7 @@ TEST_F(TransformationTestsF, SDPAScaleFusionTest6) {
                                                                                    new_mask_const,
                                                                                    new_scale_const,
                                                                                    casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{sdpa}, ParameterVector{query, key, value});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sdpa}, ParameterVector{query, key, value});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/tests/common_optimizations/shared_ops_optimization.cpp
@@ -302,7 +302,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTest) {
                                       shapeof7_i32_convert};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<pass::SharedOpOptimization>();
     }
     {
@@ -322,7 +322,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTest) {
                                       shapeof1_i32_convert};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -338,7 +338,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTestI64Only) {
         OutputVector inputs_of_concat{shapeof1_i64, shapeof2_i64, shapeof3_i64};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<pass::SharedOpOptimization>();
     }
     {
@@ -348,7 +348,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTestI64Only) {
         OutputVector inputs_of_concat{shapeof1_i64, shapeof1_i64, shapeof1_i64};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -360,7 +360,7 @@ TEST_F(SharedTransformationTestsF, Sharedv1Broadcasts) {
         auto broadcast_v1_1 = std::make_shared<v1::Broadcast>(input, target_shape, AutoBroadcastType::PDPD);
         auto broadcast_v1_2 = std::make_shared<v1::Broadcast>(input, target_shape);
         auto concat = std::make_shared<v0::Concat>(OutputVector{broadcast_v1_0, broadcast_v1_1, broadcast_v1_2}, 0);
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input, target_shape});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input, target_shape});
         manager.register_pass<pass::SharedOpOptimization>();
     }
     {
@@ -369,7 +369,7 @@ TEST_F(SharedTransformationTestsF, Sharedv1Broadcasts) {
         auto broadcast_v1_0 = std::make_shared<v1::Broadcast>(input, target_shape);
         auto broadcast_v1_1 = std::make_shared<v1::Broadcast>(input, target_shape, AutoBroadcastType::PDPD);
         auto concat = std::make_shared<v0::Concat>(OutputVector{broadcast_v1_0, broadcast_v1_1, broadcast_v1_0}, 0);
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input, target_shape});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input, target_shape});
     }
 }
 
@@ -381,7 +381,7 @@ TEST_F(SharedTransformationTestsF, Sharedv3Broadcasts) {
         auto broadcast_v1_1 = std::make_shared<v3::Broadcast>(input, target_shape, BroadcastType::BIDIRECTIONAL);
         auto broadcast_v1_2 = std::make_shared<v3::Broadcast>(input, target_shape);
         auto concat = std::make_shared<v0::Concat>(OutputVector{broadcast_v1_0, broadcast_v1_1, broadcast_v1_2}, 0);
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input, target_shape});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input, target_shape});
         manager.register_pass<pass::SharedOpOptimization>();
     }
     {
@@ -390,7 +390,7 @@ TEST_F(SharedTransformationTestsF, Sharedv3Broadcasts) {
         auto broadcast_v1_0 = std::make_shared<v3::Broadcast>(input, target_shape);
         auto broadcast_v1_1 = std::make_shared<v3::Broadcast>(input, target_shape, BroadcastType::BIDIRECTIONAL);
         auto concat = std::make_shared<v0::Concat>(OutputVector{broadcast_v1_0, broadcast_v1_1, broadcast_v1_0}, 0);
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input, target_shape});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input, target_shape});
     }
 }
 
@@ -418,7 +418,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTestI32Only) {
                                       shapeof5_i32_convert};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<pass::SharedOpOptimization>();
     }
     {
@@ -435,7 +435,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTestI32Only) {
                                       shapeof1_i32_convert};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -465,7 +465,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTestMixed) {
                                       shapeof7_i32_convert};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<pass::SharedOpOptimization>();
     }
     {
@@ -485,7 +485,7 @@ TEST_F(SharedTransformationTestsF, SharedShapeOfTestMixed) {
                                       shapeof3_i32_convert};
 
         auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -526,7 +526,7 @@ std::shared_ptr<Model> createModelWithShapes(const Shape& input_shape,
     }
 
     auto concat = std::make_shared<v0::Concat>(inputs_of_concat, 0);
-    return std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
 }
 }  // namespace
 

--- a/src/common/transformations/tests/common_optimizations/shuffle_channels_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/shuffle_channels_fusion_test.cpp
@@ -52,13 +52,13 @@ public:
             auto reshape_before = std::make_shared<opset6::Reshape>(input0, shape_reshape_before, true);
             auto permute = std::make_shared<opset6::Transpose>(reshape_before, permutation);
             auto reshape_after = std::make_shared<opset6::Reshape>(permute, shape_reshape_after, true);
-            f = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{input0});
+            f = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{input0});
         }
 
         if (values.fuse_happened == FuseHappened::YES) {
             auto input0 = std::make_shared<opset6::Parameter>(element::f32, values.inputPartialShape);
             auto shuffle_channels = std::make_shared<opset6::ShuffleChannels>(input0, 1, values.reshape_before_val[1]);
-            f_ref = std::make_shared<ov::Model>(NodeVector{shuffle_channels}, ParameterVector{input0});
+            f_ref = std::make_shared<ov::Model>(OutputVector{shuffle_channels}, ParameterVector{input0});
         } else {
             f_ref = f;
         }

--- a/src/common/transformations/tests/common_optimizations/simplify_second_input_of_reshape_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/simplify_second_input_of_reshape_test.cpp
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest1) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -51,7 +51,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest1) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -68,7 +68,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest2) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(fq, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -77,7 +77,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest2) {
         auto fq = fake_quantize(data);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(fq, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest3) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant_1, constant_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -102,7 +102,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest3) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{4}, {0, 0, 12, 64});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -120,7 +120,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest4) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant_1, constant_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(fq, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -129,7 +129,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest4) {
         auto fq = fake_quantize(data);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{4}, {0, 0, 12, 64});
         auto reshape = std::make_shared<opset7::Reshape>(fq, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest5) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -153,7 +153,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest5) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, -1});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -169,7 +169,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest6) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -177,7 +177,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest6) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, -1});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -194,7 +194,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest7) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{constant_1, constant_2, gather_op}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest7) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{4}, {64, 2, 0, 0});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -220,7 +220,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest8) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{constant_1, constant_2, gather_op, constant_3}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -228,7 +228,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest8) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{4}, {64, 2, 0, 64});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -244,7 +244,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest9) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -264,7 +264,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest10) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op_1, gather_op_2, gather_op_3}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -278,7 +278,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest10) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{constant, gather_op_2, gather_op_3}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -299,7 +299,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest11) {
             0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -307,7 +307,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest11) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto constant = opset7::Constant::create(element::i64, Shape{4}, {0, 64, 0, 128});
         auto reshape = std::make_shared<opset7::Reshape>(data, constant, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -325,7 +325,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest12) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant_1, constant_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(gelu, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -334,7 +334,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest12) {
         auto gelu = std::make_shared<opset7::Gelu>(data);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{4}, {0, 0, 12, 64});
         auto reshape = std::make_shared<opset7::Reshape>(gelu, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -350,7 +350,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest13) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -358,7 +358,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest13) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i32, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -374,7 +374,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest14) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -382,7 +382,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest14) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -399,7 +399,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest15) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(gelu, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -408,7 +408,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest15) {
         auto gelu = std::make_shared<opset7::Gelu>(data);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{4}, {0, 0, 12, 64});
         auto reshape = std::make_shared<opset7::Reshape>(gelu, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -425,7 +425,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest16) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op_1, gather_op_2, constant}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -433,7 +433,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest16) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -456,7 +456,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest17) {
             std::make_shared<opset7::Concat>(OutputVector{gather_op_1, constant_1, constant_2, gather_op_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data_2, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data_1, data_2});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -480,7 +480,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest18) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, constant, gather_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -495,7 +495,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest18) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, constant, gather_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -517,7 +517,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest19) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, constant, gather_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -532,7 +532,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest19) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, constant, gather_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -562,7 +562,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest20) {
             std::make_shared<opset7::Concat>(OutputVector{gather_1, constant_1, gather_2, constant_2, gather_3}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data, data_copy});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, data_copy});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -583,7 +583,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest20) {
             std::make_shared<opset7::Concat>(OutputVector{gather_1, constant_1, gather_2, constant_2, gather_3}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data, data_copy});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data, data_copy});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -599,7 +599,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest21) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, -1);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -607,7 +607,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTest21) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES);
 }
@@ -623,7 +623,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTestFalseSpecialZero) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, -1);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -631,7 +631,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTestFalseSpecialZero) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CONST_VALUES);
@@ -648,7 +648,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTestFalseSpecialZeroZer
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_op, constant}, -1);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SimplifySecondInputOfReshape>();
     }
@@ -656,7 +656,7 @@ TEST_F(TransformationTestsF, SimplifySecondInputOfReshapeTestFalseSpecialZeroZer
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto reshape_pattern = opset7::Constant::create(element::i64, Shape{3}, {0, 0, 768});
         auto reshape = std::make_shared<opset7::Reshape>(data, reshape_pattern, true);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::ATTRIBUTES);
     comparator.enable(FunctionsComparator::CONST_VALUES);

--- a/src/common/transformations/tests/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/tests/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -61,7 +61,7 @@ TEST_F(TransformationTestsF, ShapeSubGraphTestGatherv7) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{unsqueeze_1, unsqueeze_2, const_1, const_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SimplifyShapeOfSubGraph>();
     }
     {
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, ShapeSubGraphTestGatherv7) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, const_1, const_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -101,7 +101,7 @@ TEST_F(TransformationTestsF, ShapeSubGraphTestGatherv8) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{unsqueeze_1, unsqueeze_2, const_1, const_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SimplifyShapeOfSubGraph>();
     }
     {
@@ -116,7 +116,7 @@ TEST_F(TransformationTestsF, ShapeSubGraphTestGatherv8) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, const_1, const_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -138,14 +138,14 @@ TEST_F(TransformationTestsF, ShapeNopSubGraphTestGatherv7) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{unsqueeze_1, unsqueeze_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SimplifyShapeOfSubGraph>();
     }
     {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto shape_op_1 = std::make_shared<opset7::ShapeOf>(data);
         auto reshape = std::make_shared<opset7::Reshape>(data, shape_op_1, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -167,14 +167,14 @@ TEST_F(TransformationTestsF, ShapeNopSubGraphTestGatherv8) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{unsqueeze_1, unsqueeze_2}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SimplifyShapeOfSubGraph>();
     }
     {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto shape_op_1 = std::make_shared<opset7::ShapeOf>(data);
         auto reshape = std::make_shared<opset7::Reshape>(data, shape_op_1, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -192,7 +192,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNegative) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{constant_1, constant_2, unsqueeze}, 0);
 
         auto reshape = std::make_shared<opset7::Reshape>(data, concat, true);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::GroupedGatherElimination>();
     }
 }
@@ -211,7 +211,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesSameSi
 
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, gather_2}, 0);
 
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
         manager.register_pass<pass::GroupedGatherElimination>();
     }
     {
@@ -226,7 +226,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesSameSi
 
         auto gather = std::make_shared<opset8::Gather>(shape_op, joint_indices, axis);
 
-        model_ref = std::make_shared<Model>(NodeVector{gather}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
     }
 }
 
@@ -244,7 +244,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesCanCon
 
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, gather_2}, 0);
 
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
         manager.register_pass<pass::GroupedGatherElimination>();
     }
     {
@@ -259,7 +259,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesCanCon
 
         auto gather = std::make_shared<opset8::Gather>(shape_op, joint_indices, axis);
 
-        model_ref = std::make_shared<Model>(NodeVector{gather}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
     }
 }
 
@@ -277,7 +277,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesCanCon
 
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, gather_2}, 0);
 
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
         manager.register_pass<pass::GroupedGatherElimination>();
     }
     {
@@ -292,7 +292,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesCanCon
 
         auto gather = std::make_shared<opset8::Gather>(shape_op, joint_indices, axis);
 
-        model_ref = std::make_shared<Model>(NodeVector{gather}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
     }
 }
 
@@ -310,7 +310,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationCompatibleIndicies_1) {
 
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, gather_2}, 0);
 
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
         manager.register_pass<pass::GroupedGatherElimination>();
     }
     {
@@ -321,7 +321,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationCompatibleIndicies_1) {
 
         auto gather = std::make_shared<opset8::Gather>(shape_op, joint_indices, axis);
 
-        model_ref = std::make_shared<Model>(NodeVector{gather}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
     }
 }
 
@@ -339,7 +339,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationCompatibleIndicies_2) {
 
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, gather_2}, 0);
 
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
         manager.register_pass<pass::GroupedGatherElimination>();
     }
     {
@@ -350,7 +350,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationCompatibleIndicies_2) {
 
         auto gather = std::make_shared<opset8::Gather>(shape_op, joint_indices, axis);
 
-        model_ref = std::make_shared<Model>(NodeVector{gather}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{data});
     }
 }
 
@@ -368,7 +368,7 @@ TEST_F(TransformationTestsF, GroupedGatherEliminationNotCompatibleIndiciesCannot
 
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather_1, gather_2}, 0);
 
-        model = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
         manager.register_pass<pass::GroupedGatherElimination>();
     }
 }
@@ -385,7 +385,7 @@ TEST_F(TransformationTestsF, ConcatAbsCombo) {
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather, minus_one, one, minus_one}, 0);
         auto abs = std::make_shared<opset7::Abs>(concat);
 
-        model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{abs}, ParameterVector{data});
         manager.register_pass<pass::AbsSinking>();
     }
     {
@@ -398,7 +398,7 @@ TEST_F(TransformationTestsF, ConcatAbsCombo) {
         auto one2 = opset7::Constant::create(element::i64, {1}, {1});
         auto concat = std::make_shared<opset7::Concat>(OutputVector{gather, one0, one1, one2}, 0);
 
-        model_ref = std::make_shared<Model>(NodeVector{concat}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{concat}, ParameterVector{data});
     }
 }
 
@@ -409,7 +409,7 @@ TEST_F(TransformationTestsF, SingleAbsOnShape) {
         auto shape_op = std::make_shared<opset7::ShapeOf>(data);
         auto abs = std::make_shared<opset7::Abs>(shape_op);
 
-        model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{abs}, ParameterVector{data});
         manager.register_pass<pass::AbsSinking>();
     }
     {
@@ -426,7 +426,7 @@ TEST_F(TransformationTestsF, AbsInTheUnknown) {
         auto data = std::make_shared<opset7::Parameter>(element::f32, data_shape);
         auto abs = std::make_shared<opset7::Abs>(data);
 
-        model = std::make_shared<Model>(NodeVector{abs}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{abs}, ParameterVector{data});
         manager.register_pass<pass::AbsSinking>();
     }
 }

--- a/src/common/transformations/tests/common_optimizations/skip_gather_before_transpose_and_reshape_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/skip_gather_before_transpose_and_reshape_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeStaticShapeFpDat
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
     {
@@ -45,7 +45,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeStaticShapeFpDat
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeStaticShapeIntDa
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
     {
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeStaticShapeIntDa
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -95,7 +95,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeDynamicShapeStat
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
     {
@@ -107,7 +107,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeDynamicShapeStat
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -126,7 +126,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeIncorrectGatherA
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
 }
@@ -146,7 +146,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeDynamicBatch) {
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
 }
@@ -166,7 +166,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeDynamicRank) {
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
 }
@@ -186,7 +186,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeBatchNotEqualTo1
         auto reshape_const = opset8::Constant::create(element::i64, {1}, {-1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
 }
@@ -206,7 +206,7 @@ TEST_F(TransformationTestsF, SkipGatherBeforeTransposeAndReshapeUnsuitableReshap
         auto reshape_const = opset8::Constant::create(element::i64, {2}, {0, -1});
         auto reshape = std::make_shared<opset8::Reshape>(transpose, reshape_const, true);
 
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<ov::pass::SkipGatherBeforeTransposeAndReshape>();
     }
 }

--- a/src/common/transformations/tests/common_optimizations/softmax_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/softmax_fusion.cpp
@@ -34,7 +34,7 @@ TEST_P(SoftmaxFusionFixture, SoftmaxFusion) {
         auto reduce_sum_axis = opset6::Constant::create(element::i64, Shape{}, {reduce_sum_axis_val});
         auto reduce_sum = std::make_shared<opset6::ReduceSum>(exp, reduce_sum_axis);
         auto div = std::make_shared<opset6::Divide>(exp, reduce_sum);
-        f = std::make_shared<Model>(NodeVector{div}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{div}, ParameterVector{data});
 
         auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         pass::Manager m;
@@ -50,7 +50,7 @@ TEST_P(SoftmaxFusionFixture, SoftmaxFusion) {
         if (reduce_max_axis_val < 0)
             reduce_max_axis_val += shape.size();
         auto softmax = std::make_shared<opset6::Softmax>(data, reduce_max_axis_val);
-        f_ref = std::make_shared<Model>(NodeVector{softmax}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{softmax}, ParameterVector{data});
     }
 
     auto fc =
@@ -79,7 +79,7 @@ TEST_P(SoftmaxFusionSimplePatternFixture, SoftmaxFusionSimplePatternTest) {
         auto reduce_axis = opset6::Constant::create(element::i64, Shape{}, {reduce_axis_val});
         auto reduce_sum = std::make_shared<opset6::ReduceSum>(exp, reduce_axis, true);
         auto div = std::make_shared<opset6::Divide>(exp, reduce_sum);
-        f = std::make_shared<Model>(NodeVector{div}, ParameterVector{data});
+        f = std::make_shared<Model>(OutputVector{div}, ParameterVector{data});
 
         auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         pass::Manager m;
@@ -95,7 +95,7 @@ TEST_P(SoftmaxFusionSimplePatternFixture, SoftmaxFusionSimplePatternTest) {
         if (reduce_axis_val < 0)
             reduce_axis_val += shape.size();
         auto softmax = std::make_shared<opset6::Softmax>(data, reduce_axis_val);
-        f_ref = std::make_shared<Model>(NodeVector{softmax}, ParameterVector{data});
+        f_ref = std::make_shared<Model>(OutputVector{softmax}, ParameterVector{data});
     }
 
     auto fc =
@@ -134,7 +134,7 @@ TEST_P(NegativeSoftmaxFusionFixture, NegativeSoftmaxFusion) {
         opset6::Constant::create(element::i64, Shape{reduce_sum_axes_val.size()}, reduce_sum_axes_val);
     auto reduce_sum = std::make_shared<opset6::ReduceSum>(exp, reduce_sum_axes);
     auto div = std::make_shared<opset6::Divide>(exp, reduce_sum);
-    f = std::make_shared<Model>(NodeVector{div}, ParameterVector{data});
+    f = std::make_shared<Model>(OutputVector{div}, ParameterVector{data});
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
     pass::Manager m;

--- a/src/common/transformations/tests/common_optimizations/softplus_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/softplus_fusion_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, SoftPlusFusing) {
         auto add = std::make_shared<opset4::Add>(exp, input_const);
         auto log = std::make_shared<opset4::Log>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{log}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{log}, ParameterVector{input0});
 
         manager.register_pass<ov::pass::SoftPlusFusion>();
     }
@@ -36,7 +36,7 @@ TEST_F(TransformationTestsF, SoftPlusFusing) {
         auto data = std::make_shared<opset4::Parameter>(element::f32, Shape{3, 1, 2});
         auto softplus = std::make_shared<opset4::SoftPlus>(data);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softplus}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softplus}, ParameterVector{data});
     }
 }
 
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, SoftPlusFusingDynamic) {
         auto add = std::make_shared<opset4::Add>(exp, input_const);
         auto log = std::make_shared<opset4::Log>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{log}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{log}, ParameterVector{input0});
 
         manager.register_pass<ov::pass::SoftPlusFusion>();
     }
@@ -57,7 +57,7 @@ TEST_F(TransformationTestsF, SoftPlusFusingDynamic) {
         auto data = std::make_shared<opset4::Parameter>(element::f32, PartialShape::dynamic(1));
         auto softplus = std::make_shared<opset4::SoftPlus>(data);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softplus}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softplus}, ParameterVector{data});
     }
 }
 
@@ -69,7 +69,7 @@ TEST_F(TransformationTestsF, SoftPlusFusingNegative) {
         auto add = std::make_shared<opset4::Add>(exp, input_const);
         auto log = std::make_shared<opset4::Log>(add);
 
-        model = std::make_shared<ov::Model>(NodeVector{log}, ParameterVector{input0});
+        model = std::make_shared<ov::Model>(OutputVector{log}, ParameterVector{input0});
 
         manager.register_pass<ov::pass::SoftPlusFusion>();
     }
@@ -81,6 +81,6 @@ TEST_F(TransformationTestsF, SoftPlusFusingNegative) {
         auto add = std::make_shared<opset4::Add>(exp, input_const);
         auto log = std::make_shared<opset4::Log>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{log}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{log}, ParameterVector{input0});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/space_to_batch_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/space_to_batch_fusion.cpp
@@ -37,7 +37,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionTranspose) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionTranspose) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 1, 1}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {2, 2, 3, 3}));
 
-        model_ref = std::make_shared<Model>(NodeVector{space_to_batch}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{space_to_batch}, ParameterVector{data});
     }
 }
 
@@ -69,7 +69,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionTransposePad12) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -82,7 +82,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionTransposePad12) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 1, 1}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {2, 2, 3, 3}));
 
-        model_ref = std::make_shared<Model>(NodeVector{space_to_batch}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{space_to_batch}, ParameterVector{data});
     }
 }
 
@@ -101,7 +101,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionTransposeNegativePads) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionReshape) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -137,7 +137,7 @@ TEST_F(TransformationTestsF, SpaceToBatchFusionReshape) {
                                                    op::v0::Constant::create(element::i64, Shape{4}, {1, 1, 1, 1}),
                                                    op::v0::Constant::create(element::i64, Shape{4}, {2, 2, 3, 3}));
 
-        model_ref = std::make_shared<Model>(NodeVector{space_to_batch}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{space_to_batch}, ParameterVector{data});
     }
 }
 
@@ -156,7 +156,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidTransposePerm) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -175,7 +175,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidTransposePerm) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
     }
 }
 
@@ -194,7 +194,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidPad) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -213,7 +213,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidPad) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
     }
 }
 
@@ -232,7 +232,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidMode) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -251,7 +251,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidMode) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
     }
 }
 
@@ -271,7 +271,7 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidRank) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{5}, {1, 0, 2, 3, 4}));
-        model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SpaceToBatchFusion>();
     }
@@ -291,6 +291,6 @@ TEST_F(TransformationTestsF, NegativeSpaceToBatchFusionInvalidRank) {
         auto trans_after =
             std::make_shared<opset6::Transpose>(space_to_depth,
                                                 op::v0::Constant::create(element::i64, Shape{5}, {1, 0, 2, 3, 4}));
-        model_ref = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/split_concat_pair_to_interpolate_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/split_concat_pair_to_interpolate_fusion_test.cpp
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D1) {
         }
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -74,7 +74,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D1) {
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -98,7 +98,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D2) {
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -133,7 +133,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D2) {
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -157,7 +157,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D1) {
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -192,7 +192,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D1) {
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -215,7 +215,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2) {
         }
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -250,7 +250,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2) {
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -270,7 +270,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionTwoSplitsOneConca
         OutputVector concat_inputs_vec{split1->output(0), split1->output(1), split2->output(0), split2->output(1)};
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input1, input2});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>();
     }
     {
@@ -286,7 +286,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionTwoSplitsOneConca
         OutputVector concat_inputs_vec{split1->output(0), split1->output(1), split2->output(0), split2->output(1)};
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input1, input2});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input1, input2});
     }
 }
 
@@ -310,7 +310,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D1WithCon
         }
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>();
     }
     {
@@ -332,7 +332,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D1WithCon
         auto sizes_node = opset8::Constant::create(element::i64, {1}, std::vector<int64_t>{target_size});
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -356,7 +356,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D2WithCon
         }
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>();
     }
     {
@@ -378,7 +378,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D2WithCon
         auto sizes_node = opset8::Constant::create(element::i64, {1}, std::vector<int64_t>{target_size});
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -403,7 +403,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D1WithCon
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>();
     }
     {
@@ -425,7 +425,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D1WithCon
         auto sizes_node = opset8::Constant::create(element::i64, {1}, std::vector<int64_t>{target_size});
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -450,7 +450,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2WithCon
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>();
     }
     {
@@ -472,7 +472,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2WithCon
         auto sizes_node = opset8::Constant::create(element::i64, {1}, std::vector<int64_t>{target_size});
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -495,7 +495,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D1Dynamic
         }
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -530,7 +530,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D1Dynamic
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -554,7 +554,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D2Dynamic
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -589,7 +589,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial2D2Dynamic
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -617,7 +617,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D1Dynamic
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -652,7 +652,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D1Dynamic
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -679,7 +679,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2Dynamic
         }
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>(false);
     }
     {
@@ -714,7 +714,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSpatial3D2Dynamic
 
         auto interpolate =
             std::make_shared<opset8::Interpolate>(input, cast_mul_result_to_int, scales_node, axis_node, attrs);
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -737,7 +737,7 @@ TEST_F(TransformationTestsF, SplitConcatPairToInterpolateFusionSplitWithEmptyPor
         OutputVector concat_inputs_vec{split1->output(0), concat_const1, concat_const2};
 
         auto concat = std::make_shared<opset8::Concat>(concat_inputs_vec, axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input1});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input1});
         manager.register_pass<ov::pass::SplitConcatPairToInterpolateFusion>();
     }
 }

--- a/src/common/transformations/tests/common_optimizations/split_squeeze_concat_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/split_squeeze_concat_fusion_test.cpp
@@ -35,7 +35,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusion) {
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(false);
     }
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusion) {
             opset7::Constant::create<int64_t>(element::i64, Shape{5}, {1, 2, 640, 20, 2 * (int64_t)num_splits});
         auto reshape = std::make_shared<opset7::Reshape>(transpose, reshape_shape, false);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 }
 
@@ -67,7 +67,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionSqueezeWithoutAxesInput) {
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(false);
     }
@@ -80,7 +80,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionSqueezeWithoutAxesInput) {
             opset7::Constant::create<int64_t>(element::i64, Shape{5}, {3, 2, 640, 20, 2 * (int64_t)num_splits});
         auto reshape = std::make_shared<opset7::Reshape>(transpose, reshape_shape, false);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 }
 
@@ -100,8 +100,8 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeCaseNotAllSplitOutp
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(false);
     }
@@ -119,7 +119,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeCaseNotAllSplitOutp
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -141,8 +141,8 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeCaseSplitOutputsGoI
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(false);
     }
@@ -162,7 +162,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeCaseSplitOutputsGoI
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -182,8 +182,8 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeCaseSplitAxisDiffer
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(false);
     }
@@ -201,7 +201,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeCaseSplitAxisDiffer
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 4);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
     }
 }
 
@@ -220,7 +220,7 @@ TEST_F(TransformationTestsF, SplitSqueezeConcatFusionNegativeSqueezeWithoutAxesI
 
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, 3);
 
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(false);
     }
@@ -255,7 +255,7 @@ TEST_P(SplitReshapeConcatFusion, SplitSqueezeConcatFusion) {
             squeeze_vec.push_back(std::make_shared<opset7::Reshape>(split->output(i), reshaped_shape_node, true));
         }
         auto concat = std::make_shared<opset7::Concat>(squeeze_vec, params.concat_axis);
-        model = std::make_shared<ov::Model>(NodeVector{concat}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{concat}, ParameterVector{input});
         manager.register_pass<ov::pass::SplitSqueezeConcatFusion>(true);
     }
 
@@ -272,7 +272,7 @@ TEST_P(SplitReshapeConcatFusion, SplitSqueezeConcatFusion) {
         auto reshape_shape_node = opset7::Constant::create(element::i64, Shape{reshape_shape.size()}, reshape_shape);
         auto reshape = std::make_shared<opset7::Reshape>(transpose, reshape_shape_node, false);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);

--- a/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
+++ b/src/common/transformations/tests/common_optimizations/strides_optimization.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, StridesOptimization1) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -58,7 +58,7 @@ TEST_F(TransformationTestsF, StridesOptimization1) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
     }
 }
 
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, StridesOptimization2) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -101,7 +101,7 @@ TEST_F(TransformationTestsF, StridesOptimization2) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
     }
 }
 
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, StridesOptimization3) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -144,7 +144,7 @@ TEST_F(TransformationTestsF, StridesOptimization3) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
     }
 }
 
@@ -178,7 +178,7 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_3}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_3}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -208,7 +208,7 @@ TEST_F(TransformationTestsF, StridesOptimization4) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_3}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_3}, ParameterVector{data});
     }
 }
 
@@ -235,7 +235,7 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -259,7 +259,7 @@ TEST_F(TransformationTestsF, StridesOptimization5) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_2}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_2}, ParameterVector{data});
     }
 }
 
@@ -298,7 +298,7 @@ TEST_F(TransformationTestsF, StridesOptimization6) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_4}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_4}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -332,7 +332,7 @@ TEST_F(TransformationTestsF, StridesOptimization6) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_4}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_4}, ParameterVector{data});
     }
 }
 
@@ -374,7 +374,7 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_3, conv_4}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{conv_3, conv_4}, ParameterVector{data});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -410,7 +410,7 @@ TEST_F(TransformationTestsF, StridesOptimization7) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_3, conv_4}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_3, conv_4}, ParameterVector{data});
     }
 }
 
@@ -451,7 +451,7 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_3}, ParameterVector{data, data_2});
+        model = std::make_shared<ov::Model>(OutputVector{conv_3}, ParameterVector{data, data_2});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -491,7 +491,7 @@ TEST_F(TransformationTestsF, StridesOptimization8) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_3}, ParameterVector{data, data_2});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_3}, ParameterVector{data, data_2});
     }
 }
 
@@ -542,7 +542,7 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model = std::make_shared<ov::Model>(NodeVector{conv_3}, ParameterVector{data, data_2, data_3});
+        model = std::make_shared<ov::Model>(OutputVector{conv_3}, ParameterVector{data, data_2, data_3});
         manager.register_pass<ov::pass::StridesOptimization>();
     }
     {
@@ -597,6 +597,6 @@ TEST_F(TransformationTestsF, StridesOptimization9) {
                                                                 CoordinateDiff{},
                                                                 Strides{});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv_3}, ParameterVector{data, data_2, data_3});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv_3}, ParameterVector{data, data_2, data_3});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/subtract_fusion.cpp
+++ b/src/common/transformations/tests/common_optimizations/subtract_fusion.cpp
@@ -29,7 +29,7 @@ TEST(TransformationTests, SubtractFusionMultiply) {
         auto mul = std::make_shared<opset1::Multiply>(data2, mul_constant);
         auto add = std::make_shared<opset1::Add>(data1, mul);
 
-        f = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data1, data2});
+        f = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data1, data2});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -43,7 +43,7 @@ TEST(TransformationTests, SubtractFusionMultiply) {
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
         auto divide = std::make_shared<opset1::Subtract>(data1, data2);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data1, data2});
+        f_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
     }
 
     const auto res = FunctionsComparator::with_default()
@@ -62,7 +62,7 @@ TEST(TransformationTests, SubtractFusionMultiplyNegative) {
         auto mul = std::make_shared<opset1::Multiply>(data2, mul_constant);
         auto add = std::make_shared<opset1::Add>(data1, mul);
 
-        f = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data1, data2});
+        f = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data1, data2});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -78,7 +78,7 @@ TEST(TransformationTests, SubtractFusionMultiplyNegative) {
         auto mul = std::make_shared<opset1::Multiply>(data2, mul_constant);
         auto add = std::make_shared<opset1::Add>(data1, mul);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data1, data2});
+        f_ref = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data1, data2});
     }
 
     const auto res = FunctionsComparator::with_default()
@@ -96,7 +96,7 @@ TEST(TransformationTests, SubtractFusionNeg) {
         auto neg = std::make_shared<opset1::Negative>(data2);
         auto add = std::make_shared<opset1::Add>(neg, data1);
 
-        f = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data1, data2});
+        f = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data1, data2});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -110,7 +110,7 @@ TEST(TransformationTests, SubtractFusionNeg) {
         auto data2 = std::make_shared<opset1::Parameter>(element::f32, Shape{3, 1, 2});
         auto divide = std::make_shared<opset1::Subtract>(data1, data2);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{data1, data2});
+        f_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{data1, data2});
     }
 
     const auto res = FunctionsComparator::with_default()

--- a/src/common/transformations/tests/common_optimizations/swish_fusion_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/swish_fusion_test.cpp
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, SwishFusionWithBeta) {
         auto add = std::make_shared<opset4::Add>(exp, constant);
         auto div = std::make_shared<opset4::Divide>(input, add);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input, beta});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input, beta});
 
         manager.register_pass<ov::pass::SwishFusion>();
     }
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, SwishFusionWithBeta) {
         auto beta = std::make_shared<opset4::Parameter>(element::f32, Shape{});
         auto swish = std::make_shared<opset4::Swish>(input, beta);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{swish}, ParameterVector{input, beta});
+        model_ref = std::make_shared<ov::Model>(OutputVector{swish}, ParameterVector{input, beta});
     }
 }
 
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, SwishFusionWithoutBeta) {
         auto add = std::make_shared<opset4::Add>(exp, constant);
         auto div = std::make_shared<opset4::Divide>(input, add);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SwishFusion>();
     }
@@ -61,7 +61,7 @@ TEST_F(TransformationTestsF, SwishFusionWithoutBeta) {
         auto input = std::make_shared<opset4::Parameter>(element::f16, PartialShape::dynamic(1));
         auto swish = std::make_shared<opset4::Swish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{swish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{swish}, ParameterVector{input});
     }
 }
 
@@ -74,7 +74,7 @@ TEST_F(TransformationTestsF, SwishFusionWithoutBetaNonOneAddConstant) {
         auto add = std::make_shared<opset4::Add>(exp, constant);
         auto div = std::make_shared<opset4::Divide>(input, add);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SwishFusion>();
     }
@@ -87,9 +87,9 @@ TEST_F(TransformationTestsF, SwishFusionWithoutBetaNonOneAddConstant) {
         auto add = std::make_shared<opset4::Add>(exp, constant);
         auto div = std::make_shared<opset4::Divide>(input, add);
 
-        model = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
     }
 }
 
@@ -99,7 +99,7 @@ TEST_F(TransformationTestsF, SwishFusionWithSigmoid) {
         auto sig = std::make_shared<opset4::Sigmoid>(input);
         auto mul = std::make_shared<opset4::Multiply>(input, sig);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SwishFusion>();
     }
@@ -108,7 +108,7 @@ TEST_F(TransformationTestsF, SwishFusionWithSigmoid) {
         auto input = std::make_shared<opset4::Parameter>(element::f16, PartialShape::dynamic(1));
         auto swish = std::make_shared<opset4::Swish>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{swish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{swish}, ParameterVector{input});
     }
 }
 
@@ -120,7 +120,7 @@ TEST_F(TransformationTestsF, SwishFusionWithSigmoidWithBeta) {
         auto sig = std::make_shared<opset4::Sigmoid>(mul_beta);
         auto mul = std::make_shared<opset4::Multiply>(input, sig);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input, beta});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input, beta});
 
         manager.register_pass<ov::pass::SwishFusion>();
     }
@@ -130,7 +130,7 @@ TEST_F(TransformationTestsF, SwishFusionWithSigmoidWithBeta) {
         auto beta = std::make_shared<opset4::Parameter>(element::f16, Shape{});
         auto swish = std::make_shared<opset4::Swish>(input, beta);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{swish}, ParameterVector{input, beta});
+        model_ref = std::make_shared<ov::Model>(OutputVector{swish}, ParameterVector{input, beta});
     }
 }
 
@@ -143,7 +143,7 @@ TEST_F(TransformationTestsF, SwishFusionWithSigmoidWithBetaConstant) {
         auto sig = std::make_shared<opset4::Sigmoid>(mul_beta);
         auto mul = std::make_shared<opset4::Multiply>(input, sig);
 
-        model = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
 
         manager.register_pass<ov::pass::SwishFusion>();
     }
@@ -153,6 +153,6 @@ TEST_F(TransformationTestsF, SwishFusionWithSigmoidWithBetaConstant) {
         auto beta = opset4::Constant::create(element::f16, Shape{}, {2.0});
         auto swish = std::make_shared<opset4::Swish>(input, beta);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{swish}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{swish}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul) {
         auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
         auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {2, 0, 1});
         auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
-        model = std::make_shared<Model>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul) {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -61,14 +61,14 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_TransposedA) {
         auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
         auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {2, 0, 1});
         auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
-        model = std::make_shared<Model>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2, true, false);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -87,14 +87,14 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_TransposedB) {
         auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
         auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 0, 2});
         auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
-        model = std::make_shared<Model>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -113,14 +113,14 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_TransposedAB) 
         auto reshape_after = std::make_shared<ov::op::v1::Reshape>(matmul, const_reshape_after, false);
         auto const_tranpose_after = ov::op::v0::Constant::create(element::i32, Shape{3}, {1, 0, 2});
         auto tranpose_after = std::make_shared<ov::op::v1::Transpose>(reshape_after, const_tranpose_after);
-        model = std::make_shared<Model>(NodeVector{tranpose_after}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{tranpose_after}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
     {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_1, data_2, true, false);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -131,7 +131,7 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_Einsum) {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2}, "kl,mlj->mkj");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::EinsumDecomposition>();
         manager.register_pass<ov::pass::TransposeReshapeEliminationForMatmul>();
     }
@@ -153,6 +153,6 @@ TEST_F(TransformationTestsF, TransposeReshapeEliminationForMatMul_Einsum) {
             std::make_shared<ov::op::v0::Constant>(element::i64, Shape{data_shape_1.size()}, data_shape_1);
         auto reshape = std::make_shared<ov::op::v1::Reshape>(broadcast_1, shape_constant, false);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, broadcast_2, false, false);
-        model_ref = std::make_shared<Model>(NodeVector{matmul}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{matmul}, ParameterVector{data_1, data_2});
     }
 }

--- a/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_sinking_test.cpp
@@ -61,7 +61,7 @@ public:
                                                            test_case.reduce_axes);
             auto reduce = std::make_shared<opset6::ReduceMean>(fq, axes, test_case.reduce_keep_dims);
 
-            f = std::make_shared<ov::Model>(NodeVector{reduce}, ParameterVector{input});
+            f = std::make_shared<ov::Model>(OutputVector{reduce}, ParameterVector{input});
         }
 
         {
@@ -83,7 +83,7 @@ public:
                                                             test_case.ex_transpose_order);
             auto transpose = std::make_shared<opset6::Transpose>(reduce, order);
 
-            f_ref = std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{input});
+            f_ref = std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{input});
         }
     }
 };
@@ -173,7 +173,7 @@ public:
 
             auto reduction = get_reduction(reduction_type_info, {transpose, axes}, test_case.reduction_keep_dims);
 
-            f = std::make_shared<ov::Model>(NodeVector{reduction}, ParameterVector{input});
+            f = std::make_shared<ov::Model>(OutputVector{reduction}, ParameterVector{input});
         }
 
         {
@@ -189,7 +189,7 @@ public:
                                                             test_case.ex_transpose_order);
             auto transpose = std::make_shared<opset6::Transpose>(reduction, order);
 
-            f_ref = std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{input});
+            f_ref = std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{input});
         }
     }
 
@@ -295,7 +295,7 @@ TEST_F(TransformationTestsF, TransposeFuseEliminatesTranspose) {
         auto add_const = opset6::Constant::create(element::f32, Shape{1}, {1});
         auto add = std::make_shared<opset6::Add>(transpose2, add_const);
 
-        model = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input});
         manager.register_pass<ov::pass::TransposeFuse>();
     }
 
@@ -304,7 +304,7 @@ TEST_F(TransformationTestsF, TransposeFuseEliminatesTranspose) {
         auto add_const = opset6::Constant::create(element::f32, Shape{1}, {1});
         auto add = std::make_shared<opset6::Add>(input, add_const);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input});
     }
 }
 
@@ -342,7 +342,7 @@ TEST_F(TransformationTestsF, TransposeReduceNegative) {
         auto reduce_mean = std::make_shared<opset6::ReduceMean>(transpose, axes, true);
         auto sub = std::make_shared<opset6::Subtract>(transpose, reduce_mean);
 
-        model = std::make_shared<ov::Model>(NodeVector{sub}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{sub}, ParameterVector{input});
         manager.register_pass<ov::pass::TransposeReduction>();
     }
 }
@@ -354,7 +354,7 @@ TEST_F(TransformationTestsF, TransposeConvert) {
         auto transpose = std::make_shared<opset6::Transpose>(input, order);
         auto convert = std::make_shared<opset6::Convert>(transpose, element::f16);
 
-        model = std::make_shared<ov::Model>(NodeVector{convert}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{convert}, ParameterVector{input});
         manager.register_pass<ov::pass::TransposeConvert>();
     }
 
@@ -364,7 +364,7 @@ TEST_F(TransformationTestsF, TransposeConvert) {
         auto order = opset6::Constant::create(element::i64, Shape{6}, {0, 5, 1, 2, 3, 4});
         auto transpose = std::make_shared<opset6::Transpose>(convert, order);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{input});
     }
 }
 
@@ -375,7 +375,7 @@ TEST_F(TransformationTestsF, TransposeConvertNegativeConsumers) {
         auto transpose = std::make_shared<opset6::Transpose>(input, order);
         auto convert = std::make_shared<opset6::Convert>(transpose, element::f16);
 
-        model = std::make_shared<ov::Model>(NodeVector{convert, transpose}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{convert, transpose}, ParameterVector{input});
         manager.register_pass<ov::pass::TransposeConvert>();
     }
 }

--- a/src/common/transformations/tests/common_optimizations/transpose_to_reshape_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/transpose_to_reshape_test.cpp
@@ -65,7 +65,7 @@ private:
         // WA to test cases with transpose elimination
         auto relu = std::make_shared<opset3::Relu>(transpose);
 
-        return std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{data});
+        return std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{data});
     }
 
     std::shared_ptr<ov::Model> get_reference_function(const PartialShape& input_shape,
@@ -95,7 +95,7 @@ private:
 
         last = std::make_shared<opset3::Relu>(last);
 
-        return std::make_shared<ov::Model>(NodeVector{last.get_node_shared_ptr()}, ParameterVector{data});
+        return std::make_shared<ov::Model>(OutputVector{last.get_node_shared_ptr()}, ParameterVector{data});
     }
 };
 

--- a/src/common/transformations/tests/common_optimizations/weights_dequantize_to_fake_quantize.cpp
+++ b/src/common/transformations/tests/common_optimizations/weights_dequantize_to_fake_quantize.cpp
@@ -71,7 +71,7 @@ public:
             auto scale =
                 std::make_shared<opset6::Constant>(float_element_type, Shape{}, std::vector<float>{test_case.scale});
 
-            NodeVector output;
+            OutputVector output;
             if (zp == 0)
                 output.push_back(std::make_shared<opset6::Multiply>(f_weights, scale));
             else
@@ -98,7 +98,7 @@ public:
 
             auto fq = std::make_shared<opset6::FakeQuantize>(f_weights, i_low, i_high, o_low, o_high, test_case.levels);
 
-            f_ref = std::make_shared<ov::Model>(NodeVector{fq}, ParameterVector{});
+            f_ref = std::make_shared<ov::Model>(OutputVector{fq}, ParameterVector{});
         }
     }
 };

--- a/src/common/transformations/tests/common_optimizations/wrap_interpolate_into_transposes_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/wrap_interpolate_into_transposes_test.cpp
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DScales) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -59,7 +59,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DScales) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -84,7 +84,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DSizes) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -102,7 +102,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DSizes) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -127,7 +127,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DScales) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DScales) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DSizes) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -188,7 +188,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DSizes) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -213,7 +213,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DScalesDynamic) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -231,7 +231,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DScalesDynamic) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -256,7 +256,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DSizesDynamic) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -274,7 +274,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DSizesDynamic) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -299,7 +299,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DScalesDynamic) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -317,7 +317,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DScalesDynamic) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -342,7 +342,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DSizesDynamic) {
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, axis_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -360,7 +360,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DSizesDynamic) {
             std::make_shared<opset8::Interpolate>(first_transpose, sizes_node, scales_node, axis_node, attrs);
         auto last_transpose = std::make_shared<opset8::Transpose>(interpolate, last_transpose_perm);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{last_transpose}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{last_transpose}, ParameterVector{input});
     }
 }
 
@@ -393,7 +393,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DScalesNotApplicable)
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -412,7 +412,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DScalesNotApplicable)
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -445,7 +445,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DSizesNotApplicable) 
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -464,7 +464,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes4DSizesNotApplicable) 
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -497,7 +497,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DScalesNotApplicable)
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -516,7 +516,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DScalesNotApplicable)
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }
 
@@ -549,7 +549,7 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DSizesNotApplicable) 
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
         manager.register_pass<ov::pass::WrapInterpolateIntoTransposes>();
     }
     {
@@ -568,6 +568,6 @@ TEST_F(TransformationTestsF, WrapInterpolateIntoTransposes5DSizesNotApplicable) 
 
         auto interpolate = std::make_shared<opset8::Interpolate>(input, sizes_node, scales_node, gather_node, attrs);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{interpolate}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/const_folding_for_if.cpp
+++ b/src/common/transformations/tests/const_folding_for_if.cpp
@@ -58,7 +58,7 @@ TEST(TransformationTests, DISABLED_if_constant_folding) {
         auto param_add = make_shared<op::v0::Parameter>(element::f32, Shape{1});
         auto add = make_shared<op::v1::Add>(constant_folding_if, param_add);
         auto add_res = make_shared<op::v0::Result>(add);
-        f_ref = std::make_shared<ov::Model>(NodeVector{add_res}, ParameterVector{param_add});
+        f_ref = std::make_shared<ov::Model>(OutputVector{add_res}, ParameterVector{param_add});
     }
 
     auto res = compare_functions(fun, f_ref);

--- a/src/common/transformations/tests/const_folding_for_mvn.cpp
+++ b/src/common/transformations/tests/const_folding_for_mvn.cpp
@@ -24,7 +24,7 @@ TEST(TransformationTests, ConstFoldingMVN) {
         auto mvn = make_shared<opset10::MVN>(mvn_in, axes, false, 1e-9f, op::MVNEpsMode::OUTSIDE_SQRT);
         auto add = make_shared<opset10::Add>(in, mvn);
 
-        fun = make_shared<ov::Model>(NodeVector{add}, ParameterVector{in});
+        fun = make_shared<ov::Model>(OutputVector{add}, ParameterVector{in});
 
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -36,7 +36,7 @@ TEST(TransformationTests, ConstFoldingMVN) {
         const auto mvn_const = make_shared<opset10::Constant>(element::f32, Shape{6}, vector<float>(6, 0.0f));
         auto add = make_shared<opset10::Add>(in, mvn_const);
 
-        f_ref = make_shared<ov::Model>(NodeVector{add}, ParameterVector{in});
+        f_ref = make_shared<ov::Model>(OutputVector{add}, ParameterVector{in});
     }
 
     auto res = compare_functions(fun, f_ref);

--- a/src/common/transformations/tests/const_folding_prior_box.cpp
+++ b/src/common/transformations/tests/const_folding_prior_box.cpp
@@ -37,7 +37,7 @@ TEST(TransformationTests, ConstFoldingPriorBox) {
         auto image_shape = opset3::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
         auto pb = std::make_shared<opset3::PriorBox>(layer_shape, image_shape, attrs);
         auto res = std::make_shared<opset3::Result>(pb);
-        f = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{in});
+        f = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{in});
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::ConstantFolding>();
@@ -57,7 +57,7 @@ TEST(TransformationTests, ConstFoldingPriorBox) {
                 0.1f,       0.1f,       0.1f,      0.1f,      0.1f,       0.1f,       0.1f,      0.1f,
             });
         auto res = std::make_shared<opset3::Result>(const_prior_box);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{layer_shape});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{layer_shape});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -84,7 +84,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
         auto image_shape = opset3::Constant::create<int64_t>(element::i64, Shape{2}, {300, 300});
         auto pb = std::make_shared<opset3::PriorBoxClustered>(layer_shape, image_shape, attrs);
         auto res = std::make_shared<opset3::Result>(pb);
-        f = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{in});
+        f = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{in});
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::ConstantFolding>();
@@ -110,7 +110,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxClustered) {
              0.0f,         0.0f,         0.0f,        0.0f,        0.0f,         0.0f,         0.0f,        0.0f,
              0.0f,         0.0f,         0.0f,        0.0f,        0.0f,         0.0f,         0.0f,        0.0f});
         auto res = std::make_shared<opset3::Result>(const_prior_box);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{layer_shape});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{layer_shape});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -158,7 +158,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
                                                                std::vector<int64_t>{0});
         auto pb = std::make_shared<opset3::PriorBox>(ss_data, ss_image, attrs);
         auto res = std::make_shared<opset3::Result>(pb);
-        f = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{in, in_2});
+        f = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{in, in_2});
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::ConstantFolding>();
@@ -176,7 +176,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxSubgraph) {
              0.1f,       0.1f,       0.1f,      0.1f,      0.1f,       0.1f,       0.1f,      0.1f,
              0.1f,       0.1f,       0.1f,      0.1f,      0.1f,       0.1f,       0.1f,      0.1f});
         auto res = std::make_shared<opset3::Result>(const_prior_box);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{layer_shape});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{layer_shape});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -220,7 +220,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxClusteredSubgraph) {
                                                                std::vector<int64_t>{0});
         auto pb = std::make_shared<opset3::PriorBoxClustered>(ss_data, ss_image, attrs);
         auto res = std::make_shared<opset3::Result>(pb);
-        f = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{in, in_2});
+        f = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{in, in_2});
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::ConstantFolding>();
@@ -246,7 +246,7 @@ TEST(TransformationTests, ConstFoldingPriorBoxClusteredSubgraph) {
              0.0f,         0.0f,         0.0f,        0.0f,        0.0f,         0.0f,         0.0f,        0.0f,
              0.0f,         0.0f,         0.0f,        0.0f,        0.0f,         0.0f,         0.0f,        0.0f});
         auto res = std::make_shared<opset3::Result>(const_prior_box);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{layer_shape});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{layer_shape});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -276,7 +276,7 @@ TEST(TransformationTests, ConstFoldingPriorBox8) {
         auto image_shape = opset8::Constant::create<int64_t>(element::i64, Shape{2}, {10, 10});
         auto pb = std::make_shared<opset8::PriorBox>(layer_shape, image_shape, attrs);
         auto res = std::make_shared<opset8::Result>(pb);
-        f = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{in});
+        f = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{in});
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::ConstantFolding>();
@@ -301,7 +301,7 @@ TEST(TransformationTests, ConstFoldingPriorBox8) {
              0.1f,       0.1f,      0.1f,      0.1f,       0.1f,      0.1f,       0.1f,      0.1f,      0.1f,
              0.1f,       0.1f,      0.1f,      0.1f,       0.1f,      0.1f});
         auto res = std::make_shared<opset8::Result>(const_prior_box);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{layer_shape});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{layer_shape});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -349,7 +349,7 @@ TEST(TransformationTests, ConstFoldingPriorBox8Subgraph) {
                                                                std::vector<int64_t>{0});
         auto pb = std::make_shared<opset8::PriorBox>(ss_data, ss_image, attrs);
         auto res = std::make_shared<opset8::Result>(pb);
-        f = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{in, in_2});
+        f = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{in, in_2});
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::ConstantFolding>();
@@ -374,7 +374,7 @@ TEST(TransformationTests, ConstFoldingPriorBox8Subgraph) {
              0.1f,       0.1f,      0.1f,      0.1f,       0.1f,      0.1f,       0.1f,      0.1f,      0.1f,
              0.1f,       0.1f,      0.1f,      0.1f,       0.1f,      0.1f});
         auto res = std::make_shared<opset8::Result>(const_prior_box);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res}, ParameterVector{layer_shape});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{layer_shape});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/control_flow/unroll_if_test.cpp
+++ b/src/common/transformations/tests/control_flow/unroll_if_test.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<ov::Model> create_if_model(bool condition) {
     auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
     if_result->set_friendly_name("if_result");
 
-    return std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
+    return std::make_shared<ov::Model>(ov::OutputVector{if_result}, ov::ParameterVector{X, Y});
 }
 
 TEST(TransformationTests, UnrollIfCondIsTrue) {
@@ -170,7 +170,7 @@ TEST(TransformationTests, UnrollIfWithSplitInput) {
         if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
         auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(ov::OutputVector{if_result}, ov::ParameterVector{X, Y});
 
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -187,7 +187,7 @@ TEST(TransformationTests, UnrollIfWithSplitInput) {
             std::make_shared<ov::op::v1::Split>(X, ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0}), 2);
         auto mul_op = std::make_shared<ov::op::v1::Multiply>(split->output(1), Y);
         auto if_result = std::make_shared<ov::op::v0::Result>(mul_op);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{if_result}, ov::ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -215,7 +215,7 @@ TEST(TransformationTests, UnrollNestedIfThenBody) {
         if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
         auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(ov::OutputVector{if_result}, ov::ParameterVector{X, Y});
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<ov::pass::UnrollIf>();
@@ -252,7 +252,7 @@ TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
         if_op->set_output(then_op_result, else_op_result);
         auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
-        f = std::make_shared<ov::Model>(NodeVector{if_result}, ParameterVector{data});
+        f = std::make_shared<ov::Model>(OutputVector{if_result}, ParameterVector{data});
 
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -268,7 +268,7 @@ TEST(TransformationTests, UnrollIfCondIsTrueMultiOutput) {
                                                              ov::op::v0::Constant::create(element::i32, {1}, {0}),
                                                              ov::op::v0::Constant::create(element::i32, {2}, {1, 2}));
         auto if_result = std::make_shared<ov::op::v0::Result>(X->output(1));
-        f_ref = std::make_shared<ov::Model>(NodeVector{if_result}, ParameterVector{data});
+        f_ref = std::make_shared<ov::Model>(OutputVector{if_result}, ParameterVector{data});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -336,7 +336,7 @@ TEST(TransformationTests, UnrollIfInsideIf) {
         if_op->set_output(then_body->get_results()[0], else_body->get_results()[0]);
         auto if_result = std::make_shared<ov::op::v0::Result>(if_op);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{if_result}, ov::ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(ov::OutputVector{if_result}, ov::ParameterVector{X, Y});
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<ov::pass::PushConstantToSubgraph>();

--- a/src/common/transformations/tests/control_flow/unroll_loop_test.cpp
+++ b/src/common/transformations/tests/control_flow/unroll_loop_test.cpp
@@ -62,7 +62,7 @@ TEST(TransformationTests, UnrollLoopGRUCell) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         // auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -98,7 +98,7 @@ TEST(TransformationTests, UnrollLoopGRUCell) {
 
         auto res_ti_1 = std::make_shared<Result>(concat);
         // auto res_ti_2 = std::make_shared<Result>(unsqueeze_2);
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -146,7 +146,7 @@ TEST(TransformationTests, UnrollLoopRNNCell) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         // auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -182,7 +182,7 @@ TEST(TransformationTests, UnrollLoopRNNCell) {
 
         auto res_ti_1 = std::make_shared<Result>(concat);
         // auto res_ti_2 = std::make_shared<Result>(unsqueeze_2);
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -233,7 +233,7 @@ TEST(TransformationTests, UnrollLoopLSTMCell) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         // auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -270,7 +270,7 @@ TEST(TransformationTests, UnrollLoopLSTMCell) {
 
         auto res_ti_1 = std::make_shared<Result>(concat);
         // auto res_ti_2 = std::make_shared<Result>(unsqueeze_2);
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -318,7 +318,7 @@ TEST(TransformationTests, UnrollLoopGRUCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         // auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -348,7 +348,7 @@ TEST(TransformationTests, UnrollLoopGRUCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<Result>(unsqueeze_1);
         // auto res_ti_2 = std::make_shared<Result>(unsqueeze_2);
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -396,7 +396,7 @@ TEST(TransformationTests, UnrollLoopRNNCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         // auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -425,7 +425,7 @@ TEST(TransformationTests, UnrollLoopRNNCellSingleIteration) {
         auto unsqueeze_1 = std::make_shared<Unsqueeze>(rnn_cell_1, axis);
         auto res_ti_1 = std::make_shared<Result>(unsqueeze_1);
 
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -476,7 +476,7 @@ TEST(TransformationTests, UnrollLoopLSTMCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<Result>(loop->output(1));
         // auto res_ti_2 = std::make_shared<Result>(loop->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -506,7 +506,7 @@ TEST(TransformationTests, UnrollLoopLSTMCellSingleIteration) {
         auto unsqueeze_1 = std::make_shared<Unsqueeze>(lstm_cell_1, axis);
         auto res_ti_1 = std::make_shared<Result>(unsqueeze_1);
         // auto res_ti_2 = std::make_shared<Result>(unsqueeze_2);
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/control_flow/unroll_tensor_iterator_test.cpp
+++ b/src/common/transformations/tests/control_flow/unroll_tensor_iterator_test.cpp
@@ -60,7 +60,7 @@ TEST(TransformationTests, UnrollTensorIteratorGRUCell) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -96,7 +96,7 @@ TEST(TransformationTests, UnrollTensorIteratorGRUCell) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(concat);
         // auto res_ti_2 = std::make_shared<opset4::Result>(unsqueeze_2);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -140,7 +140,7 @@ TEST(TransformationTests, UnrollTensorIteratorRNNCell) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -176,7 +176,7 @@ TEST(TransformationTests, UnrollTensorIteratorRNNCell) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(concat);
         // auto res_ti_2 = std::make_shared<opset4::Result>(unsqueeze_2);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -223,7 +223,7 @@ TEST(TransformationTests, UnrollTensorIteratorLSTMCell) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -260,7 +260,7 @@ TEST(TransformationTests, UnrollTensorIteratorLSTMCell) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(concat);
         // auto res_ti_2 = std::make_shared<opset4::Result>(unsqueeze_2);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -304,7 +304,7 @@ TEST(TransformationTests, UnrollTensorIteratorGRUCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -334,7 +334,7 @@ TEST(TransformationTests, UnrollTensorIteratorGRUCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(unsqueeze_1);
         // auto res_ti_2 = std::make_shared<opset4::Result>(unsqueeze_2);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -378,7 +378,7 @@ TEST(TransformationTests, UnrollTensorIteratorRNNCellSingleIteration) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -407,7 +407,7 @@ TEST(TransformationTests, UnrollTensorIteratorRNNCellSingleIteration) {
         auto unsqueeze_1 = std::make_shared<opset4::Unsqueeze>(rnn_cell_1, axis);
         auto res_ti_1 = std::make_shared<opset4::Result>(unsqueeze_1);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -454,7 +454,7 @@ TEST(TransformationTests, UnrollTensorIteratorLSTMCellSingleIterationSingleItera
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -484,7 +484,7 @@ TEST(TransformationTests, UnrollTensorIteratorLSTMCellSingleIterationSingleItera
         auto unsqueeze_1 = std::make_shared<opset4::Unsqueeze>(lstm_cell_1, axis);
         auto res_ti_1 = std::make_shared<opset4::Result>(unsqueeze_1);
         // auto res_ti_2 = std::make_shared<opset4::Result>(unsqueeze_2);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -533,7 +533,7 @@ TEST(TransformationTests, CheckTensorNamesAfterConvertToTIAndUnrolling) {
         auto Y_out = std::make_shared<opset8::Result>(rnn_sequence->output(0));
         auto Ho = std::make_shared<opset8::Result>(rnn_sequence->output(1));
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho}, ParameterVector{X, Y});
     }
 
     std::vector<std::unordered_set<std::string>> names_before;
@@ -600,7 +600,7 @@ TEST(TransformationTests, CheckTensorNamesAfterUnrolling) {
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
 
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1, res_ti_2}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1, res_ti_2}, ParameterVector{X, Y, Z});
     }
 
     std::vector<std::unordered_set<std::string>> names_before;

--- a/src/common/transformations/tests/offline_transformations/pruning_test.cpp
+++ b/src/common/transformations/tests/offline_transformations/pruning_test.cpp
@@ -98,7 +98,7 @@ TEST(TransformationTests, TestInitMasks) {
                                                        CoordinateDiff(2, 0),
                                                        Strides(2, 1));
 
-    auto f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+    auto f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     pass::Manager m;
     m.register_pass<ov::pass::InitMasks>();
     m.run_passes(f);
@@ -125,7 +125,7 @@ TEST(TransformationTests, PropagateMasksNegative) {
                                                        CoordinateDiff(2, 0),
                                                        CoordinateDiff(2, 0),
                                                        Strides(2, 1));
-    auto f = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+    auto f = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
 
     pass::Manager m;
     m.register_pass<ov::pass::InitMasks>();
@@ -166,7 +166,7 @@ TEST_F(TransformationTestsF, PropagateMasksBasic) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
 
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, PropagateMasksBasic) {
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksBasic.svg").run_on_model(model);
@@ -255,7 +255,7 @@ TEST_F(TransformationTestsF, PropagateMasksDynamicConvolution) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights =
@@ -286,7 +286,7 @@ TEST_F(TransformationTestsF, PropagateMasksDynamicConvolution) {
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksDynamicConvolution.svg")
@@ -338,7 +338,7 @@ TEST(TransformationTests, PropagateMasksDynamicReshape) {
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
 
-    auto model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    auto model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksDynamicReshape.svg").run_on_model(model);
 
@@ -381,7 +381,7 @@ TEST(TransformationTests, PropagateMasksDynamicGroupConvolution) {
                                                              CoordinateDiff(2, 0),
                                                              CoordinateDiff(2, 0),
                                                              Strides(2, 1));
-    auto f = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    auto f = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
 
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksDynamicGroupConvolution.svg")
@@ -420,7 +420,7 @@ TEST(TransformationTests, PropagateMasksEmpty) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    auto f = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    auto f = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
 
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksEmpty.svg").run_on_model(f);
@@ -477,7 +477,7 @@ TEST_F(TransformationTestsF, PropagateMaskPassThrough) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights_const_1 =
@@ -516,7 +516,7 @@ TEST_F(TransformationTestsF, PropagateMaskPassThrough) {
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMaskPassThrough.svg").run_on_model(model);
@@ -573,7 +573,7 @@ TEST_F(TransformationTestsF, NegativePad12PropagateMaskPassThrough) {
                                                CoordinateDiff(2, 0),
                                                CoordinateDiff(2, 0),
                                                Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<Parameter>(element::f32, input_shape);
         auto weights_const_1 =
@@ -607,7 +607,7 @@ TEST_F(TransformationTestsF, NegativePad12PropagateMaskPassThrough) {
                                                    CoordinateDiff(2, 0),
                                                    CoordinateDiff(2, 0),
                                                    Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMaskPassThrough.svg").run_on_model(model);
@@ -689,7 +689,7 @@ TEST_F(TransformationTestsF, PropagateMasksHardDependencies) {
                                                         Strides(2, 1));
     conv3->set_friendly_name("conv3");
 
-    model = std::make_shared<Model>(NodeVector{matmul, conv3}, ParameterVector{input1, input2});
+    model = std::make_shared<Model>(OutputVector{matmul, conv3}, ParameterVector{input1, input2});
     {
         auto input1 = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         input1->set_friendly_name("input1");
@@ -757,7 +757,7 @@ TEST_F(TransformationTestsF, PropagateMasksHardDependencies) {
                                                             Strides(2, 1));
         conv3->set_friendly_name("conv3");
 
-        model_ref = std::make_shared<Model>(NodeVector{matmul, conv3}, ParameterVector{input1, input2});
+        model_ref = std::make_shared<Model>(OutputVector{matmul, conv3}, ParameterVector{input1, input2});
     }
 
     if (VISUALIZE_TESTS_TREE)
@@ -849,7 +849,7 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolution) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
 
@@ -909,7 +909,7 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolution) {
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksQuantizedGroupConvolution.svg")
@@ -1004,7 +1004,7 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolutionWithShapeOf)
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
 
@@ -1075,7 +1075,7 @@ TEST_F(TransformationTestsF, PropagateMasksQuantizedGroupConvolutionWithShapeOf)
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksQuantizedGroupConvolutionWithShapeOf.svg")
@@ -1155,7 +1155,7 @@ TEST_F(TransformationTestsF, PropagateMasksFakeQuantizePerTensor) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights_1 = opset10::Constant::create(element::i8,
@@ -1207,7 +1207,7 @@ TEST_F(TransformationTestsF, PropagateMasksFakeQuantizePerTensor) {
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksFakeQuantizePerTensor.svg")
@@ -1292,7 +1292,7 @@ TEST(TransformationTests, PropagateMasksFakeQuantizePerTensor1DScale) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    auto model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    auto model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksFakeQuantizePerTensor1DScale.svg")
             .run_on_model(model);
@@ -1365,7 +1365,7 @@ TEST_F(TransformationTestsF, PropagateMasksFakeQuantizePerChannel) {
                                                         CoordinateDiff(2, 0),
                                                         CoordinateDiff(2, 0),
                                                         Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights_1 =
@@ -1409,7 +1409,7 @@ TEST_F(TransformationTestsF, PropagateMasksFakeQuantizePerChannel) {
                                                             CoordinateDiff(2, 0),
                                                             CoordinateDiff(2, 0),
                                                             Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv2}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv2}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksFakeQuantizePerChannel.svg")
@@ -1491,7 +1491,7 @@ TEST_F(TransformationTestsF, TestConcatMaskPropagation) {
                                                            CoordinateDiff(2, 0),
                                                            CoordinateDiff(2, 0),
                                                            Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv_out}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv_out}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights_1 =
@@ -1551,7 +1551,7 @@ TEST_F(TransformationTestsF, TestConcatMaskPropagation) {
                                                                CoordinateDiff(2, 0),
                                                                CoordinateDiff(2, 0),
                                                                Strides(2, 1));
-        model_ref = std::make_shared<Model>(NodeVector{conv_out}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv_out}, ParameterVector{input});
     }
 
     if (VISUALIZE_TESTS_TREE)
@@ -1625,7 +1625,7 @@ TEST_F(TransformationTestsF, TestConcatMaskPropagationUp) {
                                                            CoordinateDiff(2, 0),
                                                            CoordinateDiff(2, 0),
                                                            Strides(2, 1));
-    model = std::make_shared<Model>(NodeVector{conv_out}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{conv_out}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights_1 = create_constant_with_zeros(
@@ -1694,7 +1694,7 @@ TEST_F(TransformationTestsF, TestConcatMaskPropagationUp) {
                                                                CoordinateDiff(2, 0),
                                                                Strides(2, 1));
 
-        model_ref = std::make_shared<Model>(NodeVector{conv_out}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv_out}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "TestConcatMaskPropagationUp.svg").run_on_model(model);
@@ -1764,7 +1764,7 @@ TEST(TransformationTests, TestConcatMaskPropagationUpEmpty) {
         create_constant_with_zeros(Shape{1, 32, 1, 1}, {{}, {0, 1, 2, 3, 15, 16, 17, 18, 28, 29, 30, 31}, {}, {}});
     auto add = std::make_shared<opset10::Add>(concat, add_const);
 
-    auto f = std::make_shared<Model>(NodeVector{add}, ParameterVector{input});
+    auto f = std::make_shared<Model>(OutputVector{add}, ParameterVector{input});
 
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "TestConcatMaskPropagationUpEmpty.svg").run_on_model(f);
@@ -3310,7 +3310,7 @@ TEST_F(TransformationTestsF, PropagateMasksLinear) {
     // Check stop mask prop for outer dim (1)
     auto weights_last_linear = create_constant_with_zeros(weights_last_linear_shape, {{3, 4, 5}, {2, 3, 4}});
     auto last_linear = std::make_shared<opset10::MatMul>(linear, weights_last_linear);
-    model = std::make_shared<Model>(NodeVector{last_linear}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{last_linear}, ParameterVector{input});
 
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
@@ -3348,7 +3348,7 @@ TEST_F(TransformationTestsF, PropagateMasksLinear) {
             },
             {{}, {}});
         auto last_linear = std::make_shared<opset10::MatMul>(linear, weights_last_linear);
-        model_ref = std::make_shared<Model>(NodeVector{last_linear}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{last_linear}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksLinear.svg").run_on_model(model);
@@ -3737,7 +3737,7 @@ TEST_F(TransformationTestsF, PruneMasksMatMulColsStopRowsUp) {
     // Do net search 0 dim zeros by now
     auto weights_last_linear = create_constant_with_zeros(weights_last_linear_shape, {{3, 4, 5}, {}});
     auto last_linear = std::make_shared<opset10::MatMul>(linear, weights_last_linear);
-    model = std::make_shared<Model>(NodeVector{last_linear}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{last_linear}, ParameterVector{input});
 
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
@@ -3768,7 +3768,7 @@ TEST_F(TransformationTestsF, PruneMasksMatMulColsStopRowsUp) {
             },
             {{}, {}});
         auto last_linear = std::make_shared<opset10::MatMul>(linear, weights_last_linear);
-        model_ref = std::make_shared<Model>(NodeVector{last_linear}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{last_linear}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneMasksMatMulColsStopRowsUp.svg")
@@ -3822,7 +3822,7 @@ TEST_F(TransformationTestsF, PruneMasksMatMulRowsStopColsUp) {
     auto weights_last_linear = create_constant_with_zeros(weights_last_linear_shape, {{}, {3, 4, 5}});
     // To prune rows we should transpose featuremap. Did it by transpose_a = true MatMul constructor attr
     auto last_linear = std::make_shared<opset10::MatMul>(linear, weights_last_linear, true, true);
-    model = std::make_shared<Model>(NodeVector{last_linear}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{last_linear}, ParameterVector{input});
 
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
@@ -3857,7 +3857,7 @@ TEST_F(TransformationTestsF, PruneMasksMatMulRowsStopColsUp) {
             create_constant_with_zeros({weights_last_linear_shape[0], weights_last_linear_shape[1] - 3}, {{}, {}});
         // To prune rows we should transpose featuremap. Did it by transpose_a = true MatMul constructor attr
         auto last_linear = std::make_shared<opset10::MatMul>(linear, weights_last_linear, true, true);
-        model_ref = std::make_shared<Model>(NodeVector{last_linear}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{last_linear}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PruneMasksMatMulRowsStopColsUp.svg")
@@ -3920,7 +3920,7 @@ TEST_F(TransformationTestsF, PropagateFlattenUp) {
     auto weights_linear = create_constant_with_zeros(weights_linear_shape, {{}, {0, 1, 2}});
     auto linear = std::make_shared<opset10::MatMul>(add, weights_linear);
 
-    model = std::make_shared<Model>(NodeVector{linear}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{linear}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
         auto weights = create_constant_with_zeros(
@@ -3953,7 +3953,7 @@ TEST_F(TransformationTestsF, PropagateFlattenUp) {
             {{}, {}});
         auto linear = std::make_shared<opset10::MatMul>(add, weights_linear);
 
-        model_ref = std::make_shared<Model>(NodeVector{linear}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{linear}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateFlattenUp.svg").run_on_model(model);
@@ -4072,7 +4072,7 @@ TEST_F(TransformationTestsF, PropagateMasksTranspose) {
     auto last_mul_weights = create_constant_with_zeros(weights_shape, {{}, {1, 2, 3}});
     auto last_mul = std::make_shared<opset10::MatMul>(relu, last_mul_weights);
 
-    model = std::make_shared<Model>(NodeVector{last_mul}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{last_mul}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
 
@@ -4085,7 +4085,7 @@ TEST_F(TransformationTestsF, PropagateMasksTranspose) {
         auto last_mul_weights = create_constant_with_zeros({weights_shape[0] - 3, weights_shape[1]}, {{}, {}});
         auto last_mul = std::make_shared<opset10::MatMul>(relu, last_mul_weights);
 
-        model_ref = std::make_shared<Model>(NodeVector{last_mul}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{last_mul}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksTranspose.svg").run_on_model(model);
@@ -4129,7 +4129,7 @@ TEST_F(TransformationTestsF, PropagateMasksTransposeComplex) {
     auto last_mul_weights = create_constant_with_zeros(last_mul_weights_shape, {{}, {1, 2, 3}});
     auto last_mul = std::make_shared<opset10::MatMul>(relu, last_mul_weights);
 
-    model = std::make_shared<Model>(NodeVector{last_mul}, ParameterVector{input});
+    model = std::make_shared<Model>(OutputVector{last_mul}, ParameterVector{input});
     {
         auto input = std::make_shared<opset10::Parameter>(element::f32, input_shape);
 
@@ -4157,7 +4157,7 @@ TEST_F(TransformationTestsF, PropagateMasksTransposeComplex) {
             create_constant_with_zeros({last_mul_weights_shape[0] - 3, last_mul_weights_shape[1]}, {{}, {}});
         auto last_mul = std::make_shared<opset10::MatMul>(relu, last_mul_weights);
 
-        model_ref = std::make_shared<Model>(NodeVector{last_mul}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{last_mul}, ParameterVector{input});
     }
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksTransposeComplex.svg")
@@ -4198,7 +4198,7 @@ TEST(TransformationTests, PropagateMasksTransposeStop) {
     auto last_mul_weights = create_constant_with_zeros(last_mul_shape, {{}, {}, {}, {1, 2, 3}});
     auto last_mul = std::make_shared<opset10::MatMul>(relu, last_mul_weights);
 
-    auto model = std::make_shared<Model>(NodeVector{last_mul}, ParameterVector{input});
+    auto model = std::make_shared<Model>(OutputVector{last_mul}, ParameterVector{input});
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "PropagateMasksTransposeStop.svg").run_on_model(model);
     {
@@ -5173,7 +5173,7 @@ TEST(TransformationTests, CheckReshapeWithNoConstInShape) {
     const auto dummy_mask = std::make_shared<Mask>(Mask{{1}});
     setMask(reshape->output(0), dummy_mask);
 
-    auto model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input, input_shape});
+    auto model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input, input_shape});
 
     if (VISUALIZE_TESTS_TREE)
         pass::VisualizeTree(std::string(VISUALIZE_TREE_ROOT) + "CheckReshapeWithNoConstInShape.svg")
@@ -5261,7 +5261,7 @@ TEST_F(TransformationTestsF, PruningWithVariadicSplitOnSecondAxis) {
                                                             CoordinateDiff{0, 0},
                                                             CoordinateDiff{0, 0},
                                                             Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv2, conv3, conv4}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv2, conv3, conv4}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::Pruning>();
@@ -5449,7 +5449,7 @@ TEST(TransformationTests, VariadicSplitMaskPropagationSplitOnSecondAxis) {
                                                             CoordinateDiff{0, 0},
                                                             CoordinateDiff{0, 0},
                                                             Strides{1, 1});
-        auto model_ref = std::make_shared<ov::Model>(NodeVector{conv2, conv3, conv4}, ParameterVector{input});
+        auto model_ref = std::make_shared<ov::Model>(OutputVector{conv2, conv3, conv4}, ParameterVector{input});
 
         auto res = compare_functions(model, model_ref);
         ASSERT_TRUE(res.first) << res.second;
@@ -5699,7 +5699,7 @@ TEST_F(TransformationTestsF, PruningWithSplitOnSecondAxis) {
                                                             CoordinateDiff{0, 0},
                                                             CoordinateDiff{0, 0},
                                                             Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv2, conv3, conv4}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv2, conv3, conv4}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::Pruning>();
@@ -5775,7 +5775,7 @@ TEST_F(TransformationTestsF, PruningWithSplitOnFirstAxis) {
                                                             CoordinateDiff{0, 0},
                                                             CoordinateDiff{0, 0},
                                                             Strides{1, 1});
-        model_ref = std::make_shared<ov::Model>(NodeVector{conv2, conv3, conv4}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{conv2, conv3, conv4}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::Pruning>();
@@ -5875,7 +5875,7 @@ TEST(TransformationTests, SplitMaskPropagationSplitOnSecondAxis) {
                                                             CoordinateDiff{0, 0},
                                                             CoordinateDiff{0, 0},
                                                             Strides{1, 1});
-        auto model_ref = std::make_shared<ov::Model>(NodeVector{conv2, conv3, conv4}, ParameterVector{input});
+        auto model_ref = std::make_shared<ov::Model>(OutputVector{conv2, conv3, conv4}, ParameterVector{input});
 
         auto res = compare_functions(model, model_ref);
         ASSERT_TRUE(res.first) << res.second;
@@ -5970,7 +5970,7 @@ TEST(TransformationTests, SplitMaskPropagationSplitOnFirstAxis) {
                                                             CoordinateDiff{0, 0},
                                                             CoordinateDiff{0, 0},
                                                             Strides{1, 1});
-        auto model_ref = std::make_shared<ov::Model>(NodeVector{conv2, conv3, conv4}, ParameterVector{input});
+        auto model_ref = std::make_shared<ov::Model>(OutputVector{conv2, conv3, conv4}, ParameterVector{input});
 
         auto res = compare_functions(model, model_ref);
         ASSERT_TRUE(res.first) << res.second;

--- a/src/common/transformations/tests/op_conversions/batch_norm_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/batch_norm_decomposition_test.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<ov::Model> get_ref_model_with_dyn_shapes(ov::element::Type preci
     // Add `(input - mean) * gamma / sqrt(variance + eps)` and `beta`
     auto add = std::make_shared<ov::op::v1::Add>(mul, beta_aligned);
 
-    return std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input, gamma, beta, mean, var});
+    return std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input, gamma, beta, mean, var});
 }
 
 TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset1) {
@@ -68,7 +68,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset1) {
         auto var = opset1::Constant::create(precision, Shape{3}, {3});
         auto batch_norm = std::make_shared<opset1::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_norm}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{batch_norm}, ParameterVector{input});
         manager.register_pass<ov::pass::BatchNormDecomposition>();
         comparator.enable(FunctionsComparator::CONST_VALUES);
     }
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset1) {
         auto add_const_2 = opset1::Constant::create(precision, {1, 3, 1, 1}, {3});
         auto add_2 = std::make_shared<opset1::Add>(mul, add_const_2);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add_2}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add_2}, ParameterVector{input});
     }
 }
 
@@ -96,7 +96,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset5) {
         auto var = opset1::Constant::create(precision, Shape{3}, {3});
         auto batch_norm = std::make_shared<opset5::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_norm}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{batch_norm}, ParameterVector{input});
         manager.register_pass<ov::pass::BatchNormDecomposition>();
         comparator.enable(FunctionsComparator::CONST_VALUES);
     }
@@ -109,7 +109,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionStaticRankOpset5) {
         auto add_const_2 = opset1::Constant::create(precision, {1, 3, 1, 1}, {3});
         auto add_2 = std::make_shared<opset1::Add>(mul, add_const_2);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{add_2}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{add_2}, ParameterVector{input});
     }
 }
 
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionDynamicShapesOpset1) {
         auto var = std::make_shared<opset1::Parameter>(precision, PartialShape{-1});
         auto batch_norm = std::make_shared<opset1::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_norm}, ParameterVector{input, gamma, beta, mean, var});
+        model = std::make_shared<ov::Model>(OutputVector{batch_norm}, ParameterVector{input, gamma, beta, mean, var});
         manager.register_pass<ov::pass::BatchNormDecomposition>();
         comparator.enable(FunctionsComparator::CONST_VALUES);
     }
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionDynamicShapesOpset5) {
         auto var = std::make_shared<opset1::Parameter>(precision, PartialShape{-1});
         auto batch_norm = std::make_shared<opset5::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_norm}, ParameterVector{input, gamma, beta, mean, var});
+        model = std::make_shared<ov::Model>(OutputVector{batch_norm}, ParameterVector{input, gamma, beta, mean, var});
         manager.register_pass<ov::pass::BatchNormDecomposition>();
         comparator.enable(FunctionsComparator::CONST_VALUES);
     }
@@ -159,7 +159,7 @@ TEST_F(TransformationTestsF, BatchNormDecompositionDynamicRank) {
         auto broadcast = std::make_shared<opset1::BatchNormInference>(input, gamma, beta, mean, var, 0.001);
         broadcast->set_friendly_name("broadcast");
 
-        model = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
         manager.register_pass<ov::pass::BatchNormDecomposition>();
     }
 }

--- a/src/common/transformations/tests/op_conversions/batch_to_space_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/batch_to_space_decomposition_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, BatchToSpaceDecompositionByElements) {
         auto crops_end = std::make_shared<opset3::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
         auto batch_to_space = std::make_shared<opset3::BatchToSpace>(data, block_shape, crops_begin, crops_end);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_to_space}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{batch_to_space}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertBatchToSpace>();
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, BatchToSpaceDecompositionByElements) {
         std::vector<int64_t> end_mask(4, 0);
         auto ss = std::make_shared<opset3::StridedSlice>(reshape_after_3, begin, end, begin_mask, end_mask);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
     }
 }
 
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, SpaceToBatchDecompositionByElements) {
         auto pads_end = std::make_shared<opset3::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
         auto batch_to_space = std::make_shared<opset3::SpaceToBatch>(data, block_shape, pads_begin, pads_end);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_to_space}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{batch_to_space}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertSpaceToBatch>();
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -129,7 +129,7 @@ TEST_F(TransformationTestsF, SpaceToBatchDecompositionByElements) {
         auto permute_4 = std::make_shared<opset3::Transpose>(reshape_before_4, axis_order_4);
         auto reshape_after_4 = std::make_shared<opset3::Reshape>(permute_4, squeezed_order_4, false);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{reshape_after_4}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{reshape_after_4}, ParameterVector{data});
     }
 }
 
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, SpaceToBatchDecomposition) {
         auto pads_end = std::make_shared<opset3::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
         auto batch_to_space = std::make_shared<opset3::SpaceToBatch>(data, block_shape, pads_begin, pads_end);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_to_space}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{batch_to_space}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertSpaceToBatch>(false);
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -162,7 +162,7 @@ TEST_F(TransformationTestsF, SpaceToBatchDecomposition) {
         auto permute = std::make_shared<opset3::Transpose>(reshape_before, axis_order);
         auto reshape_after = std::make_shared<opset3::Reshape>(permute, squeezed_order, false);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{reshape_after}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{reshape_after}, ParameterVector{data});
     }
 }
 
@@ -175,7 +175,7 @@ TEST_F(TransformationTestsF, BatchToSpaceDecomposition) {
         auto crops_end = std::make_shared<opset3::Constant>(element::i64, Shape{4}, std::vector<int64_t>{0, 3, 0, 0});
         auto batch_to_space = std::make_shared<opset3::BatchToSpace>(data, block_shape, crops_begin, crops_end);
 
-        model = std::make_shared<ov::Model>(NodeVector{batch_to_space}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{batch_to_space}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertBatchToSpace>(false);
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -197,7 +197,7 @@ TEST_F(TransformationTestsF, BatchToSpaceDecomposition) {
         std::vector<int64_t> begin_mask(4, 0);
         std::vector<int64_t> end_mask(4, 0);
         auto ss = std::make_shared<opset3::StridedSlice>(reshape_after, begin, end, begin_mask, end_mask);
-        model_ref = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{data});
     }
 }
 
@@ -214,7 +214,7 @@ void op_convertion_type_test(const Params& params) {
     const auto input_2_p = Constant::create(block_elem_type, Shape{2}, {0, 0});
     const auto input_3_p = Constant::create(block_elem_type, Shape{2}, {0, 0});
     const auto bts_or_stb = make_shared<Op>(data, block_p, input_2_p, input_3_p);
-    const auto f = make_shared<Model>(NodeVector{bts_or_stb}, ParameterVector{data});
+    const auto f = make_shared<Model>(OutputVector{bts_or_stb}, ParameterVector{data});
 
     Manager m;
     m.register_pass<Conversion>(by_elements);
@@ -269,7 +269,7 @@ void op_convertion_test(const Params& params) {
     const auto input_2_p = Constant::create(element::i64, Shape{input_2.size()}, input_2);
     const auto input_3_p = Constant::create(element::i64, Shape{input_3.size()}, input_3);
     const auto bts_or_stb = make_shared<Op>(data, block_p, input_2_p, input_3_p);
-    const auto f = make_shared<Model>(NodeVector{bts_or_stb}, ParameterVector{data});
+    const auto f = make_shared<Model>(OutputVector{bts_or_stb}, ParameterVector{data});
 
     Manager m;
     m.set_per_pass_validation(false);

--- a/src/common/transformations/tests/op_conversions/convert_broadcast3_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_broadcast3_test.cpp
@@ -58,7 +58,7 @@ public:
         auto target_shape_node = opset1::Constant::create(element::i64, Shape{target_shape.size()}, target_shape);
         auto broadcast = std::make_shared<opset3::Broadcast>(input, target_shape_node, op::BroadcastType::NUMPY);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     std::shared_ptr<Model> get_reference_broadcast(const InputShape& input_shape, const TargetShape& target_shape) {
@@ -66,7 +66,7 @@ public:
         auto target_shape_node = opset1::Constant::create(element::i64, Shape{target_shape.size()}, target_shape);
         auto broadcast = std::make_shared<opset1::Broadcast>(input, target_shape_node, op::AutoBroadcastType::NUMPY);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 };
 
@@ -89,7 +89,7 @@ public:
         auto broadcast =
             std::make_shared<opset3::Broadcast>(input, target_shape_node, op::BroadcastType::BIDIRECTIONAL);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     std::shared_ptr<Model> get_reference_broadcast(const InputShape& input_shape, const TargetShape& target_shape) {
@@ -97,7 +97,7 @@ public:
         auto const_node = opset1::Constant::create(element::f32, Shape{target_shape}, {1});
         auto mul = std::make_shared<opset1::Multiply>(input, const_node);
 
-        return std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 };
 
@@ -122,7 +122,7 @@ public:
         auto broadcast =
             std::make_shared<opset3::Broadcast>(input, target_shape_node, op::BroadcastType::BIDIRECTIONAL);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     std::shared_ptr<Model> get_reference_broadcast(const InputShape& input_shape,
@@ -132,7 +132,7 @@ public:
             opset1::Constant::create(element::i64, Shape{aligned_target_shape.size()}, aligned_target_shape);
         auto broadcast = std::make_shared<opset1::Broadcast>(input, target_shape_node, op::AutoBroadcastType::NUMPY);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 };
 
@@ -156,7 +156,7 @@ public:
         auto broadcast =
             std::make_shared<opset3::Broadcast>(input, target_shape_node, op::BroadcastType::BIDIRECTIONAL);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input, target_shape_node});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input, target_shape_node});
     }
 
     std::shared_ptr<Model> get_reference_broadcast(const InputShape& input_shape, const TargetShape& target_shape) {
@@ -166,7 +166,7 @@ public:
         auto broadcast =
             std::make_shared<opset1::Broadcast>(constant_one, target_shape_node, op::AutoBroadcastType::NUMPY);
         auto mul = std::make_shared<opset1::Multiply>(input, broadcast);
-        return std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input, target_shape_node});
+        return std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input, target_shape_node});
     }
 };
 
@@ -190,7 +190,7 @@ public:
         auto broadcast =
             std::make_shared<opset3::Broadcast>(input, target_shape_node, op::BroadcastType::BIDIRECTIONAL);
 
-        return std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input, target_shape_node});
+        return std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input, target_shape_node});
     }
 
     std::shared_ptr<Model> get_reference_broadcast(const InputShape& input_shape, const TargetShape& target_shape) {
@@ -200,7 +200,7 @@ public:
         auto broadcast =
             std::make_shared<opset1::Broadcast>(constant_one, target_shape_node, op::AutoBroadcastType::NUMPY);
         auto mul = std::make_shared<opset1::LogicalAnd>(input, broadcast);
-        return std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input, target_shape_node});
+        return std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input, target_shape_node});
     }
 };
 
@@ -331,7 +331,7 @@ TEST(TransformationTests, ConvertBroadcast3WithNumpyModeToBroadcast1) {
         auto broadcast = std::make_shared<opset3::Broadcast>(input1, target_shape, op::BroadcastType::NUMPY);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -346,7 +346,7 @@ TEST(TransformationTests, ConvertBroadcast3WithNumpyModeToBroadcast1) {
         auto broadcast = std::make_shared<opset1::Broadcast>(input1, target_shape, op::AutoBroadcastType::NUMPY);
         broadcast->set_friendly_name("broadcast");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f_ref = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -367,7 +367,7 @@ TEST(TransformationTests, ConvertBroadcast3WithPDPDModeToBroadcast1) {
         auto broadcast = std::make_shared<opset3::Broadcast>(input1, target_shape, op::BroadcastType::PDPD);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -382,7 +382,7 @@ TEST(TransformationTests, ConvertBroadcast3WithPDPDModeToBroadcast1) {
         auto broadcast = std::make_shared<opset1::Broadcast>(input1, target_shape, op::AutoBroadcastType::PDPD);
         broadcast->set_friendly_name("broadcast");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f_ref = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -405,7 +405,7 @@ TEST(TransformationTests, ConvertBroadcast3WithExplicitModeToBroadcast1) {
             std::make_shared<opset3::Broadcast>(input1, target_shape, brodcast_axis, op::BroadcastType::EXPLICIT);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -421,7 +421,7 @@ TEST(TransformationTests, ConvertBroadcast3WithExplicitModeToBroadcast1) {
         auto broadcast =
             std::make_shared<opset1::Broadcast>(input1, target_shape, brodcast_axis, op::AutoBroadcastType::EXPLICIT);
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f_ref = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -445,7 +445,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToBroadcast1Cons
         auto broadcast = std::make_shared<opset3::Broadcast>(input1, target_shape, op::BroadcastType::BIDIRECTIONAL);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -460,7 +460,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToBroadcast1Cons
         auto broadcast = std::make_shared<opset1::Broadcast>(input, target_shape, op::AutoBroadcastType::NUMPY);
         broadcast->set_friendly_name("broadcast");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input});
+        f_ref = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -481,7 +481,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToBroadcast1Cons
         auto broadcast = std::make_shared<opset3::Broadcast>(input1, target_shape, op::BroadcastType::BIDIRECTIONAL);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -496,7 +496,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToBroadcast1Cons
         auto broadcast = std::make_shared<opset1::Broadcast>(input, target_shape, op::AutoBroadcastType::NUMPY);
         broadcast->set_friendly_name("broadcast");
 
-        f_ref = std::make_shared<Model>(NodeVector{broadcast}, ParameterVector{input});
+        f_ref = std::make_shared<Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -522,7 +522,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToMultiply) {
             std::make_shared<opset3::Broadcast>(input1, const_target_shape, op::BroadcastType::BIDIRECTIONAL);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -540,7 +540,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToMultiply) {
             std::make_shared<opset1::Multiply>(input, opset1::Constant::create(element::f32, target_shape, {1}));
         broadcast->set_friendly_name("broadcast");
 
-        f_ref = std::make_shared<Model>(NodeVector{broadcast}, ParameterVector{input});
+        f_ref = std::make_shared<Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -566,7 +566,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToLogicalAnd) {
             std::make_shared<opset3::Broadcast>(input1, const_target_shape, op::BroadcastType::BIDIRECTIONAL);
         broadcast->set_friendly_name("broadcast");
 
-        f = std::make_shared<Model>(NodeVector{broadcast}, ParameterVector{input1});
+        f = std::make_shared<Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -584,7 +584,7 @@ TEST(TransformationTests, ConvertBroadcast3WithBidirectionalModeToLogicalAnd) {
             std::make_shared<opset1::LogicalAnd>(input, opset1::Constant::create(element::boolean, target_shape, {1}));
         broadcast->set_friendly_name("broadcast");
 
-        f_ref = std::make_shared<Model>(NodeVector{broadcast}, ParameterVector{input});
+        f_ref = std::make_shared<Model>(OutputVector{broadcast}, ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/op_conversions/convert_broadcast_to_tiles_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_broadcast_to_tiles_test.cpp
@@ -27,7 +27,7 @@ TEST(TransformationTests, ConvertBroadcastToTilesDynamic) {
         auto broadcast = std::make_shared<opset1::Broadcast>(input1, target_shape);
         broadcast->set_friendly_name("broadcast");
 
-        auto f = std::make_shared<ov::Model>(NodeVector{broadcast}, ParameterVector{input1});
+        auto f = std::make_shared<ov::Model>(OutputVector{broadcast}, ParameterVector{input1});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();

--- a/src/common/transformations/tests/op_conversions/convert_convertpromotetypes_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_convertpromotetypes_test.cpp
@@ -56,7 +56,7 @@ protected:
         const auto rhs = std::make_shared<ov::op::v0::Parameter>(rhsType, rhsShape);
         const auto lhs_converted = std::make_shared<ov::op::v0::Convert>(lhs, alignType);
         const auto rhs_converted = std::make_shared<ov::op::v0::Convert>(rhs, alignType);
-        return std::make_shared<ov::Model>(ov::NodeVector{lhs_converted, rhs_converted},
+        return std::make_shared<ov::Model>(ov::OutputVector{lhs_converted, rhs_converted},
                                            ov::ParameterVector{lhs, rhs},
                                            "Reference");
     }

--- a/src/common/transformations/tests/op_conversions/convert_deformable_conv_v8_to_v1_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_deformable_conv_v8_to_v1_test.cpp
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, ConvertDeformableConv8to1) {
                                                                                padding,
                                                                                dilations);
 
-        model = std::make_shared<Model>(NodeVector{deformable_conv}, ParameterVector{data, filter, offsets});
+        model = std::make_shared<Model>(OutputVector{deformable_conv}, ParameterVector{data, filter, offsets});
         manager.register_pass<ov::pass::ConvertDeformableConv8To1>();
     }
 
@@ -66,7 +66,7 @@ TEST_F(TransformationTestsF, ConvertDeformableConv8to1) {
                                                                                padding,
                                                                                dilations);
 
-        model_ref = std::make_shared<Model>(NodeVector{deformable_conv}, ParameterVector{data, filter, offsets});
+        model_ref = std::make_shared<Model>(OutputVector{deformable_conv}, ParameterVector{data, filter, offsets});
     }
 }
 
@@ -95,7 +95,7 @@ TEST_F(TransformationTestsF, ConvertDeformableConv8to1_mask) {
                                                                                padding,
                                                                                dilations);
 
-        model = std::make_shared<Model>(NodeVector{deformable_conv}, ParameterVector{data, filter, mask, offsets});
+        model = std::make_shared<Model>(OutputVector{deformable_conv}, ParameterVector{data, filter, mask, offsets});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::ConvertDeformableConv8To1>();
@@ -128,7 +128,7 @@ TEST_F(TransformationTestsF, ConvertDeformableConv8to1_bilinear_interpolation_pa
                                                                                1,
                                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{deformable_conv}, ParameterVector{data, filter, offsets});
+        model = std::make_shared<Model>(OutputVector{deformable_conv}, ParameterVector{data, filter, offsets});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::ConvertDeformableConv8To1>();

--- a/src/common/transformations/tests/op_conversions/convert_gather_0d_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_0d_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, ConvertGather0DStatic1) {
         auto axis_const = opset1::Constant::create(element::i64, Shape{}, {1});
         auto gather = std::make_shared<opset1::Gather>(input, indices, axis_const);
 
-        model = std::make_shared<Model>(NodeVector{gather}, ParameterVector{input, indices});
+        model = std::make_shared<Model>(OutputVector{gather}, ParameterVector{input, indices});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::ConvertGather0D>();
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, ConvertGather0DStatic1) {
         auto axis_const = opset1::Constant::create(element::i64, Shape{}, {1});
         auto gather = std::make_shared<opset1::Gather>(input, indices, axis_const);
 
-        model_ref = std::make_shared<Model>(NodeVector{gather}, ParameterVector{input, indices});
+        model_ref = std::make_shared<Model>(OutputVector{gather}, ParameterVector{input, indices});
     }
 }
 
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, ConvertGather0DStatic2) {
         auto axis_const = opset1::Constant::create(element::i64, Shape{}, {1});
         auto gather = std::make_shared<opset1::Gather>(input, indices, axis_const);
 
-        model = std::make_shared<Model>(NodeVector{gather}, ParameterVector{input, indices});
+        model = std::make_shared<Model>(OutputVector{gather}, ParameterVector{input, indices});
         manager.register_pass<ov::pass::ConvertGather0D>();
     }
 
@@ -63,6 +63,6 @@ TEST_F(TransformationTestsF, ConvertGather0DStatic2) {
         auto gather = std::make_shared<opset1::Gather>(input, unsqueeze, axis_const);
         auto squeeze = std::make_shared<opset1::Squeeze>(gather, opset1::Constant::create(element::i64, Shape{1}, {1}));
 
-        model_ref = std::make_shared<Model>(NodeVector{squeeze}, ParameterVector{input, indices});
+        model_ref = std::make_shared<Model>(OutputVector{squeeze}, ParameterVector{input, indices});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_gather_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_downgrade_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, ConvertGather7toGather1) {
 
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, 0);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data, indices});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data, indices});
         manager.register_pass<ov::pass::ConvertGather7ToGather1>();
     }
 
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, ConvertGather7toGather1) {
 
         auto gather_v1 = std::make_shared<opset1::Gather>(data, indices, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gather_v1}, ParameterVector{data, indices});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gather_v1}, ParameterVector{data, indices});
     }
 }
 
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, ConvertGather7toGather1_nonzero_batch_dims) {
 
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, -1);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data, indices});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data, indices});
         manager.register_pass<ov::pass::ConvertGather7ToGather1>();
     }
 }
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_param_indices) {
 
         auto gather_v8 = std::make_shared<opset8::Gather>(data, indices, axis, batch_dims);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v8}, ParameterVector{data, indices});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v8}, ParameterVector{data, indices});
 
         manager.register_pass<ov::pass::ConvertGather8ToGather7>();
     }
@@ -79,7 +79,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_const_indices) {
 
         auto gather_v8 = std::make_shared<opset8::Gather>(data, indices, axis, batch_dims);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v8}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertGather8ToGather7>();
     }
@@ -92,7 +92,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_const_indices) {
 
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, batch_dims);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data});
     }
 }
 
@@ -105,7 +105,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_negative_indices) {
 
         auto gather_v8 = std::make_shared<opset8::Gather>(data, indices, axis, batch_dims);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v8}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertGather8ToGather7>();
         comparator.enable(FunctionsComparator::CONST_VALUES);
@@ -119,7 +119,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_negative_indices) {
 
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, batch_dims);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data});
     }
 }
 
@@ -132,7 +132,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_out_of_bound_indices) {
 
         auto gather_v8 = std::make_shared<opset8::Gather>(data, indices, axis, batch_dims);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v8}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertGather8ToGather7>();
     }
@@ -147,7 +147,7 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_negative_axis) {
 
         auto gather_v8 = std::make_shared<opset8::Gather>(data, indices, axis, batch_dims);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v8}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertGather8ToGather7>();
     }
@@ -160,6 +160,6 @@ TEST_F(TransformationTestsF, ConvertGather8toGather7_negative_axis) {
 
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, batch_dims);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_to_compressed_test.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed1) {
         auto scale = std::make_shared<ov::op::v1::Multiply>(convert, scale_const);
         auto gather = std::make_shared<ov::op::v8::Gather>(scale, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<ConvertGatherToGatherCompressed>();
     }
     {
@@ -44,7 +44,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed1) {
         auto gather_compressed =
             std::make_shared<ov::op::internal::GatherCompressed>(weights_const, input1, axis_const, 0, scale_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gather_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -60,7 +60,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed2) {
         auto scale = std::make_shared<ov::op::v1::Multiply>(sub, scale_const);
         auto gather = std::make_shared<ov::op::v8::Gather>(scale, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<ConvertGatherToGatherCompressed>();
     }
     {
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed2) {
                                                                                       scale_const,
                                                                                       zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gather_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed3) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(scale, reshape_const, false);
         auto gather = std::make_shared<ov::op::v8::Gather>(reshape, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<ConvertGatherToGatherCompressed>();
     }
     {
@@ -110,7 +110,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed3) {
                                                                                       scale_const,
                                                                                       zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gather_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -128,7 +128,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed4) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(scale, reshape_const, false);
         auto gather = std::make_shared<ov::op::v8::Gather>(reshape, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<ConvertGatherToGatherCompressed>();
     }
     {
@@ -144,7 +144,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressed4) {
                                                                                       scale_const,
                                                                                       zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gather_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -161,7 +161,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedFP16) {
         auto scale_convert = std::make_shared<ov::op::v0::Convert>(scale, ov::element::f32);
         auto gather = std::make_shared<ov::op::v8::Gather>(scale_convert, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<ConvertGatherToGatherCompressed>();
     }
     {
@@ -178,7 +178,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedFP16) {
                                                                                       scale_convert,
                                                                                       zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gather_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -200,7 +200,7 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedMultiOutput) {
         auto scale = std::make_shared<ov::op::v1::Multiply>(convert, scale_const);
         auto gather = std::make_shared<ov::op::v8::Gather>(scale, topk->output(1), axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1, input2});
         manager.register_pass<ConvertGatherToGatherCompressed>();
     }
     {
@@ -222,7 +222,8 @@ TEST_F(TransformationTestsF, ConvertGatherToCompressedMultiOutput) {
                                                                                       0,
                                                                                       scale_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{gather_compressed}, ov::ParameterVector{input1, input2});
+        model_ref =
+            std::make_shared<ov::Model>(ov::OutputVector{gather_compressed}, ov::ParameterVector{input1, input2});
     }
 }
 
@@ -237,7 +238,7 @@ TEST_F(TransformationTestsF, MoveDecompressionAfterGatherFP16Weight) {
         auto convert = std::make_shared<ov::op::v0::Convert>(weights_const, ov::element::f32);
         auto gather = std::make_shared<ov::op::v8::Gather>(convert, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<MoveDecompressionAfterGather>();
     }
     {
@@ -247,7 +248,7 @@ TEST_F(TransformationTestsF, MoveDecompressionAfterGatherFP16Weight) {
         auto gather = std::make_shared<ov::op::v8::Gather>(weights_const, input1, axis_const);
         auto convert = std::make_shared<ov::op::v0::Convert>(gather, ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input1});
     }
 }
 
@@ -259,7 +260,7 @@ TEST_F(TransformationTestsF, MoveDecompressionAfterGatherBF16Weight) {
         auto convert = std::make_shared<ov::op::v0::Convert>(weights_const, ov::element::f32);
         auto gather = std::make_shared<ov::op::v8::Gather>(convert, input1, axis_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{gather}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{gather}, ov::ParameterVector{input1});
         manager.register_pass<MoveDecompressionAfterGather>();
     }
     {
@@ -269,6 +270,6 @@ TEST_F(TransformationTestsF, MoveDecompressionAfterGatherBF16Weight) {
         auto gather = std::make_shared<ov::op::v8::Gather>(weights_const, input1, axis_const);
         auto convert = std::make_shared<ov::op::v0::Convert>(gather, ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input1});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_gather_upgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_gather_upgrade_test.cpp
@@ -28,7 +28,7 @@ TEST_F(TransformationTestsF, ConvertGather1toGather7) {
 
         auto gather_v1 = std::make_shared<opset1::Gather>(data, indices, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v1}, ParameterVector{data, indices});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v1}, ParameterVector{data, indices});
         manager.register_pass<ov::pass::ConvertGather1ToGather7>();
     }
 
@@ -39,7 +39,7 @@ TEST_F(TransformationTestsF, ConvertGather1toGather7) {
 
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, 0);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data, indices});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data, indices});
     }
 }
 
@@ -51,7 +51,7 @@ TEST_F(TransformationTestsF, ConvertGather7toGather8) {
         int64_t batch_dims = 1;
         auto gather_v7 = std::make_shared<opset7::Gather>(data, indices, axis, batch_dims);
 
-        model = std::make_shared<ov::Model>(NodeVector{gather_v7}, ParameterVector{data, indices});
+        model = std::make_shared<ov::Model>(OutputVector{gather_v7}, ParameterVector{data, indices});
 
         manager.register_pass<ov::pass::ConvertGather7ToGather8>();
     }
@@ -64,6 +64,6 @@ TEST_F(TransformationTestsF, ConvertGather7toGather8) {
 
         auto gather_v8 = std::make_shared<opset8::Gather>(data, indices, axis, batch_dims);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gather_v8}, ParameterVector{data, indices});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gather_v8}, ParameterVector{data, indices});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_interpolate1_to_interpolate4_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_interpolate1_to_interpolate4_test.cpp
@@ -36,7 +36,7 @@ TEST_F(TransformationTestsF, ConvertInterpolate1ToInterpolate4) {
 
         auto interpolate1 = std::make_shared<opset1::Interpolate>(data_node, out_shape_node, interpolate1_attr);
 
-        model = std::make_shared<Model>(NodeVector{interpolate1}, ParameterVector{data_node});
+        model = std::make_shared<Model>(OutputVector{interpolate1}, ParameterVector{data_node});
 
         manager.register_pass<ov::pass::ConvertInterpolate1ToInterpolate4>();
     }
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, ConvertInterpolate1ToInterpolate4) {
                                                                   axes_node,
                                                                   interpolate4_attr);
 
-        model_ref = std::make_shared<Model>(NodeVector{interpolate4}, ParameterVector{data_node});
+        model_ref = std::make_shared<Model>(OutputVector{interpolate4}, ParameterVector{data_node});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -84,7 +84,7 @@ TEST_F(TransformationTestsF, ConvertInterpolate1ToInterpolate4_1) {
 
         auto interpolate1 = std::make_shared<opset1::Interpolate>(data_node, out_shape_node, interpolate1_attr);
 
-        model = std::make_shared<Model>(NodeVector{interpolate1}, ParameterVector{data_node});
+        model = std::make_shared<Model>(OutputVector{interpolate1}, ParameterVector{data_node});
 
         manager.register_pass<ov::pass::ConvertInterpolate1ToInterpolate4>();
     }
@@ -111,7 +111,7 @@ TEST_F(TransformationTestsF, ConvertInterpolate1ToInterpolate4_1) {
                                                                   axes_node,
                                                                   interpolate4_attr);
 
-        model_ref = std::make_shared<Model>(NodeVector{interpolate4}, ParameterVector{data_node});
+        model_ref = std::make_shared<Model>(OutputVector{interpolate4}, ParameterVector{data_node});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -129,7 +129,7 @@ TEST(TransformationTests, DynamiShapeInterpolate1To4) {
     interpolate1_attr.pads_end = std::vector<size_t>{0, 0, 0, 0};
 
     auto interpolate1 = std::make_shared<opset1::Interpolate>(data_node, out_shape_node, interpolate1_attr);
-    auto f = std::make_shared<Model>(NodeVector{interpolate1}, ParameterVector{data_node, out_shape_node});
+    auto f = std::make_shared<Model>(OutputVector{interpolate1}, ParameterVector{data_node, out_shape_node});
 
     auto manager = ov::pass::Manager();
     manager.register_pass<ov::pass::InitNodeInfo>();

--- a/src/common/transformations/tests/op_conversions/convert_matrix_nms_to_matrix_nms_ie_internal.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_matrix_nms_to_matrix_nms_ie_internal.cpp
@@ -40,7 +40,7 @@ public:
 
             auto nms = std::make_shared<opset8::MatrixNms>(boxes, scores, opset8::MatrixNms::Attributes());
 
-            model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+            model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
             manager.register_pass<ov::pass::ConvertMatrixNmsToMatrixNmsIE>();
             manager.register_pass<pass::ConstantFolding>();
@@ -54,7 +54,7 @@ public:
                 scores,
                 opset8::MatrixNms::Attributes());
 
-            model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+            model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
         }
         ASSERT_EQ(model->get_output_element_type(0), model_ref->get_output_element_type(0))
             << "Output element type mismatch " << model->get_output_element_type(0).get_type_name() << " vs "

--- a/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_maxpool_downgrade_test.cpp
@@ -159,7 +159,7 @@ TEST_F(TransformationTestsF, ConvertMaxPool8ToMaxPool1) {
         ov::Shape pads_begin{0}, pads_end{0}, kernel{1};
         auto maxpool_8 = std::make_shared<ov::op::v8::MaxPool>(data, strides, dilations, pads_begin, pads_end, kernel);
         auto result = std::make_shared<ov::op::v0::Result>(maxpool_8->output(0));
-        model = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{data});
         manager.register_pass<ov::pass::ConvertMaxPool8ToMaxPool1>();
     }
 
@@ -169,7 +169,7 @@ TEST_F(TransformationTestsF, ConvertMaxPool8ToMaxPool1) {
         ov::Shape pads_begin{0}, pads_end{0}, kernel{1};
         auto maxpool_1 = std::make_shared<ov::op::v1::MaxPool>(data, strides, pads_begin, pads_end, kernel);
         auto result = std::make_shared<ov::op::v0::Result>(maxpool_1->output(0));
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{data});
     }
 }
 

--- a/src/common/transformations/tests/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie_internal.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_multiclass_nms_to_multiclass_nms_ie_internal.cpp
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, ConvertMulticlassNmsToMulticlassNmsIE) {
 
         auto nms = std::make_shared<opset9::MulticlassNms>(boxes, scores, opset9::MulticlassNms::Attributes());
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertMulticlassNmsToMulticlassNmsIE>();
         manager.register_pass<ov::pass::ConstantFolding>();
@@ -42,6 +42,6 @@ TEST_F(TransformationTestsF, ConvertMulticlassNmsToMulticlassNmsIE) {
                                                                                scores,
                                                                                opset9::MulticlassNms::Attributes());
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_multiclass_nms_upgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_multiclass_nms_upgrade_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, ConvertMulticlassNms8ToMulticlassNms9) {
 
         auto nms = std::make_shared<opset8::MulticlassNms>(boxes, scores, opset8::MulticlassNms::Attributes());
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertMulticlassNms8ToMulticlassNms9>();
     }
@@ -37,7 +37,7 @@ TEST_F(TransformationTestsF, ConvertMulticlassNms8ToMulticlassNms9) {
         auto scores = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 1, 1000});
         auto nms = std::make_shared<opset9::MulticlassNms>(boxes, scores, opset9::MulticlassNms::Attributes());
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, ConvertMulticlassNms8ToMulticlassNms9_dynamic_rank)
 
         auto nms = std::make_shared<opset8::MulticlassNms>(boxes, scores, opset8::MulticlassNms::Attributes());
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertMulticlassNms8ToMulticlassNms9>();
     }
@@ -58,7 +58,7 @@ TEST_F(TransformationTestsF, ConvertMulticlassNms8ToMulticlassNms9_dynamic_rank)
         auto scores = std::make_shared<opset1::Parameter>(element::f32, PartialShape::dynamic());
         auto nms = std::make_shared<opset9::MulticlassNms>(boxes, scores, opset9::MulticlassNms::Attributes());
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, ConvertMulticlassNms8ToMulticlassNms9_dynamic_dims)
 
         auto nms = std::make_shared<opset8::MulticlassNms>(boxes, scores, opset8::MulticlassNms::Attributes());
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertMulticlassNms8ToMulticlassNms9>();
     }
@@ -85,6 +85,6 @@ TEST_F(TransformationTestsF, ConvertMulticlassNms8ToMulticlassNms9_dynamic_dims)
             PartialShape({Dimension::dynamic(), Dimension::dynamic(), Dimension::dynamic()}));
         auto nms = std::make_shared<opset9::MulticlassNms>(boxes, scores, opset9::MulticlassNms::Attributes());
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_mvn1_to_mvn6_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_mvn1_to_mvn6_test.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, ConvertMVN1ToMVN6) {
         auto data = std::make_shared<opset2::Parameter>(element::f32, Shape{1, 2, 3, 4});
         auto mvn = std::make_shared<op::v0::MVN>(data, false, true, 1e-5);
 
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertMVN1ToMVN6>();
     }
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, ConvertMVN1ToMVN6) {
         auto axes_const = opset6::Constant::create(element::i64, Shape{2}, {2, 3});
         auto mvn = std::make_shared<op::v6::MVN>(data, axes_const, true, 1e-5f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
     }
 }
 
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, ConvertMVN1ToMVN6_across_channels) {
         auto data = std::make_shared<opset2::Parameter>(element::f32, Shape{1, 2, 3, 4});
         auto mvn = std::make_shared<op::v0::MVN>(data, true, true, 1e-5);
 
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertMVN1ToMVN6>();
     }
@@ -53,7 +53,7 @@ TEST_F(TransformationTestsF, ConvertMVN1ToMVN6_across_channels) {
         auto axes_const = opset6::Constant::create(element::i64, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<op::v6::MVN>(data, axes_const, true, 1e-5f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
     }
 }
 
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, ConvertMVN1ToMVN6_5D) {
         auto data = std::make_shared<opset2::Parameter>(element::f32, Shape{1, 2, 3, 4, 5});
         auto mvn = std::make_shared<op::v0::MVN>(data, false, true, 1e-5);
 
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
 
         manager.register_pass<ov::pass::ConvertMVN1ToMVN6>();
     }
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, ConvertMVN1ToMVN6_5D) {
         auto axes_const = opset6::Constant::create(element::i64, Shape{3}, {2, 3, 4});
         auto mvn = std::make_shared<op::v6::MVN>(data, axes_const, true, 1e-5f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
     }
 }
 
@@ -92,14 +92,14 @@ TEST_P(ConvertMVN1ToMVN6_OutOfFloat32Eps, Limits) {
     {
         auto data = std::make_shared<opset2::Parameter>(element::f32, Shape{1, 2, 3, 4});
         auto mvn = std::make_shared<op::v0::MVN>(data, true, true, params.eps_d);
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
     }
     {
         auto data = std::make_shared<opset6::Parameter>(element::f32, Shape{1, 2, 3, 4});
         auto axes_const = opset6::Constant::create(element::i64, Shape{3}, {1, 2, 3});
         auto mvn = std::make_shared<op::v6::MVN>(data, axes_const, true, params.eps_f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
     }
 }
 

--- a/src/common/transformations/tests/op_conversions/convert_nms9_to_nms_ie_internal_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_nms9_to_nms_ie_internal_test.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
                                                                    op::v1::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                    true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS1ToNMS9>();
         manager.register_pass<ov::pass::ConvertNMS9ToNMSIEInternal>();
@@ -65,7 +65,7 @@ TEST_F(TransformationTestsF, ConvertPreviousNMSToNMSIEInternal) {
                                                                                    element::i32);
         auto convert = std::make_shared<ov::op::v0::Convert>(nms->output(0), element::i64);
 
-        model_ref = std::make_shared<Model>(NodeVector{convert}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{convert}, ParameterVector{boxes, scores});
     }
 }
 
@@ -87,7 +87,7 @@ TEST_F(TransformationTestsF, ConvertNMS9ToNMSIEInternal) {
                                                                true,
                                                                element::i32);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS9ToNMSIEInternal>();
         manager.register_pass<pass::ConstantFolding>();
@@ -110,6 +110,6 @@ TEST_F(TransformationTestsF, ConvertNMS9ToNMSIEInternal) {
                                                                                    true,
                                                                                    element::i32);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_nms_to_nms_ie_internal_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_nms_to_nms_ie_internal_test.cpp
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, ConvertNMS3ToNMSIEInternal) {
                                                                true,
                                                                element::i32);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS3ToNMS5>();
         manager.register_pass<ov::pass::ConvertNMSToNMSIEInternal>();
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, ConvertNMS3ToNMSIEInternal) {
                                                                                    true,
                                                                                    element::i32);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -84,7 +84,7 @@ TEST_F(TransformationTestsF, ConvertNMS4ToNMSIEInternal) {
                                                                true,
                                                                element::i32);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS4ToNMS5>();
         manager.register_pass<ov::pass::ConvertNMSToNMSIEInternal>();
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, ConvertNMS4ToNMSIEInternal) {
                                                                                    true,
                                                                                    element::i32);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -128,7 +128,7 @@ TEST_F(TransformationTestsF, ConvertNMS5ToNMSIEInternal) {
                                                                true,
                                                                element::i32);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMSToNMSIEInternal>();
         manager.register_pass<pass::ConstantFolding>();
@@ -151,6 +151,6 @@ TEST_F(TransformationTestsF, ConvertNMS5ToNMSIEInternal) {
                                                                                    true,
                                                                                    element::i32);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_pad_to_group_conv.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_pad_to_group_conv.cpp
@@ -125,7 +125,7 @@ TEST_BODY(ConvertPadToConv) {
         auto pad_value = Constant::create(element::f32, Shape{}, {0});
         auto pad_mode = op::PadMode::CONSTANT;
         auto pad = pad_factory->create(input, pad_begin, pad_end, pad_value, pad_mode);
-        model = std::make_shared<Model>(NodeVector{pad}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{pad}, ParameterVector{input});
 
         manager.register_pass<ov::pass::ConvertPadToGroupConvolution>();
     }
@@ -137,7 +137,7 @@ TEST_BODY(ConvertPadToConv) {
         CoordinateDiff pad_begin{1, 0}, pad_end{0, 1};
         auto conv = std::make_shared<GroupConvolution>(input, weights, stride, pad_begin, pad_end, stride);
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input});
     }
 }
 
@@ -149,7 +149,7 @@ TEST_BODY(NegativeConvertPadToConv) {
         auto pad_value = Constant::create(element::f32, Shape{}, {0});
         auto pad_mode = op::PadMode::CONSTANT;
         auto pad = pad_factory->create(input, pad_begin, pad_end, pad_value, pad_mode);
-        model = std::make_shared<Model>(NodeVector{pad}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{pad}, ParameterVector{input});
     }
     manager.register_pass<ov::pass::ConvertPadToGroupConvolution>();
 }
@@ -162,7 +162,7 @@ TEST_BODY(ConvertPadToConvNeg1) {
         auto pad_value = Constant::create(element::f32, Shape{}, {0});
         auto pad_mode = op::PadMode::CONSTANT;
         auto pad = pad_factory->create(input, pad_begin, pad_end, pad_value, pad_mode);
-        model = std::make_shared<Model>(NodeVector{pad}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{pad}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::ConvertPadToGroupConvolution>();
@@ -176,7 +176,7 @@ TEST_BODY(ConvertPadToConvNeg2) {
         auto pad_value = Constant::create(element::f32, Shape{}, {0});
         auto pad_mode = op::PadMode::CONSTANT;
         auto pad = pad_factory->create(input, pad_begin, pad_end, pad_value, pad_mode);
-        model = std::make_shared<Model>(NodeVector{pad}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{pad}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::ConvertPadToGroupConvolution>();
@@ -190,7 +190,7 @@ TEST_BODY(ConvertPadToConvNeg3) {
         auto pad_value = Constant::create(element::f32, Shape{}, {0});
         auto pad_mode = op::PadMode::SYMMETRIC;  // Unsupported mode
         auto pad = pad_factory->create(input, pad_begin, pad_end, pad_value, pad_mode);
-        model = std::make_shared<Model>(NodeVector{pad}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{pad}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::ConvertPadToGroupConvolution>();
@@ -204,7 +204,7 @@ TEST_BODY(ConvertPadToConvNeg4) {
         auto pad_value = Constant::create(element::f32, Shape{}, {1.});  // Unsupported value
         auto pad_mode = op::PadMode::CONSTANT;
         auto pad = pad_factory->create(input, pad_begin, pad_end, pad_value, pad_mode);
-        model = std::make_shared<Model>(NodeVector{pad}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{pad}, ParameterVector{input});
     }
 
     manager.register_pass<ov::pass::ConvertPadToGroupConvolution>();

--- a/src/common/transformations/tests/op_conversions/convert_previous_nms_to_nms_5.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_previous_nms_to_nms_5.cpp
@@ -38,7 +38,7 @@ TEST_F(TransformationTestsF, ConvertNMS4FiveInputsToNMS5) {
                                                                opset4::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS4ToNMS5>();
     }
@@ -57,7 +57,7 @@ TEST_F(TransformationTestsF, ConvertNMS4FiveInputsToNMS5) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -70,7 +70,7 @@ TEST_F(TransformationTestsF, ConvertNMS4TwoInputsToNMS5) {
                                                                opset4::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS4ToNMS5>();
     }
@@ -89,7 +89,7 @@ TEST_F(TransformationTestsF, ConvertNMS4TwoInputsToNMS5) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -108,7 +108,7 @@ TEST_F(TransformationTestsF, ConvertNMS3FiveInputsToNMS5) {
                                                                opset3::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS3ToNMS5>();
     }
@@ -127,7 +127,7 @@ TEST_F(TransformationTestsF, ConvertNMS3FiveInputsToNMS5) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -140,7 +140,7 @@ TEST_F(TransformationTestsF, ConvertNMS3TwoInputsToNMS5) {
                                                                opset3::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS3ToNMS5>();
     }
@@ -159,7 +159,7 @@ TEST_F(TransformationTestsF, ConvertNMS3TwoInputsToNMS5) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -178,7 +178,7 @@ TEST_F(TransformationTestsF, ConvertNMS1FiveInputsToNMS5) {
                                                                opset1::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS1ToNMS5>();
     }
@@ -197,7 +197,7 @@ TEST_F(TransformationTestsF, ConvertNMS1FiveInputsToNMS5) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -210,7 +210,7 @@ TEST_F(TransformationTestsF, ConvertNMS1TwoInputsToNMS5) {
                                                                opset1::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS1ToNMS5>();
     }
@@ -229,6 +229,6 @@ TEST_F(TransformationTestsF, ConvertNMS1TwoInputsToNMS5) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_previous_nms_to_nms_9.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_previous_nms_to_nms_9.cpp
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, ConvertNMS5SixInputsToNMS9) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS5ToNMS9>();
     }
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, ConvertNMS5SixInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -75,7 +75,7 @@ TEST_F(TransformationTestsF, ConvertNMS5TwoInputsToNMS9) {
                                                                opset5::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS5ToNMS9>();
     }
@@ -96,7 +96,7 @@ TEST_F(TransformationTestsF, ConvertNMS5TwoInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -115,7 +115,7 @@ TEST_F(TransformationTestsF, ConvertNMS4FiveInputsToNMS9) {
                                                                opset4::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS4ToNMS9>();
     }
@@ -136,7 +136,7 @@ TEST_F(TransformationTestsF, ConvertNMS4FiveInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -149,7 +149,7 @@ TEST_F(TransformationTestsF, ConvertNMS4TwoInputsToNMS9) {
                                                                opset4::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS4ToNMS9>();
     }
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, ConvertNMS4TwoInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -189,7 +189,7 @@ TEST_F(TransformationTestsF, ConvertNMS3FiveInputsToNMS9) {
                                                                opset3::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS3ToNMS9>();
     }
@@ -210,7 +210,7 @@ TEST_F(TransformationTestsF, ConvertNMS3FiveInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -223,7 +223,7 @@ TEST_F(TransformationTestsF, ConvertNMS3TwoInputsToNMS9) {
                                                                opset3::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS3ToNMS9>();
     }
@@ -244,7 +244,7 @@ TEST_F(TransformationTestsF, ConvertNMS3TwoInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -263,7 +263,7 @@ TEST_F(TransformationTestsF, ConvertNMS1FiveInputsToNMS9) {
                                                                opset1::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS1ToNMS9>();
     }
@@ -284,7 +284,7 @@ TEST_F(TransformationTestsF, ConvertNMS1FiveInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }
 
@@ -297,7 +297,7 @@ TEST_F(TransformationTestsF, ConvertNMS1TwoInputsToNMS9) {
                                                                opset1::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         manager.register_pass<ov::pass::ConvertNMS1ToNMS9>();
     }
@@ -318,6 +318,6 @@ TEST_F(TransformationTestsF, ConvertNMS1TwoInputsToNMS9) {
                                                                opset9::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        model_ref = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        model_ref = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_prior_box_v8_to_v0_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_prior_box_v8_to_v0_test.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, ConvertPriorBox8To0) {
 
         auto prior_box = std::make_shared<opset8::PriorBox>(input, image, attrs);
 
-        model = std::make_shared<Model>(NodeVector{prior_box}, ParameterVector{input, image});
+        model = std::make_shared<Model>(OutputVector{prior_box}, ParameterVector{input, image});
         manager.register_pass<ov::pass::ConvertPriorBox8To0>();
     }
 
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, ConvertPriorBox8To0) {
 
         auto prior_box = std::make_shared<opset1::PriorBox>(input, image, attrs);
 
-        model_ref = std::make_shared<Model>(NodeVector{prior_box}, ParameterVector{input, image});
+        model_ref = std::make_shared<Model>(OutputVector{prior_box}, ParameterVector{input, image});
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, ConvertPriorBox8To0_min_max_aspect_ratios_order) {
 
         auto prior_box = std::make_shared<opset8::PriorBox>(input, image, attrs);
 
-        model = std::make_shared<Model>(NodeVector{prior_box}, ParameterVector{input, image});
+        model = std::make_shared<Model>(OutputVector{prior_box}, ParameterVector{input, image});
         manager.register_pass<ov::pass::ConvertPriorBox8To0>();
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_reduce_to_pooling_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_reduce_to_pooling_test.cpp
@@ -71,7 +71,7 @@ public:
         // reduce = reduce_type->copy_with_new_inputs({input, axes_const});
         // reduce->set_keep_dims(keep_dims);
 
-        return std::make_shared<ov::Model>(NodeVector{reduce}, ParameterVector{input});
+        return std::make_shared<ov::Model>(OutputVector{reduce}, ParameterVector{input});
     }
 
     static std::shared_ptr<ov::Model> get_reference_function(const PartialShape& input_shape,
@@ -126,7 +126,7 @@ public:
                 true);
         }
 
-        return std::make_shared<ov::Model>(NodeVector{input.get_node_shared_ptr()}, ParameterVector{param});
+        return std::make_shared<ov::Model>(OutputVector{input.get_node_shared_ptr()}, ParameterVector{param});
     }
 };
 

--- a/src/common/transformations/tests/op_conversions/convert_roi_align_v3_to_v9_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_roi_align_v3_to_v9_test.cpp
@@ -44,7 +44,7 @@ TEST_F(TransformationTestsF, ConvertROIAlign3To9) {
                                                             1.0f / 16.0f,
                                                             "avg");
 
-        model = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{data, rois, batch_indices});
+        model = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{data, rois, batch_indices});
         manager.register_pass<ov::pass::ConvertROIAlign3To9>();
     }
 
@@ -73,6 +73,6 @@ TEST_F(TransformationTestsF, ConvertROIAlign3To9) {
                                                             1.0f / 16.0f,
                                                             pooling_mode);
 
-        model_ref = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{data, rois, batch_indices});
+        model_ref = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{data, rois, batch_indices});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_roi_align_v9_to_v3_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_roi_align_v9_to_v3_test.cpp
@@ -45,7 +45,7 @@ TEST_F(TransformationTestsF, ConvertROIAlign9To3) {
                                                             1.0f / 16.0f,
                                                             pooling_mode);
 
-        model = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{data, rois, batch_indices});
+        model = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{data, rois, batch_indices});
         manager.register_pass<ov::pass::ConvertROIAlign9To3>();
     }
 
@@ -73,7 +73,7 @@ TEST_F(TransformationTestsF, ConvertROIAlign9To3) {
                                                             1.0f / 16.0f,
                                                             "avg");
 
-        model_ref = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{data, rois, batch_indices});
+        model_ref = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{data, rois, batch_indices});
     }
 }
 
@@ -105,7 +105,7 @@ TEST_F(TransformationTestsF, ConvertROIAlign9To3_aligned_mode) {
                                                             pooling_mode,
                                                             aligned_mode);
 
-        model = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{data, rois, batch_indices});
+        model = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{data, rois, batch_indices});
         manager.register_pass<ov::pass::ConvertROIAlign9To3>();
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_scatter_elements_to_scatter_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_scatter_elements_to_scatter_test.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<ov::Model> get_initial_function(const PartialShape& data_shape,
 
     auto scatter = std::make_shared<opset3::ScatterElementsUpdate>(data, broadcast, updates, axis_const);
 
-    return std::make_shared<ov::Model>(NodeVector{scatter},
+    return std::make_shared<ov::Model>(OutputVector{scatter},
                                        ParameterVector{data, indexes, updates, broadcast_shape_param});
 }
 
@@ -77,7 +77,7 @@ std::shared_ptr<ov::Model> get_reference_function(const PartialShape& data_shape
 
     auto scatter = std::make_shared<opset3::ScatterUpdate>(data, index_out, updates, axis_const);
 
-    return std::make_shared<ov::Model>(NodeVector{scatter}, ParameterVector{data, indexes, updates});
+    return std::make_shared<ov::Model>(OutputVector{scatter}, ParameterVector{data, indexes, updates});
 }
 
 void gen_test(std::shared_ptr<ov::Model> f, std::shared_ptr<ov::Model> f_ref) {

--- a/src/common/transformations/tests/op_conversions/convert_sequences_to_ti_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_sequences_to_ti_test.cpp
@@ -50,7 +50,7 @@ TEST(TransformationTests, ConvertLSTMSequenceToTensorIterator) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho, Co}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho, Co}, ParameterVector{X, Y, Z});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -118,7 +118,7 @@ TEST(TransformationTests, ConvertLSTMSequenceToTensorIterator) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
         res_ti_C->set_friendly_name("Co");
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -156,7 +156,7 @@ TEST(TransformationTests, ConvertLSTMSequenceToTensorIteratorDynamic) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho, Co}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho, Co}, ParameterVector{X, Y, Z});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -225,7 +225,7 @@ TEST(TransformationTests, ConvertLSTMSequenceToTensorIteratorDynamic) {
         res_ti_H->set_friendly_name("Ho");
         res_ti_C->set_friendly_name("Co");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -266,7 +266,7 @@ TEST(TransformationTests, ConvertQuantizedLSTMSequenceToTensorIterator) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f = std::make_shared<Model>(NodeVector{Y, Ho, Co}, ParameterVector{X});
+        f = std::make_shared<Model>(OutputVector{Y, Ho, Co}, ParameterVector{X});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -337,7 +337,7 @@ TEST(TransformationTests, ConvertQuantizedLSTMSequenceToTensorIterator) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
         res_ti_C->set_friendly_name("Co");
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -371,7 +371,7 @@ TEST(TransformationTests, ConvertRNNSequenceToTensorIterator) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -426,7 +426,7 @@ TEST(TransformationTests, ConvertRNNSequenceToTensorIterator) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -460,7 +460,7 @@ TEST(TransformationTests, ConvertRNNSequenceToTensorIteratorDynamic) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -514,7 +514,7 @@ TEST(TransformationTests, ConvertRNNSequenceToTensorIteratorDynamic) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -548,7 +548,7 @@ TEST(TransformationTests, ConvertGRUSequenceToTensorIterator) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -603,7 +603,7 @@ TEST(TransformationTests, ConvertGRUSequenceToTensorIterator) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -637,7 +637,7 @@ TEST(TransformationTests, ConvertGRUSequenceToTensorIteratorDynamic) {
         Y_out->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -692,7 +692,7 @@ TEST(TransformationTests, ConvertGRUSequenceToTensorIteratorDynamic) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -730,7 +730,7 @@ TEST(TransformationTests, ConvertQuantizedGRUSequenceToTensorIterator) {
         Y->set_friendly_name("Y_out");
         Ho->set_friendly_name("Ho");
 
-        f = std::make_shared<Model>(NodeVector{Y, Ho}, ParameterVector{X});
+        f = std::make_shared<Model>(OutputVector{Y, Ho}, ParameterVector{X});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -792,7 +792,7 @@ TEST(TransformationTests, ConvertQuantizedGRUSequenceToTensorIterator) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
 
-        f_ref = std::make_shared<Model>(NodeVector{res_ti_Y, res_ti_H}, ParameterVector{X});
+        f_ref = std::make_shared<Model>(OutputVector{res_ti_Y, res_ti_H}, ParameterVector{X});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -867,7 +867,7 @@ TEST(TransformationTests, ConvertLSTMSequenceWithDynSeqLenToTensorIterator) {
         Ho->set_friendly_name("Ho");
         Co->set_friendly_name("Co");
 
-        f = std::make_shared<ov::Model>(NodeVector{Y_out, Ho, Co}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{Y_out, Ho, Co}, ParameterVector{X, Y, Z});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -938,7 +938,7 @@ TEST(TransformationTests, ConvertLSTMSequenceWithDynSeqLenToTensorIterator) {
         res_ti_Y->set_friendly_name("Y_out");
         res_ti_H->set_friendly_name("Ho");
         res_ti_C->set_friendly_name("Co");
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_Y, res_ti_H, res_ti_C}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/op_conversions/convert_shapeof3.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_shapeof3.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, ConvertShapeOf3WithI64) {
         auto shapeof = std::make_shared<opset3::ShapeOf>(input, element::i64);
         shapeof->set_friendly_name("shapeof");
 
-        model = std::make_shared<ov::Model>(NodeVector{shapeof}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{shapeof}, ParameterVector{input});
 
         manager.register_pass<ov::pass::ConvertShapeOf3>();
     }
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, ConvertShapeOf3WithI64) {
         auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 2, 3});
         auto shapeof = std::make_shared<opset1::ShapeOf>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{shapeof}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{shapeof}, ParameterVector{input});
     }
 }
 
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, ConvertShapeOf3WithI32) {
         auto input = std::make_shared<opset1::Parameter>(element::f32, Shape{1, 2, 3});
         auto shapeof = std::make_shared<opset3::ShapeOf>(input, element::i32);
 
-        model = std::make_shared<ov::Model>(NodeVector{shapeof}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{shapeof}, ParameterVector{input});
 
         manager.register_pass<ov::pass::ConvertShapeOf3>();
     }
@@ -52,6 +52,6 @@ TEST_F(TransformationTestsF, ConvertShapeOf3WithI32) {
         auto shapeof = std::make_shared<opset1::ShapeOf>(input);
         auto convert = std::make_shared<opset1::Convert>(shapeof, element::i32);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{convert}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{convert}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_shuffle_channels3_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_shuffle_channels3_test.cpp
@@ -22,7 +22,7 @@ using namespace ov;
 std::shared_ptr<ov::Model> buildInputGraph(int64_t axis, int64_t group, const ::PartialShape& p) {
     auto input = std::make_shared<::opset3::Parameter>(::element::f32, p);
     auto shuffle_channels = std::make_shared<::opset3::ShuffleChannels>(input, axis, group);
-    return std::make_shared<::Model>(::NodeVector{shuffle_channels}, ::ParameterVector{input});
+    return std::make_shared<::Model>(::OutputVector{shuffle_channels}, ::ParameterVector{input});
 }
 
 TEST_F(TransformationTestsF, ConvertShuffleChannelsAxis0) {
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, ConvertShuffleChannelsAxis0) {
                                               ::opset2::Constant::create(element::i64, Shape({3}), {1, 0, 2}));
     auto reshape_back = std::make_shared<::opset2::Reshape>(transpose->output(0), original_shape->output(0), false);
 
-    model_ref = std::make_shared<::Model>(::NodeVector{reshape_back}, ::ParameterVector{input});
+    model_ref = std::make_shared<::Model>(::OutputVector{reshape_back}, ::ParameterVector{input});
 }
 
 TEST_F(TransformationTestsF, ConvertShuffleChannelsAxis1) {
@@ -83,7 +83,7 @@ TEST_F(TransformationTestsF, ConvertShuffleChannelsAxis1) {
                                               ::opset2::Constant::create(element::i64, Shape({4}), {0, 2, 1, 3}));
     auto reshape_back = std::make_shared<::opset2::Reshape>(transpose->output(0), original_shape->output(0), false);
 
-    model_ref = std::make_shared<::Model>(::NodeVector{reshape_back}, ::ParameterVector{input});
+    model_ref = std::make_shared<::Model>(::OutputVector{reshape_back}, ::ParameterVector{input});
 }
 
 TEST_F(TransformationTestsF, ConvertShuffleChannelsAxis2) {
@@ -114,7 +114,7 @@ TEST_F(TransformationTestsF, ConvertShuffleChannelsAxis2) {
                                               ::opset2::Constant::create(element::i64, Shape({4}), {0, 2, 1, 3}));
     auto reshape_back = std::make_shared<::opset2::Reshape>(transpose->output(0), original_shape->output(0), false);
 
-    model_ref = std::make_shared<::Model>(::NodeVector{reshape_back}, ::ParameterVector{input});
+    model_ref = std::make_shared<::Model>(::OutputVector{reshape_back}, ::ParameterVector{input});
 }
 
 TEST_F(TransformationTestsF, ConvertShuffleChannelsLastAxis) {
@@ -144,5 +144,5 @@ TEST_F(TransformationTestsF, ConvertShuffleChannelsLastAxis) {
                                               ::opset2::Constant::create(element::i64, Shape({3}), {0, 2, 1}));
     auto reshape_back = std::make_shared<::opset2::Reshape>(transpose->output(0), original_shape->output(0), false);
 
-    model_ref = std::make_shared<::Model>(::NodeVector{reshape_back}, ::ParameterVector{input});
+    model_ref = std::make_shared<::Model>(::OutputVector{reshape_back}, ::ParameterVector{input});
 }

--- a/src/common/transformations/tests/op_conversions/convert_softmax_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_softmax_downgrade_test.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax8ToSoftMax1) {
         int64_t axis = 1;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertSoftMax8ToSoftMax1>();
     }
 
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax8ToSoftMax1) {
         size_t axis = 1;
         auto softmax_1 = std::make_shared<opset1::Softmax>(data, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softmax_1}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softmax_1}, ParameterVector{data});
     }
 }
 
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax8ToSoftMax1_negative_axis) {
         int64_t axis = -1;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertSoftMax8ToSoftMax1>();
     }
 
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax8ToSoftMax1_negative_axis) {
         size_t axis = 1;
         auto softmax_1 = std::make_shared<opset1::Softmax>(data, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softmax_1}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softmax_1}, ParameterVector{data});
     }
 }
 
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax8ToSoftMax1_input_rank_5) {
         int64_t axis = -2;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertSoftMax8ToSoftMax1>();
     }
 
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax8ToSoftMax1_input_rank_5) {
         size_t axis = 3;
         auto softmax_1 = std::make_shared<opset1::Softmax>(data, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softmax_1}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softmax_1}, ParameterVector{data});
     }
 }
 
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, negative_ConvertSoftMax8ToSoftMax1_dynamic_rank) {
         int64_t axis = -3;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertSoftMax8ToSoftMax1>();
     }
 
@@ -90,6 +90,6 @@ TEST_F(TransformationTestsF, negative_ConvertSoftMax8ToSoftMax1_dynamic_rank) {
         int64_t axis = -3;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_softmax_upgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_softmax_upgrade_test.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax1ToSoftMax8) {
         size_t axis = 1;
         auto softmax_1 = std::make_shared<opset1::Softmax>(data, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{softmax_1}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softmax_1}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertSoftMax1ToSoftMax8>();
     }
 
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax1ToSoftMax8) {
         int64_t axis = 1;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
     }
 }
 
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, ConvertSoftMax1ToSoftMax8_dynamic_rank) {
         size_t axis = 1;
         auto softmax_1 = std::make_shared<opset1::Softmax>(data, axis);
 
-        model = std::make_shared<ov::Model>(NodeVector{softmax_1}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softmax_1}, ParameterVector{data});
         manager.register_pass<ov::pass::ConvertSoftMax1ToSoftMax8>();
     }
 
@@ -52,6 +52,6 @@ TEST_F(TransformationTestsF, ConvertSoftMax1ToSoftMax8_dynamic_rank) {
         int64_t axis = 1;
         auto softmax_8 = std::make_shared<opset8::Softmax>(data, axis);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{softmax_8}, ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(OutputVector{softmax_8}, ParameterVector{data});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_subtract.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_subtract.cpp
@@ -22,7 +22,7 @@ TEST_F(TransformationTestsF, ConvertSubtract) {
         auto data2 = std::make_shared<opset8::Parameter>(element::f32, Shape{2});
         auto sub2 = std::make_shared<opset8::Subtract>(data1, data2);
 
-        model = std::make_shared<Model>(NodeVector{sub1, sub2}, ParameterVector{data1, data2});
+        model = std::make_shared<Model>(OutputVector{sub1, sub2}, ParameterVector{data1, data2});
 
         manager.register_pass<pass::ConvertSubtract>();
     }
@@ -35,7 +35,7 @@ TEST_F(TransformationTestsF, ConvertSubtract) {
         auto neg = std::make_shared<opset8::Multiply>(data2, opset8::Constant::create(element::f32, Shape{}, {-1}));
         auto add2 = std::make_shared<opset8::Add>(data1, neg);
 
-        model_ref = std::make_shared<Model>(NodeVector{add1, add2}, ParameterVector{data1, data2});
+        model_ref = std::make_shared<Model>(OutputVector{add1, add2}, ParameterVector{data1, data2});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -49,7 +49,7 @@ TEST_F(TransformationTestsF, ConvertSubtractWithConstant) {
         auto data2 = std::make_shared<opset8::Parameter>(element::f32, Shape{2});
         auto sub2 = std::make_shared<opset8::Subtract>(data1, data2);
 
-        model = std::make_shared<Model>(NodeVector{sub1, sub2}, ParameterVector{data1, data2});
+        model = std::make_shared<Model>(OutputVector{sub1, sub2}, ParameterVector{data1, data2});
 
         manager.register_pass<pass::ConvertSubtractWithConstant>();
     }
@@ -61,7 +61,7 @@ TEST_F(TransformationTestsF, ConvertSubtractWithConstant) {
         auto data2 = std::make_shared<opset8::Parameter>(element::f32, Shape{2});
         auto sub = std::make_shared<opset8::Subtract>(data1, data2);
 
-        model_ref = std::make_shared<Model>(NodeVector{add, sub}, ParameterVector{data1, data2});
+        model_ref = std::make_shared<Model>(OutputVector{add, sub}, ParameterVector{data1, data2});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);

--- a/src/common/transformations/tests/op_conversions/convert_ti_to_sequences_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_ti_to_sequences_test.cpp
@@ -87,7 +87,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequence) {
         res_ti_0->set_friendly_name("Result1");
         res_ti_1->set_friendly_name("Result2");
         res_ti_2->set_friendly_name("Result3");
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_0, res_ti_1, res_ti_2}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_0, res_ti_1, res_ti_2}, ParameterVector{X, Y, Z});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -134,7 +134,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequence) {
         res_ti_1->set_friendly_name("Result2");
         res_ti_2->set_friendly_name("Result3");
 
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_0, res_ti_1, res_ti_2}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_0, res_ti_1, res_ti_2}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -182,7 +182,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequenceDynamicReshapeCase)
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -224,7 +224,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequenceDynamicReshapeCase)
         auto out_1 = std::make_shared<opset5::Squeeze>(lstm_seq->output(1), axis_out);
         auto out_2 = std::make_shared<opset5::Squeeze>(lstm_seq->output(2), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -272,7 +272,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequenceDynamicSqueezeCase)
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -314,7 +314,7 @@ TEST(TransformationTests, ConvertTensorIteratorToLSTMSequenceDynamicSqueezeCase)
         auto out_1 = std::make_shared<opset5::Squeeze>(lstm_seq->output(1), axis_out);
         auto out_2 = std::make_shared<opset5::Squeeze>(lstm_seq->output(2), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -358,7 +358,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequence) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -394,7 +394,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequence) {
         auto out_0 = std::make_shared<opset5::Squeeze>(rnn_sequence->output(0), axis_out);
         auto out_1 = std::make_shared<opset5::Squeeze>(rnn_sequence->output(1), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -438,7 +438,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequenceDynamicReshapeCase) 
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -475,7 +475,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequenceDynamicReshapeCase) 
         auto out_0 = std::make_shared<opset5::Squeeze>(rnn_sequence->output(0), axis_out);
         auto out_1 = std::make_shared<opset5::Squeeze>(rnn_sequence->output(1), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -519,7 +519,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequenceDynamicSqueezeCase) 
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -555,7 +555,7 @@ TEST(TransformationTests, ConvertTensorIteratorToRNNSequenceDynamicSqueezeCase) 
         auto out_0 = std::make_shared<opset5::Squeeze>(rnn_sequence->output(0), axis_out);
         auto out_1 = std::make_shared<opset5::Squeeze>(rnn_sequence->output(1), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -599,7 +599,7 @@ TEST(TransformationTests, ConvertTensorIteratorToGRUSequence) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -635,7 +635,7 @@ TEST(TransformationTests, ConvertTensorIteratorToGRUSequence) {
         auto out_0 = std::make_shared<opset5::Squeeze>(gru_sequence->output(0), axis_out);
         auto out_1 = std::make_shared<opset5::Squeeze>(gru_sequence->output(1), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -679,7 +679,7 @@ TEST(TransformationTests, ConvertTensorIteratorToGRUSequenceDynamicReshapeCase) 
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -716,7 +716,7 @@ TEST(TransformationTests, ConvertTensorIteratorToGRUSequenceDynamicReshapeCase) 
         auto out_0 = std::make_shared<opset5::Squeeze>(gru_sequence->output(0), axis_out);
         auto out_1 = std::make_shared<opset5::Squeeze>(gru_sequence->output(1), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -760,7 +760,7 @@ TEST(TransformationTests, ConvertTensorIteratorToGRUSequenceDynamicSqueezeCase) 
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -797,7 +797,7 @@ TEST(TransformationTests, ConvertTensorIteratorToGRUSequenceDynamicSqueezeCase) 
         auto out_0 = std::make_shared<opset5::Squeeze>(gru_sequence->output(0), axis_out);
         auto out_1 = std::make_shared<opset5::Squeeze>(gru_sequence->output(1), axis_out);
         auto res_ti_1 = std::make_shared<opset5::Result>(out_0);
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
     }
 
     auto res = compare_functions(f, f_ref);

--- a/src/common/transformations/tests/op_conversions/convert_topk3_test.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_topk3_test.cpp
@@ -109,6 +109,6 @@ TEST_F(TransformationTestsF, ConvertTopK3I64Output1) {
         auto convert = std::make_shared<opset2::Convert>(topk->output(1), element::i64);
 
         // due to the 'compare_functions' limitation we will check only one output
-        model_ref = std::make_shared<ov::Model>(NodeVector{convert}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{convert}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/convert_xor_to_logical_xor.cpp
+++ b/src/common/transformations/tests/op_conversions/convert_xor_to_logical_xor.cpp
@@ -33,7 +33,7 @@ TEST_F(TransformationTestsF, ConvertXorToLogicalXor) {
         auto xor_op =
             std::make_shared<opset1::Xor>(input1, input2, ov::op::AutoBroadcastSpec(ov::op::AutoBroadcastType::NUMPY));
 
-        model = std::make_shared<ov::Model>(NodeVector{xor_op}, ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(OutputVector{xor_op}, ParameterVector{input1, input2});
         manager.register_pass<ov::pass::ConvertXorToLogicalXor>();
     }
 
@@ -52,6 +52,6 @@ TEST_F(TransformationTestsF, ConvertXorToLogicalXor) {
                                                   input2,
                                                   ov::op::AutoBroadcastSpec(ov::op::AutoBroadcastType::NUMPY));
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{logical_xor}, ParameterVector{input1, input2});
+        model_ref = std::make_shared<ov::Model>(OutputVector{logical_xor}, ParameterVector{input1, input2});
     }
 }

--- a/src/common/transformations/tests/op_conversions/detection_output_downgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/detection_output_downgrade_test.cpp
@@ -89,7 +89,7 @@ TEST(TransformationTests, DetectionOutput8ToDetectionOutput1) {
             auto detection_output_v8 =
                 std::make_shared<opset8::DetectionOutput>(box_logits, class_preds, proposals, attributes_v8);
 
-            f = std::make_shared<ov::Model>(NodeVector{detection_output_v8},
+            f = std::make_shared<ov::Model>(OutputVector{detection_output_v8},
                                             ParameterVector{box_logits, class_preds, proposals});
 
             pass::Manager manager;
@@ -105,7 +105,7 @@ TEST(TransformationTests, DetectionOutput8ToDetectionOutput1) {
             auto detection_output_v1 =
                 std::make_shared<opset1::DetectionOutput>(box_logits, class_preds, proposals, attributes_v1);
 
-            f_ref = std::make_shared<ov::Model>(NodeVector{detection_output_v1},
+            f_ref = std::make_shared<ov::Model>(OutputVector{detection_output_v1},
                                                 ParameterVector{box_logits, class_preds, proposals});
         }
         const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
@@ -160,7 +160,7 @@ TEST(TransformationTests, DetectionOutput8ToDetectionOutput1FiveArguments) {
                                                                                  attributes_v8);
 
             f = std::make_shared<ov::Model>(
-                NodeVector{detection_output_v8},
+                OutputVector{detection_output_v8},
                 ParameterVector{box_logits, class_preds, proposals, ad_class_preds, ad_box_preds});
 
             pass::Manager manager;
@@ -183,7 +183,7 @@ TEST(TransformationTests, DetectionOutput8ToDetectionOutput1FiveArguments) {
                                                                                  attributes_v1);
 
             f_ref = std::make_shared<ov::Model>(
-                NodeVector{detection_output_v1},
+                OutputVector{detection_output_v1},
                 ParameterVector{box_logits, class_preds, proposals, ad_class_preds, ad_box_preds});
         }
         const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);

--- a/src/common/transformations/tests/op_conversions/detection_output_upgrade_test.cpp
+++ b/src/common/transformations/tests/op_conversions/detection_output_upgrade_test.cpp
@@ -86,7 +86,7 @@ TEST(TransformationTests, DetectionOutput1ToDetectionOutput8) {
             auto detection_output_v1 =
                 std::make_shared<opset1::DetectionOutput>(box_logits, class_preds, proposals, attributes_v1);
 
-            f = std::make_shared<ov::Model>(NodeVector{detection_output_v1},
+            f = std::make_shared<ov::Model>(OutputVector{detection_output_v1},
                                             ParameterVector{box_logits, class_preds, proposals});
 
             pass::Manager manager;
@@ -102,7 +102,7 @@ TEST(TransformationTests, DetectionOutput1ToDetectionOutput8) {
             auto detection_output_v8 =
                 std::make_shared<opset8::DetectionOutput>(box_logits, class_preds, proposals, attributes_v8);
 
-            f_ref = std::make_shared<ov::Model>(NodeVector{detection_output_v8},
+            f_ref = std::make_shared<ov::Model>(OutputVector{detection_output_v8},
                                                 ParameterVector{box_logits, class_preds, proposals});
         }
         const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
@@ -156,7 +156,7 @@ TEST(TransformationTests, DetectionOutput1ToDetectionOutput8FiveArguments) {
                                                                                  attributes_v1);
 
             f = std::make_shared<ov::Model>(
-                NodeVector{detection_output_v1},
+                OutputVector{detection_output_v1},
                 ParameterVector{box_logits, class_preds, proposals, ad_class_preds, ad_box_preds});
 
             pass::Manager manager;
@@ -179,7 +179,7 @@ TEST(TransformationTests, DetectionOutput1ToDetectionOutput8FiveArguments) {
                                                                                  attributes_v8);
 
             f_ref = std::make_shared<ov::Model>(
-                NodeVector{detection_output_v8},
+                OutputVector{detection_output_v8},
                 ParameterVector{box_logits, class_preds, proposals, ad_class_preds, ad_box_preds});
         }
         const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);

--- a/src/common/transformations/tests/op_conversions/einsum_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/einsum_decomposition_test.cpp
@@ -166,7 +166,7 @@ TEST_F(TransformationTestsF, Einsum_2in_matmul) {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2}, "kl,mlj->mkj");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::EinsumDecomposition>();
     }
     {
@@ -205,7 +205,7 @@ TEST_F(TransformationTestsF, Einsum_2in_matmul) {
         auto order_out = ov::op::v0::Constant::create(element::i64, {3}, {1, 0, 2});
         auto transpose_out = std::make_shared<ov::op::v1::Transpose>(reshape_out, order_out);
 
-        model_ref = std::make_shared<Model>(NodeVector{transpose_out}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{transpose_out}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -217,7 +217,7 @@ TEST_F(TransformationTestsF, Einsum_2in_matmul_dynamic) {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2}, "kl,mlj->mkj");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::EinsumDecomposition>();
     }
     {
@@ -288,7 +288,7 @@ TEST_F(TransformationTestsF, Einsum_2in_matmul_dynamic) {
         auto order_out = ov::op::v0::Constant::create(element::i64, {3}, {1, 0, 2});
         auto transpose_out = std::make_shared<ov::op::v1::Transpose>(reshape_out, order_out);
 
-        model_ref = std::make_shared<Model>(NodeVector{transpose_out}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{transpose_out}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -300,7 +300,7 @@ TEST_F(TransformationTestsF, Einsum_2in_matmul_ellipsis_dynamic) {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto data_2 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_2);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2}, "kl...,m...lj->mkj");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1, data_2});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1, data_2});
         manager.register_pass<ov::pass::EinsumDecomposition>();
     }
     {
@@ -374,7 +374,7 @@ TEST_F(TransformationTestsF, Einsum_2in_matmul_ellipsis_dynamic) {
         // Transpose to the original order of output labels.
         auto Constant_1363 = makeConst(element::i64, ov::Shape({3}), {1, 0, 2});
         auto transpose_out = makeOP<opset1::Transpose>({reshape_out, Constant_1363});
-        model_ref = std::make_shared<Model>(NodeVector{transpose_out}, ParameterVector{data_1, data_2});
+        model_ref = std::make_shared<Model>(OutputVector{transpose_out}, ParameterVector{data_1, data_2});
     }
 }
 
@@ -384,7 +384,7 @@ TEST_F(TransformationTestsF, Einsum_1in_repeated_labels_ellipsis_static_cf) {
     {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1}, "ij...iji->j...i");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1});
         manager.register_pass<ov::pass::EinsumDecomposition>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -422,7 +422,7 @@ TEST_F(TransformationTestsF, Einsum_1in_repeated_labels_ellipsis_static_cf) {
         // Transpose to the original order of output labels.
         auto Constant_1386 = makeConst(element::i64, ov::Shape({3}), {1, 2, 0});
         auto transpose_out = makeOP<opset1::Transpose>({remove_reduced_dims, Constant_1386});
-        model_ref = std::make_shared<Model>(NodeVector{transpose_out}, ParameterVector{data_1});
+        model_ref = std::make_shared<Model>(OutputVector{transpose_out}, ParameterVector{data_1});
     }
 }
 
@@ -432,7 +432,7 @@ TEST_F(TransformationTestsF, Einsum_1in_repeated_labels_empty_ellipsis_dynamic) 
     {
         auto data_1 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_1);
         auto einsum = std::make_shared<opset7::Einsum>(OutputVector{data_1}, "ij...iji->j...i");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1});
         manager.register_pass<ov::pass::EinsumDecomposition>();
     }
     {
@@ -449,7 +449,7 @@ TEST_F(TransformationTestsF, Einsum_1in_repeated_labels_empty_ellipsis_dynamic) 
         // Transpose to the original order of output labels.
         auto Constant_3027 = makeConst(element::i64, ov::Shape({2}), {1, 0});
         auto transpose_out = makeOP<opset1::Transpose>({data_1_diagonal, Constant_3027});
-        model_ref = std::make_shared<Model>(NodeVector{transpose_out}, ParameterVector{data_1});
+        model_ref = std::make_shared<Model>(OutputVector{transpose_out}, ParameterVector{data_1});
     }
 }
 
@@ -464,7 +464,7 @@ TEST_F(TransformationTestsF, Einsum_3in_broadcast_duplicated_ellipsis_repeated_s
         auto data_3 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_3);
         auto einsum =
             std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2, data_3}, "ba...b,bcccdd,...dbcc->c...b");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1, data_2, data_3});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1, data_2, data_3});
         manager.register_pass<ov::pass::EinsumDecomposition>();
         manager.register_pass<ov::pass::ConstantFolding>();
     }
@@ -549,7 +549,7 @@ TEST_F(TransformationTestsF, Einsum_3in_broadcast_duplicated_ellipsis_repeated_s
         auto Reshape_8578 = makeOP<opset1::Reshape>({MatMul_8575, Constant_8577}, {{"special_zero", false}});
         auto Constant_8579 = makeConst(element::i64, ov::Shape({5}), {0, 2, 3, 4, 1});
         auto node_6 = makeOP<opset1::Transpose>({Reshape_8578, Constant_8579});
-        model_ref = std::make_shared<Model>(NodeVector{node_6}, ParameterVector{node_4, node_2, node_0});
+        model_ref = std::make_shared<Model>(OutputVector{node_6}, ParameterVector{node_4, node_2, node_0});
     }
 }
 
@@ -564,7 +564,7 @@ TEST_F(TransformationTestsF, Einsum_3in_broadcast_duplicated_ellipsis_repeated_d
         auto data_3 = std::make_shared<ov::op::v0::Parameter>(element::f32, data_shape_3);
         auto einsum =
             std::make_shared<opset7::Einsum>(OutputVector{data_1, data_2, data_3}, "a...b,bcccdd,...dbcc->c...b");
-        model = std::make_shared<Model>(NodeVector{einsum}, ParameterVector{data_1, data_2, data_3});
+        model = std::make_shared<Model>(OutputVector{einsum}, ParameterVector{data_1, data_2, data_3});
         manager.register_pass<ov::pass::EinsumDecomposition>();
     }
     {
@@ -665,6 +665,6 @@ TEST_F(TransformationTestsF, Einsum_3in_broadcast_duplicated_ellipsis_repeated_d
         auto reshape_out = makeOP<opset1::Reshape>({matmul, reshape_out_subshape}, {{"special_zero", false}});
         auto Constant_1965 = makeConst(element::i64, ov::Shape({5}), {0, 2, 3, 4, 1});
         auto transpose_out = makeOP<opset1::Transpose>({reshape_out, Constant_1965});
-        model_ref = std::make_shared<Model>(NodeVector{transpose_out}, ParameterVector{data_1, data_2, data_3});
+        model_ref = std::make_shared<Model>(OutputVector{transpose_out}, ParameterVector{data_1, data_2, data_3});
     }
 }

--- a/src/common/transformations/tests/op_conversions/eye_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/eye_decomposition_test.cpp
@@ -153,7 +153,7 @@ TEST_F(EyeTransformationTests, shift_is_not_const) {
         auto k = std::make_shared<ov::opset9::Parameter>(ov::element::i64, ov::Shape{1});
         auto node = make_test_eye<ov::opset9::Eye>(k);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data, k});
+        model = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data, k});
 
         manager.register_pass<ov::pass::EyeDecomposition>();
     }
@@ -166,7 +166,7 @@ TEST_F(EyeTransformationTests, batch_is_not_const) {
         auto batch = std::make_shared<ov::opset9::Parameter>(ov::element::i64, ov::Shape{2});
         auto node = make_test_eye_batch<ov::opset9::Eye>(batch);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data, batch});
+        model = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data, batch});
 
         manager.register_pass<ov::pass::EyeDecomposition>();
     }
@@ -178,7 +178,7 @@ TEST_F(EyeTransformationTests, use_fake_eye) {
         auto data = std::make_shared<ov::opset9::Parameter>(dtype, ov::Shape{h, w});
         auto node = make_test_eye<FakeEye>();
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data});
 
         manager.register_pass<ov::pass::EyeDecomposition>();
     }
@@ -241,7 +241,7 @@ TEST_P(EyeTransformationTestsP, eye_decompose) {
         auto data = std::make_shared<ov::opset9::Parameter>(dtype, ov::Shape{h, w});
         auto node = make_test_eye<ov::opset9::Eye>();
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data});
 
         manager.register_pass<ov::pass::EyeDecomposition>();
     }
@@ -253,7 +253,7 @@ TEST_P(EyeTransformationTestsP, eye_decompose) {
         auto k = ov::opset9::Constant::create(ov::element::i64, ov::Shape{1}, {shift});
 
         auto node = eye_decomposition_wrapper.exp_eye(height, width, k, dtype);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -279,7 +279,7 @@ TEST_P(BatchEyeTransformationTests, eye_decompose) {
         auto batch = ov::opset9::Constant::create(ov::element::i64, ov::Shape{GetParam().size()}, GetParam());
         auto node = make_test_eye_batch<ov::opset9::Eye>(batch);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data});
 
         manager.register_pass<ov::pass::EyeDecomposition>();
     }
@@ -292,7 +292,7 @@ TEST_P(BatchEyeTransformationTests, eye_decompose) {
         auto batch = ov::opset9::Constant::create(ov::element::i64, ov::Shape{GetParam().size()}, GetParam());
 
         auto node = eye_decomposition_wrapper.exp_eye(height, width, k, batch, dtype);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{node}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{data});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);

--- a/src/common/transformations/tests/op_conversions/fake_convert_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/fake_convert_decomposition_test.cpp
@@ -61,7 +61,7 @@ TEST_P(FakeConvertDecompositionTest, CompareFunctions) {
 
         const auto fake_convert = default_shift ? std::make_shared<opset13::FakeConvert>(data, scale, dst_prec)
                                                 : std::make_shared<opset13::FakeConvert>(data, scale, shift, dst_prec);
-        model = std::make_shared<ov::Model>(NodeVector{fake_convert}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{fake_convert}, ParameterVector{data});
 
         pass::Manager manager;
         manager.register_pass<ov::pass::InitNodeInfo>();
@@ -106,7 +106,7 @@ TEST_P(FakeConvertDecompositionTest, CompareFunctions) {
             result = std::make_shared<ov::op::v1::Divide>(deshift, input_scale);
         }
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{result}, params);
+        model_ref = std::make_shared<ov::Model>(OutputVector{result}, params);
     }
 
     const auto res = compare_functions(model, model_ref);

--- a/src/common/transformations/tests/op_conversions/fq_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/fq_decomposition_test.cpp
@@ -81,7 +81,7 @@ protected:
             const auto oh = std::make_shared<opset1::Constant>(ranges_prec, oh_shape);
 
             const auto fq = std::make_shared<opset1::FakeQuantize>(data, il, ih, ol, oh, levels);
-            f = std::make_shared<ov::Model>(NodeVector{fq}, ParameterVector{data});
+            f = std::make_shared<ov::Model>(OutputVector{fq}, ParameterVector{data});
 
             pass::Manager manager;
             manager.register_pass<ov::pass::InitNodeInfo>();
@@ -132,10 +132,10 @@ protected:
                     result = std::make_shared<opset1::Convert>(result, data_prec);
                 }
 
-                f_ref = std::make_shared<ov::Model>(NodeVector{result}, params);
+                f_ref = std::make_shared<ov::Model>(OutputVector{result}, params);
             } else {
                 const auto fq = std::make_shared<opset1::FakeQuantize>(data, il, ih, ol, oh, levels);
-                f_ref = std::make_shared<ov::Model>(NodeVector{fq}, params);
+                f_ref = std::make_shared<ov::Model>(OutputVector{fq}, params);
             }
         }
 

--- a/src/common/transformations/tests/op_conversions/gelu7_downgrade.cpp
+++ b/src/common/transformations/tests/op_conversions/gelu7_downgrade.cpp
@@ -20,7 +20,7 @@ TEST_F(TransformationTestsF, Gelu7Downgrade) {
         auto input = std::make_shared<opset7::Parameter>(element::f32, Shape{1, 2, 3});
         auto gelu = std::make_shared<opset7::Gelu>(input, op::GeluApproximationMode::ERF);
 
-        model = std::make_shared<ov::Model>(NodeVector{gelu}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{gelu}, ParameterVector{input});
 
         manager.register_pass<ov::pass::Gelu7Downgrade>();
     }
@@ -29,6 +29,6 @@ TEST_F(TransformationTestsF, Gelu7Downgrade) {
         auto input = std::make_shared<opset7::Parameter>(element::f32, Shape{1, 2, 3});
         auto gelu = std::make_shared<opset2::Gelu>(input);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{gelu}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{gelu}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/hsigmoid_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/hsigmoid_decomposition_test.cpp
@@ -23,7 +23,7 @@ TEST_F(TransformationTestsF, HSigmoidDecompositionTest) {
         auto input = std::make_shared<opset5::Parameter>(element::f32, PartialShape::dynamic(1));
         auto hsigmoid = std::make_shared<opset5::HSigmoid>(input);
 
-        model = std::make_shared<ov::Model>(NodeVector{hsigmoid}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{hsigmoid}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSigmoidDecomposition>();
     }
@@ -38,6 +38,6 @@ TEST_F(TransformationTestsF, HSigmoidDecompositionTest) {
         auto mul_constant = opset5::Constant::create(element::f32, Shape{}, {(1.0 / 6.0)});  // const(1/6)
         auto mul = std::make_shared<opset5::Multiply>(min, mul_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/hswish_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/hswish_decomposition_test.cpp
@@ -23,7 +23,7 @@ TEST_F(TransformationTestsF, HSwishDecompositionTest) {
         auto input = std::make_shared<opset4::Parameter>(element::f16, PartialShape::dynamic(1));
         auto hswish = std::make_shared<opset4::HSwish>(input);
 
-        model = std::make_shared<ov::Model>(NodeVector{hswish}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{hswish}, ParameterVector{input});
 
         manager.register_pass<ov::pass::HSwishDecomposition>();
     }
@@ -39,6 +39,6 @@ TEST_F(TransformationTestsF, HSwishDecompositionTest) {
         auto mul_constant = opset4::Constant::create(element::f16, Shape{}, {0.1666666716});
         auto mul_second = std::make_shared<opset4::Multiply>(mul_first, mul_constant);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mul_second}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mul_second}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/log_softmax_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/log_softmax_decomposition_test.cpp
@@ -23,7 +23,7 @@ TEST_F(TransformationTestsF, LogSoftmaxDecomposition) {
         auto data = std::make_shared<opset5::Parameter>(element::f32, Shape{3, 2});
         auto log_softmax = std::make_shared<opset5::LogSoftmax>(data, 1);
 
-        model = std::make_shared<ov::Model>(NodeVector{log_softmax}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{log_softmax}, ParameterVector{data});
 
         manager.register_pass<ov::pass::LogSoftmaxDecomposition>();
     }
@@ -39,6 +39,6 @@ TEST_F(TransformationTestsF, LogSoftmaxDecomposition) {
         auto log = std::make_shared<opset5::Log>(sum);
         auto sub_end = std::make_shared<opset5::Subtract>(sub, log);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{sub_end}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sub_end}, ParameterVector{input0});
     }
 }

--- a/src/common/transformations/tests/op_conversions/mvn6_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/mvn6_decomposition_test.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, MVN6Decomposition_No_Variance) {
         auto axes_const = opset6::Constant::create(element::i64, Shape{2}, {2, 3});
         auto mvn = std::make_shared<opset6::MVN>(data, axes_const, false, 1e-5f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MVN6Decomposition>();
     }
@@ -35,7 +35,7 @@ TEST_F(TransformationTestsF, MVN6Decomposition_No_Variance) {
         auto mean = std::make_shared<opset6::ReduceMean>(input0, axes_const, true);
         auto mean_normalization = std::make_shared<opset6::Subtract>(input0, mean);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{mean_normalization}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{mean_normalization}, ParameterVector{input0});
     }
 }
 
@@ -45,7 +45,7 @@ TEST_F(TransformationTestsF, MVN6Decomposition_Inside_Sqrt) {
         auto axes_const = opset6::Constant::create(element::i64, Shape{2}, {2, 3});
         auto mvn = std::make_shared<opset6::MVN>(data, axes_const, true, 1e-5f, op::MVNEpsMode::INSIDE_SQRT);
 
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MVN6Decomposition>();
     }
@@ -66,7 +66,7 @@ TEST_F(TransformationTestsF, MVN6Decomposition_Inside_Sqrt) {
         auto sqrt = std::make_shared<opset6::Sqrt>(eps_add);
         auto div = std::make_shared<opset6::Divide>(mean_normalization, sqrt);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input0});
     }
 }
 
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, MVN6Decomposition_Outside_Sqrt) {
         auto axes_const = opset6::Constant::create(element::i64, Shape{2}, {2, 3});
         auto mvn = std::make_shared<opset6::MVN>(data, axes_const, true, 1e-5f, op::MVNEpsMode::OUTSIDE_SQRT);
 
-        model = std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{data});
 
         manager.register_pass<ov::pass::MVN6Decomposition>();
     }
@@ -97,6 +97,6 @@ TEST_F(TransformationTestsF, MVN6Decomposition_Outside_Sqrt) {
         auto eps_add = std::make_shared<opset6::Add>(sqrt, eps_node);
         auto div = std::make_shared<opset6::Divide>(mean_normalization, eps_add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input0});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input0});
     }
 }

--- a/src/common/transformations/tests/op_conversions/ngraph_depth_to_space_transform_test.cpp
+++ b/src/common/transformations/tests/op_conversions/ngraph_depth_to_space_transform_test.cpp
@@ -29,7 +29,7 @@ TEST(TransformationTests, TestDepthToSpaceTransformBlockFirst) {
     {
         auto depth_to_space =
             std::make_shared<op::v0::DepthToSpace>(input, op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST, 2);
-        f = std::make_shared<ov::Model>(ov::NodeVector{depth_to_space}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{depth_to_space}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::ConvertDepthToSpace>();
@@ -72,7 +72,7 @@ TEST(TransformationTests, TestDepthToSpaceTransformDepthFirst) {
     {
         auto depth_to_space =
             std::make_shared<op::v0::DepthToSpace>(input, op::v0::DepthToSpace::DepthToSpaceMode::DEPTH_FIRST, 2);
-        f = std::make_shared<ov::Model>(ov::NodeVector{depth_to_space}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{depth_to_space}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::ConvertDepthToSpace>();
@@ -115,7 +115,7 @@ TEST(TransformationTests, TestSpaceToDepthTransformBlockFirst) {
     {
         auto space_to_depth =
             std::make_shared<op::v0::SpaceToDepth>(input, op::v0::SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST, 2);
-        f = std::make_shared<ov::Model>(ov::NodeVector{space_to_depth}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{space_to_depth}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::ConvertSpaceToDepth>();
@@ -158,7 +158,7 @@ TEST(TransformationTests, TestSpaceToDepthTransformDepthFirst) {
     {
         auto space_to_depth =
             std::make_shared<op::v0::SpaceToDepth>(input, op::v0::SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST, 2);
-        f = std::make_shared<ov::Model>(ov::NodeVector{space_to_depth}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{space_to_depth}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ov::pass::ConvertSpaceToDepth>();
@@ -201,7 +201,7 @@ TEST(TransformationTests, TestSpaceToDepthDynamic) {
     {
         auto space_to_depth =
             std::make_shared<op::v0::SpaceToDepth>(input, op::v0::SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST, 2);
-        f = std::make_shared<ov::Model>(ov::NodeVector{space_to_depth}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{space_to_depth}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::ConvertSpaceToDepth>();
         OV_ASSERT_NO_THROW(m.run_passes(f));
@@ -215,7 +215,7 @@ TEST(TransformationTests, TestDepthToSpaceDynamic) {
     {
         auto depth_to_space =
             std::make_shared<op::v0::DepthToSpace>(input, op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST, 2);
-        f = std::make_shared<ov::Model>(ov::NodeVector{depth_to_space}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(ov::OutputVector{depth_to_space}, ParameterVector{input});
         pass::Manager m;
         m.register_pass<ov::pass::ConvertDepthToSpace>();
         OV_ASSERT_NO_THROW(m.run_passes(f));

--- a/src/common/transformations/tests/op_conversions/ngraph_mode_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/ngraph_mode_decomposition_test.cpp
@@ -30,7 +30,7 @@ TEST(TransformationTests, ModDecompositionTests) {
     {
         auto mod = std::make_shared<op::v1::Mod>(data1, data2);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{mod}, ParameterVector{});
+        f = std::make_shared<ov::Model>(ov::OutputVector{mod}, ParameterVector{});
         auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
         pass::Manager m;
         m.register_pass<ov::pass::InitUniqueNames>(unh);

--- a/src/common/transformations/tests/op_conversions/normalize_l2_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/normalize_l2_decomposition_test.cpp
@@ -25,7 +25,7 @@ TEST_F(TransformationTestsF, NormalizeL2DecomositionFusionWithMax) {
         auto axes_const = opset8::Constant::create(element::i64, Shape{2}, {1, 2});
         auto normalize_l2 = std::make_shared<opset8::NormalizeL2>(input, axes_const, eps_value, op::EpsMode::MAX);
 
-        model = std::make_shared<ov::Model>(NodeVector{normalize_l2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{normalize_l2}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Decomposition>();
     }
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, NormalizeL2DecomositionFusionWithMax) {
         auto sqrt = std::make_shared<opset8::Sqrt>(max);
         auto divide = std::make_shared<opset8::Divide>(input, sqrt);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
     }
 }
 
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, NormalizeL2DecomositionFusionWithAdd) {
         auto axes_const = opset8::Constant::create(element::i64, Shape{2}, {0, 1});
         auto normalize_l2 = std::make_shared<opset8::NormalizeL2>(input, axes_const, eps_value, op::EpsMode::ADD);
 
-        model = std::make_shared<ov::Model>(NodeVector{normalize_l2}, ParameterVector{input});
+        model = std::make_shared<ov::Model>(OutputVector{normalize_l2}, ParameterVector{input});
 
         manager.register_pass<ov::pass::NormalizeL2Decomposition>();
     }
@@ -68,6 +68,6 @@ TEST_F(TransformationTestsF, NormalizeL2DecomositionFusionWithAdd) {
         auto sqrt = std::make_shared<opset8::Sqrt>(max);
         auto divide = std::make_shared<opset8::Divide>(input, sqrt);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{divide}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{divide}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/reduce_l1_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/reduce_l1_decomposition_test.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, ReduceL1DecompositionTest) {
         auto axes = std::make_shared<opset4::Parameter>(element::i32, Shape{1});
         auto reduce_l1 = std::make_shared<opset4::ReduceL1>(data, axes, true);
 
-        model = std::make_shared<ov::Model>(NodeVector{reduce_l1}, ParameterVector{data, axes});
+        model = std::make_shared<ov::Model>(OutputVector{reduce_l1}, ParameterVector{data, axes});
 
         manager.register_pass<ov::pass::ReduceL1Decomposition>();
     }
@@ -35,6 +35,6 @@ TEST_F(TransformationTestsF, ReduceL1DecompositionTest) {
         auto abs = std::make_shared<opset4::Abs>(data);
         auto reduce_l1 = std::make_shared<opset4::ReduceSum>(abs, axes, true);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{reduce_l1}, ParameterVector{data, axes});
+        model_ref = std::make_shared<ov::Model>(OutputVector{reduce_l1}, ParameterVector{data, axes});
     }
 }

--- a/src/common/transformations/tests/op_conversions/reduce_l2_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/reduce_l2_decomposition_test.cpp
@@ -24,7 +24,7 @@ TEST_F(TransformationTestsF, ReduceL2DecompositionTest) {
         auto axes = std::make_shared<opset4::Parameter>(element::i32, Shape{1});
         auto reduce_l2 = std::make_shared<opset4::ReduceL2>(data, axes, true);
 
-        model = std::make_shared<ov::Model>(NodeVector{reduce_l2}, ParameterVector{data, axes});
+        model = std::make_shared<ov::Model>(OutputVector{reduce_l2}, ParameterVector{data, axes});
         manager.register_pass<ov::pass::ReduceL2Decomposition>();
     }
 
@@ -35,6 +35,6 @@ TEST_F(TransformationTestsF, ReduceL2DecompositionTest) {
         auto reduce_sum = std::make_shared<opset4::ReduceSum>(pow, axes, true);
         auto sqrt = std::make_shared<opset4::Sqrt>(reduce_sum);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{sqrt}, ParameterVector{data, axes});
+        model_ref = std::make_shared<ov::Model>(OutputVector{sqrt}, ParameterVector{data, axes});
     }
 }

--- a/src/common/transformations/tests/op_conversions/scaled_dot_product_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/scaled_dot_product_decomposition_test.cpp
@@ -55,7 +55,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionStaticBasic) 
         const auto scaled_dot_product_attention =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, attention_mask, scale, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                             ParameterVector{query, key, value, attention_mask, scale});
         manager.register_pass<ov::pass::ScaledDotProductAttentionDecomposition>();
     }
@@ -63,7 +63,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionStaticBasic) 
     {
         const auto scaled_dot_product_attention =
             scaled_dot_product_attention_decomposition(query, key, value, attention_mask, scale, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model_ref = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                                 ParameterVector{query, key, value, attention_mask, scale});
     }
 }
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionStaticBroadca
         const auto scaled_dot_product_attention =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, attention_mask, scale, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                             ParameterVector{query, key, value, attention_mask, scale});
         manager.register_pass<ov::pass::ScaledDotProductAttentionDecomposition>();
     }
@@ -93,7 +93,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionStaticBroadca
     {
         const auto scaled_dot_product_attention =
             scaled_dot_product_attention_decomposition(query, key, value, attention_mask, scale, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model_ref = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                                 ParameterVector{query, key, value, attention_mask, scale});
     }
 }
@@ -115,7 +115,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionStaticBroadca
         const auto scaled_dot_product_attention =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, attention_mask, scale, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                             ParameterVector{query, key, value, attention_mask, scale});
         manager.register_pass<ov::pass::ScaledDotProductAttentionDecomposition>();
     }
@@ -123,7 +123,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionStaticBroadca
     {
         const auto scaled_dot_product_attention =
             scaled_dot_product_attention_decomposition(query, key, value, attention_mask, scale, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model_ref = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                                 ParameterVector{query, key, value, attention_mask, scale});
     }
 }
@@ -143,7 +143,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionCasualPartiallyDynamic) {
         const auto scaled_dot_product_attention =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, attention_mask, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                             ParameterVector{query, key, value, attention_mask});
         manager.register_pass<ov::pass::ScaledDotProductAttentionDecomposition>();
     }
@@ -151,7 +151,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionCasualPartiallyDynamic) {
     {
         const auto scaled_dot_product_attention =
             scaled_dot_product_attention_decomposition(query, key, value, attention_mask, nullptr, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model_ref = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                                 ParameterVector{query, key, value, attention_mask});
     }
 }
@@ -173,7 +173,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionDynamic) {
         const auto scaled_dot_product_attention =
             std::make_shared<ov::op::v13::ScaledDotProductAttention>(query, key, value, attention_mask, scale, casual);
 
-        model = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                             ParameterVector{query, key, value, attention_mask, scale});
         manager.register_pass<ov::pass::ScaledDotProductAttentionDecomposition>();
     }
@@ -181,7 +181,7 @@ TEST_F(TransformationTestsF, ScaledDotProductAttentionDecompositionDynamic) {
     {
         const auto scaled_dot_product_attention =
             scaled_dot_product_attention_decomposition(query, key, value, attention_mask, scale, casual);
-        model_ref = std::make_shared<ov::Model>(NodeVector{scaled_dot_product_attention},
+        model_ref = std::make_shared<ov::Model>(OutputVector{scaled_dot_product_attention},
                                                 ParameterVector{query, key, value, attention_mask, scale});
     }
 }

--- a/src/common/transformations/tests/op_conversions/simplify_ctc_greedy_decoder_seq_len_test.cpp
+++ b/src/common/transformations/tests/op_conversions/simplify_ctc_greedy_decoder_seq_len_test.cpp
@@ -27,7 +27,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenTest) {
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -95,7 +95,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenTest) {
         auto output_seq_len_i = std::make_shared<opset6::Convert>(output_seq_len->output(0), sl_type);
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
+            std::make_shared<ov::Model>(OutputVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
     }
 }
 
@@ -109,7 +109,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicInputShapeTest
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -177,7 +177,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicInputShapeTest
         auto output_seq_len_i = std::make_shared<opset6::Convert>(output_seq_len->output(0), sl_type);
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
+            std::make_shared<ov::Model>(OutputVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
     }
 }
 
@@ -191,7 +191,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicBatchTest) {
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -259,7 +259,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicBatchTest) {
         auto output_seq_len_i = std::make_shared<opset6::Convert>(output_seq_len->output(0), sl_type);
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
+            std::make_shared<ov::Model>(OutputVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
     }
 }
 
@@ -273,7 +273,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicSeqLenTest) {
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -341,7 +341,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicSeqLenTest) {
         auto output_seq_len_i = std::make_shared<opset6::Convert>(output_seq_len->output(0), sl_type);
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
+            std::make_shared<ov::Model>(OutputVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
     }
 }
 
@@ -360,7 +360,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenWrongBlankIndexTest) 
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -379,7 +379,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenWrongBlankIndexTest) 
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data1, seq_len1});
+        model_ref = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data1, seq_len1});
     }
 }
 
@@ -398,7 +398,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicSeqLenWithBlan
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -466,7 +466,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicSeqLenWithBlan
         auto output_seq_len_i = std::make_shared<opset6::Convert>(output_seq_len->output(0), sl_type);
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
+            std::make_shared<ov::Model>(OutputVector{output_i, output_seq_len_i}, ParameterVector{data1, seq_len1});
     }
 }
 
@@ -485,7 +485,7 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicSeqLenParamWit
         auto res_1 = std::make_shared<opset6::Result>(decoder_v6->output(0));
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
-        model = std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data, seq_len, blank_index});
+        model = std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data, seq_len, blank_index});
 
         manager.register_pass<ov::pass::SimplifyCTCGreedyDecoderSeqLen>();
     }
@@ -505,6 +505,6 @@ TEST_F(TransformationTestsF, SimplifyCTCGreedyDecoderSeqLenDynamicSeqLenParamWit
         auto res_2 = std::make_shared<opset6::Result>(decoder_v6->output(1));
 
         model_ref =
-            std::make_shared<ov::Model>(NodeVector{res_1, res_2}, ParameterVector{data1, seq_len1, blank_index1});
+            std::make_shared<ov::Model>(OutputVector{res_1, res_2}, ParameterVector{data1, seq_len1, blank_index1});
     }
 }

--- a/src/common/transformations/tests/op_conversions/softplus_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/softplus_decomposition_test.cpp
@@ -23,7 +23,7 @@ TEST_F(TransformationTestsF, SoftPlusDecompositionFP32) {
         auto data = std::make_shared<opset4::Parameter>(element::f32, Shape{3, 1, 2});
         auto softplus = std::make_shared<opset4::SoftPlus>(data);
 
-        model = std::make_shared<ov::Model>(NodeVector{softplus}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softplus}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SoftPlusDecomposition>();
     }
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, SoftPlusDecompositionFP32) {
         auto add = std::make_shared<opset4::Add>(exp, opset4::Constant::create(element::f32, Shape{1}, {1.0}));
         auto log = std::make_shared<opset4::Log>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{log}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{log}, ParameterVector{input});
     }
 }
 
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, SoftPlusDecompositionFP16) {
         auto data = std::make_shared<opset4::Parameter>(element::f16, Shape{3, 1, 2});
         auto softplus = std::make_shared<opset4::SoftPlus>(data);
 
-        model = std::make_shared<ov::Model>(NodeVector{softplus}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softplus}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SoftPlusDecomposition>();
     }
@@ -54,6 +54,6 @@ TEST_F(TransformationTestsF, SoftPlusDecompositionFP16) {
         auto add = std::make_shared<opset4::Add>(exp, opset4::Constant::create(element::f16, Shape{1}, {1.0}));
         auto log = std::make_shared<opset4::Log>(add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{log}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{log}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/op_conversions/softsign_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/softsign_decomposition_test.cpp
@@ -21,7 +21,7 @@ TEST_F(TransformationTestsF, SoftSignDecomposition) {
         auto data = std::make_shared<opset9::Parameter>(element::f32, Shape{3, 1, 2});
         auto softsign = std::make_shared<opset9::SoftSign>(data);
 
-        model = std::make_shared<ov::Model>(NodeVector{softsign}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softsign}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SoftSignDecomposition>();
     }
@@ -32,7 +32,7 @@ TEST_F(TransformationTestsF, SoftSignDecomposition) {
         auto add = std::make_shared<opset9::Add>(abs, opset9::Constant::create(element::f32, Shape{1}, {1}));
         auto div = std::make_shared<opset9::Divide>(input, add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
     }
 }
 
@@ -41,7 +41,7 @@ TEST_F(TransformationTestsF, SoftSignDecompositionFP16) {
         auto data = std::make_shared<opset9::Parameter>(element::f16, Shape{3, 1, 2});
         auto softsign = std::make_shared<opset9::SoftSign>(data);
 
-        model = std::make_shared<ov::Model>(NodeVector{softsign}, ParameterVector{data});
+        model = std::make_shared<ov::Model>(OutputVector{softsign}, ParameterVector{data});
 
         manager.register_pass<ov::pass::SoftSignDecomposition>();
     }
@@ -52,6 +52,6 @@ TEST_F(TransformationTestsF, SoftSignDecompositionFP16) {
         auto add = std::make_shared<opset9::Add>(abs, opset9::Constant::create(element::f16, Shape{1}, {1}));
         auto div = std::make_shared<opset9::Divide>(input, add);
 
-        model_ref = std::make_shared<ov::Model>(NodeVector{div}, ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(OutputVector{div}, ParameterVector{input});
     }
 }

--- a/src/common/transformations/tests/prelu_fusion.cpp
+++ b/src/common/transformations/tests/prelu_fusion.cpp
@@ -31,7 +31,7 @@ TEST_F(TransformationTestsF, PReluFusionNegativeAdd) {
         auto mul = std::make_shared<opset8::Multiply>(neg2, mul_const);
         auto add = std::make_shared<opset8::Add>(relu_pos, mul);
 
-        model = std::make_shared<Model>(NodeVector{add}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{add}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, PReluFusionNegativeAdd) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 128});
         auto prelu_const = opset8::Constant::create(element::f32, Shape{1}, {0.001});
         auto prelu = std::make_shared<opset8::PRelu>(data, prelu_const);
-        model_ref = std::make_shared<Model>(NodeVector{prelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{prelu}, ParameterVector{data});
     }
 }
 
@@ -54,7 +54,7 @@ TEST_F(TransformationTestsF, PReluFusionNegativeSub) {
         auto mul = std::make_shared<opset8::Multiply>(relu_neg, mul_const);
         auto sub = std::make_shared<opset8::Subtract>(relu_pos, mul);
 
-        model = std::make_shared<Model>(NodeVector{sub}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{sub}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -63,7 +63,7 @@ TEST_F(TransformationTestsF, PReluFusionNegativeSub) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 128});
         auto prelu_const = opset8::Constant::create(element::f32, Shape{1}, {0.001});
         auto prelu = std::make_shared<opset8::PRelu>(data, prelu_const);
-        model_ref = std::make_shared<Model>(NodeVector{prelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{prelu}, ParameterVector{data});
     }
 }
 
@@ -78,7 +78,7 @@ TEST_F(TransformationTestsF, PReluFusionMultiplyAdd) {
         auto mul = std::make_shared<opset8::Multiply>(relu_neg, mul_const);
         auto add = std::make_shared<opset8::Add>(relu_pos, mul);
 
-        model = std::make_shared<Model>(NodeVector{add}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{add}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -87,7 +87,7 @@ TEST_F(TransformationTestsF, PReluFusionMultiplyAdd) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 128});
         auto prelu_const = opset8::Constant::create(element::f32, Shape{1}, {0.001});
         auto prelu = std::make_shared<opset8::PRelu>(data, prelu_const);
-        model_ref = std::make_shared<Model>(NodeVector{prelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{prelu}, ParameterVector{data});
     }
 }
 
@@ -102,7 +102,7 @@ TEST_F(TransformationTestsF, PReluFusionMultiplySub) {
         auto mul = std::make_shared<opset8::Multiply>(relu_neg, mul_const);
         auto sub = std::make_shared<opset8::Subtract>(relu_pos, mul);
 
-        model = std::make_shared<Model>(NodeVector{sub}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{sub}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -111,7 +111,7 @@ TEST_F(TransformationTestsF, PReluFusionMultiplySub) {
         auto data = std::make_shared<opset8::Parameter>(element::f32, Shape{1, 128});
         auto prelu_const = opset8::Constant::create(element::f32, Shape{1}, {0.001});
         auto prelu = std::make_shared<opset8::PRelu>(data, prelu_const);
-        model_ref = std::make_shared<Model>(NodeVector{prelu}, ParameterVector{data});
+        model_ref = std::make_shared<Model>(OutputVector{prelu}, ParameterVector{data});
     }
 }
 
@@ -126,7 +126,7 @@ TEST_F(TransformationTestsF, PReluFusionFail) {
         auto mul = std::make_shared<opset8::Multiply>(relu_neg, mul_const);
         auto sub = std::make_shared<opset8::Subtract>(relu_pos, mul);
 
-        model = std::make_shared<Model>(NodeVector{sub}, ParameterVector{data});
+        model = std::make_shared<Model>(OutputVector{sub}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -147,7 +147,7 @@ TEST_F(TransformationTestsF, PReluFusionAbsSubMulMulAdd) {
         const auto mul_2_const = Constant::create(element::f32, Shape{1}, {0.5});
         const auto mul_2 = make_shared<Multiply>(mul_1, mul_2_const);
         const auto add = make_shared<Add>(relu, mul_2);
-        model = make_shared<Model>(NodeVector{add}, ParameterVector{data});
+        model = make_shared<Model>(OutputVector{add}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -155,7 +155,7 @@ TEST_F(TransformationTestsF, PReluFusionAbsSubMulMulAdd) {
         const auto data = make_shared<Parameter>(element::f32, Shape{1, 128});
         const auto prelu_const = Constant::create(element::f32, Shape{1}, {0.022});
         const auto prelu = make_shared<PRelu>(data, prelu_const);
-        model_ref = make_shared<Model>(NodeVector{prelu}, ParameterVector{data});
+        model_ref = make_shared<Model>(OutputVector{prelu}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -171,7 +171,7 @@ TEST_F(TransformationTestsF, PReluFusionNegReluMulAdd) {
         const auto mul_const = Constant::create(element::f32, Shape{1}, {0.235});
         const auto mul = make_shared<Multiply>(relu_neg, mul_const);
         const auto add = make_shared<Add>(relu_pos, mul);
-        model = make_shared<Model>(NodeVector{add}, ParameterVector{data});
+        model = make_shared<Model>(OutputVector{add}, ParameterVector{data});
 
         manager.register_pass<ov::pass::PReluFusion>();
     }
@@ -179,7 +179,7 @@ TEST_F(TransformationTestsF, PReluFusionNegReluMulAdd) {
         const auto data = make_shared<Parameter>(element::f32, Shape{2, 12});
         const auto prelu_const = Constant::create(element::f32, Shape{1}, {-0.235});
         const auto prelu = make_shared<PRelu>(data, prelu_const);
-        model_ref = make_shared<Model>(NodeVector{prelu}, ParameterVector{data});
+        model_ref = make_shared<Model>(OutputVector{prelu}, ParameterVector{data});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }

--- a/src/common/transformations/tests/smart_reshape/lstm_states_broadcast.cpp
+++ b/src/common/transformations/tests/smart_reshape/lstm_states_broadcast.cpp
@@ -42,7 +42,7 @@ TEST_P(LSTMStatesBroadcastTest, BareLSTM) {
                                           R,
                                           static_cast<size_t>(p.hidden_size.get_length()));
 
-        model = make_shared<ov::Model>(ov::NodeVector{cell}, ov::ParameterVector{parameter});
+        model = make_shared<ov::Model>(ov::OutputVector{cell}, ov::ParameterVector{parameter});
     }
     OV_ASSERT_NO_THROW(model->reshape(ov::PartialShape{p.new_batch_size, p.input_size}));
 }
@@ -92,7 +92,7 @@ TEST_P(LSTMStatesBroadcastTestWithTI, TI_With_LSTM) {
 
         auto res_ti_1 = make_shared<Result>(tensor_iterator->output(1));
         auto res_ti_2 = make_shared<Result>(tensor_iterator->output(0));
-        model = make_shared<ov::Model>(ov::NodeVector{res_ti_1, res_ti_2}, ov::ParameterVector{X});
+        model = make_shared<ov::Model>(ov::OutputVector{res_ti_1, res_ti_2}, ov::ParameterVector{X});
     }
     OV_ASSERT_NO_THROW(model->reshape(ov::PartialShape{p.new_batch_size, 1, p.input_size}));
 }

--- a/src/common/transformations/tests/smart_reshape/reshape_sinking.cpp
+++ b/src/common/transformations/tests/smart_reshape/reshape_sinking.cpp
@@ -35,7 +35,7 @@ TEST_P(ReshapeSinkingTest, ReshapeSinkingOnlyMatMul) {
                                                  p.transpose_b);
         auto reshape_back =
             std::make_shared<ov::opset9::Reshape>(matmul, create_constant(p.output_pattern_back), false);
-        model = std::make_shared<ov::Model>(ov::NodeVector{reshape_back}, ov::ParameterVector{parameter});
+        model = std::make_shared<ov::Model>(ov::OutputVector{reshape_back}, ov::ParameterVector{parameter});
     }
     OV_ASSERT_NO_THROW(model->reshape(p.new_shape));
 }
@@ -57,7 +57,7 @@ TEST_P(ReshapeSinkingTestWithAdd, ReshapeSinkingMatMulAdd) {
                                                  p.transpose_b);
         auto add = std::make_shared<ov::opset9::Add>(matmul, ov::op::v0::Constant::create(p.data_et, {1, 37}, {0}));
         auto reshape_back = std::make_shared<ov::opset9::Reshape>(add, create_constant(p.output_pattern_back), false);
-        model = std::make_shared<ov::Model>(ov::NodeVector{reshape_back}, ov::ParameterVector{parameter});
+        model = std::make_shared<ov::Model>(ov::OutputVector{reshape_back}, ov::ParameterVector{parameter});
     }
     OV_ASSERT_NO_THROW(model->reshape(p.new_shape));
 }

--- a/src/common/transformations/tests/smart_reshape/sr_mimicking_sbs.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_mimicking_sbs.cpp
@@ -16,7 +16,7 @@ TEST(SmartReshapeTests, MimickingSBS) {
         auto input = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 2, 3, 4});
         auto reshape =
             std::make_shared<opset5::Reshape>(input, opset5::Constant::create(element::i64, {2}, {6, -1}), true);
-        f = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
@@ -30,7 +30,7 @@ TEST(SmartReshapeTests, MimickingSBS_1) {
         auto input = std::make_shared<opset5::Parameter>(element::f32, Shape{1, 2, 3, 4});
         auto reshape =
             std::make_shared<opset5::Reshape>(input, opset5::Constant::create(element::i64, {2}, {1, -1}), true);
-        f = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
@@ -44,7 +44,7 @@ TEST(SmartReshapeTests, MimickingSBS_2) {
         auto input = std::make_shared<opset5::Parameter>(element::f32, Shape{2, 2, 3, 4});
         auto reshape =
             std::make_shared<opset5::Reshape>(input, opset5::Constant::create(element::i64, {2}, {12, -1}), true);
-        f = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();

--- a/src/common/transformations/tests/smart_reshape/sr_proposal_scales.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_proposal_scales.cpp
@@ -35,7 +35,7 @@ TEST(SmartReshapeTests, Proposal1Scales) {
         attrs.ratio = {0.5, 1.0, 2.0};
         attrs.scale = {0.25, 0.5, 1.0, 2.0};
         auto proposal = std::make_shared<opset1::Proposal>(input_0, input_1, reshape, attrs);
-        f = std::make_shared<ov::Model>(NodeVector{proposal}, ParameterVector{input_0, input_1, input_2});
+        f = std::make_shared<ov::Model>(OutputVector{proposal}, ParameterVector{input_0, input_1, input_2});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
@@ -68,7 +68,7 @@ TEST(SmartReshapeTests, Proposal1Scales_WithConvert) {
         attrs.ratio = {0.5, 1.0, 2.0};
         attrs.scale = {0.25, 0.5, 1.0, 2.0};
         auto proposal = std::make_shared<opset1::Proposal>(input_0, input_1, reshape, attrs);
-        f = std::make_shared<ov::Model>(NodeVector{proposal}, ParameterVector{input_0, input_1, input_2});
+        f = std::make_shared<ov::Model>(OutputVector{proposal}, ParameterVector{input_0, input_1, input_2});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
@@ -100,7 +100,7 @@ TEST(SmartReshapeTests, Proposal4Scales) {
         attrs.ratio = {0.5, 1.0, 2.0};
         attrs.scale = {0.25, 0.5, 1.0, 2.0};
         auto proposal = std::make_shared<opset5::Proposal>(input_0, input_1, reshape, attrs);
-        f = std::make_shared<ov::Model>(NodeVector{proposal}, ParameterVector{input_0, input_1, input_2});
+        f = std::make_shared<ov::Model>(OutputVector{proposal}, ParameterVector{input_0, input_1, input_2});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();
@@ -133,7 +133,7 @@ TEST(SmartReshapeTests, Proposal4Scales_WithConvert) {
         attrs.ratio = {0.5, 1.0, 2.0};
         attrs.scale = {0.25, 0.5, 1.0, 2.0};
         auto proposal = std::make_shared<opset5::Proposal>(input_0, input_1, reshape, attrs);
-        f = std::make_shared<ov::Model>(NodeVector{proposal}, ParameterVector{input_0, input_1, input_2});
+        f = std::make_shared<ov::Model>(OutputVector{proposal}, ParameterVector{input_0, input_1, input_2});
     }
 
     auto unh = std::make_shared<ov::pass::UniqueNamesHolder>();

--- a/src/common/transformations/tests/smart_reshape/sr_reshape_1d.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_reshape_1d.cpp
@@ -15,7 +15,7 @@ TEST(SmartReshapeTests, Reshape1d) {
     {
         auto input = std::make_shared<opset5::Parameter>(element::f32, PartialShape::dynamic());
         auto reshape = std::make_shared<opset5::Reshape>(input, opset5::Constant::create(element::i64, {1}, {5}), true);
-        f = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible(PartialShape::dynamic()));
@@ -36,7 +36,7 @@ TEST(SmartReshapeTests, Reshape1d_negative) {
         auto input = std::make_shared<opset5::Parameter>(element::f32, PartialShape::dynamic());
         auto pattern = std::make_shared<opset5::Parameter>(element::i64, Shape{1});
         auto reshape = std::make_shared<opset5::Reshape>(input, pattern, false);
-        f = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{input, pattern});
+        f = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{input, pattern});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible(PartialShape::dynamic()));

--- a/src/common/transformations/tests/smart_reshape/sr_strided_slice_squeeze.cpp
+++ b/src/common/transformations/tests/smart_reshape/sr_strided_slice_squeeze.cpp
@@ -23,7 +23,7 @@ TEST(SmartReshapeTests, SS_Squeeze) {
         auto squeeze = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {1}, {0}));
         auto relu = std::make_shared<opset5::Relu>(squeeze);
 
-        f = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({3}))
@@ -49,7 +49,7 @@ TEST(SmartReshapeTests, SS_Squeeze_partial_begin_end_mask) {
         auto squeeze = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {1}, {1}));
         auto relu = std::make_shared<opset5::Relu>(squeeze);
 
-        f = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({1, 768}))
@@ -83,7 +83,7 @@ TEST(SmartReshapeTests, SS_Squeeze_partial_begin_end) {
         auto squeeze = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {1}, {1}));
         auto relu = std::make_shared<opset5::Relu>(squeeze);
 
-        f = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({1, 768}))
@@ -114,7 +114,7 @@ TEST(SmartReshapeTests, SS_Squeeze_mask_use_negative) {
                                                          std::vector<int64_t>{0, 1});
         auto squeeze = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {1}, {0}));
 
-        f = std::make_shared<ov::Model>(NodeVector{squeeze}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{squeeze}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({1, 3}))
@@ -140,7 +140,7 @@ TEST(SmartReshapeTests, SS_Squeeze_negative_stride_negative) {
         auto squeeze = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {1}, {0}));
         auto relu = std::make_shared<opset5::Relu>(squeeze);
 
-        f = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({3}))
@@ -167,7 +167,7 @@ TEST(SmartReshapeTests, SS_SharedSqueezes) {
         auto squeeze_2 = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {1}, {0}));
         auto relu_1 = std::make_shared<opset5::Relu>(squeeze_1);
         auto relu_2 = std::make_shared<opset5::Relu>(squeeze_2);
-        f = std::make_shared<ov::Model>(NodeVector{relu_1, relu_2}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relu_1, relu_2}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({3}))
@@ -193,7 +193,7 @@ TEST(SmartReshapeTests, SS_SqueezeNegativeAxes) {
         auto squeeze = std::make_shared<opset5::Squeeze>(ss, opset5::Constant::create(element::i64, {3}, {-2, 0, -4}));
         auto relu = std::make_shared<opset5::Relu>(squeeze);
 
-        f = std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({3, 8, 2}))
@@ -218,7 +218,7 @@ TEST(SmartReshapeTests, Squeeze_SSNegativeAxes) {
                                                          std::vector<int64_t>{1, 1, 1},
                                                          std::vector<int64_t>{1, 1, 1});
 
-        f = std::make_shared<ov::Model>(NodeVector{ss}, ParameterVector{input});
+        f = std::make_shared<ov::Model>(OutputVector{ss}, ParameterVector{input});
     }
 
     ASSERT_TRUE(f->get_results()[0]->get_output_partial_shape(0).compatible({3, 8, 2}))

--- a/src/common/transformations/tests/symbolic_transformations/chained_maximum.cpp
+++ b/src/common/transformations/tests/symbolic_transformations/chained_maximum.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, ChainedMaximumAC) {
         auto data = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic());
         auto broadcast = make_shared<v1::Broadcast>(data, maximum_1);
 
-        model = make_shared<Model>(NodeVector{broadcast}, ParameterVector{input, data});
+        model = make_shared<Model>(OutputVector{broadcast}, ParameterVector{input, data});
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
         manager.register_pass<pass::ChainedMaximumOptimization>();
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, ChainedMaximumAC) {
         auto data = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic());
         auto broadcast = make_shared<v1::Broadcast>(data, maximum);
 
-        model_ref = make_shared<Model>(NodeVector{broadcast}, ParameterVector{input, data});
+        model_ref = make_shared<Model>(OutputVector{broadcast}, ParameterVector{input, data});
     }
 }
 
@@ -69,7 +69,7 @@ TEST_F(TransformationTestsF, ChainedMaximumBC) {
         auto data = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic());
         auto broadcast = make_shared<v1::Broadcast>(data, maximum_1);
 
-        model = make_shared<Model>(NodeVector{broadcast}, ParameterVector{input, data});
+        model = make_shared<Model>(OutputVector{broadcast}, ParameterVector{input, data});
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
         manager.register_pass<pass::ChainedMaximumOptimization>();
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, ChainedMaximumBC) {
         auto data = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic());
         auto broadcast = make_shared<v1::Broadcast>(data, maximum);
 
-        model_ref = make_shared<Model>(NodeVector{broadcast}, ParameterVector{input, data});
+        model_ref = make_shared<Model>(OutputVector{broadcast}, ParameterVector{input, data});
     }
 }
 
@@ -104,7 +104,7 @@ TEST_F(TransformationTestsF, ChainedMaximumNegativeNoLabels) {
         auto data = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic());
         auto broadcast = make_shared<v1::Broadcast>(data, maximum_1);
 
-        model = make_shared<Model>(NodeVector{broadcast}, ParameterVector{input, data});
+        model = make_shared<Model>(OutputVector{broadcast}, ParameterVector{input, data});
         manager.register_pass<pass::ChainedMaximumOptimization>();
     }
 }
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, ChainedMaximumNegativeDifferentLabels) {
         auto data = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic());
         auto broadcast = make_shared<v1::Broadcast>(data, maximum_1);
 
-        model = make_shared<Model>(NodeVector{broadcast}, ParameterVector{input_0, input_1, data});
+        model = make_shared<Model>(OutputVector{broadcast}, ParameterVector{input_0, input_1, data});
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
         manager.register_pass<pass::ChainedMaximumOptimization>();

--- a/src/common/transformations/tests/symbolic_transformations/dereshape_fullyconnected.cpp
+++ b/src/common/transformations/tests/symbolic_transformations/dereshape_fullyconnected.cpp
@@ -35,7 +35,7 @@ TEST_F(TransformationTestsF, DeReshapeFC) {
             make_shared<v0::Concat>(OutputVector{batch_dims, v0::Constant::create(element::i64, {1}, {80})}, 0);
         auto out_reshape = make_shared<v1::Reshape>(matmul, pattern, false);
 
-        model = make_shared<Model>(NodeVector{out_reshape}, ParameterVector{data, second_input});
+        model = make_shared<Model>(OutputVector{out_reshape}, ParameterVector{data, second_input});
         manager.register_pass<pass::SymbolicOptimizations>();
     }
     {
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, DeReshapeFC) {
         auto second_input = make_shared<v0::Parameter>(element::f32, Shape{40, 80});
         auto matmul = make_shared<v0::MatMul>(data, second_input);
 
-        model_ref = make_shared<Model>(NodeVector{matmul}, ParameterVector{data, second_input});
+        model_ref = make_shared<Model>(OutputVector{matmul}, ParameterVector{data, second_input});
     }
 }
 
@@ -63,7 +63,7 @@ TEST_F(TransformationTestsF, DeReshapeFCWithConvert) {
             make_shared<v0::Concat>(OutputVector{batch_dims, v0::Constant::create(element::i64, {1}, {80})}, 0);
         auto out_reshape = make_shared<v1::Reshape>(matmul, pattern, false);
 
-        model = make_shared<Model>(NodeVector{out_reshape}, ParameterVector{data, second_input});
+        model = make_shared<Model>(OutputVector{out_reshape}, ParameterVector{data, second_input});
         manager.register_pass<pass::SymbolicOptimizations>();
     }
     {
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, DeReshapeFCWithConvert) {
         auto second_input = make_shared<v0::Parameter>(element::f32, Shape{40, 80});
         auto matmul = make_shared<v0::MatMul>(convert, second_input);
 
-        model_ref = make_shared<Model>(NodeVector{matmul}, ParameterVector{data, second_input});
+        model_ref = make_shared<Model>(OutputVector{matmul}, ParameterVector{data, second_input});
     }
 }
 
@@ -90,7 +90,7 @@ TEST_F(TransformationTestsF, DeReshapeFCNegative) {
         auto pattern = v0::Constant::create(element::i64, {3}, {4, -1, 80});
         auto out_reshape = make_shared<v1::Reshape>(matmul, pattern, false);
 
-        model = make_shared<Model>(NodeVector{out_reshape}, ParameterVector{data, second_input});
+        model = make_shared<Model>(OutputVector{out_reshape}, ParameterVector{data, second_input});
         manager.register_pass<pass::SymbolicOptimizations>();
     }
 }

--- a/src/common/transformations/tests/symbolic_transformations/nop_broadcast.cpp
+++ b/src/common/transformations/tests/symbolic_transformations/nop_broadcast.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, NopBroadcastOpset1) {
         auto broadcast = make_shared<v1::Broadcast>(data, maximum);
         auto relu = make_shared<v0::Relu>(broadcast);
 
-        model = make_shared<Model>(NodeVector{relu}, ParameterVector{data, symbol_input});
+        model = make_shared<Model>(OutputVector{relu}, ParameterVector{data, symbol_input});
         manager.register_pass<pass::NopBroadcast>();
     }
     {
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, NopBroadcastOpset1) {
 
         auto symbol_input = make_shared<v0::Parameter>(element::f32, shape);
 
-        model_ref = make_shared<Model>(NodeVector{relu}, ParameterVector{data, symbol_input});
+        model_ref = make_shared<Model>(OutputVector{relu}, ParameterVector{data, symbol_input});
     }
 }
 
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, NopBroadcastOpset3) {
         auto broadcast = make_shared<v3::Broadcast>(data, maximum);
         auto relu = make_shared<v0::Relu>(broadcast);
 
-        model = make_shared<Model>(NodeVector{relu}, ParameterVector{data, symbol_input});
+        model = make_shared<Model>(OutputVector{relu}, ParameterVector{data, symbol_input});
         manager.register_pass<pass::NopBroadcast>();
     }
     {
@@ -71,7 +71,7 @@ TEST_F(TransformationTestsF, NopBroadcastOpset3) {
 
         auto symbol_input = make_shared<v0::Parameter>(element::f32, shape);
 
-        model_ref = make_shared<Model>(NodeVector{relu}, ParameterVector{data, symbol_input});
+        model_ref = make_shared<Model>(OutputVector{relu}, ParameterVector{data, symbol_input});
     }
 }
 
@@ -90,7 +90,7 @@ TEST_F(TransformationTestsF, NopBroadcastNegative) {
         auto broadcast = make_shared<v1::Broadcast>(data, maximum);
         auto relu = make_shared<v0::Relu>(broadcast);
 
-        model = make_shared<Model>(NodeVector{relu}, ParameterVector{data, symbol_input});
+        model = make_shared<Model>(OutputVector{relu}, ParameterVector{data, symbol_input});
         manager.register_pass<pass::NopBroadcast>();
     }
 }

--- a/src/common/transformations/tests/symbolic_transformations/reshape_optimizations.cpp
+++ b/src/common/transformations/tests/symbolic_transformations/reshape_optimizations.cpp
@@ -44,7 +44,7 @@ TEST_F(TransformationTestsF, FlattenOptimization) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, false);
 
-        model = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<pass::ReshapeOptimizations>();
     }
     {
@@ -53,7 +53,7 @@ TEST_F(TransformationTestsF, FlattenOptimization) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, true);
 
-        model_ref = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -77,7 +77,7 @@ TEST_F(TransformationTestsF, LastDimSplitStaticLast) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, false);
 
-        model = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<pass::ReshapeOptimizations>();
     }
     {
@@ -86,7 +86,7 @@ TEST_F(TransformationTestsF, LastDimSplitStaticLast) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, true);
 
-        model_ref = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -110,7 +110,7 @@ TEST_F(TransformationTestsF, LastDimSplitDymanicLast) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, false);
 
-        model = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<pass::ReshapeOptimizations>();
     }
     {
@@ -119,7 +119,7 @@ TEST_F(TransformationTestsF, LastDimSplitDymanicLast) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, true);
 
-        model_ref = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model_ref = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
     }
 }
 
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, NegativeTest) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, false);
 
-        model = make_shared<Model>(NodeVector{reshape}, ParameterVector{data});
+        model = make_shared<Model>(OutputVector{reshape}, ParameterVector{data});
         manager.register_pass<pass::ReshapeOptimizations>();
     }
 }
@@ -168,7 +168,7 @@ TEST_F(TransformationTestsF, ZeroDimsInOutputShape) {
 
         auto reshape = make_shared<v1::Reshape>(data, pattern, false);
 
-        model = make_shared<Model>(NodeVector{reshape}, ParameterVector{data, b});
+        model = make_shared<Model>(OutputVector{reshape}, ParameterVector{data, b});
         manager.register_pass<pass::ReshapeOptimizations>();
     }
 }

--- a/src/common/transformations/tests/symbolic_transformations/symbol_optimization.cpp
+++ b/src/common/transformations/tests/symbolic_transformations/symbol_optimization.cpp
@@ -30,7 +30,7 @@ TEST(TransformationTests, ApplySymbolEquivalence_Concat) {
     auto input_2 = make_shared<v0::Parameter>(element::f32, PartialShape::dynamic(4));
     auto concat = make_shared<v0::Concat>(OutputVector{input_1, input_2}, -1);
     // shape inference notes that all the non-axis dimensions are equal to each other
-    auto model = make_shared<Model>(NodeVector{concat}, ParameterVector{input_2, input_1});
+    auto model = make_shared<Model>(OutputVector{concat}, ParameterVector{input_2, input_1});
 
     pass::Manager manager;
     manager.set_per_pass_validation(false);
@@ -68,7 +68,7 @@ TEST_F(TransformationTestsF, ApplySymbolEquivalence_Concat_Values) {
             make_shared<v0::Concat>(OutputVector{gather, v0::Constant::create(element::i64, {1}, {-1})}, 0),
             false);
 
-        model = make_shared<Model>(NodeVector{reshape}, ParameterVector{input_2, input_1});
+        model = make_shared<Model>(OutputVector{reshape}, ParameterVector{input_2, input_1});
 
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
@@ -96,7 +96,7 @@ TEST_F(TransformationTestsF, ApplySymbolEquivalence_Concat_Values) {
             concat,
             make_shared<v0::Concat>(OutputVector{sum, v0::Constant::create(element::i64, {1}, {-1})}, 0),
             false);
-        model_ref = make_shared<Model>(NodeVector{reshape}, ParameterVector{input_2, input_1});
+        model_ref = make_shared<Model>(OutputVector{reshape}, ParameterVector{input_2, input_1});
     }
 }
 
@@ -139,7 +139,7 @@ TEST_F(TransformationTestsF, ValueOptimizationSingleValue) {
                                             v0::Constant::create(element::i32, {}, {1}),
                                             element::i32);
 
-        model = make_shared<Model>(NodeVector{reshape_0, reshape_1, range}, ParameterVector{input});
+        model = make_shared<Model>(OutputVector{reshape_0, reshape_1, range}, ParameterVector{input});
 
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
@@ -164,7 +164,7 @@ TEST_F(TransformationTestsF, ValueOptimizationSingleValue) {
                                             v0::Constant::create(element::i32, {}, {1}),
                                             element::i32);
 
-        model_ref = make_shared<Model>(NodeVector{reshape_0, reshape_1, range}, ParameterVector{input});
+        model_ref = make_shared<Model>(OutputVector{reshape_0, reshape_1, range}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -185,7 +185,7 @@ TEST_F(TransformationTestsF, ValueOptimizationDoubleValue) {
             make_shared<v0::Concat>(OutputVector{v0::Constant::create(element::i32, {1}, {0}), dim_1}, 0),
             false);
 
-        model = make_shared<Model>(NodeVector{reshape_0, reshape_1}, ParameterVector{input});
+        model = make_shared<Model>(OutputVector{reshape_0, reshape_1}, ParameterVector{input});
 
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
@@ -206,7 +206,7 @@ TEST_F(TransformationTestsF, ValueOptimizationDoubleValue) {
             make_shared<v0::Concat>(OutputVector{v0::Constant::create(element::i32, {1}, {0}), dim_0}, 0),
             false);
 
-        model_ref = make_shared<Model>(NodeVector{reshape_0, reshape_1}, ParameterVector{input});
+        model_ref = make_shared<Model>(OutputVector{reshape_0, reshape_1}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }
@@ -227,7 +227,7 @@ TEST_F(TransformationTestsF, ValueOptimizationSymbolAndValue) {
             make_shared<v0::Concat>(OutputVector{v0::Constant::create(element::i32, {1}, {-1}), dim_1}, 0),
             false);
 
-        model = make_shared<Model>(NodeVector{reshape_0, reshape_1}, ParameterVector{input});
+        model = make_shared<Model>(OutputVector{reshape_0, reshape_1}, ParameterVector{input});
 
         manager.set_per_pass_validation(false);
         manager.register_pass<pass::SymbolicPropagation>();
@@ -244,7 +244,7 @@ TEST_F(TransformationTestsF, ValueOptimizationSymbolAndValue) {
         auto reshape_0 = make_shared<v1::Reshape>(input, dim_1, false);
         auto reshape_1 = make_shared<v1::Reshape>(input, dim_0, false);
 
-        model_ref = make_shared<Model>(NodeVector{reshape_0, reshape_1}, ParameterVector{input});
+        model_ref = make_shared<Model>(OutputVector{reshape_0, reshape_1}, ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }

--- a/src/common/transformations/tests/transpose_sinking/ts_reset_no_sinking_attribute.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_reset_no_sinking_attribute.cpp
@@ -32,7 +32,7 @@ TEST(TransformationTests, ResetNoSinkingAttribute) {
 
     auto add = std::make_shared<Add>(transpose_a, transpose_b);
     auto trans_after = make_shared<Transpose>(add, Constant::create(element::i64, Shape{4}, {1, 0, 2, 3}));
-    auto model = std::make_shared<Model>(NodeVector{trans_after}, ParameterVector{a, b});
+    auto model = std::make_shared<Model>(OutputVector{trans_after}, ParameterVector{a, b});
 
     mark_as_no_sinking_node(transpose_a);
     mark_as_no_sinking_node(transpose_b);

--- a/src/common/transformations/tests/transpose_sinking/ts_shape_of_test.cpp
+++ b/src/common/transformations/tests/transpose_sinking/ts_shape_of_test.cpp
@@ -23,7 +23,7 @@ TEST_F(TSShapeOfForward, v0ShapeOf) {
         auto order2 = op::v0::Constant::create(element::i32, Shape{4}, {0, 2, 3, 1});
         auto transpose2 = std::make_shared<op::v1::Transpose>(transpose1, order2);
         auto abs = std::make_shared<op::v0::Abs>(transpose2);
-        model = std::make_shared<Model>(NodeVector{shape_of, abs}, ParameterVector{param});
+        model = std::make_shared<Model>(OutputVector{shape_of, abs}, ParameterVector{param});
 
         manager.register_pass<ov::pass::transpose_sinking::TSShapeOfForward>();
         manager.register_pass<ov::pass::transpose_sinking::TSFuse>();
@@ -36,7 +36,7 @@ TEST_F(TSShapeOfForward, v0ShapeOf) {
         auto axis = op::v0::Constant::create(element::i32, Shape{}, {0});
         auto gather = std::make_shared<op::v8::Gather>(shape_of, order1, axis);
         auto abs = std::make_shared<op::v0::Abs>(param);
-        model_ref = std::make_shared<Model>(NodeVector{gather, abs}, ParameterVector{param});
+        model_ref = std::make_shared<Model>(OutputVector{gather, abs}, ParameterVector{param});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
@@ -52,7 +52,7 @@ TEST_F(TSShapeOfForward, v3ShapeOf) {
         auto order2 = op::v0::Constant::create(element::i32, Shape{4}, {0, 2, 3, 1});
         auto transpose2 = std::make_shared<op::v1::Transpose>(transpose1, order2);
         auto abs = std::make_shared<op::v0::Abs>(transpose2);
-        model = std::make_shared<Model>(NodeVector{shape_of, abs}, ParameterVector{param});
+        model = std::make_shared<Model>(OutputVector{shape_of, abs}, ParameterVector{param});
 
         manager.register_pass<ov::pass::transpose_sinking::TSShapeOfForward>();
         manager.register_pass<ov::pass::transpose_sinking::TSFuse>();
@@ -65,7 +65,7 @@ TEST_F(TSShapeOfForward, v3ShapeOf) {
         auto axis = op::v0::Constant::create(element::i32, Shape{}, {0});
         auto gather = std::make_shared<op::v8::Gather>(shape_of, order1, axis);
         auto abs = std::make_shared<op::v0::Abs>(param);
-        model_ref = std::make_shared<Model>(NodeVector{gather, abs}, ParameterVector{param});
+        model_ref = std::make_shared<Model>(OutputVector{gather, abs}, ParameterVector{param});
     }
 
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);

--- a/src/common/transformations/tests/utils/compare_functions_test.cpp
+++ b/src/common/transformations/tests/utils/compare_functions_test.cpp
@@ -61,7 +61,7 @@ TEST(TransformationTests, CompareFunctoinsTIPositive) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     {
@@ -104,7 +104,7 @@ TEST(TransformationTests, CompareFunctoinsTIPositive) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -151,7 +151,7 @@ TEST(TransformationTests, CompareFunctoinsTINegative) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     {
@@ -195,7 +195,7 @@ TEST(TransformationTests, CompareFunctoinsTINegative) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 1);
 
         auto res_ti_1 = std::make_shared<opset5::Result>(tensor_iterator->output(1));
-        f_ref = std::make_shared<ov::Model>(NodeVector{res_ti_1}, ParameterVector{X, Y, Z});
+        f_ref = std::make_shared<ov::Model>(OutputVector{res_ti_1}, ParameterVector{X, Y, Z});
     }
 
     const auto fc = FunctionsComparator::with_default().enable(FunctionsComparator::ATTRIBUTES);
@@ -227,7 +227,7 @@ TEST(TransformationTests, CompareFunctoinsTINegativeDifferentElementTypeBetweenS
 
         auto out = ti->get_concatenated_slices(result, 0, 1, 1, -1, 1);
 
-        return std::make_shared<Model>(NodeVector{out.get_node_shared_ptr()}, ParameterVector{X, Y});
+        return std::make_shared<Model>(OutputVector{out.get_node_shared_ptr()}, ParameterVector{X, Y});
     };
     const auto f1 = createFunc(element::f32);
     const auto f2 = createFunc(element::f16);
@@ -263,7 +263,7 @@ TEST(TransformationTests, CompareFunctoinsTINegativeDifferentElementTypeBetweenI
 
         auto out = ti->get_concatenated_slices(result, 0, 1, 1, -1, 1);
 
-        return std::make_shared<Model>(NodeVector{out.get_node_shared_ptr()}, ParameterVector{X, Y});
+        return std::make_shared<Model>(OutputVector{out.get_node_shared_ptr()}, ParameterVector{X, Y});
     };
     const auto f1 = createFunc(element::f32);
 
@@ -298,7 +298,7 @@ TEST(TransformationTests, CompareFunctoinsTINegativeDifferentElementTypeBetweent
 
         auto out = ti->get_concatenated_slices(result, 0, 1, 1, -1, 1);
 
-        auto fn = std::make_shared<Model>(NodeVector{out.get_node_shared_ptr()}, ParameterVector{X, Y});
+        auto fn = std::make_shared<Model>(OutputVector{out.get_node_shared_ptr()}, ParameterVector{X, Y});
 
         /// <<
         auto&& result_out = result->output(0);
@@ -337,7 +337,7 @@ TEST(TransformationTests, ConstantNegativeDifferentElementType) {
         using namespace opset5;
         auto constant = Constant::create(t, Shape{1}, {1.1});
 
-        return std::make_shared<ov::Model>(NodeVector{constant}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{constant}, ParameterVector{});
     };
 
     const auto& f1 = createConstantFunc(element::f64);
@@ -354,7 +354,7 @@ TEST(TransformationTests, ConstantNegativeDifferentValues) {
         using namespace opset5;
         auto constant = Constant::create(element::f32, Shape{1}, {value});
 
-        return std::make_shared<ov::Model>(NodeVector{constant}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{constant}, ParameterVector{});
     };
 
     const auto& f1 = createConstantFunc(1.0);
@@ -371,7 +371,7 @@ TEST(TransformationTests, ConstantNegativeDifferentShapes) {
         using namespace opset5;
         auto constant = Constant::create(element::f32, s, {1.1});
 
-        return std::make_shared<ov::Model>(NodeVector{constant}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{constant}, ParameterVector{});
     };
 
     const auto& f1 = createConstantFunc(Shape{2});
@@ -389,7 +389,7 @@ TEST(TransformationTests, ClampNegativeDifferentMin) {
         auto constant = Constant::create(element::f32, Shape{1}, {1.0});
         auto clamp = std::make_shared<Clamp>(constant, min, 20.);
 
-        return std::make_shared<ov::Model>(NodeVector{clamp}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{clamp}, ParameterVector{});
     };
 
     const auto& f1 = createClampFunc(1.0);
@@ -407,7 +407,7 @@ TEST(TransformationTests, ClampNegativeDifferentMax) {
         auto constant = Constant::create(element::f32, Shape{1}, {1.0});
         auto clamp = std::make_shared<Clamp>(constant, 1., max);
 
-        return std::make_shared<ov::Model>(NodeVector{clamp}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{clamp}, ParameterVector{});
     };
 
     const auto& f1 = createClampFunc(10.1);
@@ -425,7 +425,7 @@ TEST(TransformationTests, ConcatNegativeDifferentMax) {
         auto constant = Constant::create(element::f32, Shape{10, 10, 2, 2, 3}, {1.0});
         auto clamp = std::make_shared<Concat>(OutputVector{constant}, axis);
 
-        return std::make_shared<ov::Model>(NodeVector{clamp}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{clamp}, ParameterVector{});
     };
 
     const auto& f1 = createConcatFunc(1);
@@ -546,7 +546,7 @@ template <typename Member>
 std::shared_ptr<ov::Model> createDummyFunc(const Member& m) {
     auto constant = std::make_shared<DummyConstant<Member>>(m);
 
-    return std::make_shared<ov::Model>(NodeVector{constant}, ParameterVector{});
+    return std::make_shared<ov::Model>(OutputVector{constant}, ParameterVector{});
 }
 
 }  // namespace
@@ -664,7 +664,7 @@ const auto createU1ConstantFunc = [](const Shape& s, const uint8_t* data) {
     using namespace opset5;
     auto c = std::make_shared<Constant>(element::u1, s, data);
 
-    return std::make_shared<ov::Model>(NodeVector{c}, ParameterVector{});
+    return std::make_shared<ov::Model>(OutputVector{c}, ParameterVector{});
 };
 }
 

--- a/src/common/transformations/tests/utils/compress_quantize_weights.cpp
+++ b/src/common/transformations/tests/utils/compress_quantize_weights.cpp
@@ -214,7 +214,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithDequantizationSubgraph) 
         auto sub = std::make_shared<opset8::Subtract>(second_convert, zero_point);
         auto mul = std::make_shared<opset8::Multiply>(sub, scale);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -225,7 +225,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithDequantizationSubgraph) 
         auto zero_point = opset8::Constant::create(element::f32, Shape{}, {2 - 255.0 / 10});
         auto sub = std::make_shared<opset8::Subtract>(convert, zero_point);
         auto mul = std::make_shared<opset8::Multiply>(sub, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -254,7 +254,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithDequantizationSubgraphFP
         auto sub = std::make_shared<opset8::Subtract>(second_convert, zero_point);
         auto mul = std::make_shared<opset8::Multiply>(sub, scale);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -265,7 +265,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithDequantizationSubgraphFP
         auto zero_point = opset8::Constant::create(element::f32, Shape{}, {2 - 255.0 / 10});
         auto sub = std::make_shared<opset8::Subtract>(convert, zero_point);
         auto mul = std::make_shared<opset8::Multiply>(sub, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -284,7 +284,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminated) {
         auto output_low = opset8::Constant::create(element::f32, Shape{3, 1, 1, 1}, {-0.402659, -0.383148, -0.34054});
         auto output_high = opset8::Constant::create(element::f32, Shape{3, 1, 1, 1}, {0.399513, 0.380155, 0.33788});
         auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 256);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -294,7 +294,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminated) {
         auto convert = std::make_shared<opset8::Convert>(data, element::f32);
         auto scale = opset8::Constant::create(element::f32, Shape{3, 1, 1, 1}, {0.00314577, 0.00299335, 0.00266047});
         auto mul = std::make_shared<opset8::Multiply>(convert, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -313,7 +313,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminatedZeroS
         auto output_low = opset8::Constant::create(element::f32, Shape{3, 1, 1, 1}, {-0.402659, 0.0, -0.34054});
         auto output_high = opset8::Constant::create(element::f32, Shape{3, 1, 1, 1}, {0.399513, 0.0, 0.33788});
         auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 256);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -323,7 +323,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminatedZeroS
         auto convert = std::make_shared<opset8::Convert>(data, element::f32);
         auto scale = opset8::Constant::create(element::f32, Shape{3, 1, 1, 1}, {0.00314577, 0.0, 0.00266047});
         auto mul = std::make_shared<opset8::Multiply>(convert, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -347,7 +347,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminatedFP16)
                                                     Shape{3, 1, 1, 1},
                                                     {-0.295166015625, -0.74169921875, -0.64501953125});
         auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 255);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -357,7 +357,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminatedFP16)
         auto convert = std::make_shared<opset8::Convert>(data, element::f16);
         auto scale = opset8::Constant::create(element::f16, Shape{3, 1, 1, 1}, {-0.002325, -0.00584, -0.005077});
         auto mul = std::make_shared<opset8::Multiply>(convert, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -371,7 +371,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminatedBF16)
         auto output_low = opset8::Constant::create(element::bf16, Shape{3, 1, 1, 1}, {0.30, 0.75, 0.65});
         auto output_high = opset8::Constant::create(element::bf16, Shape{3, 1, 1, 1}, {-0.30, -0.75, -0.65});
         auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 255);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -381,7 +381,7 @@ TEST_F(TransformationTestsF, CompressQuantizeWeightsWithZeroPointEliminatedBF16)
         auto convert = std::make_shared<opset8::Convert>(data, element::bf16);
         auto scale = opset8::Constant::create(element::bf16, Shape{3, 1, 1, 1}, {-0.002325, -0.00592, -0.00509});
         auto mul = std::make_shared<opset8::Multiply>(convert, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -403,7 +403,7 @@ TEST_F(TransformationTestsF, NegativeCompressQuantizeWeights) {
         auto output_low = opset8::Constant::create(element::f32, Shape{}, {-2});
         auto output_high = opset8::Constant::create(element::f32, Shape{}, {6});
         auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 256);
-        model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{});
+        model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{});
 
         manager.register_pass<ov::pass::CompressQuantizeWeights>();
     }
@@ -414,7 +414,7 @@ TEST_F(TransformationTestsF, NegativeCompressQuantizeWeights) {
         auto zero_point = opset8::Constant::create(element::f32, Shape{}, {-64.25});
         auto sub = std::make_shared<opset8::Subtract>(convert, zero_point);
         auto mul = std::make_shared<opset8::Multiply>(sub, scale);
-        model_ref = std::make_shared<Model>(NodeVector{mul}, ParameterVector{});
+        model_ref = std::make_shared<Model>(OutputVector{mul}, ParameterVector{});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::ACCURACY);
@@ -432,7 +432,7 @@ TEST_F(TransformationTestsF, NegativeCompressQuantizeWeightsNonConstantInput) {
     auto output_low = opset8::Constant::create(element::f32, Shape{}, {-2});
     auto output_high = opset8::Constant::create(element::f32, Shape{}, {6});
     auto fq = std::make_shared<opset8::FakeQuantize>(data, input_low, input_high, output_low, output_high, 256);
-    model = std::make_shared<Model>(NodeVector{fq}, ParameterVector{data});
+    model = std::make_shared<Model>(OutputVector{fq}, ParameterVector{data});
 
     manager.register_pass<ov::pass::CompressQuantizeWeights>();
 

--- a/src/common/transformations/tests/utils/convert_precision.cpp
+++ b/src/common/transformations/tests/utils/convert_precision.cpp
@@ -67,7 +67,7 @@ TEST(TransformationTests, ConvertPrecision_NMS3) {
                                                                opset3::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        f = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        f = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         pass::Manager manager;
 
@@ -97,7 +97,7 @@ TEST(TransformationTests, ConvertPrecision_NMS4) {
                                                                opset4::NonMaxSuppression::BoxEncodingType::CORNER,
                                                                true);
 
-        f = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        f = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
 
         pass::Manager manager;
 
@@ -268,7 +268,7 @@ TEST(TransformationTests, ConvertPrecision_ShapeOf) {
         auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
         auto shape_of = std::make_shared<opset4::ShapeOf>(input);
 
-        f = std::make_shared<Model>(NodeVector{shape_of}, ParameterVector{input});
+        f = std::make_shared<Model>(OutputVector{shape_of}, ParameterVector{input});
 
         pass::Manager manager;
 
@@ -291,7 +291,7 @@ TEST(TransformationTests, ConvertPrecision_Range) {
         auto shift = std::make_shared<opset4::Parameter>(element::f16, Shape{});
         auto range = std::make_shared<opset4::Range>(start, stop, shift, element::i64);
 
-        f = std::make_shared<Model>(NodeVector{range}, ParameterVector{start, stop, shift});
+        f = std::make_shared<Model>(OutputVector{range}, ParameterVector{start, stop, shift});
 
         pass::Manager manager;
 
@@ -313,7 +313,7 @@ TEST(TransformationTests, ConvertPrecision_ConstantRelu) {
         auto relu1 = std::make_shared<opset4::Relu>(input);
         auto relu2 = std::make_shared<opset4::Relu>(relu1);
 
-        f = std::make_shared<Model>(NodeVector{relu2}, ParameterVector{});
+        f = std::make_shared<Model>(OutputVector{relu2}, ParameterVector{});
 
         pass::Manager manager;
 
@@ -334,7 +334,7 @@ TEST(TransformationTests, ConvertPrecision_Convert) {
         auto input = std::make_shared<opset4::Parameter>(element::f16, Shape{1, 1000, 4});
         auto convert = std::make_shared<opset4::Convert>(input, element::i64);
 
-        f = std::make_shared<Model>(NodeVector{convert}, ParameterVector{input});
+        f = std::make_shared<Model>(OutputVector{convert}, ParameterVector{input});
 
         pass::Manager manager;
 
@@ -358,7 +358,7 @@ TEST(TransformationTests, ConvertPrecision_Convert_clamp_1) {
         auto const_node = opset10::Constant::create(element::f32, Shape{2}, {100000.0f, -100000.0f});
         auto convert = std::make_shared<opset4::Convert>(const_node, element::f16);
         auto add_1 = make_shared<opset10::Add>(input, convert);
-        model = std::make_shared<Model>(NodeVector{add_1}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{add_1}, ParameterVector{input});
 
         pass::Manager manager;
         static const precisions_map precisions = {{element::f32, element::f16}};
@@ -373,7 +373,7 @@ TEST(TransformationTests, ConvertPrecision_Convert_clamp_1) {
         auto const_node = opset10::Constant::create(element::f16, Shape{2}, {max_fp16, -max_fp16});
         auto add_1 = make_shared<opset10::Add>(input, const_node);
 
-        model_ref = std::make_shared<Model>(NodeVector{add_1}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{add_1}, ParameterVector{input});
     }
     ASSERT_NO_THROW(check_rt_info(model));
     const auto fc = FunctionsComparator::with_default()
@@ -392,7 +392,7 @@ TEST(TransformationTests, ConvertPrecision_Convert_clamp_bf16_f16) {
         auto const_node = opset10::Constant::create(element::bf16, Shape{3}, {100000.0f, -100000.0f, 10.0f});
         auto convert = std::make_shared<opset4::Convert>(const_node, element::f16);
         auto add_1 = make_shared<opset10::Add>(input, convert);
-        model = std::make_shared<Model>(NodeVector{add_1}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{add_1}, ParameterVector{input});
 
         pass::Manager manager;
         static const precisions_map precisions = {{element::bf16, element::f16}};
@@ -407,7 +407,7 @@ TEST(TransformationTests, ConvertPrecision_Convert_clamp_bf16_f16) {
         auto const_node = opset10::Constant::create(element::f16, Shape{3}, {max_fp16, -max_fp16, 10.0f});
         auto add_1 = make_shared<opset10::Add>(input, const_node);
 
-        model_ref = std::make_shared<Model>(NodeVector{add_1}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{add_1}, ParameterVector{input});
     }
     ASSERT_NO_THROW(check_rt_info(model));
     const auto fc = FunctionsComparator::with_default()
@@ -435,7 +435,7 @@ TEST(TransformationTests, DISABLED_ConvertPrecision_Convert_clamp_2) {
 
         auto add_1 = make_shared<opset10::Add>(convert_f32, const_node_2);
         auto add_2 = make_shared<opset10::Add>(input, add_1);
-        model = std::make_shared<Model>(NodeVector{add_2}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{add_2}, ParameterVector{input});
 
         pass::Manager manager;
         static const precisions_map precisions = {{element::f32, element::f16}};
@@ -451,7 +451,7 @@ TEST(TransformationTests, DISABLED_ConvertPrecision_Convert_clamp_2) {
         auto const_node = opset10::Constant::create(element::f16, Shape{2}, {max_fp16, -max_fp16});
         auto add_1 = make_shared<opset10::Add>(input, const_node);
 
-        model_ref = std::make_shared<Model>(NodeVector{add_1}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{add_1}, ParameterVector{input});
     }
 
     ASSERT_NO_THROW(check_rt_info(model));
@@ -484,7 +484,7 @@ TEST(TransformationTests, DISABLED_ConvertPrecision_Convert_clamp_int32) {
 
         auto add_1 = make_shared<opset10::Add>(convert_f32, const_node_2);
         auto add_2 = make_shared<opset10::Add>(input, add_1);
-        model = std::make_shared<Model>(NodeVector{add_2}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{add_2}, ParameterVector{input});
 
         pass::Manager manager;
         static const precisions_map precisions = {{element::f32, element::f16}};
@@ -500,7 +500,7 @@ TEST(TransformationTests, DISABLED_ConvertPrecision_Convert_clamp_int32) {
         auto const_node = opset10::Constant::create(element::f16, Shape{2}, {max_fp16, -max_fp16});
         auto add_1 = make_shared<opset10::Add>(input, const_node);
 
-        model_ref = std::make_shared<Model>(NodeVector{add_1}, ParameterVector{input});
+        model_ref = std::make_shared<Model>(OutputVector{add_1}, ParameterVector{input});
     }
 
     ASSERT_NO_THROW(check_rt_info(model));
@@ -519,7 +519,7 @@ TEST(TransformationTests, ConvertPrecision_ConvertElimination) {
         auto relu = std::make_shared<opset4::Relu>(input);
         auto convert = std::make_shared<opset4::Convert>(relu, element::f32);
 
-        f = std::make_shared<Model>(NodeVector{convert}, ParameterVector{input});
+        f = std::make_shared<Model>(OutputVector{convert}, ParameterVector{input});
 
         pass::Manager manager;
         manager.register_pass<pass::InitNodeInfo>();
@@ -532,7 +532,7 @@ TEST(TransformationTests, ConvertPrecision_ConvertElimination) {
         auto input = std::make_shared<opset4::Parameter>(element::f32, Shape{1, 1000, 4});
         auto relu = std::make_shared<opset4::Relu>(input);
 
-        f_ref = std::make_shared<Model>(NodeVector{relu}, ParameterVector{input});
+        f_ref = std::make_shared<Model>(OutputVector{relu}, ParameterVector{input});
     }
     OV_ASSERT_NO_THROW(check_rt_info(f));
     auto res = compare_functions(f, f_ref);
@@ -707,7 +707,7 @@ TEST(TransformationTests, ConvertPrecision_TIBody) {
 
         auto res_ti_1 = std::make_shared<opset4::Result>(tensor_iterator->output(1));
         // auto res_ti_2 = std::make_shared<opset4::Result>(tensor_iterator->output(0));
-        f = std::make_shared<Model>(NodeVector{res_ti_1}, ParameterVector{X, Y});
+        f = std::make_shared<Model>(OutputVector{res_ti_1}, ParameterVector{X, Y});
 
         pass::Manager manager;
 
@@ -1073,7 +1073,7 @@ TEST(TransformationTests, ConvertPrecision_Variables) {
 
         mul->add_control_dependency(m_w);
 
-        f = std::make_shared<Model>(NodeVector{mul}, ParameterVector{inp});
+        f = std::make_shared<Model>(OutputVector{mul}, ParameterVector{inp});
 
         pass::Manager manager;
         manager.register_pass<pass::InitNodeInfo>();
@@ -1103,7 +1103,7 @@ TEST(TransformationTests, ConvertPrecision_skip_precision_sensitive) {
         attrs.cube_coeff = -0.75f;
 
         interpolate = std::make_shared<opset10::Interpolate>(input, sizes, scales, attrs);
-        model = std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{input});
 
         pass::Manager manager;
         type_to_fuse_map empty_type_to_fuse_map = {};
@@ -1139,7 +1139,7 @@ TEST(TransformationTests, ConvertPrecision_without_keep_precision_sensitive_in_f
         attrs.cube_coeff = -0.75f;
 
         interpolate = std::make_shared<opset10::Interpolate>(input, sizes, scales, attrs);
-        model = std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{input});
         pass::Manager manager;
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = false;
@@ -1161,7 +1161,7 @@ TEST(TransformationTests, ConvertPrecision_check_marking_does_not_leak_in_trivia
         auto input_2 = std::make_shared<opset10::Parameter>(element::f32, Shape{1, 3, 720, 1280});
         auto new_shape = std::make_shared<opset10::ShapeOf>(input_2);
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::DisableShapeOfConstantFolding>();
@@ -1180,7 +1180,7 @@ TEST(TransformationTests, ConvertPrecision_check_marking_does_not_leak_in_trivia
         auto new_shape = std::make_shared<opset10::ShapeOf>(input_2);
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
 
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -1204,7 +1204,7 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_1) {
         auto new_shape = std::make_shared<opset10::Convert>(div, element::i64);
 
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
-        model = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::DisableShapeOfConstantFolding>();
@@ -1228,7 +1228,7 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_1) {
         auto new_shape = std::make_shared<opset10::Convert>(div, element::i64);
 
         auto reshape = std::make_shared<opset10::Reshape>(input_1, new_shape, false);
-        model_ref = std::make_shared<Model>(NodeVector{reshape}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{reshape}, ParameterVector{input_1, input_2});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -1261,7 +1261,7 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_2) {
         std::vector<int64_t> end_mask = {0, 0, 0, 0};
         auto slice = std::make_shared<opset10::StridedSlice>(input_1, begin, concat_with_ends, begin_mask, end_mask);
         auto result = std::make_shared<opset10::Result>(slice);
-        model = std::make_shared<Model>(NodeVector{result}, ParameterVector{input_1});
+        model = std::make_shared<Model>(OutputVector{result}, ParameterVector{input_1});
 
         pass::Manager manager;
         manager.register_pass<pass::DisableShapeOfConstantFolding>();
@@ -1294,7 +1294,7 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_2) {
         std::vector<int64_t> end_mask = {0, 0, 0, 0};
         auto slice = std::make_shared<opset10::StridedSlice>(input_1, begin, concat_with_ends, begin_mask, end_mask);
         auto result = std::make_shared<opset10::Result>(slice);
-        model_ref = std::make_shared<Model>(NodeVector{result}, ParameterVector{input_1});
+        model_ref = std::make_shared<Model>(OutputVector{result}, ParameterVector{input_1});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -1344,7 +1344,7 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_3) {
         auto add_1 = std::make_shared<opset10::Add>(input_1, const_4);
         auto result_1 = std::make_shared<opset10::Result>(add_1);
         auto result_2 = std::make_shared<opset10::Result>(interpolate);
-        model = std::make_shared<Model>(NodeVector{result_1, result_2}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{result_1, result_2}, ParameterVector{input_1, input_2});
 
         pass::Manager manager;
         manager.register_pass<pass::DisableShapeOfConstantFolding>();
@@ -1394,7 +1394,7 @@ TEST(TransformationTests, ConvertPrecision_whole_shape_subgraph_is_marked_3) {
         auto add_1 = std::make_shared<opset10::Add>(input_1, const_4);
         auto result_1 = std::make_shared<opset10::Result>(add_1);
         auto result_2 = std::make_shared<opset10::Result>(interpolate);
-        model_ref = std::make_shared<Model>(NodeVector{result_1, result_2}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{result_1, result_2}, ParameterVector{input_1, input_2});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -1426,7 +1426,7 @@ TEST(TransformationTests, ConvertCompressedToMixedPrecission_do_not_keep_in_fp32
         attrs.cube_coeff = -0.75f;
 
         interpolate = std::make_shared<opset10::Interpolate>(input, sizes, scales_const, attrs);
-        model = std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{input});
+        model = std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{input});
 
         pass::Manager manager;
         type_to_fuse_map empty_type_to_fuse_map = {};
@@ -1454,7 +1454,7 @@ void constant_convert_test(element::Type type_from,
     {
         auto c = std::make_shared<opset4::Constant>(type_from, Shape{size}, value.data());
         expected_friendly_name = c->get_friendly_name();
-        f = std::make_shared<Model>(NodeVector{c}, ParameterVector{});
+        f = std::make_shared<Model>(OutputVector{c}, ParameterVector{});
 
         pass::Manager manager;
         manager.register_pass<pass::ConvertPrecision>(precisions_map{{type_from, type_to}});
@@ -1484,7 +1484,7 @@ void constant_convert_test(element::Type_t type_from, element::Type_t type_to, F
     {
         auto c = std::make_shared<opset4::Constant>(type_from, Shape{}, &value);
         expected_friendly_name = c->get_friendly_name();
-        f = std::make_shared<Model>(NodeVector{c}, ParameterVector{});
+        f = std::make_shared<Model>(OutputVector{c}, ParameterVector{});
 
         pass::Manager manager;
         manager.register_pass<pass::ConvertPrecision>(precisions_map{{type_from, type_to}});
@@ -1681,7 +1681,7 @@ TEST(TransformationTests, ConvertPrecision_keep_precission_sensitive_fp32_with_e
         auto mul_1 = make_shared<opset10::Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -1704,7 +1704,7 @@ TEST(TransformationTests, ConvertPrecision_keep_precission_sensitive_fp32_with_e
         auto mul_1_compressed = make_shared<opset10::Convert>(mul_1, element::f16);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1_compressed, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -1727,7 +1727,7 @@ TEST(TransformationTests, ConvertPrecision_keep_precission_sensitive_fp32_with_r
         auto mul_1 = make_shared<opset10::Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -1750,7 +1750,7 @@ TEST(TransformationTests, ConvertPrecision_keep_precission_sensitive_fp32_with_r
         auto mul_1_compressed = make_shared<opset10::Convert>(mul_1, element::f16);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1_compressed, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -1774,7 +1774,7 @@ TEST(TransformationTests, ConvertPrecision_reducesum_without_exp) {
         auto mul_1 = make_shared<opset10::Multiply>(reduce_sum_1, factor_const);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -1794,7 +1794,7 @@ TEST(TransformationTests, ConvertPrecision_reducesum_without_exp) {
         auto mul_1 = make_shared<opset10::Multiply>(reduce_sum_1, factor_const);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -1852,7 +1852,7 @@ TEST(TransformationTests, ConvertPrecision_keep_precission_sensitive_fp32_t2t_su
         auto div_1 = make_shared<opset10::Divide>(reduce_sum_4, add_1);
         auto matmul_1 = make_shared<opset10::MatMul>(div_1, input_4, false, true);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -1913,7 +1913,7 @@ TEST(TransformationTests, ConvertPrecision_keep_precission_sensitive_fp32_t2t_su
         auto div_compressed = make_shared<opset10::Convert>(div_1, element::f16);
         auto matmul_1 = make_shared<opset10::MatMul>(div_compressed, input_4, false, true);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2, input_3, input_4});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -1932,7 +1932,7 @@ TEST(TransformationTests, ConvertPrecision_DivisionByZeroMinimalPattern) {
         auto eps_const = opset10::Constant::create(element::f32, Shape{1}, {eps_value});
         auto add = std::make_shared<opset10::Add>(input_2, eps_const);
         auto divide = std::make_shared<opset10::Divide>(input_1, add);
-        model = std::make_shared<Model>(NodeVector{divide}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{divide}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -1953,7 +1953,7 @@ TEST(TransformationTests, ConvertPrecision_DivisionByZeroMinimalPattern) {
         auto divide = std::make_shared<opset10::Divide>(input_1_decompressed, add);
         auto conv = std::make_shared<opset10::Convert>(divide, element::f16);
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2038,7 +2038,7 @@ TEST(TransformationTests, Convert_Precision_If_Body) {
         if_op->set_input(input, then_param, else_param);
         if_op->set_output(then_res, else_res);
 
-        main_model = std::make_shared<Model>(NodeVector{if_result}, ParameterVector{input});
+        main_model = std::make_shared<Model>(OutputVector{if_result}, ParameterVector{input});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2067,7 +2067,7 @@ TEST(TransformationTests, Convert_Precision_If_Body) {
         if_op->set_input(input, then_param, else_param);
         if_op->set_output(then_res, else_res);
 
-        main_model_ref = std::make_shared<Model>(NodeVector{if_result}, ParameterVector{input});
+        main_model_ref = std::make_shared<Model>(OutputVector{if_result}, ParameterVector{input});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2088,7 +2088,7 @@ TEST(TransformationTests, ConvertPrecision_PowWithNegativeExponent) {
         auto pow = std::make_shared<opset10::Power>(add, pow_exp_const);
         auto mul = std::make_shared<opset10::Multiply>(input_1, pow);
 
-        model = std::make_shared<Model>(NodeVector{mul}, ParameterVector{input_1, input_2});
+        model = std::make_shared<Model>(OutputVector{mul}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2111,7 +2111,7 @@ TEST(TransformationTests, ConvertPrecision_PowWithNegativeExponent) {
         auto mul = std::make_shared<opset10::Multiply>(input_1_decompressed, pow);
         auto conv = std::make_shared<opset10::Convert>(mul, element::f16);
 
-        model_ref = std::make_shared<Model>(NodeVector{conv}, ParameterVector{input_1, input_2});
+        model_ref = std::make_shared<Model>(OutputVector{conv}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2137,7 +2137,7 @@ TEST(TransformationTests, ConvertPrecision_exp_through_unsqueeze) {
         auto mul_1 = make_shared<opset10::Multiply>(reduce_sum_1, factor_const_decompressed);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2164,7 +2164,7 @@ TEST(TransformationTests, ConvertPrecision_exp_through_unsqueeze) {
         auto mul_1_compressed = make_shared<opset10::Convert>(mul_1, element::f16);
         auto matmul_1 = make_shared<opset10::MatMul>(mul_1_compressed, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2192,7 +2192,7 @@ TEST(TransformationTests, ConvertPrecision_disable_for_quantized_nodes_1) {
         auto fq_2 = make_shared<opset10::FakeQuantize>(reduce_sum_1, in_low, in_high, out_low, out_high, 256);
         auto matmul_1 = make_shared<opset10::MatMul>(fq_2, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2219,7 +2219,7 @@ TEST(TransformationTests, ConvertPrecision_disable_for_quantized_nodes_1) {
         auto fq_2 = make_shared<opset10::FakeQuantize>(reduce_sum_1, in_low, in_high, out_low, out_high, 256);
         auto matmul_1 = make_shared<opset10::MatMul>(fq_2, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2250,7 +2250,7 @@ TEST(TransformationTests, ConvertPrecision_disable_for_quantized_nodes_2) {
         auto fq_2 = make_shared<opset10::FakeQuantize>(reduce_sum_1, in_low, in_high, out_low, out_high, 256);
         auto matmul_1 = make_shared<opset10::MatMul>(fq_2, input_2);
 
-        model = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2280,7 +2280,7 @@ TEST(TransformationTests, ConvertPrecision_disable_for_quantized_nodes_2) {
         auto fq_2 = make_shared<opset10::FakeQuantize>(reduce_sum_1, in_low, in_high, out_low, out_high, 256);
         auto matmul_1 = make_shared<opset10::MatMul>(fq_2, input_2);
 
-        model_ref = make_shared<Model>(NodeVector{matmul_1}, ParameterVector{input_1, input_2});
+        model_ref = make_shared<Model>(OutputVector{matmul_1}, ParameterVector{input_1, input_2});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2448,8 +2448,8 @@ TEST(TransformationTests, ConvertPrecisionExplicitConvertsSingleNodeMultipleOutp
         convert_split_0->get_output_tensor(0).add_names({"split:0"});
         convert_split_1->get_output_tensor(0).add_names({"split:1"});
         convert_split_2->get_output_tensor(0).add_names({"split:2"});
-        model_ref =
-            make_shared<Model>(NodeVector{convert_split_0, convert_split_1, convert_split_2}, ParameterVector{param_1});
+        model_ref = make_shared<Model>(OutputVector{convert_split_0, convert_split_1, convert_split_2},
+                                       ParameterVector{param_1});
     }
 
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
@@ -2592,7 +2592,7 @@ TEST(TransformationTests, align_mixed_fp16_fp32_with_parameter_for_shape_1) {
         auto final_int_shape = make_shared<ov::op::v0::Convert>(final_float_shape, element::i64);
         auto reshape_1 = make_shared<ov::op::v1::Reshape>(input_1, final_int_shape, false);
 
-        model = make_shared<Model>(NodeVector{reshape_1}, ParameterVector{input_1, shape_input});
+        model = make_shared<Model>(OutputVector{reshape_1}, ParameterVector{input_1, shape_input});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2614,7 +2614,7 @@ TEST(TransformationTests, align_mixed_fp16_fp32_with_parameter_for_shape_1) {
         auto final_int_shape = make_shared<ov::op::v0::Convert>(final_float_shape, element::i64);
         auto reshape_1 = make_shared<ov::op::v1::Reshape>(input_1, final_int_shape, false);
 
-        model_ref = make_shared<Model>(NodeVector{reshape_1}, ParameterVector{input_1, shape_input});
+        model_ref = make_shared<Model>(OutputVector{reshape_1}, ParameterVector{input_1, shape_input});
     }
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
     FunctionsComparator::Result result = func_comparator(model_ref, model);
@@ -2635,7 +2635,7 @@ TEST(TransformationTests, align_mixed_fp16_fp32_with_parameter_for_shape_2) {
         auto final_int_shape = make_shared<ov::op::v0::Convert>(final_float_shape, element::i64);
         auto reshape_1 = make_shared<ov::op::v1::Reshape>(input_1, final_int_shape, false);
 
-        model = make_shared<Model>(NodeVector{reshape_1}, ParameterVector{input_1, shape_input});
+        model = make_shared<Model>(OutputVector{reshape_1}, ParameterVector{input_1, shape_input});
 
         type_to_fuse_map empty_type_to_fuse_map = {};
         bool keep_precision_sensitive_in_fp32 = true;
@@ -2661,7 +2661,7 @@ TEST(TransformationTests, align_mixed_fp16_fp32_with_parameter_for_shape_2) {
         auto reshape_1 = make_shared<ov::op::v1::Reshape>(convert_to_f16, final_int_shape, false);
         auto convert_to_f32 = make_shared<ov::op::v0::Convert>(reshape_1, element::f32);
 
-        model_ref = make_shared<Model>(NodeVector{convert_to_f32}, ParameterVector{input_1, shape_input});
+        model_ref = make_shared<Model>(OutputVector{convert_to_f32}, ParameterVector{input_1, shape_input});
     }
     const FunctionsComparator func_comparator = FunctionsComparator::with_default();
     FunctionsComparator::Result result = func_comparator(model_ref, model);

--- a/src/common/transformations/tests/utils/primitives_priority_test.cpp
+++ b/src/common/transformations/tests/utils/primitives_priority_test.cpp
@@ -35,7 +35,7 @@ TEST(TransformationTests, ConvBiasFusion) {
         auto add = std::make_shared<opset1::Add>(conv, bias);
         add->set_friendly_name("add");
 
-        f = std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{input1});
+        f = std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{input1});
     }
 
     std::unordered_map<std::string, std::string> pp;

--- a/src/core/include/openvino/core/model.hpp
+++ b/src/core/include/openvino/core/model.hpp
@@ -53,6 +53,8 @@ class OPENVINO_API Model : public std::enable_shared_from_this<Model> {
 public:
     OPENVINO_RTTI_BASE("Model")
 
+    OPENVINO_DEPRECATED("This constructor is deprecated and will be remove in 2026.0. Use Model(const "
+                        "ov::OutputVector&, const ov::ParameterVector&, const std::string&) instead.")
     Model(const ov::NodeVector& results, const ov::ParameterVector& parameters, const std::string& name = "");
 
     Model(const ov::OutputVector& results, const ov::ParameterVector& parameters, const std::string& name = "");

--- a/src/core/tests/graph_rewrite.cpp
+++ b/src/core/tests/graph_rewrite.cpp
@@ -67,7 +67,7 @@ inline std::shared_ptr<Model> get_model() {
     auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3, 1, 2});
     auto divide_constant = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1}, {1.5});
     auto divide = std::make_shared<ov::op::v1::Divide>(data, divide_constant);
-    return std::make_shared<ov::Model>(ov::NodeVector{divide}, ov::ParameterVector{data});
+    return std::make_shared<ov::Model>(ov::OutputVector{divide}, ov::ParameterVector{data});
 }
 
 inline ov::pass::param_callback get_callback() {
@@ -173,7 +173,7 @@ static std::shared_ptr<Model> get_derived_model() {
     auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3, 1, 2});
     auto divide_constant = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{1}, {1.5});
     auto divide = std::make_shared<PrivateDivide>(data, divide_constant);
-    return std::make_shared<ov::Model>(ov::NodeVector{divide}, ov::ParameterVector{data});
+    return std::make_shared<ov::Model>(ov::OutputVector{divide}, ov::ParameterVector{data});
 }
 
 TEST(GraphRewriteTest, MatcherPassCallbackDerived) {

--- a/src/core/tests/matcher_pass.cpp
+++ b/src/core/tests/matcher_pass.cpp
@@ -61,7 +61,7 @@ TEST(pattern, matcher_pass) {
         auto a = make_shared<op::v0::Parameter>(element::f32, Shape{1});
         auto b = make_shared<op::v0::Relu>(a);
         auto c = make_shared<op::v0::Relu>(b);
-        auto f = std::make_shared<Model>(ov::NodeVector{c}, ParameterVector{a});
+        auto f = std::make_shared<Model>(ov::OutputVector{c}, ParameterVector{a});
 
         ASSERT_TRUE(test_matcher.get_matcher()->match(c->output(0)));
         ASSERT_TRUE(test_matcher.get_matcher()->get_matched_nodes().size() == 2);
@@ -79,7 +79,7 @@ TEST(pattern, matcher_pass) {
         auto a = make_shared<op::v0::Parameter>(element::f32, Shape{1});
         auto b = make_shared<op::v0::Relu>(a);
         auto c = make_shared<op::v0::Relu>(b);
-        auto f = std::make_shared<Model>(ov::NodeVector{b, c}, ParameterVector{a});
+        auto f = std::make_shared<Model>(ov::OutputVector{b, c}, ParameterVector{a});
 
         ASSERT_FALSE(test_matcher.get_matcher()->match(c->output(0)));
     }
@@ -91,7 +91,7 @@ TEST(pattern, matcher_pass) {
             auto b = make_shared<op::v0::Relu>(a);
             auto c = make_shared<op::v0::Relu>(b);
             auto d = make_shared<op::v0::Relu>(c);
-            f = std::make_shared<Model>(ov::NodeVector{d}, ParameterVector{a});
+            f = std::make_shared<Model>(ov::OutputVector{d}, ParameterVector{a});
         }
 
         pass::GraphRewrite pass;

--- a/src/core/tests/pass/constant_folding.cpp
+++ b/src/core/tests/pass/constant_folding.cpp
@@ -441,39 +441,39 @@ TEST(constant_folding, constant_unary_binary) {
     auto neg_sqrt = make_shared<op::v0::Sqrt>(c);
     neg_sqrt->set_friendly_name("neg_sqrt");
 
-    auto func = make_shared<Model>(NodeVector{add,
-                                              sub,
-                                              mul,
-                                              divn,
-                                              pow,
-                                              min,
-                                              max,
-                                              absn,
-                                              neg,
-                                              sqrt,
-                                              add_autob_numpy,
-                                              sub_autob_numpy,
-                                              mul_autob_numpy,
-                                              div_autob_numpy,
-                                              pow_autob_numpy,
-                                              min_autob_numpy,
-                                              max_autob_numpy,
-                                              equal_autob_numpy,
-                                              not_equal_autob_numpy,
-                                              greater_autob_numpy,
-                                              greater_eq_autob_numpy,
-                                              less_autob_numpy,
-                                              less_eq_autob_numpy,
-                                              logical_or_autob_numpy,
-                                              logical_xor_autob_numpy,
-                                              doubles_sqrt,
-                                              sub_int8,
-                                              sub_uint8,
-                                              equal_doubles,
-                                              equal_shorts,
-                                              equal_unsigned_shorts},
+    auto func = make_shared<Model>(OutputVector{add,
+                                                sub,
+                                                mul,
+                                                divn,
+                                                pow,
+                                                min,
+                                                max,
+                                                absn,
+                                                neg,
+                                                sqrt,
+                                                add_autob_numpy,
+                                                sub_autob_numpy,
+                                                mul_autob_numpy,
+                                                div_autob_numpy,
+                                                pow_autob_numpy,
+                                                min_autob_numpy,
+                                                max_autob_numpy,
+                                                equal_autob_numpy,
+                                                not_equal_autob_numpy,
+                                                greater_autob_numpy,
+                                                greater_eq_autob_numpy,
+                                                less_autob_numpy,
+                                                less_eq_autob_numpy,
+                                                logical_or_autob_numpy,
+                                                logical_xor_autob_numpy,
+                                                doubles_sqrt,
+                                                sub_int8,
+                                                sub_uint8,
+                                                equal_doubles,
+                                                equal_shorts,
+                                                equal_unsigned_shorts},
                                    ParameterVector{});
-    auto func_error = make_shared<Model>(NodeVector{neg_sqrt}, ParameterVector{});
+    auto func_error = make_shared<Model>(OutputVector{neg_sqrt}, ParameterVector{});
 
     run_constant_folding(func);
 
@@ -2580,7 +2580,7 @@ TEST(constant_folding, const_reshape_no_data_copy) {
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(reshape);
     auto consumer2 = std::make_shared<ov::op::v0::Relu>(reshape);
 
-    auto f = std::make_shared<Model>(NodeVector{consumer1, consumer2}, ParameterVector{});
+    auto f = std::make_shared<Model>(OutputVector{consumer1, consumer2}, ParameterVector{});
 
     run_constant_folding(f);
 
@@ -2600,7 +2600,7 @@ TEST(constant_folding, const_squeeze_no_data_copy) {
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(reshape);
     auto consumer2 = std::make_shared<ov::op::v0::Relu>(reshape);
 
-    auto f = std::make_shared<Model>(NodeVector{consumer1, consumer2}, ParameterVector{});
+    auto f = std::make_shared<Model>(OutputVector{consumer1, consumer2}, ParameterVector{});
 
     run_constant_folding(f);
 
@@ -2620,7 +2620,7 @@ TEST(constant_folding, const_unsqueeze_no_data_copy) {
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(reshape);
     auto consumer2 = std::make_shared<ov::op::v0::Relu>(reshape);
 
-    auto f = std::make_shared<Model>(NodeVector{consumer1, consumer2}, ParameterVector{});
+    auto f = std::make_shared<Model>(OutputVector{consumer1, consumer2}, ParameterVector{});
 
     run_constant_folding(f);
 
@@ -3637,7 +3637,7 @@ TEST(constant_folding, disable_constant_folding) {
     interp_attr.pads_end = {0, 0, 0, 0};
 
     auto interpolate = std::make_shared<op::v0::Interpolate>(data, convert_after, interp_attr);
-    auto f = std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{data});
+    auto f = std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{data});
 
     ov::disable_constant_folding(convert);
 
@@ -3666,7 +3666,7 @@ TEST(constant_folding, disable_constant_folding_simple) {
                                                      ov::op::v0::Constant::create(element::i64, Shape{3}, {3, 1, 1}),
                                                      true);
     auto divide = std::make_shared<op::v1::Divide>(data, reshape);
-    auto f = std::make_shared<Model>(NodeVector{divide}, ParameterVector{data});
+    auto f = std::make_shared<Model>(OutputVector{divide}, ParameterVector{data});
 
     ov::disable_constant_folding(reshape);
 
@@ -3694,7 +3694,7 @@ TEST(constant_folding, disable_constant_folding_check) {
     auto reshape1 = std::make_shared<op::v1::Reshape>(data, shapeof1, true);
     auto shapeof2 = std::make_shared<op::v0::ShapeOf>(reshape1);
     auto reshape2 = std::make_shared<op::v1::Reshape>(reshape1, shapeof2, true);
-    auto f = std::make_shared<Model>(NodeVector{reshape2}, ParameterVector{data});
+    auto f = std::make_shared<Model>(OutputVector{reshape2}, ParameterVector{data});
 
     ov::disable_constant_folding(shapeof1);
 
@@ -3770,7 +3770,7 @@ TEST(constant_folding, disable_constant_folding_for_shapeof) {
     auto data = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 3, 22, 22});
     auto shapeof = std::make_shared<op::v3::ShapeOf>(data);
     auto reshape = std::make_shared<op::v1::Reshape>(data, shapeof, true);
-    auto model = std::make_shared<ov::Model>(NodeVector{reshape}, ParameterVector{data});
+    auto model = std::make_shared<ov::Model>(OutputVector{reshape}, ParameterVector{data});
 
     ov::disable_constant_folding(shapeof);
 
@@ -3787,7 +3787,7 @@ TEST(constant_folding, disable_constant_folding_for_squeeze_unsqueeze) {
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(squeeze);
     auto consumer2 = std::make_shared<ov::op::v0::Relu>(unsqueeze);
 
-    auto model = std::make_shared<ov::Model>(NodeVector{consumer1, consumer2}, ParameterVector{});
+    auto model = std::make_shared<ov::Model>(OutputVector{consumer1, consumer2}, ParameterVector{});
 
     ov::disable_constant_folding(squeeze);
     ov::disable_constant_folding(unsqueeze);
@@ -3804,7 +3804,7 @@ TEST(constant_folding, disable_constant_folding_for_convert_like) {
     auto convert_like = std::make_shared<op::v1::ConvertLike>(data, like);
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(convert_like);
 
-    auto model = std::make_shared<ov::Model>(NodeVector{consumer1}, ParameterVector{});
+    auto model = std::make_shared<ov::Model>(OutputVector{consumer1}, ParameterVector{});
 
     ov::disable_constant_folding(convert_like);
 
@@ -3819,7 +3819,7 @@ TEST(constant_folding, fold_convert_like_node) {
     auto convert_like = std::make_shared<op::v1::ConvertLike>(data, like);
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(convert_like);
 
-    auto model = std::make_shared<ov::Model>(NodeVector{consumer1}, ParameterVector{});
+    auto model = std::make_shared<ov::Model>(OutputVector{consumer1}, ParameterVector{});
 
     run_constant_folding(model);
 
@@ -3832,7 +3832,7 @@ TEST(constant_folding, fold_convert_like_but_node_is_not_foldable) {
     auto convert_like = std::make_shared<op::v1::ConvertLike>(data, like);
     auto consumer1 = std::make_shared<ov::op::v0::Relu>(convert_like);
 
-    auto model = std::make_shared<ov::Model>(NodeVector{consumer1}, ParameterVector{data});
+    auto model = std::make_shared<ov::Model>(OutputVector{consumer1}, ParameterVector{data});
 
     run_constant_folding(model);
 
@@ -3866,7 +3866,7 @@ TEST(constant_folding, evaluate_on_tensor_vector) {
     auto mock = std::make_shared<::testing::StrictMock<MockAddOp>>(a, b);
     EXPECT_CALL(*mock, evaluate).Times(1);
 
-    auto model = std::make_shared<ov::Model>(NodeVector{mock}, ParameterVector{});
+    auto model = std::make_shared<ov::Model>(OutputVector{mock}, ParameterVector{});
 
     run_constant_folding(model);
 

--- a/src/core/tests/pass/serialization/const_compression.cpp
+++ b/src/core/tests/pass/serialization/const_compression.cpp
@@ -46,7 +46,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsI32) {
     auto A = ov::op::v0::Constant::create(ov::element::i32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto B = ov::op::v0::Constant::create(ov::element::i32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -63,7 +63,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsI64) {
     auto A = ov::op::v0::Constant::create(ov::element::i64, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto B = ov::op::v0::Constant::create(ov::element::i64, shape, {1, 2, 3, 4, 5, 6, 7, 8});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -80,7 +80,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsFP32_COMPRESSED_T
     auto A = ov::op::v0::Constant::create(ov::element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto B = ov::op::v0::Constant::create(ov::element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
     ov::pass::CompressFloatConstants(/*postponed=*/true).run_on_model(model);
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -97,7 +97,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsFP16) {
     auto A = ov::op::v0::Constant::create(ov::element::f16, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto B = ov::op::v0::Constant::create(ov::element::f16, shape, {1, 2, 3, 4, 5, 6, 7, 8});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -114,7 +114,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsFP32) {
     auto A = ov::op::v0::Constant::create(ov::element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto B = ov::op::v0::Constant::create(ov::element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -132,7 +132,7 @@ TEST_F(SerializationConstantCompressionTest, NonIdenticalConstantsI64) {
     auto A = ov::op::v0::Constant::create(ov::element::i64, shape, {2, 2});
     auto B = ov::op::v0::Constant::create(ov::element::i64, shape, {0, 128});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -152,7 +152,7 @@ TEST_F(SerializationConstantCompressionTest, NonIdenticalConstantsI64_CHECK_MULT
     auto C = ov::op::v0::Constant::create(ov::element::i64, shape, {2, 2});
     auto D = ov::op::v0::Constant::create(ov::element::i64, shape, {0, 128});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B, C, D}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B, C, D}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -171,7 +171,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsTimesTwo) {
     auto C = ov::op::v0::Constant::create(ov::element::i32, shape, {0, 3, 1, 2, 5, 6, 25, 3});
     auto D = ov::op::v0::Constant::create(ov::element::i32, shape, {0, 3, 1, 2, 5, 6, 25, 3});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B, C, D}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B, C, D}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -190,7 +190,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsTimesTwo_FP32_COM
     auto C = ov::op::v0::Constant::create(ov::element::f32, shape, {0, 3, 1, 2, 5, 6, 25, 3});
     auto D = ov::op::v0::Constant::create(ov::element::f32, shape, {0, 3, 1, 2, 5, 6, 25, 3});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B, C, D}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B, C, D}, ov::ParameterVector{});
     ov::pass::CompressFloatConstants(/*postponed=*/true).run_on_model(model);
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -211,7 +211,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsTimesTwoMultipleO
     auto E = ov::op::v0::Constant::create(ov::element::i32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto F = ov::op::v0::Constant::create(ov::element::i32, shape, {0, 3, 1, 2, 5, 6, 25, 3});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B, C, D, E, F}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B, C, D, E, F}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -232,7 +232,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsTimesTwoMultipleO
     auto E = ov::op::v0::Constant::create(ov::element::f32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto F = ov::op::v0::Constant::create(ov::element::f32, shape, {0, 3, 1, 2, 5, 6, 25, 3});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B, C, D, E, F}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B, C, D, E, F}, ov::ParameterVector{});
     ov::pass::CompressFloatConstants(/*postponed=*/true).run_on_model(model);
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -253,7 +253,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsTimesTwoMultipleO
     auto E = ov::op::v0::Constant::create(ov::element::f64, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto F = ov::op::v0::Constant::create(ov::element::f64, shape, {0, 3, 1, 2, 5, 6, 25, 3});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B, C, D, E, F}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B, C, D, E, F}, ov::ParameterVector{});
     ov::pass::CompressFloatConstants(/*postponed=*/true).run_on_model(model);
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -270,7 +270,7 @@ TEST_F(SerializationConstantCompressionTest, NonIdenticalConstants) {
     auto A = ov::op::v0::Constant::create(ov::element::i32, shape, {1, 2, 3, 4, 5, 6, 7, 8});
     auto B = ov::op::v0::Constant::create(ov::element::i32, shape, {2, 2, 3, 4, 5, 6, 7, 8});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -287,7 +287,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsDifferentTypesI32
     auto A = ov::op::v0::Constant::create(ov::element::i32, shape, {1, 0, 2, 0, 3, 0, 4, 0});
     auto B = ov::op::v0::Constant::create(ov::element::i64, ov::Shape({1, 2, 2}), {1, 2, 3, 4});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -304,7 +304,7 @@ TEST_F(SerializationConstantCompressionTest, IdenticalConstantsDifferentTypesI32
     auto A = ov::op::v0::Constant::create(ov::element::i32, shape, {1, 2});
     auto B = ov::op::v0::Constant::create(ov::element::i8, ov::Shape({1, 2, 4}), {1, 0, 0, 0, 2, 0, 0, 0});
 
-    auto model = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model);
 
@@ -319,7 +319,7 @@ TEST_F(SerializationConstantCompressionTest, EmptyConstants) {
     auto A = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
     auto B = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
 
-    auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model_initial = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
 
@@ -342,7 +342,7 @@ TEST_F(SerializationConstantCompressionTest, EmptyAndNotEmptyConstantSameValues)
     auto A = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
     auto B = ov::op::v0::Constant::create(ov::element::i8, ov::Shape{1}, std::vector<int8_t>{0});
 
-    auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model_initial = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
 
@@ -365,7 +365,7 @@ TEST_F(SerializationConstantCompressionTest, EmptyAndNotEmptyConstantsDifferentV
     auto A = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{0}, std::vector<int32_t>{});
     auto B = ov::op::v0::Constant::create(ov::element::i8, ov::Shape{1}, std::vector<int8_t>{1});
 
-    auto model_initial = std::make_shared<ov::Model>(ov::NodeVector{A, B}, ov::ParameterVector{});
+    auto model_initial = std::make_shared<ov::Model>(ov::OutputVector{A, B}, ov::ParameterVector{});
 
     ov::pass::Serialize(m_out_xml_path_1, m_out_bin_path_1).run_on_model(model_initial);
 

--- a/src/core/tests/pass/serialization/deterministicity.cpp
+++ b/src/core/tests/pass/serialization/deterministicity.cpp
@@ -198,8 +198,8 @@ TEST_P(SerializationDeterministicityInputOutputTest, FromOvModel) {
         parameter1->set_friendly_name("input1");
         auto result1 = std::make_shared<ov::op::v0::Result>(parameter1);
         result1->set_friendly_name("output1");
-        modelRef =
-            std::make_shared<ov::Model>(ov::NodeVector{result0, result1}, ov::ParameterVector{parameter0, parameter1});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result0, result1},
+                                               ov::ParameterVector{parameter0, parameter1});
     }
 
     auto& expected1 = modelRef;
@@ -321,8 +321,8 @@ TEST_P(SerializationDeterministicityInputOutputTest, FromOvModelBybPath) {
         parameter1->set_friendly_name("input1");
         auto result1 = std::make_shared<ov::op::v0::Result>(parameter1);
         result1->set_friendly_name("output1");
-        modelRef =
-            std::make_shared<ov::Model>(ov::NodeVector{result0, result1}, ov::ParameterVector{parameter0, parameter1});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result0, result1},
+                                               ov::ParameterVector{parameter0, parameter1});
     }
 
     auto& expected1 = modelRef;

--- a/src/core/tests/pass_config.cpp
+++ b/src/core/tests/pass_config.cpp
@@ -79,7 +79,7 @@ static std::tuple<std::shared_ptr<Model>, std::shared_ptr<Node>, std::shared_ptr
     relu->set_friendly_name("relu");
     auto sigmoid = std::make_shared<ov::op::v0::Sigmoid>(relu);
     sigmoid->set_friendly_name("sigmoid");
-    auto f = std::make_shared<ov::Model>(ov::NodeVector{sigmoid}, ov::ParameterVector{data});
+    auto f = std::make_shared<ov::Model>(ov::OutputVector{sigmoid}, ov::ParameterVector{data});
     return std::tuple<std::shared_ptr<Model>, std::shared_ptr<Node>, std::shared_ptr<Node>>(f, relu, sigmoid);
 }
 

--- a/src/core/tests/pattern.cpp
+++ b/src/core/tests/pattern.cpp
@@ -233,7 +233,7 @@ TEST(pattern, graph_rewrite) {
         auto graph_a = make_shared<op::v1::Add>(a, iconst0);
         auto graph_b = make_shared<op::v1::Add>(b, iconst0);
 
-        auto f = std::make_shared<Model>(ov::NodeVector{a, b, graph_a, c, graph_b}, ParameterVector{a, b, c});
+        auto f = std::make_shared<Model>(ov::OutputVector{a, b, graph_a, c, graph_b}, ParameterVector{a, b, c});
         pass_manager.run_passes(f);
 
         ASSERT_TRUE(graph_a->get_output_target_inputs(0).empty());

--- a/src/core/tests/replace_node.cpp
+++ b/src/core/tests/replace_node.cpp
@@ -66,7 +66,7 @@ TEST(replace_node, replace_nodes) {
     auto mul = make_shared<op::v1::Multiply>(add, k);
     auto sub = make_shared<op::v1::Subtract>(mul, z);
 
-    auto f = make_shared<Model>(NodeVector{sub}, ParameterVector{x, y, z});
+    auto f = make_shared<Model>(OutputVector{sub}, ParameterVector{x, y, z});
 
     unordered_map<shared_ptr<ov::op::v0::Parameter>, shared_ptr<ov::op::v0::Parameter>> parameter_replacement_map;
     auto x_replacement = make_shared<ov::op::v0::Parameter>(element::f32, Shape{2});

--- a/src/core/tests/threading.cpp
+++ b/src/core/tests/threading.cpp
@@ -97,7 +97,7 @@ TEST(threading, get_friendly_name) {
 
     auto graph = make_shared<ov::op::v1::Multiply>(abs_add_a3, abs_add_b2);
 
-    auto f = std::make_shared<Model>(ov::NodeVector{graph}, ParameterVector{a, b});
+    auto f = std::make_shared<Model>(ov::OutputVector{graph}, ParameterVector{a, b});
 
     const auto compare_names = [](const std::vector<std::string>& names) {
         static std::unordered_set<std::string> ref_names;

--- a/src/frontends/ir/src/ir_deserializer.cpp
+++ b/src/frontends/ir/src/ir_deserializer.cpp
@@ -484,7 +484,7 @@ std::shared_ptr<ov::Model> ov::XmlDeserializer::parse_function(const pugi::xml_n
 
     struct FunctionNodes {
         ov::ParameterVector parameters;
-        ov::ResultVector results;
+        ov::OutputVector results;
         ov::NodeVector all;
         ov::SinkVector sinks;
     };

--- a/src/frontends/ir/tests/frontend_test_basic.cpp
+++ b/src/frontends/ir/tests/frontend_test_basic.cpp
@@ -79,7 +79,7 @@ TEST_F(IRFrontendTests, elementary_model_reading_v11) {
         parameter->set_friendly_name("input");
         auto result = std::make_shared<ov::opset1::Result>(parameter);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -140,7 +140,7 @@ TEST_F(IRFrontendTests, elementary_model_reading_v11_undefined_precisoin) {
         parameter->set_friendly_name("input");
         auto result = std::make_shared<ov::opset1::Result>(parameter);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -201,7 +201,7 @@ TEST_F(IRFrontendTests, elementary_model_reading_v11_dynamic_precisoin) {
         parameter->set_friendly_name("input");
         auto result = std::make_shared<ov::opset1::Result>(parameter);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -262,7 +262,7 @@ TEST_F(IRFrontendTests, elementary_model_reading_v10) {
         parameter->set_friendly_name("input");
         auto result = std::make_shared<ov::opset1::Result>(parameter);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -469,7 +469,7 @@ TEST_P(IRFrontendMMapTests, model_with_weights_reading_from_disk) {
         transpose->set_friendly_name("Transpose0321");
         auto result = std::make_shared<ov::opset1::Result>(transpose);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -548,7 +548,7 @@ TEST_P(IRFrontendMMapTests, model_with_lp_weights_reading_from_disk) {
         transpose->set_friendly_name("Add_4");
         auto result = std::make_shared<ov::opset1::Result>(transpose);
         result->set_friendly_name("Result_5");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -616,7 +616,7 @@ TEST_F(IRFrontendTests, model_without_weights_reading_from_disk) {
         parameter->set_friendly_name("input");
         auto result = std::make_shared<ov::opset1::Result>(parameter);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -1135,7 +1135,7 @@ TEST_F(IRFrontendTests, not_opset1) {
         shapeof->set_friendly_name("shapeof");
         auto result = std::make_shared<ov::opset1::Result>(shapeof);
         result->set_friendly_name("output");
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()

--- a/src/frontends/ir/tests/frontend_test_mmap.cpp
+++ b/src/frontends/ir/tests/frontend_test_mmap.cpp
@@ -22,7 +22,7 @@ protected:
                                                                std::vector<float>(CONST_SIZE, 0));
         auto add = std::make_shared<ov::opset1::Add>(parameter, constant);
         auto result = std::make_shared<ov::opset1::Result>(add);
-        auto model = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        auto model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
 
         auto filePrefix = ov::test::utils::generateTestFilePrefix();
         xmlFileName = filePrefix + "_IrFrontendTestModel.xml";

--- a/src/frontends/ir/tests/tensor_iterator_deserialization.cpp
+++ b/src/frontends/ir/tests/tensor_iterator_deserialization.cpp
@@ -112,7 +112,7 @@ TEST_F(IRFrontendTestsTensorIterator, tensor_iterator_merged_input) {
         internalParameter->set_friendly_name("internalParameter1");
         auto result1 = std::make_shared<ov::opset1::Result>(internalParameter);
         result1->set_friendly_name("internalResult1");
-        body = std::make_shared<ov::Model>(ov::NodeVector{result1}, ov::ParameterVector{internalParameter});
+        body = std::make_shared<ov::Model>(ov::OutputVector{result1}, ov::ParameterVector{internalParameter});
         tensor_iterator->set_body(body);
         tensor_iterator->set_friendly_name("TensorIterator");
         tensor_iterator->set_merged_input(internalParameter, parameter, result1);
@@ -121,7 +121,7 @@ TEST_F(IRFrontendTestsTensorIterator, tensor_iterator_merged_input) {
         auto result = std::make_shared<ov::opset1::Result>(tensor_iterator->output(0));
         result->set_friendly_name("Result1");
 
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()
@@ -230,7 +230,7 @@ TEST_F(IRFrontendTestsTensorIterator, tensor_iterator_slised_input) {
         internalParameter->set_friendly_name("internalParameter1");
         auto result1 = std::make_shared<ov::opset1::Result>(internalParameter);
         result1->set_friendly_name("internalResult1");
-        body = std::make_shared<ov::Model>(ov::NodeVector{result1}, ov::ParameterVector{internalParameter});
+        body = std::make_shared<ov::Model>(ov::OutputVector{result1}, ov::ParameterVector{internalParameter});
         tensor_iterator->set_body(body);
         tensor_iterator->set_friendly_name("TensorIterator");
         tensor_iterator->set_sliced_input(internalParameter, parameter, 0, 1, 1, -1, 2);
@@ -239,7 +239,7 @@ TEST_F(IRFrontendTestsTensorIterator, tensor_iterator_slised_input) {
         auto result = std::make_shared<ov::opset1::Result>(tensor_iterator->output(0));
         result->set_friendly_name("Result1");
 
-        modelRef = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{parameter});
+        modelRef = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{parameter});
     }
 
     const auto fc = FunctionsComparator::with_default()

--- a/src/frontends/paddle/tests/read_paddle_model_test.cpp
+++ b/src/frontends/paddle/tests/read_paddle_model_test.cpp
@@ -72,7 +72,7 @@ TEST(Paddle_Reader_Tests, LoadModelMemoryToCore) {
     const auto result = std::make_shared<ov::opset1::Result>(add->output(0));
     result->set_friendly_name("save_infer_model/scale_0.tmp_0/Result");
 
-    const auto reference = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{data}, "Model0");
+    const auto reference = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{data}, "Model0");
     const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::NONE);
     const FunctionsComparator::Result res = func_comparator(function, reference);
     ASSERT_TRUE(res.valid) << res.message;
@@ -104,7 +104,7 @@ TEST(Paddle_Reader_Tests, ImportBasicModelToCore) {
     const auto result = std::make_shared<ov::opset1::Result>(add->output(0));
     result->set_friendly_name("save_infer_model/scale_0.tmp_0/Result");
 
-    const auto reference = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{data}, "Model0");
+    const auto reference = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{data}, "Model0");
     const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::NAMES);
     const FunctionsComparator::Result res = func_comparator(function, reference);
     ASSERT_TRUE(res.valid) << res.message;
@@ -135,7 +135,7 @@ TEST(Paddle_Reader_Tests, ImportBasicModelToCoreWstring) {
     relu->output(0).get_tensor().add_names({"relu_0.tmp_0"});
     const auto result = std::make_shared<ov::opset1::Result>(relu->output(0));
     result->set_friendly_name("relu_0.tmp_0/Result");
-    const auto reference = std::make_shared<ov::Model>(ov::NodeVector{result}, ov::ParameterVector{data}, "Model0");
+    const auto reference = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{data}, "Model0");
     const FunctionsComparator func_comparator = FunctionsComparator::with_default().enable(FunctionsComparator::NAMES);
     const FunctionsComparator::Result res = func_comparator(function, reference);
     ASSERT_TRUE(res.valid) << res.message;

--- a/src/inference/tests/functional/matmul_sr_tests.cpp
+++ b/src/inference/tests/functional/matmul_sr_tests.cpp
@@ -138,7 +138,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeAMatMulFuse) {
         auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(data_A, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(transpose, data_B, false, false);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -150,7 +150,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeAMatMulFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 2});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 5});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, true, false);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -165,7 +165,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBMatMulFuse) {
         auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(data_B, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, transpose, false, false);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -177,7 +177,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBMatMulFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 3});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 5, 3});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, false, true);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -192,7 +192,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeAMatMulWithAttrFuse) {
         auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(data_A, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(transpose, data_B, true, false);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -204,7 +204,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeAMatMulWithAttrFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 3});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 5});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, false, false);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -219,7 +219,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBMatMulWithAttrFuse) {
         auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(data_B, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, transpose, false, true);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -231,7 +231,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBMatMulWithAttrFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 3});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 5});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, false, false);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -245,7 +245,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeAMatMulSideAttrFuse) {
         auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(data_A, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(transpose, data_B, true, true);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -257,7 +257,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeAMatMulSideAttrFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 2, 3});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 5, 3});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, false, true);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -272,7 +272,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBMatMulSideAttrFuse) {
         auto order = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto transpose = std::make_shared<ov::op::v1::Transpose>(data_B, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, transpose, true, true);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -284,7 +284,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBMatMulSideAttrFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 2});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 5});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, true, false);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -300,7 +300,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulFuse) {
         auto transpose_A = std::make_shared<ov::op::v1::Transpose>(data_A, order);
         auto transpose_B = std::make_shared<ov::op::v1::Transpose>(data_B, order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(transpose_A, transpose_B, false, false);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -312,7 +312,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulFuse) {
         auto data_A = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 2});
         auto data_B = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 5, 3});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(data_A, data_B, true, true);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -335,7 +335,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulWithAttrFuse) {
         auto transpose_A = std::make_shared<ov::op::v1::Transpose>(split_A->output(0), order);
         auto transpose_B = std::make_shared<ov::op::v1::Transpose>(split_B->output(1), order);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(transpose_A, transpose_B, false, true);
-        f = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
 
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
@@ -355,7 +355,7 @@ TEST(SmartReshapeTransposeMatMulTests, TransposeBothMatMulWithAttrFuse) {
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{}, {0}),
             ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 1}));
         auto matmul = std::make_shared<ov::op::v0::MatMul>(split_A->output(0), split_B->output(1), true, false);
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -374,7 +374,7 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeAMatMulSeveralConsumers) {
     auto reduce = std::make_shared<ov::op::v1::ReduceMax>(reshape, reduction_axes);
     auto sum = std::make_shared<ov::op::v1::Add>(data_B, reduce);
     auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, sum);
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     manager.register_pass<ov::pass::ReshapeAMatMul>();
 }
 
@@ -386,7 +386,8 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeA_1DOtherInput) {
 
         auto other_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{6});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, other_input);
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
+        model =
+            std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
         manager.register_pass<ov::pass::ReshapeAMatMul>();
     }
     {
@@ -403,7 +404,7 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeA_1DOtherInput) {
 
         auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, other_input);
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
+            std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
     }
 }
 
@@ -415,7 +416,8 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeB_1DOtherInput) {
 
         auto other_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(other_input, reshape);
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
+        model =
+            std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
         manager.register_pass<ov::pass::ReshapeBMatMul>();
     }
     {
@@ -432,7 +434,7 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeB_1DOtherInput) {
 
         auto matmul = std::make_shared<ov::op::v0::MatMul>(other_input, reshape);
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
+            std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_to_reshape, other_input});
     }
 }
 
@@ -448,7 +450,7 @@ TEST_F(TransformationTestsF, SmartReshapeReshapeBMatMulSeveralConsumers) {
     auto reduce = std::make_shared<ov::op::v1::ReduceMax>(reshape, reduction_axes);
     auto sum = std::make_shared<ov::op::v1::Add>(data_A, reduce);
     auto matmul = std::make_shared<ov::op::v0::MatMul>(sum, reshape);
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data_A, data_B});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data_A, data_B});
     manager.register_pass<ov::pass::ReshapeBMatMul>();
 }
 
@@ -477,7 +479,7 @@ TEST_F(TransformationTestsF, SmartReshape_ReshapeAMatMul_ReshapeInputSeveralCons
         auto matmul = std::make_shared<ov::op::v0::MatMul>(reshape, data_matmul);
         auto add = std::make_shared<ov::op::v1::Add>(matmul, reshape_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{data_matmul, data_reshape});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{data_matmul, data_reshape});
         ;
         manager.register_pass<ov::pass::ReshapeAMatMul>();
     }
@@ -496,7 +498,7 @@ TEST_F(TransformationTestsF, SmartReshape_ReshapeAMatMul_ReshapeInputSeveralCons
         auto add = std::make_shared<ov::op::v1::Add>(matmul, const_add_1);
 
         model_ref =
-            std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{reshape_param, shape_of_param});
+            std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{reshape_param, shape_of_param});
         ov::pass::Manager m;
         m.run_passes(model_ref);
     }

--- a/src/inference/tests/unit/query_model_test.cpp
+++ b/src/inference/tests/unit/query_model_test.cpp
@@ -465,7 +465,7 @@ TEST_F(GetSupportedNodesTest, ShuffleChannelFusion) {
         auto reshape_after = std::make_shared<ov::op::v1::Reshape>(permute, shape_reshape_after, true);
         reshape_after->set_friendly_name("reshape_after");
 
-        m_function = std::make_shared<ov::Model>(ov::NodeVector{reshape_after}, ov::ParameterVector{input});
+        m_function = std::make_shared<ov::Model>(ov::OutputVector{reshape_after}, ov::ParameterVector{input});
     }
     Run(
         [&](std::shared_ptr<ov::Model>& model) {
@@ -489,7 +489,7 @@ TEST_F(GetSupportedNodesTest, FusedNameReduceL2Test) {
         auto reduce_l2 = std::make_shared<ov::op::v4::ReduceL2>(data, axes, true);
         reduce_l2->set_friendly_name("reduce_l2");
 
-        m_function = std::make_shared<ov::Model>(ov::NodeVector{reduce_l2}, ov::ParameterVector{data});
+        m_function = std::make_shared<ov::Model>(ov::OutputVector{reduce_l2}, ov::ParameterVector{data});
     }
     Run(
         [&](std::shared_ptr<ov::Model>& model) {

--- a/src/plugins/auto/tests/unit/auto_unit_test.cpp
+++ b/src/plugins/auto/tests/unit/auto_unit_test.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<ov::Model> ov::mock_auto_plugin::tests::BaseTest::create_dynamic
                                                                score_threshold);
     auto res = std::make_shared<ov::op::v0::Result>(nms);
     res->set_friendly_name("output_dynamic");
-    return std::make_shared<ov::Model>(ov::NodeVector{nms}, ov::ParameterVector{boxes, scores});
+    return std::make_shared<ov::Model>(ov::OutputVector{nms}, ov::ParameterVector{boxes, scores});
 }
 
 ov::mock_auto_plugin::tests::BaseTest::BaseTest(const MODELTYPE modelType) {

--- a/src/plugins/auto/tests/unit/stateful_model_test.cpp
+++ b/src/plugins/auto/tests/unit/stateful_model_test.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<ov::Model> StatefulModelSupportedTest::create_dynamic_output_mod
                                                                score_threshold);
     auto res = std::make_shared<ov::op::v0::Result>(nms);
     res->set_friendly_name("output_dynamic");
-    return std::make_shared<ov::Model>(ov::NodeVector{nms}, ov::ParameterVector{boxes, scores});
+    return std::make_shared<ov::Model>(ov::OutputVector{nms}, ov::ParameterVector{boxes, scores});
 }
 
 std::shared_ptr<ov::Model> StatefulModelSupportedTest::create_stateful_model() {

--- a/src/plugins/intel_cpu/tests/functional/custom/behavior/export_import.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/behavior/export_import.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<ov::Model> MakeMatMulModel() {
     auto add = ov::test::utils::make_eltwise(matmul, add_const, ov::test::utils::EltwiseTypes::ADD);
     auto softmax = std::make_shared<ov::opset9::Softmax>(add);
 
-    ov::NodeVector results{softmax};
+    ov::OutputVector results{softmax};
     return std::make_shared<ov::Model>(results, params, "MatMulModel");
 }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -164,7 +164,7 @@ void ActivationLayerCPUTest::SetUp() {
     auto params = std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes.front());
     auto activation = utils::make_activation(params, netPrecision, activationType, activationShapes, constantsValue);
     activation->get_rt_info() = getCPUInfo();
-    function = std::make_shared<ov::Model>(ov::NodeVector{activation}, ov::ParameterVector{params}, "Activation");
+    function = std::make_shared<ov::Model>(ov::OutputVector{activation}, ov::ParameterVector{params}, "Activation");
 #if defined(OPENVINO_ARCH_ARM) || defined(OPENVINO_ARCH_ARM64)
     if (netPrecision == ov::element::f32 && outPrecision == ov::element::f32) {
         abs_threshold = 8e-4;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
@@ -73,7 +73,7 @@ void ExtremumLayerCPUTest::SetUp() {
     auto param2 = std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[1]);
     auto extremum = utils::make_extremum(param1, param2, extremumType);
     extremum->get_rt_info() = getCPUInfo();
-    function = std::make_shared<ov::Model>(ov::NodeVector{extremum}, ov::ParameterVector{param1, param2}, "Extremum");
+    function = std::make_shared<ov::Model>(ov::OutputVector{extremum}, ov::ParameterVector{param1, param2}, "Extremum");
 }
 
 std::string ExtremumLayerCPUTest::getPrimitiveType() {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/cum_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/cum_sum.cpp
@@ -60,7 +60,7 @@ protected:
             ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, std::vector<int64_t>{axis})->output(0);
         auto cumSum = std::make_shared<ov::op::v0::CumSum>(params[0], axisNode, exclusive, reverse);
 
-        function = std::make_shared<ov::Model>(ov::NodeVector{cumSum}, params, "CumSumLayerCPUTest");
+        function = std::make_shared<ov::Model>(ov::OutputVector{cumSum}, params, "CumSumLayerCPUTest");
         functionRefs = function->clone();
     }
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/not_fused_conv_simple_op.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/not_fused_conv_simple_op.cpp
@@ -43,7 +43,7 @@ protected:
         const auto postOpCandidate = ov::test::utils::make_eltwise(conv, sharedNode, utils::EltwiseTypes::ADD);
         const auto secondConsumpt = ov::test::utils::make_eltwise(inputParams[1], sharedNode, utils::EltwiseTypes::ADD);
 
-        NodeVector results{postOpCandidate, secondConsumpt};
+        OutputVector results{postOpCandidate, secondConsumpt};
         function = std::make_shared<ov::Model>(results, inputParams, "NotFusedConvSimpleOp");
     }
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/static_zero_dims.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/static_zero_dims.cpp
@@ -36,7 +36,7 @@ protected:
 
         auto relu3 = std::make_shared<ov::op::v0::Relu>(varSplit->output(2));
 
-        ov::NodeVector results{relu1, relu2, relu3};
+        ov::OutputVector results{relu1, relu2, relu3};
         function = std::make_shared<ov::Model>(results, inputParams, "StaticZeroDims");
     }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/strided_slice_zero_dims.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/strided_slice_zero_dims.cpp
@@ -51,7 +51,7 @@ public:
                                                                         std::vector<int64_t>{},
                                                                         std::vector<int64_t>{},
                                                                         std::vector<int64_t>{});
-        NodeVector results{strided_slice};
+        OutputVector results{strided_slice};
         function = std::make_shared<ov::Model>(results, inputParams, "StridedSliceStaticShape");
     }
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/tile_with_two_output_edges.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/tile_with_two_output_edges.cpp
@@ -28,7 +28,7 @@ protected:
         const auto add1 = utils::make_eltwise(tile->output(0), const1, utils::EltwiseTypes::ADD);
         const auto add2 = utils::make_eltwise(tile->output(0), const2, utils::EltwiseTypes::ADD);
 
-        NodeVector results{add1, add2};
+        OutputVector results{add1, add2};
         function = std::make_shared<ov::Model>(results, inputParams, "TileWithTwoOutputEdges");
     }
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/causal_mask_preprocess.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/causal_mask_preprocess.cpp
@@ -144,7 +144,7 @@ static std::shared_ptr<ov::Model> buildCausalMaskPreprocess(const int max_seq_le
                                                    {{"batch_dims", 0}});  //  tensor_array<f32[?,1,?,..8192]>
     auto result = index_Gather;
 
-    return std::make_shared<ov::Model>(ov::NodeVector{result},
+    return std::make_shared<ov::Model>(ov::OutputVector{result},
                                        ov::ParameterVector{attention_mask, batch_size, cache_positions, kvLen});
 }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/mlp_fusion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/mlp_fusion.cpp
@@ -99,7 +99,7 @@ protected:
         auto gate_up = std::make_shared<ov::op::v1::Multiply>(gate_act, up_proj);
         auto output = std::make_shared<ov::op::v0::MatMul>(gate_up, down_weight, false, true);
 
-        function = std::make_shared<ov::Model>(ov::NodeVector{output}, ov::ParameterVector{src});
+        function = std::make_shared<ov::Model>(ov::OutputVector{output}, ov::ParameterVector{src});
     }
 
     void check_results() {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/qkv_proj_fusion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/qkv_proj_fusion.cpp
@@ -92,7 +92,7 @@ protected:
         auto k_proj = std::make_shared<ov::op::v0::MatMul>(src, k_proj_weight, false, true);
         auto v_proj = std::make_shared<ov::op::v0::MatMul>(src, v_proj_weight, false, true);
 
-        function = std::make_shared<ov::Model>(ov::NodeVector{q_proj, k_proj, v_proj}, ov::ParameterVector{src});
+        function = std::make_shared<ov::Model>(ov::OutputVector{q_proj, k_proj, v_proj}, ov::ParameterVector{src});
     }
     void check_results() {
         auto exec_model = compiledModel.get_runtime_model();

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/subgraph_serialize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/subgraph_serialize.cpp
@@ -31,9 +31,10 @@ TEST_F(SubgraphSnippetSerializationTest, smoke_SerializeSubgraph) {
         auto ininput0 = std::make_shared<Parameter>(ov::element::f32, shape);
         auto ininput1 = std::make_shared<Parameter>(ov::element::f32, shape);
         auto add = std::make_shared<Add>(ininput0, ininput1);
-        auto subgraph_body = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{ininput0, ininput1});
+        auto subgraph_body =
+            std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{ininput0, ininput1});
         auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(ov::NodeVector{input0, input1}, subgraph_body.get()->clone());
-        return std::make_shared<ov::Model>(ov::NodeVector{subgraph}, ov::ParameterVector{input0, input1});
+        return std::make_shared<ov::Model>(ov::OutputVector{subgraph}, ov::ParameterVector{input0, input1});
     })();
     ov::Core core;
     ov::CompiledModel compiled_model = core.compile_model(model, "CPU");
@@ -79,9 +80,10 @@ TEST_F(SubgraphSnippetSerializationTest, smoke_SerializeSubgraphWithScalarConst)
         auto internal_constant = std::make_shared<Constant>(ov::element::f32, shape, 2);
         auto add = std::make_shared<Add>(input, constant);
         auto internal_add = std::make_shared<Add>(internal_input, internal_constant);
-        auto subgraph_body = std::make_shared<ov::Model>(ov::NodeVector{internal_add}, ov::ParameterVector{internal_input});
+        auto subgraph_body =
+            std::make_shared<ov::Model>(ov::OutputVector{internal_add}, ov::ParameterVector{internal_input});
         auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(ov::NodeVector{add}, subgraph_body.get()->clone());
-        return std::make_shared<ov::Model>(ov::NodeVector{subgraph}, ov::ParameterVector{input});
+        return std::make_shared<ov::Model>(ov::OutputVector{subgraph}, ov::ParameterVector{input});
     })();
     ov::Core core;
     ov::CompiledModel compiled_model = core.compile_model(model, "CPU");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_infer_request/infer_request_dynamic.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_infer_request/infer_request_dynamic.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<ov::Model> getFunction1() {
     auto relu2 = std::make_shared<ov::op::v0::Relu>(add->output(0));
     relu2->get_output_tensor(0).set_names({"relu2"});
 
-    ov::NodeVector results{relu1, relu2};
+    ov::OutputVector results{relu1, relu2};
     return std::make_shared<ov::Model>(results, params, "AddTwoOutputEdges");
 }
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
@@ -49,7 +49,7 @@ namespace {
         auto nms = std::make_shared<ov::op::internal::NonMaxSuppressionIEInternal>(boxes, scores, max_output_boxes_per_class,
                 iou_threshold, score_threshold, 0, true, element::i32);
         auto res = std::make_shared<ov::op::v0::Result>(nms);
-        auto func = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        auto func = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
         return func;
     }
 
@@ -61,7 +61,7 @@ namespace {
         attr.output_type = element::i32;
         auto nms = std::make_shared<ov::op::internal::NmsStaticShapeIE<ov::op::v8::MatrixNms>>(boxes, scores, attr);
         auto res = std::make_shared<ov::op::v0::Result>(nms);
-        auto func = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        auto func = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
         return func;
     }
 
@@ -72,7 +72,7 @@ namespace {
         attr.output_type = element::i32;
         auto nms = std::make_shared<ov::op::internal::MulticlassNmsIEInternal>(boxes, scores, attr);
         auto res = std::make_shared<ov::op::v0::Result>(nms);
-        auto func = std::make_shared<Model>(NodeVector{nms}, ParameterVector{boxes, scores});
+        auto func = std::make_shared<Model>(OutputVector{nms}, ParameterVector{boxes, scores});
         return func;
     }
 

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/common/mul_add_to_fma.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/common/mul_add_to_fma.cpp
@@ -55,7 +55,7 @@ protected:
         const auto& sec_input = add_input_idx == 0 ? data2->output(0) : mul->output(0);
         auto add = std::make_shared<op::v1::Add>(fst_input, sec_input);
 
-        return std::make_shared<Model>(NodeVector{add}, parameters);
+        return std::make_shared<Model>(OutputVector{add}, parameters);
     }
 
     std::shared_ptr<ov::Model> initLowered() const override {
@@ -77,7 +77,7 @@ protected:
         auto c = scalar_input || add_input_idx == 0 ? data2 : data0;
 
         auto fma = std::make_shared<ov::intel_cpu::FusedMulAdd>(a, b, c);
-        return std::make_shared<ov::Model>(NodeVector{fma}, parameters);
+        return std::make_shared<ov::Model>(OutputVector{fma}, parameters);
     }
 
     void validate_function(const std::shared_ptr<Model> &m) const override {
@@ -176,7 +176,8 @@ TEST_F(TransformationTestsF, smoke_Snippets_MulAddToFMATestsNegative) {
     auto additional_consumer = std::make_shared<op::v0::Relu>(mul);
     auto add = std::make_shared<op::v1::Add>(mul, data2);
 
-    model = std::make_shared<Model>(ov::NodeVector{add, additional_consumer}, ov::ParameterVector{data0, data1, data2});
+    model =
+        std::make_shared<Model>(ov::OutputVector{add, additional_consumer}, ov::ParameterVector{data0, data1, data2});
     manager.register_pass<ov::intel_cpu::pass::MulAddToFMA>();
 }
 }  // namespace snippets

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
@@ -32,7 +32,7 @@ static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Pa
                                         ov::CoordinateDiff{0},
                                         ov::Strides{1});
 
-        return std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{param});
 }
 
 TEST(TransformationTests, CheckConvertGroupConvIsApplied) {
@@ -68,7 +68,7 @@ TEST(TransformationTests, CheckConvertGroupConvIsApplied) {
             concat_inputs.push_back(conv);
         }
         auto concat = std::make_shared<ov::op::v0::Concat>(concat_inputs, 1);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ concat }, ov::ParameterVector{ param });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{concat}, ov::ParameterVector{param});
     }
     auto res = compare_functions(model, model_ref);
     ASSERT_TRUE(res.first) << res.second;

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
@@ -35,7 +35,7 @@ static std::shared_ptr<ov::Model> createInitGraph(ov::Shape param_shape, ov::Sha
                                         is1Dinput ? ov::CoordinateDiff{0} : ov::CoordinateDiff{0, 0},
                                         is1Dinput ? ov::Strides{1} :        ov::Strides{1, 1});
 
-        return std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{param});
 }
 
 template <class T>
@@ -59,7 +59,7 @@ static std::shared_ptr<ov::Model> createTransformedGraph(ov::Shape param_shape, 
 
         auto reshape = std::make_shared<ov::opset1::Squeeze>(conv2d,
             ov::opset1::Constant::create(ov::element::i64, ov::Shape{1}, {3}));
-        return std::make_shared<ov::Model>(ov::NodeVector{ reshape }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{reshape}, ov::ParameterVector{param});
 }
 
 TEST(TransformationTests, CheckConvertConv1DIsAppliedFor1DShapes) {

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
@@ -29,7 +29,7 @@ template <class T>
 static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Parameter> param) {
         auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
         auto reduce = std::make_shared<T>(param, axes, true);
-        return std::make_shared<ov::Model>(ov::NodeVector{ reduce }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param});
 }
 
 template <class T>
@@ -42,7 +42,7 @@ static std::shared_ptr<ov::Model> createRefGraph(ov::Shape param_shape) {
             node = std::make_shared<T>(node, reduction_axis, true);
         }
 
-        return std::make_shared<ov::Model>(ov::NodeVector{ node }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{node}, ov::ParameterVector{param});
 }
 
 template <class T>

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
@@ -17,7 +17,7 @@ template <class T>
 static std::shared_ptr<ov::Model> createInitGraph(std::shared_ptr<ov::opset1::Parameter> param) {
         auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
         auto reduce = std::make_shared<T>(param, axes, false);
-        return std::make_shared<ov::Model>(ov::NodeVector{ reduce }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{reduce}, ov::ParameterVector{param});
 }
 
 template <class T>
@@ -25,7 +25,7 @@ static std::shared_ptr<ov::Model> createRefGraph(std::shared_ptr<ov::opset1::Par
         auto axes = ov::opset1::Constant::create(ov::element::i64, ov::Shape{2}, {0, 1});
         auto reduce = std::make_shared<T>(param, axes, true);
         auto squeeze = std::make_shared<ov::opset1::Squeeze>(reduce, axes);
-        return std::make_shared<ov::Model>(ov::NodeVector{ squeeze }, ov::ParameterVector{ param });
+        return std::make_shared<ov::Model>(ov::OutputVector{squeeze}, ov::ParameterVector{param});
 }
 
 template <class T>

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
@@ -29,7 +29,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest1) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, true, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -46,7 +46,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest1) {
             transpose2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -56,7 +56,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest2) {
         auto input2 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1, input2});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -64,7 +64,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest2) {
         auto input2 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, false);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1, input2});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1, input2});
     }
 }
 
@@ -74,7 +74,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest3) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest3) {
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -95,7 +95,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest4) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest4) {
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -115,7 +115,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest5) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2, 2}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFC>();
 }
 
@@ -124,7 +124,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest6) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 1, 2}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFC>();
 }
 
@@ -134,7 +134,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest7) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest7) {
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -155,7 +155,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest8) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -172,7 +172,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest8) {
         auto O = ov::opset1::Constant::create(ov::element::i64, {1}, {3});
         auto output_shape = std::make_shared<ov::opset1::Concat>(ov::OutputVector{I, O}, 0);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -182,7 +182,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest9) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -193,7 +193,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest9) {
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest10) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFC>();
 }
 
@@ -211,7 +211,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest11) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{18, 80, 1}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFC>();
 }
 
@@ -220,7 +220,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest12) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 80, 1}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFC>();
 }
 
@@ -230,7 +230,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest13) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 80, 1}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -241,7 +241,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest13) {
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -257,7 +257,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest14) {
             false,
             true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -270,7 +270,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest14) {
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
             ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -280,7 +280,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_1) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{6, 5}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -293,7 +293,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_1) {
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
             ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -303,7 +303,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_2) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 10, 5}, {1});
         auto fc = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -314,7 +314,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_2) {
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -324,7 +324,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_3) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -336,7 +336,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_3) {
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
             ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -346,7 +346,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_4) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -358,7 +358,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_4) {
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
             ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -368,7 +368,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_5) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 1, 5, 4}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -380,7 +380,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_4d_5) {
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}),
             ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -390,7 +390,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_1) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -400,7 +400,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_1) {
             input1,
             input2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -410,7 +410,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_2) {
         auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 3}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, weights, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -421,7 +421,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_2) {
             weights,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -431,7 +431,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3) {
         auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, weights, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -442,7 +442,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_second_input_rank_adj_3) {
             input1,
             weights,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -454,7 +454,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_0) {
         ov::mark_as_decompression(convert);
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, convert, false, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -470,7 +470,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_0) {
             transpose,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -482,7 +482,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
         ov::mark_as_decompression(convert);
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, convert, true, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -500,7 +500,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_decompress_convert_1) {
             transpose2,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -515,7 +515,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_compressed_u8_weights) {
         auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
         auto matmul = std::make_shared<ov::opset1::MatMul>(data, mul);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
         manager.register_pass<ConvertMatMulToFC>();
     }
     {
@@ -534,6 +534,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFCTest_compressed_u8_weights) {
             transpose,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
     }
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
@@ -27,7 +27,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest1) {
         auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -38,7 +38,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest1) {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{ 1, 3, 16, 16 });
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
 
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -52,7 +52,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest2) {
         auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -63,7 +63,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest2) {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
 
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -77,7 +77,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest3) {
         auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{}, { -2.f });
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -88,7 +88,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest3) {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::PartialShape::dynamic());
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
 
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -106,7 +106,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest4) {
             ov::op::TemporaryReplaceOutputType(input, ov::element::f32).get(),
             ov::op::TemporaryReplaceOutputType(slope, ov::element::f32).get());
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{ relaxed_prelu }, ov::ParameterVector{ input });
+        f = std::make_shared<ov::Model>(ov::OutputVector{relaxed_prelu}, ov::ParameterVector{input});
         ov::pass::Manager m;
         m.register_pass<ov::pass::InitNodeInfo>();
         m.register_pass<ConvertToLeakyRelu>();
@@ -117,7 +117,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest4) {
         auto input = std::make_shared<ov::opset1::Parameter>(ov::element::u8, ov::Shape{ 1, 3, 16, 16 });
         auto prelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(input, -2.f, ov::element::f32);
 
-        f_ref = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f_ref = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
     }
 
     auto res = compare_functions(f, f_ref);
@@ -131,7 +131,7 @@ TEST(TransformationTests, ConvertToLeakyReluTest5) {
         auto slope = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 3 }, { -2.f, -1.f, -2.f });
         auto prelu = std::make_shared<ov::opset1::PRelu>(input, slope);
 
-        f = std::make_shared<ov::Model>(ov::NodeVector{ prelu }, ov::ParameterVector{ input });
+        f = std::make_shared<ov::Model>(ov::OutputVector{prelu}, ov::ParameterVector{input});
         f_ref = f;
 
         ov::pass::Manager m;

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
@@ -121,7 +121,7 @@ public:
             weights_path,
             std::make_shared<ov::op::v0::Constant>(ov::element::dynamic, ov::Shape{0}));
 
-        return std::make_shared<ov::Model>(ov::NodeVector{fully_connected}, ov::ParameterVector{data});
+        return std::make_shared<ov::Model>(ov::OutputVector{fully_connected}, ov::ParameterVector{data});
     }
 
 protected:

--- a/src/plugins/intel_cpu/tests/unit/transformations/permute_slice_n_interpolation.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/permute_slice_n_interpolation.cpp
@@ -42,7 +42,7 @@ TEST_F(PermuteSliceInterpolateTest, 3D) {
                                                                      interpolate_axes,
                                                                      intp_attr);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{interpolate}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{interpolate}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::PermuteSliceAndInterpolation>();
     }
     {
@@ -72,7 +72,7 @@ TEST_F(PermuteSliceInterpolateTest, 3D) {
                                                          slice_step,
                                                          slice_axes);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{slice}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{slice}, ov::ParameterVector{input});
     }
 }
 
@@ -105,7 +105,7 @@ TEST_F(PermuteSliceInterpolateTest, 4D) {
                                                                      interpolate_axes,
                                                                      intp_attr);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{interpolate}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{interpolate}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::PermuteSliceAndInterpolation>();
     }
     {
@@ -135,7 +135,7 @@ TEST_F(PermuteSliceInterpolateTest, 4D) {
                                                          slice_step,
                                                          slice_axes);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{slice}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{slice}, ov::ParameterVector{input});
     }
 }
 
@@ -171,7 +171,7 @@ TEST_F(PermuteSliceInterpolateTest, 5D_Add) {
         auto add_val = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{1}, {1});
         auto add = std::make_shared<ov::op::v1::Add>(interpolate, add_val);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::PermuteSliceAndInterpolation>();
     }
     {
@@ -204,6 +204,6 @@ TEST_F(PermuteSliceInterpolateTest, 5D_Add) {
         auto add_val = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{1}, {1});
         auto add = std::make_shared<ov::op::v1::Add>(slice, add_val);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
 }

--- a/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/readvalue_subgraph.cpp
@@ -38,7 +38,7 @@ static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubG
 
     auto func_output = std::make_shared<ov::op::v0::Result>(matmul);
 
-    auto func = std::make_shared<ov::Model>(ov::NodeVector({func_output}),
+    auto func = std::make_shared<ov::Model>(ov::OutputVector({func_output}),
                                             ov::ParameterVector{func_input},
                                             "state_init_submodel");
 
@@ -141,7 +141,7 @@ static std::shared_ptr<ov::intel_cpu::ReadValueWithSubgraph> constructRVWithSubG
 
     auto func_output = std::make_shared<ov::op::v0::Result>(add5);
 
-    auto func = std::make_shared<ov::Model>(ov::NodeVector({func_output}), func_inputs, "state_init_submodel");
+    auto func = std::make_shared<ov::Model>(ov::OutputVector({func_output}), func_inputs, "state_init_submodel");
 
     auto readvalue = std::make_shared<ov::intel_cpu::ReadValueWithSubgraph>(variable, func);
     for (size_t i = 0; i < inputs.size(); i++) {

--- a/src/plugins/intel_cpu/tests/unit/transformations/swap_convert_transpose.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/swap_convert_transpose.cpp
@@ -35,7 +35,7 @@ TEST_F(SwapConvertTransposeTest, SwapConvertTranspose) {
         auto transpose = std::make_shared<ov::op::v1::Transpose>(convert, transpose_const);
         transpose->set_friendly_name(transpose_name);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{transpose}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{transpose}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::SwapConvertTranspose>();
     }
     {
@@ -49,7 +49,7 @@ TEST_F(SwapConvertTransposeTest, SwapConvertTranspose) {
         transpose->set_friendly_name(transpose_name + "_original");
         convert->set_friendly_name(transpose_name);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input});
     }
 }
 
@@ -73,7 +73,7 @@ TEST_F(SwapConvertTransposeTest, SwapConvertTransposeImpossible) {
         auto transpose1 = std::make_shared<ov::op::v1::Transpose>(convert, transpose1_const);
         transpose1->set_friendly_name(transpose_name + "_1");
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{transpose0, transpose1}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{transpose0, transpose1}, ov::ParameterVector{input});
         manager.register_pass<ov::intel_cpu::SwapConvertTranspose>();
     }
 }

--- a/src/plugins/intel_gpu/tests/common/subgraphs_builders.hpp
+++ b/src/plugins/intel_gpu/tests/common/subgraphs_builders.hpp
@@ -366,7 +366,7 @@ inline std::shared_ptr<ov::Model> makeLSTMSequence(ov::element::Type_t model_typ
     Ho->set_friendly_name("Ho");
     Co->set_friendly_name("Co");
 
-    auto fn_ptr = std::make_shared<ov::Model>(ov::NodeVector{Y_out, Ho, Co}, ov::ParameterVector{X, Y, Z});
+    auto fn_ptr = std::make_shared<ov::Model>(ov::OutputVector{Y_out, Ho, Co}, ov::ParameterVector{X, Y, Z});
     fn_ptr->set_friendly_name("LSTMSequence");
     return fn_ptr;
 }

--- a/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
+++ b/src/plugins/intel_gpu/tests/functional/behavior/infer_request.cpp
@@ -62,7 +62,7 @@ void InferRequestIOPrecision::SetUp() {
                                                        {},
                                                        {clamp_min, clamp_max});
 
-    function = std::make_shared<ov::Model>(ov::NodeVector{activation}, params);
+    function = std::make_shared<ov::Model>(ov::OutputVector{activation}, params);
 }
 
 TEST_P(InferRequestIOPrecision, Inference) {

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -2895,7 +2895,7 @@ public:
         auto input1 = std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape{1, 2, 10, 10});
         auto constant = ov::op::v0::Constant::create(element_type, ov::Shape{1, 2, 10, 10}, {1});
         auto add = std::make_shared<ov::op::v1::Add>(input1, constant);
-        fn_ptr = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input1});
+        fn_ptr = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input1});
     }
     static std::string getTestCaseName(const testing::TestParamInfo<RemoteTensorDataTypesOptionsParams>& obj) {
         ov::element::Type_t elem_type;

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/subgraph_tests/matmul_conversion.cpp
@@ -100,7 +100,7 @@ protected:
         auto matmul_1 = std::make_shared<ov::op::v0::MatMul>(convert_0, convert_1, matmul1_tran_0, matmul1_tran_1);
 
         ov::ParameterVector params{input0};
-        return std::make_shared<ov::Model>(ov::NodeVector{matmul_1}, params, "MatmulConversionsSameParent");
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_1}, params, "MatmulConversionsSameParent");
     }
 
     void SetUp() override {
@@ -248,7 +248,7 @@ protected:
         auto matmul_1 = std::make_shared<ov::op::v0::MatMul>(convert_0, convert_1, matmul1_tran_0, matmul1_tran_1);
         auto matmul_0 = std::make_shared<ov::op::v0::MatMul>(convert_2, convert_0, matmul0_tran_0, matmul0_tran_1);
 
-        return std::make_shared<ov::Model>(ov::NodeVector{matmul_1}, ov::ParameterVector{input0, input1}, "MatmulConversions");
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_1}, ov::ParameterVector{input0, input1}, "MatmulConversions");
     }
 
     void SetUp() override {
@@ -343,7 +343,7 @@ protected:
         auto matmul_1 = std::make_shared<ov::op::v0::MatMul>(convert_1, convert_0, matmul1_tran_0, matmul1_tran_1);
         auto matmul_0 = std::make_shared<ov::op::v0::MatMul>(convert_2, convert_0, matmul0_tran_0, matmul0_tran_1);
 
-        return std::make_shared<ov::Model>(ov::NodeVector{matmul_1}, ov::ParameterVector{input0, input1}, "MatmulConversionsOtherTypeSibling");
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_1}, ov::ParameterVector{input0, input1}, "MatmulConversionsOtherTypeSibling");
     }
 
     void SetUp() override {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/activations_scaling.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/activations_scaling.cpp
@@ -151,7 +151,7 @@ protected:
 
         auto add = std::make_shared<ov::op::v1::Add>(concat0, concat1);
 
-        return std::make_shared<ov::Model>(ov::NodeVector{add}, params, "ActivationsScaling");
+        return std::make_shared<ov::Model>(ov::OutputVector{add}, params, "ActivationsScaling");
     }
 
     void SetUp() override {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/convert_bf16_fp32_fp16.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/convert_bf16_fp32_fp16.cpp
@@ -62,21 +62,21 @@ protected:
         auto r = std::make_shared<ov::op::v0::Convert>(weights_right, ov::element::f32);
         r->set_friendly_name("conversion_bf16_to_f32");
         auto matmul_res = std::make_shared<ov::op::v0::MatMul>(weights_left, r);
-        return std::make_shared<ov::Model>(ov::NodeVector{matmul_res}, ov::ParameterVector{}, "BF16WeightsDecompression");
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_res}, ov::ParameterVector{}, "BF16WeightsDecompression");
     }
 
     std::shared_ptr<ov::Model> init_subgraph_without_convert(float right_val) {
         const auto weights_left = init_compressed_weights_subgraph(ov::element::bf16, 2);
         const auto weights_right = init_compressed_weights_subgraph(ov::element::bf16, right_val);
         auto matmul_res = std::make_shared<ov::op::v0::MatMul>(weights_left, weights_right);
-        return std::make_shared<ov::Model>(ov::NodeVector{matmul_res}, ov::ParameterVector{}, "BF16WeightsDecompression");
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_res}, ov::ParameterVector{}, "BF16WeightsDecompression");
     }
 
     std::shared_ptr<ov::Model> init_subgraph_without_convert_add() {
         const auto weights_left = init_compressed_weights_subgraph(ov::element::bf16, 2);
         const auto weights_right = init_compressed_weights_subgraph(ov::element::bf16, 3);
         auto matmul_res = std::make_shared<ov::op::v1::Add>(weights_left, weights_right);
-        return std::make_shared<ov::Model>(ov::NodeVector{matmul_res}, ov::ParameterVector{}, "BF16WeightsDecompression");
+        return std::make_shared<ov::Model>(ov::OutputVector{matmul_res}, ov::ParameterVector{}, "BF16WeightsDecompression");
     }
 };
 

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/dynamic_fc_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/dynamic_fc_horizontal_fusion.cpp
@@ -284,7 +284,7 @@ protected:
             matmul4->set_friendly_name("gemm1");
             auto matmul5 = std::make_shared<ov::op::v0::MatMul>(matmul4, matmul3_result, true, true);
             matmul5->set_friendly_name("gemm2");
-            return std::make_shared<ov::Model>(ov::NodeVector{matmul5}, params, "FCHorizontalFusion");
+            return std::make_shared<ov::Model>(ov::OutputVector{matmul5}, params, "FCHorizontalFusion");
         } else {
             ov::test::utils::InputGenerateData in_data;
             in_data.start_from = -0.5;
@@ -311,7 +311,7 @@ protected:
             matmul4->set_friendly_name("gemm1");
             auto matmul5 = std::make_shared<ov::op::v0::MatMul>(matmul4, bias_add3, true, true);
             matmul5->set_friendly_name("gemm2");
-            return std::make_shared<ov::Model>(ov::NodeVector{matmul5}, params, "FCHorizontalFusion");
+            return std::make_shared<ov::Model>(ov::OutputVector{matmul5}, params, "FCHorizontalFusion");
         }
     }
 

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/dynamic_unfusion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/dynamic_unfusion.cpp
@@ -67,7 +67,7 @@ protected:
         matmul->set_friendly_name("MatMul");
         mul->set_friendly_name("Multiply");
 
-        return std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input0, input1, input2}, "DynamicUnfusions");
+        return std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input0, input1, input2}, "DynamicUnfusions");
     }
 
     void SetUp() override {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/eltwise_fusion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/eltwise_fusion.cpp
@@ -62,7 +62,7 @@ protected:
         mul->set_friendly_name("Mul1");
         mul2->set_friendly_name("Mul2");
 
-        return std::make_shared<ov::Model>(ov::NodeVector{mul2}, ov::ParameterVector{input0, input1}, "StaticEltwiseDynamicFusions");
+        return std::make_shared<ov::Model>(ov::OutputVector{mul2}, ov::ParameterVector{input0, input1}, "StaticEltwiseDynamicFusions");
     }
 
     void SetUp() override {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/hybrid.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/hybrid.cpp
@@ -128,7 +128,7 @@ protected:
         reshape->set_friendly_name("reshape");
 
         auto conv = init_quantized_convolution_subgraph(reshape);
-        return std::make_shared<ov::Model>(ov::NodeVector{conv}, params, "MatmulWeightsDecompressionQuantizeConvolution");
+        return std::make_shared<ov::Model>(ov::OutputVector{conv}, params, "MatmulWeightsDecompressionQuantizeConvolution");
     }
 
     std::shared_ptr<ov::Node> init_compressed_weights_subgraph(const ov::Shape& weights_shape,

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -131,7 +131,7 @@ protected:
                                                                        per_tensor_zp);
 
         auto mat_mul = std::make_shared<ov::op::v0::MatMul>(params[0], weights_subgraph);
-        return std::make_shared<ov::Model>(ov::NodeVector{mat_mul}, params, "MatmulWeightsDecompression");
+        return std::make_shared<ov::Model>(ov::OutputVector{mat_mul}, params, "MatmulWeightsDecompression");
     }
 
     std::shared_ptr<ov::Node> init_compressed_weights_subgraph(const ov::Shape& weights_shape,

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/rms_norm_decomposition.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/rms_norm_decomposition.cpp
@@ -109,7 +109,7 @@ protected:
 
         auto comp = std::make_shared<ov::op::v0::Convert>(mul2, ov::element::f16);
 
-        return std::make_shared<ov::Model>(ov::NodeVector{comp}, params, "RMSNormDecomposition");
+        return std::make_shared<ov::Model>(ov::OutputVector{comp}, params, "RMSNormDecomposition");
     }
 
     void SetUp() override {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/swiglu_fusion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/swiglu_fusion.cpp
@@ -64,7 +64,7 @@ protected:
         // Mul(Xw, Xv) = Swish(Xw) * Xv
         auto mul = std::make_shared<ov::op::v1::Multiply>(swish, variadic_split->output(1));
 
-        return std::make_shared<ov::Model>(ov::NodeVector{mul}, params, "SwiGLUFusion");
+        return std::make_shared<ov::Model>(ov::OutputVector{mul}, params, "SwiGLUFusion");
     }
 
     void SetUp() override {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/shared_constant.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/shared_constant.cpp
@@ -42,8 +42,8 @@ protected:
         // explicitly set the output name, to avoid global conflict
         mul2->set_friendly_name("Multiply_0");
         mul->set_friendly_name("Multiply_1");
-        function = std::make_shared<ov::Model>(ov::NodeVector{convBprop, conv, groupConvBprop, mul2, mul},
-                ov::ParameterVector{input1, input2, input3, input4, input5});
+        function = std::make_shared<ov::Model>(ov::OutputVector{convBprop, conv, groupConvBprop, mul2, mul},
+                                               ov::ParameterVector{input1, input2, input3, input4, input5});
     }
 };
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/bcast_and_pad_zp_buffers_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/bcast_and_pad_zp_buffers_test.cpp
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_1) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<BroadcastAndPadZeroPointBuffers>(32);
     }
     {
@@ -72,7 +72,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_1) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -102,7 +102,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_2) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<BroadcastAndPadZeroPointBuffers>(32);
     }
     {
@@ -126,7 +126,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_2) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -156,7 +156,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_3) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<BroadcastAndPadZeroPointBuffers>(32);
     }
     {
@@ -180,7 +180,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_3) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -210,7 +210,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_scalar_wzp) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<BroadcastAndPadZeroPointBuffers>(8, true);
     }
     {
@@ -234,7 +234,7 @@ TEST_F(TransformationTestsF, BroadcastAndPadZeroPointBuffers_scalar_wzp) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/clamp_fp16_output_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/clamp_fp16_output_test.cpp
@@ -36,7 +36,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest1) {
         auto matmul = std::make_shared<ov::op::v0::MatMul>(input1, input2, true, false);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(matmul, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -48,7 +48,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest1) {
         auto clamp = std::make_shared<ov::op::v0::Clamp>(matmul, min, max);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(clamp, 1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -62,7 +62,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest2) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(matmul, target_shape, false);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(reshape, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest2) {
         auto clamp = std::make_shared<ov::op::v0::Clamp>(reshape, min, max);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(clamp, 1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -88,7 +88,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest3) {
         auto matmul = std::make_shared<ov::op::v0::MatMul>(input1, input2, true, false);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(matmul, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -104,7 +104,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest4) {
         auto matmul = std::make_shared<ov::op::v0::MatMul>(input1, input2, true, false);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(matmul, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -122,7 +122,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest5) {
         auto add = std::make_shared<ov::op::v1::Add>(matmul, data);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(add, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2, data });
+        model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2, data});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -136,7 +136,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest5) {
         auto clamp = std::make_shared<ov::op::v0::Clamp>(add, min, max);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(clamp, 1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2, data });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2, data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -150,7 +150,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputTest6) {
         auto maximum = std::make_shared<ov::op::v1::Maximum>(matmul, data);
         auto softmax = std::make_shared<ov::op::v8::Softmax>(maximum, 1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ softmax }, ov::ParameterVector{ input1, input2, data });
+        model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input1, input2, data});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -171,7 +171,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputRMS) {
         auto gamma2 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 2560 }, {1});
         auto rms = std::make_shared<ov::op::internal::RMS>(add1, gamma2, 1e-5f, ov::element::f16);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ rms }, ov::ParameterVector{ input1, input2, data });
+        model = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input1, input2, data});
         manager.register_pass<ClampFP16Output>();
     }
     {
@@ -188,7 +188,7 @@ TEST_F(TransformationTestsF, ClampFp16OutputRMS) {
         auto gamma2 = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 1, 1, 2560 }, {1});
         auto rms = std::make_shared<ov::op::internal::RMS>(clamp, gamma2, 1e-5f, ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rms }, ov::ParameterVector{ input1, input2, data });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rms}, ov::ParameterVector{input1, input2, data});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_binary_conv_to_conv_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_binary_conv_to_conv_test.cpp
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, ConvertBinaryConvolutionToConvolutionTest1) {
                                                                            ov::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT,
                                                                            -1.0f);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ binary_conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{binary_conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertBinaryConvolutionToConvolution>();
     }
     {
@@ -68,6 +68,6 @@ TEST_F(TransformationTestsF, ConvertBinaryConvolutionToConvolutionTest1) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_convolution_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_convolution_test.cpp
@@ -42,7 +42,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_1) {
                                                               dilations,
                                                               ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -60,7 +60,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_1) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -80,7 +80,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_2) {
                                                               dilations,
                                                               ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -98,7 +98,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_2) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -125,7 +125,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_3) {
                                                                dilations,
                                                                ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -149,7 +149,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_3) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -183,7 +183,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_4) {
                                                                dilations,
                                                                ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -207,7 +207,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_4) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -241,7 +241,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_5) {
                                                                dilations,
                                                                ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -265,7 +265,7 @@ TEST_F(TransformationTestsF, ConvertConvolutionToInternal_5) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -285,7 +285,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_1) {
                                                                    dilations,
                                                                    ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -303,7 +303,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_1) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -323,7 +323,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_2) {
                                                                    dilations,
                                                                    ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -341,7 +341,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_2) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f16);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -368,7 +368,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_3) {
                                                                     dilations,
                                                                     ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -392,7 +392,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_3) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -426,7 +426,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_4) {
                                                                     dilations,
                                                                     ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -450,7 +450,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_4) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 
@@ -484,7 +484,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_5) {
                                                                     dilations,
                                                                     ov::op::PadType::EXPLICIT);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
         manager.register_pass<ConvertConvolutionToInternal>();
     }
     {
@@ -508,7 +508,7 @@ TEST_F(TransformationTestsF, ConvertGroupConvolutionToInternal_5) {
                                                                      ov::op::PadType::EXPLICIT,
                                                                      ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ conv }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
 }
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_fc_to_compressed_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_fc_to_compressed_test.cpp
@@ -40,7 +40,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed1) {
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, scale, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -50,7 +50,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed1) {
         auto scale_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{ 32, 1 }, { 1 });
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -66,7 +66,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed2) {
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, scale, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -77,7 +77,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed2) {
         auto zp_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{ 32, 1 }, { 1 });
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -95,7 +95,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed3) {
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, reshape, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed3) {
         auto zp_const = ov::op::v0::Constant::create(ov::element::f32, ov::Shape{ 32, 4 }, { 1 });
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -125,7 +125,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed4) {
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, reshape, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -136,7 +136,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed4) {
         auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 1, 1 }, { 1 });
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -157,7 +157,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed5) {
         auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, transpose, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -172,7 +172,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed5) {
         auto zp_const = ov::op::v0::Constant::create(ov::element::u8, ov::Shape{ 1, 1 }, { 1 });
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, transpose_weights, no_bias, transpose_scale, zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -193,7 +193,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed6) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, transpose, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -210,7 +210,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed6) {
         auto transpose_zp = std::make_shared<ov::op::v1::Transpose>(zp_const, transpose_zp_const);
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, transpose_weights, no_bias, transpose_scale, transpose_zp);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -231,7 +231,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed7) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, transpose, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -248,7 +248,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed7) {
         auto transpose_zp = std::make_shared<ov::op::v1::Transpose>(zp_const, transpose_zp_const);
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, transpose_weights, no_bias, transpose_scale, transpose_zp);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -367,7 +367,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed8) {
         auto subgraph_op = std::make_shared<TestSubgraph>(args, submodel);
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(subgraph_op->output(1), transpose, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{std::make_shared<ov::op::v0::Result>(subgraph_op->output(0)), fc}, subgraph_parameters);
+        model = std::make_shared<ov::Model>(ov::OutputVector{std::make_shared<ov::op::v0::Result>(subgraph_op->output(0)), fc}, subgraph_parameters);
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -403,7 +403,8 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed8) {
         auto subgraph_op = std::make_shared<TestSubgraph>(args, submodel);
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(subgraph_op->output(1), transpose_weights, no_bias, transpose_scale, transpose_zp);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ std::make_shared<ov::op::v0::Result>(subgraph_op->output(0)), fc_compressed }, subgraph_parameters);
+        model_ref =
+            std::make_shared<ov::Model>(ov::OutputVector{std::make_shared<ov::op::v0::Result>(subgraph_op->output(0)), fc_compressed}, subgraph_parameters);
     }
 }
 
@@ -419,7 +420,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed9) {
 	    auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, scale, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -430,7 +431,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed9) {
 	    auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 
@@ -447,7 +448,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed10) {
 	    auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<ov::intel_gpu::op::FullyConnected>(input1, scale, no_bias);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ fc }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
         manager.register_pass<ConvertFullyConnectedToFullyConnectedCompressed>();
     }
     {
@@ -458,7 +459,7 @@ TEST_F(TransformationTestsF, ConvertFCToCompressed10) {
 	    auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input1, weights_const, no_bias, scale_const, zp_const);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input1});
     }
 }
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_matmul_to_fc_test.cpp
@@ -31,7 +31,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest1) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 2, 2 }, { 1 });
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, true, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -47,7 +47,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest1) {
 
         auto matmul = std::make_shared<op::FullyConnected>(transpose1, transpose2, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -57,7 +57,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest2) {
         auto input2 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1, input2});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -65,7 +65,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest2) {
         auto input2 = std::make_shared<ov::opset1::Parameter>(ov::element::f32, ov::Shape{3, 2, 1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, false);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1, input2});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1, input2});
     }
 }
 
@@ -75,7 +75,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest3) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -84,7 +84,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest3) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -94,7 +94,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest4) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -103,7 +103,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest4) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -112,7 +112,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest5) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 3, 2, 2 }, { 1 });
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFullyConnected>();
 }
 
@@ -121,7 +121,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest6) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 3, 1, 2 }, { 1 });
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFullyConnected>();
 }
 
@@ -131,7 +131,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest7) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -140,7 +140,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest7) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto fc = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -150,7 +150,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest8) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{3, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -165,7 +165,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest8) {
         auto O = ov::opset1::Constant::create(ov::element::i64, { 1 }, { 3 });
         auto output_shape = std::make_shared<ov::opset1::Concat>(ov::OutputVector{I, O}, 0);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{fc}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc}, ov::ParameterVector{input1});
     }
 }
 
@@ -175,7 +175,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest9) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 2}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -184,7 +184,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest9) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -193,7 +193,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest10) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 2, 2 }, { 1 });
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFullyConnected>();
 }
 
@@ -202,7 +202,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest11) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{18, 80, 1}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFullyConnected>();
 }
 
@@ -211,7 +211,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest12) {
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{2, 80, 1}, {1});
     auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+    model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     manager.register_pass<ConvertMatMulToFullyConnected>();
 }
 
@@ -221,7 +221,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest13) {
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 80, 1}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -230,7 +230,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest13) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -246,7 +246,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest14) {
             false,
             true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -255,7 +255,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest14) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias, ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -271,7 +271,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest15) {
         auto matmul1 = std::make_shared<ov::opset1::MatMul>(input1, convert, false, false);
         auto matmul2 = std::make_shared<ov::opset1::MatMul>(input2, convert, false, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul1, matmul2}, ov::ParameterVector{input1, input2});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul1, matmul2}, ov::ParameterVector{input1, input2});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -287,7 +287,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest15) {
         auto matmul1 = std::make_shared<op::FullyConnected>(input1, convert, no_bias);
         auto matmul2 = std::make_shared<op::FullyConnected>(input2, convert, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul1, matmul2}, ov::ParameterVector{input1, input2});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul1, matmul2}, ov::ParameterVector{input1, input2});
     }
 }
 
@@ -297,7 +297,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_second_input_rank
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, input2, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -305,7 +305,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_second_input_rank
         auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{1, 2, 3}, {1});
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -315,7 +315,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_second_input_rank
         auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 2, 3 }, { 1 });
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, weights, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -324,7 +324,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_second_input_rank
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, weights, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -334,7 +334,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_second_input_rank
         auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 2, 3 }, { 1 });
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, weights, false, true);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -343,7 +343,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_second_input_rank
         auto weights = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 1, 2, 3 }, { 1 });
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, weights, no_bias);
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -355,7 +355,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_decompress_conver
         ov::mark_as_decompression(convert);
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, convert, false, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -369,7 +369,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_decompress_conver
 
         auto matmul = std::make_shared<op::FullyConnected>(input1, convert, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -381,7 +381,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_decompress_conver
         ov::mark_as_decompression(convert);
         auto matmul = std::make_shared<ov::opset1::MatMul>(input1, convert, true, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -397,7 +397,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_decompress_conver
 
         auto matmul = std::make_shared<op::FullyConnected>(transpose1, convert, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }
 
@@ -412,7 +412,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_wei
         auto mul = std::make_shared<ov::opset1::Multiply>(sub, mul_const);
         auto matmul = std::make_shared<ov::opset1::MatMul>(data, mul);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul}, ov::ParameterVector{data});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -429,7 +429,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedTest_compressed_u8_wei
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(data, transpose, no_bias);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ data });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{data});
     }
 }
 
@@ -443,7 +443,7 @@ TEST(TransformationTests, ConvertMatMulToFullyConnectedExceptionTest_sibling_mat
         auto matmul1 = std::make_shared<ov::opset1::MatMul>(input1, input_const, mat1_transpose_a, mat1_transpose_b);
         auto matmul2 = std::make_shared<ov::opset1::MatMul>(input_const, input_const, mat2_transpose_a, mat2_transpose_b);
 
-        auto model = std::make_shared<ov::Model>(ov::NodeVector{matmul2, matmul1}, ov::ParameterVector{input1});
+        auto model = std::make_shared<ov::Model>(ov::OutputVector{matmul2, matmul1}, ov::ParameterVector{input1});
         return model;
     };
 
@@ -503,7 +503,7 @@ TEST(TransformationTests, ConvertMatMulToFullyConnectedExceptionTest_sibling_mat
         auto matmul1 = std::make_shared<ov::opset1::MatMul>(input1, convert, mat1_transpose_a, mat1_transpose_b);
         auto matmul2 = std::make_shared<ov::opset1::MatMul>(convert, input2, mat2_transpose_a, mat2_transpose_b);
 
-        auto model = std::make_shared<ov::Model>(ov::NodeVector{matmul1, matmul2}, ov::ParameterVector{input1, input2});
+        auto model = std::make_shared<ov::Model>(ov::OutputVector{matmul1, matmul2}, ov::ParameterVector{input1, input2});
         return model;
     };
 
@@ -550,7 +550,7 @@ TEST(TransformationTests, ConvertMatMulToFullyConnectedExceptionTest_sibling_mat
         auto matmul1 = std::make_shared<ov::opset1::MatMul>(input1, convert, mat1_transpose_a, mat1_transpose_b);
         auto matmul2 = std::make_shared<ov::opset1::MatMul>(convert, convert, mat2_transpose_a, mat2_transpose_b);
 
-        auto model = std::make_shared<ov::Model>(ov::NodeVector{matmul2, matmul1}, ov::ParameterVector{input1});
+        auto model = std::make_shared<ov::Model>(ov::OutputVector{matmul2, matmul1}, ov::ParameterVector{input1});
         return model;
     };
 
@@ -608,7 +608,7 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedExceptionTest) {
         auto matmul1 = std::make_shared<ov::opset1::MatMul>(input1, convert, false, false);
         auto matmul2 = std::make_shared<ov::opset1::MatMul>(convert, convert, true, false);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{matmul1, matmul2}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul1, matmul2}, ov::ParameterVector{input1});
         manager.register_pass<ConvertMatMulToFullyConnected>();
     }
     {
@@ -622,6 +622,6 @@ TEST_F(TransformationTestsF, ConvertMatMulToFullyConnectedExceptionTest) {
         auto matmul1 = std::make_shared<ov::opset1::MatMul>(input1, convert, false, false);
         auto matmul2 = std::make_shared<ov::opset1::MatMul>(convert_2, convert, true, false);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{matmul1, matmul2}, ov::ParameterVector{input1});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul1, matmul2}, ov::ParameterVector{input1});
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/convert_pooling_to_reduce_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/convert_pooling_to_reduce_test.cpp
@@ -33,7 +33,7 @@ static std::shared_ptr<ov::Model> CreateFunction(const ov::Shape& input_shape,
                                                             exclude_pad,
                                                             rounding_type,
                                                             pad_type);
-    return std::make_shared<ov::Model>(ov::NodeVector{avgPool}, ov::ParameterVector{in});
+    return std::make_shared<ov::Model>(ov::OutputVector{avgPool}, ov::ParameterVector{in});
 }
 
 TEST(TransformationTests, ConvertAvgPoolToReduce) {

--- a/src/plugins/intel_gpu/tests/unit/transformations/decompose_reduce_for_false_keepdims_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/decompose_reduce_for_false_keepdims_test.cpp
@@ -79,8 +79,7 @@ public:
         else
             throw std::runtime_error("Invalid reduce type for this test-case.");
 
-        return std::make_shared<ov::Model>(ov::NodeVector{input.get_node_shared_ptr()},
-                                                  ov::ParameterVector{param});
+        return std::make_shared<ov::Model>(ov::OutputVector{input.get_node_shared_ptr()}, ov::ParameterVector{param});
     }
 };
 

--- a/src/plugins/intel_gpu/tests/unit/transformations/fc_convert_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/fc_convert_fusion_test.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, FullyConnectedConvertFusionTest1) {
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, no_bias, scale_const, zp_const);
         auto convert = std::make_shared<ov::op::v0::Convert>(fc_compressed, ov::element::f32);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input});
         manager.register_pass<FullyConnectedConvertFusion>();
     }
     {
@@ -45,7 +45,7 @@ TEST_F(TransformationTestsF, FullyConnectedConvertFusionTest1) {
         auto zp_const = ov::op::v0::Constant::create(ov::element::f16, ov::Shape{ 32, 1 }, { 1 });
         auto fc_compressed = std::make_shared<ov::intel_gpu::op::FullyConnectedCompressed>(input, weights_const, no_bias, scale_const, zp_const, ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ fc_compressed }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{fc_compressed}, ov::ParameterVector{input});
     }
 }
 
@@ -57,7 +57,7 @@ TEST_F(TransformationTestsF, FullyConnectedConvertFusionTest2) {
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias);
         auto convert = std::make_shared<ov::op::v0::Convert>(matmul, ov::element::f32);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{input1});
+        model = std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{input1});
         manager.register_pass<FullyConnectedConvertFusion>();
     }
     {
@@ -66,6 +66,6 @@ TEST_F(TransformationTestsF, FullyConnectedConvertFusionTest2) {
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto matmul = std::make_shared<op::FullyConnected>(input1, input2, no_bias, ov::element::f32);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input1 });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input1});
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/increase_position_ids_precision_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/increase_position_ids_precision_test.cpp
@@ -51,7 +51,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionWithoutUnsqueeze) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
     {
@@ -75,7 +75,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionWithoutUnsqueeze) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_convert, sin_convert}, ov::op::internal::RoPE::Config());
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -100,7 +100,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionWithUnsqueeze) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
     {
@@ -127,7 +127,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsPrecisionWithUnsqueeze) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -149,7 +149,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsMatmulWithoutUnsqueeze) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
     {
@@ -173,7 +173,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsMatmulWithoutUnsqueeze) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_convert, sin_convert}, ov::op::internal::RoPE::Config());
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -197,7 +197,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsReshapeAfterMatmul) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos, sin}, ov::op::internal::RoPE::Config());
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input, reshape_dims });
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input, reshape_dims});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
     {
@@ -223,7 +223,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsReshapeAfterMatmul) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_convert, sin_convert}, ov::op::internal::RoPE::Config());
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input, reshape_dims });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input, reshape_dims});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -254,7 +254,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLongRoPE) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input, rotary_embd });
+        model = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input, rotary_embd});
         manager.register_pass<IncreasePositionIdsPrecision>();
     }
     {
@@ -288,7 +288,7 @@ TEST_F(TransformationTestsF, IncreasePositionIdsLongRoPE) {
         auto rope_input = std::make_shared<ov::op::v0::Parameter>(ov::element::f16, ov::PartialShape::dynamic(4));
         auto rope = std::make_shared<ov::op::internal::RoPE>(ov::OutputVector{rope_input, cos_unsqueeze, sin_unsqueeze}, ov::op::internal::RoPE::Config());
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ rope }, ov::ParameterVector{ input, rope_input, rotary_embd });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{rope}, ov::ParameterVector{input, rope_input, rotary_embd});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/lora_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/lora_horizontal_fusion.cpp
@@ -84,7 +84,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_default) {
         auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
         auto result2 = std::make_shared<ov::op::v0::Result>(reshape2);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{result0, result1, result2}, ov::ParameterVector{lora_input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{result0, result1, result2}, ov::ParameterVector{lora_input});
         manager.register_pass<LoRAHorizontalFusion>();
     }
 
@@ -160,7 +160,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_default) {
         auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
         auto result2 = std::make_shared<ov::op::v0::Result>(reshape2);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{result0, result1, result2}, ov::ParameterVector{lora_input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result0, result1, result2}, ov::ParameterVector{lora_input});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -231,7 +231,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_swap_add_and_multiply_inputs) 
         auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
         auto result2 = std::make_shared<ov::op::v0::Result>(reshape2);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{result0, result1, result2}, ov::ParameterVector{lora_input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{result0, result1, result2}, ov::ParameterVector{lora_input});
         manager.register_pass<LoRAHorizontalFusion>();
     }
 
@@ -307,7 +307,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_swap_add_and_multiply_inputs) 
         auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
         auto result2 = std::make_shared<ov::op::v0::Result>(reshape2);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{result0, result1, result2}, ov::ParameterVector{lora_input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result0, result1, result2}, ov::ParameterVector{lora_input});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -361,7 +361,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_split_two_outputs) {
         auto result0 = std::make_shared<ov::op::v0::Result>(reshape0);
         auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{result0, result1}, ov::ParameterVector{lora_input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{result0, result1}, ov::ParameterVector{lora_input});
         manager.register_pass<LoRAHorizontalFusion>();
     }
 
@@ -424,7 +424,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_split_two_outputs) {
         auto result0 = std::make_shared<ov::op::v0::Result>(reshape0);
         auto result1 = std::make_shared<ov::op::v0::Result>(reshape1);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{result0, result1}, ov::ParameterVector{lora_input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result0, result1}, ov::ParameterVector{lora_input});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -487,7 +487,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_multiple_split_output_users) {
         auto result4 = std::make_shared<ov::op::v0::Result>(shape_of2);
         auto result5 = std::make_shared<ov::op::v0::Result>(shape_of3);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{result0, result1, result2, result3, result4, result5}, ov::ParameterVector{lora_input});
+        model = std::make_shared<ov::Model>(ov::OutputVector{result0, result1, result2, result3, result4, result5}, ov::ParameterVector{lora_input});
         manager.register_pass<LoRAHorizontalFusion>();
     }
 
@@ -559,7 +559,7 @@ TEST_F(TransformationTestsF, LoRAHorizontalFusion_multiple_split_output_users) {
         auto result4 = std::make_shared<ov::op::v0::Result>(shape_of2);
         auto result5 = std::make_shared<ov::op::v0::Result>(shape_of3);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{result0, result1, result2, result3, result4, result5}, ov::ParameterVector{lora_input});
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result0, result1, result2, result3, result4, result5}, ov::ParameterVector{lora_input});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
@@ -75,7 +75,7 @@ public:
 	auto no_bias = std::make_shared<ov::intel_gpu::op::Placeholder>();
 
         auto fully_connected = std::make_shared<op::FullyConnected>(data, weights_path, no_bias);
-        return std::make_shared<ov::Model>(ov::NodeVector{fully_connected}, ov::ParameterVector{data});
+        return std::make_shared<ov::Model>(ov::OutputVector{fully_connected}, ov::ParameterVector{data});
     }
 
 protected:

--- a/src/plugins/intel_gpu/tests/unit/transformations/optimize_subsequent_reshapes_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/optimize_subsequent_reshapes_test.cpp
@@ -34,7 +34,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes1) {
         auto second_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape, second_reshape_pattern, true);
         auto result = std::make_shared<ov::op::v0::Result>(second_reshape);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
         manager.register_pass<OptimizeSubsequentReshapes>();
     }
     {
@@ -43,7 +43,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes1) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(input, reshape_pattern, false);
         auto result = std::make_shared<ov::op::v0::Result>(reshape);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -58,7 +58,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes2) {
         auto second_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape, second_reshape_pattern, true);
         auto result = std::make_shared<ov::op::v0::Result>(second_reshape);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
         manager.register_pass<OptimizeSubsequentReshapes>();
     }
     {
@@ -67,7 +67,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes2) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(input, reshape_pattern, false);
         auto result = std::make_shared<ov::op::v0::Result>(reshape);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -82,7 +82,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes3) {
         auto second_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape, second_reshape_pattern, true);
         auto result = std::make_shared<ov::op::v0::Result>(second_reshape);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
         manager.register_pass<OptimizeSubsequentReshapes>();
     }
     {
@@ -91,7 +91,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes3) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(input, reshape_pattern, false);
         auto result = std::make_shared<ov::op::v0::Result>(reshape);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes4) {
         auto second_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape, second_reshape_pattern, false);
         auto result = std::make_shared<ov::op::v0::Result>(second_reshape);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
         manager.register_pass<OptimizeSubsequentReshapes>();
     }
     {
@@ -115,7 +115,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes4) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(input, reshape_pattern, false);
         auto result = std::make_shared<ov::op::v0::Result>(reshape);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }
@@ -130,7 +130,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes5) {
         auto second_reshape = std::make_shared<ov::op::v1::Reshape>(first_reshape, second_reshape_pattern, true);
         auto result = std::make_shared<ov::op::v0::Result>(second_reshape);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
         manager.register_pass<OptimizeSubsequentReshapes>();
     }
     {
@@ -139,7 +139,7 @@ TEST_F(TransformationTestsF, OptimizeSubsequentReshapes5) {
         auto reshape = std::make_shared<ov::op::v1::Reshape>(input, reshape_pattern, false);
         auto result = std::make_shared<ov::op::v0::Result>(reshape);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ result }, ov::ParameterVector{ input });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{result}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CmpValues::ATTRIBUTES);
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/sink_reshape_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/sink_reshape_test.cpp
@@ -18,10 +18,10 @@
 using namespace testing;
 using namespace ov::intel_gpu;
 
-using SinkReshapeParams = std::tuple<bool,                                    // add eltwise
-                                     bool,                                    // add activation
-                                     bool,                                    // eligible rotation
-                                     bool>;                                   // eligible reshape                                  
+using SinkReshapeParams = std::tuple<bool,   // add eltwise
+                                     bool,   // add activation
+                                     bool,   // eligible rotation
+                                     bool>;  // eligible reshape
 
 class SinkReshapeTests : public TransformationTestsF, public WithParamInterface<SinkReshapeParams> {
 public:
@@ -73,16 +73,16 @@ public:
             auto order = eligible_rotation ? std::vector<int>{0 ,2, 1} : std::vector<int>{2, 1, 0};
             auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {3}, order);
             auto transpose = std::make_shared<ov::opset1::Transpose>(reshape, transpose_const);
-        
+
             auto softmax = std::make_shared<ov::op::v8::Softmax>(transpose);
-            model = std::make_shared<ov::Model>(ov::NodeVector{softmax}, ov::ParameterVector{input});
+            model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input});
         } else {
             auto transpose_const = ov::opset1::Constant::create(ov::element::i32, {4}, {0, 2, 3, 1});
             auto transpose = std::make_shared<ov::opset1::Transpose>(reshape_input_node, transpose_const);
             auto reshape_const = ov::opset1::Constant::create(ov::element::i32, {3}, {2, 100, 4});
             auto reshape = std::make_shared<ov::opset1::Reshape>(transpose, reshape_const, true);
             auto softmax = std::make_shared<ov::op::v8::Softmax>(reshape);
-            model = std::make_shared<ov::Model>(ov::NodeVector{softmax}, ov::ParameterVector{input});
+            model = std::make_shared<ov::Model>(ov::OutputVector{softmax}, ov::ParameterVector{input});
         }
         ov::pass::Manager manager;
         manager.register_pass<ConvertConvolutionToInternal>();
@@ -145,12 +145,12 @@ TEST_F(TransformationTestsF, SinkReshapeFalsePattern) {
     auto softmax = std::make_shared<ov::op::v8::Softmax>(transpose);
     auto input2 = ov::opset1::Constant::create(ov::element::f32, ov::Shape{ 2, 100, 4 }, { 1 });
     auto matmul = std::make_shared<ov::opset1::MatMul>(reshape, input2, false, false);
-    model = std::make_shared<ov::Model>(ov::NodeVector{softmax, matmul}, ov::ParameterVector{input});
+    model = std::make_shared<ov::Model>(ov::OutputVector{softmax, matmul}, ov::ParameterVector{input});
     ov::pass::Manager manager;
     manager.register_pass<ConvertConvolutionToInternal>();
     manager.register_pass<SinkReshape>();
     OV_ASSERT_NO_THROW(manager.run_passes(model));
-    model_ref = std::make_shared<ov::Model>(ov::NodeVector{softmax, matmul}, ov::ParameterVector{input});
+    model_ref = std::make_shared<ov::Model>(ov::OutputVector{softmax, matmul}, ov::ParameterVector{input});
     ov::pass::Manager manager_ref;
     manager_ref.register_pass<ConvertConvolutionToInternal>();
     manager.run_passes(model_ref);

--- a/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
@@ -30,7 +30,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion1) {
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -46,7 +46,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion1) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -59,7 +59,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion2) {
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, input_b);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -75,7 +75,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion2) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -90,7 +90,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion3) {
         auto tranpose_b = std::make_shared<ov::op::v1::Transpose>(input_b, tranpose_b_const);
         auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, tranpose_b);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -106,7 +106,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion3) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -123,7 +123,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion4) {
         auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
         auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{tranpose_c}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -139,7 +139,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion4) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -152,7 +152,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion5) {
         auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
         auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{tranpose_c}, ov::ParameterVector{input_a, input_b});
 
         const auto supports_immad = false;
         manager.register_pass<TransposeFusion>(supports_immad);
@@ -170,7 +170,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion5) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -182,7 +182,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion6) {
     auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
     auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+    model = std::make_shared<ov::Model>(ov::OutputVector{tranpose_c}, ov::ParameterVector{input_a, input_b});
 
     const auto supports_immad = false;
     manager.register_pass<TransposeFusion>(supports_immad);
@@ -198,7 +198,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion7) {
     auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{2}, {1, 0});
     auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
 
-    model = std::make_shared<ov::Model>(ov::NodeVector{ tranpose_c }, ov::ParameterVector{ input_a, input_b });
+    model = std::make_shared<ov::Model>(ov::OutputVector{tranpose_c}, ov::ParameterVector{input_a, input_b});
 
     const auto supports_immad = false;
     manager.register_pass<TransposeFusion>(supports_immad);
@@ -213,7 +213,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion_Illegal_1) {
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{20, 30});
         auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ matmul }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{matmul}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<TransposeFusion>();
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/transpose_sdpa_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/transpose_sdpa_fusion_test.cpp
@@ -32,7 +32,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion1) {
         auto input_c = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(input_a, input_b, input_c, is_causal);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -51,7 +51,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion1) {
                                                               order_output,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -66,7 +66,7 @@ TEST_F(TransformationTestsF, TransformationTestsF) {
         auto input_c = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(tranpose_a, input_b, input_c, is_causal);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -85,7 +85,7 @@ TEST_F(TransformationTestsF, TransformationTestsF) {
                                                               order_output,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -103,7 +103,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion3) {
 
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(tranpose_a, tranpose_b, input_c, is_causal);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -122,7 +122,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion3) {
                                                               order_output,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -142,7 +142,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion4) {
 
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(tranpose_a, tranpose_b, tranpose_c, is_causal);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -161,7 +161,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion4) {
                                                               order_output,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -181,7 +181,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion5) {
 
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(tranpose_a, tranpose_b, tranpose_c, is_causal);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         manager.register_pass<TransposeFusion>();
     }
     {
@@ -197,7 +197,7 @@ TEST_F(TransformationTestsF, TranposeSDPAFusion5) {
 
         auto sdpa = std::make_shared<ov::op::v13::ScaledDotProductAttention>(tranpose_a, tranpose_b, tranpose_c, is_causal);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_a, input_b, input_c });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_a, input_b, input_c});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/transformations/unsqueeze_broadcast_reshape_matmul_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/unsqueeze_broadcast_reshape_matmul_fusion_test.cpp
@@ -57,7 +57,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeMatmulFusion1) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, new_token_param, beam_idx });
+        model = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, new_token_param, beam_idx});
         manager.register_pass<UnsqueezeBroadcastReshapeMatmulFusion>();
     }
     {
@@ -76,7 +76,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeMatmulFusion1) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, new_token_param, beam_idx });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, new_token_param, beam_idx});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -110,7 +110,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeMatmulFusion2) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, new_token_param, beam_idx, abs_param });
+        model = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, new_token_param, beam_idx, abs_param});
         manager.register_pass<UnsqueezeBroadcastReshapeMatmulFusion>();
     }
     {
@@ -129,7 +129,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeMatmulFusion2) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, new_token_param, beam_idx });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, new_token_param, beam_idx});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -157,7 +157,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeMatmulFusion3) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<UnsqueezeBroadcastReshapeMatmulFusion>();
     }
     {
@@ -189,7 +189,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeMatmulFusion4) {
                                                               order_c,
                                                               ov::element::dynamic);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ gemm }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{gemm}, ov::ParameterVector{input_a, input_b});
         manager.register_pass<UnsqueezeBroadcastReshapeMatmulFusion>();
     }
     {

--- a/src/plugins/intel_gpu/tests/unit/transformations/unsqueeze_broadcast_reshape_sdpa_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/unsqueeze_broadcast_reshape_sdpa_fusion_test.cpp
@@ -63,7 +63,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion1) {
         auto inputs = ov::OutputVector{input_q, key_reshape, value_reshape};
         auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_q, key_token_param, value_token_param, beam_idx });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, key_token_param, value_token_param, beam_idx});
         manager.register_pass<UnsqueezeBroadcastReshapeSDPAFusion>();
     }
     {
@@ -83,7 +83,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion1) {
         auto inputs = ov::OutputVector{input_q, key_cache, value_cache};
         auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_q, key_token_param, value_token_param, beam_idx });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, key_token_param, value_token_param, beam_idx});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -123,7 +123,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion2) {
         auto inputs = ov::OutputVector{input_q, key_cache, value_cache};
         auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_q, key_token_param, value_token_param, beam_idx });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, key_token_param, value_token_param, beam_idx});
         manager.register_pass<UnsqueezeBroadcastReshapeSDPAFusion>();
     }
     {
@@ -143,7 +143,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion2) {
         auto inputs = ov::OutputVector{input_q, key_cache, value_cache};
         auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
 
-        model_ref = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_q, key_token_param, value_token_param, beam_idx });
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, key_token_param, value_token_param, beam_idx});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }
@@ -173,7 +173,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion3) {
         auto inputs = ov::OutputVector{input_q, key_reshape, value_reshape};
         auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_q, input_k, input_v });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, input_k, input_v});
         manager.register_pass<UnsqueezeBroadcastReshapeSDPAFusion>();
     }
     {
@@ -219,7 +219,7 @@ TEST_F(TransformationTestsF, UnsqueezeBroadReshapeSDPAFusion4) {
         auto inputs = ov::OutputVector{input_q, key_reshape, value_reshape};
         auto sdpa = std::make_shared<ov::intel_gpu::op::SDPA>(inputs, is_causal, in0_order, in1_order, in2_order, out_order);
 
-        model = std::make_shared<ov::Model>(ov::NodeVector{ sdpa }, ov::ParameterVector{ input_q, key_token_param, value_token_param, beam_idx });
+        model = std::make_shared<ov::Model>(ov::OutputVector{sdpa}, ov::ParameterVector{input_q, key_token_param, value_token_param, beam_idx});
         manager.register_pass<UnsqueezeBroadcastReshapeSDPAFusion>();
     }
     {

--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -746,7 +746,7 @@ std::shared_ptr<ov::npuw::CompiledModel> ov::npuw::CompiledModel::deserialize(
     read(stream, parameters);
     read(stream, results);
 
-    auto ov_model = std::make_shared<ov::Model>(results, parameters, model_name);
+    auto ov_model = std::make_shared<ov::Model>(ov::as_output_vector(results), parameters, model_name);
 
     auto compiled = std::make_shared<ov::npuw::CompiledModel>(ov_model, plugin, true);
 

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -957,7 +957,7 @@ std::shared_ptr<ov::npuw::LLMCompiledModel> ov::npuw::LLMCompiledModel::deserial
         read(model_stream, parameters);
         read(model_stream, results);
 
-        auto ov_model = std::make_shared<ov::Model>(results, parameters, model_name);
+        auto ov_model = std::make_shared<ov::Model>(ov::as_output_vector(results), parameters, model_name);
 
         auto compiled = std::make_shared<ov::npuw::LLMCompiledModel>(ov_model, plugin, true);
 

--- a/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/compiled_model.cpp
@@ -96,7 +96,7 @@ void CompiledModel::export_model(std::ostream& stream) const {
 
 std::shared_ptr<const ov::Model> CompiledModel::get_runtime_model() const {
     ov::ParameterVector parameters;
-    ov::NodeVector results;
+    ov::ResultVector results;
 
     for (const IODescriptor& inputDescriptor : _graph->get_metadata().inputs) {
         if (inputDescriptor.isStateInput || inputDescriptor.isStateOutput || inputDescriptor.isShapeTensor) {
@@ -130,10 +130,9 @@ std::shared_ptr<const ov::Model> CompiledModel::get_runtime_model() const {
                                                      outputDescriptor.shapeFromCompiler,
                                                      outputDescriptor.outputTensorNames);
 
-        std::shared_ptr<ov::Node> result = std::make_shared<ov::op::v0::Result>(constantDummy);
+        auto& result = results.emplace_back(std::make_shared<ov::op::v0::Result>(constantDummy));
         result->output(0).set_tensor_ptr(tensorDummy);
         result->set_friendly_name(outputDescriptor.nodeFriendlyName);
-        results.push_back(std::move(result));
     }
 
     _logger.warning("Returning a dummy ov::Model object that contains only the given parameter and result nodes");

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -51,7 +51,7 @@ const char* NPU_PLUGIN_LIB_NAME = "openvino_intel_npu_plugin";
 std::shared_ptr<ov::Model> create_dummy_model(const std::vector<IODescriptor>& inputDescriptors,
                                               const std::vector<IODescriptor>& outputDescriptors) {
     ov::ParameterVector parameters;
-    ov::NodeVector results;
+    ov::ResultVector results;
 
     for (const IODescriptor& inputDescriptor : inputDescriptors) {
         if (inputDescriptor.isStateInput || inputDescriptor.isStateOutput || inputDescriptor.isShapeTensor) {
@@ -86,10 +86,9 @@ std::shared_ptr<ov::Model> create_dummy_model(const std::vector<IODescriptor>& i
                                                           : outputDescriptor.shapeFromCompiler,
             outputDescriptor.outputTensorNames);
 
-        std::shared_ptr<ov::Node> result = std::make_shared<ov::op::v0::Result>(constantDummy);
+        auto& result = results.emplace_back(std::make_shared<ov::op::v0::Result>(constantDummy));
         result->output(0).set_tensor_ptr(tensorDummy);
         result->set_friendly_name(outputDescriptor.nodeFriendlyName);
-        results.push_back(std::move(result));
     }
 
     return std::make_shared<ov::Model>(results, parameters);

--- a/src/plugins/intel_npu/tests/functional/behavior/fail_gracefully_forward_compatibility.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/fail_gracefully_forward_compatibility.hpp
@@ -107,7 +107,7 @@ private:
         auto constant = ov::test::utils::make_constant(precision, ov::Shape{4096, 1024});
         auto custom_op = std::make_shared<UnsupportedTestOperation>(constant);
 
-        ov::NodeVector results{custom_op};
+        ov::OutputVector results{custom_op};
         return std::make_shared<ov::Model>(results, ov::ParameterVector{params}, "CustomOpModel");
     }
 };

--- a/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/query_network.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npu_driver_compiler_adapter/query_network.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<ov::Model> createModelWithUnknownNode() {
     auto constant = ov::test::utils::make_constant(precision, ov::Shape{4096, 1024});
     auto custom_op = std::make_shared<UnsupportedTestOp>(constant);
 
-    ov::NodeVector results{custom_op};
+    ov::OutputVector results{custom_op};
     return std::make_shared<ov::Model>(results, ov::ParameterVector{params}, "CustomOpModel");
 }
 

--- a/src/plugins/intel_npu/tests/functional/common/utils.cpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.cpp
@@ -129,6 +129,6 @@ std::shared_ptr<ov::Model> createModelWithStates(ov::element::Type type, const o
     mem_w2->add_control_dependency(mem_r2);
     sigm->add_control_dependency(mem_w2);
 
-    auto function = std::make_shared<ov::Model>(ov::NodeVector{sigm}, ov::ParameterVector{input}, "add_output");
+    auto function = std::make_shared<ov::Model>(ov::OutputVector{sigm}, ov::ParameterVector{input}, "add_output");
     return function;
 }

--- a/src/plugins/template/tests/functional/op_reference/abs.cpp
+++ b/src/plugins/template/tests/functional/op_reference/abs.cpp
@@ -56,7 +56,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto log = std::make_shared<op::v0::Abs>(in);
-        return std::make_shared<Model>(NodeVector{log}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{log}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/acos.cpp
+++ b/src/plugins/template/tests/functional/op_reference/acos.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto acos = std::make_shared<op::v0::Acos>(in);
-        return std::make_shared<Model>(NodeVector{acos}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{acos}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/acosh.cpp
+++ b/src/plugins/template/tests/functional/op_reference/acosh.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto acosh = std::make_shared<op::v3::Acosh>(in);
-        return std::make_shared<ov::Model>(NodeVector{acosh}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{acosh}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/adaptive_avg_pool.cpp
+++ b/src/plugins/template/tests/functional/op_reference/adaptive_avg_pool.cpp
@@ -73,7 +73,7 @@ private:
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto out = op::v0::Constant::create<int64_t>(element::Type_t::i64, adaptive_shape, adaptive_values);
         const auto adaptive_avg_pool = std::make_shared<op::v8::AdaptiveAvgPool>(in, out);
-        return std::make_shared<Model>(NodeVector{adaptive_avg_pool}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{adaptive_avg_pool}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/add.cpp
+++ b/src/plugins/template/tests/functional/op_reference/add.cpp
@@ -66,7 +66,7 @@ private:
         const auto in1 = std::make_shared<op::v0::Parameter>(input_type, input_shape1);
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto add = std::make_shared<op::v1::Add>(in1, in2);
-        return std::make_shared<Model>(NodeVector{add}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{add}, ParameterVector{in1, in2});
     }
 };
 
@@ -100,7 +100,7 @@ private:
         add = std::make_shared<op::v1::Add>(add, add);
         add = std::make_shared<op::v1::Add>(add, add);
         add = std::make_shared<op::v1::Add>(add, add);
-        return std::make_shared<Model>(NodeVector{add}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{add}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/asin.cpp
+++ b/src/plugins/template/tests/functional/op_reference/asin.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Asin = std::make_shared<op::v0::Asin>(in);
-        return std::make_shared<ov::Model>(NodeVector{Asin}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Asin}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/asinh.cpp
+++ b/src/plugins/template/tests/functional/op_reference/asinh.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Asinh = std::make_shared<op::v3::Asinh>(in);
-        return std::make_shared<ov::Model>(NodeVector{Asinh}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Asinh}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/atan.cpp
+++ b/src/plugins/template/tests/functional/op_reference/atan.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto atan = std::make_shared<op::v0::Atan>(in);
-        return std::make_shared<ov::Model>(NodeVector{atan}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{atan}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/atanh.cpp
+++ b/src/plugins/template/tests/functional/op_reference/atanh.cpp
@@ -48,7 +48,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto out = std::make_shared<op::v3::Atanh>(in);
-        return std::make_shared<ov::Model>(NodeVector{out}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{out}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/augru_cell.cpp
+++ b/src/plugins/template/tests/functional/op_reference/augru_cell.cpp
@@ -97,7 +97,7 @@ private:
 
         const auto augru_cell = std::make_shared<ov::op::internal::AUGRUCell>(X, H_t, W, R, B, A, params.hiddenSize);
 
-        auto function = std::make_shared<Model>(NodeVector{augru_cell}, ParameterVector{X, H_t, W, R, B, A});
+        auto function = std::make_shared<Model>(OutputVector{augru_cell}, ParameterVector{X, H_t, W, R, B, A});
         return function;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/avg_pool.cpp
+++ b/src/plugins/template/tests/functional/op_reference/avg_pool.cpp
@@ -106,7 +106,7 @@ private:
                                                                exclude_pad,
                                                                rounding_type,
                                                                pad_type);
-        return std::make_shared<Model>(NodeVector{avgPool}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{avgPool}, ParameterVector{in});
     }
 };
 
@@ -341,7 +341,7 @@ private:
                                                                 exclude_pad,
                                                                 rounding_type,
                                                                 pad_type);
-        return std::make_shared<Model>(NodeVector{avgPool}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{avgPool}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/batch_to_space.cpp
+++ b/src/plugins/template/tests/functional/op_reference/batch_to_space.cpp
@@ -75,7 +75,7 @@ private:
         const auto cropsBegin = std::make_shared<op::v0::Parameter>(element::i64, params.cropsBeginTensor.shape);
         const auto cropsEnd = std::make_shared<op::v0::Parameter>(element::i64, params.cropsEndTensor.shape);
         const auto batchToSpace = std::make_shared<op::v1::BatchToSpace>(data, blockShape, cropsBegin, cropsEnd);
-        return std::make_shared<Model>(NodeVector{batchToSpace},
+        return std::make_shared<Model>(OutputVector{batchToSpace},
                                        ParameterVector{data, blockShape, cropsBegin, cropsEnd});
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/binary_convolution.cpp
+++ b/src/plugins/template/tests/functional/op_reference/binary_convolution.cpp
@@ -105,7 +105,7 @@ private:
                                                                                    params.mode,
                                                                                    params.padValue,
                                                                                    auto_pad);
-        return std::make_shared<ov::Model>(NodeVector{BinaryConvolution}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{BinaryConvolution}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/bitwise.hpp
+++ b/src/plugins/template/tests/functional/op_reference/bitwise.hpp
@@ -90,7 +90,7 @@ private:
         }
         }
         EXPECT_TRUE(bitwise_op) << "Incorrect type of Bitwise operation";
-        return std::make_shared<ov::Model>(ov::NodeVector{bitwise_op}, ov::ParameterVector{params_vec});
+        return std::make_shared<ov::Model>(ov::OutputVector{bitwise_op}, ov::ParameterVector{params_vec});
     }
 };
 }  // namespace BitwiseOpsRefTestDefinitions

--- a/src/plugins/template/tests/functional/op_reference/broadcast.cpp
+++ b/src/plugins/template/tests/functional/op_reference/broadcast.cpp
@@ -254,7 +254,7 @@ private:
         auto reverse = std::make_shared<op::v1::Reverse>(broadcast,
                                                          op::v0::Constant::create(element::i64, {1}, {1}),
                                                          op::v1::Reverse::Mode::INDEX);
-        auto f = std::make_shared<Model>(NodeVector{reverse}, ParameterVector{A});
+        auto f = std::make_shared<Model>(OutputVector{reverse}, ParameterVector{A});
         return f;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/ceiling.cpp
+++ b/src/plugins/template/tests/functional/op_reference/ceiling.cpp
@@ -56,7 +56,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto ceiling = std::make_shared<op::v0::Ceiling>(in);
-        return std::make_shared<Model>(NodeVector{ceiling}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{ceiling}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/clamp.cpp
+++ b/src/plugins/template/tests/functional/op_reference/clamp.cpp
@@ -65,7 +65,7 @@ private:
                                                  const double max) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Clamp = std::make_shared<op::v0::Clamp>(in, min, max);
-        return std::make_shared<ov::Model>(NodeVector{Clamp}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Clamp}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/col2im.cpp
+++ b/src/plugins/template/tests/functional/op_reference/col2im.cpp
@@ -79,7 +79,8 @@ private:
                                                                   params.dilations,
                                                                   params.pads_begin,
                                                                   params.pads_end);
-        return std::make_shared<ov::Model>(ov::NodeVector{col2im}, ov::ParameterVector{data, output_size, kernel_size});
+        return std::make_shared<ov::Model>(ov::OutputVector{col2im},
+                                           ov::ParameterVector{data, output_size, kernel_size});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/comparison.hpp
+++ b/src/plugins/template/tests/functional/op_reference/comparison.hpp
@@ -110,7 +110,7 @@ private:
             throw std::runtime_error("Incorrect type of Comparison operation");
         }
         }
-        return std::make_shared<ov::Model>(ov::NodeVector{comp}, ov::ParameterVector{in0, in1});
+        return std::make_shared<ov::Model>(ov::OutputVector{comp}, ov::ParameterVector{in0, in1});
     }
 };
 }  // namespace ComparisonOpsRefTestDefinitions

--- a/src/plugins/template/tests/functional/op_reference/constant.cpp
+++ b/src/plugins/template/tests/functional/op_reference/constant.cpp
@@ -81,7 +81,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const ParamType& params) {
         auto A = op::v0::Constant::create(params.inType, params.inputShape, params.inputData.data());
         auto B = op::v0::Constant::create(params.inType, params.inputShape, params.inputData.data());
-        return std::make_shared<Model>(NodeVector{A, B}, ParameterVector{});
+        return std::make_shared<Model>(OutputVector{A, B}, ParameterVector{});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/conversion.hpp
+++ b/src/plugins/template/tests/functional/op_reference/conversion.hpp
@@ -77,7 +77,7 @@ private:
         } else {
             throw std::runtime_error("Incorrect type of Conversion operation");
         }
-        return std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{in});
+        return std::make_shared<ov::Model>(ov::OutputVector{convert}, ov::ParameterVector{in});
     }
 };
 }  // namespace ConversionOpsRefTestDefinitions

--- a/src/plugins/template/tests/functional/op_reference/convolution.cpp
+++ b/src/plugins/template/tests/functional/op_reference/convolution.cpp
@@ -130,9 +130,9 @@ private:
                                                                             params.padEnd,
                                                                             params.dialations,
                                                                             auto_pad);
-            return std::make_shared<ov::Model>(NodeVector{Convolution2}, ParameterVector{in, filter});
+            return std::make_shared<ov::Model>(OutputVector{Convolution2}, ParameterVector{in, filter});
         } else {
-            return std::make_shared<ov::Model>(NodeVector{Convolution}, ParameterVector{in, filter});
+            return std::make_shared<ov::Model>(OutputVector{Convolution}, ParameterVector{in, filter});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/convolution_backprop.cpp
+++ b/src/plugins/template/tests/functional/op_reference/convolution_backprop.cpp
@@ -122,7 +122,7 @@ private:
                                                                                            auto_pad,
                                                                                            params.outPadding);
 
-        return std::make_shared<ov::Model>(NodeVector{ConvolutionBackprop}, ParameterVector{in, filter});
+        return std::make_shared<ov::Model>(OutputVector{ConvolutionBackprop}, ParameterVector{in, filter});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/cos.cpp
+++ b/src/plugins/template/tests/functional/op_reference/cos.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Cos = std::make_shared<op::v0::Cos>(in);
-        return std::make_shared<ov::Model>(NodeVector{Cos}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Cos}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/cosh.cpp
+++ b/src/plugins/template/tests/functional/op_reference/cosh.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Cosh = std::make_shared<op::v0::Cosh>(in);
-        return std::make_shared<ov::Model>(NodeVector{Cosh}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Cosh}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/ctc_greedy_decoder.cpp
+++ b/src/plugins/template/tests/functional/op_reference/ctc_greedy_decoder.cpp
@@ -65,7 +65,7 @@ private:
         const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, params.dataTensor.shape);
         const auto indices = std::make_shared<op::v0::Parameter>(params.masksTensor.type, params.masksTensor.shape);
         const auto decoder = std::make_shared<op::v0::CTCGreedyDecoder>(data, indices, params.ctcMergedRepeat);
-        function = std::make_shared<ov::Model>(NodeVector{decoder}, ParameterVector{data, indices});
+        function = std::make_shared<ov::Model>(OutputVector{decoder}, ParameterVector{data, indices});
         return function;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/ctc_loss.cpp
+++ b/src/plugins/template/tests/functional/op_reference/ctc_loss.cpp
@@ -88,7 +88,7 @@ private:
                                                                params.preprocessCollapseRepeated,
                                                                params.ctcMergeRepeated,
                                                                params.unique);
-        return std::make_shared<ov::Model>(NodeVector{ctcLoss}, ParameterVector{A, B, C, D, E});
+        return std::make_shared<ov::Model>(OutputVector{ctcLoss}, ParameterVector{A, B, C, D, E});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/cum_sum.cpp
+++ b/src/plugins/template/tests/functional/op_reference/cum_sum.cpp
@@ -111,13 +111,13 @@ private:
         const auto data_param = std::make_shared<op::v0::Parameter>(data_type, data_shape);
         const auto axis_param = std::make_shared<op::v0::Parameter>(axis_type, axis_shape);
         const auto cum_sum = std::make_shared<op::v0::CumSum>(data_param, axis_param, execlusive, reverse);
-        return std::make_shared<ov::Model>(NodeVector{cum_sum}, ParameterVector{data_param, axis_param});
+        return std::make_shared<ov::Model>(OutputVector{cum_sum}, ParameterVector{data_param, axis_param});
     }
 
     static std::shared_ptr<Model> CreateFunction(const Shape& data_shape, const element::Type& data_type) {
         const auto data_param = std::make_shared<op::v0::Parameter>(data_type, data_shape);
         const auto cum_sum = std::make_shared<op::v0::CumSum>(data_param);
-        return std::make_shared<ov::Model>(NodeVector{cum_sum}, ParameterVector{data_param});
+        return std::make_shared<ov::Model>(OutputVector{cum_sum}, ParameterVector{data_param});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/deformable_convolution.cpp
+++ b/src/plugins/template/tests/functional/op_reference/deformable_convolution.cpp
@@ -169,7 +169,7 @@ private:
                                                                                            auto_pad,
                                                                                            params.group,
                                                                                            params.deformableGroup);
-        return std::make_shared<ov::Model>(NodeVector{DeformableConvolution}, ParameterVector{in, offset, filter});
+        return std::make_shared<ov::Model>(OutputVector{DeformableConvolution}, ParameterVector{in, offset, filter});
     }
 };
 
@@ -233,7 +233,7 @@ private:
                                                                 params.group,
                                                                 params.deformableGroup,
                                                                 params.use_bilinear_interpolation_padding);
-            return std::make_shared<ov::Model>(NodeVector{DeformableConvolutionV8},
+            return std::make_shared<ov::Model>(OutputVector{DeformableConvolutionV8},
                                                ParameterVector{in, offset, filter, mask});
         } else {
             const auto DeformableConvolutionV8 =
@@ -248,7 +248,7 @@ private:
                                                                 params.group,
                                                                 params.deformableGroup,
                                                                 params.use_bilinear_interpolation_padding);
-            return std::make_shared<ov::Model>(NodeVector{DeformableConvolutionV8},
+            return std::make_shared<ov::Model>(OutputVector{DeformableConvolutionV8},
                                                ParameterVector{in, offset, filter});
         }
     }

--- a/src/plugins/template/tests/functional/op_reference/deformable_psroi_pooling.cpp
+++ b/src/plugins/template/tests/functional/op_reference/deformable_psroi_pooling.cpp
@@ -200,7 +200,7 @@ private:
                                                                                                  params.spatialBinsY,
                                                                                                  params.transStd,
                                                                                                  params.partSize);
-            return std::make_shared<ov::Model>(NodeVector{DeformablePSROIPooling},
+            return std::make_shared<ov::Model>(OutputVector{DeformablePSROIPooling},
                                                ParameterVector{input, rois, offsets});
         } else {
             const auto DeformablePSROIPooling = std::make_shared<op::v1::DeformablePSROIPooling>(input,
@@ -213,7 +213,7 @@ private:
                                                                                                  params.spatialBinsY,
                                                                                                  params.transStd,
                                                                                                  params.partSize);
-            return std::make_shared<ov::Model>(NodeVector{DeformablePSROIPooling}, ParameterVector{input, rois});
+            return std::make_shared<ov::Model>(OutputVector{DeformablePSROIPooling}, ParameterVector{input, rois});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/depth_to_space.cpp
+++ b/src/plugins/template/tests/functional/op_reference/depth_to_space.cpp
@@ -62,7 +62,7 @@ private:
                                                        : op::v0::DepthToSpace::DepthToSpaceMode::BLOCKS_FIRST;
         const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, params.dataTensor.shape);
         const auto depthToSpace = std::make_shared<op::v0::DepthToSpace>(data, mode, params.blockSize);
-        return std::make_shared<Model>(NodeVector{depthToSpace}, ParameterVector{data});
+        return std::make_shared<Model>(OutputVector{depthToSpace}, ParameterVector{data});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/detection_output.cpp
+++ b/src/plugins/template/tests/functional/op_reference/detection_output.cpp
@@ -211,11 +211,11 @@ private:
             const auto auxLoc = std::make_shared<op::v0::Parameter>(params.inType, params.auxLocShape);
             const auto DetectionOutput =
                 std::make_shared<op::v0::DetectionOutput>(loc, conf, priorBoxes, auxConf, auxLoc, params.attrs);
-            return std::make_shared<ov::Model>(NodeVector{DetectionOutput},
+            return std::make_shared<ov::Model>(OutputVector{DetectionOutput},
                                                ParameterVector{loc, conf, priorBoxes, auxConf, auxLoc});
         } else {
             const auto DetectionOutput = std::make_shared<op::v0::DetectionOutput>(loc, conf, priorBoxes, params.attrs);
-            return std::make_shared<ov::Model>(NodeVector{DetectionOutput}, ParameterVector{loc, conf, priorBoxes});
+            return std::make_shared<ov::Model>(OutputVector{DetectionOutput}, ParameterVector{loc, conf, priorBoxes});
         }
     }
 };
@@ -258,12 +258,12 @@ private:
             const auto auxLoc = std::make_shared<op::v0::Parameter>(params.inType, params.auxLocShape);
             const auto DetectionOutput =
                 std::make_shared<op::v8::DetectionOutput>(loc, conf, priorBoxes, auxConf, auxLoc, params.attrs_v8);
-            return std::make_shared<ov::Model>(NodeVector{DetectionOutput},
+            return std::make_shared<ov::Model>(OutputVector{DetectionOutput},
                                                ParameterVector{loc, conf, priorBoxes, auxConf, auxLoc});
         } else {
             const auto DetectionOutput =
                 std::make_shared<op::v8::DetectionOutput>(loc, conf, priorBoxes, params.attrs_v8);
-            return std::make_shared<ov::Model>(NodeVector{DetectionOutput}, ParameterVector{loc, conf, priorBoxes});
+            return std::make_shared<ov::Model>(OutputVector{DetectionOutput}, ParameterVector{loc, conf, priorBoxes});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/divide.cpp
+++ b/src/plugins/template/tests/functional/op_reference/divide.cpp
@@ -82,7 +82,7 @@ private:
         const auto in1 = std::make_shared<op::v0::Parameter>(input_type, input_shape1);
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto divide = std::make_shared<op::v1::Divide>(in1, in2);
-        return std::make_shared<Model>(NodeVector{divide}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{divide}, ParameterVector{in1, in2});
     }
 };
 
@@ -115,7 +115,7 @@ private:
         const auto in1 = std::make_shared<op::v0::Parameter>(input_type, input_shape1);
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto divide = std::make_shared<op::v1::Divide>(in1, in2, pythondiv);
-        return std::make_shared<Model>(NodeVector{divide}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{divide}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/elu.cpp
+++ b/src/plugins/template/tests/functional/op_reference/elu.cpp
@@ -60,7 +60,7 @@ private:
                                                  const double alpha) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Elu = std::make_shared<op::v0::Elu>(in, alpha);
-        return std::make_shared<ov::Model>(NodeVector{Elu}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Elu}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/embedding_segments_sum.cpp
+++ b/src/plugins/template/tests/functional/op_reference/embedding_segments_sum.cpp
@@ -96,18 +96,18 @@ private:
                                                                                 num_segments,
                                                                                 default_index,
                                                                                 per_sample_weights);
-                return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+                return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
             } else {
                 const auto ess = std::make_shared<op::v3::EmbeddingSegmentsSum>(in,
                                                                                 indices,
                                                                                 segment_ids,
                                                                                 num_segments,
                                                                                 default_index);
-                return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+                return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
             }
         } else {
             const auto ess = std::make_shared<op::v3::EmbeddingSegmentsSum>(in, indices, segment_ids, num_segments);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/embeddingbag_offsets.cpp
+++ b/src/plugins/template/tests/functional/op_reference/embeddingbag_offsets.cpp
@@ -96,15 +96,15 @@ private:
                                                                                 default_index,
                                                                                 per_sample_weights,
                                                                                 reduction);
-                return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+                return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
             } else {
                 const auto ess =
                     std::make_shared<op::v15::EmbeddingBagOffsets>(in, indices, offsets, default_index, reduction);
-                return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+                return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
             }
         } else {
             const auto ess = std::make_shared<op::v15::EmbeddingBagOffsets>(in, indices, offsets, reduction);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/embeddingbag_offsetssum.cpp
+++ b/src/plugins/template/tests/functional/op_reference/embeddingbag_offsetssum.cpp
@@ -88,14 +88,14 @@ private:
                                                                                   offsets,
                                                                                   default_index,
                                                                                   per_sample_weights);
-                return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+                return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
             } else {
                 const auto ess = std::make_shared<op::v3::EmbeddingBagOffsetsSum>(in, indices, offsets, default_index);
-                return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+                return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
             }
         } else {
             const auto ess = std::make_shared<op::v3::EmbeddingBagOffsetsSum>(in, indices, offsets);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/embeddingbag_packed.cpp
+++ b/src/plugins/template/tests/functional/op_reference/embeddingbag_packed.cpp
@@ -77,10 +77,10 @@ private:
 
         if (per_sample_weights) {
             const auto ess = std::make_shared<op::v15::EmbeddingBagPacked>(in, indices, per_sample_weights, reduction);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         } else {
             const auto ess = std::make_shared<op::v15::EmbeddingBagPacked>(in, indices, reduction);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/embeddingbag_packedsum.cpp
+++ b/src/plugins/template/tests/functional/op_reference/embeddingbag_packedsum.cpp
@@ -71,10 +71,10 @@ private:
 
         if (per_sample_weights) {
             const auto ess = std::make_shared<op::v3::EmbeddingBagPackedSum>(in, indices, per_sample_weights);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         } else {
             const auto ess = std::make_shared<op::v3::EmbeddingBagPackedSum>(in, indices);
-            return std::make_shared<Model>(NodeVector{ess}, ParameterVector{in});
+            return std::make_shared<Model>(OutputVector{ess}, ParameterVector{in});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/erf.cpp
+++ b/src/plugins/template/tests/functional/op_reference/erf.cpp
@@ -69,7 +69,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto erf = std::make_shared<op::v0::Erf>(in);
-        return std::make_shared<ov::Model>(NodeVector{erf}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{erf}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/exp.cpp
+++ b/src/plugins/template/tests/functional/op_reference/exp.cpp
@@ -56,7 +56,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Exp = std::make_shared<op::v0::Exp>(in);
-        return std::make_shared<ov::Model>(NodeVector{Exp}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Exp}, ParameterVector{in});
     }
 };
 
@@ -84,7 +84,7 @@ private:
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Exp = std::make_shared<op::v0::Exp>(in);
         const auto ExpInPlace = std::make_shared<op::v0::Exp>(Exp);
-        return std::make_shared<ov::Model>(NodeVector{ExpInPlace}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{ExpInPlace}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/experimental_detectron_detection_prior_grid.cpp
+++ b/src/plugins/template/tests/functional/op_reference/experimental_detectron_detection_prior_grid.cpp
@@ -117,7 +117,7 @@ private:
                                                                                                        featureMap,
                                                                                                        im_info,
                                                                                                        params.attrs);
-        return std::make_shared<Model>(NodeVector{ExperimentalPGG}, ParameterVector{priors, featureMap, im_info});
+        return std::make_shared<Model>(OutputVector{ExperimentalPGG}, ParameterVector{priors, featureMap, im_info});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/eye.cpp
+++ b/src/plugins/template/tests/functional/op_reference/eye.cpp
@@ -100,7 +100,7 @@ private:
             std::make_shared<op::v0::Parameter>(diagonal_index.type,
                                                 set_dynamic_shape ? PartialShape::dynamic() : diagonal_index.shape);
         const auto Eye = std::make_shared<op::v9::Eye>(in1, in2, in3, output_type);
-        return std::make_shared<Model>(NodeVector{Eye}, ParameterVector{in1, in2, in3});
+        return std::make_shared<Model>(OutputVector{Eye}, ParameterVector{in1, in2, in3});
     }
 };
 
@@ -145,7 +145,7 @@ private:
             std::make_shared<op::v0::Parameter>(batch_shape.type,
                                                 set_dynamic_shape ? PartialShape::dynamic() : batch_shape.shape);
         const auto Eye = std::make_shared<op::v9::Eye>(in1, in2, in3, in4, output_type);
-        return std::make_shared<Model>(NodeVector{Eye}, ParameterVector{in1, in2, in3, in4});
+        return std::make_shared<Model>(OutputVector{Eye}, ParameterVector{in1, in2, in3, in4});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/fake_quantize.cpp
+++ b/src/plugins/template/tests/functional/op_reference/fake_quantize.cpp
@@ -103,13 +103,13 @@ private:
         auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         if (broadcast == op::AutoBroadcastType::NONE) {
             return std::make_shared<Model>(
-                NodeVector{
+                OutputVector{
                     std::make_shared<op::v0::FakeQuantize>(in, input_low, input_high, output_low, output_high, levels)},
                 ParameterVector{in});
 
         } else {
             return std::make_shared<Model>(
-                NodeVector{std::make_shared<
+                OutputVector{std::make_shared<
                     op::v0::FakeQuantize>(in, input_low, input_high, output_low, output_high, levels, broadcast)},
                 ParameterVector{in});
         }

--- a/src/plugins/template/tests/functional/op_reference/floor.cpp
+++ b/src/plugins/template/tests/functional/op_reference/floor.cpp
@@ -56,7 +56,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto floor = std::make_shared<op::v0::Floor>(in);
-        return std::make_shared<Model>(NodeVector{floor}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{floor}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/floor_mod.cpp
+++ b/src/plugins/template/tests/functional/op_reference/floor_mod.cpp
@@ -67,7 +67,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto floormod = std::make_shared<op::v1::FloorMod>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{floormod}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{floormod}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/gather_elements.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gather_elements.cpp
@@ -66,7 +66,7 @@ private:
         const auto indices =
             std::make_shared<op::v0::Parameter>(params.indicesTensor.type, PartialShape{params.indicesTensor.shape});
         const auto gatherElement = std::make_shared<op::v6::GatherElements>(data, indices, params.axis);
-        function = std::make_shared<ov::Model>(NodeVector{gatherElement}, ParameterVector{data, indices});
+        function = std::make_shared<ov::Model>(OutputVector{gatherElement}, ParameterVector{data, indices});
         return function;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/gather_nd.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gather_nd.cpp
@@ -71,7 +71,7 @@ private:
         } else {
             gatherND = std::make_shared<op::v5::GatherND>(data, indices, params.batchDims);
         }
-        function = std::make_shared<ov::Model>(NodeVector{gatherND}, ParameterVector{data, indices});
+        function = std::make_shared<ov::Model>(OutputVector{gatherND}, ParameterVector{data, indices});
         return function;
     }
 };
@@ -247,7 +247,7 @@ private:
         } else {
             gatherND = std::make_shared<op::v8::GatherND>(data, indices, params.batchDims);
         }
-        function = std::make_shared<ov::Model>(NodeVector{gatherND}, ParameterVector{data, indices});
+        function = std::make_shared<ov::Model>(OutputVector{gatherND}, ParameterVector{data, indices});
         return function;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/gelu.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gelu.cpp
@@ -58,7 +58,7 @@ private:
                                                  const op::GeluApproximationMode mode) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Gelu = std::make_shared<op::v0::Gelu>(in);
-        return std::make_shared<ov::Model>(NodeVector{Gelu}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Gelu}, ParameterVector{in});
     }
 };
 
@@ -87,7 +87,7 @@ private:
                                                  const op::GeluApproximationMode mode) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Gelu = std::make_shared<op::v7::Gelu>(in, mode);
-        return std::make_shared<ov::Model>(NodeVector{Gelu}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Gelu}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/grid_sample.cpp
+++ b/src/plugins/template/tests/functional/op_reference/grid_sample.cpp
@@ -50,7 +50,7 @@ private:
         const auto in1 = std::make_shared<op::v0::Parameter>(data.type, data.shape);
         const auto in2 = std::make_shared<op::v0::Parameter>(grid.type, grid.shape);
         const auto grid_sample = std::make_shared<op::v9::GridSample>(in1, in2, attributes);
-        return std::make_shared<Model>(NodeVector{grid_sample}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{grid_sample}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/grn.cpp
+++ b/src/plugins/template/tests/functional/op_reference/grn.cpp
@@ -57,7 +57,7 @@ private:
                                                  const element::Type& input_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto grn = std::make_shared<op::v0::GRN>(in, bias);
-        return std::make_shared<ov::Model>(NodeVector{grn}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{grn}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/group_convolution.cpp
+++ b/src/plugins/template/tests/functional/op_reference/group_convolution.cpp
@@ -90,7 +90,7 @@ private:
                                                                                  params.padEnd,
                                                                                  params.dialations,
                                                                                  auto_pad);
-        return std::make_shared<ov::Model>(NodeVector{GroupConvolution}, ParameterVector{in, filter});
+        return std::make_shared<ov::Model>(OutputVector{GroupConvolution}, ParameterVector{in, filter});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/group_convolution_backprop.cpp
+++ b/src/plugins/template/tests/functional/op_reference/group_convolution_backprop.cpp
@@ -142,7 +142,7 @@ private:
                                                                        params.dialations,
                                                                        auto_pad,
                                                                        params.outPadding);
-            return std::make_shared<ov::Model>(NodeVector{GroupConvolutionBackpropData}, ParameterVector{in, filter});
+            return std::make_shared<ov::Model>(OutputVector{GroupConvolutionBackpropData}, ParameterVector{in, filter});
         } else {
             const auto GroupConvolutionBackpropData =
                 std::make_shared<op::v1::GroupConvolutionBackpropData>(in,
@@ -152,7 +152,7 @@ private:
                                                                        params.padEnd,
                                                                        params.dialations,
                                                                        auto_pad);
-            return std::make_shared<ov::Model>(NodeVector{GroupConvolutionBackpropData}, ParameterVector{in, filter});
+            return std::make_shared<ov::Model>(OutputVector{GroupConvolutionBackpropData}, ParameterVector{in, filter});
         }
     }
 };
@@ -197,7 +197,7 @@ private:
                                                                    params.strides,
                                                                    params.dialations,
                                                                    auto_pad);
-        return std::make_shared<ov::Model>(NodeVector{GroupConvolutionBackpropData}, ParameterVector{in, filter});
+        return std::make_shared<ov::Model>(OutputVector{GroupConvolutionBackpropData}, ParameterVector{in, filter});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/group_normalization.cpp
+++ b/src/plugins/template/tests/functional/op_reference/group_normalization.cpp
@@ -67,7 +67,7 @@ private:
         const auto in_bias = make_shared<op::v0::Parameter>(params.bias_tensor.type, params.bias_tensor.shape);
         const auto group_norm =
             make_shared<op::v12::GroupNormalization>(in_data, in_scale, in_bias, params.num_groups, params.epsilon);
-        return make_shared<Model>(NodeVector{group_norm}, ParameterVector{in_data, in_scale, in_bias});
+        return make_shared<Model>(OutputVector{group_norm}, ParameterVector{in_data, in_scale, in_bias});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/gru_cell.cpp
+++ b/src/plugins/template/tests/functional/op_reference/gru_cell.cpp
@@ -109,7 +109,7 @@ private:
                                                                 clip,
                                                                 params.linearBeforeReset);
 
-        auto function = std::make_shared<Model>(NodeVector{gru_cell}, ParameterVector{X, H_t, W, R, B});
+        auto function = std::make_shared<Model>(OutputVector{gru_cell}, ParameterVector{X, H_t, W, R, B});
         return function;
     }
 };
@@ -147,7 +147,7 @@ private:
                                                                 clip,
                                                                 params.linearBeforeReset);
 
-        auto function = std::make_shared<Model>(NodeVector{gru_cell}, ParameterVector{X, H_t, W, R, B});
+        auto function = std::make_shared<Model>(OutputVector{gru_cell}, ParameterVector{X, H_t, W, R, B});
         return function;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/hard_sigmoid.cpp
+++ b/src/plugins/template/tests/functional/op_reference/hard_sigmoid.cpp
@@ -71,7 +71,7 @@ private:
         const auto alpha = ov::op::v0::Constant::create(input_type, Shape{}, {alphaData});
         const auto beta = ov::op::v0::Constant::create(input_type, Shape{}, {betaData});
         const auto HardSigmoid = std::make_shared<op::v0::HardSigmoid>(in, alpha, beta);
-        return std::make_shared<ov::Model>(NodeVector{HardSigmoid}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{HardSigmoid}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/hsigmoid.cpp
+++ b/src/plugins/template/tests/functional/op_reference/hsigmoid.cpp
@@ -54,7 +54,7 @@ private:
                                                  const element::Type& HSigmoidected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto HSigmoid = std::make_shared<op::v5::HSigmoid>(in);
-        return std::make_shared<ov::Model>(NodeVector{HSigmoid}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{HSigmoid}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/hswish.cpp
+++ b/src/plugins/template/tests/functional/op_reference/hswish.cpp
@@ -54,7 +54,7 @@ private:
                                                  const element::Type& HSwishected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto HSwish = std::make_shared<op::v4::HSwish>(in);
-        return std::make_shared<ov::Model>(NodeVector{HSwish}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{HSwish}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/interpolate.cpp
+++ b/src/plugins/template/tests/functional/op_reference/interpolate.cpp
@@ -113,7 +113,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const InterpolateV1Params& params) {
         const auto input = std::make_shared<op::v0::Parameter>(params.inType, params.inShape);
         const auto interpolate = std::make_shared<op::v0::Interpolate>(input, params.outShapeInput, params.attrs);
-        return std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{input});
+        return std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{input});
     }
 };
 
@@ -144,7 +144,7 @@ private:
         const auto node_scales = op::v0::Constant::create(element::Type_t::f32, {params.scales.size()}, params.scales);
         auto interpolate =
             std::make_shared<op::v4::Interpolate>(node_input, node_output_shape_input, node_scales, params.attrs);
-        return std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{node_input});
+        return std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{node_input});
     }
 };
 
@@ -779,7 +779,7 @@ private:
         auto axes = op::v0::Constant::create<int64_t>(element::i64, Shape{axes_data.size()}, axes_data);
         auto interpolate =
             std::make_shared<op::v4::Interpolate>(image, target_spatial_shape, scales, axes, param.attrs);
-        return std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{image});
+        return std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{image});
     }
 };
 
@@ -1609,10 +1609,10 @@ private:
         if (!axes_data.empty()) {
             auto axes = op::v0::Constant::create<int64_t>(element::i64, Shape{axes_data.size()}, axes_data);
             auto interpolate = std::make_shared<op::v11::Interpolate>(image, sizes_or_scales, axes, param.attrs);
-            return std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{image});
+            return std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{image});
         }
         auto interpolate = std::make_shared<op::v11::Interpolate>(image, sizes_or_scales, param.attrs);
-        return std::make_shared<Model>(NodeVector{interpolate}, ParameterVector{image});
+        return std::make_shared<Model>(OutputVector{interpolate}, ParameterVector{image});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/is_finite.cpp
+++ b/src/plugins/template/tests/functional/op_reference/is_finite.cpp
@@ -57,7 +57,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto is_finite = std::make_shared<op::v10::IsFinite>(in);
-        return std::make_shared<Model>(NodeVector{is_finite}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{is_finite}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/is_inf.cpp
+++ b/src/plugins/template/tests/functional/op_reference/is_inf.cpp
@@ -67,7 +67,7 @@ private:
                                                  op::v10::IsInf::Attributes attrs) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto is_inf = std::make_shared<op::v10::IsInf>(in, attrs);
-        return std::make_shared<Model>(NodeVector{is_inf}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{is_inf}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/is_nan.cpp
+++ b/src/plugins/template/tests/functional/op_reference/is_nan.cpp
@@ -57,7 +57,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto is_nan = std::make_shared<op::v10::IsNaN>(in);
-        return std::make_shared<Model>(NodeVector{is_nan}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{is_nan}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/log.cpp
+++ b/src/plugins/template/tests/functional/op_reference/log.cpp
@@ -56,7 +56,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto log = std::make_shared<op::v0::Log>(in);
-        return std::make_shared<Model>(NodeVector{log}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{log}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/log_softmax.cpp
+++ b/src/plugins/template/tests/functional/op_reference/log_softmax.cpp
@@ -60,7 +60,7 @@ private:
                                                  const int64_t axis) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto LogSoftmax = std::make_shared<op::v5::LogSoftmax>(in, axis);
-        return std::make_shared<ov::Model>(NodeVector{LogSoftmax}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{LogSoftmax}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/logical.hpp
+++ b/src/plugins/template/tests/functional/op_reference/logical.hpp
@@ -82,7 +82,7 @@ private:
             throw std::runtime_error("Incorrect type of Logical operation");
         }
         }
-        return std::make_shared<ov::Model>(ov::NodeVector{logical_op}, ov::ParameterVector{params_vec});
+        return std::make_shared<ov::Model>(ov::OutputVector{logical_op}, ov::ParameterVector{params_vec});
     }
 };
 }  // namespace LogicalOpsRefTestDefinitions

--- a/src/plugins/template/tests/functional/op_reference/maximum.cpp
+++ b/src/plugins/template/tests/functional/op_reference/maximum.cpp
@@ -66,7 +66,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto maximum = std::make_shared<op::v1::Maximum>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{maximum}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{maximum}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/mish.cpp
+++ b/src/plugins/template/tests/functional/op_reference/mish.cpp
@@ -61,7 +61,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const PartialShape& input_shape, const element::Type& input_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Mish = std::make_shared<op::v4::Mish>(in);
-        return std::make_shared<Model>(NodeVector{Mish}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{Mish}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/mod.cpp
+++ b/src/plugins/template/tests/functional/op_reference/mod.cpp
@@ -67,7 +67,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto mod = std::make_shared<op::v1::Mod>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{mod}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{mod}, ParameterVector{in1, in2});
     }
 };
 
@@ -100,7 +100,7 @@ private:
         auto mod = std::make_shared<op::v1::Mod>(in1, in2);
         mod = std::make_shared<op::v1::Mod>(mod, mod);
 
-        return std::make_shared<Model>(NodeVector{mod}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{mod}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/multiply.cpp
+++ b/src/plugins/template/tests/functional/op_reference/multiply.cpp
@@ -67,7 +67,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto multiply = std::make_shared<op::v1::Multiply>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{multiply}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{multiply}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/mvn.cpp
+++ b/src/plugins/template/tests/functional/op_reference/mvn.cpp
@@ -74,7 +74,7 @@ private:
         if (!reductionAxes.empty()) {
             mvn = std::make_shared<op::v0::MVN>(in, reductionAxes, normalizeVariance, eps);
         }
-        return std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{in});
     }
 };
 
@@ -235,7 +235,7 @@ private:
         }
         const auto axes = std::make_shared<op::v0::Constant>(reductionAxes.type, reductionAxes.shape, dataVector);
         auto mvn = std::make_shared<op::v6::MVN>(in, axes, normalizeVariance, static_cast<float>(eps), epsMode);
-        return std::make_shared<ov::Model>(NodeVector{mvn}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{mvn}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/negative.cpp
+++ b/src/plugins/template/tests/functional/op_reference/negative.cpp
@@ -56,7 +56,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto negative = std::make_shared<op::v0::Negative>(in);
-        return std::make_shared<Model>(NodeVector{negative}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{negative}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/nonzero.cpp
+++ b/src/plugins/template/tests/functional/op_reference/nonzero.cpp
@@ -72,7 +72,7 @@ private:
                                                  const element::Type& output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto NonZero = std::make_shared<op::v3::NonZero>(in, output_type);
-        return std::make_shared<Model>(NodeVector{NonZero}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{NonZero}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/power.cpp
+++ b/src/plugins/template/tests/functional/op_reference/power.cpp
@@ -67,7 +67,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto power = std::make_shared<op::v1::Power>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{power}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{power}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/prelu.cpp
+++ b/src/plugins/template/tests/functional/op_reference/prelu.cpp
@@ -71,7 +71,7 @@ private:
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto SLOPE = std::make_shared<op::v0::Parameter>(input_type, slope_shape);
         const auto Prelu = std::make_shared<op::v0::PRelu>(in, SLOPE);
-        return std::make_shared<ov::Model>(NodeVector{Prelu}, ParameterVector{in, SLOPE});
+        return std::make_shared<ov::Model>(OutputVector{Prelu}, ParameterVector{in, SLOPE});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/prior_box.cpp
+++ b/src/plugins/template/tests/functional/op_reference/prior_box.cpp
@@ -102,7 +102,7 @@ private:
         const auto LS = std::make_shared<op::v0::Constant>(params.layerShapeData);
         const auto IS = std::make_shared<op::v0::Constant>(params.imageShapeData);
         const auto PriorBox = std::make_shared<op::v0::PriorBox>(LS, IS, params.attrs);
-        return std::make_shared<ov::Model>(NodeVector{PriorBox}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{PriorBox}, ParameterVector{});
     }
 };
 
@@ -129,7 +129,7 @@ private:
         const auto LS = std::make_shared<op::v0::Constant>(params.layerShapeData);
         const auto IS = std::make_shared<op::v0::Constant>(params.imageShapeData);
         const auto PriorBoxV8 = std::make_shared<op::v8::PriorBox>(LS, IS, params.attrs);
-        return std::make_shared<ov::Model>(NodeVector{PriorBoxV8}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{PriorBoxV8}, ParameterVector{});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/prior_box_clustered.cpp
+++ b/src/plugins/template/tests/functional/op_reference/prior_box_clustered.cpp
@@ -73,7 +73,7 @@ private:
         auto LS = std::make_shared<op::v0::Constant>(params.layerShapeData);
         auto IS = std::make_shared<op::v0::Constant>(params.imageShapeData);
         const auto PriorBoxClustered = std::make_shared<op::v0::PriorBoxClustered>(LS, IS, params.attrs);
-        return std::make_shared<ov::Model>(NodeVector{PriorBoxClustered}, ParameterVector{});
+        return std::make_shared<ov::Model>(OutputVector{PriorBoxClustered}, ParameterVector{});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/proposal.cpp
+++ b/src/plugins/template/tests/functional/op_reference/proposal.cpp
@@ -175,7 +175,7 @@ private:
         const auto image_shape_param = std::make_shared<op::v0::Parameter>(params.inType, params.imageShapeShape);
         const auto Proposal =
             std::make_shared<op::v0::Proposal>(class_probs_param, bbox_deltas_param, image_shape_param, params.attrs);
-        return std::make_shared<ov::Model>(NodeVector{Proposal},
+        return std::make_shared<ov::Model>(OutputVector{Proposal},
                                            ParameterVector{class_probs_param, bbox_deltas_param, image_shape_param});
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/psroi_pooling.cpp
+++ b/src/plugins/template/tests/functional/op_reference/psroi_pooling.cpp
@@ -107,7 +107,7 @@ private:
                                                                          static_cast<int>(params.spatialBinsX),
                                                                          static_cast<int>(params.spatialBinsY),
                                                                          params.mode);
-        return std::make_shared<ov::Model>(NodeVector{PSROIPooling}, ParameterVector{image, coords});
+        return std::make_shared<ov::Model>(OutputVector{PSROIPooling}, ParameterVector{image, coords});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/range.cpp
+++ b/src/plugins/template/tests/functional/op_reference/range.cpp
@@ -69,7 +69,7 @@ private:
         auto stop = std::make_shared<op::v0::Constant>(ntype, Shape{}, fstop);
         auto step = std::make_shared<op::v0::Constant>(ntype, Shape{}, fstep);
         auto range = std::make_shared<op::v0::Range>(start, stop, step);
-        return std::make_shared<Model>(NodeVector{range}, ParameterVector{});
+        return std::make_shared<Model>(OutputVector{range}, ParameterVector{});
     }
 };
 
@@ -102,7 +102,7 @@ private:
         auto stop = std::make_shared<op::v0::Constant>(ntype, Shape{}, fstop);
         auto step = std::make_shared<op::v0::Constant>(ntype, Shape{}, fstep);
         auto range = std::make_shared<op::v4::Range>(start, stop, step, otype);
-        return std::make_shared<Model>(NodeVector{range}, ParameterVector{});
+        return std::make_shared<Model>(OutputVector{range}, ParameterVector{});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/region_yolo.cpp
+++ b/src/plugins/template/tests/functional/op_reference/region_yolo.cpp
@@ -110,7 +110,7 @@ private:
                                                                      params.mask,
                                                                      params.axis,
                                                                      params.end_axis);
-        return std::make_shared<ov::Model>(NodeVector{RegionYolo}, ParameterVector{p});
+        return std::make_shared<ov::Model>(OutputVector{RegionYolo}, ParameterVector{p});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/relu.cpp
+++ b/src/plugins/template/tests/functional/op_reference/relu.cpp
@@ -54,7 +54,7 @@ private:
                                                  const element::Type& Reluected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Relu = std::make_shared<op::v0::Relu>(in);
-        return std::make_shared<ov::Model>(NodeVector{Relu}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Relu}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/reorg_yolo.cpp
+++ b/src/plugins/template/tests/functional/op_reference/reorg_yolo.cpp
@@ -74,7 +74,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const ReorgYoloParams& params) {
         const auto p = std::make_shared<op::v0::Parameter>(params.inType, params.inputShape);
         const auto ReorgYolo = std::make_shared<op::v0::ReorgYolo>(p, params.stride);
-        return std::make_shared<ov::Model>(NodeVector{ReorgYolo}, ParameterVector{p});
+        return std::make_shared<ov::Model>(OutputVector{ReorgYolo}, ParameterVector{p});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/reshape.cpp
+++ b/src/plugins/template/tests/functional/op_reference/reshape.cpp
@@ -136,7 +136,7 @@ private:
             in,
             op::v0::Constant::create(element::Type_t::u64, {expected_shape.size()}, expected_shape),
             zero_flag);
-        return std::make_shared<Model>(NodeVector{reshape}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{reshape}, ParameterVector{in});
     }
 };
 
@@ -189,7 +189,7 @@ private:
             reshape2,
             op::v0::Constant::create(element::Type_t::u64, {expected_shape.size()}, expected_shape),
             zero_flag);
-        return std::make_shared<Model>(NodeVector{reshape3}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{reshape3}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/reverse.cpp
+++ b/src/plugins/template/tests/functional/op_reference/reverse.cpp
@@ -66,7 +66,7 @@ private:
                                                                  params.constantTensor.shape,
                                                                  params.constantTensor.data.data());
         const auto reverse = std::make_shared<op::v1::Reverse>(data, constant, params.reverseMode);
-        return std::make_shared<ov::Model>(NodeVector{reverse}, ParameterVector{data});
+        return std::make_shared<ov::Model>(OutputVector{reverse}, ParameterVector{data});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/reverse_sequence.cpp
+++ b/src/plugins/template/tests/functional/op_reference/reverse_sequence.cpp
@@ -57,7 +57,7 @@ private:
             std::make_shared<op::v0::Parameter>(params.mSeqLengthsTensor.type, params.mSeqLengthsTensor.shape);
         const auto reverseSequence =
             std::make_shared<op::v0::ReverseSequence>(data, seqLengths, params.mBatchAxis, params.mSeqAxis);
-        return std::make_shared<ov::Model>(NodeVector{reverseSequence}, ParameterVector{data, seqLengths});
+        return std::make_shared<ov::Model>(OutputVector{reverseSequence}, ParameterVector{data, seqLengths});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/rms_internal.cpp
+++ b/src/plugins/template/tests/functional/op_reference/rms_internal.cpp
@@ -77,11 +77,11 @@ private:
         if (!scale.data) {
             const auto scale_const = std::make_shared<op::v0::Constant>(input.type, input.shape, 1.0);
             const auto rms_norm = std::make_shared<op::internal::RMS>(in, scale_const, eps, output_type);
-            return std::make_shared<ov::Model>(NodeVector{rms_norm}, ParameterVector{in});
+            return std::make_shared<ov::Model>(OutputVector{rms_norm}, ParameterVector{in});
         }
         const auto scale_param = std::make_shared<op::v0::Parameter>(scale.type, scale.shape);
         const auto rms_norm = std::make_shared<op::internal::RMS>(in, scale_param, eps, output_type);
-        return std::make_shared<ov::Model>(NodeVector{rms_norm}, ParameterVector{in, scale_param});
+        return std::make_shared<ov::Model>(OutputVector{rms_norm}, ParameterVector{in, scale_param});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/rms_norm.cpp
+++ b/src/plugins/template/tests/functional/op_reference/rms_norm.cpp
@@ -75,11 +75,11 @@ private:
 
         if (!scale.data) {
             const auto rms_norm = std::make_shared<op::internal::RMSNorm>(in, axes, eps);
-            return std::make_shared<ov::Model>(NodeVector{rms_norm}, ParameterVector{in, axes});
+            return std::make_shared<ov::Model>(OutputVector{rms_norm}, ParameterVector{in, axes});
         }
         const auto scale_param = std::make_shared<op::v0::Parameter>(scale.type, scale.shape);
         const auto rms_norm = std::make_shared<op::internal::RMSNorm>(in, axes, scale_param, eps);
-        return std::make_shared<ov::Model>(NodeVector{rms_norm}, ParameterVector{in, axes, scale_param});
+        return std::make_shared<ov::Model>(OutputVector{rms_norm}, ParameterVector{in, axes, scale_param});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/rnn_cell.cpp
+++ b/src/plugins/template/tests/functional/op_reference/rnn_cell.cpp
@@ -88,7 +88,7 @@ private:
         const auto B = std::make_shared<op::v0::Parameter>(params.B.type, params.B.shape);
 
         const auto rnn_cell = std::make_shared<op::v0::RNNCell>(X, H_t, W, R, B, params.hiddenSize);
-        auto function = std::make_shared<Model>(NodeVector{rnn_cell}, ParameterVector{X, H_t, W, R, B});
+        auto function = std::make_shared<Model>(OutputVector{rnn_cell}, ParameterVector{X, H_t, W, R, B});
         return function;
     }
 };
@@ -114,7 +114,7 @@ private:
                                                                 std::vector<float>{},
                                                                 std::vector<float>{},
                                                                 clip);
-        auto function = std::make_shared<Model>(NodeVector{rnn_cell}, ParameterVector{X, H_t, W, R, B});
+        auto function = std::make_shared<Model>(OutputVector{rnn_cell}, ParameterVector{X, H_t, W, R, B});
         return function;
     }
 };
@@ -148,7 +148,7 @@ private:
                                                                 std::vector<float>{},
                                                                 std::vector<float>{},
                                                                 clip);
-        auto function = std::make_shared<Model>(NodeVector{rnn_cell}, ParameterVector{X, H_t, W, R, B});
+        auto function = std::make_shared<Model>(OutputVector{rnn_cell}, ParameterVector{X, H_t, W, R, B});
         return function;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/roi_align.cpp
+++ b/src/plugins/template/tests/functional/op_reference/roi_align.cpp
@@ -145,7 +145,7 @@ private:
                                                                   params.poolingRatio,
                                                                   params.spatialScale,
                                                                   params.poolingMode);
-        auto f = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{featureMap});
+        auto f = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{featureMap});
         return f;
     }
 };
@@ -200,7 +200,7 @@ private:
                                                                   params.spatialScale,
                                                                   pooling_mode,
                                                                   aligned_mode);
-        auto f = std::make_shared<Model>(NodeVector{roi_align}, ParameterVector{featureMap});
+        auto f = std::make_shared<Model>(OutputVector{roi_align}, ParameterVector{featureMap});
         return f;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/roi_align_rotated.cpp
+++ b/src/plugins/template/tests/functional/op_reference/roi_align_rotated.cpp
@@ -110,7 +110,7 @@ private:
                                                                               params.samplingRatio,
                                                                               params.spatialScale,
                                                                               params.clockwise);
-        return std::make_shared<Model>(NodeVector{roi_align_rot}, ParameterVector{featureMap});
+        return std::make_shared<Model>(OutputVector{roi_align_rot}, ParameterVector{featureMap});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/roll.cpp
+++ b/src/plugins/template/tests/functional/op_reference/roll.cpp
@@ -71,7 +71,7 @@ private:
                                                              params.axesTensor.shape,
                                                              params.axesTensor.data.data());
         const auto roll = std::make_shared<op::v7::Roll>(data, shift, axes);
-        return std::make_shared<Model>(NodeVector{roll}, ParameterVector{data});
+        return std::make_shared<Model>(OutputVector{roll}, ParameterVector{data});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/round.cpp
+++ b/src/plugins/template/tests/functional/op_reference/round.cpp
@@ -55,7 +55,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto round = std::make_shared<op::v5::Round>(in, op::v5::Round::RoundMode::HALF_TO_EVEN);
-        return std::make_shared<Model>(NodeVector{round}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{round}, ParameterVector{in});
     }
 };
 
@@ -82,7 +82,7 @@ private:
                                                  const element::Type& expected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto round = std::make_shared<op::v5::Round>(in, op::v5::Round::RoundMode::HALF_AWAY_FROM_ZERO);
-        return std::make_shared<Model>(NodeVector{round}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{round}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/scatter_elements_update.cpp
+++ b/src/plugins/template/tests/functional/op_reference/scatter_elements_update.cpp
@@ -69,7 +69,7 @@ private:
         const auto C = std::make_shared<op::v0::Parameter>(params.updates.type, params.updates.shape);
         const auto D = std::make_shared<op::v0::Parameter>(params.axis.type, params.axis.shape);
         auto scatterElts = std::make_shared<op::v3::ScatterElementsUpdate>(A, B, C, D);
-        return std::make_shared<ov::Model>(NodeVector{scatterElts}, ParameterVector{A, B, C, D});
+        return std::make_shared<ov::Model>(OutputVector{scatterElts}, ParameterVector{A, B, C, D});
     }
 };
 
@@ -112,7 +112,7 @@ private:
                                                                            axis,
                                                                            params.reduction,
                                                                            params.use_init_value);
-        return std::make_shared<ov::Model>(NodeVector{scatter_eu}, ParameterVector{data, indices, updates, axis});
+        return std::make_shared<ov::Model>(OutputVector{scatter_eu}, ParameterVector{data, indices, updates, axis});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/scatter_nd_update.cpp
+++ b/src/plugins/template/tests/functional/op_reference/scatter_nd_update.cpp
@@ -88,7 +88,7 @@ private:
                                                                 params.updateTensor.shape,
                                                                 params.updateTensor.data.data());
         const auto scatter = std::make_shared<op::v3::ScatterNDUpdate>(data, indices, updates);
-        return std::make_shared<ov::Model>(NodeVector{scatter}, ParameterVector{data});
+        return std::make_shared<ov::Model>(OutputVector{scatter}, ParameterVector{data});
     }
 };
 
@@ -121,7 +121,7 @@ private:
                                                                 params.updateTensor.shape,
                                                                 params.updateTensor.data.data());
         const auto scatter = std::make_shared<op::v15::ScatterNDUpdate>(data, indices, updates, params.reduction);
-        return std::make_shared<ov::Model>(NodeVector{scatter}, ParameterVector{data});
+        return std::make_shared<ov::Model>(OutputVector{scatter}, ParameterVector{data});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/scatter_update.cpp
+++ b/src/plugins/template/tests/functional/op_reference/scatter_update.cpp
@@ -74,7 +74,7 @@ private:
         const auto updates = std::make_shared<ov::op::v0::Parameter>(numeric_type, updates_shape);
         const auto axis = std::make_shared<ov::op::v0::Parameter>(axis_type, axis_shape);
         const auto scatter_update = std::make_shared<ov::op::v3::ScatterUpdate>(data, indices, updates, axis);
-        return std::make_shared<ov::Model>(ov::NodeVector{scatter_update},
+        return std::make_shared<ov::Model>(ov::OutputVector{scatter_update},
                                            ov::ParameterVector{data, indices, updates, axis});
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/search_sorted.cpp
+++ b/src/plugins/template/tests/functional/op_reference/search_sorted.cpp
@@ -77,7 +77,7 @@ private:
 
         const auto op = std::make_shared<op::v15::SearchSorted>(sorted, values, params.rightMode);
 
-        return std::make_shared<Model>(NodeVector{op}, ParameterVector{sorted, values});
+        return std::make_shared<Model>(OutputVector{op}, ParameterVector{sorted, values});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/segment_max.cpp
+++ b/src/plugins/template/tests/functional/op_reference/segment_max.cpp
@@ -80,7 +80,7 @@ private:
         } else {
             segmentMax = std::make_shared<ov::op::v16::SegmentMax>(data, segmentIds, params.fillMode);
         }
-        return std::make_shared<ov::Model>(ov::NodeVector{segmentMax}, parameters);
+        return std::make_shared<ov::Model>(ov::OutputVector{segmentMax}, parameters);
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/selu.cpp
+++ b/src/plugins/template/tests/functional/op_reference/selu.cpp
@@ -77,7 +77,7 @@ private:
         const auto alpha = std::make_shared<op::v0::Parameter>(params.inType, params.alphaShape);
         const auto lambda = std::make_shared<op::v0::Parameter>(params.inType, params.lambdaShape);
         const auto Selu = std::make_shared<op::v0::Selu>(in, alpha, lambda);
-        return std::make_shared<ov::Model>(NodeVector{Selu}, ParameterVector{in, alpha, lambda});
+        return std::make_shared<ov::Model>(OutputVector{Selu}, ParameterVector{in, alpha, lambda});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/shape_of.cpp
+++ b/src/plugins/template/tests/functional/op_reference/shape_of.cpp
@@ -91,7 +91,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const element::Type& input_type, const Shape& input_shape) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto shapeof = std::make_shared<op::v0::ShapeOf>(in);
-        return std::make_shared<Model>(NodeVector{shapeof}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{shapeof}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/shuffle_channels.cpp
+++ b/src/plugins/template/tests/functional/op_reference/shuffle_channels.cpp
@@ -63,7 +63,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const ShuffleChannelsParams& params) {
         const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, params.dataTensor.shape);
         const auto function = std::make_shared<op::v0::ShuffleChannels>(data, params.axis, params.group);
-        return std::make_shared<Model>(NodeVector{function}, ParameterVector{data});
+        return std::make_shared<Model>(OutputVector{function}, ParameterVector{data});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/sigmoid.cpp
+++ b/src/plugins/template/tests/functional/op_reference/sigmoid.cpp
@@ -54,7 +54,7 @@ private:
                                                  const element::Type& Sigmoidected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Sigmoid = std::make_shared<op::v0::Sigmoid>(in);
-        return std::make_shared<ov::Model>(NodeVector{Sigmoid}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Sigmoid}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/sign.cpp
+++ b/src/plugins/template/tests/functional/op_reference/sign.cpp
@@ -51,7 +51,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const PartialShape& input_shape, const element::Type& input_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto sign = std::make_shared<op::v0::Sign>(in);
-        return std::make_shared<ov::Model>(NodeVector{sign}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{sign}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/sin.cpp
+++ b/src/plugins/template/tests/functional/op_reference/sin.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Sin = std::make_shared<op::v0::Sin>(in);
-        return std::make_shared<ov::Model>(NodeVector{Sin}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Sin}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/sinh.cpp
+++ b/src/plugins/template/tests/functional/op_reference/sinh.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Sinh = std::make_shared<op::v0::Sinh>(in);
-        return std::make_shared<ov::Model>(NodeVector{Sinh}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Sinh}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/slice.cpp
+++ b/src/plugins/template/tests/functional/op_reference/slice.cpp
@@ -112,7 +112,7 @@ private:
         const auto axes_param = std::make_shared<op::v0::Parameter>(axes.type, axes.shape);
 
         const auto slice = std::make_shared<op::v8::Slice>(data_param, start_param, stop_param, step_param, axes_param);
-        return std::make_shared<Model>(NodeVector{slice},
+        return std::make_shared<Model>(OutputVector{slice},
                                        ParameterVector{data_param, start_param, stop_param, step_param, axes_param});
     }
 
@@ -127,7 +127,7 @@ private:
         const auto step_param = std::make_shared<op::v0::Parameter>(step.type, step.shape);
 
         const auto slice = std::make_shared<op::v8::Slice>(data_param, start_param, stop_param, step_param);
-        return std::make_shared<Model>(NodeVector{slice},
+        return std::make_shared<Model>(OutputVector{slice},
                                        ParameterVector{data_param, start_param, stop_param, step_param});
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/slice_scatter.cpp
+++ b/src/plugins/template/tests/functional/op_reference/slice_scatter.cpp
@@ -136,7 +136,7 @@ private:
                                                                            step_param,
                                                                            axes_param);
         return std::make_shared<Model>(
-            NodeVector{slice_scatter},
+            OutputVector{slice_scatter},
             ParameterVector{data_param, updates_param, start_param, stop_param, step_param, axes_param});
     }
 
@@ -154,7 +154,7 @@ private:
 
         const auto slice_scatter =
             std::make_shared<op::v15::SliceScatter>(data_param, updates_param, start_param, stop_param, step_param);
-        return std::make_shared<Model>(NodeVector{slice_scatter},
+        return std::make_shared<Model>(OutputVector{slice_scatter},
                                        ParameterVector{data_param, updates_param, start_param, stop_param, step_param});
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/softmax.cpp
+++ b/src/plugins/template/tests/functional/op_reference/softmax.cpp
@@ -72,7 +72,7 @@ private:
                                                  const int64_t axis) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto Softmax = std::make_shared<op::v1::Softmax>(in, axis);
-        return std::make_shared<ov::Model>(NodeVector{Softmax}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Softmax}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/softplus.cpp
+++ b/src/plugins/template/tests/functional/op_reference/softplus.cpp
@@ -54,7 +54,7 @@ private:
                                                  const element::Type& SoftPlusected_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto SoftPlus = std::make_shared<op::v4::SoftPlus>(in);
-        return std::make_shared<ov::Model>(NodeVector{SoftPlus}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{SoftPlus}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/softsign.cpp
+++ b/src/plugins/template/tests/functional/op_reference/softsign.cpp
@@ -54,7 +54,7 @@ private:
                                                  const element::Type& SoftSign_output_type) {
         const auto in = std::make_shared<op::v0::Parameter>(input_type, input_shape);
         const auto SoftSign = std::make_shared<op::v9::SoftSign>(in);
-        return std::make_shared<ov::Model>(NodeVector{SoftSign}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{SoftSign}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/space_to_batch.cpp
+++ b/src/plugins/template/tests/functional/op_reference/space_to_batch.cpp
@@ -76,7 +76,7 @@ private:
         const auto padsBegin = std::make_shared<op::v0::Parameter>(element::i64, params.padsBeginTensor.shape);
         const auto padsEnd = std::make_shared<op::v0::Parameter>(element::i64, params.padsEndTensor.shape);
         const auto batchToSpace = std::make_shared<op::v1::SpaceToBatch>(data, blockShape, padsBegin, padsEnd);
-        return std::make_shared<ov::Model>(NodeVector{batchToSpace},
+        return std::make_shared<ov::Model>(OutputVector{batchToSpace},
                                            ParameterVector{data, blockShape, padsBegin, padsEnd});
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/space_to_depth.cpp
+++ b/src/plugins/template/tests/functional/op_reference/space_to_depth.cpp
@@ -62,7 +62,7 @@ private:
                                                        : op::v0::SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST;
         const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, params.dataTensor.shape);
         const auto SpaceToDepth = std::make_shared<op::v0::SpaceToDepth>(data, mode, params.blockSize);
-        return std::make_shared<Model>(NodeVector{SpaceToDepth}, ParameterVector{data});
+        return std::make_shared<Model>(OutputVector{SpaceToDepth}, ParameterVector{data});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/sqrt.cpp
+++ b/src/plugins/template/tests/functional/op_reference/sqrt.cpp
@@ -44,7 +44,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const reference_tests::Tensor& input) {
         const auto in = std::make_shared<op::v0::Parameter>(input.type, input.shape);
         const auto sqrt = std::make_shared<op::v0::Sqrt>(in);
-        return std::make_shared<Model>(NodeVector{sqrt}, ParameterVector{in});
+        return std::make_shared<Model>(OutputVector{sqrt}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/squared_difference.cpp
+++ b/src/plugins/template/tests/functional/op_reference/squared_difference.cpp
@@ -68,7 +68,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto squared_difference = std::make_shared<op::v0::SquaredDifference>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{squared_difference}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{squared_difference}, ParameterVector{in1, in2});
     }
 };
 
@@ -102,7 +102,7 @@ private:
         auto squared_difference = std::make_shared<op::v0::SquaredDifference>(in1, in2);
         squared_difference = std::make_shared<op::v0::SquaredDifference>(squared_difference, squared_difference);
 
-        return std::make_shared<Model>(NodeVector{squared_difference}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{squared_difference}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/strided_slice.cpp
+++ b/src/plugins/template/tests/functional/op_reference/strided_slice.cpp
@@ -151,7 +151,7 @@ private:
                                                                              params.newAxisMask,
                                                                              params.shrinkAxisMask,
                                                                              params.ellipsisMask);
-            function = std::make_shared<ov::Model>(NodeVector{StridedSlice}, ParameterVector{data});
+            function = std::make_shared<ov::Model>(OutputVector{StridedSlice}, ParameterVector{data});
         } else {
             const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, PartialShape::dynamic());
             const auto beginOp = std::make_shared<op::v0::Parameter>(params.beginTensor.type, params.beginTensor.shape);
@@ -167,8 +167,8 @@ private:
                                                                              params.newAxisMask,
                                                                              params.shrinkAxisMask,
                                                                              params.ellipsisMask);
-            function =
-                std::make_shared<ov::Model>(NodeVector{StridedSlice}, ParameterVector{data, beginOp, endOp, stridesOp});
+            function = std::make_shared<ov::Model>(OutputVector{StridedSlice},
+                                                   ParameterVector{data, beginOp, endOp, stridesOp});
         }
         return function;
     }
@@ -227,7 +227,7 @@ private:
                                                                              params.newAxisMask,
                                                                              params.shrinkAxisMask,
                                                                              params.ellipsisMask);
-            function = std::make_shared<ov::Model>(NodeVector{StridedSlice}, ParameterVector{data});
+            function = std::make_shared<ov::Model>(OutputVector{StridedSlice}, ParameterVector{data});
         } else {
             const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, PartialShape::dynamic());
             const auto beginOp = std::make_shared<op::v0::Parameter>(params.beginTensor.type, params.beginTensor.shape);
@@ -240,7 +240,7 @@ private:
                                                                              params.newAxisMask,
                                                                              params.shrinkAxisMask,
                                                                              params.ellipsisMask);
-            function = std::make_shared<ov::Model>(NodeVector{StridedSlice}, ParameterVector{data, beginOp, endOp});
+            function = std::make_shared<ov::Model>(OutputVector{StridedSlice}, ParameterVector{data, beginOp, endOp});
         }
         return function;
     }

--- a/src/plugins/template/tests/functional/op_reference/subtract.cpp
+++ b/src/plugins/template/tests/functional/op_reference/subtract.cpp
@@ -67,7 +67,7 @@ private:
         const auto in2 = std::make_shared<op::v0::Parameter>(input_type, input_shape2);
         const auto subtract = std::make_shared<op::v1::Subtract>(in1, in2);
 
-        return std::make_shared<Model>(NodeVector{subtract}, ParameterVector{in1, in2});
+        return std::make_shared<Model>(OutputVector{subtract}, ParameterVector{in1, in2});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/swish.cpp
+++ b/src/plugins/template/tests/functional/op_reference/swish.cpp
@@ -87,10 +87,10 @@ private:
         if (beta != 1) {
             const auto BETA = std::make_shared<op::v0::Parameter>(input_type, Shape{});
             const auto Swish = std::make_shared<op::v4::Swish>(in, BETA);
-            return std::make_shared<Model>(NodeVector{Swish}, ParameterVector{in, BETA});
+            return std::make_shared<Model>(OutputVector{Swish}, ParameterVector{in, BETA});
         } else {
             const auto Swish = std::make_shared<op::v4::Swish>(in);
-            return std::make_shared<ov::Model>(NodeVector{Swish}, ParameterVector{in});
+            return std::make_shared<ov::Model>(OutputVector{Swish}, ParameterVector{in});
         }
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/tanh.cpp
+++ b/src/plugins/template/tests/functional/op_reference/tanh.cpp
@@ -43,7 +43,7 @@ private:
     static std::shared_ptr<Model> CreateFunction(const Shape& shape, const element::Type& type) {
         const auto in = std::make_shared<op::v0::Parameter>(type, shape);
         const auto Tanh = std::make_shared<op::v0::Tanh>(in);
-        return std::make_shared<ov::Model>(NodeVector{Tanh}, ParameterVector{in});
+        return std::make_shared<ov::Model>(OutputVector{Tanh}, ParameterVector{in});
     }
 };
 

--- a/src/plugins/template/tests/functional/op_reference/tile.cpp
+++ b/src/plugins/template/tests/functional/op_reference/tile.cpp
@@ -62,7 +62,7 @@ private:
         const auto repeats =
             std::make_shared<op::v0::Constant>(params.repeats.type, params.repeats.shape, params.repeats.data.data());
         const auto tile = std::make_shared<op::v0::Tile>(A, repeats);
-        const auto f = std::make_shared<Model>(NodeVector{tile}, ParameterVector{A});
+        const auto f = std::make_shared<Model>(OutputVector{tile}, ParameterVector{A});
         return f;
     }
 };

--- a/src/plugins/template/tests/functional/op_reference/transpose.cpp
+++ b/src/plugins/template/tests/functional/op_reference/transpose.cpp
@@ -74,14 +74,14 @@ private:
                                                                  params.axisTensor.data.data());
             const auto axisI64 = std::make_shared<op::v0::Convert>(axis, element::i64);
             const auto transpose = std::make_shared<op::v1::Transpose>(data, axisI64);
-            function = std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{data});
+            function = std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{data});
         } else {
             const auto data = std::make_shared<op::v0::Parameter>(params.dataTensor.type, PartialShape::dynamic());
             const auto axis =
                 std::make_shared<op::v0::Parameter>(params.axisTensor.type, PartialShape{Dimension::dynamic()});
             const auto axisI64 = std::make_shared<op::v0::Convert>(axis, element::i64);
             const auto transpose = std::make_shared<op::v1::Transpose>(data, axisI64);
-            function = std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{data, axis});
+            function = std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{data, axis});
         }
         return function;
     }

--- a/src/plugins/template/tests/functional/transformations/disable_transformations_test.cpp
+++ b/src/plugins/template/tests/functional/transformations/disable_transformations_test.cpp
@@ -24,13 +24,13 @@ TEST(DisableTransformationsTests, TestTemplatePluginProperty) {
         auto like = ov::op::v0::Constant::create(ov::element::i32, ov::Shape{1}, {1});
         auto cvtlike = std::make_shared<ov::op::v1::ConvertLike>(data, like);
 
-        m = std::make_shared<ov::Model>(ov::NodeVector{cvtlike}, ov::ParameterVector{data});
+        m = std::make_shared<ov::Model>(ov::OutputVector{cvtlike}, ov::ParameterVector{data});
     }
     {
         auto data = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3, 1, 2});
         auto cvt = std::make_shared<ov::op::v0::Convert>(data, ov::element::i32);
 
-        m_ref = std::make_shared<ov::Model>(ov::NodeVector{cvt}, ov::ParameterVector{data});
+        m_ref = std::make_shared<ov::Model>(ov::OutputVector{cvt}, ov::ParameterVector{data});
     }
 
     auto core = ov::test::utils::PluginCache::get().core("TEMPLATE");

--- a/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_infer_request/infer_request_dynamic.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/api_conformance_runner/src/ov_infer_request/infer_request_dynamic.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<ov::Model> ovGetFunction1() {
     auto relu2 = std::make_shared<ov::op::v0::Relu>(add->output(0));
     relu2->get_output_tensor(0).set_names({"relu2"});
 
-    ov::NodeVector results{relu1, relu2};
+    ov::OutputVector results{relu1, relu2};
     return std::make_shared<ov::Model>(results, params, "AddTwoOutputEdges");
 }
 

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/iteration_chaining.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/iteration_chaining.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<ov::Model> OVIterationChaining::getIterativeFunction() {
     eltwise->get_output_tensor(0).set_names({"result_tensor_1"});
     eltwise->set_friendly_name("result_1");
 
-    return std::make_shared<ov::Model>(ov::NodeVector{concat, eltwise}, ov::ParameterVector{params});
+    return std::make_shared<ov::Model>(ov::OutputVector{concat, eltwise}, ov::ParameterVector{params});
 }
 
 void OVIterationChaining::SetUp() {

--- a/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/memory_states.cpp
+++ b/src/tests/functional/plugin/shared/src/behavior/ov_infer_request/memory_states.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<ov::Model> OVInferRequestVariableStateTest::get_network() {
     mem_w2->add_control_dependency(mem_r2);
     sigm->add_control_dependency(mem_w2);
 
-    auto function = std::make_shared<ov::Model>(ov::NodeVector{sigm}, ov::ParameterVector{input}, "add_output");
+    auto function = std::make_shared<ov::Model>(ov::OutputVector{sigm}, ov::ParameterVector{input}, "add_output");
     return function;
 }
 

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/keep_assign.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/keep_assign.cpp
@@ -42,10 +42,7 @@ TEST_P(ExecGraphKeepAssignNode, KeepAssignNode) {
     mem_w->add_control_dependency(mem_r);
     sum->add_control_dependency(mem_w);
 
-    auto model = std::make_shared<ov::Model>(
-        ov::NodeVector      {sum},
-        ov::ParameterVector {input},
-        "SimpleNet");
+    auto model = std::make_shared<ov::Model>(ov::OutputVector{sum}, ov::ParameterVector{input}, "SimpleNet");
 
     // Load into plugin and get exec graph
     auto core  = ov::Core();

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/normalize_l2_decomposition.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/normalize_l2_decomposition.cpp
@@ -31,7 +31,7 @@ TEST_P(ExecGrapDecomposeNormalizeL2, CheckIfDecomposeAppliedForNonContiguousAxes
       const auto axes_const = ov::opset9::Constant::create(ov::element::i64, ov::Shape{2}, {0, 2});
       const auto normalize_l2 = std::make_shared<ov::opset9::NormalizeL2>(input, axes_const, eps_value, ov::op::EpsMode::MAX);
 
-      const auto model = std::make_shared<ov::Model>(ov::NodeVector{normalize_l2}, ov::ParameterVector{input});
+      const auto model = std::make_shared<ov::Model>(ov::OutputVector{normalize_l2}, ov::ParameterVector{input});
 
       auto core = ov::Core();
       ov::AnyMap config;
@@ -51,7 +51,7 @@ TEST_P(ExecGrapDecomposeNormalizeL2, CheckIfDecomposeAppliedForNormalizeOverAllA
       const auto axes_const = ov::opset9::Constant::create(ov::element::i64, ov::Shape{3}, {0, 1, 2});
       const auto normalize_l2 = std::make_shared<ov::opset9::NormalizeL2>(input, axes_const, eps_value, ov::op::EpsMode::MAX);
 
-      const auto model = std::make_shared<ov::Model>(ov::NodeVector{normalize_l2}, ov::ParameterVector{input});
+      const auto model = std::make_shared<ov::Model>(ov::OutputVector{normalize_l2}, ov::ParameterVector{input});
 
       auto core = ov::Core();
       ov::AnyMap config;
@@ -71,7 +71,7 @@ TEST_P(ExecGrapDecomposeNormalizeL2, CheckIfDecomposeNotAppliedForNotSorted) {
       const auto axes_const = ov::opset9::Constant::create(ov::element::i64, ov::Shape{1}, {1});
       const auto normalize_l2 = std::make_shared<ov::opset9::NormalizeL2>(input, axes_const, eps_value, ov::op::EpsMode::ADD);
 
-      const auto model = std::make_shared<ov::Model>(ov::NodeVector{normalize_l2}, ov::ParameterVector{input});
+      const auto model = std::make_shared<ov::Model>(ov::OutputVector{normalize_l2}, ov::ParameterVector{input});
 
       auto core = ov::Core();
       ov::AnyMap config;
@@ -91,7 +91,7 @@ TEST_P(ExecGrapDecomposeNormalizeL2, CheckIfDecomposeNotAppliedForSingleAxis) {
       const auto axes_const = ov::opset9::Constant::create(ov::element::i64, ov::Shape{1}, {1});
       const auto normalize_l2 = std::make_shared<ov::opset9::NormalizeL2>(input, axes_const, eps_value, ov::op::EpsMode::ADD);
 
-      const auto model = std::make_shared<ov::Model>(ov::NodeVector{normalize_l2}, ov::ParameterVector{input});
+      const auto model = std::make_shared<ov::Model>(ov::OutputVector{normalize_l2}, ov::ParameterVector{input});
 
       auto core = ov::Core();
       ov::AnyMap config;

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/remove_parameter.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/remove_parameter.cpp
@@ -45,9 +45,7 @@ TEST_P(ExecGraphRemoveParameterNode, RemoveParameterNode) {
   auto mul = std::make_shared<ov::op::v1::Multiply>(input2, input);
   auto sum = std::make_shared<ov::op::v1::Add>(mul, input);
 
-  auto function = std::make_shared<ov::Model>(
-      ov::NodeVector{sum}, ov::ParameterVector{input2, input},
-      "SimpleNet");
+  auto function = std::make_shared<ov::Model>(ov::OutputVector{sum}, ov::ParameterVector{input2, input}, "SimpleNet");
 
   // Load into plugin and get exec graph
   auto core = ov::Core();

--- a/src/tests/functional/shared_test_classes/src/single_op/fake_convert.cpp
+++ b/src/tests/functional/shared_test_classes/src/single_op/fake_convert.cpp
@@ -75,7 +75,7 @@ void FakeConvertLayerTest::SetUp() {
 
     const auto fake_convert = default_shift ? std::make_shared<opset13::FakeConvert>(data, scale, dst_prec)
                                             : std::make_shared<opset13::FakeConvert>(data, scale, shift, dst_prec);
-    function = std::make_shared<ov::Model>(NodeVector{fake_convert}, ParameterVector{data});
+    function = std::make_shared<ov::Model>(OutputVector{fake_convert}, ParameterVector{data});
 }
 }  // namespace test
 }  // namespace ov

--- a/src/tests/functional/shared_test_classes/src/subgraph/gather_weights_decompression.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/gather_weights_decompression.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<ov::Model> GatherWeightsDecompression::init_subgraph(const ov::S
 
     auto gather = std::make_shared<ov::op::v8::Gather>(data_subgraph, params[0], axis_const, batch_dims);
     gather->set_friendly_name("gather_node");
-    return std::make_shared<ov::Model>(ov::NodeVector{gather}, params, "GatherDataDecompression");
+    return std::make_shared<ov::Model>(ov::OutputVector{gather}, params, "GatherDataDecompression");
 }
 
 void GatherWeightsDecompression::check_results() {
@@ -185,7 +185,9 @@ std::shared_ptr<ov::Model> GatherWeightsDecompressionWithoutScale::init_subgraph
     auto gather = std::make_shared<ov::op::v8::Gather>(convert, params[0], axis_const, batch_dims);
     gather->set_friendly_name("gather_node");
     auto convert_to_output_precision = std::make_shared<ov::op::v0::Convert>(gather, output_precision);
-    return std::make_shared<ov::Model>(ov::NodeVector{convert_to_output_precision}, params, "GatherDataDecompression");
+    return std::make_shared<ov::Model>(ov::OutputVector{convert_to_output_precision},
+                                       params,
+                                       "GatherDataDecompression");
 }
 
 void GatherWeightsDecompressionWithoutScale::SetUp() {

--- a/src/tests/functional/shared_test_classes/src/subgraph/group_normalization_fusion.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/group_normalization_fusion.cpp
@@ -59,7 +59,7 @@ std::shared_ptr<Model> GroupNormalizationFusionTestBase::create_model() {
         std::make_shared<op::v1::Multiply>(post_instance_norm_reshape, group_norm_gamma_const);
     auto group_norm_beta_add = std::make_shared<op::v1::Add>(group_norm_gamma_multiply, group_norm_beta_const);
 
-    return std::make_shared<Model>(NodeVector{group_norm_beta_add}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{group_norm_beta_add}, ParameterVector{input});
 }
 
 std::string GroupNormalizationFusionSubgraphTestsF::getTestCaseName(

--- a/src/tests/functional/shared_test_classes/src/subgraph/rotary_pos_emb.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/rotary_pos_emb.cpp
@@ -41,7 +41,7 @@ std::shared_ptr<ov::Model> RoPETestFlux::build_rope_flux(int batch,
     auto y2 = std::make_shared<ov::op::v1::Multiply>(x3, t_sin);
     auto y = std::make_shared<ov::op::v1::Add>(y1, y2);
 
-    return std::make_shared<ov::Model>(ov::NodeVector{y}, ov::ParameterVector{x, t_cos, t_sin});
+    return std::make_shared<ov::Model>(ov::OutputVector{y}, ov::ParameterVector{x, t_cos, t_sin});
 }
 
 void RoPETestFlux::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
@@ -197,7 +197,7 @@ std::shared_ptr<ov::Model> RoPETestLlama2StridedSlice::buildROPE_Llama2(int batc
         makeOP<ov::op::v1::Multiply>({cat_Concat, unsqueeze_Unsqueeze_447}, {{"auto_broadcast", "numpy"}});
     auto add_Add = makeOP<ov::op::v1::Add>({mul_Multiply, mul_Multiply_463}, {{"auto_broadcast", "numpy"}});
 
-    return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
+    return std::make_shared<ov::Model>(ov::OutputVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
 }
 
 ov::Tensor RoPETestLlama2StridedSlice::create_i32_tensor(const ov::Shape& shape, int start, int step) {
@@ -345,7 +345,7 @@ std::shared_ptr<ov::Model> RoPETestChatGLMStridedSlice::buildROPE_ChatGLM(int ba
                                       {"shrink_axis_mask", {}},
                                       {"ellipsis_mask", {}}});
     auto cat_Concat_425 = makeOP<opset1::Concat>({flatten_Reshape_421, slice_Slice_363}, {{"axis", -1}});
-    return std::make_shared<ov::Model>(ov::NodeVector{cat_Concat_425},
+    return std::make_shared<ov::Model>(ov::OutputVector{cat_Concat_425},
                                        ov::ParameterVector{input, cos_sin_cache, position_ids});
 }
 
@@ -494,7 +494,7 @@ std::shared_ptr<ov::Model> RoPETestQwen7bStridedSlice::buildROPE_QWen7b(bool spe
                                       {"ellipsis_mask", {}}});
     auto mul_Multiply_503 = makeOP<opset1::Multiply>({cat_Concat, slice_Slice_461}, {{"auto_broadcast", "numpy"}});
     auto add_Add = makeOP<opset1::Add>({mul_Multiply, mul_Multiply_503}, {{"auto_broadcast", "numpy"}});
-    return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, ov::ParameterVector{input, cos_cache, sin_cache});
+    return std::make_shared<ov::Model>(ov::OutputVector{add_Add}, ov::ParameterVector{input, cos_cache, sin_cache});
 }
 
 void RoPETestQwen7bStridedSlice::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
@@ -618,7 +618,7 @@ std::shared_ptr<ov::Model> RoPETestGPTJStridedSlice::buildROPE_GPTJ(int num_head
                                           {"ellipsis_mask", {}}});
     auto cat_Concat_1211 = makeOP<opset1::Concat>({rotary_emb, slice_Slice_971}, {{"axis", -1}});
     auto permute_Transpose_1213 = makeOP<opset1::Transpose>({cat_Concat_1211, {0, 2, 1, 3}});
-    ov::NodeVector model_output = {permute_Transpose_1213};
+    ov::OutputVector model_output = {permute_Transpose_1213};
     if (hasShapeOf) {
         auto shapeOf = makeOP<opset1::ShapeOf>({rotary_emb}, {{"output_type", "i32"}});
         auto gather = makeOP<opset8::Gather>({shapeOf, {1}, 0}, {{"batch_dims", 0}});
@@ -768,7 +768,7 @@ std::shared_ptr<ov::Model> RoPETestRotateHalfWithoutTranspose::buildROPE_RotateH
         makeOP<ov::op::v1::Multiply>({cat_Concat, unsqueeze_Unsqueeze_447}, {{"auto_broadcast", "numpy"}});
     auto add_Add = makeOP<ov::op::v1::Add>({mul_Multiply, mul_Multiply_463}, {{"auto_broadcast", "numpy"}});
 
-    return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
+    return std::make_shared<ov::Model>(ov::OutputVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
 }
 
 ov::Tensor RoPETestRotateHalfWithoutTranspose::create_i32_tensor(const ov::Shape& shape, int start, int step) {
@@ -891,7 +891,7 @@ std::shared_ptr<ov::Model> RoPETestLlama2Slice::buildROPE_Llama2(int batch,
         makeOP<ov::op::v1::Multiply>({cat_Concat, unsqueeze_Unsqueeze_447}, {{"auto_broadcast", "numpy"}});
     auto add_Add = makeOP<ov::op::v1::Add>({mul_Multiply, mul_Multiply_463}, {{"auto_broadcast", "numpy"}});
 
-    return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
+    return std::make_shared<ov::Model>(ov::OutputVector{add_Add}, ov::ParameterVector{input, pos_id_end, pos_ids});
 }
 
 void RoPETestChatGLMSlice::SetUp() {
@@ -973,7 +973,7 @@ std::shared_ptr<ov::Model> RoPETestChatGLMSlice::buildROPE_ChatGLM(int batch, in
     auto flatten_Reshape_421 = makeOP<opset1::Reshape>({stack_401, flatten_Concat_420}, {{"special_zero", true}});
     auto slice_Slice_363 = makeOP<opset8::Slice>({view_Reshape, slice_Unsqueeze_112, {INT_MAX}, {1}, {3}});
     auto cat_Concat_425 = makeOP<opset1::Concat>({flatten_Reshape_421, slice_Slice_363}, {{"axis", -1}});
-    return std::make_shared<ov::Model>(ov::NodeVector{cat_Concat_425},
+    return std::make_shared<ov::Model>(ov::OutputVector{cat_Concat_425},
                                        ov::ParameterVector{input, cos_sin_cache, position_ids});
 }
 
@@ -1039,7 +1039,7 @@ std::shared_ptr<ov::Model> RoPETestQwen7bSlice::buildROPE_Qwen7b(bool specialRes
     auto slice_Slice_449 = makeOP<opset8::Slice>({sin_cache, slice_Unsqueeze_422, {LLONG_MAX}, {1}, {1}});
     auto mul_Multiply_503 = makeOP<opset1::Multiply>({cat_Concat, slice_Slice_449}, {{"auto_broadcast", "numpy"}});
     auto add_Add = makeOP<opset1::Add>({mul_Multiply, mul_Multiply_503}, {{"auto_broadcast", "numpy"}});
-    return std::make_shared<ov::Model>(ov::NodeVector{add_Add}, ov::ParameterVector{input, cos_cache, sin_cache});
+    return std::make_shared<ov::Model>(ov::OutputVector{add_Add}, ov::ParameterVector{input, cos_cache, sin_cache});
 }
 
 void RoPETestGPTJSlice::SetUp() {
@@ -1118,7 +1118,7 @@ std::shared_ptr<ov::Model> RoPETestGPTJSlice::buildROPE_GPTJ(int num_head,
     auto slice_Slice_971 = makeOP<ov::op::v8::Slice>({input, {rotary_dims}, {int32_max}, {1}, {3}});
     auto cat_Concat_1211 = makeOP<opset1::Concat>({rotary_emb, slice_Slice_971}, {{"axis", -1}});
     auto permute_Transpose_1213 = makeOP<opset1::Transpose>({cat_Concat_1211, {0, 2, 1, 3}});
-    ov::NodeVector model_output = {permute_Transpose_1213};
+    ov::OutputVector model_output = {permute_Transpose_1213};
     if (hasShapeOf) {
         auto shapeOf = makeOP<opset1::ShapeOf>({rotary_emb}, {{"output_type", "i32"}});
         auto gather = makeOP<opset8::Gather>({shapeOf, {1}, 0}, {{"batch_dims", 0}});
@@ -1199,7 +1199,7 @@ std::shared_ptr<ov::Model> RoPETestChatGLM2DRoPEStridedSlice::buildROPE_ChatGLM(
                                       {"shrink_axis_mask", {}},
                                       {"ellipsis_mask", {}}});
     auto cat_Concat_425 = makeOP<opset1::Concat>({flatten_Reshape_421, slice_Slice_363}, {{"axis", -1}});
-    return std::make_shared<ov::Model>(ov::NodeVector{cat_Concat_425},
+    return std::make_shared<ov::Model>(ov::OutputVector{cat_Concat_425},
                                        ov::ParameterVector{input, cos_sin_cache, position_ids});
 }
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/split_concat_memory.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/split_concat_memory.cpp
@@ -79,9 +79,8 @@ void SplitConcatMemory::SetUp() {
     mem_w->add_control_dependency(mem_r);
     plus->add_control_dependency(mem_w);
 
-    function = std::make_shared<ov::Model>(ov::NodeVector{plus}, ov::ParameterVector{input}, "CyclicBuffer4");
+    function = std::make_shared<ov::Model>(ov::OutputVector{plus}, ov::ParameterVector{input}, "CyclicBuffer4");
 }
 
 }  // namespace test
 }  // namespace ov
-

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_convert.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_convert.cpp
@@ -20,12 +20,12 @@ std::shared_ptr<ov::Node> createRollAsStub(const std::shared_ptr<ov::Node>& pare
 std::shared_ptr<ov::Model> ConvertFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inType, input_shapes[0]);
     auto convert = std::make_shared<op::v0::Convert>(data0, outType);
-    return std::make_shared<ov::Model>(NodeVector{convert}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{convert}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ConvertFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inType, input_shapes[0]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0});
 }
 
 std::shared_ptr<ov::Model> ConvertInputFunction::initOriginal() const {
@@ -33,13 +33,13 @@ std::shared_ptr<ov::Model> ConvertInputFunction::initOriginal() const {
     auto data1 = std::make_shared<op::v0::Parameter>(outType, input_shapes[1]);
     auto convert = std::make_shared<op::v0::Convert>(data0, outType);
     auto add = std::make_shared<op::v1::Add>(convert, data1);
-    return std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> ConvertInputFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inType, input_shapes[0]);
     auto data1 = std::make_shared<op::v0::Parameter>(outType, input_shapes[1]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> ConvertOutputFunction::initOriginal() const {
@@ -47,13 +47,13 @@ std::shared_ptr<ov::Model> ConvertOutputFunction::initOriginal() const {
     auto data1 = std::make_shared<op::v0::Parameter>(inType, input_shapes[1]);
     auto add = std::make_shared<op::v1::Add>(data0, data1);
     auto convert = std::make_shared<op::v0::Convert>(add, outType);
-    return std::make_shared<ov::Model>(NodeVector{convert}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{convert}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> ConvertOutputFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inType, input_shapes[0]);
     auto data1 = std::make_shared<op::v0::Parameter>(inType, input_shapes[1]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> ConvertStubFunction::initOriginal() const {
@@ -62,13 +62,13 @@ std::shared_ptr<ov::Model> ConvertStubFunction::initOriginal() const {
     auto add = std::make_shared<op::v1::Add>(data0, data1);
     auto convert = std::make_shared<op::v0::Convert>(add, outType);
     auto relu = std::make_shared<op::v0::Relu>(convert);
-    return std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> ConvertStubFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inType, input_shapes[0]);
     auto data1 = std::make_shared<op::v0::Parameter>(inType, input_shapes[1]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> ConvertPartialInputsAndResultsFunction::initOriginal() const {
@@ -82,7 +82,7 @@ std::shared_ptr<ov::Model> ConvertPartialInputsAndResultsFunction::initOriginal(
     auto sub = std::make_shared<op::v1::Subtract>(relu, data2);
     auto stub3 = createRollAsStub(sub);
     auto convert2 = std::make_shared<op::v0::Convert>(relu, outTypes[1]);
-    return std::make_shared<ov::Model>(NodeVector{convert2, stub3}, ParameterVector{data0, data1, data2});
+    return std::make_shared<ov::Model>(OutputVector{convert2, stub3}, ParameterVector{data0, data1, data2});
 }
 std::shared_ptr<ov::Model> ConvertPartialInputsAndResultsFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inTypes[0], input_shapes[0]);
@@ -98,7 +98,8 @@ std::shared_ptr<ov::Model> ConvertPartialInputsAndResultsFunction::initReference
     auto sub = std::make_shared<op::v1::Subtract>(relu, indata2);
     auto convert2 = std::make_shared<op::v0::Convert>(relu, outTypes[1]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
-            NodeVector{data0, data1, data2}, std::make_shared<ov::Model>(NodeVector{sub, convert2}, ParameterVector{indata0, indata1, indata2}));
+        NodeVector{data0, data1, data2},
+        std::make_shared<ov::Model>(OutputVector{sub, convert2}, ParameterVector{indata0, indata1, indata2}));
     auto stub3 = createRollAsStub(subgraph);
     return std::make_shared<ov::Model>(OutputVector{subgraph->output(1), stub3->output(0)},
                                        ParameterVector{data0, data1, data2});
@@ -112,12 +113,12 @@ std::shared_ptr<ov::Model> ConvertManyOnInputsFunction::initOriginal() const {
         out = convert;
     }
     auto relu = std::make_shared<op::v0::Relu>(out);
-    return std::make_shared<ov::Model>(NodeVector{relu}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ConvertManyOnInputsFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(types[0], input_shapes[0]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0});
 }
 
 std::shared_ptr<ov::Model> ConvertManyOnOutputsFunction::initOriginal() const {
@@ -128,12 +129,12 @@ std::shared_ptr<ov::Model> ConvertManyOnOutputsFunction::initOriginal() const {
         auto convert = std::make_shared<op::v0::Convert>(out, types[i]);
         out = convert;
     }
-    return std::make_shared<ov::Model>(NodeVector{out}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{out}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ConvertManyOnOutputsFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(types[0], input_shapes[0]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0});
 }
 
 std::shared_ptr<ov::Model> ConvertManyOnInputOutputFunction::initOriginal() const {
@@ -149,12 +150,12 @@ std::shared_ptr<ov::Model> ConvertManyOnInputOutputFunction::initOriginal() cons
         auto convert = std::make_shared<op::v0::Convert>(out, outTypes[i]);
         out = convert;
     }
-    return std::make_shared<ov::Model>(NodeVector{out}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{out}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ConvertManyOnInputOutputFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(inTypes[0], input_shapes[0]);
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data0});
 }
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_customizable.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_customizable.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<ov::Model> ConvMulActivationFunction::initOriginal() const {
     auto eltwise_unary_1 = custom_ops[1]->clone_with_new_inputs({eltwise_binary->output(0)});
     auto eltwise_unary_2 = custom_ops[2]->clone_with_new_inputs({eltwise_unary_1->output(0)});
 
-    return std::make_shared<ov::Model>(NodeVector{eltwise_unary_2}, ParameterVector{conv_param, eltwise_param});
+    return std::make_shared<ov::Model>(OutputVector{eltwise_unary_2}, ParameterVector{conv_param, eltwise_param});
 }
 std::shared_ptr<ov::Model> ConvMulActivationFunction::initReference() const {
     auto conv_param = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -50,10 +50,10 @@ std::shared_ptr<ov::Model> ConvMulActivationFunction::initReference() const {
     auto ineltwise_unary_1 = custom_ops[1]->clone_with_new_inputs({ineltwise_binary->output(0)});
     auto ineltwise_unary_2 = custom_ops[2]->clone_with_new_inputs({ineltwise_unary_1->output(0)});
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{conv, eltwise_sinh},
-                                          std::make_shared<ov::Model>(NodeVector{ineltwise_unary_2},
-                                                                  ParameterVector{indata0, indata1}));
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{conv_param, eltwise_param});
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{conv, eltwise_sinh},
+        std::make_shared<ov::Model>(OutputVector{ineltwise_unary_2}, ParameterVector{indata0, indata1}));
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{conv_param, eltwise_param});
 }
 std::shared_ptr<ov::Model> ConvBiasActivationFunction::initOriginal() const {
     auto conv_param = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -73,7 +73,7 @@ std::shared_ptr<ov::Model> ConvBiasActivationFunction::initOriginal() const {
     auto add = std::make_shared<op::v1::Add>(conv->output(0), add_const->output(0));
     auto unary = custom_ops[1]->clone_with_new_inputs({add->output(0)});
 
-    return std::make_shared<ov::Model>(NodeVector{unary}, ParameterVector{conv_param});
+    return std::make_shared<ov::Model>(OutputVector{unary}, ParameterVector{conv_param});
 }
 std::shared_ptr<ov::Model> ConvBiasTwoActivationFunction::initOriginal() const {
     auto conv_param = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -94,7 +94,7 @@ std::shared_ptr<ov::Model> ConvBiasTwoActivationFunction::initOriginal() const {
     auto unary_1 = custom_ops[1]->clone_with_new_inputs({add->output(0)});
     auto unary_2 = custom_ops[2]->clone_with_new_inputs({unary_1->output(0)});
 
-    return std::make_shared<ov::Model>(NodeVector{unary_2}, ParameterVector{conv_param});
+    return std::make_shared<ov::Model>(OutputVector{unary_2}, ParameterVector{conv_param});
 }
 std::shared_ptr<ov::Model> ConvBiasTwoActivationFunction::initReference() const {
     auto conv_param = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -118,10 +118,10 @@ std::shared_ptr<ov::Model> ConvBiasTwoActivationFunction::initReference() const 
 
     auto unary_2 = custom_ops[2]->clone_with_new_inputs({indata->output(0)});
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{unary_1},
-                                                                 std::make_shared<ov::Model>(NodeVector{unary_2},
-                                                                 ParameterVector{indata}));
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{conv_param});
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{unary_1},
+        std::make_shared<ov::Model>(OutputVector{unary_2}, ParameterVector{indata}));
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{conv_param});
 }
 std::shared_ptr<ov::Model> MatMulTwoActivationFunction::initOriginal() const {
     auto matmul_param0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -138,7 +138,7 @@ std::shared_ptr<ov::Model> MatMulTwoActivationFunction::initOriginal() const {
     auto unary_1 = custom_ops[1]->clone_with_new_inputs({add->output(0)});
     auto unary_2 = custom_ops[2]->clone_with_new_inputs({unary_1->output(0)});
 
-    return std::make_shared<ov::Model>(NodeVector{unary_2}, ParameterVector{matmul_param0, matmul_param1});
+    return std::make_shared<ov::Model>(OutputVector{unary_2}, ParameterVector{matmul_param0, matmul_param1});
 }
 std::shared_ptr<ov::Model> MatMulBiasActivationBinaryFunction::initOriginal() const {
     auto matmul_param0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -157,7 +157,8 @@ std::shared_ptr<ov::Model> MatMulBiasActivationBinaryFunction::initOriginal() co
     auto binary_param = std::make_shared<op::v0::Parameter>(precision, input_shapes[2]);
     auto binary = custom_ops[2]->clone_with_new_inputs({unary->output(0), binary_param});
 
-    return std::make_shared<ov::Model>(NodeVector{binary}, ParameterVector{matmul_param0, matmul_param1, binary_param});
+    return std::make_shared<ov::Model>(OutputVector{binary},
+                                       ParameterVector{matmul_param0, matmul_param1, binary_param});
 }
 std::shared_ptr<ov::Model> MatMulBiasActivationBinaryFunction::initReference() const {
     auto matmul_param0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -180,11 +181,12 @@ std::shared_ptr<ov::Model> MatMulBiasActivationBinaryFunction::initReference() c
 
     auto binary = custom_ops[2]->clone_with_new_inputs({indata0->output(0), indata1->output(0)});
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{unary, binary_param},
-                                                                 std::make_shared<ov::Model>(NodeVector{binary},
-                                                                 ParameterVector{indata0, indata1}));
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{unary, binary_param},
+        std::make_shared<ov::Model>(OutputVector{binary}, ParameterVector{indata0, indata1}));
 
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{matmul_param0, matmul_param1, binary_param});
+    return std::make_shared<ov::Model>(OutputVector{subgraph},
+                                       ParameterVector{matmul_param0, matmul_param1, binary_param});
 }
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_fq.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_fq.cpp
@@ -37,7 +37,7 @@ std::shared_ptr<ov::Model> ThreeFQFunction::initOriginal() const {
                                                                               std::vector<float>{255},
                                                                               ov::element::u8);
     auto fq2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq1, ov::element::f32, fq2_data);
-    return std::make_shared<ov::Model>(NodeVector{fq2}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{fq2}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ThreeFQFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -67,10 +67,11 @@ std::shared_ptr<ov::Model> ThreeFQFunction::initReference() const {
                                                                               std::vector<float>{255},
                                                                               ov::element::u8);
     auto fq2 = ov::builder::subgraph::makeFakeQuantizeTypeRelaxed(fq1, ov::element::f32, fq2_data);
-    auto subgraph1 = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0},
-                                      std::make_shared<ov::Model>(NodeVector{fq2}, ParameterVector{indata0}));
+    auto subgraph1 = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{data0},
+        std::make_shared<ov::Model>(OutputVector{fq2}, ParameterVector{indata0}));
 
-    return std::make_shared<ov::Model>(NodeVector{subgraph1}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{subgraph1}, ParameterVector{data0});
 }
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_group_normalization.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_group_normalization.cpp
@@ -14,7 +14,7 @@ std::shared_ptr<ov::Model> GroupNormalizationFunction::initOriginal() const {
     auto scale = std::make_shared<op::v0::Parameter>(precision, input_shapes[1]);
     auto shift = std::make_shared<op::v0::Parameter>(precision, input_shapes[2]);
     const auto groupNormalization = std::make_shared<ov::op::v12::GroupNormalization>(data, scale, shift, num_groups, epsilon);
-    return std::make_shared<ov::Model>(NodeVector{groupNormalization}, ParameterVector{data, scale, shift});
+    return std::make_shared<ov::Model>(OutputVector{groupNormalization}, ParameterVector{data, scale, shift});
 }
 
 std::shared_ptr<ov::Model> GroupNormalizationFunction::initReference() const {
@@ -26,10 +26,11 @@ std::shared_ptr<ov::Model> GroupNormalizationFunction::initReference() const {
     auto shift_ = std::make_shared<op::v0::Parameter>(precision, input_shapes[2]);
     const auto groupNormalization = std::make_shared<ov::op::v12::GroupNormalization>(data_, scale_, shift_, num_groups, epsilon);
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data, scale, shift},
-            std::make_shared<ov::Model>(NodeVector{groupNormalization}, ParameterVector{data_, scale_, shift_}));
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{data, scale, shift},
+        std::make_shared<ov::Model>(OutputVector{groupNormalization}, ParameterVector{data_, scale_, shift_}));
 
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ParameterVector{data, scale, shift});
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ParameterVector{data, scale, shift});
 }
 
 std::shared_ptr<ov::Model> GroupNormalizationFunction::initLowered() const {
@@ -91,7 +92,7 @@ std::shared_ptr<ov::Model> GroupNormalizationFunction::initLowered() const {
     // reshape_back [N, group, C / group, spatial] to [N, C, spatial]
     const auto reshape_back_node = std::make_shared<ov::snippets::op::Reshape>(biased_node, orig_shape);
 
-    return std::make_shared<ov::Model>(NodeVector{reshape_back_node}, ParameterVector{data, scale, bias});
+    return std::make_shared<ov::Model>(OutputVector{reshape_back_node}, ParameterVector{data, scale, bias});
 }
 
 }  // namespace snippets

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_lowered.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_lowered.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<ov::Model> AddFunctionLoweredBroadcast::initLowered() const {
     auto add = std::make_shared<op::v1::Add>(add_input0, add_input1);
     auto store = std::make_shared<ov::snippets::op::Store>(add);
     ParameterVector input_params {data0, data1};
-    return std::make_shared<ov::Model>(NodeVector{store}, input_params);
+    return std::make_shared<ov::Model>(OutputVector{store}, input_params);
 }
 std::shared_ptr<ov::Model> EltwiseThreeInputsLoweredFunction::initLowered() const {
     // todo: implement conversion between std::vector<size_t> and std::vector<Shape>
@@ -68,7 +68,7 @@ std::shared_ptr<ov::Model> EltwiseThreeInputsLoweredFunction::initLowered() cons
         sub_out = std::make_shared<ov::snippets::op::BroadcastMove>(sub, *broadcast_shapes[2].rbegin());
     auto mul = std::make_shared<op::v1::Multiply>(add, sub_out);
     auto store = std::make_shared<ov::snippets::op::Store>(mul);
-    return std::make_shared<ov::Model>(NodeVector{store}, input_params);
+    return std::make_shared<ov::Model>(OutputVector{store}, input_params);
 }
 
 std::shared_ptr<ov::Model> Transpose0213MatMulLoweredFunction::initLowered() const {
@@ -107,7 +107,7 @@ std::shared_ptr<ov::Model> Transpose0213MatMulLoweredFunction::initLowered() con
                                                                                                                                 layout));
     }
     matmul->validate_and_infer_types();
-    return std::make_shared<ov::Model>(NodeVector{matmul}, data);
+    return std::make_shared<ov::Model>(OutputVector{matmul}, data);
 }
 
 std::shared_ptr<ov::Model> BroadcastAddLoweredFunction::initLowered() const {
@@ -125,7 +125,7 @@ std::shared_ptr<ov::Model> BroadcastAddLoweredFunction::initLowered() const {
     }
     auto add = std::make_shared<op::v1::Add>(loads[0], loads[1]);
     auto store = std::make_shared<ov::snippets::op::Store>(add);
-    return std::make_shared<Model>(NodeVector{store}, ParameterVector{data0, data1});
+    return std::make_shared<Model>(OutputVector{store}, ParameterVector{data0, data1});
 }
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_matmul.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_matmul.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<ov::Model> MatMulFunction::initOriginal() const {
     } else {
         matmul = std::make_shared<op::v0::MatMul>(data0, data1, false, transpose_b);
     }
-    return std::make_shared<ov::Model>(NodeVector{matmul}, params);
+    return std::make_shared<ov::Model>(OutputVector{matmul}, params);
 }
 std::shared_ptr<ov::Model> MatMulFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precisions[0], input_shapes[0]);
@@ -117,10 +117,10 @@ std::shared_ptr<ov::Model> MatMulFunction::initReference() const {
     } else {
         matmul = std::make_shared<op::v0::MatMul>(indata0, indata1, false, transpose_b);
     }
-    const auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1},
-                                                                std::make_shared<ov::Model>(NodeVector{matmul},
-                                                                                            ParameterVector{indata0, indata1}));
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, params);
+    const auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{data0, data1},
+        std::make_shared<ov::Model>(OutputVector{matmul}, ParameterVector{indata0, indata1}));
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, params);
 }
 std::shared_ptr<ov::Model> FQMatMulFunction::initOriginal() const {
     auto const_order = std::make_shared<op::v0::Constant>(ov::element::i32, Shape {4}, std::vector<int>{0, 2, 1, 3});
@@ -145,7 +145,7 @@ std::shared_ptr<ov::Model> FQMatMulFunction::initOriginal() const {
     if (pos == 2) {
         out = std::make_shared<op::v1::Transpose>(out, const_order);
     }
-    return std::make_shared<ov::Model>(NodeVector{out}, params);
+    return std::make_shared<ov::Model>(OutputVector{out}, params);
 }
 std::shared_ptr<ov::Model> MatMulBiasFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -165,7 +165,7 @@ std::shared_ptr<ov::Model> MatMulBiasFunction::initOriginal() const {
         matmul = std::make_shared<op::v0::MatMul>(data0, data1);
     }
     auto bias = std::make_shared<op::v1::Add>(matmul, data2);
-    return std::make_shared<ov::Model>(NodeVector{bias}, params);
+    return std::make_shared<ov::Model>(OutputVector{bias}, params);
 }
 std::shared_ptr<ov::Model> MatMulBiasQuantizedFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precisions[0], input_shapes[0]);
@@ -181,7 +181,7 @@ std::shared_ptr<ov::Model> MatMulBiasQuantizedFunction::initOriginal() const {
         ov::op::TemporaryReplaceOutputType(data1, element::f32).get());
     auto fq2 = make_fake_quantize(matmul, true);
     auto bias = std::make_shared<op::v1::Add>(fq2, data2);
-    return std::make_shared<ov::Model>(NodeVector{bias}, params);
+    return std::make_shared<ov::Model>(OutputVector{bias}, params);
 }
 std::shared_ptr<ov::Model> MatMulsQuantizedFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precisions[0], input_shapes[0]);
@@ -204,7 +204,7 @@ std::shared_ptr<ov::Model> MatMulsQuantizedFunction::initOriginal() const {
         ov::op::TemporaryReplaceOutputType(fq0, element::f32).get(),
         ov::op::TemporaryReplaceOutputType(reshape, element::f32).get());
     auto fq3 = make_fake_quantize(matmul1, true);
-    return std::make_shared<ov::Model>(NodeVector{fq3}, params);
+    return std::make_shared<ov::Model>(OutputVector{fq3}, params);
 }
 std::shared_ptr<ov::Model> Transpose0213MatMulFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precisions[0], input_shapes[0]);
@@ -252,7 +252,7 @@ std::shared_ptr<ov::Model> Transpose0213MatMulFunction::initOriginal() const {
             break;
         }
     }
-    return std::make_shared<ov::Model>(NodeVector{result}, params);
+    return std::make_shared<ov::Model>(OutputVector{result}, params);
 }
 
 std::shared_ptr<ov::Model> TransposeMatMulFunction::initOriginal() const {
@@ -261,7 +261,7 @@ std::shared_ptr<ov::Model> TransposeMatMulFunction::initOriginal() const {
     auto const_order = std::make_shared<op::v0::Constant>(ov::element::i32, Shape {4}, std::vector<int>{0, 2, 3, 1});
     auto transpose = std::make_shared<op::v1::Transpose>(data1, const_order);
     auto matmul = std::make_shared<op::v0::MatMul>(data0, transpose);
-    return std::make_shared<ov::Model>(NodeVector{matmul}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{matmul}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> TransposeMatMulBiasFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -271,7 +271,7 @@ std::shared_ptr<ov::Model> TransposeMatMulBiasFunction::initOriginal() const {
     auto transpose = std::make_shared<op::v1::Transpose>(data1, const_order);
     auto matmul = std::make_shared<op::v0::MatMul>(data0, transpose);
     auto bias = std::make_shared<op::v1::Add>(matmul, data2);
-    return std::make_shared<ov::Model>(NodeVector{bias}, ParameterVector{data0, data1, data2});
+    return std::make_shared<ov::Model>(OutputVector{bias}, ParameterVector{data0, data1, data2});
 }
 std::shared_ptr<ov::Model> TransposeMulMatMulBiasFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -283,7 +283,7 @@ std::shared_ptr<ov::Model> TransposeMulMatMulBiasFunction::initOriginal() const 
     auto mul = std::make_shared<op::v1::Multiply>(transpose, data2);
     auto matmul = std::make_shared<op::v0::MatMul>(data0, mul);
     auto bias = std::make_shared<op::v1::Add>(matmul, data3);
-    return std::make_shared<ov::Model>(NodeVector{bias}, ParameterVector{data0, data1, data2, data3});
+    return std::make_shared<ov::Model>(OutputVector{bias}, ParameterVector{data0, data1, data2, data3});
 }
 std::shared_ptr<ov::Model> MatMulsQuantizedSoftmaxFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precisions[0], input_shapes[0]);
@@ -307,7 +307,7 @@ std::shared_ptr<ov::Model> MatMulsQuantizedSoftmaxFunction::initOriginal() const
         ov::op::TemporaryReplaceOutputType(fq0, element::f32).get(),
         ov::op::TemporaryReplaceOutputType(reshape, element::f32).get());
     auto fq3 = make_fake_quantize(matmul1, true);
-    return std::make_shared<ov::Model>(NodeVector{fq3}, params);
+    return std::make_shared<ov::Model>(OutputVector{fq3}, params);
 }
 
 std::shared_ptr<ov::Model> MatMulEltwiseChainFunction::initOriginal() const {
@@ -332,7 +332,7 @@ std::shared_ptr<ov::Model> MatMulEltwiseChainFunction::initOriginal() const {
     auto bias_op = std::make_shared<op::v1::Add>(mul, bias);
 
     auto add = std::make_shared<op::v1::Add>(matmul, bias_op);
-    return std::make_shared<ov::Model>(NodeVector{add}, params);
+    return std::make_shared<ov::Model>(OutputVector{add}, params);
 }
 
 std::shared_ptr<ov::Model> MatMulEltwiseChainCascadeFunction::initOriginal() const {
@@ -370,7 +370,7 @@ std::shared_ptr<ov::Model> MatMulEltwiseChainCascadeFunction::initOriginal() con
         ov::op::TemporaryReplaceOutputType(data2, element::f32).get());
 
     auto eltwise_chain_2 = build_eltwise_chain(matmul2);
-    return std::make_shared<ov::Model>(NodeVector{eltwise_chain_2}, params);
+    return std::make_shared<ov::Model>(OutputVector{eltwise_chain_2}, params);
 }
 
 }  // namespace snippets

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_mha.cpp
@@ -153,10 +153,11 @@ std::shared_ptr<ov::Model> MHAFunction::initReference() const {
     const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(softMax, transpose2);
     const auto transpose3 = std::make_shared<ov::op::v1::Transpose>(matMul1, transpose3Const);
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(subgraph_inputs,
-            std::make_shared<ov::Model>(NodeVector{transpose3}, subgraph_params));
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        subgraph_inputs,
+        std::make_shared<ov::Model>(OutputVector{transpose3}, subgraph_params));
 
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ngraphParams);
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ngraphParams);
 }
 
 std::shared_ptr<ov::Model> MHA2DFunction::initOriginal() const {
@@ -204,10 +205,11 @@ std::shared_ptr<ov::Model> MHA2DFunction::initReference() const {
     const auto softMax = std::make_shared<ov::opset1::Softmax>(add, rank - 1);
     const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(softMax, param2);
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(subgraph_inputs,
-            std::make_shared<ov::Model>(NodeVector{matMul1}, subgraph_params));
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        subgraph_inputs,
+        std::make_shared<ov::Model>(OutputVector{matMul1}, subgraph_params));
 
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ngraphParams);
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ngraphParams);
 }
 
 std::shared_ptr<ov::Model> MHASplitMFunction::initReference() const {
@@ -393,10 +395,11 @@ std::shared_ptr<ov::Model> MHAMatMul0TransposeFunction::initReference() const {
     const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(softMax, transpose2);
     const auto transpose3 = std::make_shared<ov::op::v1::Transpose>(matMul1, transpose3Const);
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(subgraph_inputs,
-            std::make_shared<ov::Model>(NodeVector{transpose3}, subgraph_params));
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        subgraph_inputs,
+        std::make_shared<ov::Model>(OutputVector{transpose3}, subgraph_params));
 
-    return std::make_shared<ov::Model>(NodeVector{subgraph}, ngraphParams);
+    return std::make_shared<ov::Model>(OutputVector{subgraph}, ngraphParams);
 }
 
 std::shared_ptr<ov::Model> MHASelectFunction::initOriginal() const {
@@ -929,13 +932,14 @@ std::shared_ptr<ov::Model> MHAINT8MatMulTypeRelaxedFunction::initReference() con
             ov::op::TemporaryReplaceOutputType(transpose2, element::f32).get(), transA, transB);
     const auto fq5 = decomposed_fq(matMul1, ov::element::i8, fq_signed_params.inputLowValues[0], fq_signed_params.inputHighValues[0], 0.00346764503f);
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(subgraph_inputs,
-                                                                     std::make_shared<ov::Model>(NodeVector{fq5}, subgraph_params));
+    auto subgraph =
+        std::make_shared<ov::snippets::op::Subgraph>(subgraph_inputs,
+                                                     std::make_shared<ov::Model>(OutputVector{fq5}, subgraph_params));
     // TODO: At the moment Snippets don't support explicitly Transpose.
     //       So we cannot collapse Transpose into Subgraph if there are ops between MatMul2 and Transpose3
     auto transpose3 = std::make_shared<ov::op::v1::Transpose>(subgraph, transpose3Const);
 
-    return std::make_shared<ov::Model>(NodeVector{transpose3}, ngraphParams);
+    return std::make_shared<ov::Model>(OutputVector{transpose3}, ngraphParams);
 }
 
 std::shared_ptr<ov::Model> MHAMulAddFunction::initOriginal() const {
@@ -1032,7 +1036,9 @@ std::shared_ptr<ov::Model> MHATransposedInputFunction::initReference() const {
     const auto softmax = std::make_shared<ov::op::v8::Softmax>(matMul0, -1);
     const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(softmax, param2);
 
-    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(subgraphs_inputs, std::make_shared<ov::Model>(NodeVector{matMul1}, subgraph_params));
+    auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(
+        subgraphs_inputs,
+        std::make_shared<ov::Model>(OutputVector{matMul1}, subgraph_params));
 
     ov::ResultVector results{std::make_shared<ov::opset1::Result>(subgraph)};
     return std::make_shared<ov::Model>(results, ngraphParam, "mha");
@@ -1112,7 +1118,8 @@ std::shared_ptr<ov::Model> MHAWithExtractedReshapeFunction::initReference() cons
     const auto softmax = std::make_shared<ov::op::v8::Softmax>(add_internal, -1);
     const auto matmul_1 = std::make_shared<ov::op::v0::MatMul>(softmax, param_3);
 
-    auto subgraph_model = std::make_shared<ov::Model>(NodeVector{matmul_1}, ov::ParameterVector{param_0, param_1, param_2, param_3});
+    auto subgraph_model =
+        std::make_shared<ov::Model>(OutputVector{matmul_1}, ov::ParameterVector{param_0, param_1, param_2, param_3});
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(ov::NodeVector{data_0, data_1, reshape, data_4}, subgraph_model);
 
     ov::ResultVector results{std::make_shared<ov::opset1::Result>(subgraph)};

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_reduce.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_reduce.cpp
@@ -18,7 +18,7 @@ std::shared_ptr<ov::Model> ReduceFunction::initOriginal() const {
     auto data = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     auto constant = ov::op::v0::Constant::create(ov::element::i32, {axes.size()}, axes);
     auto reduce = ov::test::utils::make_reduce(data, constant, keep_dims, reduce_type);
-    return std::make_shared<ov::Model>(NodeVector{reduce}, ParameterVector{data});
+    return std::make_shared<ov::Model>(OutputVector{reduce}, ParameterVector{data});
 }
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_simple.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_simple.cpp
@@ -15,32 +15,32 @@ std::shared_ptr<ov::Model> AddFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     auto data1 = std::make_shared<op::v0::Parameter>(precision, input_shapes[1]);
     auto add = std::make_shared<op::v1::Add>(data0, data1);
-    return std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> AddFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     auto data1 = std::make_shared<op::v0::Parameter>(precision, input_shapes[1]);
     auto add = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1}, getOriginal());
-    return std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> ExpFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     auto exp = std::make_shared<op::v0::Exp>(data0);
-    return std::make_shared<ov::Model>(NodeVector{exp}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{exp}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> ExpReciprocalFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     auto factor = std::make_shared<op::v0::Constant>(precision, ov::Shape{1}, std::vector<float>{-1.f});
     auto exp = std::make_shared<op::v0::Exp>(data0);
     auto reciprocal = std::make_shared<op::v1::Power>(exp, factor);
-    return std::make_shared<ov::Model>(NodeVector{reciprocal}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{reciprocal}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> AddConstFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     const std::vector<float> const_values = ov::test::utils::generate_float_numbers(shape_size(m_const_shape.get_shape()), -10., 10.);
     auto const_data1 = std::make_shared<op::v0::Constant>(precision, m_const_shape.get_shape(), const_values);
     auto add = std::make_shared<op::v1::Add>(data0, const_data1);
-    return std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> AddRollConstFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -53,7 +53,7 @@ std::shared_ptr<ov::Model> AddRollConstFunction::initOriginal() const {
     // The limitation for BF16 in CPU Plugin:
     roll0->get_rt_info()["enforceBF16evenForGraphTail"] = true;
     add->get_rt_info()["enforceBF16evenForGraphTail"] = true;
-    return std::make_shared<ov::Model>(NodeVector{add}, ParameterVector{data0});
+    return std::make_shared<ov::Model>(OutputVector{add}, ParameterVector{data0});
 }
 std::shared_ptr<ov::Model> EltwiseFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -63,7 +63,7 @@ std::shared_ptr<ov::Model> EltwiseFunction::initOriginal() const {
     auto add = std::make_shared<op::v1::Add>(data0, data1);
     auto sub = std::make_shared<op::v1::Subtract>(add, const_data);
     auto mul = std::make_shared<op::v1::Multiply>(add, sub);
-    return std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> EltwiseFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -75,10 +75,11 @@ std::shared_ptr<ov::Model> EltwiseFunction::initReference() const {
     auto indata2 = std::make_shared<op::v0::Parameter>(precision, data1->get_shape());
     auto add = std::make_shared<op::v1::Add>(indata0, indata1);
     auto sub = std::make_shared<op::v1::Subtract>(add, indata2);
-    auto mul = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1, const_data},
-                                          std::make_shared<ov::Model>(NodeVector{std::make_shared<op::v1::Multiply>(add, sub)},
-                                                                  ParameterVector{indata0, indata1, indata2}));
-    return std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data0, data1});
+    auto mul = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{data0, data1, const_data},
+        std::make_shared<ov::Model>(OutputVector{std::make_shared<op::v1::Multiply>(add, sub)},
+                                    ParameterVector{indata0, indata1, indata2}));
+    return std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> EltwiseThreeInputsFunction::initOriginal() const {
@@ -90,7 +91,7 @@ std::shared_ptr<ov::Model> EltwiseThreeInputsFunction::initOriginal() const {
     auto add = std::make_shared<op::v1::Add>(data0, data1);
     auto sub = std::make_shared<op::v1::Subtract>(data2, const_data);
     auto mul = std::make_shared<op::v1::Multiply>(add, sub);
-    return std::make_shared<ov::Model>(NodeVector{mul}, ParameterVector{data0, data1, data2});
+    return std::make_shared<ov::Model>(OutputVector{mul}, ParameterVector{data0, data1, data2});
 }
 
 std::shared_ptr<ov::Model> EltwiseMaxNumParamsFunction::initOriginal() const {
@@ -111,7 +112,7 @@ std::shared_ptr<ov::Model> EltwiseMaxNumParamsFunction::initOriginal() const {
     auto sub = std::make_shared<op::v1::Subtract>(mul[0], mul[1]);
     auto power = std::make_shared<op::v1::Power>(params.back(), sub);
     auto exit_sinh = std::make_shared<op::v0::Sinh>(power);
-    return std::make_shared<ov::Model>(NodeVector{sub, exit_sinh}, params);
+    return std::make_shared<ov::Model>(OutputVector{sub, exit_sinh}, params);
 }
 
 std::shared_ptr<ov::Model> MatMulEltwiseBranchesFunction::initOriginal() const {
@@ -167,13 +168,13 @@ std::shared_ptr<ov::Model> MatMulEltwiseBranchesFunction::initReference() const 
 
     auto add = std::make_shared<op::v1::Add>(elu, relu);
     ParameterVector subgraph_params{ snippet_input };
-    auto snippet_function = std::make_shared<Model>(NodeVector{ add }, subgraph_params);
+    auto snippet_function = std::make_shared<Model>(OutputVector{add}, subgraph_params);
 
     ov::NodeVector snippet_inputs{ non_snippet_op };
     auto snippet = std::make_shared<ov::snippets::op::Subgraph>(snippet_inputs, snippet_function);
     auto result = std::make_shared<op::v0::Result>(snippet);
 
-    return std::make_shared<Model>(NodeVector{ result }, ParameterVector{ data_1, data_2 });
+    return std::make_shared<Model>(OutputVector{result}, ParameterVector{data_1, data_2});
 }
 
 std::shared_ptr<ov::Model> EltwiseLogLoopFunction::initOriginal() const {
@@ -183,7 +184,7 @@ std::shared_ptr<ov::Model> EltwiseLogLoopFunction::initOriginal() const {
     auto hswish = std::make_shared<op::v4::HSwish>(add);
     auto log = std::make_shared<op::v0::Log>(add);
     auto mul = std::make_shared<op::v1::Multiply>(hswish, log);
-    return std::make_shared<Model>(NodeVector{mul}, ParameterVector{data0, data1});
+    return std::make_shared<Model>(OutputVector{mul}, ParameterVector{data0, data1});
 }
 std::shared_ptr<ov::Model> EltwiseLogLoopFunction::initReference() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -192,7 +193,7 @@ std::shared_ptr<ov::Model> EltwiseLogLoopFunction::initReference() const {
     auto indata1 = std::make_shared<op::v0::Parameter>(precision, input_shapes[1]);
     auto inAdd = std::make_shared<op::v1::Add>(indata0, indata1);
     auto inHswish = std::make_shared<op::v4::HSwish>(inAdd);
-    auto body = std::make_shared<Model>(NodeVector{inAdd, inHswish}, ParameterVector{indata0, indata1});
+    auto body = std::make_shared<Model>(OutputVector{inAdd, inHswish}, ParameterVector{indata0, indata1});
     auto subgraph = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1}, body);
     auto log = std::make_shared<op::v0::Log>(subgraph->output(0));
     //Note that log is not currently supported by snippets, so it won't be converted to subgraph.
@@ -200,10 +201,11 @@ std::shared_ptr<ov::Model> EltwiseLogLoopFunction::initReference() const {
     //  before the node outputs. So the Subgraph{Add}.output(1)->Log{} becomes Subgraph{Add+Hswish}.output(0)->Log{}
     auto subgraph_param = std::make_shared<op::v0::Parameter>(precision, subgraph->get_output_shape(1));
     auto log_param = std::make_shared<op::v0::Parameter>(precision, log->get_output_shape(0));
-    auto mul = std::make_shared<ov::snippets::op::Subgraph>(OutputVector{subgraph->output(1), log->output(0)},
-                                          std::make_shared<Model>(NodeVector{std::make_shared<op::v1::Multiply>(subgraph_param, log_param)},
-                                                                  ParameterVector{subgraph_param, log_param}));
-    return std::make_shared<Model>(NodeVector{mul}, ParameterVector{data0, data1});
+    auto mul = std::make_shared<ov::snippets::op::Subgraph>(
+        OutputVector{subgraph->output(1), log->output(0)},
+        std::make_shared<Model>(OutputVector{std::make_shared<op::v1::Multiply>(subgraph_param, log_param)},
+                                ParameterVector{subgraph_param, log_param}));
+    return std::make_shared<Model>(OutputVector{mul}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> EltwiseTwoResultsFunction::initOriginal() const {
@@ -242,16 +244,16 @@ std::shared_ptr<ov::Model> EltwiseTwoResultsFunction::initReference() const {
     add->set_friendly_name("add");
     auto hswish = std::make_shared<op::v4::HSwish>(add);
     hswish->set_friendly_name("hswish");
-    auto subgraph0 = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data0, data1},
-                                        std::make_shared<ov::Model>(NodeVector{add, hswish},
-                                                                    ParameterVector{indata0, indata1}));
+    auto subgraph0 = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{data0, data1},
+        std::make_shared<ov::Model>(OutputVector{add, hswish}, ParameterVector{indata0, indata1}));
     subgraph0->set_friendly_name("add");
     auto indata2 = std::make_shared<op::v0::Parameter>(precision, subgraph0->get_output_shape(1));
     auto relu = std::make_shared<op::v0::Relu>(indata2);
     relu->set_friendly_name("relu");
-    auto subgraph1 = std::make_shared<ov::snippets::op::Subgraph>(OutputVector{subgraph0->output(1)},
-                                        std::make_shared<ov::Model>(NodeVector{relu},
-                                                                    ParameterVector{indata2}));
+    auto subgraph1 = std::make_shared<ov::snippets::op::Subgraph>(
+        OutputVector{subgraph0->output(1)},
+        std::make_shared<ov::Model>(OutputVector{relu}, ParameterVector{indata2}));
     subgraph1->set_friendly_name("relu");
     auto& out_tensor0 = subgraph0->get_output_tensor(0);
     out_tensor0.set_names({"add_out", "y0"});
@@ -274,7 +276,7 @@ std::shared_ptr<ov::Model> TwoInputsAndOutputsFunction::initOriginal() const {
     auto relu = std::make_shared<op::v0::Relu>(add);
     auto sin3 = std::make_shared<op::v0::Sin>(relu);
 
-    return std::make_shared<Model>(NodeVector{hswish, sin3}, ParameterVector{data0, data1});
+    return std::make_shared<Model>(OutputVector{hswish, sin3}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> TwoInputsAndOutputsWithReversedOutputsFunction::initOriginal() const {
@@ -285,7 +287,7 @@ std::shared_ptr<ov::Model> TwoInputsAndOutputsWithReversedOutputsFunction::initO
     auto relu = std::make_shared<op::v0::Relu>(add);
     auto sin3 = std::make_shared<op::v0::Sin>(relu);
 
-    return std::make_shared<Model>(NodeVector{sin3, hswish}, ParameterVector{data0, data1});
+    return std::make_shared<Model>(OutputVector{sin3, hswish}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> SelectFunction::initOriginal() const {
@@ -294,7 +296,7 @@ std::shared_ptr<ov::Model> SelectFunction::initOriginal() const {
     auto data2 = std::make_shared<op::v0::Parameter>(precision, input_shapes[2]);
     auto select = std::make_shared<op::v1::Select>(data0, data1, data2);
 
-    return std::make_shared<Model>(NodeVector{select}, ParameterVector{data0, data1, data2});
+    return std::make_shared<Model>(OutputVector{select}, ParameterVector{data0, data1, data2});
 }
 
 std::shared_ptr<ov::Model> BroadcastAddFunction::initOriginal() const {
@@ -304,7 +306,7 @@ std::shared_ptr<ov::Model> BroadcastAddFunction::initOriginal() const {
     auto broadcast = std::make_shared<ov::op::v1::Broadcast>(data0, target_shape);
     auto add = std::make_shared<op::v1::Add>(broadcast, data1);
 
-    return std::make_shared<Model>(NodeVector{add}, ParameterVector{data0, data1});
+    return std::make_shared<Model>(OutputVector{add}, ParameterVector{data0, data1});
 }
 
 
@@ -316,7 +318,7 @@ std::shared_ptr<ov::Model> BroadcastSelectFunction::initOriginal() const {
     auto broadcast = std::make_shared<ov::op::v1::Broadcast>(data0, target_shape);
     auto select = std::make_shared<op::v1::Select>(broadcast, data1, data2);
 
-    return std::make_shared<Model>(NodeVector{select}, ParameterVector{data0, data1, data2});
+    return std::make_shared<Model>(OutputVector{select}, ParameterVector{data0, data1, data2});
 }
 
 std::shared_ptr<ov::Model> EdgeReplaceFunction::initOriginal() const {
@@ -349,7 +351,7 @@ std::shared_ptr<ov::Model> EdgeReplaceFunction::initOriginal() const {
 
     auto concat = std::make_shared<op::v0::Concat>(ov::OutputVector{add_a3, add_a2}, 0);
 
-    return std::make_shared<Model>(NodeVector{concat}, ParameterVector{input});
+    return std::make_shared<Model>(OutputVector{concat}, ParameterVector{input});
 }
 }  // namespace snippets
 }  // namespace test

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_softmax.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_softmax.cpp
@@ -40,7 +40,7 @@ std::ostream &operator<<(std::ostream& os, const SoftmaxVersion& version) {
 std::shared_ptr<ov::Model> SoftmaxFunction::initOriginal() const {
     auto data = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     const auto softmax = buildSoftmax(data, axis, softmax_version);
-    return std::make_shared<ov::Model>(NodeVector{softmax}, ParameterVector{data});
+    return std::make_shared<ov::Model>(OutputVector{softmax}, ParameterVector{data});
 }
 
 std::shared_ptr<ov::Model> SoftmaxFunction::initLowered() const {
@@ -55,7 +55,7 @@ std::shared_ptr<ov::Model> SoftmaxFunction::initLowered() const {
     const auto power = std::make_shared<ov::snippets::op::PowerStatic>(reduce_sum, -1.f);
     const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
 
-    return std::make_shared<ov::Model>(NodeVector{multiply}, ParameterVector{data});
+    return std::make_shared<ov::Model>(OutputVector{multiply}, ParameterVector{data});
 }
 
 std::shared_ptr<ov::Model> AddSoftmaxFunction::initOriginal() const {
@@ -63,7 +63,7 @@ std::shared_ptr<ov::Model> AddSoftmaxFunction::initOriginal() const {
     auto data1 = std::make_shared<op::v0::Parameter>(precision, input_shapes[1]);
     auto add = std::make_shared<ov::op::v1::Add>(data0, data1);
     auto softmax = std::make_shared<ov::op::v8::Softmax>(add, axis);
-    return std::make_shared<ov::Model>(NodeVector{softmax}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{softmax}, ParameterVector{data0, data1});
 }
 
 std::shared_ptr<ov::Model> TransposeSoftmaxFunction::initOriginal() const {
@@ -71,7 +71,9 @@ std::shared_ptr<ov::Model> TransposeSoftmaxFunction::initOriginal() const {
     const auto transpose0Const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{m_order.size()}, m_order);
     const auto transpose2 = std::make_shared<ov::op::v1::Transpose>(transpose0Param, transpose0Const);
     const auto softMax = std::make_shared<ov::op::v8::Softmax>(transpose2, m_axis);
-    return std::make_shared<ov::Model>(ov::NodeVector{softMax}, ov::ParameterVector {transpose0Param}, "softmax_transpose");
+    return std::make_shared<ov::Model>(ov::OutputVector{softMax},
+                                       ov::ParameterVector{transpose0Param},
+                                       "softmax_transpose");
 }
 
 std::shared_ptr<ov::Model> TransposeSoftmaxEltwiseFunction::initOriginal() const {
@@ -82,7 +84,8 @@ std::shared_ptr<ov::Model> TransposeSoftmaxEltwiseFunction::initOriginal() const
     const auto mul = std::make_shared<ov::op::v1::Multiply>(transpose2, mul1Param);
     const auto softMax = std::make_shared<ov::op::v8::Softmax>(mul, m_axis);
     const auto hswish = std::make_shared<ov::op::v4::HSwish>(softMax);
-    return std::make_shared<ov::Model>(ov::NodeVector{hswish}, ov::ParameterVector{transpose0Param, mul1Param},
+    return std::make_shared<ov::Model>(ov::OutputVector{hswish},
+                                       ov::ParameterVector{transpose0Param, mul1Param},
                                        "softmax_transpose");
 }
 

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_transpose.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_transpose.cpp
@@ -13,7 +13,7 @@ std::shared_ptr<ov::Model> TransposeFunction::initOriginal() const {
     auto data = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
     auto const_order = std::make_shared<op::v0::Constant>(ov::element::i32, Shape {order.size()}, order);
     auto transpose = std::make_shared<op::v1::Transpose>(data, const_order);
-    return std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{data});
+    return std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{data});
 }
 std::shared_ptr<ov::Model> TransposeFunction::initReference() const {
     auto data = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -21,10 +21,11 @@ std::shared_ptr<ov::Model> TransposeFunction::initReference() const {
     auto indata0 = std::make_shared<op::v0::Parameter>(precision, data->get_output_partial_shape(0));
     auto indata1 = std::make_shared<op::v0::Parameter>(const_order->get_output_element_type(0),
                                                        const_order->get_output_partial_shape(0));
-    auto transpose = std::make_shared<ov::snippets::op::Subgraph>(NodeVector{data, const_order},
-                                          std::make_shared<ov::Model>(NodeVector{std::make_shared<op::v1::Transpose>(indata0, indata1)},
-                                                                      ParameterVector{indata0, indata1}));
-    return std::make_shared<ov::Model>(NodeVector{transpose}, ParameterVector{data});
+    auto transpose = std::make_shared<ov::snippets::op::Subgraph>(
+        NodeVector{data, const_order},
+        std::make_shared<ov::Model>(OutputVector{std::make_shared<op::v1::Transpose>(indata0, indata1)},
+                                    ParameterVector{indata0, indata1}));
+    return std::make_shared<ov::Model>(OutputVector{transpose}, ParameterVector{data});
 }
 std::shared_ptr<ov::Model> TransposeMulFunction::initOriginal() const {
     auto data0 = std::make_shared<op::v0::Parameter>(precision, input_shapes[0]);
@@ -32,7 +33,7 @@ std::shared_ptr<ov::Model> TransposeMulFunction::initOriginal() const {
     auto const_order = std::make_shared<op::v0::Constant>(ov::element::i32, Shape {order.size()}, order);
     auto transpose = std::make_shared<op::v1::Transpose>(data0, const_order);
     auto multiply = std::make_shared<op::v1::Multiply>(transpose, data1);
-    return std::make_shared<ov::Model>(NodeVector{multiply}, ParameterVector{data0, data1});
+    return std::make_shared<ov::Model>(OutputVector{multiply}, ParameterVector{data0, data1});
 }
 
 }  // namespace snippets

--- a/src/tests/test_utils/common_test_utils/src/subgraph_builders/detection_output.cpp
+++ b/src/tests/test_utils/common_test_utils/src/subgraph_builders/detection_output.cpp
@@ -64,7 +64,9 @@ std::shared_ptr<ov::Model> make_detection_output(ov::element::Type type) {
     const auto& detection = std::make_shared<ov::op::v0::DetectionOutput>(four_times, four_times, third_input, attr);
     const auto& convert = std::make_shared<ov::op::v0::Convert>(detection, type);
 
-    return std::make_shared<ov::Model>(ov::NodeVector{convert}, ov::ParameterVector{data}, "SplitableDetectionOutput");
+    return std::make_shared<ov::Model>(ov::OutputVector{convert},
+                                       ov::ParameterVector{data},
+                                       "SplitableDetectionOutput");
 }
 }  // namespace utils
 }  // namespace test

--- a/src/tests/test_utils/common_test_utils/tests/graph_comparator_tests.cpp
+++ b/src/tests/test_utils/common_test_utils/tests/graph_comparator_tests.cpp
@@ -23,7 +23,7 @@ TEST(GraphComparatorTests, AllEnablePositiveCheck) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         function = function_ref->clone();
     }
     comparator.enable(FunctionsComparator::NAMES)
@@ -45,13 +45,13 @@ TEST(GraphComparatorTests, CheckbyDefault) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto add = std::make_shared<ov::op::v1::Add>(input, input2);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input, input2});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input, input2});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {12});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     auto res = comparator.compare(function, function_ref);
     ASSERT_FALSE(res.valid) << res.message;
@@ -64,7 +64,7 @@ TEST(GraphComparatorTests, CheckResultsNumber) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto input2 = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto add = std::make_shared<ov::op::v1::Add>(input, input2);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input, input2});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input, input2});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
@@ -88,7 +88,7 @@ TEST(GraphComparatorTests, NamesCheckPositive) {
         constant->set_friendly_name("new_name2");
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3");
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
@@ -97,7 +97,7 @@ TEST(GraphComparatorTests, NamesCheckPositive) {
         constant->set_friendly_name("new_name2");
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3");
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NAMES).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -114,7 +114,7 @@ TEST(GraphComparatorTests, NamesCheckNegative) {
         constant->set_friendly_name("new_name2");
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3");
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
@@ -123,7 +123,7 @@ TEST(GraphComparatorTests, NamesCheckNegative) {
         constant->set_friendly_name("new_name2");
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->set_friendly_name("new_name3_different");
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NAMES).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -137,13 +137,13 @@ TEST(GraphComparatorTests, ConstCheckWithoutEnable) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {12});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -157,13 +157,13 @@ TEST(GraphComparatorTests, ConstCheckNegative) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {12});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::CONST_VALUES).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -177,7 +177,7 @@ TEST(GraphComparatorTests, TensorNamesCheckNegative) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         function = function_ref->clone();
         add->get_input_tensor(0).set_names({"new_name"});
     }
@@ -193,7 +193,7 @@ TEST(GraphComparatorTests, TensorNamesCheckWithoutEnable) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         function = function_ref->clone();
         add->get_input_tensor(0).set_names({"new_name"});
     }
@@ -218,7 +218,7 @@ TEST(GraphComparatorTests, CheckAttributesNegative) {
                                                               ov::CoordinateDiff{1, 1},
                                                               ov::CoordinateDiff{1, 1},
                                                               ov::Strides{1, 1});
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
@@ -233,7 +233,7 @@ TEST(GraphComparatorTests, CheckAttributesNegative) {
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::CoordinateDiff{0, 0},
                                                               ov::Strides{1, 1});
-        function = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::ATTRIBUTES).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -247,13 +247,13 @@ TEST(GraphComparatorTests, CheckPrecisionsNegative) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::f32, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::PRECISIONS).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -267,13 +267,13 @@ TEST(GraphComparatorTests, CheckPrecisionsWithoutEnable) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::f32, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -288,13 +288,13 @@ TEST(GraphComparatorTests, CheckRTInfo) {
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->get_rt_info()["my_info"] = 42;
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -308,14 +308,14 @@ TEST(GraphComparatorTests, CheckRTInfoReverse) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->get_rt_info()["my_info"] = 42;
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -330,13 +330,13 @@ TEST(GraphComparatorTests, CheckRTInfoInput) {
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->input(0).get_rt_info()["my_info"] = 42;
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -351,13 +351,13 @@ TEST(GraphComparatorTests, CheckRTInfoOutput) {
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
         add->output(0).get_rt_info()["my_info"] = 42;
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{3});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {3}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::RUNTIME_KEYS).enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -401,7 +401,7 @@ TEST(GraphComparatorTests, CheckTensorIteratorPositive) {
         auto out1 = tensor_iterator->get_concatenated_slices(res_2, 0, 1, 1, -1, 0);
 
         auto res_ti_1 = std::make_shared<ov::op::v0::Result>(tensor_iterator->output(1));
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{res_ti_1}, ov::ParameterVector{X, Y});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{res_ti_1}, ov::ParameterVector{X, Y});
         function = function_ref->clone();
     }
     comparator.enable(FunctionsComparator::NODES);
@@ -563,7 +563,7 @@ TEST(GraphComparatorTests, DisableCheck) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
         function = function_ref->clone();
     }
     comparator.enable(FunctionsComparator::NODES);
@@ -579,13 +579,13 @@ TEST(GraphComparatorTests, CheckAccuracyPositive) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {0});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::ACCURACY);
     auto res = comparator.compare(function, function_ref);
@@ -599,13 +599,13 @@ TEST(GraphComparatorTests, CheckAccuracyNegative) {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {12});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
         auto constant = ov::op::v0::Constant::create(ov::element::i64, {1}, {200});
         auto add = std::make_shared<ov::op::v1::Add>(input, constant);
-        function = std::make_shared<ov::Model>(ov::NodeVector{add}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{add}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::ACCURACY);
     auto res = comparator.compare(function, function_ref);
@@ -628,7 +628,7 @@ TEST(GraphComparatorTests, CheckAccuracyNotEnabled) {
                                                               ov::CoordinateDiff{1, 1},
                                                               ov::CoordinateDiff{1, 1},
                                                               ov::Strides{1, 1});
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::Shape{1, 3, 12, 12});
@@ -643,7 +643,7 @@ TEST(GraphComparatorTests, CheckAccuracyNotEnabled) {
                                                               ov::CoordinateDiff{1, 1},
                                                               ov::CoordinateDiff{1, 1},
                                                               ov::Strides{1, 1});
-        function = std::make_shared<ov::Model>(ov::NodeVector{conv}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{conv}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NODES);
     auto res = comparator.compare(function, function_ref);
@@ -659,7 +659,7 @@ TEST(GraphComparatorTests, CheckConsumersCountPositive) {
         auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant);
         auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant);
         auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
@@ -667,7 +667,7 @@ TEST(GraphComparatorTests, CheckConsumersCountPositive) {
         auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant);
         auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant);
         auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
-        function = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NODES).enable(FunctionsComparator::CONSUMERS_COUNT);
     auto res = comparator.compare(function, function_ref);
@@ -683,7 +683,7 @@ TEST(GraphComparatorTests, CheckConsumersCountNegative) {
         auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant);
         auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant);
         auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
-        function_ref = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        function_ref = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }
     {
         auto input = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
@@ -692,7 +692,7 @@ TEST(GraphComparatorTests, CheckConsumersCountNegative) {
         auto add_1 = std::make_shared<ov::op::v1::Add>(input, constant_1);
         auto add_2 = std::make_shared<ov::op::v1::Add>(input, constant_2);
         auto mul = std::make_shared<ov::op::v1::Multiply>(add_1, add_2);
-        function = std::make_shared<ov::Model>(ov::NodeVector{mul}, ov::ParameterVector{input});
+        function = std::make_shared<ov::Model>(ov::OutputVector{mul}, ov::ParameterVector{input});
     }
     comparator.enable(FunctionsComparator::NODES).enable(FunctionsComparator::CONSUMERS_COUNT);
     auto res = comparator.compare(function, function_ref);


### PR DESCRIPTION
### Details:
 - Deprecate `ov::Model` ctor using ov::NodeVector` as model outputs
 - Use only `ov::ResultVector` or `ov::OutputVector` as model outputs

### Tickets:
 - CVS-72662
