### PR TITLE
fix process hang when dumping passes. 

### DIFF
--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1290,6 +1290,8 @@ bool pass::Serialize::run_on_model(const std::shared_ptr<ov::Model>& model) {
 
         try {
             serializeFunc(xml_file, bin_file, model, m_version);
+            xml_file.close();
+            bin_file.close();
         } catch (const ov::AssertFailure&) {
             // optimization decision was made to create .bin file upfront and
             // write to it directly instead of buffering its content in memory,


### PR DESCRIPTION
when using OV_ENABLE_PROFILE_PASS with no pass selected, the process hangs because too many files are opened at the same time. fix this by closing files.