### PR TITLE
[BuildTime][CPU] Remove needless ops.hpp includes from cpu plugin - tests/unit

### DIFF
--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/adaptive_avg_pool_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/adaptive_avg_pool_shape_inference_test.cpp
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
 #include "utils.hpp"
+#include "openvino/op/adaptive_avg_pool.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/adaptive_max_pool_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/adaptive_max_pool_shape_inference_test.cpp
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
 #include "utils.hpp"
+#include "openvino/op/adaptive_max_pool.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/avg_pool_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/avg_pool_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
 #include "utils.hpp"
+#include "openvino/op/avg_pool.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/batch_to_space_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/batch_to_space_shape_inference_test.cpp
@@ -3,9 +3,11 @@
 //
 
 #include <gtest/gtest.h>
-
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/batch_to_space.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/bec_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/bec_shape_inference_test.cpp
@@ -7,6 +7,12 @@
 #include "common_test_utils/test_assertions.hpp"
 #include "openvino/op/parameter.hpp"
 #include "utils.hpp"
+#include "openvino/op/equal.hpp"
+#include "openvino/op/greater.hpp"
+#include "openvino/op/greater_eq.hpp"
+#include "openvino/op/less.hpp"
+#include "openvino/op/less_eq.hpp"
+#include "openvino/op/not_equal.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/bel_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/bel_shape_inference_test.cpp
@@ -7,6 +7,9 @@
 #include "common_test_utils/test_assertions.hpp"
 #include "openvino/op/parameter.hpp"
 #include "utils.hpp"
+#include "openvino/op/logical_and.hpp"
+#include "openvino/op/logical_or.hpp"
+#include "openvino/op/logical_xor.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/binary_convolution_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/binary_convolution_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/binary_convolution.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/broadcast_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/broadcast_shape_inference.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/col2im_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/col2im_shape_inference_test.cpp
@@ -6,6 +6,8 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/col2im.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/convolution_backprop_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/convolution_backprop_shape_inference_test.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "convolution_backprop_shape_inference.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/ctc_loss_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/ctc_loss_shape_inference_test.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "ctc_loss_shape_inference.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/prior_box.cpp
@@ -8,7 +8,8 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "custom_shape_infer.hpp"
-#include "openvino/opsets/opset8.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/prior_box.hpp"
 namespace ov {
 namespace intel_cpu {
 namespace unit_test {

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/deformable_convolution_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/deformable_convolution_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/deformable_convolution.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/deformable_psroi_pooling_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/deformable_psroi_pooling_shape_inference_test.cpp
@@ -6,8 +6,10 @@
 #include <array>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/deformable_psroi_pooling.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/depth_to_space_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/depth_to_space_shape_inference_test.cpp
@@ -3,9 +3,10 @@
 //
 
 #include <gtest/gtest.h>
-
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/depth_to_space.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/elementwises.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/elementwises.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/relu.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/embedding_segments_sum_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/embedding_segments_sum_test.cpp
@@ -4,7 +4,7 @@
 
 #include "embedding_segments_sum_shape_inference.hpp"
 #include "gmock/gmock.h"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/embeddingbag_offsets_sum_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/embeddingbag_offsets_sum_shape_inference_test.cpp
@@ -7,7 +7,7 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "embeddingbag_offsets_shape_inference.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/embeddingbag_packed_sum_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/embeddingbag_packed_sum_shape_inference_test.cpp
@@ -7,7 +7,8 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "embeddingbag_packed_shape_inference.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/op/embeddingbag_packedsum.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_detection_output_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_detection_output_shape_inference_test.cpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/experimental_detectron_detection_output.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_prior_grid_generator_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_prior_grid_generator_shape_inference_test.cpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/experimental_detectron_prior_grid_generator.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_roi_feature_extractor_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/experimental_detectron_roi_feature_extractor_shape_inference_test.cpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/experimental_detectron_roi_feature.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/eye_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/eye_shape_inference_test.cpp
@@ -7,8 +7,11 @@
 #include <array>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/eye.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/fft_base_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/fft_base_shape_inference_test.cpp
@@ -5,6 +5,11 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/dft.hpp"
+#include "openvino/op/idft.hpp"
+#include "openvino/op/irdft.hpp"
+#include "openvino/op/rdft.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/glu_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/glu_shape_inference_test.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/test_assertions.hpp"
 #include "ov_ops/glu.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/grid_sample_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/grid_sample_shape_inference_test.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
-#include "openvino/opsets/opset9.hpp"
+#include "openvino/opsets/opset9_decl.hpp"
 #include "grid_sample_shape_inference.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/group_convolution_backprop_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/group_convolution_backprop_shape_inference_test.cpp
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/group_conv.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/group_convolution_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/group_convolution_shape_inference_test.cpp
@@ -6,7 +6,6 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "group_convolution_shape_inference.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/gru_cell_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/gru_cell_shape_inference_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/gru_cell.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/gru_sequence_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/gru_sequence_shape_inference_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/gru_sequence.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/interpolate_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/interpolate_shape_inference_test.cpp
@@ -7,6 +7,8 @@
 #include <chrono>
 
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/interpolate.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/lstm_cell_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/lstm_cell_shape_inference_test.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/lstm_cell.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/lstm_seq_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/lstm_seq_shape_inference_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/lstm_sequence.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/matmul_shape_inference.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/matmul_shape_inference.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/matmul.hpp"
 using namespace ov;
 using namespace ov::intel_cpu;
 using namespace testing;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/max_pool_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/max_pool_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
 #include "utils.hpp"
+#include "openvino/op/max_pool.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/nms_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/nms_shape_inference_test.cpp
@@ -3,9 +3,9 @@
 //
 
 #include <gmock/gmock.h>
-
-#include "openvino/opsets/opset10.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/non_max_suppression.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/pad_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/pad_shape_inference_test.cpp
@@ -5,7 +5,7 @@
 #include <pad_shape_inference.hpp>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
 
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_clustered_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_clustered_shape_inference_test.cpp
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/prior_box_clustered.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/prior_box_shape_inference_test.cpp
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/prior_box.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/proposal_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/proposal_shape_inference_test.cpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/proposal.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/psroi_pooling_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/psroi_pooling_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/psroi_pooling.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/random_uniform_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/random_uniform_shape_inference_test.cpp
@@ -5,8 +5,9 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset12.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/random_uniform.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/reduce_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/reduce_shape_inference_test.cpp
@@ -2,11 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#include "reduce_shape_inference.hpp"
+
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
+#include "openvino/op/reduce_l1.hpp"
+#include "openvino/op/reduce_l2.hpp"
+#include "openvino/op/reduce_logical_and.hpp"
+#include "openvino/op/reduce_logical_or.hpp"
+#include "openvino/op/reduce_max.hpp"
+#include "openvino/op/reduce_mean.hpp"
+#include "openvino/op/reduce_min.hpp"
+#include "openvino/op/reduce_prod.hpp"
+#include "openvino/op/reduce_sum.hpp"
 #include "utils.hpp"
-#include "reduce_shape_inference.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/reshape_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/reshape_shape_inference_test.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/test_assertions.hpp"
 #include "openvino/op/reshape.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/reverse_sequence_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/reverse_sequence_shape_inference_test.cpp
@@ -3,8 +3,10 @@
 //
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/reverse_sequence.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/reverse_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/reverse_shape_inference_test.cpp
@@ -4,8 +4,10 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "openvino/op/reverse.hpp"
-#include "openvino/opsets/opset1.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/opsets/opset1_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/rms_norm_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/rms_norm_shape_inference_test.cpp
@@ -7,6 +7,7 @@
 #include "common_test_utils/test_assertions.hpp"
 #include "openvino/op/rms_norm.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/rnn_cell_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/rnn_cell_shape_inference_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/rnn_cell.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/rnn_seq_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/rnn_seq_shape_inference_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/rnn_sequence.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/roi_align_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/roi_align_shape_inference_test.cpp
@@ -6,6 +6,7 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/roi_align.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/roi_pooling_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/roi_pooling_shape_inference_test.cpp
@@ -5,8 +5,8 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset11.hpp"
 #include "utils.hpp"
+#include "openvino/op/roi_pooling.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/roll_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/roll_shape_inference_test.cpp
@@ -6,8 +6,11 @@
 #include <array>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/roll.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/scaled_dot_product_attention_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/scaled_dot_product_attention_shape_inference_test.cpp
@@ -5,8 +5,10 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset13.hpp"
+#include "openvino/opsets/opset13_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
+#include "openvino/opsets/opset13_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/scatter_elements_update_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/scatter_elements_update_shape_inference_test.cpp
@@ -5,8 +5,11 @@
 #include <gtest/gtest.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/scatter_elements_update.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::opset10;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/scatter_nd_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/scatter_nd_shape_inference_test.cpp
@@ -3,9 +3,8 @@
 //
 
 #include <gtest/gtest.h>
-
-#include "openvino/opsets/opset10.hpp"
 #include "utils.hpp"
+#include "openvino/op/scatter_nd_update.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/scatter_update_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/scatter_update_shape_inference_test.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/scatter_update.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/search_sorted_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/search_sorted_shape_inference_test.cpp
@@ -6,6 +6,8 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/search_sorted.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/segment_max_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/segment_max_shape_inference_test.cpp
@@ -6,6 +6,8 @@
 
 #include "common_test_utils/test_assertions.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/segment_max.hpp"
 
 using namespace ov::intel_cpu;
 using ov::op::v0::Constant, ov::op::v0::Parameter;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/select_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/select_shape_inference_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/select.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/shape_node_tests.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/shape_node_tests.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/shape_of.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/shuffle_channels_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/shuffle_channels_shape_inference_test.cpp
@@ -3,9 +3,10 @@
 //
 
 #include <gtest/gtest.h>
-
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/shuffle_channels.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/space_to_batch_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/space_to_batch_shape_inference_test.cpp
@@ -3,9 +3,11 @@
 //
 
 #include <gtest/gtest.h>
-
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/space_to_batch.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/space_to_depth_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/space_to_depth_shape_inference_test.cpp
@@ -3,9 +3,10 @@
 //
 
 #include <gtest/gtest.h>
-
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "utils.hpp"
+#include "openvino/op/space_to_depth.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/tile_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/tile_shape_inference_test.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 
 #include "utils.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/tile.hpp"
 
 using namespace ov;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/topk_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/topk_shape_inference_test.cpp
@@ -5,7 +5,7 @@
 #include <gmock/gmock.h>
 
 #include "common_test_utils/test_assertions.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "topk_shape_inference.hpp"
 #include "utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/utils.hpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/utils.hpp
@@ -5,7 +5,6 @@
 #pragma once
 #include <gtest/gtest.h>
 
-#include "openvino/op/ops.hpp"
 #include "openvino/op/parameter.hpp"
 #include "shape_inference/shape_inference.hpp"
 #include "shape_inference/static_shape.hpp"

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/lowered/brgemm_blocking.cpp
@@ -8,7 +8,7 @@
 #endif
 
 #include "lir_test_utils.hpp"
-#include "openvino/opsets/opset10.hpp"
+#include "openvino/opsets/opset10_decl.hpp"
 #include "snippets/lowered/loop_info.hpp"
 #include "snippets/snippets_isa.hpp"
 #include "transformations/snippets/x64/op/brgemm_copy_b.hpp"

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv.cpp
@@ -8,9 +8,9 @@
 #include <memory>
 
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset3.hpp>
-#include <openvino/opsets/opset7.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset3_decl.hpp"
+#include "openvino/opsets/opset7_decl.hpp"
 #include <transformations/cpu_opset/arm/pass/convert_group_conv.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_group_conv1d.cpp
@@ -8,9 +8,9 @@
 #include <memory>
 
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset3.hpp>
-#include <openvino/opsets/opset7.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset3_decl.hpp"
+#include "openvino/opsets/opset7_decl.hpp"
 #include <transformations/cpu_opset/arm/pass/convert_group_conv1d.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_multi_axis.cpp
@@ -8,9 +8,9 @@
 #include <memory>
 
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset3.hpp>
-#include <openvino/opsets/opset7.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset3_decl.hpp"
+#include "openvino/opsets/opset7_decl.hpp"
 #include <transformations/cpu_opset/arm/pass/convert_reduce_multi_axis.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>

--- a/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/arm/convert_reduce_no_keep_dims.cpp
@@ -3,8 +3,7 @@
 //
 
 #include <gtest/gtest.h>
-
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
 #include <transformations/cpu_opset/arm/pass/convert_reduce_no_keep_dims.hpp>
 #include "common_test_utils/ov_test_utils.hpp"
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_matmul_test.cpp
@@ -6,9 +6,9 @@
 
 #include <memory>
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset3.hpp>
-#include <openvino/opsets/opset7.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset3_decl.hpp"
+#include "openvino/opsets/opset7_decl.hpp"
 #include <openvino/pass/manager.hpp>
 #include <ov_ops/type_relaxed.hpp>
 #include <transformations/cpu_opset/common/pass/convert_matmul_to_fc.hpp>
@@ -19,6 +19,12 @@
 #include "openvino/op/constant.hpp"
 #include "ov_ops/fully_connected.hpp"
 #include "transformations/rt_info/decompression.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/convert_to_leaky_relu_test.cpp
@@ -8,7 +8,7 @@
 #include <memory>
 
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
 #include <transformations/cpu_opset/common/pass/convert_to_leaky_relu.hpp>
 #include <transformations/cpu_opset/common/op/leaky_relu.hpp>
 #include <transformations/init_node_info.hpp>
@@ -16,6 +16,7 @@
 #include <ov_ops/type_relaxed.hpp>
 #include <openvino/pass/manager.hpp>
 #include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/prelu.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
@@ -10,12 +10,16 @@
 #include <memory>
 
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
 #include "ov_ops/fully_connected.hpp"
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
 
 #include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/optimize_sequence_transposes_test.cpp
@@ -8,15 +8,22 @@
 #include <memory>
 
 #include <openvino/core/model.hpp>
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset5.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset5_decl.hpp"
+#include "openvino/opsets/opset8_decl.hpp"
 #include <transformations/cpu_opset/common/pass/rnn_sequences_optimization.hpp>
 #include <transformations/init_node_info.hpp>
 #include <transformations/utils/utils.hpp>
 #include <ov_ops/type_relaxed.hpp>
 #include <openvino/pass/manager.hpp>
 #include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/gru_sequence.hpp"
+#include "openvino/op/lstm_sequence.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/rnn_sequence.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -6,8 +6,7 @@
 
 #include <string>
 #include <memory>
-
-#include <openvino/opsets/opset13.hpp>
+#include "openvino/opsets/opset13_decl.hpp"
 #include <transformations/cpu_opset/common/op/sdpa.hpp>
 #include <transformations/cpu_opset/common/pass/stateful_sdpa_fusion.hpp>
 #include <transformations/init_node_info.hpp>
@@ -18,6 +17,15 @@
 
 #include "common_test_utils/ov_test_utils.hpp"
 #include "transformations/utils/print_model.hpp"
+#include "openvino/op/abs.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/broadcast.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/scaled_dot_product_attention.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/unsqueeze.hpp"
 
 using namespace testing;
 using namespace ov;

--- a/src/plugins/intel_cpu/tests/unit/transformations/swap_convert_transpose.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/swap_convert_transpose.cpp
@@ -7,8 +7,8 @@
 #include "common_test_utils/ov_test_utils.hpp"
 #include <transformations/cpu_opset/common/pass/swap_convert_transpose.hpp>
 #include <transformations/init_node_info.hpp>
-
-#include "openvino/opsets/opset1.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace testing;
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/x64/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/x64/convert_to_interaction.cpp
@@ -6,9 +6,8 @@
 
 #include <string>
 #include <memory>
-
-#include <openvino/opsets/opset1.hpp>
-#include <openvino/opsets/opset8.hpp>
+#include "openvino/opsets/opset1_decl.hpp"
+#include "openvino/opsets/opset8_decl.hpp"
 #include <transformations/cpu_opset/x64/op/interaction.hpp>
 #include <transformations/cpu_opset/x64/pass/convert_to_interaction.hpp>
 #include <transformations/common_optimizations/nop_elimination.hpp>
@@ -19,6 +18,13 @@
 #include "ov_ops/type_relaxed.hpp"
 
 #include "common_test_utils/ov_test_utils.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/fake_quantize.hpp"
+#include "openvino/op/gather.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/shape_of.hpp"
+#include "openvino/op/transpose.hpp"
 
 using namespace testing;
 using namespace ov::intel_cpu;


### PR DESCRIPTION
### Details:
 - Replaced includes of opset definition with its declaration.
 - Adds necessary operator header includes


### Tickets:
 - Epic: CVS-165431
 - Task: CVS-166360
