### PR TITLE
[PT FE] Add support for built-in neg in FX graph

### DIFF
--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -805,6 +805,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"<built-in function floordiv>", op::translate_floor_divide},
         {"<built-in function getitem>", op::translate_getitem},  // TODO: Check if there is any other way to handle this
         {"<built-in function mul>", op::translate_mul},
+        {"<built-in function neg>", op::translate_neg},
         {"<built-in function sub>", op::translate_sub},
         {"aten._adaptive_avg_pool1d.default", op::translate_adaptive_avg_pool1d},
         {"aten._adaptive_avg_pool2d.default", op::translate_adaptive_avg_pool2d},

--- a/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
+++ b/tests/layer_tests/pytorch_tests/pytorch_layer_test_class.py
@@ -123,7 +123,9 @@ class PytorchLayerTest:
                 from openvino import convert_model
                 from torch.export import export
 
-                em = export(model, tuple(torch_inputs))
+                dynamic_shapes = kwargs.get('dynamic_shapes_for_export', {})
+
+                em = export(model, tuple(torch_inputs), dynamic_shapes=dynamic_shapes)
 
                 converted_model = convert_model(
                     em, example_input=torch_inputs, verbose=True)

--- a/tests/layer_tests/pytorch_tests/test_neg.py
+++ b/tests/layer_tests/pytorch_tests/test_neg.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2018-2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class neg_model(torch.nn.Module):
+    def forward(self, x):
+        return x.shape[-1].__neg__() * x
+
+
+class TestNeg(PytorchLayerTest):
+    def _prepare_input(self):
+        import numpy as np
+        return (np.random.randn(2, 4, 224, 224).astype(np.float32),)
+
+    @pytest.mark.nightly
+    @pytest.mark.precommit
+    @pytest.mark.precommit_torch_export
+    def test_neg(self, ie_device, precision, ir_version):
+        self._test(neg_model(), None, "aten::neg",
+                   ie_device, precision, ir_version,
+                   dynamic_shapes_for_export={
+                       "x": {3: torch.export.Dim("width")}
+        })

--- a/tests/layer_tests/pytorch_tests/test_neg.py
+++ b/tests/layer_tests/pytorch_tests/test_neg.py
@@ -9,7 +9,7 @@ from pytorch_layer_test_class import PytorchLayerTest
 
 class neg_model(torch.nn.Module):
     def forward(self, x):
-        return x.shape[-1].__neg__() * x
+        return x * (-x.shape[-1])
 
 
 class TestNeg(PytorchLayerTest):


### PR DESCRIPTION
### Details:
 - *Support `<built-in function neg>` which appears on the shape path only in FX graph*

### Tickets:
 - *ticket-id*
