### PR TITLE
[PT][FE] Fix FX Stack Translate to Process ListConstruct Args

### DIFF
--- a/src/frontends/pytorch/src/utils.cpp
+++ b/src/frontends/pytorch/src/utils.cpp
@@ -614,10 +614,10 @@ std::tuple<Output<Node>, Output<Node>> get_inputs_with_promoted_types(const Node
     return std::make_tuple(lhs, rhs);
 }
 
-std::deque<Output<Node>> get_list_as_outputs(const Output<Node>& start, bool unsqueeze_for_concat) {
+std::deque<Output<Node>> get_list_as_outputs(const Output<Node>& start, bool unsqueeze_for_concat, int64_t axis) {
     std::deque<Output<Node>> res;
     auto current_output = start;
-    auto zero = v0::Constant::create(element::i32, Shape{}, {0});
+    auto zero = v0::Constant::create(element::i32, Shape{}, {axis}); // Default axis is 0
     while (const auto& input_fw_node =
                ov::as_type_ptr<ov::op::util::FrameworkNode>(current_output.get_node_shared_ptr())) {
         const auto& attrs = input_fw_node->get_attrs();

--- a/src/frontends/pytorch/src/utils.hpp
+++ b/src/frontends/pytorch/src/utils.hpp
@@ -102,7 +102,7 @@ void align_eltwise_input_types(const NodeContext& context,
                                const bool& ir_rhs_python_scalar = false);
 void align_output_types(const NodeContext& context, OutputVector& outputs);
 
-std::deque<Output<Node>> get_list_as_outputs(const Output<Node>& start, bool unsqueeze_for_concat = false);
+std::deque<Output<Node>> get_list_as_outputs(const Output<Node>& start, bool unsqueeze_for_concat = false, int64_t axis = 0);
 
 void copy_runtime_info_and_name(const std::shared_ptr<Node>& from,
                                 ov::NodeVector to,

--- a/tests/layer_tests/pytorch_tests/test_stack.py
+++ b/tests/layer_tests/pytorch_tests/test_stack.py
@@ -39,6 +39,7 @@ class TestStack2D(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_torch_export
+    @pytest.mark.precommit_fx_backend
     def test_stack2D(self, input_shape, dim, ie_device, precision, ir_version):
         self.input_tensors = [
             np.random.randn(*input_shape).astype(np.float32),
@@ -79,6 +80,7 @@ class TestStack3D(PytorchLayerTest):
     @pytest.mark.nightly
     @pytest.mark.precommit
     @pytest.mark.precommit_torch_export
+    @pytest.mark.precommit_fx_backend
     def test_stack3D(self, input_shape, dim, ie_device, precision, ir_version):
         self.input_tensors = [
             np.random.randn(*input_shape).astype(np.float32),


### PR DESCRIPTION
### Details:
- modified existing FX stack translate function so that it can process the ListConstruct args object using the appropriate `get_list_as_outputs` function
- Modify the `get_list_as_outputs` to accept axis as input for non-zero axis
- Extended test to cover the above case

