### PR TITLE
[CPU] Fix Coverity remarks regarding potential null pointer dereference and out-of-bounds access

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/dft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/dft.cpp
@@ -445,7 +445,11 @@ void DFT::naiveDFT(float* data, size_t dataLength, bool inverse) const {
     std::vector<float> outputBuffer(dataLength);
     const size_t nComplex = dataLength / 2;
     const float reciprocalNComplex = 1.0f / nComplex;
-    const auto& twiddles = twiddlesMapDFT.find(nComplex)->second;
+    auto twiddlesIter = twiddlesMapDFT.find(nComplex);
+    if (twiddlesIter == twiddlesMapDFT.end()) {
+        THROW_CPU_NODE_ERR("Twiddles for nComplex=", nComplex, " not found");
+    }
+    const auto& twiddles = twiddlesIter->second;
 
     std::function<void(size_t)> blockIteration;
     if (dftKernel != nullptr) {

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -965,17 +965,17 @@ int TensorIterator::getNumIteration(const std::vector<PortMap>& inputPortMap,
     int numIterations = 1;
     bool isDefault = true;
     for (const auto& rule : inputPortMap) {
-        const auto& dims = getSrcMemoryAtPort(rule.from)->getStaticDims();
-        if (!isIterable(rule)) {
-            continue;
-        }
-
         if (rule.from < 0 || rule.from >= static_cast<int64_t>(inputShapes.size())) {
             THROW_CPU_NODE_ERR(": Invalid \"from\" value: \"from\" = ",
                                rule.from,
                                " inputs number = ",
                                inputShapes.size(),
                                " (out of range)");
+        }
+
+        const auto& dims = getSrcMemoryAtPort(rule.from)->getStaticDims();
+        if (!isIterable(rule)) {
+            continue;
         }
 
         const auto currentNumIterations = getNumIterations(rule, dims);

--- a/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
@@ -18,9 +18,12 @@ public:
 
     IShapeInfer::Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                               [[maybe_unused]] const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+        OPENVINO_ASSERT(input_shapes.size() >= 3,
+                        "SDPAShapeInfer: expected at least 3 inputs, got ",
+                        input_shapes.size());
         const auto& query_dims = input_shapes.front().get();
         VectorDims present_v_dims = input_shapes.back().get();
-        const auto& beam_idx_dims = input_shapes.end()[-3].get();
+        const auto& beam_idx_dims = input_shapes[input_shapes.size() - 3].get();
         const auto& permute_axes = m_config.permute_axes;
 
         if (permute_axes.empty()) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.cpp
@@ -259,11 +259,21 @@ CausalMaskPreprocess::CausalMaskPreprocess() {
             }
         }
 
+        auto attention_mask_it = pattern_map.find(attention_mask);
+        auto batch_size_it = pattern_map.find(batch_size);
+        auto cache_positions_it = pattern_map.find(cache_positions);
+        auto kvLen_it = pattern_map.find(kvLen);
+
+        if (attention_mask_it == pattern_map.end() || batch_size_it == pattern_map.end() ||
+            cache_positions_it == pattern_map.end() || kvLen_it == pattern_map.end()) {
+            return false;
+        }
+
         ov::OutputVector inputs{
-            pattern_map.find(attention_mask)->second,
-            pattern_map.find(batch_size)->second,
-            pattern_map.find(cache_positions)->second,
-            pattern_map.find(kvLen)->second,
+            attention_mask_it->second,
+            batch_size_it->second,
+            cache_positions_it->second,
+            kvLen_it->second,
         };
         auto replacement = std::make_shared<ov::intel_cpu::CausalMaskPreprocessNode>(inputs, config);
         ov::replace_node(root, replacement);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
@@ -106,12 +106,11 @@ ov::intel_cpu::FuseFQtoInteraction::FuseFQtoInteraction() {
     matcher_pass_callback callback = [=](Matcher& m) {
         auto& pattern_to_output = m.get_pattern_value_map();
         auto fq_node = ov::as_type_ptr<ov::opset8::FakeQuantize>(pattern_to_output.at(fq_m).get_node_shared_ptr());
+        OPENVINO_ASSERT(fq_node != nullptr, "FakeQuantize node is not found");
         std::vector<float> fq_scale;
-        if (fq_node) {
-            fq_scale = simplifyToScale(fq_node, 0.001f);
-            if (fq_scale.empty()) {
-                return false;
-            }
+        fq_scale = simplifyToScale(fq_node, 0.001f);
+        if (fq_scale.empty()) {
+            return false;
         }
         bool success = ov::replace_output_update_name(fq_node->output(0), fq_node->input_value(0));
         if (!success) {


### PR DESCRIPTION
### Details:
Fix Coverity remarks:
 - 1502517 - Dereference after null check
 - 1538950, 1538782 - Improper use of negative value
 - 1542737, 1511142 - Using invalid iterator

### Tickets:
 - 165923
