### PR TITLE
[JS] Replace deprecated '-undefined suppress' flag on macOS

### DIFF
--- a/src/bindings/js/node/CMakeLists.txt
+++ b/src/bindings/js/node/CMakeLists.txt
@@ -90,7 +90,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
 endif()
 
 if(APPLE)
-    target_link_options(${PROJECT_NAME} PRIVATE -Wl,-undefined,suppress,-flat_namespace)
+    target_link_options(${PROJECT_NAME} PRIVATE -Wl,-undefined,dynamic_lookup,-bundle,-flat_namespace)
 elseif(AARCH64 OR ARM)
     target_link_options(${PROJECT_NAME} PRIVATE -Wl,--unresolved-symbols=ignore-all)
 endif()


### PR DESCRIPTION
### Details:
Xcode 15 introduced a new linker and all types of behavior in case of undefined symbols in dynamic library (except the default one `-undefined dynamic_lookup`) have been deprecated:
```
ld: warning: -undefined suppress is deprecated
```

`-bundle` option is used to produce shared object (`.node` file) instead of `.dylib`

### Tickets:
 - N/A
