### PR TITLE
[GPU] enable u8,i8 for fc 5 dims

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -273,6 +273,8 @@ attach_fully_connected_impl::attach_fully_connected_impl() {
         std::make_tuple(data_types::f32, format::bs_fs_fsv8_bsv8),
         std::make_tuple(data_types::f16, format::bs_fs_fsv8_bsv8),
         std::make_tuple(data_types::f16, format::bs_fs_fsv8_bsv16),
+        std::make_tuple(data_types::i8, format::bfzyx),
+        std::make_tuple(data_types::u8, format::bfzyx),
     });
 }
 


### PR DESCRIPTION
### Details:
 - enable u8,i8 with bfzyx format in FC
 - has_impl_for function checked FC layer's original input which is 5-dim. But In runtime, the FC layer executed as bfyx by optimizing out its dependency node, Reshape, which changes bfyx to bfzyx.
  As has_impl_for is in add_required_reorders pass, it could not know whether its dependency node would be optimized out or not. 

### Tickets:
 - CVS-165888