### PR TITLE
Expose env option to release build as well

### DIFF
--- a/src/inference/src/dev/plugin_config.cpp
+++ b/src/inference/src/dev/plugin_config.cpp
@@ -118,9 +118,7 @@ void PluginConfig::finalize(const IRemoteContext* context, const ov::Model* mode
 
     finalize_impl(context);
 
-#ifdef ENABLE_DEBUG_CAPS
     apply_env_options();
-#endif
 
     // Clear properties after finalize_impl to be able to check if a property was set by user during plugin-side
     // finalization

--- a/src/inference/tests/unit/config_test.cpp
+++ b/src/inference/tests/unit/config_test.cpp
@@ -316,7 +316,7 @@ TEST(plugin_config, can_read_from_env_with_debug_caps) {
         NotEmptyTestConfig cfg;
         ASSERT_EQ(cfg.get_int_property(), -1);
         set_env("OV_INT_PROPERTY", "10");
-        ASSERT_EQ(cfg.get_int_property(), -1);  // env is applied after finalization only for build with debug caps
+        ASSERT_EQ(cfg.get_int_property(), -1);  // env is applied after finalization
 
 #ifdef ENABLE_DEBUG_CAPS
         set_env("OV_DEBUG_PROPERTY", "20");
@@ -326,11 +326,9 @@ TEST(plugin_config, can_read_from_env_with_debug_caps) {
         cfg.finalize(nullptr, nullptr);
 
 #ifdef ENABLE_DEBUG_CAPS
-        ASSERT_EQ(cfg.get_int_property(), 10);
         ASSERT_EQ(cfg.get_debug_property(), 20);
-#else
-        ASSERT_EQ(cfg.get_int_property(), -1);  // no effect
 #endif
+        ASSERT_EQ(cfg.get_int_property(), 10);
     } catch (std::exception&) {
     }
 
@@ -348,17 +346,15 @@ TEST(plugin_config, can_read_from_config) {
 
         dump_config(filepath.generic_string(), config);
 
-        ASSERT_EQ(cfg.get_int_property(), -1);  // config is applied after finalization only for build with debug caps
+        ASSERT_EQ(cfg.get_int_property(), -1);  // config is applied after finalization
 #ifdef ENABLE_DEBUG_CAPS
         ASSERT_EQ(cfg.get_debug_property(), 2);  // same for debug option
 #endif
 
         cfg.finalize(nullptr, nullptr);
-#ifdef ENABLE_DEBUG_CAPS
         ASSERT_EQ(cfg.get_int_property(), 10);
+#ifdef ENABLE_DEBUG_CAPS
         ASSERT_EQ(cfg.get_debug_property(), 20);
-#else
-        ASSERT_EQ(cfg.get_int_property(), -1);  // no effect
 #endif
     } catch (std::exception&) {
     }

--- a/src/inference/tests/unit/config_test.cpp
+++ b/src/inference/tests/unit/config_test.cpp
@@ -145,7 +145,9 @@ struct NotEmptyTestConfig : public ov::PluginConfig {
         if (!is_set_by_user(low_level_property)) {
             m_low_level_property.value = m_high_level_property.value;
         }
+#ifdef ENABLE_DEBUG_CAPS
         apply_config_options(device_name, test_config_path);
+#endif
     }
 
     void apply_model_specific_options(const IRemoteContext* context, const ov::Model& model) override {
@@ -344,15 +346,17 @@ TEST(plugin_config, can_read_from_config) {
 
         dump_config(filepath.generic_string(), config);
 
-        ASSERT_EQ(cfg.get_int_property(), -1);  // config is applied after finalization
+        ASSERT_EQ(cfg.get_int_property(), -1);  // config is applied after finalization only for build with debug caps
 #ifdef ENABLE_DEBUG_CAPS
         ASSERT_EQ(cfg.get_debug_property(), 2);  // same for debug option
 #endif
 
         cfg.finalize(nullptr, nullptr);
-        ASSERT_EQ(cfg.get_int_property(), 10);
 #ifdef ENABLE_DEBUG_CAPS
+        ASSERT_EQ(cfg.get_int_property(), 10);
         ASSERT_EQ(cfg.get_debug_property(), 20);
+#else
+        ASSERT_EQ(cfg.get_int_property(), -1);  // no effect
 #endif
     } catch (std::exception&) {
     }

--- a/src/inference/tests/unit/config_test.cpp
+++ b/src/inference/tests/unit/config_test.cpp
@@ -145,9 +145,7 @@ struct NotEmptyTestConfig : public ov::PluginConfig {
         if (!is_set_by_user(low_level_property)) {
             m_low_level_property.value = m_high_level_property.value;
         }
-#ifdef ENABLE_DEBUG_CAPS
         apply_config_options(device_name, test_config_path);
-#endif
     }
 
     void apply_model_specific_options(const IRemoteContext* context, const ov::Model& model) override {

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -218,7 +218,7 @@ void ExecutionConfig::finalize_impl(const IRemoteContext* context) {
     }
 
 #ifdef ENABLE_DEBUG_CAPS
-    // For now we apply env/config only for build with debug caps, but it can be updated in the future to allow
+    // For now we apply config file only for build with debug caps, but it can be updated in the future to allow
     // reading release options for any build type
     apply_config_options(context->get_device_name(), get_debug_config());
 #endif // ENABLE_DEBUG_CAPS


### PR DESCRIPTION
### Details:
 - Currently, env option is only available in build with DEBUG_CAPS
 - Enable it for release build as well
 - Document was already updated that it is supported on all builds
