### PR TITLE
[Snippets] Disable reference implementation for Scalar node

### DIFF
--- a/src/common/snippets/include/snippets/op/scalar.hpp
+++ b/src/common/snippets/include/snippets/op/scalar.hpp
@@ -37,6 +37,8 @@ public:
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
     void validate_and_infer_types() override;
     bool visit_attributes(AttributeVisitor& visitor) override;
+
+    bool has_evaluate() const override { return false; }
 };
 
 } // namespace op


### PR DESCRIPTION
### Details:
Snippets nodes normally do not have reference implementation. Disable it for ones that do have one inherited from the parent operation class

### Tickets:
 - 163186
