### PR TITLE
Turn the assert to a static_assert to allow compilation

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.cpp
@@ -221,7 +221,7 @@ void jit_emitter::emit_data() const {
     h->L(*l_table.get());
 
     // Assumption: entries can be inserted with dd, so they should be 4 bytes.
-    assert(sizeof(table_entry_val_t) == 4);
+    static_assert(sizeof(table_entry_val_t) == 4);
 
     // Run through the map and insert values stored there
     for (const auto& it : entry_map_) {


### PR DESCRIPTION
### Details:

This allows compilation with all warnings turned to errors on the master branch.

### Tickets:
CVS-166682
