### PR TITLE
[GPU] Do not enable dyn_quan for f16 wzp

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -897,7 +897,6 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 // WA: OneDNN weight-compressed matmul does not support fusion with quantization
                 bool is_onednn_compressed_weights = supports_immad && desc->compressed_weights;
                 should_fuse |= !is_onednn_compressed_weights && quantize_node.get_scale_shift_opt();
-
             }
 
             should_fuse |= input_data.is_type<lrn>() && quantize_node.get_scale_shift_opt();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1220,6 +1220,12 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     return true;
                 }
 
+                if (has_wzp && !cldnn::one_of(root->get_input_element_type(4), {ov::element::i8, ov::element::u8, ov::element::i4, ov::element::u4})) {
+                    GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off:"
+                                                                    " unsupported weight zp type: " << root->get_input_element_type(4) << std::endl;
+                    return true;
+                }
+
                 return false;
             });
             manager.register_pass<ov::intel_gpu::DynamicQuantizeFullyConnected>(dynamic_quantization_group_size, asymmetric_dyn_quant);


### PR DESCRIPTION
### Details:
 -  f16 wzp is not supposed to happen, but it is happening.
 -  In such case, we should disable dynamic quantization to avoid ref FC.

