### PR TITLE
[intel-npu] Quickfix for specific development usecase when used w/o driver and mlir

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -222,14 +222,15 @@ void Plugin::init_options() {
         }
     }
 
+    // parse again env_variables to update registered configs which have env vars set
+    _globalConfig.parseEnvVars();
+
+    // filter out unsupported options
     filter_config_by_compiler_support(_globalConfig);
 
     if (_backend) {
         _backend->registerOptions(*_options);
     }
-
-    // parse again env_variables to update registered configs which have env vars set
-    _globalConfig.parseEnvVars();
 }
 
 void Plugin::filter_config_by_compiler_support(FilteredConfig& cfg) const {


### PR DESCRIPTION
### Details:
 - On systems without NPU device and offline-mode NPU driver (i.e. MLIR+IMD) IE_NPU_COMPILER_TYPE envinronment variable needs to be picked up (if set) before options filtering, in order construct straight away with the correct compiler. 
 - Without this a corner-case occurs on aforementioned setups, where compiler options get marked as unsupported (because there is no valid compiler @ filtering stage) and get stuck there because compiler-change logic will not get triggered either

### Tickets:
 - EISW-165899
