### PR TITLE
[CPU] Extend TopK node to support  internal dynamic input

### DIFF
--- a/src/core/shape_inference/include/topk_shape_inference.hpp
+++ b/src/core/shape_inference/include/topk_shape_inference.hpp
@@ -81,8 +81,13 @@ std::vector<TRShape> shape_infer(const util::TopKBase* op,
                                   " elements).");
 
             const auto& k = (*k_as_shape)[0];
-            if (k.is_static()) {
-                dim_axis = k;
+            if (k.is_static() && input_shape.is_static()) {
+                // For the scenario that Topk is a subsequent node of NMS, if k equals in_shape[axis] which equals
+                // max_output_boxes_per_class of NMS in original model, but in_shape[axis] is updated to be valid
+                // object number which is less than max_output_boxes_per_class, i.e., less than k, then k should
+                // also be updated to be valid object number, so should sorting dimension size of output shape.
+                dim_axis =
+                    k.get_length() > input_shape[normalized_axis].get_length() ? input_shape[normalized_axis] : k;
             } else {
                 // in this dynamic branch we are sure of dim_axis's type
                 const auto in_min = dim_axis.get_min_length();

--- a/src/core/shape_inference/include/topk_shape_inference.hpp
+++ b/src/core/shape_inference/include/topk_shape_inference.hpp
@@ -91,16 +91,14 @@ std::vector<TRShape> shape_infer(const util::TopKBase* op,
             } else {
                 // in this dynamic branch we are sure of dim_axis's type
                 const auto in_min = dim_axis.get_min_length();
-                const auto in_max = dim_axis.get_max_length();
+                const auto in_max =
+                    dim_axis.get_max_length() < 0 ? std::numeric_limits<TDimValue>::max() : dim_axis.get_max_length();
 
                 const auto k_min = k.get_min_length();
-                const auto k_max = k.get_max_length();
+                const auto k_max = k.get_max_length() < 0 ? std::numeric_limits<TDimValue>::max() : k.get_max_length();
 
                 const auto lower = std::min<TDimValue>(in_min, k_min);
-                const auto upper =
-                    in_max < 0
-                        ? Dimension::dynamic().get_max_length()
-                        : std::min<TDimValue>(in_max, (k_max < 0 ? std::numeric_limits<TDimValue>::max() : k_max));
+                const auto upper = std::min<TDimValue>(in_max, k_max);
                 dim_axis = TDim(lower, upper);
             }
         } else {

--- a/src/core/tests/type_prop/top_k.cpp
+++ b/src/core/tests/type_prop/top_k.cpp
@@ -134,7 +134,7 @@ TYPED_TEST_P(topk_type_prop, default_index_element_type) {
         EXPECT_THAT(op->outputs(),
                     ElementsAre(Property("Value type", &Output<Node>::get_element_type, exp_data_type),
                                 Property("Index type", &Output<Node>::get_element_type, this->exp_default_idx_type)));
-        EXPECT_THAT(op->outputs(), Each(Property("Shape", &Output<Node>::get_shape, Shape({3, 2, 3, 4}))));
+        EXPECT_THAT(op->outputs(), Each(Property("Shape", &Output<Node>::get_shape, Shape({1, 2, 3, 4}))));
     }
     {
         // k < dimension
@@ -162,7 +162,7 @@ TYPED_TEST_P(topk_type_prop, k_for_dynamic_dimension) {
     const auto op = this->make_op(data, k, 0, "max", "value");
 
     EXPECT_THAT(op->outputs(),
-                Each(Property("Partial Shape", &Output<Node>::get_partial_shape, PartialShape({5, {-1, 2}}))));
+                Each(Property("Partial Shape", &Output<Node>::get_partial_shape, PartialShape({{0, 5}, {-1, 2}}))));
 }
 
 TYPED_TEST_P(topk_type_prop, k_for_interval_dimension) {
@@ -171,7 +171,7 @@ TYPED_TEST_P(topk_type_prop, k_for_interval_dimension) {
     const auto op = this->make_op(data, k, 0, "max", "value");
 
     EXPECT_THAT(op->outputs(),
-                Each(Property("Partial Shape", &Output<Node>::get_partial_shape, PartialShape({6, {-1, 2}}))));
+                Each(Property("Partial Shape", &Output<Node>::get_partial_shape, PartialShape({{2, 6}, {-1, 2}}))));
 }
 
 TYPED_TEST_P(topk_type_prop, k_is_unknown_for_static_dimension) {
@@ -308,10 +308,10 @@ TYPED_TEST_P(topk_type_prop, preserve_partial_values_and_symbols_k_is_interval) 
                                    ElementsAre(symbols[0], symbols[1], symbols[2], symbols[3], nullptr, symbols[5]))));
     }
     {
-        // dim{15,inf} k{10,20} -> {10,inf}
+        // dim{15,inf} k{10,20} -> {10,20}
         const auto op = this->make_op(data, k, 5, "max", "value");
         EXPECT_THAT(op->get_output_partial_shape(0),
-                    AllOf(PartialShape({{2, 5}, {12, 18}, {2, 30}, {30, 40}, {-1, 15}, {10, -1}}),
+                    AllOf(PartialShape({{2, 5}, {12, 18}, {2, 30}, {30, 40}, {-1, 15}, {10, 20}}),
                           ResultOf(get_shape_symbols,
                                    ElementsAre(symbols[0], symbols[1], symbols[2], symbols[3], symbols[4], nullptr))));
     }

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -2069,9 +2069,9 @@ void TopK::prepareParams() {
     dst_dims = dstMemPtr->getDesc().getShape().getDims();
 
     if (isDynamicNode()) {
-        const int src_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
+        int src_k = getSrcDataAtPortAs<int>(TOPK_K)[0];
         if (static_cast<size_t>(src_k) > src_dims[axis]) {
-            THROW_CPU_NODE_ERR("gets top_k out of range!");
+            src_k = static_cast<int>(src_dims[axis]);
         }
         if (top_k != src_k) {
             top_k = src_k;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/nms_topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/nms_topk.cpp
@@ -1,0 +1,97 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "nms_topk.hpp"
+
+#include "common_test_utils/node_builders/constant.hpp"
+#include "openvino/op/non_max_suppression.hpp"
+#include "openvino/op/topk.hpp"
+
+namespace ov {
+namespace test {
+
+std::string NMSTopKTest::getTestCaseName(const testing::TestParamInfo<NMSTopKParams>& obj) {
+    std::ostringstream results;
+    ov::Shape inputShape;
+    ov::element::Type inputPrecision;
+    int64_t maxOutputBoxesPerClass;
+    float iouThreshold;
+    float scoreThreshold;
+    std::string targetName;
+    std::tie(inputShape, inputPrecision, maxOutputBoxesPerClass, iouThreshold, scoreThreshold, targetName) = obj.param;
+
+    results << "inputShape=" << ov::test::utils::vec2str(inputShape) << "_";
+    results << "inputPrecision=" << inputPrecision << "_";
+    results << "maxOutputBoxesPerClass=" << maxOutputBoxesPerClass << "_";
+    results << "iouThreshold=" << iouThreshold << "_";
+    results << "scoreThreshold=" << scoreThreshold << "_";
+    results << "targetDevice=" << targetName;
+
+    return results.str();
+}
+
+void NMSTopKTest::SetUp() {
+    ov::Shape inputShape;
+    ov::element::Type inputPrecision;
+    int64_t maxOutputBoxesPerClass;
+    float iouThreshold;
+    float scoreThreshold;
+    std::tie(inputShape, inputPrecision, maxOutputBoxesPerClass, iouThreshold, scoreThreshold, targetDevice) =
+        this->GetParam();
+
+    OPENVINO_ASSERT(inputShape.size() >= 2,
+                    "Unexpected NMS input shape dimension ",
+                    inputShape.size(),
+                    ", which should be at least 2.");
+    const ov::Shape inputShape1 = inputShape;
+    ov::Shape inputShape2 = inputShape;
+    inputShape2[-1] = inputShape2[-2];
+    inputShape2[-2] = 1;
+    ov::ParameterVector inputParams{std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputShape1),
+                                    std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputShape2)};
+
+    const auto nms = std::make_shared<ov::op::v9::NonMaxSuppression>(
+        inputParams[0],
+        inputParams[1],
+        ov::op::v0::Constant::create(ov::element::i64, {}, {maxOutputBoxesPerClass}),
+        ov::op::v0::Constant::create(inputPrecision, {}, {iouThreshold}),
+        ov::op::v0::Constant::create(inputPrecision, {}, {scoreThreshold}),
+        ov::op::v9::NonMaxSuppression::BoxEncodingType::CORNER,
+        false);
+
+    int k = static_cast<int>(maxOutputBoxesPerClass);
+    const auto topK = std::make_shared<ov::op::v1::TopK>(nms,
+                                                         ov::op::v0::Constant::create(ov::element::i32, {}, {k}),
+                                                         0,
+                                                         ov::op::TopKMode::MAX,
+                                                         ov::op::TopKSortType::SORT_VALUES);
+
+    ov::ResultVector results;
+    for (size_t i = 0; i < topK->get_output_size(); i++) {
+        results.push_back(std::make_shared<ov::op::v0::Result>(topK->output(i)));
+    }
+
+    function = std::make_shared<ov::Model>(results, inputParams, "nms_topk");
+}
+
+void NMSTopKTest::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
+    inputs.clear();
+    const auto& funcInputs = function->inputs();
+    for (size_t i = 0; i < funcInputs.size(); ++i) {
+        const auto& funcInput = funcInputs[i];
+        ov::Tensor tensor;
+        ov::test::utils::InputGenerateData in_data(0, 1, 100);
+        tensor =
+            ov::test::utils::create_and_fill_tensor(funcInput.get_element_type(), targetInputStaticShapes[i], in_data);
+
+        inputs.insert({funcInput.get_node_shared_ptr(), tensor});
+    }
+}
+
+TEST_P(NMSTopKTest, CompareWithRefs) {
+    run();
+}
+
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/nms_topk.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/nms_topk.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <vector>
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+namespace ov {
+namespace test {
+
+using NMSTopKParams = std::tuple<ov::Shape,          // Input shape
+                                 ov::element::Type,  // Input Precision
+                                 int64_t,            // NMS max output boxes per class
+                                 float,              // NMS iou threshold
+                                 float,              // NMS score threshold
+                                 std::string         // Device name
+                                 >;
+
+// NMSTopKTest is intended to cover the case where NMS node gets dynamic output shape because of
+// internal dynamism, so the subsequent TopK node will also get dynamic input shape even in
+// static model. For this scenario, if runtime sorting dimension size of input shape is less
+// than k in TopK node, then k as well as sorting dimension size of output shape should be updated
+// to be the valid object number of NMS.
+// Note that in real model, plenty of nodes are used to exact location and score information from
+// NMS input data based on NMS output indices, then feed to the input of TopK node. While in this
+// subgraph test, TopK node is directly connected to NMS node because such usage can already assure
+// the internal dynamism behavior be passed down to the TopK node without extra complexity.
+class NMSTopKTest : public testing::WithParamInterface<NMSTopKParams>, virtual public SubgraphBaseStaticTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<NMSTopKParams>& obj);
+
+protected:
+    void SetUp() override;
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
+};
+
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/nms_topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/nms_topk.cpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "custom/subgraph_tests/src/classes/nms_topk.hpp"
+
+namespace ov {
+namespace test {
+
+namespace {
+
+const ov::Shape inputShape = {1, 3614, 4};
+
+const std::vector<ov::element::Type> inputPrecisions = {ElementType::f32, ElementType::f16, ElementType::bf16};
+
+const int64_t maxOutputBoxesPerClass = {200};
+
+const float iouThreshold = {0.1f};
+
+const std::vector<float> scoreThresholds = {0.8f, 0.9f};
+
+INSTANTIATE_TEST_SUITE_P(smoke_NMSTopK,
+                         NMSTopKTest,
+                         ::testing::Combine(::testing::Values(inputShape),
+                                            ::testing::ValuesIn(inputPrecisions),
+                                            ::testing::Values(maxOutputBoxesPerClass),
+                                            ::testing::Values(iouThreshold),
+                                            ::testing::ValuesIn(scoreThresholds),
+                                            ::testing::Values(ov::test::utils::DEVICE_CPU)),
+                         NMSTopKTest::getTestCaseName);
+}  // namespace
+
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/topk_shape_inference_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/topk_shape_inference_test.cpp
@@ -30,8 +30,8 @@ protected:
     int64_t axis, k;
 };
 
-const auto TopkTestValues = Values(make_tuple(StaticShapeVector{{0}, {}}, 0, 1, StaticShape{1}),
-                                   make_tuple(StaticShapeVector{{5, 2, 10, 0}, {}}, -1, 5, StaticShape{5, 2, 10, 5}),
+const auto TopkTestValues = Values(make_tuple(StaticShapeVector{{0}, {}}, 0, 1, StaticShape{0}),
+                                   make_tuple(StaticShapeVector{{5, 2, 10, 0}, {}}, -1, 5, StaticShape{5, 2, 10, 0}),
                                    make_tuple(StaticShapeVector{{3, 5, 6}, {}}, 1, 2, StaticShape{3, 2, 6}));
 
 namespace v1 {

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/arg_max_min_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/arg_max_min_si_test.cpp
@@ -122,9 +122,9 @@ INSTANTIATE_TEST_SUITE_P(smoke, arg_max_min_test,
             {layout{ov::PartialShape::dynamic(4), data_types::f32, format::bfyx},
              layout{ov::PartialShape{1}, data_types::f32, format::bfyx}},
             ov::op::TopKMode::MIN, 2, 0, data_types::f32, {input_info("input", 0), input_info("const0", 0)}, 2,
-            {layout{ov::PartialShape{2, ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension::dynamic()},
+            {layout{ov::PartialShape{{0, 2}, ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension::dynamic()},
                     data_types::f32, format::bfyx},
-             layout{ov::PartialShape{2, ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension::dynamic()},
+             layout{ov::PartialShape{{0, 2} , ov::Dimension::dynamic(), ov::Dimension::dynamic(), ov::Dimension::dynamic()},
                     data_types::f32, format::bfyx}}
         },
     }));


### PR DESCRIPTION
### Details:
 - *Extend TopK node to support internal dynamic input in static model, where data size on sorting axis is less than k.*
 - *Add subgraph test cases to reproduce this issue beforehand.*

### Tickets:
 - *[CVS-163208](https://jira.devtools.intel.com/browse/CVS-163208)*
