### PR TITLE
[GPU] resample supports bsv16_fsv32

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/resample.cpp
@@ -185,6 +185,7 @@ attach_resample_impl::attach_resample_impl() {
         format::b_fs_yx_fsv16,
         format::b_fs_yx_fsv32,
         format::bs_fs_yx_bsv16_fsv16,
+        format::bs_fs_yx_bsv16_fsv32,
         format::bs_fs_yx_bsv32_fsv16,
         format::bs_fs_yx_bsv32_fsv32,
 

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1198,14 +1198,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     return true;
                 }
 
-                // AZP does not support 8bit weight
-                // XXX: This is currently wrapped as GPU_DEBUG_IF as dynamic_quantize_asym is not exposed through public API.
-                GPU_DEBUG_IF(asymmetric_dyn_quant
-                    && (root->get_input_element_type(1) == ov::element::i8 || root->get_input_element_type(1) == ov::element::u8)) {
-                    GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off: asym quantization does not support 8bit weight" << std::endl;
-                    return true;
-                }
-
                 // AZP does not support grouped size dyn-quan
                 GPU_DEBUG_IF(asymmetric_dyn_quant && (dynamic_quantization_group_size != UINT64_MAX)) {
                     GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off: asym quantization does not support grouped quantization" <<


### PR DESCRIPTION
### Details:
 - For yolo v5m b16 case, resample should run in bsv16_fsv32. It was missing in supported layout.
 - Allow OneDNN asym_dyn_quan for i8 weight case. (not related to resample, but a minor change)

### Tickets:
 - 166362
