### PR TITLE
[Snippets] Support multiple consumers for Scalar operation

### DIFF
--- a/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
+++ b/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
@@ -26,9 +26,17 @@ bool MoveScalarToConsumer::run(LinearIR& linear_ir) {
         const auto expr = expr_it->get();
         if (ov::is_type<op::Scalar>(expr->get_node())) {
             const auto consumers = expr->get_output_port_connector(0)->get_consumers();
-            OPENVINO_ASSERT(consumers.size() == 1, "Scalar expression is expected to have a single consumer");
+            OPENVINO_ASSERT(!consumers.empty(), "Scalar expression should have at least one consumer");
+            const auto loop_ids = consumers.begin()->get_expr()->get_loop_ids();
+            for (const auto& consumer : consumers) {
+                OPENVINO_ASSERT(consumer.get_expr()->get_loop_ids() == loop_ids,
+                                "All consumers of a Scalar expression are expected to have the same loop IDs");
+            }
+            auto consumer_expr = std::min_element(consumers.begin(), consumers.end(),
+                [](const ExpressionPort& lhs, const ExpressionPort& rhs) {
+                    return lhs.get_expr()->get_exec_num() < rhs.get_expr()->get_exec_num();
+                })->get_expr();
 
-            const auto& consumer_expr = consumers.begin()->get_expr();
             // Move something only if
             //  - Consumer is not already the next one (previous since the iterator is a reverse one)
             //  - The next operation is not already a Scalar (since it was just moved there on the previous iteration)

--- a/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
+++ b/src/common/snippets/src/lowered/pass/move_scalar_to_consumer.cpp
@@ -27,15 +27,15 @@ bool MoveScalarToConsumer::run(LinearIR& linear_ir) {
         if (ov::is_type<op::Scalar>(expr->get_node())) {
             const auto consumers = expr->get_output_port_connector(0)->get_consumers();
             OPENVINO_ASSERT(!consumers.empty(), "Scalar expression should have at least one consumer");
-            const auto loop_ids = consumers.begin()->get_expr()->get_loop_ids();
+            auto consumer_expr = consumers.begin()->get_expr();
+            const auto& loop_ids = consumer_expr->get_loop_ids();
             for (const auto& consumer : consumers) {
                 OPENVINO_ASSERT(consumer.get_expr()->get_loop_ids() == loop_ids,
                                 "All consumers of a Scalar expression are expected to have the same loop IDs");
+                if (consumer.get_expr()->get_exec_num() < consumer_expr->get_exec_num()) {
+                    consumer_expr = consumer.get_expr();
+                }
             }
-            auto consumer_expr = std::min_element(consumers.begin(), consumers.end(),
-                [](const ExpressionPort& lhs, const ExpressionPort& rhs) {
-                    return lhs.get_expr()->get_exec_num() < rhs.get_expr()->get_exec_num();
-                })->get_expr();
 
             // Move something only if
             //  - Consumer is not already the next one (previous since the iterator is a reverse one)

--- a/src/common/snippets/tests/src/lowered/pass/move_scalar_to_consumer.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/move_scalar_to_consumer.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "lir_test_utils.hpp"
+
+#include "openvino/opsets/opset10.hpp"
+#include "snippets/lowered/pass/move_scalar_to_consumer.hpp"
+#include "snippets/op/load.hpp"
+#include "snippets/op/store.hpp"
+#include "snippets/op/scalar.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+using namespace ov::snippets::lowered;
+using namespace ov::snippets::lowered::pass;
+
+TEST_F(LoweredPassTestsF, MoveScalarToConsumer) {
+    const auto input_precision = ov::element::i8;
+    const ov::Shape scalar_shape{1};
+    {
+        auto scalar = linear_ir->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 42.f);
+        auto add1 = linear_ir->push_node<ov::opset10::Add>(scalar.second, scalar.second);
+        auto add2 = linear_ir->push_node<ov::opset10::Add>(add1.second, scalar.second);
+        auto result = linear_ir->push_node<ov::opset10::Result>(add2.second);
+    }
+    pipeline.register_pass<MoveScalarToConsumer>();
+    {
+        // No changes in IR are expected
+        auto scalar = linear_ir_ref->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 42.f);
+        auto add1 = linear_ir_ref->push_node<ov::opset10::Add>(scalar.second, scalar.second);
+        auto add2 = linear_ir_ref->push_node<ov::opset10::Add>(add1.second, scalar.second);
+        auto result = linear_ir_ref->push_node<ov::opset10::Result>(add2.second);
+    }
+}
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/src/lowered/pass/move_scalar_to_consumer.cpp
+++ b/src/common/snippets/tests/src/lowered/pass/move_scalar_to_consumer.cpp
@@ -21,17 +21,20 @@ TEST_F(LoweredPassTestsF, MoveScalarToConsumer) {
     const auto input_precision = ov::element::i8;
     const ov::Shape scalar_shape{1};
     {
-        auto scalar = linear_ir->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 42.f);
-        auto add1 = linear_ir->push_node<ov::opset10::Add>(scalar.second, scalar.second);
-        auto add2 = linear_ir->push_node<ov::opset10::Add>(add1.second, scalar.second);
+        auto relu_scalar = linear_ir->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 0.f);
+        auto add_scalar = linear_ir->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 42.f);
+        auto relu = linear_ir->push_node<ov::opset10::Relu>(relu_scalar.second);
+        auto add1 = linear_ir->push_node<ov::opset10::Add>(add_scalar.second, add_scalar.second);
+        auto add2 = linear_ir->push_node<ov::opset10::Add>(add1.second, add_scalar.second);
         auto result = linear_ir->push_node<ov::opset10::Result>(add2.second);
     }
     pipeline.register_pass<MoveScalarToConsumer>();
     {
-        // No changes in IR are expected
-        auto scalar = linear_ir_ref->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 42.f);
-        auto add1 = linear_ir_ref->push_node<ov::opset10::Add>(scalar.second, scalar.second);
-        auto add2 = linear_ir_ref->push_node<ov::opset10::Add>(add1.second, scalar.second);
+        auto relu_scalar = linear_ir_ref->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 0.f);
+        auto relu = linear_ir_ref->push_node<ov::opset10::Relu>(relu_scalar.second);
+        auto add_scalar = linear_ir_ref->push_node<ov::snippets::op::Scalar>(input_precision, scalar_shape, 42.f);
+        auto add1 = linear_ir_ref->push_node<ov::opset10::Add>(add_scalar.second, add_scalar.second);
+        auto add2 = linear_ir_ref->push_node<ov::opset10::Add>(add1.second, add_scalar.second);
         auto result = linear_ir_ref->push_node<ov::opset10::Result>(add2.second);
     }
 }


### PR DESCRIPTION
### Details:
Remove the limitation that restricted `Scalar` snippets operation to a single consumer

### Tickets:
 - required by: 163186
 - part of: 166528
