### PR TITLE
[FE][PT][FX] Add Support for aten.zero.default

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
@@ -255,6 +255,7 @@ class OperatorSupport(OpSupport):
             "torch.ops.aten.view.default": None,
             "torch.ops.aten.view_copy.default": None,
             "torch.ops.aten.where.self": None,
+            "torch.ops.aten.zero.default": None,
             "torch.ops.aten.zeros.default": None,
             "torch.ops.aten.zeros_like.default": None,
             "torch.ops.torchvision.deform_conv2d.default": None,

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -1074,6 +1074,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.view_as_complex.default", op::translate_view_as_complex},
         {"aten.view_as_real.default", op::translate_view_as_real},
         {"aten.where.self", op::translate_where},
+        {"aten.zero.default", op::translate_zeros_like_fx},
         {"aten.zeros.default", op::translate_zeros_fx},
         {"aten.zeros.names", op::translate_zeros_fx},
         {"aten.zeros_like.default", op::translate_zeros_like_fx},


### PR DESCRIPTION
### Details:
In Pytorch 2.7, Exported Swin Model causes graph breaks in torch compile due to `aten.zero.default` operation not being supported. This PR aims to achieve support for this operation.
