### PR TITLE
[GPU] Implement on-demand device initialization

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
@@ -32,7 +32,7 @@ private:
     void register_primitives() const;
     std::string get_device_id_from_config(const ov::AnyMap& config) const;
     std::string get_device_id(const ov::AnyMap& config) const;
-    std::shared_ptr<RemoteContextImpl> get_default_context(const std::string& device_id) const;
+    std::shared_ptr<RemoteContextImpl> get_default_context(const std::string& device_id, bool initialize = true) const;
 
     std::vector<ov::PropertyName> get_caching_properties() const;
     std::vector<ov::PropertyName> get_supported_properties() const;

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -26,7 +26,29 @@ class RemoteContextImpl : public ov::IRemoteContext {
 public:
     using Ptr = std::shared_ptr<RemoteContextImpl>;
 
-    RemoteContextImpl(const std::string& device_name, std::vector<cldnn::device::ptr> devices);
+    /**
+     * @brief Constructs a RemoteContextImpl for internal plugin use.
+     *
+     * @param device_name Name of the target device.
+     * @param devices List of devices associated with the plugin.
+     * @param initialize_ctx If true (default), the context is initialized immediately.
+     *                       If false, the context is created in an uninitialized state.
+     *
+     * Used to serve internal plugin needs, such as creating a context for a specific device.
+     * Supports optional delayed initialization.
+     */
+    RemoteContextImpl(const std::string& device_name, std::vector<cldnn::device::ptr> devices, bool initialize_ctx = true);
+
+    /**
+     * @brief Constructs a RemoteContextImpl from a user-provided external context or device.
+     *
+     * @param known_contexts Map of existing in Plugin contexts.
+     * @param params Configuration parameters for the remote context. May include:
+     *               context, device handles, target device index, tile index, or an external queue handle.
+     *
+     * Used to serve external context requests, such as when the user provides an existing context.
+     * Always creates an initialized context.
+     */
     RemoteContextImpl(const std::map<std::string, RemoteContextImpl::Ptr>& known_contexts, const ov::AnyMap& params);
 
     const std::string& get_device_name() const override;
@@ -43,6 +65,14 @@ public:
     cldnn::memory::ptr try_get_cached_memory(size_t hash);
     void add_to_cache(size_t hash, cldnn::memory::ptr memory);
 
+    /**
+     * @brief Initializes the RemoteContext and its associated device.
+     *
+     * This method performs context initialization if it was deferred during construction
+     * (i.e., when the constructor was called with initialize_ctx = false).
+     *
+     * Has no effect if the context is already initialized.
+     */
     void initialize();
     bool is_initialized() const { return m_is_initialized; }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -35,12 +35,16 @@ public:
     ov::SoPtr<ov::ITensor> create_host_tensor(const ov::element::Type type, const ov::Shape& shape) override;
     ov::SoPtr<ov::IRemoteTensor> create_tensor(const ov::element::Type& type, const ov::Shape& shape, const ov::AnyMap& params) override;
 
-    cldnn::engine& get_engine() { return *m_engine; }
-    const cldnn::engine& get_engine() const { return *m_engine; }
+    cldnn::engine& get_engine();
+    const cldnn::engine& get_engine() const;
+    const cldnn::device& get_device() { return *m_device; }
     ov::intel_gpu::gpu_handle_param get_external_queue() const { return m_external_queue; }
 
     cldnn::memory::ptr try_get_cached_memory(size_t hash);
     void add_to_cache(size_t hash, cldnn::memory::ptr memory);
+
+    void initialize();
+    bool is_initialized() const { return m_is_initialized; }
 
 private:
     std::shared_ptr<RemoteContextImpl> get_this_shared_ptr();
@@ -54,6 +58,7 @@ private:
 
     void init_properties();
 
+    std::shared_ptr<cldnn::device> m_device;
     std::shared_ptr<cldnn::engine> m_engine;
     ov::intel_gpu::gpu_handle_param m_va_display = nullptr;
     ov::intel_gpu::gpu_handle_param m_external_queue = nullptr;
@@ -63,6 +68,8 @@ private:
     static const size_t cache_capacity = 100;
     cldnn::LruCache<size_t, cldnn::memory::ptr> m_memory_cache = cldnn::LruCache<size_t, cldnn::memory::ptr>(cache_capacity);
     std::mutex m_cache_mutex;
+
+    bool m_is_initialized = false;
 
     ov::AnyMap properties;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/remote_context.hpp
@@ -70,6 +70,7 @@ private:
     std::mutex m_cache_mutex;
 
     bool m_is_initialized = false;
+    std::once_flag m_initialize_flag;
 
     ov::AnyMap properties;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device.hpp
@@ -21,11 +21,14 @@ public:
     virtual const device_info& get_info() const = 0;
     virtual memory_capabilities get_mem_caps() const = 0;
 
+    virtual void initialize() = 0;
+    virtual bool is_initialized() const = 0;
+
     virtual bool is_same(const device::ptr other) = 0;
 
     float get_gops(cldnn::data_types dt) const;
     bool use_unified_shared_memory() const;
-    virtual void set_mem_caps(memory_capabilities memory_capabilities) = 0;
+    virtual void set_mem_caps(const memory_capabilities& memory_capabilities) = 0;
 
     virtual ~device() = default;
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_info.hpp
@@ -45,6 +45,34 @@ struct gfx_version {
         return std::tie(l.major, l.minor, l.revision)
                < std::tie(r.major, r.minor, r.revision); // same order
     }
+
+    bool operator==(const gfx_version& other) {
+        return major == other.major &&
+               minor == other.minor &&
+               revision == other.revision;
+    }
+
+    bool operator!=(const gfx_version& other) {
+        return !(*this == other);
+    }
+};
+
+struct pci_bus_info {
+    uint32_t pci_domain = 0;
+    uint32_t pci_bus = 0;
+    uint32_t pci_device = 0;
+    uint32_t pci_function = 0;
+
+    bool operator==(const pci_bus_info& other) {
+        return pci_domain == other.pci_domain &&
+               pci_bus == other.pci_bus &&
+               pci_device == other.pci_device &&
+               pci_function == other.pci_function;
+    }
+
+    bool operator!=(const pci_bus_info& other) {
+        return !(*this == other);
+    }
 };
 
 /// @brief Information about the device properties and capabilities.
@@ -97,6 +125,9 @@ struct device_info {
     uint32_t num_eus_per_sub_slice;             ///< Number of execution units per subslice
     uint32_t num_threads_per_eu;                ///< Number of hardware threads per execution unit
     uint32_t num_ccs;                           ///< Number of compute command streamers
+    uint32_t sub_device_idx;                    ///< Index of sub-device
+
+    pci_bus_info pci_info;                      ///< PCI bus information for the device
 
     ov::device::UUID uuid;                      ///< UUID of the gpu device
     ov::device::LUID luid;                      ///< LUID of the gpu device

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/device_query.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/device_query.hpp
@@ -22,7 +22,8 @@ public:
                           void* user_context = nullptr,
                           void* user_device = nullptr,
                           int ctx_device_id = 0,
-                          int target_tile_id = -1);
+                          int target_tile_id = -1,
+                          bool initialize_devices = false);
 
     std::map<std::string, device::ptr> get_available_devices() const {
         return _available_devices;

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -147,7 +147,9 @@ std::map<std::string, RemoteContextImpl::Ptr> Plugin::get_default_contexts() con
     std::call_once(m_default_contexts_once, [this]() {
         // Create default context
         for (auto& device : m_device_map) {
-            auto ctx = std::make_shared<RemoteContextImpl>(get_device_name() + "." + device.first, std::vector<cldnn::device::ptr>{ device.second });
+            const auto device_name = get_device_name() + "." + device.first;
+            const auto initialize = false;
+            auto ctx = std::make_shared<RemoteContextImpl>(device_name, std::vector<cldnn::device::ptr>{device.second}, initialize);
             m_default_contexts.insert({device.first, ctx});
         }
     });

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -280,6 +280,7 @@ ov::SupportedOpsMap Plugin::query_model(const std::shared_ptr<const ov::Model>& 
     std::string device_id = get_device_id(orig_config);
 
     auto ctx = get_default_context(device_id);
+    ctx->initialize();
 
     ExecutionConfig config = m_configs_map.at(device_id);
     config.set_user_property(orig_config, OptionVisibility::RELEASE);

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -25,12 +25,12 @@ Type extract_object(const ov::AnyMap& params, const ov::Property<Type>& p) {
 
 }  // namespace
 
-RemoteContextImpl::RemoteContextImpl(const std::string& device_name, std::vector<cldnn::device::ptr> devices) : m_device_name(device_name) {
+RemoteContextImpl::RemoteContextImpl(const std::string& device_name, std::vector<cldnn::device::ptr> devices, bool initialize_ctx)
+    : m_device_name(device_name) {
     OPENVINO_ASSERT(devices.size() == 1, "[GPU] Currently context can be created for single device only");
     m_device = devices.front();
 
-    // Initialize RemoteContext if corresponding device is initialized
-    if (m_device->is_initialized()) {
+    if (initialize_ctx) {
         initialize();
     }
 }
@@ -244,7 +244,7 @@ void RemoteContextImpl::check_if_shared() const {
 
 void RemoteContextImpl::initialize() {
     std::call_once(m_initialize_flag, [this]() {
-        GPU_DEBUG_INFO << "Initialize RemoteContext for " << m_device_name << " (" << m_engine->get_device_info().dev_name << ")" << std::endl;
+        GPU_DEBUG_INFO << "Initialize RemoteContext for " << m_device_name << " (" << m_device->get_info().dev_name << ")" << std::endl;
 
 #ifdef OV_GPU_WITH_SYCL
         const auto engine_type = cldnn::engine_types::sycl;

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -76,9 +76,6 @@ RemoteContextImpl::RemoteContextImpl(const std::map<std::string, RemoteContextIm
     OPENVINO_ASSERT(device_map.size() == 1, "[GPU] Exactly one device expected in case of context sharing, but ", device_map.size(), " found");
 
     m_device = device_map.begin()->second;
-
-    GPU_DEBUG_INFO << "Initialize RemoteContext for " << m_device_name << " (" << m_engine->get_device_info().dev_name << ")" << std::endl;
-
     m_device_name = get_device_name(known_contexts, m_device);
 
     initialize();

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -27,18 +27,7 @@ Type extract_object(const ov::AnyMap& params, const ov::Property<Type>& p) {
 
 RemoteContextImpl::RemoteContextImpl(const std::string& device_name, std::vector<cldnn::device::ptr> devices) : m_device_name(device_name) {
     OPENVINO_ASSERT(devices.size() == 1, "[GPU] Currently context can be created for single device only");
-#ifdef OV_GPU_WITH_SYCL
-    const auto engine_type = cldnn::engine_types::sycl;
-#else
-    const auto engine_type = cldnn::engine_types::ocl;
-#endif
-
-    const auto runtime_type = cldnn::runtime_types::ocl;
-
-    m_engine = cldnn::engine::create(engine_type, runtime_type, devices.front());
-
-    GPU_DEBUG_LOG << "Initialize RemoteContext for " << m_device_name << " (" << m_engine->get_device_info().dev_name << ")" << std::endl;
-    init_properties();
+    m_device = devices.front();
 }
 
 RemoteContextImpl::RemoteContextImpl(const std::map<std::string, RemoteContextImpl::Ptr>& known_contexts, const AnyMap& params) {
@@ -73,19 +62,31 @@ RemoteContextImpl::RemoteContextImpl(const std::map<std::string, RemoteContextIm
 
     const auto engine_type = cldnn::engine_types::ocl;
     const auto runtime_type = cldnn::runtime_types::ocl;
+    const auto initialize_devices = true;
 
     // Use actual runtime and engine types
-    cldnn::device_query device_query(engine_type, runtime_type, context_id, m_va_display, ctx_device_id, target_tile_id);
+    cldnn::device_query device_query(engine_type, runtime_type, context_id, m_va_display, ctx_device_id, target_tile_id, initialize_devices);
     auto device_map = device_query.get_available_devices();
 
     OPENVINO_ASSERT(device_map.size() == 1, "[GPU] Exactly one device expected in case of context sharing, but ", device_map.size(), " found");
 
-    m_engine = cldnn::engine::create(engine_type, runtime_type, device_map.begin()->second);
-    m_device_name = get_device_name(known_contexts, m_engine->get_device());
+    m_device = device_map.begin()->second;
 
     GPU_DEBUG_LOG << "Initialize RemoteContext for " << m_device_name << " (" << m_engine->get_device_info().dev_name << ")" << std::endl;
 
-    init_properties();
+    m_device_name = get_device_name(known_contexts, m_device);
+
+    initialize();
+}
+
+cldnn::engine& RemoteContextImpl::get_engine() {
+    OPENVINO_ASSERT(m_is_initialized, "[GPU] Can't retrieve engine from uninitialized RemoteContext. Please initialize the context first");
+    return *m_engine;
+}
+
+const cldnn::engine& RemoteContextImpl::get_engine() const {
+    OPENVINO_ASSERT(m_is_initialized, "[GPU] Can't retrieve engine from uninitialized RemoteContext. Please initialize the context first");
+    return *m_engine;
 }
 
 void RemoteContextImpl::init_properties() {
@@ -106,6 +107,7 @@ void RemoteContextImpl::init_properties() {
 }
 
 const ov::AnyMap& RemoteContextImpl::get_property() const {
+    OPENVINO_ASSERT(m_is_initialized, "[GPU] get_property() called on uninitialized context. Please initialize the context before use");
     return properties;
 }
 
@@ -114,6 +116,7 @@ std::shared_ptr<RemoteContextImpl> RemoteContextImpl::get_this_shared_ptr() {
 }
 
 ov::SoPtr<ov::ITensor> RemoteContextImpl::create_host_tensor(const ov::element::Type type, const ov::Shape& shape) {
+    OPENVINO_ASSERT(m_is_initialized, "[GPU] create_host_tensor() called on uninitialized context. Please initialize the context before use");
     if (m_engine->use_unified_shared_memory()) {
         return { std::make_shared<USMHostTensor>(get_this_shared_ptr(), type, shape), nullptr };
     } else {
@@ -122,6 +125,8 @@ ov::SoPtr<ov::ITensor> RemoteContextImpl::create_host_tensor(const ov::element::
 }
 
 ov::SoPtr<ov::IRemoteTensor> RemoteContextImpl::create_tensor(const ov::element::Type& type, const ov::Shape& shape, const ov::AnyMap& params) {
+    OPENVINO_ASSERT(m_is_initialized, "[GPU] create_tensor() called on uninitialized context. Please initialize the context before use");
+
     if (params.empty()) {
         // user wants plugin to allocate tensor by itself and return handle
         return { create_buffer(type, shape), nullptr };
@@ -176,7 +181,7 @@ std::string RemoteContextImpl::get_device_name(const std::map<std::string, Remot
                                                const cldnn::device::ptr current_device) const {
     std::string device_name = "GPU";
     for (auto& c : known_contexts) {
-        if (c.second->get_engine().get_device()->is_same(current_device)) {
+        if (c.second->m_device->is_same(current_device)) {
             device_name = c.second->get_device_name();
             break;
         }
@@ -230,6 +235,27 @@ std::shared_ptr<ov::IRemoteTensor> RemoteContextImpl::create_usm(const ov::eleme
 
 void RemoteContextImpl::check_if_shared() const {
     OPENVINO_ASSERT(m_type == ContextType::VA_SHARED, "[GPU] Shared context is required to to share this type of memory");
+}
+
+void RemoteContextImpl::initialize() {
+    if (m_is_initialized)
+        return;
+
+    GPU_DEBUG_TRACE_DETAIL << "Initialize RemoteContext for " << m_device_name << " (" << m_engine->get_device_info().dev_name << ")" << std::endl;
+
+#ifdef OV_GPU_WITH_SYCL
+    const auto engine_type = cldnn::engine_types::sycl;
+#else
+    const auto engine_type = cldnn::engine_types::ocl;
+#endif
+    const auto runtime_type = cldnn::runtime_types::ocl;
+
+    m_device->initialize();  // Initialize associated device before use
+    m_engine = cldnn::engine::create(engine_type, runtime_type, m_device);
+
+    init_properties();
+
+    m_is_initialized = true;
 }
 
 }  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/remote_context.cpp
+++ b/src/plugins/intel_gpu/src/plugin/remote_context.cpp
@@ -28,6 +28,11 @@ Type extract_object(const ov::AnyMap& params, const ov::Property<Type>& p) {
 RemoteContextImpl::RemoteContextImpl(const std::string& device_name, std::vector<cldnn::device::ptr> devices) : m_device_name(device_name) {
     OPENVINO_ASSERT(devices.size() == 1, "[GPU] Currently context can be created for single device only");
     m_device = devices.front();
+
+    // Initialize RemoteContext if corresponding device is initialized
+    if (m_device->is_initialized()) {
+        initialize();
+    }
 }
 
 RemoteContextImpl::RemoteContextImpl(const std::map<std::string, RemoteContextImpl::Ptr>& known_contexts, const AnyMap& params) {

--- a/src/plugins/intel_gpu/src/runtime/device_query.cpp
+++ b/src/plugins/intel_gpu/src/runtime/device_query.cpp
@@ -15,7 +15,8 @@ device_query::device_query(engine_types engine_type,
                            void* user_context,
                            void* user_device,
                            int ctx_device_id,
-                           int target_tile_id) {
+                           int target_tile_id,
+                           bool initialize_devices) {
     switch (engine_type) {
     case engine_types::sycl:
     case engine_types::ocl: {
@@ -23,7 +24,7 @@ device_query::device_query(engine_types engine_type,
             throw std::runtime_error("Unsupported runtime type for ocl engine");
 
         ocl::ocl_device_detector ocl_detector;
-        _available_devices = ocl_detector.get_available_devices(user_context, user_device, ctx_device_id, target_tile_id);
+        _available_devices = ocl_detector.get_available_devices(user_context, user_device, ctx_device_id, target_tile_id, initialize_devices);
         break;
     }
     default: throw std::runtime_error("Unsupported engine type in device_query");

--- a/src/plugins/intel_gpu/src/runtime/engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/engine.cpp
@@ -266,7 +266,7 @@ std::shared_ptr<cldnn::engine> engine::create(engine_types engine_type, runtime_
 }
 
 std::shared_ptr<cldnn::engine> engine::create(engine_types engine_type, runtime_types runtime_type) {
-    device_query query(engine_type, runtime_type);
+    device_query query(engine_type, runtime_type, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
 
     OPENVINO_ASSERT(!devices.empty(), "[GPU] Can't create ", engine_type, " engine for ", runtime_type, " runtime as no suitable devices are found\n"

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -113,7 +113,6 @@ ExecutionConfig ExecutionConfig::clone() const {
 
 void ExecutionConfig::finalize(cldnn::engine& engine) {
     auto ctx = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
-    ctx->initialize();
     PluginConfig::finalize(ctx.get(), nullptr);
 }
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -113,6 +113,7 @@ ExecutionConfig ExecutionConfig::clone() const {
 
 void ExecutionConfig::finalize(cldnn::engine& engine) {
     auto ctx = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+    ctx->initialize();
     PluginConfig::finalize(ctx.get(), nullptr);
 }
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -470,16 +470,18 @@ void ocl_device::initialize() {
     ocl::ocl_device_detector detector;
     auto device_map = detector.get_available_devices(nullptr, nullptr, 0, -1, true);
 
+    bool found = false;
     for (auto& device : device_map) {
         if (this->is_same(device.second)) {
+            OPENVINO_ASSERT(!found, "[GPU] Multiple matching devices found for ", this->get_info().dev_name, ". Only one matching device is expected");
             if (auto casted = downcast<ocl_device>(device.second.get())) {
                 initialize_device(casted->get_device(), casted->get_context());
-                return;
+                found = true;
             }
         }
     }
 
-    OPENVINO_THROW("[GPU] Unable to initialize the requested device ", this->get_info().dev_name, ". Please ensure the device is available");
+    OPENVINO_ASSERT(found, "[GPU] Unable to initialize the requested device ", this->get_info().dev_name, ". Please ensure the device is available");
 }
 
 }  // namespace ocl

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.cpp
@@ -424,7 +424,9 @@ bool ocl_device::is_same(const device::ptr other) {
     if (_platform == casted->_platform && _device.get() && casted->_device.get() && _device == casted->_device)
         return true;
 
-    // Check other device attributes
+    // Relying solely on the UUID is not reliable in all the cases (particularly on legacy platforms),
+    // where the UUID may be missing or incorrectly generated
+    // Therefore, we also validate other attributes
     if (_info.uuid.uuid != casted->_info.uuid.uuid)
         return false;
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
@@ -13,8 +13,35 @@ namespace ocl {
 struct ocl_device : public device {
 public:
     using ptr = std::shared_ptr<ocl_device>;
+
+    /**
+     * @brief Constructs an ocl_device from a given OpenCL device, context, and platform.
+     *
+     * @param dev OpenCL device handle.
+     * @param ctx OpenCL context associated with the device.
+     * @param platform OpenCL platform for the device.
+     * @param initialize If true, the device is initialized immediately.
+     *                   If false, initialization is deferred and must be performed explicitly
+     *                   before any use of the device.
+     *
+     * Initializes device info and memory capabilities.
+     * If @p initialize is true, performs full device initialization.
+     */
     ocl_device(const cl::Device dev, const cl::Context& ctx, const cl::Platform& platform, bool initialize = true);
-    ocl_device(const ocl_device::ptr other, bool initialize);
+
+    /**
+     * @brief Constructs an ocl_device by copying properties from another ocl_device instance.
+     *
+     * @param other Pointer to an existing ocl_device instance.
+     * @param initialize If true, performs full device initialization using the @p other ocl_device's
+     *                   device and context. The source device must be already initialized.
+     *                   If false, initialization is deferred and must be performed explicitly
+     *                   before any use of the device.
+     *
+     * Copies platform, device info, and memory capabilities.
+     * If @p initialize is true, initializes the new ocl_device instance accordingly.
+     */
+    ocl_device(const ocl_device::ptr other, bool initialize = true);
 
     const device_info& get_info() const override { return _info; }
     memory_capabilities get_mem_caps() const override { return _mem_caps; }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
@@ -12,7 +12,9 @@ namespace ocl {
 
 struct ocl_device : public device {
 public:
-    ocl_device(const cl::Device dev, const cl::Context& ctx, const cl::Platform& platform);
+    using ptr = std::shared_ptr<ocl_device>;
+    ocl_device(const cl::Device dev, const cl::Context& ctx, const cl::Platform& platform, bool initialize = true);
+    ocl_device(const ocl_device::ptr other, bool initialize);
 
     const device_info& get_info() const override { return _info; }
     memory_capabilities get_mem_caps() const override { return _mem_caps; }
@@ -25,11 +27,18 @@ public:
 
     bool is_same(const device::ptr other) override;
 
-    void set_mem_caps(memory_capabilities memory_capabilities) override;
+    void set_mem_caps(const memory_capabilities& memory_capabilities) override;
+
+    void initialize() override;
+    bool is_initialized() const override { return _is_initialized; };
 
     ~ocl_device() = default;
 
 private:
+    void initialize_device(const cl::Device dev, const cl::Context& ctx);
+
+    bool _is_initialized = false;
+
     cl::Context _context;
     cl::Device _device;
     cl::Platform _platform;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device.hpp
@@ -28,13 +28,14 @@ public:
     bool is_same(const device::ptr other) override;
 
     void set_mem_caps(const memory_capabilities& memory_capabilities) override;
+    void set_sub_device_idx(uint32_t idx);
 
     void initialize() override;
     bool is_initialized() const override { return _is_initialized; };
 
     ~ocl_device() = default;
 
-private:
+protected:
     void initialize_device(const cl::Device dev, const cl::Context& ctx);
 
     bool _is_initialized = false;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
@@ -158,7 +158,7 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
 
     devices_list = sort_devices(devices_list);
 
-    bool initialize_device = user_context != nullptr || user_device != nullptr || initialize_devices;
+    const bool initialize_device = user_context != nullptr || user_device != nullptr || initialize_devices;
     std::map<std::string, device::ptr> ret;
     uint32_t idx = 0;
     for (auto& dptr : devices_list) {
@@ -179,6 +179,7 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
                     continue;
                 }
                 auto sub_device_ptr = std::make_shared<ocl_device>(sub_device, cl::Context(sub_device), root_device->get_platform(), initialize_device);
+                sub_device_ptr->set_sub_device_idx(sub_idx);
                 ret[map_id + "." + std::to_string(sub_idx++)] = sub_device_ptr;
             }
         }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.cpp
@@ -145,7 +145,8 @@ std::vector<device::ptr> ocl_device_detector::sort_devices(const std::vector<dev
 std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(void* user_context,
                                                                               void* user_device,
                                                                               int ctx_device_id,
-                                                                              int target_tile_id) const {
+                                                                              int target_tile_id,
+                                                                              bool initialize_devices) const {
     std::vector<device::ptr> devices_list;
     if (user_context != nullptr) {
         devices_list = create_device_list_from_user_context(user_context, ctx_device_id);
@@ -157,14 +158,17 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
 
     devices_list = sort_devices(devices_list);
 
+    bool initialize_device = user_context != nullptr || user_device != nullptr || initialize_devices;
     std::map<std::string, device::ptr> ret;
     uint32_t idx = 0;
     for (auto& dptr : devices_list) {
-        auto map_id = std::to_string(idx++);
-        ret[map_id] = dptr;
-
         auto root_device = std::dynamic_pointer_cast<ocl_device>(dptr);
         OPENVINO_ASSERT(root_device != nullptr, "[GPU] Invalid device type created in ocl_device_detector");
+
+        auto map_id = std::to_string(idx++);
+        ret[map_id] = std::make_shared<ocl_device>(root_device, initialize_device);
+
+        OPENVINO_ASSERT(root_device->is_initialized(), "[GPU] Device is not initialized");
 
         auto sub_devices = getSubDevices(root_device->get_device());
         if (!sub_devices.empty()) {
@@ -174,7 +178,7 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
                     sub_idx++;
                     continue;
                 }
-                auto sub_device_ptr = std::make_shared<ocl_device>(sub_device, cl::Context(sub_device), root_device->get_platform());
+                auto sub_device_ptr = std::make_shared<ocl_device>(sub_device, cl::Context(sub_device), root_device->get_platform(), initialize_device);
                 ret[map_id + "." + std::to_string(sub_idx++)] = sub_device_ptr;
             }
         }
@@ -184,7 +188,7 @@ std::map<std::string, device::ptr> ocl_device_detector::get_available_devices(vo
 
 std::vector<device::ptr> ocl_device_detector::create_device_list() const {
     cl_uint num_platforms = 0;
-    // Get number of platforms availible
+    // Get number of platforms available
     cl_int error_code = clGetPlatformIDs(0, NULL, &num_platforms);
     if (num_platforms == 0 || error_code == CL_PLATFORM_NOT_FOUND_KHR) {
         return {};

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_device_detector.hpp
@@ -19,7 +19,11 @@ class ocl_device_detector {
 public:
     ocl_device_detector() = default;
 
-    std::map<std::string, device::ptr> get_available_devices(void *user_context, void *user_device, int ctx_device_id = 0, int target_tile_id = -1) const;
+    std::map<std::string, device::ptr> get_available_devices(void* user_context,
+                                                             void* user_device,
+                                                             int ctx_device_id = 0,
+                                                             int target_tile_id = -1,
+                                                             bool initialize_devices = false) const;
 
     static std::vector<device::ptr> sort_devices(const std::vector<device::ptr>& devices_list);
 

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -289,6 +289,18 @@ typedef struct _cl_device_pci_bus_info_khr {
 
 #endif // cl_khr_pci_bus_info
 
+// some versions of CL/opencl.hpp don't define C++ wrapper for CL_DEVICE_BUS_INFO_KHR
+// we are checking it in cmake and defined macro OV_GPU_OPENCL_HPP_HAS_BUS_INFO if it is defined
+#ifndef OV_GPU_OPENCL_HPP_HAS_BUS_INFO
+
+namespace cl {
+namespace detail {
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_PCI_BUS_INFO_KHR, cl_device_pci_bus_info_khr)
+}  // namespace detail
+}  // namespace cl
+
+#endif // OV_GPU_OPENCL_HPP_HAS_BUS_INFO
+
 #ifndef CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_
 #define CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(F) \
     F(cl_device_info, CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL, cl::vector<cl_queue_family_properties_intel>) \

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_ext.hpp
@@ -268,6 +268,27 @@ typedef cl_bitfield         cl_device_feature_capabilities_intel;
 
 #endif // cl_intel_device_attribute_query
 
+/***************************************************************
+* cl_khr_pci_bus_info
+***************************************************************/
+
+#if !defined(cl_khr_pci_bus_info)
+#define cl_khr_pci_bus_info 1
+
+#define CL_KHR_PCI_BUS_INFO_EXTENSION_VERSION CL_MAKE_VERSION(1, 0, 0)
+
+typedef struct _cl_device_pci_bus_info_khr {
+    cl_uint pci_domain;
+    cl_uint pci_bus;
+    cl_uint pci_device;
+    cl_uint pci_function;
+} cl_device_pci_bus_info_khr;
+
+/* cl_device_info */
+#define CL_DEVICE_PCI_BUS_INFO_KHR                          0x410F
+
+#endif // cl_khr_pci_bus_info
+
 #ifndef CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_
 #define CL_HPP_PARAM_NAME_CL_INTEL_COMMAND_QUEUE_FAMILIES_(F) \
     F(cl_device_info, CL_DEVICE_QUEUE_FAMILY_PROPERTIES_INTEL, cl::vector<cl_queue_family_properties_intel>) \

--- a/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
@@ -195,9 +195,10 @@ TEST(devices_test, on_demand_initialization) {
     // Check that devices are not initialized, but have their descriptions configured
     for (const auto& device : devices) {
         auto ocl_device = std::dynamic_pointer_cast<ocl::ocl_device>(device.second);
-        ASSERT_FALSE(ocl_device->is_initialized());
-        ASSERT_FALSE(ocl_device->get_device().get());
-        ASSERT_FALSE(ocl_device->get_context().get());
+        auto should_be_initialized = ocl_device->get_info().vendor_id == cldnn::INTEL_VENDOR_ID;
+        ASSERT_EQ(ocl_device->is_initialized(), should_be_initialized);
+        ASSERT_EQ(ocl_device->get_device().get() != nullptr, should_be_initialized);
+        ASSERT_EQ(ocl_device->get_context().get() != nullptr, should_be_initialized);
         ASSERT_FALSE(ocl_device->get_info().execution_units_count == 0);
         ASSERT_FALSE(ocl_device->get_info().vendor_id == 0);
         ASSERT_TRUE(ocl_device->get_info().sub_device_idx == std::numeric_limits<uint32_t>::max() /* root devices only */);

--- a/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
@@ -5,6 +5,8 @@
 #include "test_utils.h"
 #include "intel_gpu/runtime/device.hpp"
 #include "runtime/ocl/ocl_device_detector.hpp"
+#include "runtime/ocl/ocl_device.hpp"
+
 #include <memory>
 
 using namespace cldnn;
@@ -109,4 +111,129 @@ TEST(devices_test, sort_order_three_vendors) {
     });
 
     ASSERT_EQ(expected_devices_order, actual_devices_order);
+}
+
+namespace cldnn::ocl {
+struct ocl_device_extended : public ocl_device {
+public:
+    using ptr = std::shared_ptr<ocl_device_extended>;
+    ocl_device_extended(const ocl_device::ptr other) : ocl_device(other, false) {}
+
+    void set_device_info(const device_info& new_device_info) {
+        _info = new_device_info;
+    }
+};
+}  // namespace ocl
+
+TEST(devices_test, is_same_device) {
+    ocl::ocl_device_detector device_detector;
+
+    const bool initialize = false;
+    auto devices = device_detector.get_available_devices(nullptr, nullptr, 0, std::numeric_limits<int>::max() /* ignore sub-devices */, initialize);
+
+    for (const auto& device : devices) {
+        ASSERT_TRUE(device.second->is_same(device.second));
+    }
+
+    if (devices.size() > 1) {
+        auto first_device = devices.begin()->second;
+        auto second_device = devices.rbegin()->second;
+
+        ASSERT_FALSE(first_device->is_same(second_device));
+    }
+
+    if (devices.size() > 1) {
+        auto orig_device = std::dynamic_pointer_cast<ocl::ocl_device>(devices.begin()->second);
+        auto new_device = std::make_shared<ocl::ocl_device_extended>(orig_device);
+
+        ASSERT_TRUE(new_device->is_same(orig_device));
+
+        auto new_device_info = new_device->get_info();
+        auto orig_uuid = new_device_info.uuid.uuid;
+        new_device_info.uuid.uuid[0] += 1;
+        new_device->set_device_info(new_device_info);
+        ASSERT_FALSE(new_device->is_same(orig_device));
+        new_device_info.uuid.uuid = orig_uuid;
+
+        auto orig_pci_bus = new_device_info.pci_info.pci_bus;
+        new_device_info.pci_info.pci_bus += 1;
+        new_device->set_device_info(new_device_info);
+        ASSERT_FALSE(new_device->is_same(orig_device));
+        new_device_info.pci_info.pci_bus = orig_pci_bus;
+
+        auto orig_sub_device_idx = new_device_info.sub_device_idx;
+        new_device_info.sub_device_idx += 1;
+        new_device->set_device_info(new_device_info);
+        ASSERT_FALSE(new_device->is_same(orig_device));
+        new_device_info.sub_device_idx = orig_sub_device_idx;
+        new_device_info.pci_info.pci_bus = orig_pci_bus;
+
+        auto orig_vendor = new_device_info.vendor_id;
+        new_device_info.vendor_id += 1;
+        new_device->set_device_info(new_device_info);
+        ASSERT_FALSE(new_device->is_same(orig_device));
+        new_device_info.vendor_id = orig_vendor;
+
+        auto orig_eu_count = new_device_info.execution_units_count;
+        new_device_info.execution_units_count += 1;
+        new_device->set_device_info(new_device_info);
+        ASSERT_FALSE(new_device->is_same(orig_device));
+        new_device_info.execution_units_count = orig_eu_count;
+
+        new_device->set_device_info(new_device_info);
+        ASSERT_TRUE(new_device->is_same(orig_device));
+    }
+}
+
+TEST(devices_test, on_demand_initialization) {
+    ocl::ocl_device_detector device_detector;
+
+    const bool initialize = false;
+    auto devices = device_detector.get_available_devices(nullptr, nullptr, 0, std::numeric_limits<int>::max() /* ignore sub-devices */, initialize);
+
+    // Check that devices are not initialized, but have their descriptions configured
+    for (const auto& device : devices) {
+        auto ocl_device = std::dynamic_pointer_cast<ocl::ocl_device>(device.second);
+        ASSERT_FALSE(ocl_device->is_initialized());
+        ASSERT_FALSE(ocl_device->get_device().get());
+        ASSERT_FALSE(ocl_device->get_context().get());
+        ASSERT_FALSE(ocl_device->get_info().execution_units_count == 0);
+        ASSERT_FALSE(ocl_device->get_info().vendor_id == 0);
+        ASSERT_TRUE(ocl_device->get_info().sub_device_idx == std::numeric_limits<uint32_t>::max() /* root devices only */);
+    }
+
+    // Initialize all devices
+    for (const auto& device : devices) {
+        ASSERT_NO_THROW(device.second->initialize());
+    }
+
+    // Check that devices were initialized
+    for (const auto& device : devices) {
+        auto ocl_device = std::dynamic_pointer_cast<ocl::ocl_device>(device.second);
+        ASSERT_TRUE(ocl_device->is_initialized());
+        ASSERT_TRUE(ocl_device->get_device().get());
+        ASSERT_TRUE(ocl_device->get_context().get());
+    }
+}
+
+TEST(devices_test, user_context_initialization) {
+    ocl::ocl_device_detector device_detector;
+
+    const bool initialize = true;
+    auto devices = device_detector.get_available_devices(nullptr, nullptr, 0, -1, initialize);
+
+    if (!devices.empty()) {
+        auto initialized_device = std::dynamic_pointer_cast<ocl::ocl_device>(devices.begin()->second);
+        auto user_context = initialized_device->get_context();
+
+        auto shared_devices = device_detector.get_available_devices(user_context.get(), nullptr, 0, std::numeric_limits<int>::max() /* ignore sub-devices */);
+        ASSERT_EQ(shared_devices.size(), 1);
+
+        auto shared_ocl_device = std::dynamic_pointer_cast<ocl::ocl_device>(shared_devices.begin()->second);
+        ASSERT_TRUE(shared_ocl_device->is_initialized());
+
+        ASSERT_EQ(shared_ocl_device->get_device(), initialized_device->get_device());
+        ASSERT_EQ(shared_ocl_device->get_context(), initialized_device->get_context());
+        ASSERT_TRUE(initialized_device->is_same(shared_ocl_device));
+    }
 }

--- a/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
@@ -192,7 +192,7 @@ TEST(devices_test, on_demand_initialization) {
     const bool initialize = false;
     auto devices = device_detector.get_available_devices(nullptr, nullptr, 0, std::numeric_limits<int>::max() /* ignore sub-devices */, initialize);
 
-    // Check that devices are not initialized, but have their descriptions configured
+    // Check that devices have the expected initialization state and their descriptions are properly configured
     for (const auto& device : devices) {
         auto ocl_device = std::dynamic_pointer_cast<ocl::ocl_device>(device.second);
         auto should_be_initialized = ocl_device->get_info().vendor_id == cldnn::INTEL_VENDOR_ID;

--- a/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/device_test.cpp
@@ -27,7 +27,13 @@ public:
         return this == other.get();
     }
 
-    void set_mem_caps(memory_capabilities memory_capabilities) override {
+    void initialize() override {};
+
+    bool is_initialized() const override {
+        return true;
+    };
+
+    void set_mem_caps(const memory_capabilities& memory_capabilities) override {
         _mem_caps = memory_capabilities;
     }
     ~dummy_device() = default;

--- a/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/usm_memory_test.cpp
@@ -45,7 +45,7 @@ static void init_device_and_engine(std::shared_ptr<ocl::ocl_device>& device,
                                    std::shared_ptr<ocl::ocl_engine>& engine,
                                    bool& supports_usm) {
     // Find device, which supports USMs.
-    device_query query(engine_types::ocl, runtime_types::ocl);
+    device_query query(engine_types::ocl, runtime_types::ocl, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
     for (const auto& d : devices) {
         if (d.second->get_mem_caps().supports_usm()) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/cl_mem_input_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/cl_mem_input_test.cpp
@@ -15,7 +15,7 @@ using namespace cldnn;
 using namespace ::tests;
 
 TEST(cl_mem_check, check_write_access_type) {
-    device_query query(engine_types::ocl, runtime_types::ocl);
+    device_query query(engine_types::ocl, runtime_types::ocl, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
     ASSERT_TRUE(!devices.empty());
     cldnn::device::ptr device = devices.begin()->second;
@@ -50,7 +50,7 @@ TEST(cl_mem_check, check_write_access_type) {
 }
 
 TEST(cl_mem_check, check_read_access_type) {
-    device_query query(engine_types::ocl, runtime_types::ocl);
+    device_query query(engine_types::ocl, runtime_types::ocl, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
     ASSERT_TRUE(!devices.empty());
     cldnn::device::ptr device = devices.begin()->second;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convert_color_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convert_color_gpu_test.cpp
@@ -308,7 +308,7 @@ TEST(convert_color, nv12_to_rgb_two_planes_surface_u8) {
     int width = 224;
     int height = 448;
 
-    device_query query(engine_types::ocl, runtime_types::ocl);
+    device_query query(engine_types::ocl, runtime_types::ocl, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
     ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));
@@ -391,7 +391,7 @@ TEST(convert_color, nv12_to_rgb_single_plane_surface_u8) {
     int height = 448;
     int input_height = height + height / 2;
 
-    device_query query(engine_types::ocl, runtime_types::ocl);
+    device_query query(engine_types::ocl, runtime_types::ocl, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
     ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));
@@ -552,7 +552,7 @@ void test_convert_color_i420_to_rgb_three_planes_surface_u8(bool is_caching_test
     int width = 224;
     int height = 448;
 
-    device_query query(engine_types::ocl, runtime_types::ocl);
+    device_query query(engine_types::ocl, runtime_types::ocl, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
     ASSERT_TRUE(!devices.empty());
     auto iter = devices.find(std::to_string(device_query::device_id));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/variable.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/variable.cpp
@@ -42,6 +42,7 @@ struct variable_test : public ::testing::TestWithParam<VariableParams<T>> {
         cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+        context->initialize();
         auto variable = std::make_shared<VariableState>(VariableStateInfo{"v0", variable_layout}, context, network->get_shape_predictor());
         network->set_variable("v0", variable);
         network->set_input_data("input", input_data);
@@ -136,6 +137,7 @@ void test_exception_on_wrong_layout(bool is_caching_test) {
     cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+    context->initialize();
     auto variable = std::make_shared<VariableState>(VariableStateInfo{"v0", variable_layout}, context, network->get_shape_predictor());
     network->set_variable("v0", variable);
     network->set_input_data("input", input_data);
@@ -174,6 +176,7 @@ void test_different_output_data_type(bool is_caching_test) {
     config.set_property(ov::intel_gpu::optimize_data(true));
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
     auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+    context->initialize();
     auto variable = std::make_shared<VariableState>(VariableStateInfo{"v0", variable_layout}, context, network->get_shape_predictor());
     network->set_variable("v0", variable);
     network->set_input_data("input", input_data);
@@ -230,6 +233,7 @@ void test_variables_are_preserved_across_inferences(bool is_caching_test) {
     cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
+    context->initialize();
     auto variable1 = std::make_shared<VariableState>(VariableStateInfo{"v1", variable_layout}, context, network->get_shape_predictor());
     auto variable2 = std::make_shared<VariableState>(VariableStateInfo{"v2", variable_layout}, context, network->get_shape_predictor());
     auto variable3 = std::make_shared<VariableState>(VariableStateInfo{"v_result", variable_layout}, context, network->get_shape_predictor());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/variable.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/variable.cpp
@@ -42,7 +42,6 @@ struct variable_test : public ::testing::TestWithParam<VariableParams<T>> {
         cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
         auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
-        context->initialize();
         auto variable = std::make_shared<VariableState>(VariableStateInfo{"v0", variable_layout}, context, network->get_shape_predictor());
         network->set_variable("v0", variable);
         network->set_input_data("input", input_data);
@@ -137,7 +136,6 @@ void test_exception_on_wrong_layout(bool is_caching_test) {
     cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
-    context->initialize();
     auto variable = std::make_shared<VariableState>(VariableStateInfo{"v0", variable_layout}, context, network->get_shape_predictor());
     network->set_variable("v0", variable);
     network->set_input_data("input", input_data);
@@ -176,7 +174,6 @@ void test_different_output_data_type(bool is_caching_test) {
     config.set_property(ov::intel_gpu::optimize_data(true));
     cldnn::network::ptr network = get_network(engine, topology, config, get_test_stream_ptr(), is_caching_test);
     auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
-    context->initialize();
     auto variable = std::make_shared<VariableState>(VariableStateInfo{"v0", variable_layout}, context, network->get_shape_predictor());
     network->set_variable("v0", variable);
     network->set_input_data("input", input_data);
@@ -233,7 +230,6 @@ void test_variables_are_preserved_across_inferences(bool is_caching_test) {
     cldnn::network::ptr network = get_network(engine, topology, get_test_default_config(engine), get_test_stream_ptr(), is_caching_test);
 
     auto context = std::make_shared<RemoteContextImpl>("GPU", std::vector<cldnn::device::ptr>{engine.get_device()});
-    context->initialize();
     auto variable1 = std::make_shared<VariableState>(VariableStateInfo{"v1", variable_layout}, context, network->get_shape_predictor());
     auto variable2 = std::make_shared<VariableState>(VariableStateInfo{"v2", variable_layout}, context, network->get_shape_predictor());
     auto variable3 = std::make_shared<VariableState>(VariableStateInfo{"v_result", variable_layout}, context, network->get_shape_predictor());

--- a/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/test_utils.cpp
@@ -313,7 +313,7 @@ std::shared_ptr<cldnn::engine> create_test_engine() {
 std::shared_ptr<cldnn::engine> create_test_engine(cldnn::engine_types engine_type,
                                                   cldnn::runtime_types runtime_type,
                                                   bool allow_usm_mem) {
-    device_query query(engine_type, runtime_type);
+    device_query query(engine_type, runtime_type, nullptr, nullptr, 0, -1, true);
     auto devices = query.get_available_devices();
 
     OPENVINO_ASSERT(!devices.empty(), "[GPU] Can't create ", engine_type, " engine for ", runtime_type, " runtime as no suitable devices are found\n"

--- a/thirdparty/dependencies.cmake
+++ b/thirdparty/dependencies.cmake
@@ -119,6 +119,12 @@ if(ENABLE_INTEL_GPU)
                 list(APPEND opencl_interface_definitions OV_GPU_OPENCL_HPP_HAS_UUID)
             endif()
 
+            # check whether CL/opencl.hpp contains C++ wrapper for property CL_DEVICE_PCI_BUS_INFO_KHR
+            file(STRINGS "${OpenCL_HPP}" CL_DEVICE_PCI_BUS_INFO_KHR_CPP REGEX ".*CL_DEVICE_PCI_BUS_INFO_KHR.*")
+            if(CL_DEVICE_PCI_BUS_INFO_KHR_CPP)
+                list(APPEND opencl_interface_definitions OV_GPU_OPENCL_HPP_HAS_BUS_INFO)
+            endif()
+
             set_target_properties(OpenCL::OpenCL PROPERTIES
                 INTERFACE_COMPILE_DEFINITIONS "${opencl_interface_definitions}")
         endif()

--- a/thirdparty/ocl/CMakeLists.txt
+++ b/thirdparty/ocl/CMakeLists.txt
@@ -51,7 +51,8 @@ add_subdirectory(icd_loader EXCLUDE_FROM_ALL)
 
 # use CL/opencl.hpp
 target_compile_definitions(OpenCL INTERFACE OV_GPU_USE_OPENCL_HPP
-                                            OV_GPU_OPENCL_HPP_HAS_UUID)
+                                            OV_GPU_OPENCL_HPP_HAS_UUID
+                                            OV_GPU_OPENCL_HPP_HAS_BUS_INFO)
 target_include_directories(OpenCL INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/cl_headers>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/clhpp_headers/include>)


### PR DESCRIPTION
### Details:
 - Implement on-demand device initialization to prevent unused devices from being active
 - These changes adjust the logic to obtain device information once during plugin initialization step, then remove cl::Device and cl::Context handles to avoid keeping devices in active mode. cl::Device and cl::Context will be initialized only when the device is used for inference by matching the device UUID with all available devices (and will remain active afterward in current implementation)
 
### Tickets:
 - [CVS-166110](https://jira.devtools.intel.com/browse/CVS-166110)
