### PR TITLE
[CORE]Coverity performance inefficiencies

### DIFF
--- a/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
+++ b/src/common/snippets/src/lowered/pass/propagate_subtensors.cpp
@@ -59,7 +59,6 @@ void propagate_updated_subtensor_through_loop(const LinearIR& linear_ir,
             if (port.is_processed()) {
                 const auto& expr = port.get_expr_port()->get_expr();
                 const auto& desc = port.get_expr_port()->get_descriptor_ptr();
-                auto subtensor = desc->get_subtensor();
                 if (port.get_dim_idx() < desc->get_subtensor().size()) {
                     desc->set_subtensor_dim(port.get_dim_idx(), new_dim_value);
                 }

--- a/src/common/snippets/src/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/pass/softmax_decomposition.cpp
@@ -53,12 +53,9 @@ SoftmaxDecomposition::SoftmaxDecomposition() {
         const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
 
         OPENVINO_ASSERT(axis < rank, "Softmax has incorrect axis");
-        const auto& subtensor = [&]() {
-            std::vector<size_t> subtensor(rank, 1);
-            for (size_t i = axis; i < rank; ++i)
-                subtensor[i] = utils::get_full_dim_value();
-            return subtensor;
-        }();
+        std::vector<size_t> subtensor(rank, 1);
+        for (size_t i = axis; i < rank; ++i)
+            subtensor[i] = utils::get_full_dim_value();
 
         PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
         PortDescriptorUtils::set_port_descriptor(power->output(0), subtensor);

--- a/src/common/snippets/src/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/pass/softmax_decomposition.cpp
@@ -58,7 +58,7 @@ SoftmaxDecomposition::SoftmaxDecomposition() {
             subtensor[i] = utils::get_full_dim_value();
 
         PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
-        PortDescriptorUtils::set_port_descriptor(power->output(0), subtensor);
+        PortDescriptorUtils::set_port_descriptor(power->output(0), std::move(subtensor));
 
         copy_runtime_info(softmax, {reduce_max, subtract, exp, reduce_sum, power, multiply});
         return ov::replace_node_update_name(softmax, multiply);

--- a/src/common/snippets/src/pass/softmax_decomposition.cpp
+++ b/src/common/snippets/src/pass/softmax_decomposition.cpp
@@ -53,9 +53,12 @@ SoftmaxDecomposition::SoftmaxDecomposition() {
         const auto multiply = std::make_shared<ov::op::v1::Multiply>(exp, power);
 
         OPENVINO_ASSERT(axis < rank, "Softmax has incorrect axis");
-        std::vector<size_t> subtensor(rank, 1);
-        for (size_t i = axis; i < rank; ++i)
-            subtensor[i] = utils::get_full_dim_value();
+        const auto& subtensor = [&]() {
+            std::vector<size_t> subtensor(rank, 1);
+            for (size_t i = axis; i < rank; ++i)
+                subtensor[i] = utils::get_full_dim_value();
+            return subtensor;
+        }();
 
         PortDescriptorUtils::set_port_descriptor(power->input(0), subtensor);
         PortDescriptorUtils::set_port_descriptor(power->output(0), subtensor);

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -209,7 +209,7 @@ VectorDims get_preordered_vdims(const snippets::lowered::ExpressionPort& expr_po
 
 VectorDims get_projected_subtensor(const snippets::lowered::ExpressionPort& expr_port) {
     const auto& desc = expr_port.get_descriptor_ptr();
-    const auto shape = expr_port.get_type() == snippets::lowered::ExpressionPort::Type::Input
+    const auto& shape = expr_port.get_type() == snippets::lowered::ExpressionPort::Type::Input
                            ? get_planar_vdims(expr_port)
                            : get_preordered_vdims(expr_port);
     auto subtensor = desc->get_subtensor();

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -214,7 +214,7 @@ VectorDims get_projected_subtensor(const snippets::lowered::ExpressionPort& expr
                            : get_preordered_vdims(expr_port);
     auto subtensor = desc->get_subtensor();
     for (size_t i = 1; i <= std::min(subtensor.size(), shape.size()); i++) {
-        if (auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim)){
+        if (auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim) {
             dim = shape[shape.size() - i];
         }
     }

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -214,7 +214,7 @@ VectorDims get_projected_subtensor(const snippets::lowered::ExpressionPort& expr
                            : get_preordered_vdims(expr_port);
     auto subtensor = desc->get_subtensor();
     for (size_t i = 1; i <= std::min(subtensor.size(), shape.size()); i++) {
-        if (auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim) {
+        if (auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim)) {
             dim = shape[shape.size() - i];
         }
     }

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -214,9 +214,9 @@ VectorDims get_projected_subtensor(const snippets::lowered::ExpressionPort& expr
                            : get_preordered_vdims(expr_port);
     auto subtensor = desc->get_subtensor();
     for (size_t i = 1; i <= std::min(subtensor.size(), shape.size()); i++) {
-        auto& dim = subtensor[subtensor.size() - i];
-        if (utils::is_full_dim_value(dim))
-            dim = shape[shape.size() - i];
+        if (const auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim)) {
+            subtensor[subtensor.size() - i] = shape[shape.size() - i];
+        }
     }
     return subtensor;
 }

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -214,9 +214,9 @@ VectorDims get_projected_subtensor(const snippets::lowered::ExpressionPort& expr
                            : get_preordered_vdims(expr_port);
     auto subtensor = desc->get_subtensor();
     for (size_t i = 1; i <= std::min(subtensor.size(), shape.size()); i++) {
-        auto& dim = subtensor[subtensor.size() - i];
-        if (utils::is_full_dim_value(dim))
+        if (auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim)){
             dim = shape[shape.size() - i];
+        }
     }
     return subtensor;
 }

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -214,9 +214,9 @@ VectorDims get_projected_subtensor(const snippets::lowered::ExpressionPort& expr
                            : get_preordered_vdims(expr_port);
     auto subtensor = desc->get_subtensor();
     for (size_t i = 1; i <= std::min(subtensor.size(), shape.size()); i++) {
-        if (const auto& dim = subtensor[subtensor.size() - i]; utils::is_full_dim_value(dim)) {
-            subtensor[subtensor.size() - i] = shape[shape.size() - i];
-        }
+        auto& dim = subtensor[subtensor.size() - i];
+        if (utils::is_full_dim_value(dim))
+            dim = shape[shape.size() - i];
     }
     return subtensor;
 }


### PR DESCRIPTION
### Details:
- fix for: Use of auto that causes a copy at utils.cpp 
- fix for: COPY_INSTEAD_OF_MOVE at softmax_decomposition.cpp
- fix for: Use of auto that causes a copy at propagate_subtensors.cpp 

### Tickets:
 - [*CVS-148602*](https://jira.devtools.intel.com/browse/CVS-148602)
