### PR TITLE
[ONNX] Added dequantize linear channel wise pattern

### DIFF
--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -231,7 +231,8 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
         (axis == 0 && src_x.get_shape()[0] % block_size == 0) || (axis == 1 && src_x.get_shape()[1] % block_size == 0),
         "DequantizeLinear doesn't support case when dimension of X cannot be divided by block_size");
 
-    bool is_cw_quantize = (src_x.get_shape()[0] == block_size) || (src_x.get_shape()[1] == block_size);
+    bool is_cw_quantize = (axis == 0 && src_x.get_shape()[0] == block_size) || \
+                          (axis == 1 && src_x.get_shape()[1] == block_size);
     if (is_cw_quantize)
     {
         ov::Output<ov::Node> converted_x = std::make_shared<v0::Convert>(src_x, scale.get_element_type());

--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -225,17 +225,38 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
     const auto axis = node.get_attribute_value<int64_t>("axis", 1);
     const auto block_size = static_cast<size_t>(node.get_attribute_value<int64_t>("block_size", 0));
 
-    FRONT_END_GENERAL_CHECK(axis == 0, "Axis != 0 isn't supported");
+    FRONT_END_GENERAL_CHECK(axis <= 1, "Axis > 1 isn't supported");
     FRONT_END_GENERAL_CHECK(block_size > 0, "block_size must be greater than zero");
     FRONT_END_GENERAL_CHECK(
-        src_x.get_shape()[0] % block_size == 0,
-        "DequantizeLinear doesn't support case when first dimension of X cannot be divided by block_size");
+        (axis == 0 && src_x.get_shape()[0] % block_size == 0) || (axis == 1 && src_x.get_shape()[1] % block_size == 0),
+        "DequantizeLinear doesn't support case when dimension of X cannot be divided by block_size");
 
-    // For further broadcasting scales and zp - reshape input to a shape [x.shape[0]/block_size, block_size, x.shape[1]]
-    ov::Output<ov::Node> broadcastable_x = op::util::reshape(
-        src_x,
-        Shape{static_cast<size_t>(src_x.get_shape()[0]) / block_size, block_size, src_x.get_shape()[1]});
+    bool is_cw_quantize = (src_x.get_shape()[0] == block_size) || (src_x.get_shape()[1] == block_size);
+    if (is_cw_quantize)
+    {
+        ov::Output<ov::Node> converted_x = std::make_shared<v0::Convert>(src_x, scale.get_element_type());
+        if (inputs.size() > 2) {
+            zp = inputs[2];
+            zp = std::make_shared<v0::Convert>(zp, scale.get_element_type());
+            converted_x = std::make_shared<v1::Subtract>(converted_x, zp);
+        }
+        auto scaled_x = std::make_shared<v1::Multiply>(converted_x, scale);
+        return {scaled_x};
+    }
 
+    // For further broadcasting scales and zp - reshape input to a shape
+    // axis == 0, [x.shape[0]/block_size, block_size, x.shape[1]]
+    // axis == 1, [x.shape[0], block_size, x.shape[1]/block_size]
+    ov::Output<ov::Node> broadcastable_x;
+    if (axis == 0) {
+        broadcastable_x = op::util::reshape(
+            src_x,
+            Shape{static_cast<size_t>(src_x.get_shape()[0]) / block_size, block_size, src_x.get_shape()[1]});
+    } else {
+        broadcastable_x = op::util::reshape(
+            src_x,
+            Shape{src_x.get_shape()[0], block_size, static_cast<size_t>(src_x.get_shape()[1]) / block_size});
+    }
     const auto& unsqueezed_axes = std::make_shared<v0::Constant>(ov::element::i64, Shape{1}, std::vector<int64_t>{1});
 
     const auto scale_type = scale.get_element_type();

--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -231,10 +231,9 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
         (axis == 0 && src_x.get_shape()[0] % block_size == 0) || (axis == 1 && src_x.get_shape()[1] % block_size == 0),
         "DequantizeLinear doesn't support case when dimension of X cannot be divided by block_size");
 
-    bool is_cw_quantize = (axis == 0 && src_x.get_shape()[0] == block_size) || \
-                          (axis == 1 && src_x.get_shape()[1] == block_size);
-    if (is_cw_quantize)
-    {
+    bool is_cw_quantize =
+        (axis == 0 && src_x.get_shape()[0] == block_size) || (axis == 1 && src_x.get_shape()[1] == block_size);
+    if (is_cw_quantize) {
         ov::Output<ov::Node> converted_x = std::make_shared<v0::Convert>(src_x, scale.get_element_type());
         if (inputs.size() > 2) {
             zp = inputs[2];

--- a/src/frontends/onnx/tests/models/dequantize_linear_21_cw.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_21_cw.prototxt
@@ -1,0 +1,63 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test_dequantize_21"
+  initializer {
+      dims: 6
+      dims: 4
+      data_type: 21
+      name: "data"
+      raw_data: "\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99\x99"
+  }
+  initializer {
+      dims: 6
+      dims: 1
+      data_type: 1
+      name: "scale"
+      raw_data: "\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f\x00\x00\x80\x3f"
+  }
+  initializer {
+      dims: 6
+      dims: 1
+      data_type: 21
+      name: "zp"
+      raw_data: "\x78\x56\x34"
+  }
+  node {
+    input: "data"
+    input: "scale"
+    input: "zp"
+    output: "output"
+    name: "DequantizeNode"
+    op_type: "DequantizeLinear"
+    attribute {
+      name: "axis"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 4
+      type: INT
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 21
+}

--- a/src/frontends/onnx/tests/models/dequantize_linear_21_no_zero_point_cw.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_21_no_zero_point_cw.prototxt
@@ -1,0 +1,55 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  name: "test_dequantize_21"
+  initializer {
+      dims: 6
+      dims: 4
+      data_type: 21
+      name: "data"
+      raw_data: "\x21\x43\x65\x87\xA9\xCB\xED\xFF\x21\x43\x65\x87"
+  }
+  initializer {
+      dims: 6
+      dims: 1
+      data_type: 1
+      name: "scale"
+      raw_data: "\x00\x00\x80\x3f\x00\x00\x00\x40\x00\x00\x40\x40\x00\x00\x80\x40\x00\x00\xA0\x40\x00\x00\xC0\x40"
+  }
+  node {
+    input: "data"
+    input: "scale"
+    output: "output"
+    name: "DequantizeNode"
+    op_type: "DequantizeLinear"
+    attribute {
+      name: "axis"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 4
+      type: INT
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 21
+}

--- a/src/frontends/onnx/tests/onnx_import_quant.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_quant.in.cpp
@@ -207,9 +207,8 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_21_no_zero_point_cw)
 
     auto test_case = ov::test::TestCase(model, s_device);
 
-    test_case.add_expected_output<float>(
-        {6, 4},
-        std::vector<float>{1, 2, 3, 4, 10, 12, 14, 16, 27, 30, 33, 36, 52, 56, 60, 60, 5, 10, 15, 20, 30, 36, 42, 48});
+    test_case.add_expected_output<float>({6, 4}, std::vector<float>{1,  2,  3,  4,  10, 12, 14, 16, 27, 30, 33, 36,
+                                                                    52, 56, 60, 60, 5,  10, 15, 20, 30, 36, 42, 48});
     test_case.run();
 }
 
@@ -354,8 +353,8 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_cw) {
 
     auto test_case = ov::test::TestCase(model, s_device);
 
-    test_case.add_expected_output<float>({6, 4},
-                                         std::vector<float>{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6});
+    test_case.add_expected_output<float>({6, 4}, std::vector<float>{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+                                                                    4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6});
     test_case.run();
 }
 

--- a/src/frontends/onnx/tests/onnx_import_quant.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_quant.in.cpp
@@ -202,6 +202,17 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_21_no_zero_point) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_21_no_zero_point_cw) {
+    auto model = convert_model("dequantize_linear_21_no_zero_point_cw.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_expected_output<float>(
+        {6, 4},
+        std::vector<float>{1, 2, 3, 4, 10, 12, 14, 16, 27, 30, 33, 36, 52, 56, 60, 60, 5, 10, 15, 20, 30, 36, 42, 48});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_uint8) {
     auto model = convert_model("dequantize_linear_0.onnx");
 
@@ -335,6 +346,16 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21) {
 
     test_case.add_expected_output<float>({6, 3},
                                          std::vector<float>{1, 2, 3, 1, 2, 3, 1, 2, 3, 4, 5, 6, 4, 5, 6, 4, 5, 6});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_opset21_cw) {
+    auto model = convert_model("dequantize_linear_21_cw.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_expected_output<float>({6, 4},
+                                         std::vector<float>{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6});
     test_case.run();
 }
 


### PR DESCRIPTION
### Details:
- when DequantizeLinear OP met requirements of NPU (sym INT4, channel-wised Quantization) the performance raised a lot

        // For NPU Optimization
        // reference: https://github.com/openvinotoolkit/openvino.genai/tree/master/samples/python/text_generation#npu-support
        //  1. model must be exported with symmetric INT4 quantization.
        //  2. The quantized LLM MatMul Op need to use Channel-wised quantization for better performance. (block_size = K)
        // with the limitation, the NPU vpux-plugin compiler could use mix-precision matmul with i4 weight input.
        // it raised the performance a lot in NPU.

This PR is going to optimize the decomposition OPs in ONNX frontend (DequantizeLinear) to match the NPU optimize pattern, before this PR, the INT4 phi3 onnx model using NPUW runs:
`1st token 8000ms, 2nd token 9040ms, 3rd+ token avg 4000ms`

apply this PR, the same model could reach to:
`1st token 3400ms, 2nd token 3400ms, 3rd+ token avg 250ms`

16x speed up in NPUW for phi3 model