### PR TITLE
[GPU] Fix memory issues in weightless cache with ov::Model

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -294,6 +294,9 @@ public:
 
     bool is_new_shape_infer() const { return new_shape_infer; }
     layout_optimizer& get_layout_optimizer() const { return *_layout_optimizer; }
+    void set_model_ptr(std::shared_ptr<const ov::Model> model_ptr) {
+        _model_ptr = model_ptr;
+    }
 
 private:
     uint32_t prog_id = 0;
@@ -327,6 +330,7 @@ private:
     graph_optimizer_info optimizer_passes_info;
 
     std::map<std::string, std::vector<primitive_id>> state_initializers;
+    std::shared_ptr<const ov::Model> _model_ptr;
 
     primitives_info get_current_stage_info() const;
     /*

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1862,10 +1862,9 @@ void program::load(cldnn::BinaryInputBuffer& ib) {
 
     std::shared_ptr<WeightsMemory> weights_memory = nullptr;
     std::string weights_path = _config.get_weights_path();
-    auto model_ptr = _config.get_model();
     if (_config.get_cache_mode() == ov::CacheMode::OPTIMIZE_SIZE) {
-        if (model_ptr) {
-            weights_memory = std::make_shared<WeightsMemory>(model_ptr);
+        if (_model_ptr) {
+            weights_memory = std::make_shared<WeightsMemory>(_model_ptr);
         } else if (!weights_path.empty()) {
             ov::util::validate_weights_path(weights_path);
             weights_memory = std::make_shared<WeightsMemory>(ov::load_mmap_object(weights_path));
@@ -1889,6 +1888,7 @@ void program::load(cldnn::BinaryInputBuffer& ib) {
         }
         get_or_create(prim);
     }
+    _model_ptr.reset();
 
     size_t num_output_sharing_mutable_datas;
     ib >> num_output_sharing_mutable_datas;

--- a/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
+++ b/src/plugins/intel_gpu/src/plugin/compiled_model.cpp
@@ -162,6 +162,7 @@ CompiledModel::CompiledModel(cldnn::BinaryInputBuffer& ib,
         auto graph = n == 0 ? graph_base : std::make_shared<Graph>(graph_base, n);
         m_graphs.push_back(graph);
     }
+    m_config.set_user_property({ov::hint::model(std::shared_ptr<const ov::Model>(nullptr))});
 }
 
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -92,9 +92,13 @@ Graph::Graph(cldnn::BinaryInputBuffer &ib, const RemoteContextImpl::Ptr& context
     IstreamAttributeVisitor<cldnn::BinaryInputBuffer> visitor(ib);
     m_config.visit_attributes(visitor);
     m_config.set_user_property(config.get_user_properties()); // Copy user properties if those were modified on import call
+    m_config.set_user_property({ov::hint::model(std::shared_ptr<const ov::Model>(nullptr))});
     m_config.finalize(context.get(), nullptr);
 
     auto imported_prog = std::make_shared<cldnn::program>(get_engine(), m_config);
+    // Not passing MODEL_PTR through m_config because imported_prog->load() resets the shared_ptr to enable memory
+    // release once the import is finished. And values in m_config are immutable after config finalization.
+    imported_prog->set_model_ptr(config.get_model());
     imported_prog->load(ib);
     build(imported_prog);
 }


### PR DESCRIPTION
### Details:
 - This change makes sure that the shared_ptr to ov::Model is not held anywhere so that the memory can be released once the import is completed.

### Tickets:
 - CVS-165231
