### PR TITLE
Revert "Enable `-pie` compile option for MacOS (#18568)"

### DIFF
--- a/cmake/developer_package/compile_flags/sdl.cmake
+++ b/cmake/developer_package/compile_flags/sdl.cmake
@@ -14,8 +14,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG OR (UNIX AND OV_COMPILER_IS_
             set(OV_C_CXX_FLAGS "${OV_C_CXX_FLAGS} -D_FORTIFY_SOURCE=2")
         endif()
     endif()
-
-    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -pie")
+    if(NOT APPLE)
+        set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -pie")
+    endif()
 
     if(CMAKE_COMPILER_IS_GNUCXX)
         set(OV_C_CXX_FLAGS "${OV_C_CXX_FLAGS} -fno-strict-overflow -fno-delete-null-pointer-checks -fwrapv")


### PR DESCRIPTION
This reverts commit 37d055e477d743c10a05e27c55e153506c8e784e.

### Details:
```bash
clang++: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
```
`-pie` is enable by default on `macOS` and this flag is not supported:
 - https://github.com/swiftlang/swift/issues/48291#issuecomment-1108257194
 - https://hg-edge.mozilla.org/integration/autoland/rev/6087ce1bca59

### Tickets:
 - N/A
