### PR TITLE
[CPU] Disable failing smoke_BroadcastEltwise test on ARM64

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/broadcast_eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/broadcast_eltwise.cpp
@@ -107,6 +107,7 @@ private:
 };
 
 TEST_P(BroadcastEltwise, smoke_CompareWithRefs) {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
     CheckLastNode(compiledModel);
 }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -363,6 +363,8 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(smoke_LPT/MatMulTransformation.*)");
         // Ticket: 162260
         retVector.emplace_back(R"(smoke_Snippets_FQDecomposition.*netPRC=f32_D=CPU.*)");
+        // Ticket: 166771
+        retVector.emplace_back(R"(.*smoke_BroadcastEltwise/BroadcastEltwise.smoke_CompareWithRefs.*)");
     }
     // invalid test: checks u8 precision for runtime graph, while it should be f32
     retVector.emplace_back(R"(smoke_NegativeQuantizedMatMulMultiplyFusion.*)");


### PR DESCRIPTION
### Details:
`smoke_BroadcastEltwise/BroadcastEltwise.smoke_CompareWithRefs/precision=f32IS=([?.?.?.?])_TS=((1.3.16.16)_)_target_shape=(16.16)` and other BroadcastEltwise related tests fail with the exception: `to_shape was called on a dynamic shape`

### Tickets:
 - 166771