### PR TITLE
[GPU] Fixed issue on fc kernel when dyn_quant kernel exists but slm kernel is not generated 

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_bf_tiled.cpp
@@ -845,7 +845,7 @@ void FullyConnected_bf_tiled::GetUpdateDispatchDataFunc(KernelData& kd) const {
             // [optional:dyn_quant kernel] | default kernel | [optional:slm kernel]
             int32_t quantize_kernel_idx = (kd.internalBuffers.empty()) ? -1 : 0;
             int32_t default_kernel_idx = quantize_kernel_idx + 1;
-            int32_t slm_kernel_idx = (quantize_kernel_idx >= 0) && kd.kernels.size() == 3 ? 2 : -1;
+            int32_t slm_kernel_idx = (static_cast<int32_t>(kd.kernels.size()) > default_kernel_idx + 1) ? default_kernel_idx + 1 : -1;
 
             // Choose one of the two shape agnostic kernels: N == added kernel number
             // - kd.kernels[N-1] for batches <= 240 (default version)

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/matmul_weights_decompression.cpp
@@ -430,4 +430,20 @@ INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_dyn_quan,
                                             ::testing::Values(2.0f)),   // Note: this is because of potential cldnn accuracy issue
                          MatmulWeightsDecompression::get_test_case_name);
 
+INSTANTIATE_TEST_SUITE_P(smoke_MatMulCompressedWeights_dyn_quan_no_slm,
+                         MatmulWeightsDecompression,
+                         ::testing::Combine(::testing::Values(ShapeParams{{{-1, -1, 1024}, {{2, 1, 1024}, {1, 1, 1024}, {2, 1, 1024}}},
+                                                                            {1024, 1}, 128}),  // shape
+                                            ::testing::Values(ov::element::u8),
+                                            ::testing::Values(ov::element::f16),
+                                            ::testing::Values(false),
+                                            ::testing::ValuesIn(add_decompression_sub),
+                                            ::testing::Values(true),
+                                            ::testing::Values(false),
+                                            ::testing::Values(true),  // per_tensor_zp
+                                            ::testing::ValuesIn(group_size),
+                                            ::testing::Values(2.0f)),   // Note: this is because of potential cldnn accuracy issue
+                         MatmulWeightsDecompression::get_test_case_name);
+
+
 } // namespace


### PR DESCRIPTION
### Details:
 - Fixed issue on fc_tiled kernel when only dyn_quant kernel exists  and slm kernel is not generated
 - In that case, all kernels were skipped because the skipping kernel idx was calculated assuming that there is all three kernels exist

### Tickets:
 - CVS-165900
