### PR TITLE
[Snippets][CPU] Supported bf16, fp16 MHA on LNL

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.cpp
@@ -53,7 +53,11 @@ cpu_isa_t get_primitive_isa(const ov::element::Type& dt_in0, bool is_with_amx) {
             SUPPORT_ONE(avx512_core_amx,
                         "Unsupported hardware configuration: amx is supported only on avx512 platforms")
     } else if (dt_in0 == ov::element::bf16) {
-        SUPPORT_ONE(avx512_core_bf16, "Unsupported hardware configuration: bf16 is supported only on avx512 platforms")
+        SUPPORT_TWO(avx512_core_bf16,
+                    avx2_vnni_2,
+                    "Unsupported hardware configuration: bf16 is supported only on avx512 and avx2_vnni_2 platforms")
+    } else if (dt_in0 == ov::element::f16) {
+        SUPPORT_ONE(avx2_vnni_2, "Unsupported hardware configuration: fp16 is supported only on avx2_vnni_2 platforms")
     } else if (one_of(dt_in0, ov::element::u8, ov::element::i8)) {
         SUPPORT_THREE(avx512_core_vnni,
                       avx2_vnni_2,
@@ -75,10 +79,12 @@ BRGEMM_TYPE get_brgemm_type(const ov::element::Type& element_type_a, bool transp
         return transpose_b ? BRGEMM_TYPE::REPACKING_ONLY : BRGEMM_TYPE::STAND_ALONE;
     }
 
-    OPENVINO_ASSERT(element_type_a != element::bf16 || mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16),
-                    "BrgemmCPU BF16 precision is not supported on non avx512_core_bf16 system");
-    OPENVINO_ASSERT(element_type_a != element::f16 || mayiuse(dnnl::impl::cpu::x64::avx512_core_amx_fp16),
-                    "BrgemmCPU FP16 precision is not supported on non avx512_core_amx_fp16 system");
+    if (element_type_a == element::bf16) {
+        OPENVINO_ASSERT(is_bf16_supported(), "BrgemmCPU BF16 precision is not supported on the current system");
+    }
+    if (element_type_a == element::f16) {
+        OPENVINO_ASSERT(is_fp16_supported(), "BrgemmCPU FP16 precision is not supported on the current system");
+    }
 
     if (one_of(element_type_a, element::u8, element::i8, element::bf16) &&
         dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx)) {
@@ -95,7 +101,7 @@ BRGEMM_TYPE get_brgemm_type(const ov::element::Type& element_type_a, bool transp
                                                                                 : BRGEMM_TYPE::WITH_COMPENSATIONS;
     }
 
-    if (one_of(element_type_a, element::u8, ov::element::bf16)) {
+    if (one_of(element_type_a, element::u8, ov::element::bf16, ov::element::f16)) {
         return BRGEMM_TYPE::REPACKING_ONLY;
     }
     OV_CPU_JIT_EMITTER_THROW("Failed to determine brgemm mode");

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/enforce_precision.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/enforce_precision.cpp
@@ -10,7 +10,6 @@
 #include <set>
 #include <vector>
 
-#include "cpu/x64/cpu_isa_traits.hpp"
 #include "openvino/cc/pass/itt.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/model.hpp"
@@ -25,6 +24,7 @@
 #include "snippets/op/brgemm.hpp"
 #include "snippets/op/convert_saturation.hpp"
 #include "snippets/pass/propagate_precision.hpp"
+#include "transformations/snippets/x64/op/brgemm_utils.hpp"
 #include "transformations/utils/utils.hpp"
 
 using namespace ov::intel_cpu::pass;
@@ -137,10 +137,10 @@ std::set<std::vector<ov::element::Type>> EnforcePrecision::get_supported_precisi
     const std::shared_ptr<ov::Node>& op) noexcept {
     std::set<std::vector<ov::element::Type>> types;
     if (ov::is_type<snippets::op::Brgemm>(op)) {
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx_fp16)) {
+        if (brgemm_utils::is_fp16_supported()) {
             types.insert({element::f16, element::f16});
         }
-        if (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16)) {
+        if (brgemm_utils::is_bf16_supported()) {
             types.insert({element::bf16, element::bf16});
         }
     }

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/remove_converts.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/remove_converts.hpp
@@ -10,7 +10,7 @@ namespace ov::intel_cpu::pass {
 
 /**
  * @interface RemoveConverts
- * @brief Remove sequence of two ConvertSaturation operations for specific precisions: FP32 => BF16 => FP32
+ * @brief Remove sequence of two ConvertSaturation operations for specific precisions: FP32 => BF16 | FP16 => FP32
  * @ingroup snippets
  */
 class RemoveConverts : public ov::pass::MatcherPass {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1210,14 +1210,14 @@ void Transformations::MainSnippets() {
     const auto is_LLM = ov::op::util::is_large_language_model(*model) ||
                         ov::op::util::has_op_with_type<intel_cpu::ScaledDotProductAttentionWithKVCache>(model);
 
-    // CPU Plugin Subgraph supports f32, bf16, quantized and fp16(on avx_512_core_amx_fp16 target) BRGEMM
+    // CPU Plugin Subgraph supports f32, bf16, quantized and fp16 BRGEMM
     const auto is_infer_prc_supported_by_brgemm =
-        (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2) &&
-         one_of(config.inferencePrecision, ov::element::f32, element::dynamic)) ||
-        (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core) &&
-         one_of(config.inferencePrecision, ov::element::bf16, ov::element::f32, element::dynamic)) ||
-        (dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx_fp16) &&
-         one_of(config.inferencePrecision, ov::element::f16));
+        (one_of(config.inferencePrecision, ov::element::f32, ov::element::dynamic) &&
+         ov::intel_cpu::brgemm_utils::is_fp32_supported()) ||
+        (one_of(config.inferencePrecision, ov::element::bf16, ov::element::f32, ov::element::dynamic) &&
+         ov::intel_cpu::brgemm_utils::is_bf16_supported()) ||
+        (one_of(config.inferencePrecision, ov::element::f16, ov::element::f32, ov::element::dynamic) &&
+         ov::intel_cpu::brgemm_utils::is_fp16_supported());
     const bool isMHASupported = !is_LLM && is_infer_prc_supported_by_brgemm;
 #else
     const bool isMHASupported = false;
@@ -1258,22 +1258,10 @@ void Transformations::MainSnippets() {
         if (matmul->get_transpose_a()) {
             return false;
         }
-        if (is_fp32) {
-            return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2);
-        }
-        if (is_int8) {
-            return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) ||
-                   dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_vnni) ||
-                   dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx2_vnni);
-        }
-        if (is_bf16) {
-            return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx) ||
-                   dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_bf16);
-        }
-        if (is_fp16) {
-            return dnnl::impl::cpu::x64::mayiuse(dnnl::impl::cpu::x64::avx512_core_amx_fp16);
-        }
-        return false;
+        return (is_fp32 && ov::intel_cpu::brgemm_utils::is_fp32_supported()) ||
+               (is_bf16 && ov::intel_cpu::brgemm_utils::is_bf16_supported()) ||
+               (is_fp16 && ov::intel_cpu::brgemm_utils::is_fp16_supported()) ||
+               (is_int8 && ov::intel_cpu::brgemm_utils::is_i8_supported());
     };
     auto is_unsupported_parallel_work_amount = [&](const std::shared_ptr<const ov::Node>& n,
                                                    const ov::PartialShape& shape) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/mha.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/mha.cpp
@@ -20,6 +20,14 @@ using namespace CPUTestUtils;
 
 namespace ov {
 namespace test {
+namespace {
+static inline bool is_bf16_supported() {
+    return ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx512_core_amx_bf16() || CPUTestUtils::with_cpu_x86_avx2_vnni_2();
+}
+static inline bool is_fp16_supported() {
+    return ov::with_cpu_x86_avx512_core_amx_fp16() || CPUTestUtils::with_cpu_x86_avx2_vnni_2();
+}
+} // namepace
 using ExpectedNodes = std::vector<std::pair<std::string, size_t>>;
 
 typedef std::tuple<std::vector<InputShape>,   // Input shapes
@@ -259,10 +267,10 @@ TEST_P(MHATest, CompareWithRefs) {
     std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetDevice) =
         this->GetParam();
 
-    if (inputPrecisions[0] == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
+    if (inputPrecisions[0] == ElementType::bf16 && !is_bf16_supported())
         GTEST_SKIP();
 
-    if (inputPrecisions[0] == ElementType::f16 && !ov::with_cpu_x86_avx512_core_amx_fp16())
+    if (inputPrecisions[0] == ElementType::f16 && !is_fp16_supported())
         GTEST_SKIP();
 
     if (!ov::with_cpu_x86_avx512_core())
@@ -656,7 +664,7 @@ TEST_P(MHAQuantTest, CompareWithRefs) {
     std::tie(inputShapes, inputPrecisions, matMulIn0Precisions, patternType, expectedNodes, targetDevice) =
         this->GetParam();
 
-    if (inputPrecisions[0] == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
+    if (inputPrecisions[0] == ElementType::bf16 && !is_bf16_supported())
         GTEST_SKIP();
 
     if (!ov::with_cpu_x86_avx512_core_vnni())

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -613,21 +613,21 @@ std::vector<std::string> disabledTestPatterns() {
         // TODO: Issue 92895
         // on platforms which do not support AMX, we are disabling I8 input tests
         retVector.emplace_back(R"(smoke_LPT/FakeQuantizeWithNotOptimalTransformation.CompareWithRefImpl.*CPU.*i8.*)");
-    if (!ov::with_cpu_x86_avx512_core_amx_bf16() && !ov::with_cpu_x86_bfloat16()) {
-        // ignored for not supported bf16 platforms
+    // MHA BF16 precision is only supported on BF16 supported platform
+    if (!ov::with_cpu_x86_avx512_core_amx_bf16() && !ov::with_cpu_x86_bfloat16() && !CPUTestUtils::with_cpu_x86_avx2_vnni_2()) {
         retVector.emplace_back(R"(.*smoke_Snippets_EnforcePrecision_bf16.*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MHAWOTransposeEnforceBF16.*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MHA.*EnforceBF16.*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MLP.*bf16.*)");
         retVector.emplace_back(R"(.*ConcatSDPTest.*bf16.*)");
     }
-        // RNN/LSTM/GRU/AUGRU BF16 tests on avx512 core ISA
+    // RNN/LSTM/GRU/AUGRU BF16 tests on avx512 core ISA
     if (ov::with_cpu_x86_avx512_core() && !ov::with_cpu_x86_avx512_core_amx_bf16()) {
         retVector.emplace_back(R"(smoke.*(AUGRUCellCPUTest|GRUCellCPUTest|RNNCellCPUTest|LSTMCellLayerCPUTest).CompareWithRefs.*INFERENCE_PRECISION_HINT=bf16.*)");
         retVector.emplace_back(R"(nightly.*bf16.*(AUGRUSequenceCPUTest|GRUSequenceCPUTest|LSTMSequenceCPUTest).CompareWithRefs.*INFERENCE_PRECISION_HINT=bf16.*)");
     }
-    // MHA FP16 precision is only supported on amx_fp16 platform
-    if (!ov::with_cpu_x86_avx512_core_amx_fp16()) {
+    // MHA FP16 precision is only supported on amx_fp16 and avx2_vnni_2 platform
+    if (!ov::with_cpu_x86_avx512_core_amx_fp16() && !CPUTestUtils::with_cpu_x86_avx2_vnni_2()) {
         retVector.emplace_back(R"(.*smoke_Snippets_MHA.*FP16.*)");
     }
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -674,7 +674,7 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(R"(.*smoke_MatMulCompressedWeights_(amx|sym_amx|corner_cases_amx)/MatmulWeightsDecompression.CompareWithRefs.*INFERENCE_PRECISION_HINT.*bf16.*)");
         retVector.emplace_back(R"(.*smoke_Snippets_EnforcePrecision_bf16/EnforcePrecisionTest.*)");
         retVector.emplace_back(R"(.*smoke_Snippets_MHABF16_4D/MHA.CompareWithRefImpl/.*\[1.58.16.34\]_IS\[1\]=\[1.58.16.34\]_IS\[2\]=\[1.1.1.58\]_IS\[3\]=\[1.58.16.34\].*)");
-        retVector.emplace_back(R"(.*smoke_Snippets_MHAWOTransposeBF16_(3|4)D/MHAWOTranspose.*)");
+        retVector.emplace_back(R"(.*smoke_Snippets_MHAWOTransposeBF16/MHAWOTranspose.CompareWithRefImpl/.*IS\[0\]=\[2.\?.64\].*IS\[1\]=\[2.64.\?\].*IS\[2\]=\[2.\?.64\].*)");
         // Issue: 141705
         retVector.emplace_back(R"(.*smoke_Deconv_(2|3)D_NSPC_INT8_AMX/DeconvolutionLayerCPUTest.*)");
         retVector.emplace_back(R"(.*smoke_Deconv_(2|3)D_NSPC_INT8_AMX/DeconvolutionLayerCPUTest.*)");
@@ -697,6 +697,10 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(
             R"(smoke_GroupConv_.*D_Gemm_BF16/GroupConvolutionLayerCPUTest.CompareWithRefs.*primitive=jit_gemm.*)");
         retVector.emplace_back(R"(smoke_.*MatMulLayerCPUTest.*INFERENCE_PRECISION_HINT=bf16.*_primitive=jit_gemm.*)");
+        // by calc abs_threshold with expected value
+        retVector.emplace_back(R"(smoke_Snippets_MHAWOTransposeBF16/MHAWOTranspose.CompareWithRefImpl/.*IS\[0\]=\[\]_\(\[12.128.100\]\).*)");
+        retVector.emplace_back(R"(smoke_Snippets_MHAWOTransposeBF16/MHAWOTranspose.CompareWithRefImpl/.*IS\[0\]=\[2.\?.64\].*)");
+        retVector.emplace_back(R"(smoke_Snippets_MHAWOTransposeBF16/MHAWOTranspose.CompareWithRefImpl/.*IS\[0\]=\[\?.\?.\?.\?\].*)");
     }
 
     return retVector;

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
@@ -20,6 +20,8 @@ static inline std::vector<std::vector<element::Type>> precisions() {
     std::copy(quant.begin(), quant.end(), std::back_inserter(prc));
     auto bfloat = precision_bf16_if_supported(2);
     std::copy(bfloat.begin(), bfloat.end(), std::back_inserter(prc));
+    auto halffloat = precision_fp16_if_supported(2);
+    std::copy(halffloat.begin(), halffloat.end(), std::back_inserter(prc));
 #endif
     return prc;
 }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha_wo_transpose.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/mha_wo_transpose.cpp
@@ -13,32 +13,22 @@ namespace snippets {
 namespace {
 
 std::vector<std::vector<ov::test::InputShape>> originalShape_4D {
-    { {{}, {{1, 12, 197, 64}}}, {{}, {{1, 12, 64, 197}}}, {{}, {{1, 12, 197, 64}}} },
-    { {{}, {{1, 12, 12, 64}}},  {{}, {{1, 12, 64, 48}}},  {{}, {{1, 12, 48, 64}}} },
+    { {{}, {{2, 12, 197, 64}}}, {{}, {{2, 12, 64, 197}}}, {{}, {{2, 12, 197, 64}}} },
     {
         {PartialShape{-1, -1, -1, -1}, {{1, 3, 128, 64}, {1, 12, 197, 100}, {1, 3, 128, 64}, {1, 12, 197, 600}}},
         {PartialShape{-1, -1, -1, -1}, {{1, 3, 64, 128}, {1, 12, 100, 197}, {1, 3, 64, 128}, {1, 12, 600, 197}}},
         {PartialShape{-1, -1, -1, -1}, {{1, 3, 128, 64}, {1, 12, 197, 100}, {1, 3, 128, 64}, {1, 12, 197, 600}}},
     },
-    {
-        {PartialShape{1, 4, -1, -1}, {{1, 4, 384, 64}, {1, 4, 197, 64}, {1, 4, 384, 560}}},
-        {PartialShape{1, 4, -1, -1}, {{1, 4, 64, 128}, {1, 4, 64, 197}, {1, 4, 560, 384}}},
-        {PartialShape{1, 4, -1, 64}, {{1, 4, 128, 64}, {1, 4, 197, 64}, {1, 4, 384, 64}}},
-    }
 };
 
-std::vector<std::vector<ov::test::InputShape>> originalShape_3D {
+std::vector<std::vector<ov::test::InputShape>> originalShapes {
     { {{}, {{12, 197, 64}}},  {{}, {{12, 64, 197}}},  {{}, {{12, 197, 64}}} },
     { {{}, {{12, 128, 100}}}, {{}, {{12, 100, 128}}}, {{}, {{12, 128, 100}}} },
+    { {{}, {{2, 12, 197, 64}}}, {{}, {{2, 12, 64, 197}}}, {{}, {{2, 12, 197, 64}}} },
     {
         {PartialShape{-1, -1, 64},  {{2, 9, 64},   {1, 64, 64},  {2, 64, 64}}},
         {PartialShape{-1, 64, 124}, {{2, 64, 124}, {1, 64, 124}, {2, 64, 124}}},
         {PartialShape{-1, 124, 64}, {{2, 124, 64}, {1, 124, 64}, {2, 124, 64}}},
-    },
-    {
-        {PartialShape{-1, -1, -1}, {{12, 19, 85}, {1, 40, 36}}},
-        {PartialShape{-1, -1, -1}, {{1, 85, 19}, {2, 36, 40}}},
-        {PartialShape{-1, -1, -1}, {{12, 19, 85}, {1, 40, 36}}},
     },
     {
         {PartialShape{2, -1, 64}, {{2, 9, 64}, {2, 4, 64}, {2, 9, 64}}},
@@ -49,6 +39,16 @@ std::vector<std::vector<ov::test::InputShape>> originalShape_3D {
         {PartialShape{-1, 128, 64}, {{1, 128, 64}, {2, 128, 64}, {1, 128, 64}}},
         {PartialShape{-1, 64, 128}, {{1, 64, 128}, {2, 64, 128}, {1, 64, 128}}},
         {PartialShape{-1, 128, 64}, {{1, 128, 64}, {2, 128, 64}, {1, 128, 64}}},
+    },
+    {
+        {PartialShape{-1, -1, -1, -1}, {{1, 3, 128, 64}, {1, 12, 197, 100}, {1, 3, 128, 64}, {1, 12, 197, 600}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 3, 64, 128}, {1, 12, 100, 197}, {1, 3, 64, 128}, {1, 12, 600, 197}}},
+        {PartialShape{-1, -1, -1, -1}, {{1, 3, 128, 64}, {1, 12, 197, 100}, {1, 3, 128, 64}, {1, 12, 197, 600}}},
+    },
+    {
+        {PartialShape{1, 4, -1, -1}, {{1, 4, 384, 64}, {1, 4, 197, 64}, {1, 4, 384, 560}}},
+        {PartialShape{1, 4, -1, -1}, {{1, 4, 64, 128}, {1, 4, 64, 197}, {1, 4, 560, 384}}},
+        {PartialShape{1, 4, -1, 64}, {{1, 4, 128, 64}, {1, 4, 197, 64}, {1, 4, 384, 64}}},
     }
 };
 
@@ -67,9 +67,9 @@ INSTANTIATE_TEST_SUITE_P(
     MHA::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTranspose_4D,
+    smoke_Snippets_MHAWOTransposeFP32,
     MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+    ::testing::Combine(::testing::ValuesIn(originalShapes),
                        ::testing::ValuesIn(precision_f32(3)),
                        ::testing::Values(ov::element::f32),
                        ::testing::Values(true),  // Need to support False for graph builder in tests
@@ -81,23 +81,9 @@ INSTANTIATE_TEST_SUITE_P(
     MHA::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTranspose_3D,
+    smoke_Snippets_MHAWOTransposeBF16,
     MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(originalShape_3D),
-                       ::testing::ValuesIn(precision_f32(3)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::Values(true),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(1),
-                       ::testing::Values(1),
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeBF16_4D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+    ::testing::Combine(::testing::ValuesIn(originalShapes),
                        ::testing::ValuesIn(precision_bf16_if_supported(3)),
                        ::testing::Values(ov::element::f32),
                        ::testing::Values(true),  // Need to support False for graph builder in tests
@@ -108,24 +94,11 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(CPUTestUtils::empty_plugin_config)),
     MHA::getTestCaseName);
 
-INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeBF16_3D,
-    MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(originalShape_3D),
-                       ::testing::ValuesIn(precision_bf16_if_supported(3)),
-                       ::testing::Values(ov::element::f32),
-                       ::testing::Values(true),  // Need to support False for graph builder in tests
-                       ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::empty_plugin_config)),
-    MHA::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeEnforceBF16_4D,
+    smoke_Snippets_MHAWOTransposeEnforceBF16,
     MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(originalShape_4D),
+    ::testing::Combine(::testing::ValuesIn(originalShapes),
                        ::testing::ValuesIn(precision_f32(3)),
                        ::testing::Values(ov::element::bf16),
                        ::testing::Values(true),  // Need to support False for graph builder in tests
@@ -136,18 +109,19 @@ INSTANTIATE_TEST_SUITE_P(
                        ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
     MHA::getTestCaseName);
 
+
 INSTANTIATE_TEST_SUITE_P(
-    smoke_Snippets_MHAWOTransposeEnforceBF16_3D,
+    smoke_Snippets_MHAWOTransposeEnforceFP16,
     MHAWOTranspose,
-    ::testing::Combine(::testing::ValuesIn(originalShape_3D),
+    ::testing::Combine(::testing::ValuesIn(originalShapes),
                        ::testing::ValuesIn(precision_f32(3)),
-                       ::testing::Values(ov::element::bf16),
+                       ::testing::Values(ov::element::f16),
                        ::testing::Values(true),  // Need to support False for graph builder in tests
                        ::testing::Values(MHA::default_thread_count),
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
-                       ::testing::Values(5),  // MHA + 4 extra Converts on inputs and output
+                       ::testing::Values(1),
+                       ::testing::Values(1),
                        ::testing::Values(ov::test::utils::DEVICE_CPU),
-                       ::testing::Values(CPUTestUtils::cpu_bf16_plugin_config)),
+                       ::testing::Values(CPUTestUtils::cpu_f16_plugin_config)),
     MHA::getTestCaseName);
 
 }  // namespace

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/transpose_matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/transpose_matmul.cpp
@@ -22,6 +22,8 @@ static inline std::vector<std::vector<element::Type>> precisions(bool only_fp32 
         std::copy(quant.begin(), quant.end(), std::back_inserter(prc));
         auto bfloat = precision_bf16_if_supported(2);
         std::copy(bfloat.begin(), bfloat.end(), std::back_inserter(prc));
+        auto halffloat = precision_fp16_if_supported(2);
+        std::copy(halffloat.begin(), halffloat.end(), std::back_inserter(prc));
     }
 #endif
     return prc;
@@ -169,19 +171,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_FullyConnected, TransposeMatMul,
 
 namespace explicit_transpose {
 static inline std::vector<std::vector<element::Type>> precisions(bool only_fp32 = true) {
-    std::vector<std::vector<element::Type>> prc = {
-            {element::f32, element::f32},
-    };
+    std::vector<std::vector<element::Type>> prc = precision_f32(2);
     if (!only_fp32) {
-        // In Snippets MatMul INT8 is supported only on VNNI/AMX platforms
-        if (ov::with_cpu_x86_avx512_core_vnni() || ov::with_cpu_x86_avx512_core_amx_int8()) {
-            prc.emplace_back(std::vector<element::Type>{element::i8, element::i8});
-            prc.emplace_back(std::vector<element::Type>{element::u8, element::i8});
-        }
-        // In Snippets MatMul BF16 is supported only on bf16/AMX platforms
-        if (ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx512_core_amx_bf16()) {
-            prc.emplace_back(std::vector<element::Type>{element::bf16, element::bf16});
-        }
+        auto quant = quantized_precisions_if_supported();
+        std::copy(quant.begin(), quant.end(), std::back_inserter(prc));
+        auto bfloat = precision_bf16_if_supported(2);
+        std::copy(bfloat.begin(), bfloat.end(), std::back_inserter(prc));
+        auto halffloat = precision_fp16_if_supported(2);
+        std::copy(halffloat.begin(), halffloat.end(), std::back_inserter(prc));
     }
     return prc;
 }

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/utils.hpp
@@ -13,11 +13,11 @@ namespace snippets {
 #define SNIPPETS_TESTS_STATIC_SHAPES(...) static_shapes_to_test_representation(std::vector<std::vector<ov::Shape>>{__VA_ARGS__})
 
 static inline bool is_bf16_supported_by_brgemm() {
-    return ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx512_core_amx_bf16();
+    return ov::with_cpu_x86_bfloat16() || ov::with_cpu_x86_avx512_core_amx_bf16() || CPUTestUtils::with_cpu_x86_avx2_vnni_2();
 }
 
 static inline bool is_fp16_supported_by_brgemm() {
-    return ov::with_cpu_x86_avx512_core_amx_fp16();
+    return ov::with_cpu_x86_avx512_core_amx_fp16() || CPUTestUtils::with_cpu_x86_avx2_vnni_2();
 }
 
 static inline bool is_i8_supported_by_brgemm() {

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_matmul.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_matmul.cpp
@@ -64,7 +64,8 @@ MatMulFunctionBase::MatMulFunctionBase(const std::vector<PartialShape>& inputSha
         const bool is_f32 = ov::snippets::utils::everyone_is(element::f32, precisions[0], precisions[1]);
         const bool is_int8 = ov::snippets::utils::one_of(precisions[0], element::i8, element::u8) && precisions[1] == element::i8;
         const bool is_bf16 = ov::snippets::utils::everyone_is(element::bf16, precisions[0], precisions[1]);
-        OPENVINO_ASSERT(is_f32 || is_bf16 || is_int8, "Invalid precisions");
+        const bool is_f16 = ov::snippets::utils::everyone_is(element::f16, precisions[0], precisions[1]);
+        OPENVINO_ASSERT(is_f32 || is_bf16 || is_f16 || is_int8, "Invalid precisions");
     }
 }
 


### PR DESCRIPTION
### Details:
 - *Added support BF16, FP16 MHA tokenization on x64 platforms with `avx2_vnni_2` ISA*

### Tickets:
 - *150682*

### TODO:
- [x] Validate performance using benchmark