### PR TITLE
Add a new C API function for reading IR models from memory.

### DIFF
--- a/src/bindings/c/include/openvino/c/ov_core.h
+++ b/src/bindings/c/include/openvino/c/ov_core.h
@@ -194,6 +194,25 @@ ov_core_read_model_from_memory_buffer(const ov_core_t* core,
                                       ov_model_t** model);
 
 /**
+ * @brief Reads IR model from memory.
+ * @ingroup ov_core_c_api
+ * @param core A pointer to the ov_core_t instance.
+ * @param xml_str XML string buffer.
+ * @param str_len The length of XML string.
+ * @param bin_str BIN string buffer.
+ * @param bin_len The length of BIN string.
+ * @param model A pointer to the newly created model.
+ * @return Status code of the operation: OK(0) for success.
+ */
+OPENVINO_C_API(ov_status_e)
+ov_core_read_ir_model_from_memory_buffer(const ov_core_t* core,
+                                         const char* xml_str,
+                                         const size_t xml_len,
+                                         const char* bin_str,
+                                         const size_t bin_len,
+                                         ov_model_t** model);
+
+/**
  * @brief Creates a compiled model from a source model object.
  * Users can create as many compiled models as they need and use
  * them simultaneously (up to the limitation of the hardware resources).

--- a/src/bindings/c/src/ov_core.cpp
+++ b/src/bindings/c/src/ov_core.cpp
@@ -132,6 +132,25 @@ ov_status_e ov_core_read_model_from_memory_buffer(const ov_core_t* core,
     return ov_status_e::OK;
 }
 
+ov_status_e ov_core_read_ir_model_from_memory_buffer(const ov_core_t* core,
+                                                     const char* xml_str,
+                                                     const size_t xml_len,
+                                                     const char* bin_str,
+                                                     const size_t bin_len,
+                                                     ov_model_t** model) {
+    if (!core || !xml_str || !xml_len || !bin_str || !bin_len || !model) {
+        return ov_status_e::INVALID_C_PARAM;
+    }
+
+    try {
+        std::unique_ptr<ov_model_t> _model(new ov_model_t);
+        _model->object = core->object->read_model(xml_str, xml_len, bin_str, bin_len);
+        *model = _model.release();
+    }
+    CATCH_OV_EXCEPTIONS
+    return ov_status_e::OK;
+}
+
 ov_status_e ov_core_compile_model(const ov_core_t* core,
                                   const ov_model_t* model,
                                   const char* device_name,

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -157,6 +157,20 @@ public:
     std::shared_ptr<ov::Model> read_model(const std::string& model, const Tensor& weights) const;
 
     /**
+     * @brief Reads models from IR format using pre-existing data.
+     * @param xml_str XML string buffer.
+     * @param str_len The length of XML string.
+     * @param bin_str BIN string buffer.
+     * @param bin_len The length of BIN string.
+     * @return A model.
+     */
+    std::shared_ptr<ov::Model> read_model(const char* xml_buffer,
+                                          size_t xml_len,
+                                          const char* bin_buffer,
+                                          size_t bin_len) const;
+
+
+    /**
      * @brief Creates and loads a compiled model from a source model to the default OpenVINO device selected by the AUTO
      * plugin.
      *

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -99,6 +99,19 @@ std::shared_ptr<ov::Model> Core::read_model(const std::string& model, const ov::
     OV_CORE_CALL_STATEMENT(return _impl->read_model(model, weights););
 }
 
+std::shared_ptr<ov::Model> Core::read_model(const char* xml_buffer,
+                                            size_t xml_len,
+                                            const char* bin_buffer,
+                                            size_t bin_len) const {
+    std::shared_ptr<AlignedBuffer> model_buffer(std::make_shared<AlignedBuffer>(xml_len));
+    std::shared_ptr<AlignedBuffer> weight_buffer(std::make_shared<AlignedBuffer>(bin_len));
+
+    memcpy((*model_buffer).get_ptr(), xml_buffer, xml_len);
+    memcpy((*weight_buffer).get_ptr(), bin_buffer, bin_len);
+
+    OV_CORE_CALL_STATEMENT(return _impl->read_model(model_buffer, weight_buffer););
+}
+
 CompiledModel Core::compile_model(const std::shared_ptr<const ov::Model>& model, const AnyMap& config) {
     return compile_model(model, ov::DEFAULT_DEVICE_NAME, config);
 }


### PR DESCRIPTION
The C API was missing the ability to read an IR model from memory buffers. I needed this functionality for game enabling, thus I've added the ability to do so.

It would be ideal not to have to allocate additional memory and copy it before reading but I found no other way to do so without making significant changes to other parts of the code.