### PR TITLE
fix get_input_node_shared_ptr() to input_value()

### DIFF
--- a/src/common/low_precision_transformations/include/low_precision/network_helper.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/network_helper.hpp
@@ -326,8 +326,8 @@ template <typename T, typename... Args>
 std::shared_ptr<Node> fold_reshape(Args&&... args) {
     std::shared_ptr<Node> node = std::make_shared<T>(args...);
     if (node->get_output_size() == 1) {
-        const auto data_const = ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(0));
-        const auto target_shape = ov::as_type_ptr<ov::opset1::Constant>(node->get_input_node_shared_ptr(1));
+        const auto data_const = ov::as_type_ptr<ov::opset1::Constant>(node->input_value(0).get_node_shared_ptr());
+        const auto target_shape = ov::as_type_ptr<ov::opset1::Constant>(node->input_value(1).get_node_shared_ptr());
         if (data_const && target_shape) {
             return std::make_shared<ov::opset1::Constant>(node->get_input_element_type(0),
                                                       node->get_output_shape(0),

--- a/src/common/low_precision_transformations/include/low_precision/propagate_shared_value.hpp
+++ b/src/common/low_precision_transformations/include/low_precision/propagate_shared_value.hpp
@@ -117,7 +117,7 @@ private:
             if (!dequantization.empty() &&
                 (ov::is_type<opset1::Convert>(dequantization.data.get_node())) &&
                  ov::is_type<opset1::FakeQuantize>(dequantization.data.get_node()->get_input_node_ptr(0))) {
-                inputNode = dequantization.data.get_node()->get_input_node_shared_ptr(0);
+                inputNode = dequantization.data.get_node()->input_value(0).get_node_shared_ptr();
             }
 
             if (NetworkHelper::isPrecisionPreserved(inputNode)) {

--- a/src/common/low_precision_transformations/src/assign_and_read_value.cpp
+++ b/src/common/low_precision_transformations/src/assign_and_read_value.cpp
@@ -57,7 +57,7 @@ bool AssignAndReadValueTransformation::transform(ov::pass::pattern::Matcher& m) 
     // set new precision for oldVar to update precision in newReadValue
     oldVar->update({variableInfo.data_shape, dequantization.data.get_element_type(), variableInfo.variable_id});
     // transform ReadValue part
-    const auto newConstant = foldConvert(readValue->get_input_node_shared_ptr(0), dequantization.data.get_element_type());
+    const auto newConstant = foldConvert(readValue->input_value(0).get_node_shared_ptr(), dequantization.data.get_element_type());
     const auto newReadValue = readValue->copy_with_new_inputs({newConstant});
     const auto newDequantization = dequantization.copyWithNewInput(newReadValue);
     replace_node(readValue, newDequantization);
@@ -107,7 +107,7 @@ bool AssignAndReadValueTransformation::canBeTransformed(const std::shared_ptr<No
     }
 
     // TODO: remove this limitation and change the transformation when this constant will be accepted to be non-zero
-    if (!NetworkHelper::isZeroConst(readValue->get_input_node_shared_ptr(0))) {
+    if (!NetworkHelper::isZeroConst(readValue->input_value(0).get_node_shared_ptr())) {
         return false;
     }
 

--- a/src/common/low_precision_transformations/src/broadcast.cpp
+++ b/src/common/low_precision_transformations/src/broadcast.cpp
@@ -61,13 +61,13 @@ bool BroadcastTransformation::canBeTransformed(const std::shared_ptr<ov::Node>& 
         return false;
     }
 
-    const auto targetShapeConstant = ov::as_type_ptr<ov::opset1::Constant>(layer->get_input_node_shared_ptr(1));
+    const auto targetShapeConstant = ov::as_type_ptr<ov::opset1::Constant>(layer->input_value(1).get_node_shared_ptr());
     const auto& targetShape = targetShapeConstant->cast_vector<int64_t>();
     if (targetShape[dequantization.channelDimIndex] != inputShape[dequantization.channelDimIndex].get_length()) {
         return false;
     }
 
-    const auto axesMappingConstant = ov::as_type_ptr<ov::opset1::Constant>(layer->get_input_node_shared_ptr(2));
+    const auto axesMappingConstant = ov::as_type_ptr<ov::opset1::Constant>(layer->input_value(2).get_node_shared_ptr());
     const auto& axesMapping = axesMappingConstant->cast_vector<int64_t>();
     if (static_cast<size_t>(axesMapping[dequantization.channelDimIndex]) != dequantization.channelDimIndex) {
         return false;

--- a/src/common/low_precision_transformations/src/convolution.cpp
+++ b/src/common/low_precision_transformations/src/convolution.cpp
@@ -239,7 +239,8 @@ bool ConvolutionTransformation::transform(ov::pass::pattern::Matcher &m) {
             reshapeFromWeights == nullptr ?
             convolution->input_value(1).get_node_shared_ptr() :
             convolution->get_input_node_ptr(1)->input_value(0).get_node_shared_ptr());
-        std::shared_ptr<ov::opset1::Subtract> subtractFromWeights = ov::as_type_ptr<ov::opset1::Subtract>(multiplyFromWeights->input_value(0).get_node_shared_ptr());
+        std::shared_ptr<ov::opset1::Subtract> subtractFromWeights =
+            ov::as_type_ptr<ov::opset1::Subtract>(multiplyFromWeights->input_value(0).get_node_shared_ptr());
 
         {
             if (reshapeFromWeights != nullptr) {

--- a/src/common/low_precision_transformations/src/eliminate_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/eliminate_fake_quantize.cpp
@@ -70,10 +70,10 @@ bool check_interval(const std::shared_ptr<ov::opset1::FakeQuantize>& fq,
     if (need_to_check_intervals) {
         auto tmp_fq = as_type_ptr<ov::opset1::FakeQuantize>(fq->clone_with_new_inputs({
             constant,
-            fq->get_input_node_shared_ptr(1),
-            fq->get_input_node_shared_ptr(2),
-            fq->get_input_node_shared_ptr(3),
-            fq->get_input_node_shared_ptr(4)}));
+            fq->input_value(1),
+            fq->input_value(2),
+            fq->input_value(3),
+            fq->input_value(4)}));
         auto result = NetworkHelper::fold_fake_quantize(tmp_fq, false);
         const auto result_constant = as_type_ptr<ov::opset1::Constant>(result);
         if (result_constant == nullptr) {

--- a/src/common/low_precision_transformations/src/eliminate_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/eliminate_fake_quantize.cpp
@@ -105,13 +105,13 @@ bool check_intervals(const std::shared_ptr<ov::opset1::FakeQuantize>& fakeQuanti
     const auto exact_comparison = !element_type.is_integral();
 
     return
-        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(1)),
+        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->input_value(1).get_node_shared_ptr()),
                        min_value, max_diff, exact_comparison) &&
-        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(2)),
+        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->input_value(2).get_node_shared_ptr()),
                        max_value, max_diff, exact_comparison) &&
-        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(3)),
+        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->input_value(3).get_node_shared_ptr()),
                        min_value, max_diff, true) &&
-        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(4)),
+        check_interval(fakeQuantize, ov::as_type_ptr<ov::opset1::Constant>(fakeQuantize->input_value(4).get_node_shared_ptr()),
                        max_value, max_diff, true);
 }
 } // namespace

--- a/src/common/low_precision_transformations/src/fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize.cpp
@@ -70,12 +70,12 @@ std::shared_ptr<Node> updateShape(std::shared_ptr<Node> constantOp, const Partia
 }
 
 std::shared_ptr<Node> getDataNode(const std::shared_ptr<Node>& eltwise) {
-    if (!ov::is_type<opset1::Constant>(eltwise->get_input_node_shared_ptr(0))) {
-        return eltwise->get_input_node_shared_ptr(0);
+    if (!ov::is_type<opset1::Constant>(eltwise->input_value(0).get_node_shared_ptr())) {
+        return eltwise->input_value(0).get_node_shared_ptr();
     }
 
-    if (!ov::is_type<opset1::Constant>(eltwise->get_input_node_shared_ptr(1))) {
-        return eltwise->get_input_node_shared_ptr(1);
+    if (!ov::is_type<opset1::Constant>(eltwise->input_value(1).get_node_shared_ptr())) {
+        return eltwise->input_value(1).get_node_shared_ptr();
     }
 
     return nullptr;
@@ -86,12 +86,12 @@ std::shared_ptr<opset1::Constant> getConstant(const std::shared_ptr<Node>& eltwi
         return nullptr;
     }
 
-    std::shared_ptr<opset1::Constant> constant = ov::as_type_ptr<opset1::Constant>(eltwise->get_input_node_shared_ptr(1));
+    std::shared_ptr<opset1::Constant> constant = ov::as_type_ptr<opset1::Constant>(eltwise->input_value(1).get_node_shared_ptr());
     if (constant != nullptr) {
         return constant;
     }
 
-    return ov::as_type_ptr<opset1::Constant>(eltwise->get_input_node_shared_ptr(0));
+    return ov::as_type_ptr<opset1::Constant>(eltwise->input_value(0).get_node_shared_ptr());
 }
 
 bool all_precisions_equal(const std::shared_ptr<Node>& node) {
@@ -164,7 +164,7 @@ std::shared_ptr<opset1::FakeQuantize> FakeQuantizeTransformation::fuseElementwis
     MatcherPass* matcherPass,
     const std::shared_ptr<opset1::FakeQuantize>& fakeQuantize,
     const bool updatePrecisions) {
-    const std::shared_ptr<Node> eltwise = fakeQuantize->get_input_node_shared_ptr(0);
+    const std::shared_ptr<Node> eltwise = fakeQuantize->input_value(0).get_node_shared_ptr();
 
     if (!updatePrecisions && !fq::all_precisions_equal(eltwise)) {
         return nullptr;
@@ -216,7 +216,7 @@ std::shared_ptr<opset1::FakeQuantize> FakeQuantizeTransformation::fuseElementwis
     }
 
     // issue #79980
-    const auto data = eltwise->get_input_size() == 1ul ? eltwise->get_input_node_shared_ptr(0) : fq::getDataNode(eltwise);
+    const auto data = eltwise->get_input_size() == 1ul ? eltwise->input_value(0).get_node_shared_ptr() : fq::getDataNode(eltwise);
     const size_t outputIdx = NetworkHelper::getParentOutputIndex(data, eltwise);
 
     const auto newFakeQuantize = ov::as_type_ptr<opset1::FakeQuantize>(fakeQuantize->clone_with_new_inputs({

--- a/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize_decomposition.cpp
@@ -99,8 +99,8 @@ DataPrecision getDataPrecisionByOutputPortAndFakeQuantize(std::shared_ptr<opset1
 // 2. Precisions on port
 DataPrecision getDataPrecisionByOutputPort(std::shared_ptr<opset1::FakeQuantize> layer) {
     const size_t levels = layer->get_levels();
-    const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(layer->get_input_node_shared_ptr(3))->cast_vector<float>();
-    const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(layer->get_input_node_shared_ptr(4))->cast_vector<float>();
+    const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(layer->input_value(3).get_node_shared_ptr())->cast_vector<float>();
+    const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(layer->input_value(4).get_node_shared_ptr())->cast_vector<float>();
 
     auto precisionsAttribute = getAttributeFromOutput<PrecisionsAttribute>(layer->output(0));
     if (precisionsAttribute.empty()) {
@@ -189,8 +189,8 @@ std::tuple<std::shared_ptr<Node>, std::shared_ptr<Node>> decomposeFakeQuantize(
 
     if (!intervalsAlignment.empty()) {
         OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::LPT_LT, "decomposeFakeQuantize1");
-        const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(layer->get_input_node_shared_ptr(3))->cast_vector<float>();
-        const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(layer->get_input_node_shared_ptr(4))->cast_vector<float>();
+        const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(layer->input_value(3).get_node_shared_ptr())->cast_vector<float>();
+        const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(layer->input_value(4).get_node_shared_ptr())->cast_vector<float>();
 
         float dequantizationMul;
         float dequantizationSub;
@@ -367,8 +367,8 @@ bool FakeQuantizeDecompositionTransformation::transform(ov::pass::pattern::Match
     if (dataPrecision.precision == element::dynamic) {
         element::Type precision;
         const auto levels = layer->get_levels();
-        const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(layer->get_input_node_shared_ptr(3))->cast_vector<float>();
-        const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(layer->get_input_node_shared_ptr(4))->cast_vector<float>();
+        const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(layer->input_value(3).get_node_shared_ptr())->cast_vector<float>();
+        const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(layer->input_value(4).get_node_shared_ptr())->cast_vector<float>();
         if (intervalsAlignment.empty()) {
             // define precision by FakeQuantize intervals
             LayerTransformation::PrecisionDetails precisionDetailsAtOutputIntervals = LayerTransformation::getPrecisionDetails(

--- a/src/common/low_precision_transformations/src/fake_quantize_dequantization.cpp
+++ b/src/common/low_precision_transformations/src/fake_quantize_dequantization.cpp
@@ -53,9 +53,9 @@ bool FakeQuantizeDequantization::multiplyHasZeroOrDenormal() const {
         return false;
     }
 
-    std::shared_ptr<opset1::Constant> multiplyConstant = ov::as_type_ptr<opset1::Constant>(multiply->get_input_node_shared_ptr(1));
+    std::shared_ptr<opset1::Constant> multiplyConstant = ov::as_type_ptr<opset1::Constant>(multiply->input_value(1).get_node_shared_ptr());
     if (multiplyConstant == nullptr) {
-        multiplyConstant = ov::as_type_ptr<opset1::Constant>(multiply->get_input_node_shared_ptr(0));
+        multiplyConstant = ov::as_type_ptr<opset1::Constant>(multiply->input_value(0).get_node_shared_ptr());
     }
     if (multiplyConstant == nullptr) {
         return false;
@@ -247,14 +247,14 @@ int FakeQuantizeDequantization::fillDequantizationParams(
         const size_t branchIndex,
         std::shared_ptr<ov::opset1::Convert>& convert,
         std::shared_ptr<ov::opset1::Constant>& constant) {
-        convert = ov::as_type_ptr<opset1::Convert>(elementwise->get_input_node_shared_ptr(branchIndex));
+        convert = ov::as_type_ptr<opset1::Convert>(elementwise->input_value(branchIndex).get_node_shared_ptr());
         if (convert != nullptr) {
             constant = convert->get_destination_type().is_real() ?
-                ov::as_type_ptr<opset1::Constant>(convert->get_input_node_shared_ptr(0)) :
+                ov::as_type_ptr<opset1::Constant>(convert->input_value(0).get_node_shared_ptr()) :
                 nullptr;
         } else {
             constant = elementwise->get_input_element_type(branchIndex).is_real() ?
-                ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(branchIndex)) :
+                ov::as_type_ptr<opset1::Constant>(elementwise->input_value(branchIndex).get_node_shared_ptr()) :
                 nullptr;
         }
     };
@@ -276,7 +276,7 @@ int FakeQuantizeDequantization::fillDequantizationParams(
     const std::shared_ptr<ov::Node>& elementwise,
     std::shared_ptr<ov::opset1::Constant>& constant) {
     constant = elementwise->get_input_element_type(1ul).is_real() ?
-        ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(1ul)) :
+        ov::as_type_ptr<opset1::Constant>(elementwise->input_value(1ul).get_node_shared_ptr()) :
         nullptr;
 
     if (constant != nullptr) {
@@ -284,7 +284,7 @@ int FakeQuantizeDequantization::fillDequantizationParams(
     }
 
     constant = elementwise->get_input_element_type(0ul).is_real() ?
-        ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(0ul)) :
+        ov::as_type_ptr<opset1::Constant>(elementwise->input_value(0ul).get_node_shared_ptr()) :
         nullptr;
 
     if (constant != nullptr) {

--- a/src/common/low_precision_transformations/src/fold_convert.cpp
+++ b/src/common/low_precision_transformations/src/fold_convert.cpp
@@ -38,8 +38,8 @@ bool FoldConvertTransformation::transform(ov::pass::pattern::Matcher &m) {
     }
 
     auto foldConvert = [&](const size_t branch) {
-        const auto convert = subtract->get_input_node_shared_ptr(branch);
-        if (!ov::is_type<ov::opset1::Convert>(convert) || !ov::is_type<ov::opset1::Constant>(convert->get_input_node_shared_ptr(0))) {
+        const auto convert = subtract->input_value(branch).get_node_shared_ptr();
+        if (!ov::is_type<ov::opset1::Convert>(convert) || !ov::is_type<ov::opset1::Constant>(convert->input_value(0).get_node_shared_ptr())) {
             return;
         }
 

--- a/src/common/low_precision_transformations/src/fold_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fold_fake_quantize.cpp
@@ -64,8 +64,8 @@ bool FoldFakeQuantizeTransformation::isConstantOutput(std::shared_ptr<ov::Node> 
         return false;
     }
 
-    const auto outputLow = as_type_ptr<ov::opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(3));
-    const auto outputHigh = as_type_ptr<ov::opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(4));
+    const auto outputLow = as_type_ptr<ov::opset1::Constant>(fakeQuantize->input_value(3).get_node_shared_ptr());
+    const auto outputHigh = as_type_ptr<ov::opset1::Constant>(fakeQuantize->input_value(4).get_node_shared_ptr());
 
     if (outputLow == nullptr || outputHigh == nullptr) {
         return false;

--- a/src/common/low_precision_transformations/src/fuse_convert.cpp
+++ b/src/common/low_precision_transformations/src/fuse_convert.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Node> removeConvertIfPossibleForSubtract(
     std::shared_ptr<Node> newSubtract;
 
     const element::Type precisionBeforeConvert = convert->input(0).get_element_type();
-    if (NetworkHelper::checkConstantValuePrecision(precisionBeforeConvert, subtract->get_input_node_shared_ptr(1))) {
+    if (NetworkHelper::checkConstantValuePrecision(precisionBeforeConvert, subtract->input_value(1).get_node_shared_ptr())) {
         newSubtract = std::make_shared<ov::op::TypeRelaxed<ov::opset1::Subtract>>(
             std::vector<ov::element::Type>{ element::f32, element::f32 }, std::vector<ov::element::Type>{},
             ov::op::TemporaryReplaceOutputType(convert->input_value(0), element::f32).get(),
@@ -75,7 +75,7 @@ bool FuseConvertTransformation::transform(ov::pass::pattern::Matcher &m) {
         return false;
     }
 
-    const auto convert = ov::as_type_ptr<ov::opset1::Convert>(op->get_input_node_shared_ptr(0));
+    const auto convert = ov::as_type_ptr<ov::opset1::Convert>(op->input_value(0).get_node_shared_ptr());
     auto parent = convert->input_value(0);
 
     if (ov::is_type<ov::opset1::Constant>(parent.get_node_shared_ptr())) {
@@ -120,7 +120,7 @@ bool FuseConvertTransformation::canBeTransformed(const std::shared_ptr<Node>& op
         return false;
     }
 
-    const auto convert = ov::as_type_ptr<ov::opset1::Convert>(op->get_input_node_shared_ptr(0));
+    const auto convert = ov::as_type_ptr<ov::opset1::Convert>(op->input_value(0).get_node_shared_ptr());
     // issue #40395
     if (convert == nullptr) {
         return false;

--- a/src/common/low_precision_transformations/src/fuse_elementwise_to_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fuse_elementwise_to_fake_quantize.cpp
@@ -20,7 +20,7 @@ bool FuseElementwiseToFakeQuantizeTransformation::canBeTransformed(const std::sh
         return false;
     }
 
-    if (!ov::is_type<ov::opset1::Constant>(operation->get_input_node_shared_ptr(1))) {
+    if (!ov::is_type<ov::opset1::Constant>(operation->input_value(1).get_node_shared_ptr())) {
         return false;
     }
 
@@ -28,12 +28,12 @@ bool FuseElementwiseToFakeQuantizeTransformation::canBeTransformed(const std::sh
         return false;
     }
 
-    const auto parent = operation->get_input_node_shared_ptr(0);
+    const auto parent = operation->input_value(0).get_node_shared_ptr();
     auto fq = ov::as_type_ptr<ov::opset1::FakeQuantize>(parent);
     const auto convert = ov::as_type_ptr<ov::opset1::Convert>(parent);
 
     if (convert) {
-        fq = ov::as_type_ptr<ov::opset1::FakeQuantize>(convert->get_input_node_shared_ptr(0));
+        fq = ov::as_type_ptr<ov::opset1::FakeQuantize>(convert->input_value(0).get_node_shared_ptr());
     }
 
     if (!fq) {

--- a/src/common/low_precision_transformations/src/fuse_multiply_to_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fuse_multiply_to_fake_quantize.cpp
@@ -39,15 +39,15 @@ bool FuseMultiplyToFakeQuantizeTransformation::transform(ov::pass::pattern::Matc
         return false;
     }
 
-    const auto parent = multiply->get_input_node_shared_ptr(0);
+    const auto parent = multiply->input_value(0).get_node_shared_ptr();
     auto fakeQuantize = ov::as_type_ptr<ov::opset1::FakeQuantize>(parent);
     const auto convert = ov::as_type_ptr<ov::opset1::Convert>(parent);
 
     if (convert) {
-        fakeQuantize = ov::as_type_ptr<ov::opset1::FakeQuantize>(convert->get_input_node_shared_ptr(0));
+        fakeQuantize = ov::as_type_ptr<ov::opset1::FakeQuantize>(convert->input_value(0).get_node_shared_ptr());
     }
 
-    const auto multiplyConstant = multiply->get_input_node_shared_ptr(1);
+    const auto multiplyConstant = multiply->input_value(1).get_node_shared_ptr();
     if (!ov::is_type<ov::opset1::Constant>(multiplyConstant)) {
         return false;
     }
@@ -61,10 +61,10 @@ bool FuseMultiplyToFakeQuantizeTransformation::transform(ov::pass::pattern::Matc
 
     const auto inputLow = foldConvert(fakeQuantize->input_value(1), deqPrecision);
     const auto inputHigh = foldConvert(fakeQuantize->input_value(2), deqPrecision);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(1), inputLow);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(2), inputHigh);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(3), outputLow);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(4), outputHigh);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(1).get_node_shared_ptr(), inputLow);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(2).get_node_shared_ptr(), inputHigh);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(3).get_node_shared_ptr(), outputLow);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(4).get_node_shared_ptr(), outputHigh);
 
     auto newFakeQuantize = std::make_shared<ov::op::TypeRelaxed<ov::opset1::FakeQuantize>>(
         ov::opset1::FakeQuantize(

--- a/src/common/low_precision_transformations/src/fuse_subtract_to_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/fuse_subtract_to_fake_quantize.cpp
@@ -39,15 +39,15 @@ bool FuseSubtractToFakeQuantizeTransformation::transform(ov::pass::pattern::Matc
         return false;
     }
 
-    const auto parent = subtract->get_input_node_shared_ptr(0);
+    const auto parent = subtract->input_value(0).get_node_shared_ptr();
     auto fakeQuantize = ov::as_type_ptr<ov::opset1::FakeQuantize>(parent);
     const auto convert = ov::as_type_ptr<ov::opset1::Convert>(parent);
 
     if (convert) {
-        fakeQuantize = ov::as_type_ptr<ov::opset1::FakeQuantize>(convert->get_input_node_shared_ptr(0));
+        fakeQuantize = ov::as_type_ptr<ov::opset1::FakeQuantize>(convert->input_value(0).get_node_shared_ptr());
     }
 
-    const auto subtractConstant = subtract->get_input_node_shared_ptr(1);
+    const auto subtractConstant = subtract->input_value(1).get_node_shared_ptr();
     if (!ov::is_type<ov::opset1::Constant>(subtractConstant)) {
         return false;
     }
@@ -61,10 +61,10 @@ bool FuseSubtractToFakeQuantizeTransformation::transform(ov::pass::pattern::Matc
 
     const auto inputLow = foldConvert(fakeQuantize->input_value(1), deqPrecision);
     const auto inputHigh = foldConvert(fakeQuantize->input_value(2), deqPrecision);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(1), inputLow);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(2), inputHigh);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(3), outputLow);
-    NetworkHelper::copyInfo(fakeQuantize->get_input_node_shared_ptr(4), outputHigh);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(1).get_node_shared_ptr(), inputLow);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(2).get_node_shared_ptr(), inputHigh);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(3).get_node_shared_ptr(), outputLow);
+    NetworkHelper::copyInfo(fakeQuantize->input_value(4).get_node_shared_ptr(), outputHigh);
 
     auto newFakeQuantize = std::make_shared<ov::op::TypeRelaxed<ov::opset1::FakeQuantize>>(
         ov::opset1::FakeQuantize(

--- a/src/common/low_precision_transformations/src/gather.cpp
+++ b/src/common/low_precision_transformations/src/gather.cpp
@@ -47,7 +47,7 @@ std::shared_ptr<opset1::Constant> gatherDeqConstant(
         constant = ov::as_type_ptr<ov::opset1::Constant>(newConstant);
     }
 
-    const int64_t axis = ov::as_type_ptr<opset1::Constant>(gather->get_input_node_shared_ptr(2))->cast_vector<int64_t>()[0];
+    const int64_t axis = ov::as_type_ptr<opset1::Constant>(gather->input_value(2).get_node_shared_ptr())->cast_vector<int64_t>()[0];
     const size_t normalizedAxis =
         ov::util::try_normalize_axis(axis, gather->get_input_partial_shape(0).rank(), *gather);
 
@@ -159,7 +159,7 @@ bool GatherTransformation::canBeTransformed(const std::shared_ptr<Node>& operati
     // If dequantization constant is not scalar, Gather axis must be constant.
     // If the Gather axis matches with dequantization channel, the Gather indices
     // must be constant and have 0D or 1D shape so we can do folding.
-    const auto axisConstant = ov::as_type_ptr<opset1::Constant>(operation->get_input_node_shared_ptr(2));
+    const auto axisConstant = ov::as_type_ptr<opset1::Constant>(operation->input_value(2).get_node_shared_ptr());
     if (axisConstant == nullptr) {
         return false;
     }
@@ -180,7 +180,7 @@ bool GatherTransformation::canBeTransformed(const std::shared_ptr<Node>& operati
             ov::util::try_normalize_axis(axis, operation->get_input_partial_shape(0).rank(), *operation);
 
         if (constantShape[normalizedAxis] != 1ul) {
-            const auto indicesConstant = ov::as_type_ptr<opset1::Constant>(operation->get_input_node_shared_ptr(1));
+            const auto indicesConstant = ov::as_type_ptr<opset1::Constant>(operation->input_value(1).get_node_shared_ptr());
             if (indicesConstant == nullptr)
                 return false;
             const auto indicesShape = indicesConstant->get_shape();

--- a/src/common/low_precision_transformations/src/layer_transformation.cpp
+++ b/src/common/low_precision_transformations/src/layer_transformation.cpp
@@ -148,8 +148,8 @@ bool LayerTransformation::canSubtractBeHandled(const std::shared_ptr<Node>& op, 
 
     if (ov::is_type<ov::opset1::Constant>(parent)) {
         return true;
-    } else if (ov::is_type<ov::opset1::Convert>(parent) && ov::is_type<ov::opset1::Constant>(parent->get_input_node_shared_ptr(0))) {
-        const auto constant = parent->get_input_node_shared_ptr(0);
+    } else if (ov::is_type<ov::opset1::Convert>(parent) && ov::is_type<ov::opset1::Constant>(parent->input_value(0).get_node_shared_ptr())) {
+        const auto constant = parent->input_value(0).get_node_shared_ptr();
         const auto constantType = constant->output(0).get_element_type();
         return operationType == constantType;
     } else {

--- a/src/common/low_precision_transformations/src/low_precision.cpp
+++ b/src/common/low_precision_transformations/src/low_precision.cpp
@@ -329,7 +329,7 @@ bool ov::pass::low_precision::LowPrecision::isFunctionQuantized(
         nodes.pop_front();
 
         for (size_t i = 0; i < node->inputs().size(); ++i) {
-            const auto parent = node->get_input_node_shared_ptr(i);
+            const auto parent = node->input_value(i).get_node_shared_ptr();
             if (handledNodes.find(parent) != handledNodes.end()) {
                 continue;
             }

--- a/src/common/low_precision_transformations/src/move_fake_quantize.cpp
+++ b/src/common/low_precision_transformations/src/move_fake_quantize.cpp
@@ -65,7 +65,7 @@ bool MoveFakeQuantize::transform(ov::pass::pattern::Matcher& m) {
         return false;
     }
 
-    const auto operation = fq->get_input_node_shared_ptr(0);
+    const auto operation = fq->input_value(0).get_node_shared_ptr();
     std::shared_ptr<ov::Node> concat;
     bool without_operation = true;
     const std::string fq_original_name = fq->get_friendly_name();
@@ -74,7 +74,7 @@ bool MoveFakeQuantize::transform(ov::pass::pattern::Matcher& m) {
         concat = operation;
     } else {
         operation_original_name = operation->get_friendly_name();
-        concat = operation->get_input_node_shared_ptr(0);
+        concat = operation->input_value(0).get_node_shared_ptr();
         without_operation = false;
     }
 
@@ -97,7 +97,7 @@ bool MoveFakeQuantize::transform(ov::pass::pattern::Matcher& m) {
     const auto concat_axis = ov::util::normalize(concat_node->get_axis(), rank.get_length());
 
     for (size_t i = 0; i < 4; i++) {
-        curr_constants[i] = as_type_ptr<opset1::Constant>(fq->get_input_node_shared_ptr(i + 1));
+        curr_constants[i] = as_type_ptr<opset1::Constant>(fq->input_value(i + 1).get_node_shared_ptr());
         if (!multi_chanels && curr_constants[i]->get_shape().size() > static_cast<size_t>(concat_axis)
             && curr_constants[i]->get_shape()[concat_axis] != 1) {
             multi_chanels = true;
@@ -170,12 +170,12 @@ bool MoveFakeQuantize::transform(ov::pass::pattern::Matcher& m) {
 }
 
 bool MoveFakeQuantize::canBeTransformed(const std::shared_ptr<Node>& layer) const {
-    auto operation = layer->get_input_node_shared_ptr(0);
+    auto operation = layer->input_value(0).get_node_shared_ptr();
     std::shared_ptr<ov::Node> concat;
     if (is_type<opset1::Concat>(operation)) {
         concat = operation;
     } else {
-        concat = operation->get_input_node_shared_ptr(0);
+        concat = operation->input_value(0).get_node_shared_ptr();
     }
     if (!ConcatTransformation::isQuantizedStatic(concat)) {
         return false;

--- a/src/common/low_precision_transformations/src/multiply_partial.cpp
+++ b/src/common/low_precision_transformations/src/multiply_partial.cpp
@@ -50,7 +50,7 @@ bool MultiplyPartialTransformation::transform(ov::pass::pattern::Matcher& m) {
     auto newMultiply = multiply;
 
     auto fold_fake_quantizes = [](std::shared_ptr<Node>& multiply, const size_t index) {
-        auto fakeQuantizeOnWeights = ov::as_type_ptr<ov::opset1::FakeQuantize>(multiply->get_input_node_shared_ptr(index));
+        auto fakeQuantizeOnWeights = ov::as_type_ptr<ov::opset1::FakeQuantize>(multiply->input_value(index).get_node_shared_ptr());
         if (fakeQuantizeOnWeights != nullptr) {
             auto result = NetworkHelper::fold_fake_quantize(fakeQuantizeOnWeights);
             if (ov::is_type<ov::opset1::Constant>(result)) {

--- a/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
+++ b/src/common/low_precision_transformations/src/multiply_to_group_convolution.cpp
@@ -40,12 +40,12 @@ bool MultiplyToGroupConvolutionTransformation::transform(ov::pass::pattern::Matc
         return false;
     }
 
-    auto input = multiply->get_input_node_shared_ptr(0);
-    auto constant = multiply->get_input_node_shared_ptr(1);
+    auto input = multiply->input_value(0).get_node_shared_ptr();
+    auto constant = multiply->input_value(1).get_node_shared_ptr();
     auto inputIndex = 0;
     if (!ov::is_type<ov::opset1::Constant>(constant)) {
-        input = multiply->get_input_node_shared_ptr(1);
-        constant = multiply->get_input_node_shared_ptr(0);
+        input = multiply->input_value(1).get_node_shared_ptr();
+        constant = multiply->input_value(0).get_node_shared_ptr();
         inputIndex = 1;
     }
 
@@ -171,15 +171,15 @@ bool MultiplyToGroupConvolutionTransformation::canBeTransformed(const std::share
 
     Shape constShape;
     int inputIndex;
-    if (const auto constant = ov::as_type_ptr<ov::opset1::Constant>(operation->get_input_node_shared_ptr(1))) {
+    if (const auto constant = ov::as_type_ptr<ov::opset1::Constant>(operation->input_value(1).get_node_shared_ptr())) {
         inputIndex = 0;
         constShape = constant->get_shape();
-        if (ov::is_type<ov::opset1::Constant>(operation->get_input_node_shared_ptr(0)) ||
-            (ov::is_type<ov::opset1::Subtract>(operation->get_input_node_shared_ptr(0)) &&
-            ov::is_type<ov::opset1::Constant>(operation->get_input_node_shared_ptr(0)->get_input_node_shared_ptr(0)))) {
+        if (ov::is_type<ov::opset1::Constant>(operation->input_value(0).get_node_shared_ptr()) ||
+            (ov::is_type<ov::opset1::Subtract>(operation->input_value(0).get_node_shared_ptr()) &&
+            ov::is_type<ov::opset1::Constant>(operation->input_value(0).get_node_shared_ptr()->input_value(0).get_node_shared_ptr()))) {
             return false;
         }
-    } else if (const auto constant = ov::as_type_ptr<ov::opset1::Constant>(operation->get_input_node_shared_ptr(0))) {
+    } else if (const auto constant = ov::as_type_ptr<ov::opset1::Constant>(operation->input_value(0).get_node_shared_ptr())) {
         inputIndex = 1;
         constShape = constant->get_shape();
     } else {
@@ -214,8 +214,8 @@ bool MultiplyToGroupConvolutionTransformation::isQuantized(const std::shared_ptr
 }
 
 bool MultiplyToGroupConvolutionTransformation::canBeTransformedToGroupConvolution(const std::shared_ptr<const Node>& layer) {
-    const auto parent0 = layer->get_input_node_shared_ptr(0);
-    const auto parent1 = layer->get_input_node_shared_ptr(1);
+    const auto parent0 = layer->input_value(0).get_node_shared_ptr();
+    const auto parent1 = layer->input_value(1).get_node_shared_ptr();
 
     if (!ov::is_type<ov::opset1::Constant>(parent0) && !ov::is_type<ov::opset1::Constant>(parent1)) {
         return false;
@@ -232,10 +232,10 @@ bool MultiplyToGroupConvolutionTransformation::canBeTransformedToGroupConvolutio
 
 bool MultiplyToGroupConvolutionTransformation::isDynamicOrScalar(const std::shared_ptr<const Node>& node) {
     auto getConstantIndex = [](const std::shared_ptr<const Node>& node) -> int {
-        if (ov::is_type<ov::opset1::Constant>(node->get_input_node_shared_ptr(1))) {
+        if (ov::is_type<ov::opset1::Constant>(node->input_value(1).get_node_shared_ptr())) {
             return 1;
         }
-        if (ov::is_type<ov::opset1::Constant>(node->get_input_node_shared_ptr(0))) {
+        if (ov::is_type<ov::opset1::Constant>(node->input_value(0).get_node_shared_ptr())) {
             return 0;
         }
         return -1;

--- a/src/common/low_precision_transformations/src/mvn.cpp
+++ b/src/common/low_precision_transformations/src/mvn.cpp
@@ -84,7 +84,7 @@ bool MVNTransformation::canBeTransformed(const std::shared_ptr<Node>& operation)
     } else {
         // MVN-6 allows negative values in reduction axes: [-r, r-1]
         // given static rank of input data of MVN node, we can recover the exact axis number
-        auto axis_set = ov::as_type_ptr<ov::opset1::Constant>(mvn->get_input_node_shared_ptr(1))->cast_vector<int64_t>();
+        auto axis_set = ov::as_type_ptr<ov::opset1::Constant>(mvn->input_value(1).get_node_shared_ptr())->cast_vector<int64_t>();
 
         Dimension::value_type ndims = 0;
         if (std::any_of(axis_set.begin(), axis_set.end(), [](int64_t v) { return v < 0; })) {

--- a/src/common/low_precision_transformations/src/normalize_l2.cpp
+++ b/src/common/low_precision_transformations/src/normalize_l2.cpp
@@ -71,7 +71,7 @@ bool NormalizeL2Transformation::canBeTransformed(const std::shared_ptr<Node>& op
     }
 
     // TODO: Expand transformation for all cases of axes values
-    const auto axes = ov::as_type_ptr<ov::opset1::Constant>(operation->get_input_node_shared_ptr(1));
+    const auto axes = ov::as_type_ptr<ov::opset1::Constant>(operation->input_value(1).get_node_shared_ptr());
     const std::vector<int64_t> axesAcrossSpatial = { 1 };
     const std::vector<int64_t> axesByChannels = { 1, 2, 3 };
 
@@ -106,11 +106,11 @@ bool NormalizeL2Transformation::transform(ov::pass::pattern::Matcher &m) {
 
     auto normalize = ov::as_type_ptr<ov::opset1::NormalizeL2>(NetworkHelper::separateInStandaloneBranch(operation, defaultPrecisions));
 
-    const auto axes = ov::as_type_ptr<ov::opset1::Constant>(normalize->get_input_node_shared_ptr(1));
+    const auto axes = ov::as_type_ptr<ov::opset1::Constant>(normalize->input_value(1).get_node_shared_ptr());
     FakeQuantizeDequantization dequantization = NetworkHelper::getDequantization(normalize, defaultPrecisions);
-    auto scalesConst = ov::as_type_ptr<ov::opset1::Constant>(dequantization.multiply->get_input_node_shared_ptr(1));
+    auto scalesConst = ov::as_type_ptr<ov::opset1::Constant>(dequantization.multiply->input_value(1).get_node_shared_ptr());
     if (scalesConst == nullptr) {
-        scalesConst = ov::as_type_ptr<ov::opset1::Constant>(dequantization.multiply->get_input_node_shared_ptr(0));
+        scalesConst = ov::as_type_ptr<ov::opset1::Constant>(dequantization.multiply->input_value(0).get_node_shared_ptr());
     }
 
     std::shared_ptr<ov::opset1::Constant> newScalesConst;

--- a/src/common/low_precision_transformations/src/pad.cpp
+++ b/src/common/low_precision_transformations/src/pad.cpp
@@ -59,7 +59,7 @@ bool PadTransformation::transform(ov::pass::pattern::Matcher& m) {
     }
 
     const auto pad = ov::as_type_ptr<ov::op::util::PadBase>(NetworkHelper::separateInStandaloneBranch(m.get_match_root(), defaultPrecisions));
-    const auto padConstant = ov::as_type_ptr<ov::opset1::Constant>(pad->get_input_node_shared_ptr(3));
+    const auto padConstant = ov::as_type_ptr<ov::opset1::Constant>(pad->input_value(3).get_node_shared_ptr());
     const auto padConstantValue = padConstant->cast_vector<float>()[0];
 
     const auto padsBegin = pad->get_pads_begin();
@@ -266,7 +266,7 @@ bool PadTransformation::canBeTransformed(const std::shared_ptr<Node>& op) const 
             return false;
         }
 
-        const auto constant = ov::as_type_ptr<ov::opset1::Constant>(pad->get_input_node_shared_ptr(3));
+        const auto constant = ov::as_type_ptr<ov::opset1::Constant>(pad->input_value(3).get_node_shared_ptr());
         const auto constantValue = constant->cast_vector<float>()[0];
         if (constantValue != 0.f && !padAndDqByTheSameDimension(dequantization.multiplyConstant)) {
             return false;

--- a/src/common/low_precision_transformations/src/pull_reshape_through_dequantization.cpp
+++ b/src/common/low_precision_transformations/src/pull_reshape_through_dequantization.cpp
@@ -21,13 +21,13 @@ namespace pull_reshape_through_dequantization {
 namespace {
 
 std::shared_ptr<Node> moveThroughElementwise(const std::shared_ptr<Node>& reshape, const std::shared_ptr<Node>& elementwise) {
-    const auto reshapeValues = ov::as_type_ptr<opset1::Constant>(reshape->get_input_node_shared_ptr(1));
+    const auto reshapeValues = ov::as_type_ptr<opset1::Constant>(reshape->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(reshapeValues != nullptr, "Reshape constant was not found");
 
-    auto elementwiseValuesConvert = ov::as_type_ptr<opset1::Convert>(elementwise->get_input_node_shared_ptr(1));
+    auto elementwiseValuesConvert = ov::as_type_ptr<opset1::Convert>(elementwise->input_value(1).get_node_shared_ptr());
     auto elementwiseValues = elementwiseValuesConvert == nullptr ?
-        ov::as_type_ptr<opset1::Constant>(elementwise->get_input_node_shared_ptr(1)) :
-        ov::as_type_ptr<opset1::Constant>(elementwiseValuesConvert->get_input_node_shared_ptr(0));
+        ov::as_type_ptr<opset1::Constant>(elementwise->input_value(1).get_node_shared_ptr()) :
+        ov::as_type_ptr<opset1::Constant>(elementwiseValuesConvert->input_value(0).get_node_shared_ptr());
     assert(elementwiseValues != nullptr);
 
     const auto newElementwiseValues = [&]() -> std::shared_ptr<Node> {
@@ -149,7 +149,7 @@ ov::pass::low_precision::PullReshapeThroughDequantization::PullReshapeThroughDeq
         }
 
         do {
-            const auto parent = reshape->get_input_node_shared_ptr(0);
+            const auto parent = reshape->input_value(0).get_node_shared_ptr();
             if (ov::is_type<opset1::Multiply>(parent) || ov::is_type<opset1::Subtract>(parent)) {
                 reshape = pull_reshape_through_dequantization::moveThroughElementwise(reshape, parent);
             } else if (ov::is_type<opset1::Convert>(parent)) {

--- a/src/common/low_precision_transformations/src/quantization_details.cpp
+++ b/src/common/low_precision_transformations/src/quantization_details.cpp
@@ -68,11 +68,11 @@ void QuantizationDetails::getInputIntervals(
         std::shared_ptr<ov::opset1::FakeQuantize> quantize,
         std::vector<float>& inputLowValues,
         std::vector<float>& inputHighValues) {
-    std::shared_ptr<ov::opset1::Constant> inputLowLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(1));
+    std::shared_ptr<ov::opset1::Constant> inputLowLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(1).get_node_shared_ptr());
     const std::vector<float>& inputLowBlobValues = getBlobValue(inputLowLayer);
     inputLowValues.insert(inputLowValues.end(), inputLowBlobValues.begin(), inputLowBlobValues.end());
 
-    std::shared_ptr<ov::opset1::Constant> inputHighLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(2));
+    std::shared_ptr<ov::opset1::Constant> inputHighLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(2).get_node_shared_ptr());
     const std::vector<float> inputHighBlobValues = getBlobValue(inputHighLayer);
     inputHighValues.insert(inputHighValues.end(), inputHighBlobValues.begin(), inputHighBlobValues.end());
 
@@ -86,11 +86,11 @@ void QuantizationDetails::getOutputIntervals(
         std::shared_ptr<ov::opset1::FakeQuantize> quantize,
         std::vector<float>& outputLowValues,
         std::vector<float>& outputHighValues) {
-    std::shared_ptr<ov::opset1::Constant> outputLowLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(3));
+    std::shared_ptr<ov::opset1::Constant> outputLowLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(3).get_node_shared_ptr());
     const std::vector<float>& outputLowBlobValues = getBlobValue(outputLowLayer);
     outputLowValues.insert(outputLowValues.end(), outputLowBlobValues.begin(), outputLowBlobValues.end());
 
-    std::shared_ptr<ov::opset1::Constant> outputHighLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(4));
+    std::shared_ptr<ov::opset1::Constant> outputHighLayer = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(4).get_node_shared_ptr());
     const std::vector<float> outputHighBlobValues = getBlobValue(outputHighLayer);
     outputHighValues.insert(outputHighValues.end(), outputHighBlobValues.begin(), outputHighBlobValues.end());
 
@@ -104,11 +104,11 @@ QuantizationDetails QuantizationDetails::getDetails(std::shared_ptr<ov::opset1::
         return QuantizationDetails();
     }
 
-    const std::vector<float> inputLowValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(1))->cast_vector<float>();
-    const std::vector<float> inputHighValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(2))->cast_vector<float>();
+    const std::vector<float> inputLowValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(1).get_node_shared_ptr())->cast_vector<float>();
+    const std::vector<float> inputHighValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(2).get_node_shared_ptr())->cast_vector<float>();
 
-    const std::vector<float> outputLowValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(3))->cast_vector<float>();
-    const std::vector<float> outputHighValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->get_input_node_shared_ptr(4))->cast_vector<float>();
+    const std::vector<float> outputLowValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(3).get_node_shared_ptr())->cast_vector<float>();
+    const std::vector<float> outputHighValues = ov::as_type_ptr<ov::opset1::Constant>(quantize->input_value(4).get_node_shared_ptr())->cast_vector<float>();
 
     return QuantizationDetails(
         quantize->get_levels(),

--- a/src/common/low_precision_transformations/src/reduce_base_transformation.cpp
+++ b/src/common/low_precision_transformations/src/reduce_base_transformation.cpp
@@ -42,7 +42,7 @@ bool ReduceBaseTransformation::canBeTransformed(const std::shared_ptr<Node>& red
         return false;
     }
 
-    const auto axesConstant = ov::as_type_ptr<ov::opset1::Constant>(reduce->get_input_node_shared_ptr(1));
+    const auto axesConstant = ov::as_type_ptr<ov::opset1::Constant>(reduce->input_value(1).get_node_shared_ptr());
     if (axesConstant == nullptr) {
         return false;
     }

--- a/src/common/low_precision_transformations/src/rt_info/intervals_alignment_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/intervals_alignment_attribute.cpp
@@ -56,8 +56,8 @@ ov::Any IntervalsAlignmentAttribute::create(
             }
         }
 
-        const auto outLow = ov::as_type_ptr<opset1::Constant>(node->get_input_node_shared_ptr(3));
-        const auto outHigh = ov::as_type_ptr<opset1::Constant>(node->get_input_node_shared_ptr(4));
+        const auto outLow = ov::as_type_ptr<opset1::Constant>(node->input_value(3).get_node_shared_ptr());
+        const auto outHigh = ov::as_type_ptr<opset1::Constant>(node->input_value(4).get_node_shared_ptr());
         if (!NetworkHelper::isScalarLike(outLow) || !NetworkHelper::isScalarLike(outHigh)) {
             return nullptr;
         }
@@ -112,8 +112,8 @@ ov::Any IntervalsAlignmentAttribute::create(
                 fakeQuantize->get_levels());
         auto& result = (rtInfo[IntervalsAlignmentAttribute::get_type_info_static()] = attribute);
 
-        const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(3))->cast_vector<float>();
-        const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(fakeQuantize->get_input_node_shared_ptr(4))->cast_vector<float>();
+        const std::vector<float> outputLowValues = ov::as_type_ptr<opset1::Constant>(fakeQuantize->input_value(3).get_node_shared_ptr())->cast_vector<float>();
+        const std::vector<float> outputHighValues = ov::as_type_ptr<opset1::Constant>(fakeQuantize->input_value(4).get_node_shared_ptr())->cast_vector<float>();
         LayerTransformation::PrecisionDetails preferablePrecision = LayerTransformation::getPrecisionDetails(
             fakeQuantize->get_levels(),
             outputLowValues,

--- a/src/common/low_precision_transformations/src/rt_info/quantization_alignment_attribute.cpp
+++ b/src/common/low_precision_transformations/src/rt_info/quantization_alignment_attribute.cpp
@@ -40,7 +40,7 @@ ov::Any QuantizationAlignmentAttribute::create(
         if (!dequantization.empty() &&
             (ov::is_type<opset1::Convert>(dequantization.data.get_node())) &&
             ov::is_type<opset1::FakeQuantize>(dequantization.data.get_node()->get_input_node_ptr(0))) {
-            inputNode = dequantization.data.get_node()->get_input_node_shared_ptr(0);
+            inputNode = dequantization.data.get_node()->input_value(0).get_node_shared_ptr();
         }
 
         if (ov::is_type<opset1::Constant>(inputNode)) {

--- a/src/common/low_precision_transformations/src/split.cpp
+++ b/src/common/low_precision_transformations/src/split.cpp
@@ -48,7 +48,7 @@ bool SplitTransformation::transform(ov::pass::pattern::Matcher& m) {
     newSplit->set_friendly_name(split->get_friendly_name());
     ov::copy_runtime_info(split, newSplit);
 
-    const int64_t axis = ov::as_type_ptr<ov::opset1::Constant>(split->get_input_node_shared_ptr(1))->cast_vector<int64_t>()[0];
+    const int64_t axis = ov::as_type_ptr<ov::opset1::Constant>(split->input_value(1).get_node_shared_ptr())->cast_vector<int64_t>()[0];
     const size_t normalizedAxis = ov::util::try_normalize_axis(axis, split->get_input_partial_shape(0).rank(), *split);
     const size_t outputSize = newSplit->get_output_size();
 

--- a/src/common/low_precision_transformations/src/transpose.cpp
+++ b/src/common/low_precision_transformations/src/transpose.cpp
@@ -71,7 +71,7 @@ void transposeDequantizationConstant(std::shared_ptr<Node>& transpose, const std
         const auto constant = transposeDeqConstant(
             dequantization.subtractConstant,
             transpose->get_output_partial_shape(0),
-            transpose->get_input_node_shared_ptr(1));
+            transpose->input_value(1).get_node_shared_ptr());
         replace_node(dequantization.subtractConstant, constant);
     }
 
@@ -79,7 +79,7 @@ void transposeDequantizationConstant(std::shared_ptr<Node>& transpose, const std
         const auto constant = transposeDeqConstant(
             dequantization.multiplyConstant,
             transpose->get_output_partial_shape(0),
-            transpose->get_input_node_shared_ptr(1));
+            transpose->input_value(1).get_node_shared_ptr());
         replace_node(dequantization.multiplyConstant, constant);
     }
 }
@@ -109,7 +109,7 @@ bool TransposeTransformation::canBeTransformed(const std::shared_ptr<Node>& op) 
         return false;
     }
 
-    const std::shared_ptr<ov::opset1::Constant> constant = ov::as_type_ptr<ov::opset1::Constant>(op->get_input_node_shared_ptr(1));
+    const std::shared_ptr<ov::opset1::Constant> constant = ov::as_type_ptr<ov::opset1::Constant>(op->input_value(1).get_node_shared_ptr());
     if (constant == nullptr) {
         return false;
     }

--- a/src/common/low_precision_transformations/tests/is_function_quantized_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/is_function_quantized_transformation.cpp
@@ -41,7 +41,7 @@ public:
             testValues.constantSubgraphOnParameters);
 
         if (testValues.inputOnParameters) {
-            replace_node(fakeQuantize->get_input_node_shared_ptr(3), input);
+            replace_node(fakeQuantize->input_value(3).get_node_shared_ptr(), input);
         }
 
         ov::ResultVector results{ std::make_shared<ov::op::v0::Result>(fakeQuantize) };

--- a/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
+++ b/src/common/low_precision_transformations/tests/lpt_avoid_shapeof_propagation_test.cpp
@@ -94,7 +94,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationAddTransformation) {
     m.register_pass<ov::pass::low_precision::AddTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -116,7 +116,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationAvgPoolTransformation) {
     m.register_pass<ov::pass::low_precision::AvgPoolTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -137,7 +137,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationClampTransformation) {
     m.register_pass<ov::pass::low_precision::ClampTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -162,7 +162,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConcatTransformation) {
     m.register_pass<ov::pass::low_precision::ConcatTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -192,7 +192,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionTransformation) {
     pass::Manager m;
     m.register_pass<ov::pass::low_precision::ConvolutionTransformation>();
     m.run_passes(f);
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -222,7 +222,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationConvolutionBackpropDataTransfor
     pass::Manager m;
     m.register_pass<ov::pass::low_precision::ConvolutionBackpropDataTransformation>();
     m.run_passes(f);
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -242,7 +242,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationDepthToSpaceTransformation) {
     m.register_pass<ov::pass::low_precision::DepthToSpaceTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -265,7 +265,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationFakeQuantizeDecompositionTransf
     m.register_pass<ov::pass::low_precision::FakeQuantizeDecompositionTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -296,7 +296,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationGroupConvolutionTransformation)
     pass::Manager m;
     m.register_pass<ov::pass::low_precision::GroupConvolutionTransformation>();
     m.run_passes(f);
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -324,7 +324,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationInterpolateTransformation) {
     m.register_pass<ov::pass::low_precision::InterpolateTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -348,7 +348,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMatMulTransformation) {
     pass::Manager m;
     m.register_pass<ov::pass::low_precision::MatMulTransformation>();
     m.run_passes(f);
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -367,7 +367,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMaxPoolTransformation) {
     pass::Manager m;
     m.register_pass<ov::pass::low_precision::MaxPoolTransformation>();
     m.run_passes(f);
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -392,7 +392,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMultiplyTransformation) {
     m.register_pass<ov::pass::low_precision::MultiplyPartialTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -412,7 +412,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationMVNTransformation) {
     m.register_pass<ov::pass::low_precision::MVNTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -433,7 +433,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationNormalizeL2Transformation) {
     m.register_pass<ov::pass::low_precision::NormalizeL2Transformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -455,7 +455,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationPadTransformation) {
     m.register_pass<ov::pass::low_precision::PadTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -477,7 +477,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationPReluTransformation) {
     m.register_pass<ov::pass::low_precision::PReluTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -498,7 +498,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMaxTransformation) {
     m.register_pass<ov::pass::low_precision::ReduceMaxTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -520,7 +520,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMeanTransformation) {
     m.register_pass<ov::pass::low_precision::ReduceMeanTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -541,7 +541,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceMinTransformation) {
     m.register_pass<ov::pass::low_precision::ReduceMinTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -563,7 +563,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReduceSumTransformation) {
     m.register_pass<ov::pass::low_precision::ReduceSumTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -584,7 +584,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReshapeTransformation) {
     m.register_pass<ov::pass::low_precision::ReshapeTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -604,7 +604,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationReluTransformation) {
     m.register_pass<ov::pass::low_precision::ReluTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -625,7 +625,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationSqueezeTransformation) {
     m.register_pass<ov::pass::low_precision::SqueezeTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -648,7 +648,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationSplitTransformation) {
     m.register_pass<ov::pass::low_precision::SplitTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -668,7 +668,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationShuffleChannelsTransformation) 
     m.register_pass<ov::pass::low_precision::ShuffleChannelsTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -696,7 +696,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationStridedSliceTransformation) {
     m.register_pass<ov::pass::low_precision::StridedSliceTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -717,7 +717,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationTransposeTransformation) {
     m.register_pass<ov::pass::low_precision::TransposeTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -738,7 +738,7 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationUnsqueezeTransformation) {
     m.register_pass<ov::pass::low_precision::UnsqueezeTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }
 
@@ -761,6 +761,6 @@ TEST(LPT, AvoidDequantizationToShapeOfPropagationVariadicSplitTransformation) {
     m.register_pass<ov::pass::low_precision::VariadicSplitTransformation>();
     m.run_passes(f);
 
-    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->get_input_node_shared_ptr(0));
+    auto dqBeforeShapeOf = ov::pass::low_precision::NetworkHelper::getDequantization(result2->input_value(0).get_node_shared_ptr());
     ASSERT_TRUE(dqBeforeShapeOf.empty());
 }

--- a/src/common/low_precision_transformations/tests/move_dequantization_after_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/move_dequantization_after_transformation.cpp
@@ -77,7 +77,7 @@ public:
             testValues.actual.dequantization,
             testValues.typeRelaxed);
 
-        const auto targetNode = actualFunction->get_output_op(0)->get_input_node_shared_ptr(0);
+        const auto targetNode = actualFunction->get_output_op(0)->input_value(0).get_node_shared_ptr();
         const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(targetNode);
         ov::pass::low_precision::NetworkHelper::moveDequantizationAfter(
             targetNode,
@@ -312,7 +312,7 @@ TEST(LPT, MoveDequantizationAfterTransformationNegative) {
         ov::builder::subgraph::DequantizationOperations{{ov::element::f32}, {7.f}, {10.f}},
         typeRelaxed);
 
-    const auto targetNode = model->get_output_op(0)->get_input_node_shared_ptr(0);
+    const auto targetNode = model->get_output_op(0)->input_value(0).get_node_shared_ptr();
     const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(targetNode);
 
     // updateOutputPrecision is supported only for type relaxed nodes

--- a/src/common/low_precision_transformations/tests/normalize_dequantization_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/normalize_dequantization_transformation.cpp
@@ -51,7 +51,7 @@ public:
             testValues.actual.dequantization,
             testValues.constantPath);
 
-        const auto targetNode = actualFunction->get_output_op(0)->get_input_node_shared_ptr(0);
+        const auto targetNode = actualFunction->get_output_op(0)->input_value(0).get_node_shared_ptr();
         const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(targetNode);
         ov::pass::low_precision::NetworkHelper::normalizeDequantization(dequantization);
 

--- a/src/common/low_precision_transformations/tests/round_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/round_transformation.cpp
@@ -35,9 +35,9 @@ public:
             ov::builder::subgraph::RoundWithToleranceFunction::getOriginal(testValues.inputPrecision,
                                                                                testValues.inputShape,
                                                                                testValues.actualDequantization);
-        const auto lastNode = actualFunction->get_output_op(0)->get_input_node_shared_ptr(0);
+        const auto lastNode = actualFunction->get_output_op(0)->input_value(0).get_node_shared_ptr();
         const auto dequantization = ov::pass::low_precision::NetworkHelper::getDequantization(lastNode);
-        const auto subtractConstant = dequantization.subtract->get_input_node_shared_ptr(1);
+        const auto subtractConstant = dequantization.subtract->input_value(1).get_node_shared_ptr();
         const auto roundedConst =
             ov::pass::low_precision::NetworkHelper::round(subtractConstant, testValues.inputPrecision);
 

--- a/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/separate_in_standalone_branch_transformation.cpp
@@ -81,7 +81,7 @@ public:
         };
         actualFunction = createActualFunction(testValues.precisionBefore, shape, testValues.dequantization);
         const auto result = actualFunction->get_results()[0];
-        ov::pass::low_precision::NetworkHelper::separateInStandaloneBranch(result->get_input_node_shared_ptr(0));
+        ov::pass::low_precision::NetworkHelper::separateInStandaloneBranch(result->input_value(0).get_node_shared_ptr());
 
         const auto createReferenceFunction = [](
             const ov::element::Type precision,

--- a/src/common/offline_transformations/src/compress_quantize_weigths.cpp
+++ b/src/common/offline_transformations/src/compress_quantize_weigths.cpp
@@ -95,7 +95,7 @@ ov::pass::CompressWeightsWithFakeQuantize::CompressWeightsWithFakeQuantize() {
             return false;
         const auto& high_precision_type = fq->get_element_type();
 
-        auto weights = ov::util::constantfold_subgraph(fq->get_input_node_shared_ptr(0));
+        auto weights = ov::util::constantfold_subgraph(fq->input_value(0));
         if (!weights)
             return false;
         auto input_low = ov::as_type_ptr<op::v0::Constant>(fq->get_input_node_shared_ptr(1));

--- a/src/common/offline_transformations/src/pruning/init_masks.cpp
+++ b/src/common/offline_transformations/src/pruning/init_masks.cpp
@@ -35,11 +35,11 @@ public:
             // Initializing weights mask:
             // 1. Looking for Const node with weights
             NodeVector weights_calculation_nodes;
-            auto cur_node = m_output.get_node()->get_input_node_shared_ptr(1);
+            auto cur_node = m_output.get_node()->input_value(1).get_node_shared_ptr();
 
             while (!ov::is_type<opset6::Constant>(cur_node) && cur_node->inputs().size()) {
                 weights_calculation_nodes.push_back(cur_node);
-                cur_node = cur_node->get_input_node_shared_ptr(0);
+                cur_node = cur_node->input_value(0).get_node_shared_ptr();
             }
             if (!ov::is_type<opset6::Constant>(cur_node)) {
                 OPENVINO_DEBUG("Can't find Constant weights for Convolution: ",
@@ -76,7 +76,7 @@ public:
             // Initializing weights mask:
             // 1. Looking for Const node with weights
             NodeVector weights_calculation_nodes;
-            auto cur_node = matmul->get_input_node_shared_ptr(1);
+            auto cur_node = matmul->input_value(1).get_node_shared_ptr();
 
             if (cur_node->get_output_partial_shape(0).is_dynamic())
                 return false;
@@ -88,7 +88,7 @@ public:
                 weights_calculation_nodes.push_back(cur_node);
                 if (ov::is_type<opset6::Transpose>(cur_node)) {
                     const auto forward_order =
-                        ov::util::get_constant_from_source(cur_node->get_input_node_shared_ptr(1));
+                        ov::util::get_constant_from_source(cur_node->input_value(1).get_node_shared_ptr());
                     if (!forward_order)
                         return false;
                     const auto forward_order_vec = forward_order->cast_vector<int64_t>();
@@ -109,7 +109,7 @@ public:
                         return false;
                     }
                 }
-                cur_node = cur_node->get_input_node_shared_ptr(0);
+                cur_node = cur_node->input_value(0).get_node_shared_ptr();
             }
             if (!ov::is_type<opset6::Constant>(cur_node)) {
                 OPENVINO_DEBUG("Can't find Constant weights for MatMul: ", matmul->get_friendly_name(), "\n");

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -138,7 +138,7 @@ auto Subgraph::get_estimated_buffer_count(const ov::NodeVector& ops) -> size_t {
                                                            [](const ov::Input<ov::Node>& in) {
                                                                return ov::is_type<ov::op::v0::Result>(in.get_node());
                                                            }) ||
-                                              !ov::is_type<ov::op::v0::Parameter>(transpose->get_input_node_shared_ptr(0));
+                                              !ov::is_type<ov::op::v0::Parameter>(transpose->input_value(0).get_node_shared_ptr());
             if (are_prev_or_next_ops) {
                 push_prc_size(transpose->get_element_type().size());
             }
@@ -148,9 +148,9 @@ auto Subgraph::get_estimated_buffer_count(const ov::NodeVector& ops) -> size_t {
             push_prc_size(ov::element::f32.size());
         } else if (const auto matmul = ov::as_type_ptr<ov::op::v0::MatMul>(op)) {
             // Since all buffers around Matmul must be unique, we explicitely add values to the vector without any checks
-            if (!ov::is_type<ov::op::v0::Parameter>(matmul->get_input_node_shared_ptr(0)))
+            if (!ov::is_type<ov::op::v0::Parameter>(matmul->input_value(0).get_node_shared_ptr()))
                 used_precision_size.push_back(matmul->get_input_element_type(0).size());
-            if (!ov::is_type<ov::op::v0::Parameter>(matmul->get_input_node_shared_ptr(1)))
+            if (!ov::is_type<ov::op::v0::Parameter>(matmul->input_value(1).get_node_shared_ptr()))
                 used_precision_size.push_back(matmul->get_input_element_type(1).size());
 
             const auto consumers = matmul->get_output_target_inputs(0);

--- a/src/common/snippets/src/pass/analyze_broadcastable_inputs.cpp
+++ b/src/common/snippets/src/pass/analyze_broadcastable_inputs.cpp
@@ -56,7 +56,7 @@ bool pass::AnalyzeBroadcastableInputs::run_on_model(const std::shared_ptr<ov::Mo
                     OPENVINO_ASSERT(consumers.size() == 1, "Incorrect count of outputs of Parameter!");
                     const auto transpose = consumers.begin()->get_node();
                     std::vector<size_t> order;
-                    const auto& constant = ov::as_type_ptr<const opset1::Constant>(transpose->get_input_node_shared_ptr(1));
+                    const auto& constant = ov::as_type_ptr<const opset1::Constant>(transpose->input_value(1).get_node_shared_ptr());
                     OPENVINO_ASSERT(constant, "Unsupported order node of Transpose");
                     order = constant->cast_vector<size_t>();
                     if (order.empty()) {

--- a/src/common/snippets/src/pass/convert_power_to_powerstatic.cpp
+++ b/src/common/snippets/src/pass/convert_power_to_powerstatic.cpp
@@ -13,12 +13,12 @@ ov::snippets::pass::ConvertPowerToPowerStatic::ConvertPowerToPowerStatic() {
     auto scalarPower = std::make_shared<ov::pass::pattern::op::Label>(ov::pass::pattern::any_input(),
                                                                       [](std::shared_ptr<Node> n) {
                                                                           return is_type<ov::op::v1::Power>(n) &&
-                                                                                 is_type<snippets::op::Scalar>(n->get_input_node_shared_ptr(1));
+                                                                                 is_type<snippets::op::Scalar>(n->input_value(1).get_node_shared_ptr());
                                                                       });
     ov::graph_rewrite_callback callback = [](ov::pass::pattern::Matcher &m) {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::op::ConvertPowerToPowerStatic")
         auto power = ov::as_type_ptr<ov::op::v1::Power>(m.get_match_root());
-        auto scalar = ov::as_type_ptr<snippets::op::Scalar>(power->get_input_node_shared_ptr(1));
+        auto scalar = ov::as_type_ptr<snippets::op::Scalar>(power->input_value(1).get_node_shared_ptr());
         auto value = scalar->cast_vector<float>()[0];
         auto power_static = std::make_shared<snippets::op::PowerStatic>(power->input(0).get_source_output(), value);
         power_static->set_friendly_name(power->get_friendly_name());

--- a/src/common/snippets/src/pass/explicit_transpose_matmul_inputs.cpp
+++ b/src/common/snippets/src/pass/explicit_transpose_matmul_inputs.cpp
@@ -26,13 +26,13 @@ void ov::snippets::pass::ExplicitTransposeMatMulInputs::extract(const ov::Input<
         if (!are_weights_scalar(parent))
             break;
 
-        parent = parent->get_input_node_shared_ptr(0);
+        parent = parent->input_value(0).get_node_shared_ptr();
         transpose = ov::as_type_ptr<ov::op::v1::Transpose>(parent);
     }
 
     // If there isn't another Transpose, need to create new Transpose
     if (transpose) {
-        const auto transpose_pattern = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        const auto transpose_pattern = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
         OPENVINO_ASSERT(transpose_pattern,
                         "ExplicitTransposeMatMulInputs expects existing Transpose with Constant order");
 

--- a/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
+++ b/src/common/snippets/src/pass/extract_unsupported_transposes.cpp
@@ -29,7 +29,7 @@ bool ov::snippets::pass::ExtractUnsupportedTransposes::run_on_subgraph(const std
         if (!transpose)
             continue;
 
-        const auto& order = ov::as_type_ptr<opset1::Constant>(transpose->get_input_node_shared_ptr(1));
+        const auto& order = ov::as_type_ptr<opset1::Constant>(transpose->input_value(1).get_node_shared_ptr());
         OPENVINO_ASSERT(order, "ExtractUnsupportedTransposes expects Transposes with constant order");
 
         const auto order_value = order->cast_vector<int>();

--- a/src/common/snippets/src/pass/fq_decomposition.cpp
+++ b/src/common/snippets/src/pass/fq_decomposition.cpp
@@ -175,10 +175,10 @@ bool ov::snippets::pass::FakeQuantizeDecomposition::getScalesAndShifts(
     std::vector<float>& ish,
     std::vector<float>& osc,
     std::vector<float>& osh) {
-    auto input_low_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(1));
-    auto input_high_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(2));
-    auto output_low_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(3));
-    auto output_high_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(4));
+    auto input_low_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(1).get_node_shared_ptr());
+    auto input_high_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(2).get_node_shared_ptr());
+    auto output_low_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(3).get_node_shared_ptr());
+    auto output_high_constant = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(4).get_node_shared_ptr());
     if (!input_low_constant || !input_high_constant || !output_low_constant || !output_high_constant)
         return false;
 
@@ -365,10 +365,10 @@ bool ov::snippets::pass::CommonFakeQuantizeDecomposition::is_supported_fq(const 
         });
     };
     return fq && fq->get_levels() != 2 &&
-           ov::is_type<ov::op::v0::Constant>(fq->get_input_node_shared_ptr(1)) &&
-           ov::is_type<ov::op::v0::Constant>(fq->get_input_node_shared_ptr(2)) &&
-           ov::is_type<ov::op::v0::Constant>(fq->get_input_node_shared_ptr(3)) &&
-           ov::is_type<ov::op::v0::Constant>(fq->get_input_node_shared_ptr(4)) &&
+           ov::is_type<ov::op::v0::Constant>(fq->input_value(1).get_node_shared_ptr()) &&
+           ov::is_type<ov::op::v0::Constant>(fq->input_value(2).get_node_shared_ptr()) &&
+           ov::is_type<ov::op::v0::Constant>(fq->input_value(3).get_node_shared_ptr()) &&
+           ov::is_type<ov::op::v0::Constant>(fq->input_value(4).get_node_shared_ptr()) &&
            utils::one_of(fq->get_auto_broadcast(), ov::op::AutoBroadcastType::NUMPY, ov::op::AutoBroadcastType::NONE) &&
            is_valid_range_values(fq);
 }

--- a/src/common/snippets/src/pass/fuse_transpose_brgemm.cpp
+++ b/src/common/snippets/src/pass/fuse_transpose_brgemm.cpp
@@ -21,7 +21,7 @@ bool FuseTransposeBrgemm::is_supported_transpose(const Output<Node>& transpose_o
     const auto transpose = ov::as_type_ptr<const ov::opset1::Transpose>(transpose_out.get_node_shared_ptr());
     if (!transpose)
         return false;
-    const auto order = ov::as_type_ptr<const ov::opset1::Constant>(transpose->get_input_node_shared_ptr(1));
+    const auto order = ov::as_type_ptr<const ov::opset1::Constant>(transpose->input_value(1).get_node_shared_ptr());
     if (!order)
         return false;
     return is_supported_transpose_order(order->cast_vector<int32_t>());
@@ -70,10 +70,10 @@ FuseTransposeBrgemm::FuseTransposeBrgemm() {
 
         // Transpose on the Brgemm's output
         if (!brgemm) {
-            brgemm = ov::as_type_ptr<op::Brgemm>(m.get_match_root()->get_input_node_shared_ptr(0));
+            brgemm = ov::as_type_ptr<op::Brgemm>(m.get_match_root()->input_value(0).get_node_shared_ptr());
             const auto& brgemm_out = brgemm->output(0);
             const auto& transpose_out = m.get_match_value();
-            const auto& const_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose_out.get_node_shared_ptr()->get_input_node_shared_ptr(1));
+            const auto& const_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose_out.get_node_shared_ptr()->input_value(1).get_node_shared_ptr());
             const auto& original_port = ov::snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(brgemm_out);
             original_port->set_shape(utils::pshape_to_vdims(transpose_out.get_partial_shape()));
             const auto& out_layout = original_port->get_layout();
@@ -88,7 +88,7 @@ FuseTransposeBrgemm::FuseTransposeBrgemm() {
             const auto& in_value = in.get_source_output();
             if (transpose_matcher->match(in_value)) {
                 const auto& transpose = as_type_ptr<ov::op::v1::Transpose>(in_value.get_node_shared_ptr());
-                const auto& const_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+                const auto& const_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
                 brgemm->set_argument(i, transpose->input_value(0));
                 const auto& original_port = ov::snippets::lowered::PortDescriptorUtils::get_port_descriptor_ptr(in);
                 const auto& in_layout = original_port->get_layout();

--- a/src/common/snippets/src/pass/propagate_precision.cpp
+++ b/src/common/snippets/src/pass/propagate_precision.cpp
@@ -171,7 +171,7 @@ bool ov::snippets::pass::PropagatePrecision::run_on_model(const std::shared_ptr<
         if (actual_type != it->second) {
             was_updated = true;
             auto convert = std::make_shared<ov::snippets::op::ConvertSaturation>(
-                result->get_input_node_shared_ptr(0),
+                result->input_value(0),
                 expected_type);
             copy_runtime_info(result->get_input_node_shared_ptr(0), convert);
             result->set_argument(0, convert);

--- a/src/common/snippets/src/pass/propagate_precision.cpp
+++ b/src/common/snippets/src/pass/propagate_precision.cpp
@@ -140,7 +140,7 @@ bool ov::snippets::pass::PropagatePrecision::run_on_model(const std::shared_ptr<
                     if (can_be_fused(actual_after, required_after)) {
                         // fuse existing convert
                         auto convert = std::make_shared<ov::snippets::op::ConvertSaturation>(
-                            existing_convert->get_input_node_shared_ptr(0),
+                            existing_convert->input_value(0).get_node_shared_ptr(),
                             required_after);
                         copy_runtime_info(parent_output.get_node_shared_ptr(), convert);
                         op->set_argument(op_input.get_index(), convert);
@@ -173,7 +173,7 @@ bool ov::snippets::pass::PropagatePrecision::run_on_model(const std::shared_ptr<
             auto convert = std::make_shared<ov::snippets::op::ConvertSaturation>(
                 result->input_value(0),
                 expected_type);
-            copy_runtime_info(result->get_input_node_shared_ptr(0), convert);
+            copy_runtime_info(result->input_value(0).get_node_shared_ptr(), convert);
             result->set_argument(0, convert);
         }
     }

--- a/src/common/snippets/src/pass/reduce_to_snippets_reduce.cpp
+++ b/src/common/snippets/src/pass/reduce_to_snippets_reduce.cpp
@@ -26,7 +26,7 @@ snippets::pass::ReduceToSnippetsReduce::ReduceToSnippetsReduce() {
         auto reduce = m.get_match_root();
         const auto& reduce_base = ov::as_type_ptr<ov::op::util::ArithmeticReductionKeepDims>(reduce);
         OPENVINO_ASSERT(reduce_base, "Failed to cast Reduce operation to ArithmeticReductionKeepDims");
-        const auto& axis_constant = ov::as_type_ptr<ov::op::v0::Constant>(reduce->get_input_node_shared_ptr(1));
+        const auto& axis_constant = ov::as_type_ptr<ov::op::v0::Constant>(reduce->input_value(1).get_node_shared_ptr());
         // Note: we do not check the Constant value here. If the Reduce was tokenized, then we assume that it is supported
         OPENVINO_ASSERT(reduce_base->get_keep_dims() && axis_constant, "Unspported Reduce was tokenized by Snippets");
 

--- a/src/common/snippets/src/pass/transpose_decomposition.cpp
+++ b/src/common/snippets/src/pass/transpose_decomposition.cpp
@@ -19,7 +19,7 @@ bool TransposeDecomposition::is_supported_transpose(const Output<Node>& transpos
     const auto transpose = ov::as_type_ptr<const ov::opset1::Transpose>(transpose_out.get_node_shared_ptr());
     if (!transpose)
         return false;
-    const auto order = ov::as_type_ptr<const ov::opset1::Constant>(transpose->get_input_node_shared_ptr(1));
+    const auto order = ov::as_type_ptr<const ov::opset1::Constant>(transpose->input_value(1).get_node_shared_ptr());
     if (!order)
         return false;
     return is_supported_transpose_order(order->cast_vector<int32_t>());

--- a/src/common/snippets/src/pass/validate.cpp
+++ b/src/common/snippets/src/pass/validate.cpp
@@ -74,7 +74,7 @@ bool Validate::is_supported_fq(const std::shared_ptr<const ov::Node>& node) {
 bool Validate::is_supported_transpose(const std::shared_ptr<const ov::Node>& node) {
     // Transpose is supported only on Inputs or Outputs of body
     const auto consumers = node->get_output_target_inputs(0);
-    return (ov::is_type<ov::op::v0::Parameter>(node->get_input_node_shared_ptr(0))) ||
+    return (ov::is_type<ov::op::v0::Parameter>(node->input_value(0).get_node_shared_ptr())) ||
            (consumers.size() == 1 && ov::is_type<ov::op::v0::Result>(consumers.cbegin()->get_node()));
 }
 

--- a/src/common/snippets/src/utils/tokenization_utils.cpp
+++ b/src/common/snippets/src/utils/tokenization_utils.cpp
@@ -203,14 +203,14 @@ bool tokenize_node(const std::shared_ptr<ov::Node>& node, const SnippetsTokeniza
 
                         auto internal = input_body_parameters[i];
                         auto internal_consumers = internal->outputs();
-                        if (auto to_replace_with = ov::as_type_ptr<op::Subgraph>(subgraph->get_input_node_shared_ptr(i))) {
+                        if (auto to_replace_with = ov::as_type_ptr<op::Subgraph>(subgraph->input_value(i).get_node_shared_ptr())) {
                             // todo: In principle, we can still attach the node to the subgraph if cyclic dependency is introduced during ternary merge.
                             //  Need to support.
                             if (cyclicDependencyIsIntoduced(to_replace_with, currentTopoBounds))
                                 return abort("Attempt to perform recurrent merge for cyclic-dependent subgraphs. Aborting.");
                             for (const auto& output : internal_consumers) {
                                     for (auto consumer : output.get_target_inputs()) {
-                                        auto other_body = clones[subgraph->get_input_node_shared_ptr(i)];
+                                        auto other_body = clones[subgraph->input_value(i).get_node_shared_ptr()];
                                         auto other_body_result = other_body->get_results()[consumer.get_source_output().get_index()];
                                         auto result_producer = other_body_result->input(0).get_source_output();
 

--- a/src/common/snippets/src/utils/utils.cpp
+++ b/src/common/snippets/src/utils/utils.cpp
@@ -311,13 +311,13 @@ std::shared_ptr<ov::Node> get_leaf_node_of_first_parent_shape_infer_seq(const st
     }
     if (start_node->get_input_size() == 0)
         return leaf_node;
-    auto first_parent = start_node->get_input_node_shared_ptr(0);
+    auto first_parent = start_node->input_value(0).get_node_shared_ptr();
     while (op::Subgraph::is_shape_infer_op(first_parent)) {
         OPENVINO_ASSERT(first_parent->input(0).get_source_output().get_target_inputs().size() == 1, "Shape infer ops are supposed to be the only consumer.");
         leaf_node = first_parent;
         if (leaf_node->get_input_size() == 0)
             break;
-        first_parent = leaf_node->get_input_node_shared_ptr(0);
+        first_parent = leaf_node->input_value(0).get_node_shared_ptr();
     }
     return leaf_node;
 }

--- a/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
@@ -127,7 +127,7 @@ ov::pass::activations_scaling::ScaleDownSingleLayer::ScaleDownSingleLayer(float 
         size_t bias_index = 1;
         {
             if (scaled_op->get_output_target_inputs(0).size() == 1 && ov::is_type<ov::op::v1::Add>(child_node)) {
-                bias_index = (child_node->get_input_node_shared_ptr(0) == scaled_op) ? 1 : 0;
+                bias_index = (child_node->input_value(0).get_node_shared_ptr() == scaled_op) ? 1 : 0;
                 const auto& bias_pshape = child_node->get_input_partial_shape(bias_index);
                 if (bias_pshape.is_static()) {
                     const auto& bias_shape = bias_pshape.get_shape();

--- a/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/activations_scaling.cpp
@@ -127,7 +127,7 @@ ov::pass::activations_scaling::ScaleDownSingleLayer::ScaleDownSingleLayer(float 
         size_t bias_index = 1;
         {
             if (scaled_op->get_output_target_inputs(0).size() == 1 && ov::is_type<ov::op::v1::Add>(child_node)) {
-                bias_index = (child_node->input_value(0).get_node_shared_ptr() == scaled_op) ? 1 : 0;
+                bias_index = (child_node->get_input_node_shared_ptr(0) == scaled_op) ? 1 : 0;
                 const auto& bias_pshape = child_node->get_input_partial_shape(bias_index);
                 if (bias_pshape.is_static()) {
                     const auto& bias_shape = bias_pshape.get_shape();

--- a/src/common/transformations/src/transformations/common_optimizations/align_eltwise_input_ranks.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/align_eltwise_input_ranks.cpp
@@ -57,7 +57,7 @@ ov::pass::AlignEltwiseInputRanks::AlignEltwiseInputRanks() {
                 Shape new_shape = const_shape;
                 new_shape.insert(new_shape.begin(), diff, 1);
                 auto new_const = std::make_shared<ov::op::v0::Constant>(*const_node, new_shape);
-                copy_runtime_info(node->get_input_node_shared_ptr(i), new_const);
+                copy_runtime_info(node->input_value(i).get_node_shared_ptr(), new_const);
                 node->input(i).replace_source_output(new_const);
             }
         }

--- a/src/common/transformations/src/transformations/common_optimizations/align_eltwise_input_ranks.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/align_eltwise_input_ranks.cpp
@@ -57,7 +57,7 @@ ov::pass::AlignEltwiseInputRanks::AlignEltwiseInputRanks() {
                 Shape new_shape = const_shape;
                 new_shape.insert(new_shape.begin(), diff, 1);
                 auto new_const = std::make_shared<ov::op::v0::Constant>(*const_node, new_shape);
-                copy_runtime_info(node->input_value(i).get_node_shared_ptr(), new_const);
+                copy_runtime_info(node->get_input_node_shared_ptr(i), new_const);
                 node->input(i).replace_source_output(new_const);
             }
         }

--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
@@ -24,7 +24,7 @@ bool can_eliminate_broadcast(const ov::Output<ov::Node>& eltwise,
     // Check that eltwise_input is the same input which comes to ShapeOf which comes
     // to Broadcast operation as a output shape target. In this case we can eliminate
     // Broadcast since eltwise_input will broadcast another eltwise input automatically.
-    auto broadcast_input = broadcast.get_node()->get_input_node_shared_ptr(1);
+    auto broadcast_input = broadcast.get_node()->input_value(1).get_node_shared_ptr();
     if ((ov::is_type<ov::op::v3::ShapeOf>(broadcast_input) || ov::is_type<ov::op::v0::ShapeOf>(broadcast_input)) &&
         broadcast_input->input_value(0) == eltwise_input) {
         return true;

--- a/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/broadcast_elementwise_fusion.cpp
@@ -24,7 +24,7 @@ bool can_eliminate_broadcast(const ov::Output<ov::Node>& eltwise,
     // Check that eltwise_input is the same input which comes to ShapeOf which comes
     // to Broadcast operation as a output shape target. In this case we can eliminate
     // Broadcast since eltwise_input will broadcast another eltwise input automatically.
-    auto broadcast_input = broadcast.get_node()->input_value(1).get_node_shared_ptr();
+    auto broadcast_input = broadcast.get_node()->get_input_node_shared_ptr(1);
     if ((ov::is_type<ov::op::v3::ShapeOf>(broadcast_input) || ov::is_type<ov::op::v0::ShapeOf>(broadcast_input)) &&
         broadcast_input->input_value(0) == eltwise_input) {
         return true;

--- a/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
@@ -52,7 +52,7 @@ ov::pass::PullSqueezeThroughEltwise::PullSqueezeThroughEltwise() {
 
         size_t eltwise_inputs_size = eltwise->get_input_size();
         for (size_t input_index = 0; input_index < eltwise_inputs_size; ++input_index) {
-            const auto input_node = eltwise->get_input_node_shared_ptr(input_index);
+            const auto input_node = eltwise->input_value(input_index).get_node_shared_ptr();
             // check that we will able to fuse propagated squeeze in NopElimination pass
             if (!is_type<ov::op::v0::Constant>(input_node) && !is_type<ov::op::v0::Unsqueeze>(input_node) &&
                 !is_type<ov::op::v1::Reshape>(input_node)) {

--- a/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/concat_reduce_fusion.cpp
@@ -52,7 +52,7 @@ ov::pass::PullSqueezeThroughEltwise::PullSqueezeThroughEltwise() {
 
         size_t eltwise_inputs_size = eltwise->get_input_size();
         for (size_t input_index = 0; input_index < eltwise_inputs_size; ++input_index) {
-            const auto input_node = eltwise->input_value(input_index).get_node_shared_ptr();
+            const auto input_node = eltwise->get_input_node_shared_ptr(input_index);
             // check that we will able to fuse propagated squeeze in NopElimination pass
             if (!is_type<ov::op::v0::Constant>(input_node) && !is_type<ov::op::v0::Unsqueeze>(input_node) &&
                 !is_type<ov::op::v1::Reshape>(input_node)) {

--- a/src/common/transformations/src/transformations/common_optimizations/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_pagedattn_inputs.cpp
@@ -72,8 +72,8 @@ ov::pass::ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& co
     auto result = pa_1 | pa_2;
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto pa_op = m.get_match_root();
-        auto key_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->input_value(3).get_node_shared_ptr());
-        auto value_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->input_value(4).get_node_shared_ptr());
+        auto key_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->get_input_node_shared_ptr(3));
+        auto value_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->get_input_node_shared_ptr(4));
         auto format_cache_precision = [](ov::element::Type cache_precision, ov::element::Type infer_precision) {
             return cache_precision == ov::element::f16 && infer_precision == ov::element::bf16 ? infer_precision
                                                                                                : cache_precision;

--- a/src/common/transformations/src/transformations/common_optimizations/convert_pagedattn_inputs.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convert_pagedattn_inputs.cpp
@@ -72,8 +72,8 @@ ov::pass::ConvertPagedAttnInputs::ConvertPagedAttnInputs(const KVCacheConfig& co
     auto result = pa_1 | pa_2;
     ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto pa_op = m.get_match_root();
-        auto key_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->get_input_node_shared_ptr(3));
-        auto value_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->get_input_node_shared_ptr(4));
+        auto key_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->input_value(3).get_node_shared_ptr());
+        auto value_cache = ov::as_type_ptr<ov::op::v0::Parameter>(pa_op->input_value(4).get_node_shared_ptr());
         auto format_cache_precision = [](ov::element::Type cache_precision, ov::element::Type infer_precision) {
             return cache_precision == ov::element::f16 && infer_precision == ov::element::bf16 ? infer_precision
                                                                                                : cache_precision;

--- a/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
@@ -57,9 +57,9 @@ static std::shared_ptr<ov::op::v0::Concat> create_new_weights(ov::pass::NodeRegi
     weights_to_concat.reserve(num_inputs);
 
     for (size_t i = 0; i < num_inputs; i++) {
-        const auto conv = concat->get_input_node_shared_ptr(i);
+        const auto conv = concat->input_value(i).get_node_shared_ptr();
         const auto weights_output = conv->input_value(1);
-        const auto weights = conv->get_input_node_shared_ptr(1);
+        const auto weights = conv->input_value(1).get_node_shared_ptr();
         const auto& shape = weights->get_output_partial_shape(0);
         if (shape.is_dynamic() || weights->get_output_shape(0) != weights_shape)
             return nullptr;
@@ -111,8 +111,8 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         const auto& pattern_value_map = m.get_pattern_value_map();
         const auto& concat = pattern_value_map.at(concat_label).get_node_shared_ptr();
 
-        const auto first_conv = as_type_ptr<ov::op::v1::Convolution>(concat->get_input_node_shared_ptr(0));
-        const auto split = first_conv->get_input_node_shared_ptr(0);
+        const auto first_conv = as_type_ptr<ov::op::v1::Convolution>(concat->input_value(0).get_node_shared_ptr());
+        const auto split = first_conv->input_value(0).get_node_shared_ptr();
         const bool is_split = is_type<ov::op::v1::Split>(split);
         const bool is_variadic_split = is_type<ov::op::v1::VariadicSplit>(split);
         if (!is_split && !is_variadic_split)
@@ -158,7 +158,7 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         from.push_back(split);
         from.push_back(first_conv);
         for (size_t i = 1; i < concat_num_inputs; i++) {
-            from.push_back(concat->get_input_node_shared_ptr(i));
+            from.push_back(concat->input_value(i).get_node_shared_ptr());
         }
         from.push_back(concat);
 

--- a/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
@@ -57,8 +57,8 @@ static std::shared_ptr<ov::op::v0::Concat> create_new_weights(ov::pass::NodeRegi
     weights_to_concat.reserve(num_inputs);
 
     for (size_t i = 0; i < num_inputs; i++) {
-        const auto conv = concat->get_input_node_shared_ptr(i);
-        const auto weights = conv->get_input_node_shared_ptr(1);
+        const auto conv = concat->input_value(i).get_node_shared_ptr();
+        const auto weights = conv->input_value(1).get_node_shared_ptr();
         const auto& shape = weights->get_output_partial_shape(0);
         if (shape.is_dynamic() || weights->get_output_shape(0) != weights_shape)
             return nullptr;
@@ -110,8 +110,8 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         const auto& pattern_value_map = m.get_pattern_value_map();
         const auto& concat = pattern_value_map.at(concat_label).get_node_shared_ptr();
 
-        const auto first_conv = as_type_ptr<ov::op::v1::Convolution>(concat->get_input_node_shared_ptr(0));
-        const auto split = first_conv->get_input_node_shared_ptr(0);
+        const auto first_conv = as_type_ptr<ov::op::v1::Convolution>(concat->input_value(0).get_node_shared_ptr());
+        const auto split = first_conv->input_value(0).get_node_shared_ptr();
         const bool is_split = is_type<ov::op::v1::Split>(split);
         const bool is_variadic_split = is_type<ov::op::v1::VariadicSplit>(split);
         if (!is_split && !is_variadic_split)
@@ -141,7 +141,7 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         if (!weights)
             return false;
 
-        const auto conv = node_registry.make<ov::op::v1::GroupConvolution>(split->get_input_node_shared_ptr(0),
+        const auto conv = node_registry.make<ov::op::v1::GroupConvolution>(split->input_value(0).get_node_shared_ptr(),
                                                                            weights,
                                                                            first_conv->get_strides(),
                                                                            first_conv->get_pads_begin(),
@@ -157,7 +157,7 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         from.push_back(split);
         from.push_back(first_conv);
         for (size_t i = 1; i < concat_num_inputs; i++) {
-            from.push_back(concat->get_input_node_shared_ptr(i));
+            from.push_back(concat->input_value(i).get_node_shared_ptr());
         }
         from.push_back(concat);
 

--- a/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/convolution_to_group_convolution.cpp
@@ -57,8 +57,9 @@ static std::shared_ptr<ov::op::v0::Concat> create_new_weights(ov::pass::NodeRegi
     weights_to_concat.reserve(num_inputs);
 
     for (size_t i = 0; i < num_inputs; i++) {
-        const auto conv = concat->input_value(i).get_node_shared_ptr();
-        const auto weights = conv->input_value(1).get_node_shared_ptr();
+        const auto conv = concat->get_input_node_shared_ptr(i);
+        const auto weights_output = conv->input_value(1);
+        const auto weights = conv->get_input_node_shared_ptr(1);
         const auto& shape = weights->get_output_partial_shape(0);
         if (shape.is_dynamic() || weights->get_output_shape(0) != weights_shape)
             return nullptr;
@@ -66,7 +67,7 @@ static std::shared_ptr<ov::op::v0::Concat> create_new_weights(ov::pass::NodeRegi
             weights_to_concat.push_back(node_registry.make<ov::op::v0::Constant>(*constant, new_shape));
         } else {
             weights_to_concat.push_back(node_registry.make<ov::op::v0::Unsqueeze>(
-                weights,
+                weights_output,
                 ov::op::v0::Constant::create(ov::element::i32, ov::Shape{}, {0})));
         }
         weights_to_concat.back().get_node()->set_friendly_name(weights->get_friendly_name());
@@ -110,8 +111,8 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         const auto& pattern_value_map = m.get_pattern_value_map();
         const auto& concat = pattern_value_map.at(concat_label).get_node_shared_ptr();
 
-        const auto first_conv = as_type_ptr<ov::op::v1::Convolution>(concat->input_value(0).get_node_shared_ptr());
-        const auto split = first_conv->input_value(0).get_node_shared_ptr();
+        const auto first_conv = as_type_ptr<ov::op::v1::Convolution>(concat->get_input_node_shared_ptr(0));
+        const auto split = first_conv->get_input_node_shared_ptr(0);
         const bool is_split = is_type<ov::op::v1::Split>(split);
         const bool is_variadic_split = is_type<ov::op::v1::VariadicSplit>(split);
         if (!is_split && !is_variadic_split)
@@ -141,7 +142,7 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         if (!weights)
             return false;
 
-        const auto conv = node_registry.make<ov::op::v1::GroupConvolution>(split->input_value(0).get_node_shared_ptr(),
+        const auto conv = node_registry.make<ov::op::v1::GroupConvolution>(split->input_value(0),
                                                                            weights,
                                                                            first_conv->get_strides(),
                                                                            first_conv->get_pads_begin(),
@@ -157,7 +158,7 @@ ov::pass::ConvolutionToGroupConvolutionFusion::ConvolutionToGroupConvolutionFusi
         from.push_back(split);
         from.push_back(first_conv);
         for (size_t i = 1; i < concat_num_inputs; i++) {
-            from.push_back(concat->input_value(i).get_node_shared_ptr());
+            from.push_back(concat->get_input_node_shared_ptr(i));
         }
         from.push_back(concat);
 

--- a/src/common/transformations/src/transformations/common_optimizations/depth_to_space_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/depth_to_space_fusion.cpp
@@ -137,12 +137,12 @@ ov::pass::DepthToSpaceFusion::DepthToSpaceFusion() {
             return false;
         }
 
-        auto permute = ov::as_type_ptr<ov::op::v1::Transpose>(reshape_after->input_value(0).get_node_shared_ptr());
+        auto permute = ov::as_type_ptr<ov::op::v1::Transpose>(reshape_after->get_input_node_shared_ptr(0));
         if (!permute) {
             return false;
         }
 
-        auto reshape_before = ov::as_type_ptr<ov::op::v1::Reshape>(permute->input_value(0).get_node_shared_ptr());
+        auto reshape_before = ov::as_type_ptr<ov::op::v1::Reshape>(permute->get_input_node_shared_ptr(0));
         if (!reshape_before) {
             return false;
         }
@@ -173,7 +173,7 @@ ov::pass::DepthToSpaceFusion::DepthToSpaceFusion() {
         }
 
         ov::AxisVector permutation;
-        if (auto input_const = ov::as_type_ptr<ov::op::v0::Constant>(permute->input_value(1).get_node_shared_ptr())) {
+        if (auto input_const = ov::as_type_ptr<ov::op::v0::Constant>(permute->get_input_node_shared_ptr(1))) {
             permutation = input_const->get_axis_vector_val();
         } else {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/depth_to_space_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/depth_to_space_fusion.cpp
@@ -137,12 +137,12 @@ ov::pass::DepthToSpaceFusion::DepthToSpaceFusion() {
             return false;
         }
 
-        auto permute = ov::as_type_ptr<ov::op::v1::Transpose>(reshape_after->get_input_node_shared_ptr(0));
+        auto permute = ov::as_type_ptr<ov::op::v1::Transpose>(reshape_after->input_value(0).get_node_shared_ptr());
         if (!permute) {
             return false;
         }
 
-        auto reshape_before = ov::as_type_ptr<ov::op::v1::Reshape>(permute->get_input_node_shared_ptr(0));
+        auto reshape_before = ov::as_type_ptr<ov::op::v1::Reshape>(permute->input_value(0).get_node_shared_ptr());
         if (!reshape_before) {
             return false;
         }
@@ -173,7 +173,7 @@ ov::pass::DepthToSpaceFusion::DepthToSpaceFusion() {
         }
 
         ov::AxisVector permutation;
-        if (auto input_const = ov::as_type_ptr<ov::op::v0::Constant>(permute->get_input_node_shared_ptr(1))) {
+        if (auto input_const = ov::as_type_ptr<ov::op::v0::Constant>(permute->input_value(1).get_node_shared_ptr())) {
             permutation = input_const->get_axis_vector_val();
         } else {
             return false;

--- a/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
@@ -258,7 +258,7 @@ bool ov::batch_util::detach_detection_output(const std::shared_ptr<ov::Model>& f
     for (auto& result_node : f->get_results()) {
         auto do_node = result_node->input_value(0).get_node_shared_ptr();
         if (ov::is_type<ov::op::v0::Convert>(do_node))  // cases with do->convert->result
-            do_node = do_node->get_input_node_shared_ptr(0);
+            do_node = do_node->input_value(0).get_node_shared_ptr();
         if (ov::is_type<ov::op::v0::DetectionOutput>(do_node) || ov::is_type<ov::op::v8::DetectionOutput>(do_node)) {
             for (auto& new_result_src : do_node->input_values()) {
                 auto new_result = std::make_shared<ov::op::v0::Result>(new_result_src);

--- a/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/dimension_tracking.cpp
@@ -258,7 +258,7 @@ bool ov::batch_util::detach_detection_output(const std::shared_ptr<ov::Model>& f
     for (auto& result_node : f->get_results()) {
         auto do_node = result_node->input_value(0).get_node_shared_ptr();
         if (ov::is_type<ov::op::v0::Convert>(do_node))  // cases with do->convert->result
-            do_node = do_node->input_value(0).get_node_shared_ptr();
+            do_node = do_node->get_input_node_shared_ptr(0);
         if (ov::is_type<ov::op::v0::DetectionOutput>(do_node) || ov::is_type<ov::op::v8::DetectionOutput>(do_node)) {
             for (auto& new_result_src : do_node->input_values()) {
                 auto new_result = std::make_shared<ov::op::v0::Result>(new_result_src);

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -759,7 +759,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
 
         auto new_node = std::make_shared<op::internal::RoPE>(new_args, config);
         new_node->set_friendly_name(old_node->get_friendly_name());
-        ov::copy_runtime_info({root->get_input_node_shared_ptr(0), root}, new_node);
+        ov::copy_runtime_info({root->input_value(0).get_node_shared_ptr(), root}, new_node);
         ov::replace_node(old_node, new_node);
         return true;
     };

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -759,7 +759,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
 
         auto new_node = std::make_shared<op::internal::RoPE>(new_args, config);
         new_node->set_friendly_name(old_node->get_friendly_name());
-        ov::copy_runtime_info({root->input_value(0).get_node_shared_ptr(), root}, new_node);
+        ov::copy_runtime_info({root->get_input_node_shared_ptr(0), root}, new_node);
         ov::replace_node(old_node, new_node);
         return true;
     };

--- a/src/common/transformations/src/transformations/common_optimizations/glu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/glu_fusion.cpp
@@ -68,7 +68,7 @@ GLUFusion::GLUFusion() {
             glu_type = ov::op::internal::GLU::GluType::Swish;
             split_to_glu_idx = swish->input_value(0).get_index();
 
-            size_t split_in_idx = ov::is_type<ov::op::v4::Swish>(mul->input_value(0).get_node_shared_ptr()) ? 1 : 0;
+            size_t split_in_idx = ov::is_type<ov::op::v4::Swish>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
             if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
                 return false;
         } else if (isGeGLU) {
@@ -78,7 +78,7 @@ GLUFusion::GLUFusion() {
                            : ov::op::internal::GLU::GluType::Gelu_Tanh;
             split_to_glu_idx = gelu->input_value(0).get_index();
 
-            size_t split_in_idx = ov::is_type<ov::op::v7::Gelu>(mul->input_value(0).get_node_shared_ptr()) ? 1 : 0;
+            size_t split_in_idx = ov::is_type<ov::op::v7::Gelu>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
             if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
                 return false;
         } else {

--- a/src/common/transformations/src/transformations/common_optimizations/glu_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/glu_fusion.cpp
@@ -68,7 +68,7 @@ GLUFusion::GLUFusion() {
             glu_type = ov::op::internal::GLU::GluType::Swish;
             split_to_glu_idx = swish->input_value(0).get_index();
 
-            size_t split_in_idx = ov::is_type<ov::op::v4::Swish>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
+            size_t split_in_idx = ov::is_type<ov::op::v4::Swish>(mul->input_value(0).get_node_shared_ptr()) ? 1 : 0;
             if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
                 return false;
         } else if (isGeGLU) {
@@ -78,7 +78,7 @@ GLUFusion::GLUFusion() {
                            : ov::op::internal::GLU::GluType::Gelu_Tanh;
             split_to_glu_idx = gelu->input_value(0).get_index();
 
-            size_t split_in_idx = ov::is_type<ov::op::v7::Gelu>(mul->get_input_node_shared_ptr(0)) ? 1 : 0;
+            size_t split_in_idx = ov::is_type<ov::op::v7::Gelu>(mul->input_value(0).get_node_shared_ptr()) ? 1 : 0;
             if (mul->input_value(split_in_idx).get_index() == split_to_glu_idx)
                 return false;
         } else {

--- a/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
@@ -85,12 +85,12 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
         }
 
         for (size_t i = 1; i < eltwise->get_input_size(); ++i) {
-            if (!is_scalar_like(eltwise->get_input_node_shared_ptr(i))) {
+            if (!is_scalar_like(eltwise->input_value(i).get_node_shared_ptr())) {
                 return false;
             }
         }
 
-        auto current = eltwise->get_input_node_shared_ptr(0);
+        auto current = eltwise->input_value(0).get_node_shared_ptr();
         auto child = eltwise;
 
         while (is_data_movement_operation(current, allowed_data_movement_ops)) {
@@ -100,7 +100,7 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
             }
 
             child = current;
-            current = current->get_input_node_shared_ptr(0);
+            current = current->input_value(0).get_node_shared_ptr();
         }
 
         // now current is the first not data movement op
@@ -111,7 +111,7 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
         // eltwise constant shape should match new input shape
         for (size_t i = 1; i < eltwise->get_input_size(); i++) {
             if (current->get_output_partial_shape(0).size() != eltwise->get_input_partial_shape(i).size()) {
-                auto old_eltwise_const = ov::as_type_ptr<ov::opset8::Constant>(eltwise->get_input_node_shared_ptr(i));
+                auto old_eltwise_const = ov::as_type_ptr<ov::opset8::Constant>(eltwise->input_value(i).get_node_shared_ptr());
                 if (old_eltwise_const->get_shape().size() != 0) {
                     auto new_constant = std::make_shared<ov::opset8::Constant>(*old_eltwise_const.get(), ov::Shape{});
                     ov::replace_node_update_name(old_eltwise_const, new_constant);
@@ -206,7 +206,7 @@ ov::pass::MoveEltwiseUpThroughDataMovPerChannel::MoveEltwiseUpThroughDataMovPerC
             }
         }
 
-        auto parent = eltwise->get_input_node_shared_ptr(data_flow_idx);
+        auto parent = eltwise->input_value(data_flow_idx).get_node_shared_ptr();
         const auto& parent_in_pshape = parent->get_input_partial_shape(0);
         auto parent_in_channel_dim =
             parent_in_pshape.size() <= channel_idx ? ov::Dimension(1) : parent_in_pshape[channel_idx];
@@ -218,7 +218,7 @@ ov::pass::MoveEltwiseUpThroughDataMovPerChannel::MoveEltwiseUpThroughDataMovPerC
         auto new_shape = ov::Shape(parent->get_input_partial_shape(0).size(), 1);
 
         new_shape[channel_idx] = const_shape[channel_idx];
-        auto old_const = ov::as_type_ptr<ov::op::v0::Constant>(eltwise->get_input_node_shared_ptr(const_idx));
+        auto old_const = ov::as_type_ptr<ov::op::v0::Constant>(eltwise->input_value(const_idx).get_node_shared_ptr());
         auto new_const = std::make_shared<ov::op::v0::Constant>(*old_const, new_shape);
         ov::replace_node_update_name(old_const, new_const);
         ov::replace_output_update_name(eltwise->output(0), eltwise->input_value(data_flow_idx));

--- a/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/move_eltwise_up_data_movement.cpp
@@ -85,12 +85,12 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
         }
 
         for (size_t i = 1; i < eltwise->get_input_size(); ++i) {
-            if (!is_scalar_like(eltwise->input_value(i).get_node_shared_ptr())) {
+            if (!is_scalar_like(eltwise->get_input_node_shared_ptr(i))) {
                 return false;
             }
         }
 
-        auto current = eltwise->input_value(0).get_node_shared_ptr();
+        auto current = eltwise->get_input_node_shared_ptr(0);
         auto child = eltwise;
 
         while (is_data_movement_operation(current, allowed_data_movement_ops)) {
@@ -100,7 +100,7 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
             }
 
             child = current;
-            current = current->input_value(0).get_node_shared_ptr();
+            current = current->get_input_node_shared_ptr(0);
         }
 
         // now current is the first not data movement op
@@ -111,7 +111,7 @@ ov::pass::MoveEltwiseUpThroughDataMovScalar::MoveEltwiseUpThroughDataMovScalar(
         // eltwise constant shape should match new input shape
         for (size_t i = 1; i < eltwise->get_input_size(); i++) {
             if (current->get_output_partial_shape(0).size() != eltwise->get_input_partial_shape(i).size()) {
-                auto old_eltwise_const = ov::as_type_ptr<ov::opset8::Constant>(eltwise->input_value(i).get_node_shared_ptr());
+                auto old_eltwise_const = ov::as_type_ptr<ov::opset8::Constant>(eltwise->get_input_node_shared_ptr(i));
                 if (old_eltwise_const->get_shape().size() != 0) {
                     auto new_constant = std::make_shared<ov::opset8::Constant>(*old_eltwise_const.get(), ov::Shape{});
                     ov::replace_node_update_name(old_eltwise_const, new_constant);
@@ -206,7 +206,7 @@ ov::pass::MoveEltwiseUpThroughDataMovPerChannel::MoveEltwiseUpThroughDataMovPerC
             }
         }
 
-        auto parent = eltwise->input_value(data_flow_idx).get_node_shared_ptr();
+        auto parent = eltwise->get_input_node_shared_ptr(data_flow_idx);
         const auto& parent_in_pshape = parent->get_input_partial_shape(0);
         auto parent_in_channel_dim =
             parent_in_pshape.size() <= channel_idx ? ov::Dimension(1) : parent_in_pshape[channel_idx];
@@ -218,7 +218,7 @@ ov::pass::MoveEltwiseUpThroughDataMovPerChannel::MoveEltwiseUpThroughDataMovPerC
         auto new_shape = ov::Shape(parent->get_input_partial_shape(0).size(), 1);
 
         new_shape[channel_idx] = const_shape[channel_idx];
-        auto old_const = ov::as_type_ptr<ov::op::v0::Constant>(eltwise->input_value(const_idx).get_node_shared_ptr());
+        auto old_const = ov::as_type_ptr<ov::op::v0::Constant>(eltwise->get_input_node_shared_ptr(const_idx));
         auto new_const = std::make_shared<ov::op::v0::Constant>(*old_const, new_shape);
         ov::replace_node_update_name(old_const, new_const);
         ov::replace_output_update_name(eltwise->output(0), eltwise->input_value(data_flow_idx));

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -574,13 +574,13 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                     return false;
                 }
 
-                auto begin_node = strided_slice_node->input_value(1).get_node_shared_ptr();
+                auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
                 const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
                 if (begin_constant_node == nullptr)
                     return false;
                 auto begin_values = begin_constant_node->cast_vector<int64_t>();
 
-                auto end_node = strided_slice_node->input_value(2).get_node_shared_ptr();
+                auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
                 const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
                 if (end_constant_node == nullptr)
                     return false;
@@ -688,14 +688,14 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 std::vector<std::shared_ptr<Node>> new_slice_in_nodes{};
                 new_slice_in_nodes.push_back(new_concat_node);
 
-                auto begin_node = slice_node->input_value(1).get_node_shared_ptr();
+                auto begin_node = slice_node->get_input_node_shared_ptr(1);
                 const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
                 auto begin_values = begin_constant_node->cast_vector<int64_t>();
                 begin_values[concat_axis] = slice_begin - new_start_value;
                 new_slice_in_nodes.push_back(
                     ov::op::v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
 
-                auto end_node = slice_node->input_value(2).get_node_shared_ptr();
+                auto end_node = slice_node->get_input_node_shared_ptr(2);
                 const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
                 auto end_values = end_constant_node->cast_vector<int64_t>();
                 end_values[concat_axis] = slice_end - new_start_value + 1;
@@ -1209,7 +1209,7 @@ ov::pass::EliminateStridedSlice::EliminateStridedSlice() {
             }
             return;
         };
-        auto begin_node = strided_slice_node->input_value(1).get_node_shared_ptr();
+        auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
         if (const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node)) {
             auto values = begin_constant_node->cast_vector<int64_t>();
             auto begin_mask = strided_slice_node->get_begin_mask();
@@ -1226,7 +1226,7 @@ ov::pass::EliminateStridedSlice::EliminateStridedSlice() {
             return false;
         }
 
-        auto end_node = strided_slice_node->input_value(2).get_node_shared_ptr();
+        auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
         if (const auto& end_constant_node = ov::util::get_constant_from_source(end_node)) {
             int64_t max_value = end_node->get_element_type() == ov::element::i32 ? std::numeric_limits<int32_t>::max()
                                                                                  : std::numeric_limits<int64_t>::max();

--- a/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/nop_elimination.cpp
@@ -574,13 +574,13 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                     return false;
                 }
 
-                auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
+                auto begin_node = strided_slice_node->input_value(1).get_node_shared_ptr();
                 const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
                 if (begin_constant_node == nullptr)
                     return false;
                 auto begin_values = begin_constant_node->cast_vector<int64_t>();
 
-                auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
+                auto end_node = strided_slice_node->input_value(2).get_node_shared_ptr();
                 const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
                 if (end_constant_node == nullptr)
                     return false;
@@ -688,14 +688,14 @@ pass::EliminateConcatStridedSlice::EliminateConcatStridedSlice() {
                 std::vector<std::shared_ptr<Node>> new_slice_in_nodes{};
                 new_slice_in_nodes.push_back(new_concat_node);
 
-                auto begin_node = slice_node->get_input_node_shared_ptr(1);
+                auto begin_node = slice_node->input_value(1).get_node_shared_ptr();
                 const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node);
                 auto begin_values = begin_constant_node->cast_vector<int64_t>();
                 begin_values[concat_axis] = slice_begin - new_start_value;
                 new_slice_in_nodes.push_back(
                     ov::op::v0::Constant::create(ov::element::i64, ov::Shape{begin_values.size()}, begin_values));
 
-                auto end_node = slice_node->get_input_node_shared_ptr(2);
+                auto end_node = slice_node->input_value(2).get_node_shared_ptr();
                 const auto& end_constant_node = ov::util::get_constant_from_source(end_node);
                 auto end_values = end_constant_node->cast_vector<int64_t>();
                 end_values[concat_axis] = slice_end - new_start_value + 1;
@@ -1209,7 +1209,7 @@ ov::pass::EliminateStridedSlice::EliminateStridedSlice() {
             }
             return;
         };
-        auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
+        auto begin_node = strided_slice_node->input_value(1).get_node_shared_ptr();
         if (const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node)) {
             auto values = begin_constant_node->cast_vector<int64_t>();
             auto begin_mask = strided_slice_node->get_begin_mask();
@@ -1226,7 +1226,7 @@ ov::pass::EliminateStridedSlice::EliminateStridedSlice() {
             return false;
         }
 
-        auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
+        auto end_node = strided_slice_node->input_value(2).get_node_shared_ptr();
         if (const auto& end_constant_node = ov::util::get_constant_from_source(end_node)) {
             int64_t max_value = end_node->get_element_type() == ov::element::i32 ? std::numeric_limits<int32_t>::max()
                                                                                  : std::numeric_limits<int64_t>::max();

--- a/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
@@ -40,7 +40,7 @@ bool ov::pass::UselessSliceEraser::run_on_model(const std::shared_ptr<ov::Model>
         if (node->get_input_shape(0) != node->get_output_shape(0))
             continue;
 
-        auto stridesNode = ov::as_type_ptr<ov::op::v0::Constant>(node->input_value(3).get_node_shared_ptr());
+        auto stridesNode = ov::as_type_ptr<ov::op::v0::Constant>(node->get_input_node_shared_ptr(3));
         if (stridesNode) {
             auto strides = stridesNode->cast_vector<int64_t>();
             if (!std::any_of(strides.begin(), strides.end(), [](int64_t strd) {
@@ -251,9 +251,9 @@ bool slice_is_suitable_for_optimization(const std::shared_ptr<ov::op::v8::Slice>
     enum { START = 1, STOP, STRIDE, AXIS };
 
     int64_t stride;
-    if (!get_scalar(op->input_value(STRIDE).get_node_shared_ptr(), stride) || stride != 1)
+    if (!get_scalar(op->get_input_node_shared_ptr(STRIDE), stride) || stride != 1)
         return false;
-    if (!get_scalar(op->input_value(AXIS).get_node_shared_ptr(), attrs.axis))
+    if (!get_scalar(op->get_input_node_shared_ptr(AXIS), attrs.axis))
         return false;
     attrs.axis = attrs.axis >= 0 ? attrs.axis : attrs.axis + rank;
 
@@ -263,7 +263,7 @@ bool slice_is_suitable_for_optimization(const std::shared_ptr<ov::op::v8::Slice>
 
     for (int i = START; i <= STOP; i++) {
         int64_t value;
-        if (!get_scalar(op->input_value(i).get_node_shared_ptr(), value))
+        if (!get_scalar(op->get_input_node_shared_ptr(i), value))
             return false;
         value = value >= 0 ? value : value + dimension;
         value = std::max<int64_t>(std::min(value, dimension), 0);

--- a/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/optimize_strided_slice.cpp
@@ -40,7 +40,7 @@ bool ov::pass::UselessSliceEraser::run_on_model(const std::shared_ptr<ov::Model>
         if (node->get_input_shape(0) != node->get_output_shape(0))
             continue;
 
-        auto stridesNode = ov::as_type_ptr<ov::op::v0::Constant>(node->get_input_node_shared_ptr(3));
+        auto stridesNode = ov::as_type_ptr<ov::op::v0::Constant>(node->input_value(3).get_node_shared_ptr());
         if (stridesNode) {
             auto strides = stridesNode->cast_vector<int64_t>();
             if (!std::any_of(strides.begin(), strides.end(), [](int64_t strd) {
@@ -251,9 +251,9 @@ bool slice_is_suitable_for_optimization(const std::shared_ptr<ov::op::v8::Slice>
     enum { START = 1, STOP, STRIDE, AXIS };
 
     int64_t stride;
-    if (!get_scalar(op->get_input_node_shared_ptr(STRIDE), stride) || stride != 1)
+    if (!get_scalar(op->input_value(STRIDE).get_node_shared_ptr(), stride) || stride != 1)
         return false;
-    if (!get_scalar(op->get_input_node_shared_ptr(AXIS), attrs.axis))
+    if (!get_scalar(op->input_value(AXIS).get_node_shared_ptr(), attrs.axis))
         return false;
     attrs.axis = attrs.axis >= 0 ? attrs.axis : attrs.axis + rank;
 
@@ -263,7 +263,7 @@ bool slice_is_suitable_for_optimization(const std::shared_ptr<ov::op::v8::Slice>
 
     for (int i = START; i <= STOP; i++) {
         int64_t value;
-        if (!get_scalar(op->get_input_node_shared_ptr(i), value))
+        if (!get_scalar(op->input_value(i).get_node_shared_ptr(), value))
             return false;
         value = value >= 0 ? value : value + dimension;
         value = std::max<int64_t>(std::min(value, dimension), 0);

--- a/src/common/transformations/src/transformations/common_optimizations/reduce_merge.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reduce_merge.cpp
@@ -44,7 +44,7 @@ bool fuse_reduce_operations(const std::shared_ptr<Node>& node) {
         return false;
     }
 
-    const auto top_reduce = as_type_ptr<T>(bottom_reduce->get_input_node_shared_ptr(0));
+    const auto top_reduce = as_type_ptr<T>(bottom_reduce->input_value(0).get_node_shared_ptr());
     if (!top_reduce) {
         return false;
     }

--- a/src/common/transformations/src/transformations/common_optimizations/reduce_merge.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reduce_merge.cpp
@@ -44,7 +44,7 @@ bool fuse_reduce_operations(const std::shared_ptr<Node>& node) {
         return false;
     }
 
-    const auto top_reduce = as_type_ptr<T>(bottom_reduce->input_value(0).get_node_shared_ptr());
+    const auto top_reduce = as_type_ptr<T>(bottom_reduce->get_input_node_shared_ptr(0));
     if (!top_reduce) {
         return false;
     }

--- a/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -85,7 +85,8 @@ ov::pass::ReshapeSequenceFusion::ReshapeSequenceFusion(bool use_shape_for_elimin
         NodeVector nodes{pattern_map.at(reshape_a).get_node_shared_ptr(), reshape};
         while (ov::as_type_ptr<ov::op::v1::Reshape>(input.get_node_shared_ptr())) {
             auto node = input.get_node_shared_ptr();
-            if (!has_valid_pattern(node->get_input_node_shared_ptr(1)) || input.get_target_inputs().size() != 1) {
+            if (!has_valid_pattern(node->input_value(1).get_node_shared_ptr()) ||
+                input.get_target_inputs().size() != 1) {
                 break;
             }
             nodes.push_back(node);

--- a/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -85,7 +85,7 @@ ov::pass::ReshapeSequenceFusion::ReshapeSequenceFusion(bool use_shape_for_elimin
         NodeVector nodes{pattern_map.at(reshape_a).get_node_shared_ptr(), reshape};
         while (ov::as_type_ptr<ov::op::v1::Reshape>(input.get_node_shared_ptr())) {
             auto node = input.get_node_shared_ptr();
-            if (!has_valid_pattern(node->get_input_node_shared_ptr(1)) || input.get_target_inputs().size() != 1) {
+            if (!has_valid_pattern(node->input_value(1).get_node_shared_ptr()) || input.get_target_inputs().size() != 1) {
                 break;
             }
             nodes.push_back(node);

--- a/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/reshape_sequence_fusion.cpp
@@ -85,7 +85,7 @@ ov::pass::ReshapeSequenceFusion::ReshapeSequenceFusion(bool use_shape_for_elimin
         NodeVector nodes{pattern_map.at(reshape_a).get_node_shared_ptr(), reshape};
         while (ov::as_type_ptr<ov::op::v1::Reshape>(input.get_node_shared_ptr())) {
             auto node = input.get_node_shared_ptr();
-            if (!has_valid_pattern(node->input_value(1).get_node_shared_ptr()) || input.get_target_inputs().size() != 1) {
+            if (!has_valid_pattern(node->get_input_node_shared_ptr(1)) || input.get_target_inputs().size() != 1) {
                 break;
             }
             nodes.push_back(node);

--- a/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
@@ -64,8 +64,8 @@ bool inputs_from_same_source_or_equal_constants(const std::shared_ptr<Node>& lhs
     for (size_t i = 0; i < input_size; ++i) {
         if (ov::op::util::input_sources_are_equal(lhs, rhs, i))
             continue;
-        auto lhs_constant = as_type_ptr<v0::Constant>(lhs->input_value(i).get_node_shared_ptr());
-        auto rhs_constant = as_type_ptr<v0::Constant>(rhs->input_value(i).get_node_shared_ptr());
+        auto lhs_constant = as_type<v0::Constant>(lhs->get_input_node_ptr(i));
+        auto rhs_constant = as_type<v0::Constant>(rhs->get_input_node_ptr(i));
         if (!lhs_constant || !rhs_constant)
             return false;
         if (lhs_constant->get_element_type() != rhs_constant->get_element_type())

--- a/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
@@ -64,8 +64,8 @@ bool inputs_from_same_source_or_equal_constants(const std::shared_ptr<Node>& lhs
     for (size_t i = 0; i < input_size; ++i) {
         if (ov::op::util::input_sources_are_equal(lhs, rhs, i))
             continue;
-        auto lhs_constant = as_type<v0::Constant>(lhs->get_input_node_ptr(i));
-        auto rhs_constant = as_type<v0::Constant>(rhs->get_input_node_ptr(i));
+        auto lhs_constant = as_type<v0::Constant>(lhs->input_value(i).get_node_shared_ptr());
+        auto rhs_constant = as_type<v0::Constant>(rhs->input_value(i).get_node_shared_ptr());
         if (!lhs_constant || !rhs_constant)
             return false;
         if (lhs_constant->get_element_type() != rhs_constant->get_element_type())

--- a/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/shared_ops_optimization.cpp
@@ -64,8 +64,8 @@ bool inputs_from_same_source_or_equal_constants(const std::shared_ptr<Node>& lhs
     for (size_t i = 0; i < input_size; ++i) {
         if (ov::op::util::input_sources_are_equal(lhs, rhs, i))
             continue;
-        auto lhs_constant = as_type<v0::Constant>(lhs->input_value(i).get_node_shared_ptr());
-        auto rhs_constant = as_type<v0::Constant>(rhs->input_value(i).get_node_shared_ptr());
+        auto lhs_constant = as_type_ptr<v0::Constant>(lhs->input_value(i).get_node_shared_ptr());
+        auto rhs_constant = as_type_ptr<v0::Constant>(rhs->input_value(i).get_node_shared_ptr());
         if (!lhs_constant || !rhs_constant)
             return false;
         if (lhs_constant->get_element_type() != rhs_constant->get_element_type())

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -152,7 +152,7 @@ pass::AbsSinking::AbsSinking() {
 
         bool graph_got_changed = false;
 
-        if (auto concat = as_type_ptr<v0::Concat>(abs_ops[0]->input_value(0).get_node_shared_ptr())) {
+        if (auto concat = as_type_ptr<v0::Concat>(abs_ops[0]->get_input_node_shared_ptr(0))) {
             for (const auto& input : concat->inputs()) {
                 auto new_abs = ov::op::util::make_try_fold<v0::Abs>(input.get_source_output());
                 if (!as_type_ptr<v0::Constant>(new_abs))
@@ -260,7 +260,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
             return false;
         }
 
-        const auto concat = as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
+        const auto concat = as_type_ptr<v0::Concat>(reshape->get_input_node_shared_ptr(1));
         if (!concat)
             return false;
 
@@ -274,7 +274,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
         }
 
         auto check_shape_of_gather = [&](const std::shared_ptr<Node>& gather) {
-            auto shape_of = gather->input_value(0).get_node_shared_ptr();
+            auto shape_of = gather->get_input_node_shared_ptr(0);
             if (!is_type<op::util::ShapeOfBase>(shape_of)) {
                 return false;
             }
@@ -300,8 +300,8 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
         for (auto& concat_input : new_concat_inputs) {
             auto node = concat_input.get_node_shared_ptr();
             if (ov::is_type<op::util::GatherBase>(node) &&
-                ov::is_type<v0::Constant>(node->input_value(1).get_node_shared_ptr()) && check_shape_of_gather(node)) {
-                auto indices_constant = as_type_ptr<v0::Constant>(node->input_value(1).get_node_shared_ptr());
+                ov::is_type<v0::Constant>(node->get_input_node_shared_ptr(1)) && check_shape_of_gather(node)) {
+                auto indices_constant = as_type_ptr<v0::Constant>(node->get_input_node_shared_ptr(1));
                 bool gather_can_be_fused = true;
                 const auto indices = indices_constant->cast_vector<std::int64_t>();
                 for (size_t i = 0; i < indices.size(); ++i) {

--- a/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/simplify_shape_of_sub_graph.cpp
@@ -152,7 +152,7 @@ pass::AbsSinking::AbsSinking() {
 
         bool graph_got_changed = false;
 
-        if (auto concat = as_type_ptr<v0::Concat>(abs_ops[0]->get_input_node_shared_ptr(0))) {
+        if (auto concat = as_type_ptr<v0::Concat>(abs_ops[0]->input_value(0).get_node_shared_ptr())) {
             for (const auto& input : concat->inputs()) {
                 auto new_abs = ov::op::util::make_try_fold<v0::Abs>(input.get_source_output());
                 if (!as_type_ptr<v0::Constant>(new_abs))
@@ -260,7 +260,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
             return false;
         }
 
-        const auto concat = as_type_ptr<v0::Concat>(reshape->get_input_node_shared_ptr(1));
+        const auto concat = as_type_ptr<v0::Concat>(reshape->input_value(1).get_node_shared_ptr());
         if (!concat)
             return false;
 
@@ -274,7 +274,7 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
         }
 
         auto check_shape_of_gather = [&](const std::shared_ptr<Node>& gather) {
-            auto shape_of = gather->get_input_node_shared_ptr(0);
+            auto shape_of = gather->input_value(0).get_node_shared_ptr();
             if (!is_type<op::util::ShapeOfBase>(shape_of)) {
                 return false;
             }
@@ -300,8 +300,8 @@ pass::SimplifySecondInputOfReshape::SimplifySecondInputOfReshape() {
         for (auto& concat_input : new_concat_inputs) {
             auto node = concat_input.get_node_shared_ptr();
             if (ov::is_type<op::util::GatherBase>(node) &&
-                ov::is_type<v0::Constant>(node->get_input_node_shared_ptr(1)) && check_shape_of_gather(node)) {
-                auto indices_constant = as_type_ptr<v0::Constant>(node->get_input_node_shared_ptr(1));
+                ov::is_type<v0::Constant>(node->input_value(1).get_node_shared_ptr()) && check_shape_of_gather(node)) {
+                auto indices_constant = as_type_ptr<v0::Constant>(node->input_value(1).get_node_shared_ptr());
                 bool gather_can_be_fused = true;
                 const auto indices = indices_constant->cast_vector<std::int64_t>();
                 for (size_t i = 0; i < indices.size(); ++i) {

--- a/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
@@ -39,17 +39,17 @@ ov::pass::SplitSqueezeConcatFusion::SplitSqueezeConcatFusion(bool use_shapes) {
         int64_t split_axis = 0;
 
         for (size_t i = 0; i < concat->get_input_size(); i++) {
-            auto squeeze_node = concat->input_value(i).get_node_shared_ptr();
+            auto squeeze_node = concat->get_input_node_shared_ptr(i);
             if (!ov::is_type<ov::op::v0::Squeeze>(squeeze_node) && !ov::is_type<ov::op::v1::Reshape>(squeeze_node))
                 return false;
-            auto split_to_check = ov::as_type_ptr<ov::op::v1::Split>(squeeze_node->input_value(0).get_node_shared_ptr());
+            auto split_to_check = ov::as_type_ptr<ov::op::v1::Split>(squeeze_node->get_input_node_shared_ptr(0));
             if (!split_to_check)
                 return false;
 
             if (i == 0) {
                 nodes_to_delete.push_back(split_to_check);
                 split = split_to_check;
-                auto split_axis_node = ov::as_type_ptr<ov::op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
+                auto split_axis_node = ov::as_type_ptr<ov::op::v0::Constant>(split->get_input_node_shared_ptr(1));
                 if (!split_axis_node)
                     return false;
                 auto axis_vec = split_axis_node->cast_vector<int64_t>();
@@ -156,7 +156,7 @@ bool is_axis_squeezed_by_node(const std::shared_ptr<ov::Node>& squeeze_node, int
             }
         } else {
             // The second Squeeze input has explicit axes
-            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(squeeze_node->input_value(1).get_node_shared_ptr());
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(squeeze_node->get_input_node_shared_ptr(1));
             if (!constant)
                 return false;
             if (ov::shape_size(constant->get_shape()) != 1)

--- a/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
@@ -39,17 +39,19 @@ ov::pass::SplitSqueezeConcatFusion::SplitSqueezeConcatFusion(bool use_shapes) {
         int64_t split_axis = 0;
 
         for (size_t i = 0; i < concat->get_input_size(); i++) {
-            auto squeeze_node = concat->get_input_node_shared_ptr(i);
+            auto squeeze_node = concat->input_value(i).get_node_shared_ptr();
             if (!ov::is_type<ov::op::v0::Squeeze>(squeeze_node) && !ov::is_type<ov::op::v1::Reshape>(squeeze_node))
                 return false;
-            auto split_to_check = ov::as_type_ptr<ov::op::v1::Split>(squeeze_node->get_input_node_shared_ptr(0));
+            auto split_to_check =
+                ov::as_type_ptr<ov::op::v1::Split>(squeeze_node->input_value(0).get_node_shared_ptr());
             if (!split_to_check)
                 return false;
 
             if (i == 0) {
                 nodes_to_delete.push_back(split_to_check);
                 split = split_to_check;
-                auto split_axis_node = ov::as_type_ptr<ov::op::v0::Constant>(split->get_input_node_shared_ptr(1));
+                auto split_axis_node =
+                    ov::as_type_ptr<ov::op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
                 if (!split_axis_node)
                     return false;
                 auto axis_vec = split_axis_node->cast_vector<int64_t>();
@@ -156,7 +158,7 @@ bool is_axis_squeezed_by_node(const std::shared_ptr<ov::Node>& squeeze_node, int
             }
         } else {
             // The second Squeeze input has explicit axes
-            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(squeeze_node->get_input_node_shared_ptr(1));
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(squeeze_node->input_value(1).get_node_shared_ptr());
             if (!constant)
                 return false;
             if (ov::shape_size(constant->get_shape()) != 1)

--- a/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/split_squeeze_concat_fusion.cpp
@@ -39,17 +39,17 @@ ov::pass::SplitSqueezeConcatFusion::SplitSqueezeConcatFusion(bool use_shapes) {
         int64_t split_axis = 0;
 
         for (size_t i = 0; i < concat->get_input_size(); i++) {
-            auto squeeze_node = concat->get_input_node_shared_ptr(i);
+            auto squeeze_node = concat->input_value(i).get_node_shared_ptr();
             if (!ov::is_type<ov::op::v0::Squeeze>(squeeze_node) && !ov::is_type<ov::op::v1::Reshape>(squeeze_node))
                 return false;
-            auto split_to_check = ov::as_type_ptr<ov::op::v1::Split>(squeeze_node->get_input_node_shared_ptr(0));
+            auto split_to_check = ov::as_type_ptr<ov::op::v1::Split>(squeeze_node->input_value(0).get_node_shared_ptr());
             if (!split_to_check)
                 return false;
 
             if (i == 0) {
                 nodes_to_delete.push_back(split_to_check);
                 split = split_to_check;
-                auto split_axis_node = ov::as_type_ptr<ov::op::v0::Constant>(split->get_input_node_shared_ptr(1));
+                auto split_axis_node = ov::as_type_ptr<ov::op::v0::Constant>(split->input_value(1).get_node_shared_ptr());
                 if (!split_axis_node)
                     return false;
                 auto axis_vec = split_axis_node->cast_vector<int64_t>();
@@ -156,7 +156,7 @@ bool is_axis_squeezed_by_node(const std::shared_ptr<ov::Node>& squeeze_node, int
             }
         } else {
             // The second Squeeze input has explicit axes
-            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(squeeze_node->get_input_node_shared_ptr(1));
+            auto constant = ov::as_type_ptr<ov::op::v0::Constant>(squeeze_node->input_value(1).get_node_shared_ptr());
             if (!constant)
                 return false;
             if (ov::shape_size(constant->get_shape()) != 1)

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
@@ -179,9 +179,9 @@ ov::pass::TransposeReshapeEliminationForMatmul::TransposeReshapeEliminationForMa
             return false;
 
         auto transpose_before_constant =
-            ov::as_type_ptr<ov::op::v0::Constant>(transpose_before->get_input_node_shared_ptr(1));
+            ov::as_type_ptr<ov::op::v0::Constant>(transpose_before->input_value(1).get_node_shared_ptr());
         auto transpose_after_constant =
-            ov::as_type_ptr<ov::op::v0::Constant>(transpose_after->get_input_node_shared_ptr(1));
+            ov::as_type_ptr<ov::op::v0::Constant>(transpose_after->input_value(1).get_node_shared_ptr());
         if (!transpose_before_constant || !transpose_after_constant)
             return false;
 
@@ -200,7 +200,7 @@ ov::pass::TransposeReshapeEliminationForMatmul::TransposeReshapeEliminationForMa
                 return false;
             }
             auto broadcast_before_constant =
-                ov::as_type_ptr<ov::op::v0::Constant>(broadcast_before->get_input_node_shared_ptr(1));
+                ov::as_type_ptr<ov::op::v0::Constant>(broadcast_before->input_value(1).get_node_shared_ptr());
             if (!broadcast_before_constant) {
                 return false;
             }

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_reshape_elimination_for_matmul.cpp
@@ -179,9 +179,9 @@ ov::pass::TransposeReshapeEliminationForMatmul::TransposeReshapeEliminationForMa
             return false;
 
         auto transpose_before_constant =
-            ov::as_type_ptr<ov::op::v0::Constant>(transpose_before->input_value(1).get_node_shared_ptr());
+            ov::as_type_ptr<ov::op::v0::Constant>(transpose_before->get_input_node_shared_ptr(1));
         auto transpose_after_constant =
-            ov::as_type_ptr<ov::op::v0::Constant>(transpose_after->input_value(1).get_node_shared_ptr());
+            ov::as_type_ptr<ov::op::v0::Constant>(transpose_after->get_input_node_shared_ptr(1));
         if (!transpose_before_constant || !transpose_after_constant)
             return false;
 
@@ -200,7 +200,7 @@ ov::pass::TransposeReshapeEliminationForMatmul::TransposeReshapeEliminationForMa
                 return false;
             }
             auto broadcast_before_constant =
-                ov::as_type_ptr<ov::op::v0::Constant>(broadcast_before->input_value(1).get_node_shared_ptr());
+                ov::as_type_ptr<ov::op::v0::Constant>(broadcast_before->get_input_node_shared_ptr(1));
             if (!broadcast_before_constant) {
                 return false;
             }

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -177,8 +177,8 @@ ov::pass::TransposeReduction::TransposeReduction() {
         else if (arithmetic_reduce)
             keep_dims = arithmetic_reduce->get_keep_dims();
 
-        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
-        auto reduction_axes = ov::as_type_ptr<ov::op::v0::Constant>(reduction->input_value(1).get_node_shared_ptr());
+        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto reduction_axes = ov::as_type_ptr<ov::op::v0::Constant>(reduction->get_input_node_shared_ptr(1));
         if (!transpose_order || !reduction_axes)
             return false;
 
@@ -242,7 +242,7 @@ ov::pass::TransposeFQReduction::TransposeFQReduction() {
         if (!transpose)
             return false;
 
-        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
         auto fq = pattern_to_output.at(fq_label).get_node_shared_ptr();
         if (!transpose_order || !fq)
             return false;
@@ -306,8 +306,8 @@ ov::pass::TransposeFuse::TransposeFuse() {
         auto transpose2 = pattern_to_output.at(transpose_2).get_node_shared_ptr();
         auto input = transpose1->input_value(0);
 
-        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->input_value(1).get_node_shared_ptr());
-        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->input_value(1).get_node_shared_ptr());
+        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
+        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
         if (!transpose1_order || !transpose2_order)
             return false;
 

--- a/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/transpose_sinking.cpp
@@ -177,8 +177,8 @@ ov::pass::TransposeReduction::TransposeReduction() {
         else if (arithmetic_reduce)
             keep_dims = arithmetic_reduce->get_keep_dims();
 
-        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
-        auto reduction_axes = ov::as_type_ptr<ov::op::v0::Constant>(reduction->get_input_node_shared_ptr(1));
+        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        auto reduction_axes = ov::as_type_ptr<ov::op::v0::Constant>(reduction->input_value(1).get_node_shared_ptr());
         if (!transpose_order || !reduction_axes)
             return false;
 
@@ -242,7 +242,7 @@ ov::pass::TransposeFQReduction::TransposeFQReduction() {
         if (!transpose)
             return false;
 
-        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
         auto fq = pattern_to_output.at(fq_label).get_node_shared_ptr();
         if (!transpose_order || !fq)
             return false;
@@ -306,8 +306,8 @@ ov::pass::TransposeFuse::TransposeFuse() {
         auto transpose2 = pattern_to_output.at(transpose_2).get_node_shared_ptr();
         auto input = transpose1->input_value(0);
 
-        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
-        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
+        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->input_value(1).get_node_shared_ptr());
+        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->input_value(1).get_node_shared_ptr());
         if (!transpose1_order || !transpose2_order)
             return false;
 

--- a/src/common/transformations/src/transformations/op_conversions/convert_convertpromotetypes.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_convertpromotetypes.cpp
@@ -29,9 +29,9 @@ ov::pass::ConvertConvertPromoteTypes::ConvertConvertPromoteTypes() {
         NodeRegistry node_registry;
         const auto out0 = node_registry.make<ov::op::v0::Convert>(convert_promote_types->input_value(0), dest_type);
         const auto out1 = node_registry.make<ov::op::v0::Convert>(convert_promote_types->input_value(1), dest_type);
-        out0->set_friendly_name(convert_promote_types->get_input_node_shared_ptr(0)->get_friendly_name() + "/" +
+        out0->set_friendly_name(convert_promote_types->input_value(0).get_node_shared_ptr()->get_friendly_name() + "/" +
                                 friendly_name + ".0");
-        out1->set_friendly_name(convert_promote_types->get_input_node_shared_ptr(1)->get_friendly_name() + "/" +
+        out1->set_friendly_name(convert_promote_types->input_value(1).get_node_shared_ptr()->get_friendly_name() + "/" +
                                 friendly_name + ".1");
         copy_runtime_info(convert_promote_types, node_registry.get());
         replace_node(convert_promote_types, {out0, out1});

--- a/src/common/transformations/src/transformations/op_conversions/convert_convertpromotetypes.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_convertpromotetypes.cpp
@@ -29,9 +29,9 @@ ov::pass::ConvertConvertPromoteTypes::ConvertConvertPromoteTypes() {
         NodeRegistry node_registry;
         const auto out0 = node_registry.make<ov::op::v0::Convert>(convert_promote_types->input_value(0), dest_type);
         const auto out1 = node_registry.make<ov::op::v0::Convert>(convert_promote_types->input_value(1), dest_type);
-        out0->set_friendly_name(convert_promote_types->input_value(0).get_node_shared_ptr()->get_friendly_name() + "/" +
+        out0->set_friendly_name(convert_promote_types->get_input_node_shared_ptr(0)->get_friendly_name() + "/" +
                                 friendly_name + ".0");
-        out1->set_friendly_name(convert_promote_types->input_value(1).get_node_shared_ptr()->get_friendly_name() + "/" +
+        out1->set_friendly_name(convert_promote_types->get_input_node_shared_ptr(1)->get_friendly_name() + "/" +
                                 friendly_name + ".1");
         copy_runtime_info(convert_promote_types, node_registry.get());
         replace_node(convert_promote_types, {out0, out1});

--- a/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
@@ -32,7 +32,7 @@ bool convert_divide(std::shared_ptr<ov::Node> node) {
         div->input_value(1),
         ov::op::v0::Constant::create(div->get_input_element_type(1), ov::Shape{}, {-1}));
 
-    if (ov::as_type_ptr<ov::op::v0::Constant>(div->input_value(1).get_node_shared_ptr())) {
+    if (ov::as_type_ptr<ov::op::v0::Constant>(div->get_input_node_shared_ptr(1))) {
         if (auto const_pow = ov::util::get_constant_from_source(pow)) {
             pow = const_pow;
         } else {

--- a/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_divide.cpp
@@ -32,7 +32,7 @@ bool convert_divide(std::shared_ptr<ov::Node> node) {
         div->input_value(1),
         ov::op::v0::Constant::create(div->get_input_element_type(1), ov::Shape{}, {-1}));
 
-    if (ov::as_type_ptr<ov::op::v0::Constant>(div->get_input_node_shared_ptr(1))) {
+    if (ov::as_type_ptr<ov::op::v0::Constant>(div->input_value(1).get_node_shared_ptr())) {
         if (auto const_pow = ov::util::get_constant_from_source(pow)) {
             pow = const_pow;
         } else {

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -490,7 +490,7 @@ bool check_lstm_cell_pattern(
                 return false;
             }
             const auto& hidden_state_result = body_results[merged_desc->m_body_value_index];
-            if ((hidden_state_result->get_input_node_shared_ptr(0) != lstm_cell_node) ||
+            if ((hidden_state_result->input_value(0).get_node_shared_ptr() != lstm_cell_node) ||
                 (hidden_state_result->input_value(0).get_index() != 0)) {
                 return false;
             }
@@ -502,7 +502,7 @@ bool check_lstm_cell_pattern(
                 return false;
             }
             const auto& cell_state_result = body_results[merged_desc->m_body_value_index];
-            if ((cell_state_result->get_input_node_shared_ptr(0) != lstm_cell_node) ||
+            if ((cell_state_result->input_value(0).get_node_shared_ptr() != lstm_cell_node) ||
                 (cell_state_result->input_value(0).get_index() != 1)) {
                 return false;
             }
@@ -1348,16 +1348,16 @@ public:
 
             const auto shapeof_gather = pattern_map.at(shapeof_gather_label).get_node_shared_ptr();
             const auto shapeof_gather_indexes_node =
-                ov::as_type_ptr<op::v0::Constant>(shapeof_gather->get_input_node_shared_ptr(1));
+                ov::as_type_ptr<op::v0::Constant>(shapeof_gather->input_value(1).get_node_shared_ptr());
             auto shapeof_gather_indexes = shapeof_gather_indexes_node->cast_vector<int64_t>();
             if (shapeof_gather_indexes.size() != 3)
                 return false;
             const auto shapeof_gather2 = pattern_map.at(shapeof_gather2_label).get_node_shared_ptr();
             int64_t shapeof_gather2_index = -1;
             int64_t shapeof_gather2_axis = -1;
-            if (!get_constant_value(shapeof_gather2->get_input_node_shared_ptr(1), shapeof_gather2_index))
+            if (!get_constant_value(shapeof_gather2->input_value(1).get_node_shared_ptr(), shapeof_gather2_index))
                 return false;
-            if (!get_constant_value(shapeof_gather2->get_input_node_shared_ptr(2), shapeof_gather2_axis) ||
+            if (!get_constant_value(shapeof_gather2->input_value(2).get_node_shared_ptr(), shapeof_gather2_axis) ||
                 shapeof_gather2_axis != 0)
                 return false;
             const auto reshape = pattern_map.at(reshape_label).get_node_shared_ptr();
@@ -1367,13 +1367,13 @@ public:
             const auto range = pattern_map.at(range_label).get_node_shared_ptr();
             int64_t range_start = -1;
             int64_t range_step = -1;
-            if (!get_constant_value(range->get_input_node_shared_ptr(0), range_start) || range_start != 0)
+            if (!get_constant_value(range->input_value(0).get_node_shared_ptr(), range_start) || range_start != 0)
                 return false;
-            if (!get_constant_value(range->get_input_node_shared_ptr(2), range_step) || range_step != 1)
+            if (!get_constant_value(range->input_value(2).get_node_shared_ptr(), range_step) || range_step != 1)
                 return false;
 
             int64_t gather_axis = -1;
-            if (!get_constant_value(gather->get_input_node_shared_ptr(2), gather_axis) ||
+            if (!get_constant_value(gather->input_value(2).get_node_shared_ptr(), gather_axis) ||
                 gather_axis != shapeof_gather_indexes[shapeof_gather2_index])
                 return false;
 
@@ -1415,7 +1415,7 @@ ov::pass::FuseReverseLSTMSequence::FuseReverseLSTMSequence() {
         const auto& data = pattern_map.at(data_label);
         const auto second_transpose = pattern_map.at(second_transpose_label).get_node_shared_ptr();
         const auto second_transpose_perm =
-            ov::as_type_ptr<op::v0::Constant>(second_transpose->get_input_node_shared_ptr(1));
+            ov::as_type_ptr<op::v0::Constant>(second_transpose->input_value(1).get_node_shared_ptr());
         auto lstm = ov::as_type_ptr<op::v5::LSTMSequence>(pattern_map.at(lstm_label).get_node_shared_ptr());
         if (lstm->get_direction() != op::v5::LSTMSequence::direction::FORWARD)
             return false;
@@ -1492,7 +1492,7 @@ ov::pass::FuseReverseLSTMSequence::FuseReverseLSTMSequence() {
         if (squeeze->input_value(0) != lstm->output(0))
             return false;
         int64_t squeeze_axis = -1;
-        if (!get_constant_value(squeeze->get_input_node_shared_ptr(1), squeeze_axis) || squeeze_axis != 1)
+        if (!get_constant_value(squeeze->input_value(1).get_node_shared_ptr(), squeeze_axis) || squeeze_axis != 1)
             return false;
         auto new_squeeze = node_registry.make<op::v0::Squeeze>(new_lstm->output(0), squeeze->input_value(1));
         const auto match_root = m.get_match_root();
@@ -1609,7 +1609,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
         if (squeeze_forward->input_value(0) != lstm_forward->output(0))
             return false;
         int64_t squeeze_forward_axis = -1;
-        if (!get_constant_value(squeeze_forward->get_input_node_shared_ptr(1), squeeze_forward_axis) ||
+        if (!get_constant_value(squeeze_forward->input_value(1).get_node_shared_ptr(), squeeze_forward_axis) ||
             squeeze_forward_axis != 1)
             return false;
 
@@ -1617,7 +1617,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
         if (squeeze_reverse->input_value(0) != lstm_reverse->output(0))
             return false;
         int64_t squeeze_reverse_axis = -1;
-        if (!get_constant_value(squeeze_reverse->get_input_node_shared_ptr(1), squeeze_reverse_axis) ||
+        if (!get_constant_value(squeeze_reverse->input_value(1).get_node_shared_ptr(), squeeze_reverse_axis) ||
             squeeze_reverse_axis != 1)
             return false;
 
@@ -1667,17 +1667,17 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
             auto gather_forward = pattern_map.at(gather_forward_label);
             int64_t gather_index = -1;
             int64_t gather_axis = -1;
-            if (!get_constant_value(gather_forward->get_input_node_shared_ptr(1), gather_index) || gather_index != 0)
+            if (!get_constant_value(gather_forward->input_value(1).get_node_shared_ptr(), gather_index) || gather_index != 0)
                 return false;
-            if (!get_constant_value(gather_forward->get_input_node_shared_ptr(2), gather_axis) || gather_axis != 0)
+            if (!get_constant_value(gather_forward->input_value(2).get_node_shared_ptr(), gather_axis) || gather_axis != 0)
                 return false;
 
             auto gather_reverse = pattern_map.at(gather_reverse_label);
             gather_index = -1;
             gather_axis = -1;
-            if (!get_constant_value(gather_reverse->get_input_node_shared_ptr(1), gather_index) || gather_index != 0)
+            if (!get_constant_value(gather_reverse->input_value(1).get_node_shared_ptr(), gather_index) || gather_index != 0)
                 return false;
-            if (!get_constant_value(gather_reverse->get_input_node_shared_ptr(2), gather_axis) || gather_axis != 0)
+            if (!get_constant_value(gather_reverse->input_value(2).get_node_shared_ptr(), gather_axis) || gather_axis != 0)
                 return false;
 
             from.push_back(max_sequence_len_forward);

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -490,7 +490,7 @@ bool check_lstm_cell_pattern(
                 return false;
             }
             const auto& hidden_state_result = body_results[merged_desc->m_body_value_index];
-            if ((hidden_state_result->input_value(0).get_node_shared_ptr() != lstm_cell_node) ||
+            if ((hidden_state_result->get_input_node_shared_ptr(0) != lstm_cell_node) ||
                 (hidden_state_result->input_value(0).get_index() != 0)) {
                 return false;
             }
@@ -502,7 +502,7 @@ bool check_lstm_cell_pattern(
                 return false;
             }
             const auto& cell_state_result = body_results[merged_desc->m_body_value_index];
-            if ((cell_state_result->input_value(0).get_node_shared_ptr() != lstm_cell_node) ||
+            if ((cell_state_result->get_input_node_shared_ptr(0) != lstm_cell_node) ||
                 (cell_state_result->input_value(0).get_index() != 1)) {
                 return false;
             }
@@ -1348,16 +1348,16 @@ public:
 
             const auto shapeof_gather = pattern_map.at(shapeof_gather_label).get_node_shared_ptr();
             const auto shapeof_gather_indexes_node =
-                ov::as_type_ptr<op::v0::Constant>(shapeof_gather->input_value(1).get_node_shared_ptr());
+                ov::as_type_ptr<op::v0::Constant>(shapeof_gather->get_input_node_shared_ptr(1));
             auto shapeof_gather_indexes = shapeof_gather_indexes_node->cast_vector<int64_t>();
             if (shapeof_gather_indexes.size() != 3)
                 return false;
             const auto shapeof_gather2 = pattern_map.at(shapeof_gather2_label).get_node_shared_ptr();
             int64_t shapeof_gather2_index = -1;
             int64_t shapeof_gather2_axis = -1;
-            if (!get_constant_value(shapeof_gather2->input_value(1).get_node_shared_ptr(), shapeof_gather2_index))
+            if (!get_constant_value(shapeof_gather2->get_input_node_shared_ptr(1), shapeof_gather2_index))
                 return false;
-            if (!get_constant_value(shapeof_gather2->input_value(2).get_node_shared_ptr(), shapeof_gather2_axis) ||
+            if (!get_constant_value(shapeof_gather2->get_input_node_shared_ptr(2), shapeof_gather2_axis) ||
                 shapeof_gather2_axis != 0)
                 return false;
             const auto reshape = pattern_map.at(reshape_label).get_node_shared_ptr();
@@ -1367,13 +1367,13 @@ public:
             const auto range = pattern_map.at(range_label).get_node_shared_ptr();
             int64_t range_start = -1;
             int64_t range_step = -1;
-            if (!get_constant_value(range->input_value(0).get_node_shared_ptr(), range_start) || range_start != 0)
+            if (!get_constant_value(range->get_input_node_shared_ptr(0), range_start) || range_start != 0)
                 return false;
-            if (!get_constant_value(range->input_value(2).get_node_shared_ptr(), range_step) || range_step != 1)
+            if (!get_constant_value(range->get_input_node_shared_ptr(2), range_step) || range_step != 1)
                 return false;
 
             int64_t gather_axis = -1;
-            if (!get_constant_value(gather->input_value(2).get_node_shared_ptr(), gather_axis) ||
+            if (!get_constant_value(gather->get_input_node_shared_ptr(2), gather_axis) ||
                 gather_axis != shapeof_gather_indexes[shapeof_gather2_index])
                 return false;
 
@@ -1415,7 +1415,7 @@ ov::pass::FuseReverseLSTMSequence::FuseReverseLSTMSequence() {
         const auto& data = pattern_map.at(data_label);
         const auto second_transpose = pattern_map.at(second_transpose_label).get_node_shared_ptr();
         const auto second_transpose_perm =
-            ov::as_type_ptr<op::v0::Constant>(second_transpose->input_value(1).get_node_shared_ptr());
+            ov::as_type_ptr<op::v0::Constant>(second_transpose->get_input_node_shared_ptr(1));
         auto lstm = ov::as_type_ptr<op::v5::LSTMSequence>(pattern_map.at(lstm_label).get_node_shared_ptr());
         if (lstm->get_direction() != op::v5::LSTMSequence::direction::FORWARD)
             return false;
@@ -1492,7 +1492,7 @@ ov::pass::FuseReverseLSTMSequence::FuseReverseLSTMSequence() {
         if (squeeze->input_value(0) != lstm->output(0))
             return false;
         int64_t squeeze_axis = -1;
-        if (!get_constant_value(squeeze->input_value(1).get_node_shared_ptr(), squeeze_axis) || squeeze_axis != 1)
+        if (!get_constant_value(squeeze->get_input_node_shared_ptr(1), squeeze_axis) || squeeze_axis != 1)
             return false;
         auto new_squeeze = node_registry.make<op::v0::Squeeze>(new_lstm->output(0), squeeze->input_value(1));
         const auto match_root = m.get_match_root();
@@ -1609,7 +1609,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
         if (squeeze_forward->input_value(0) != lstm_forward->output(0))
             return false;
         int64_t squeeze_forward_axis = -1;
-        if (!get_constant_value(squeeze_forward->input_value(1).get_node_shared_ptr(), squeeze_forward_axis) ||
+        if (!get_constant_value(squeeze_forward->get_input_node_shared_ptr(1), squeeze_forward_axis) ||
             squeeze_forward_axis != 1)
             return false;
 
@@ -1617,7 +1617,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
         if (squeeze_reverse->input_value(0) != lstm_reverse->output(0))
             return false;
         int64_t squeeze_reverse_axis = -1;
-        if (!get_constant_value(squeeze_reverse->input_value(1).get_node_shared_ptr(), squeeze_reverse_axis) ||
+        if (!get_constant_value(squeeze_reverse->get_input_node_shared_ptr(1), squeeze_reverse_axis) ||
             squeeze_reverse_axis != 1)
             return false;
 
@@ -1667,17 +1667,17 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
             auto gather_forward = pattern_map.at(gather_forward_label);
             int64_t gather_index = -1;
             int64_t gather_axis = -1;
-            if (!get_constant_value(gather_forward->input_value(1).get_node_shared_ptr(), gather_index) || gather_index != 0)
+            if (!get_constant_value(gather_forward->get_input_node_shared_ptr(1), gather_index) || gather_index != 0)
                 return false;
-            if (!get_constant_value(gather_forward->input_value(2).get_node_shared_ptr(), gather_axis) || gather_axis != 0)
+            if (!get_constant_value(gather_forward->get_input_node_shared_ptr(2), gather_axis) || gather_axis != 0)
                 return false;
 
             auto gather_reverse = pattern_map.at(gather_reverse_label);
             gather_index = -1;
             gather_axis = -1;
-            if (!get_constant_value(gather_reverse->input_value(1).get_node_shared_ptr(), gather_index) || gather_index != 0)
+            if (!get_constant_value(gather_reverse->get_input_node_shared_ptr(1), gather_index) || gather_index != 0)
                 return false;
-            if (!get_constant_value(gather_reverse->input_value(2).get_node_shared_ptr(), gather_axis) || gather_axis != 0)
+            if (!get_constant_value(gather_reverse->get_input_node_shared_ptr(2), gather_axis) || gather_axis != 0)
                 return false;
 
             from.push_back(max_sequence_len_forward);

--- a/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/convert_ti_to_sequences.cpp
@@ -490,7 +490,7 @@ bool check_lstm_cell_pattern(
                 return false;
             }
             const auto& hidden_state_result = body_results[merged_desc->m_body_value_index];
-            if ((hidden_state_result->get_input_node_shared_ptr(0) != lstm_cell_node) ||
+            if ((hidden_state_result->input_value(0).get_node_shared_ptr() != lstm_cell_node) ||
                 (hidden_state_result->input_value(0).get_index() != 0)) {
                 return false;
             }
@@ -502,7 +502,7 @@ bool check_lstm_cell_pattern(
                 return false;
             }
             const auto& cell_state_result = body_results[merged_desc->m_body_value_index];
-            if ((cell_state_result->get_input_node_shared_ptr(0) != lstm_cell_node) ||
+            if ((cell_state_result->input_value(0).get_node_shared_ptr() != lstm_cell_node) ||
                 (cell_state_result->input_value(0).get_index() != 1)) {
                 return false;
             }
@@ -1348,16 +1348,16 @@ public:
 
             const auto shapeof_gather = pattern_map.at(shapeof_gather_label).get_node_shared_ptr();
             const auto shapeof_gather_indexes_node =
-                ov::as_type_ptr<op::v0::Constant>(shapeof_gather->get_input_node_shared_ptr(1));
+                ov::as_type_ptr<op::v0::Constant>(shapeof_gather->input_value(1).get_node_shared_ptr());
             auto shapeof_gather_indexes = shapeof_gather_indexes_node->cast_vector<int64_t>();
             if (shapeof_gather_indexes.size() != 3)
                 return false;
             const auto shapeof_gather2 = pattern_map.at(shapeof_gather2_label).get_node_shared_ptr();
             int64_t shapeof_gather2_index = -1;
             int64_t shapeof_gather2_axis = -1;
-            if (!get_constant_value(shapeof_gather2->get_input_node_shared_ptr(1), shapeof_gather2_index))
+            if (!get_constant_value(shapeof_gather2->input_value(1).get_node_shared_ptr(), shapeof_gather2_index))
                 return false;
-            if (!get_constant_value(shapeof_gather2->get_input_node_shared_ptr(2), shapeof_gather2_axis) ||
+            if (!get_constant_value(shapeof_gather2->input_value(2).get_node_shared_ptr(), shapeof_gather2_axis) ||
                 shapeof_gather2_axis != 0)
                 return false;
             const auto reshape = pattern_map.at(reshape_label).get_node_shared_ptr();
@@ -1367,13 +1367,13 @@ public:
             const auto range = pattern_map.at(range_label).get_node_shared_ptr();
             int64_t range_start = -1;
             int64_t range_step = -1;
-            if (!get_constant_value(range->get_input_node_shared_ptr(0), range_start) || range_start != 0)
+            if (!get_constant_value(range->input_value(0).get_node_shared_ptr(), range_start) || range_start != 0)
                 return false;
-            if (!get_constant_value(range->get_input_node_shared_ptr(2), range_step) || range_step != 1)
+            if (!get_constant_value(range->input_value(2).get_node_shared_ptr(), range_step) || range_step != 1)
                 return false;
 
             int64_t gather_axis = -1;
-            if (!get_constant_value(gather->get_input_node_shared_ptr(2), gather_axis) ||
+            if (!get_constant_value(gather->input_value(2).get_node_shared_ptr(), gather_axis) ||
                 gather_axis != shapeof_gather_indexes[shapeof_gather2_index])
                 return false;
 
@@ -1415,7 +1415,7 @@ ov::pass::FuseReverseLSTMSequence::FuseReverseLSTMSequence() {
         const auto& data = pattern_map.at(data_label);
         const auto second_transpose = pattern_map.at(second_transpose_label).get_node_shared_ptr();
         const auto second_transpose_perm =
-            ov::as_type_ptr<op::v0::Constant>(second_transpose->get_input_node_shared_ptr(1));
+            ov::as_type_ptr<op::v0::Constant>(second_transpose->input_value(1).get_node_shared_ptr());
         auto lstm = ov::as_type_ptr<op::v5::LSTMSequence>(pattern_map.at(lstm_label).get_node_shared_ptr());
         if (lstm->get_direction() != op::v5::LSTMSequence::direction::FORWARD)
             return false;
@@ -1492,7 +1492,7 @@ ov::pass::FuseReverseLSTMSequence::FuseReverseLSTMSequence() {
         if (squeeze->input_value(0) != lstm->output(0))
             return false;
         int64_t squeeze_axis = -1;
-        if (!get_constant_value(squeeze->get_input_node_shared_ptr(1), squeeze_axis) || squeeze_axis != 1)
+        if (!get_constant_value(squeeze->input_value(1).get_node_shared_ptr(), squeeze_axis) || squeeze_axis != 1)
             return false;
         auto new_squeeze = node_registry.make<op::v0::Squeeze>(new_lstm->output(0), squeeze->input_value(1));
         const auto match_root = m.get_match_root();
@@ -1609,7 +1609,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
         if (squeeze_forward->input_value(0) != lstm_forward->output(0))
             return false;
         int64_t squeeze_forward_axis = -1;
-        if (!get_constant_value(squeeze_forward->get_input_node_shared_ptr(1), squeeze_forward_axis) ||
+        if (!get_constant_value(squeeze_forward->input_value(1).get_node_shared_ptr(), squeeze_forward_axis) ||
             squeeze_forward_axis != 1)
             return false;
 
@@ -1617,7 +1617,7 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
         if (squeeze_reverse->input_value(0) != lstm_reverse->output(0))
             return false;
         int64_t squeeze_reverse_axis = -1;
-        if (!get_constant_value(squeeze_reverse->get_input_node_shared_ptr(1), squeeze_reverse_axis) ||
+        if (!get_constant_value(squeeze_reverse->input_value(1).get_node_shared_ptr(), squeeze_reverse_axis) ||
             squeeze_reverse_axis != 1)
             return false;
 
@@ -1667,17 +1667,21 @@ ov::pass::FuseLSTMSequencesToBidirectionalLSTMSequence::FuseLSTMSequencesToBidir
             auto gather_forward = pattern_map.at(gather_forward_label);
             int64_t gather_index = -1;
             int64_t gather_axis = -1;
-            if (!get_constant_value(gather_forward->get_input_node_shared_ptr(1), gather_index) || gather_index != 0)
+            if (!get_constant_value(gather_forward->input_value(1).get_node_shared_ptr(), gather_index) ||
+                gather_index != 0)
                 return false;
-            if (!get_constant_value(gather_forward->get_input_node_shared_ptr(2), gather_axis) || gather_axis != 0)
+            if (!get_constant_value(gather_forward->input_value(2).get_node_shared_ptr(), gather_axis) ||
+                gather_axis != 0)
                 return false;
 
             auto gather_reverse = pattern_map.at(gather_reverse_label);
             gather_index = -1;
             gather_axis = -1;
-            if (!get_constant_value(gather_reverse->get_input_node_shared_ptr(1), gather_index) || gather_index != 0)
+            if (!get_constant_value(gather_reverse->input_value(1).get_node_shared_ptr(), gather_index) ||
+                gather_index != 0)
                 return false;
-            if (!get_constant_value(gather_reverse->get_input_node_shared_ptr(2), gather_axis) || gather_axis != 0)
+            if (!get_constant_value(gather_reverse->input_value(2).get_node_shared_ptr(), gather_axis) ||
+                gather_axis != 0)
                 return false;
 
             from.push_back(max_sequence_len_forward);

--- a/src/common/transformations/src/transformations/op_conversions/hard_sigmoid_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/hard_sigmoid_decomposition.cpp
@@ -46,8 +46,13 @@ ov::pass::HardSigmoidDecomposition::HardSigmoidDecomposition() {
         max->set_friendly_name(m.get_match_root()->get_friendly_name());
         ov::copy_runtime_info(hard_sigmoid_node,
                               {alpha_constant.get_node_shared_ptr(),
-                                  multiply, betta_constant.get_node_shared_ptr(),
-                                  add, min_constant, min, max_constant, max});
+                               multiply,
+                               betta_constant.get_node_shared_ptr(),
+                               add,
+                               min_constant,
+                               min,
+                               max_constant,
+                               max});
         ov::replace_node(m.get_match_root(), max);
         return true;
     };

--- a/src/common/transformations/src/transformations/op_conversions/hard_sigmoid_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/hard_sigmoid_decomposition.cpp
@@ -30,10 +30,10 @@ ov::pass::HardSigmoidDecomposition::HardSigmoidDecomposition() {
             return false;
         }
 
-        auto alpha_constant = hard_sigmoid_node->input_value(1).get_node_shared_ptr();
+        auto alpha_constant = hard_sigmoid_node->input_value(1);
         auto multiply = std::make_shared<ov::op::v1::Multiply>(hard_sigmoid_node->input_value(0), alpha_constant);
 
-        auto betta_constant = hard_sigmoid_node->input_value(2).get_node_shared_ptr();
+        auto betta_constant = hard_sigmoid_node->input_value(2);
         auto add = std::make_shared<ov::op::v1::Add>(multiply, betta_constant);
 
         auto input_type = hard_sigmoid_node->input_value(0).get_element_type();
@@ -45,7 +45,9 @@ ov::pass::HardSigmoidDecomposition::HardSigmoidDecomposition() {
 
         max->set_friendly_name(m.get_match_root()->get_friendly_name());
         ov::copy_runtime_info(hard_sigmoid_node,
-                              {alpha_constant, multiply, betta_constant, add, min_constant, min, max_constant, max});
+                              {alpha_constant.get_node_shared_ptr(),
+                                  multiply, betta_constant.get_node_shared_ptr(),
+                                  add, min_constant, min, max_constant, max});
         ov::replace_node(m.get_match_root(), max);
         return true;
     };

--- a/src/common/transformations/src/transformations/op_conversions/hard_sigmoid_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/hard_sigmoid_decomposition.cpp
@@ -30,10 +30,10 @@ ov::pass::HardSigmoidDecomposition::HardSigmoidDecomposition() {
             return false;
         }
 
-        auto alpha_constant = hard_sigmoid_node->get_input_node_shared_ptr(1);
+        auto alpha_constant = hard_sigmoid_node->input_value(1).get_node_shared_ptr();
         auto multiply = std::make_shared<ov::op::v1::Multiply>(hard_sigmoid_node->input_value(0), alpha_constant);
 
-        auto betta_constant = hard_sigmoid_node->get_input_node_shared_ptr(2);
+        auto betta_constant = hard_sigmoid_node->input_value(2).get_node_shared_ptr();
         auto add = std::make_shared<ov::op::v1::Add>(multiply, betta_constant);
 
         auto input_type = hard_sigmoid_node->input_value(0).get_element_type();

--- a/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
@@ -132,11 +132,11 @@ bool relax_batch_for_initial_states_of_lstm_in_ti(const shared_ptr<ov::op::v0::T
     auto batch_delivering_node = deduce_outer_source_of_batch_for_inner_lstm_cell(ti, lstm_cell);
     if (batch_delivering_node == nullptr)
         return rewritten;
-    if (auto init_hidden_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->input_value(1).get_node_shared_ptr())) {
+    if (auto init_hidden_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
         auto outer_init_hidden_state_input = get_outer_input_of_ti_by_parameter(init_hidden_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_hidden_state_input, batch_delivering_node) || rewritten;
     }
-    if (auto init_cell_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->input_value(2).get_node_shared_ptr())) {
+    if (auto init_cell_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
         auto outer_init_cell_state_input = get_outer_input_of_ti_by_parameter(init_cell_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_cell_state_input, batch_delivering_node) || rewritten;
     }

--- a/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
@@ -132,11 +132,13 @@ bool relax_batch_for_initial_states_of_lstm_in_ti(const shared_ptr<ov::op::v0::T
     auto batch_delivering_node = deduce_outer_source_of_batch_for_inner_lstm_cell(ti, lstm_cell);
     if (batch_delivering_node == nullptr)
         return rewritten;
-    if (auto init_hidden_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
+    if (auto init_hidden_state =
+            ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->input_value(1).get_node_shared_ptr())) {
         auto outer_init_hidden_state_input = get_outer_input_of_ti_by_parameter(init_hidden_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_hidden_state_input, batch_delivering_node) || rewritten;
     }
-    if (auto init_cell_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
+    if (auto init_cell_state =
+            ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->input_value(2).get_node_shared_ptr())) {
         auto outer_init_cell_state_input = get_outer_input_of_ti_by_parameter(init_cell_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_cell_state_input, batch_delivering_node) || rewritten;
     }

--- a/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/lstm_states_broadcast.cpp
@@ -132,11 +132,11 @@ bool relax_batch_for_initial_states_of_lstm_in_ti(const shared_ptr<ov::op::v0::T
     auto batch_delivering_node = deduce_outer_source_of_batch_for_inner_lstm_cell(ti, lstm_cell);
     if (batch_delivering_node == nullptr)
         return rewritten;
-    if (auto init_hidden_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(1))) {
+    if (auto init_hidden_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->input_value(1).get_node_shared_ptr())) {
         auto outer_init_hidden_state_input = get_outer_input_of_ti_by_parameter(init_hidden_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_hidden_state_input, batch_delivering_node) || rewritten;
     }
-    if (auto init_cell_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->get_input_node_shared_ptr(2))) {
+    if (auto init_cell_state = ov::as_type_ptr<ov::op::v0::Parameter>(lstm_cell->input_value(2).get_node_shared_ptr())) {
         auto outer_init_cell_state_input = get_outer_input_of_ti_by_parameter(init_cell_state, ti);
         rewritten = broadcast_state_by_batch(outer_init_cell_state_input, batch_delivering_node) || rewritten;
     }

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -128,7 +128,7 @@ ov::pass::TransposeMatMul::TransposeMatMul() {
             const auto& input_rank = input->get_output_partial_shape(0).rank();
             if (input_rank.is_static() && input_rank.get_length() >= 2) {
                 if (auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(input)) {
-                    if (auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1))) {
+                    if (auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr())) {
                         const auto& order_vector = order->cast_vector<int64_t>();
                         std::vector<int64_t> fusable_order(input_rank.get_length());
                         std::iota(fusable_order.begin(), fusable_order.end(), 0);

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -128,7 +128,8 @@ ov::pass::TransposeMatMul::TransposeMatMul() {
             const auto& input_rank = input->get_output_partial_shape(0).rank();
             if (input_rank.is_static() && input_rank.get_length() >= 2) {
                 if (auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(input)) {
-                    if (auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1))) {
+                    if (auto order =
+                            ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr())) {
                         const auto& order_vector = order->cast_vector<int64_t>();
                         std::vector<int64_t> fusable_order(input_rank.get_length());
                         std::iota(fusable_order.begin(), fusable_order.end(), 0);

--- a/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/matmul_sr.cpp
@@ -128,7 +128,7 @@ ov::pass::TransposeMatMul::TransposeMatMul() {
             const auto& input_rank = input->get_output_partial_shape(0).rank();
             if (input_rank.is_static() && input_rank.get_length() >= 2) {
                 if (auto transpose = ov::as_type_ptr<ov::op::v1::Transpose>(input)) {
-                    if (auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr())) {
+                    if (auto order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1))) {
                         const auto& order_vector = order->cast_vector<int64_t>();
                         std::vector<int64_t> fusable_order(input_rank.get_length());
                         std::iota(fusable_order.begin(), fusable_order.end(), 0);

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
@@ -52,7 +52,8 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check first Reshape eligibility: has a constant output pattern in a form of [-1, K]
         auto reshape = pattern_to_node.at(reshape_label);
         int64_t K = -1;
-        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1))) {
+        if (const auto& constant =
+                ov::as_type_ptr<ov::op::v0::Constant>(reshape->input_value(1).get_node_shared_ptr())) {
             auto output_pattern_vector = constant->cast_vector<int64_t>();
             if (output_pattern_vector.size() != 2 || output_pattern_vector[0] != -1)
                 return false;
@@ -74,7 +75,8 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         if (!matmul || matmul->get_transpose_a())
             return false;
         int64_t O = -1;
-        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(matmul->get_input_node_shared_ptr(1))) {
+        if (const auto& constant =
+                ov::as_type_ptr<ov::op::v0::Constant>(matmul->input_value(1).get_node_shared_ptr())) {
             const auto& constant_shape = constant->get_shape();
             if (constant_shape.size() != 2)
                 return false;
@@ -93,7 +95,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
             auto add = ov::as_type_ptr<ov::op::v1::Add>(pattern_to_node.at(add_label));
             if (!add || add->get_autob() != ov::op::AutoBroadcastType::NUMPY)
                 return false;
-            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
+            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->input_value(1).get_node_shared_ptr());
             if (!constant)
                 return false;
             const auto& constant_shape = constant->get_shape();
@@ -110,7 +112,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // input_shape of the pattern except for the batch and last dimension
         auto reshape_1 = m.get_match_root();
 
-        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->get_input_node_shared_ptr(1));
+        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->input_value(1).get_node_shared_ptr());
         if (constant == nullptr)
             return false;
         auto output_pattern = constant->cast_vector<int64_t>();

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
@@ -52,7 +52,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check first Reshape eligibility: has a constant output pattern in a form of [-1, K]
         auto reshape = pattern_to_node.at(reshape_label);
         int64_t K = -1;
-        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1))) {
+        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape->input_value(1).get_node_shared_ptr())) {
             auto output_pattern_vector = constant->cast_vector<int64_t>();
             if (output_pattern_vector.size() != 2 || output_pattern_vector[0] != -1)
                 return false;
@@ -74,7 +74,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         if (!matmul || matmul->get_transpose_a())
             return false;
         int64_t O = -1;
-        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(matmul->get_input_node_shared_ptr(1))) {
+        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(matmul->input_value(1).get_node_shared_ptr())) {
             const auto& constant_shape = constant->get_shape();
             if (constant_shape.size() != 2)
                 return false;
@@ -93,7 +93,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
             auto add = ov::as_type_ptr<ov::op::v1::Add>(pattern_to_node.at(add_label));
             if (!add || add->get_autob() != ov::op::AutoBroadcastType::NUMPY)
                 return false;
-            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
+            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->input_value(1).get_node_shared_ptr());
             if (!constant)
                 return false;
             const auto& constant_shape = constant->get_shape();
@@ -110,7 +110,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // input_shape of the pattern except for the batch and last dimension
         auto reshape_1 = m.get_match_root();
 
-        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->get_input_node_shared_ptr(1));
+        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->input_value(1).get_node_shared_ptr());
         if (constant == nullptr)
             return false;
         auto output_pattern = constant->cast_vector<int64_t>();

--- a/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/reshape_sinking.cpp
@@ -52,7 +52,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // check first Reshape eligibility: has a constant output pattern in a form of [-1, K]
         auto reshape = pattern_to_node.at(reshape_label);
         int64_t K = -1;
-        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape->input_value(1).get_node_shared_ptr())) {
+        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape->get_input_node_shared_ptr(1))) {
             auto output_pattern_vector = constant->cast_vector<int64_t>();
             if (output_pattern_vector.size() != 2 || output_pattern_vector[0] != -1)
                 return false;
@@ -74,7 +74,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         if (!matmul || matmul->get_transpose_a())
             return false;
         int64_t O = -1;
-        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(matmul->input_value(1).get_node_shared_ptr())) {
+        if (const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(matmul->get_input_node_shared_ptr(1))) {
             const auto& constant_shape = constant->get_shape();
             if (constant_shape.size() != 2)
                 return false;
@@ -93,7 +93,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
             auto add = ov::as_type_ptr<ov::op::v1::Add>(pattern_to_node.at(add_label));
             if (!add || add->get_autob() != ov::op::AutoBroadcastType::NUMPY)
                 return false;
-            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->input_value(1).get_node_shared_ptr());
+            const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(add->get_input_node_shared_ptr(1));
             if (!constant)
                 return false;
             const auto& constant_shape = constant->get_shape();
@@ -110,7 +110,7 @@ ov::pass::ReshapeSinkingMatMul::ReshapeSinkingMatMul() {
         // input_shape of the pattern except for the batch and last dimension
         auto reshape_1 = m.get_match_root();
 
-        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->input_value(1).get_node_shared_ptr());
+        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(reshape_1->get_input_node_shared_ptr(1));
         if (constant == nullptr)
             return false;
         auto output_pattern = constant->cast_vector<int64_t>();

--- a/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
@@ -25,8 +25,8 @@ ov::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
 
     matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
         const auto& squeeze = m.get_match_root();
-        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->get_input_node_shared_ptr(1));
-        auto slice = ov::as_type_ptr<ov::op::v1::StridedSlice>(squeeze->get_input_node_shared_ptr(0));
+        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->input_value(1).get_node_shared_ptr());
+        auto slice = ov::as_type_ptr<ov::op::v1::StridedSlice>(squeeze->input_value(0).get_node_shared_ptr());
         if (!const_axes || !slice)
             return false;
 
@@ -125,8 +125,8 @@ ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
         auto slice = ov::as_type_ptr<ov::op::v1::StridedSlice>(m.get_match_root());
         if (!slice)
             return false;
-        auto squeeze = slice->get_input_node_shared_ptr(0);
-        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->get_input_node_shared_ptr(1));
+        auto squeeze = slice->input_value(0).get_node_shared_ptr();
+        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->input_value(1).get_node_shared_ptr());
         if (!const_axes)
             return false;
 
@@ -176,7 +176,7 @@ ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
         }
 
         auto new_slice = std::make_shared<ov::op::v1::StridedSlice>(
-            slice->get_input_node_shared_ptr(0)->input_value(0),
+            slice->input_value(0).get_node_shared_ptr()->input_value(0),
             ov::op::v0::Constant::create(element::i64, {begin_vec.size()}, begin_vec),
             ov::op::v0::Constant::create(element::i64, {end_vec.size()}, end_vec),
             ov::op::v0::Constant::create(element::i64, {strides_vec.size()}, strides_vec),

--- a/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
+++ b/src/common/transformations/src/transformations/smart_reshape/strided_slice_squeeze.cpp
@@ -25,8 +25,8 @@ ov::pass::StridedSliceSqueeze::StridedSliceSqueeze() {
 
     matcher_pass_callback callback = [](pattern::Matcher& m) -> bool {
         const auto& squeeze = m.get_match_root();
-        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->input_value(1).get_node_shared_ptr());
-        auto slice = ov::as_type_ptr<ov::op::v1::StridedSlice>(squeeze->input_value(0).get_node_shared_ptr());
+        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->get_input_node_shared_ptr(1));
+        auto slice = ov::as_type_ptr<ov::op::v1::StridedSlice>(squeeze->get_input_node_shared_ptr(0));
         if (!const_axes || !slice)
             return false;
 
@@ -125,8 +125,8 @@ ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
         auto slice = ov::as_type_ptr<ov::op::v1::StridedSlice>(m.get_match_root());
         if (!slice)
             return false;
-        auto squeeze = slice->input_value(0).get_node_shared_ptr();
-        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->input_value(1).get_node_shared_ptr());
+        auto squeeze = slice->get_input_node_shared_ptr(0);
+        const auto& const_axes = ov::as_type_ptr<ov::op::v0::Constant>(squeeze->get_input_node_shared_ptr(1));
         if (!const_axes)
             return false;
 
@@ -176,7 +176,7 @@ ov::pass::SqueezeStridedSlice::SqueezeStridedSlice() {
         }
 
         auto new_slice = std::make_shared<ov::op::v1::StridedSlice>(
-            slice->input_value(0).get_node_shared_ptr()->input_value(0),
+            slice->get_input_node_shared_ptr(0)->input_value(0),
             ov::op::v0::Constant::create(element::i64, {begin_vec.size()}, begin_vec),
             ov::op::v0::Constant::create(element::i64, {end_vec.size()}, end_vec),
             ov::op::v0::Constant::create(element::i64, {strides_vec.size()}, strides_vec),

--- a/src/common/transformations/src/transformations/symbolic_transformations/reshape_optimizations.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/reshape_optimizations.cpp
@@ -49,7 +49,7 @@ ov::pass::ReshapeOptimizations::ReshapeOptimizations() {
         int64_t cnt_neg_ones = std::count(output_pattern.begin(), output_pattern.end(), -1);
         if (cnt_neg_ones == 0 || (cnt_neg_ones == 1 && cnt_static_zeros == 0)) {
             auto new_pattern = ov::op::v0::Constant::create(element::i64, Shape{output_pattern.size()}, output_pattern);
-            ov::copy_runtime_info(reshape->get_input_node_shared_ptr(1), new_pattern);
+            ov::copy_runtime_info(reshape->input_value(1).get_node_shared_ptr(), new_pattern);
             reshape->set_special_zero(true);
             reshape->input(1).replace_source_output(new_pattern->output(0));
             return true;

--- a/src/common/transformations/src/transformations/symbolic_transformations/reshape_optimizations.cpp
+++ b/src/common/transformations/src/transformations/symbolic_transformations/reshape_optimizations.cpp
@@ -49,7 +49,7 @@ ov::pass::ReshapeOptimizations::ReshapeOptimizations() {
         int64_t cnt_neg_ones = std::count(output_pattern.begin(), output_pattern.end(), -1);
         if (cnt_neg_ones == 0 || (cnt_neg_ones == 1 && cnt_static_zeros == 0)) {
             auto new_pattern = ov::op::v0::Constant::create(element::i64, Shape{output_pattern.size()}, output_pattern);
-            ov::copy_runtime_info(reshape->input_value(1).get_node_shared_ptr(), new_pattern);
+            ov::copy_runtime_info(reshape->get_input_node_shared_ptr(1), new_pattern);
             reshape->set_special_zero(true);
             reshape->input(1).replace_source_output(new_pattern->output(0));
             return true;

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
@@ -34,8 +34,8 @@ TSFuse::TSFuse() {
         auto transpose2 = pattern_to_output.at(transpose_2_label);
         auto input = transpose1->input_value(0);
 
-        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
-        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
+        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->input_value(1).get_node_shared_ptr());
+        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->input_value(1).get_node_shared_ptr());
         if (!transpose1_order || !transpose2_order)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_fuse.cpp
@@ -34,8 +34,8 @@ TSFuse::TSFuse() {
         auto transpose2 = pattern_to_output.at(transpose_2_label);
         auto input = transpose1->input_value(0);
 
-        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->input_value(1).get_node_shared_ptr());
-        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->input_value(1).get_node_shared_ptr());
+        auto transpose1_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose1->get_input_node_shared_ptr(1));
+        auto transpose2_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose2->get_input_node_shared_ptr(1));
         if (!transpose1_order || !transpose2_order)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
@@ -33,7 +33,7 @@ TSGatherForward::TSGatherForward() {
         }
 
         auto transpose_order = transpose_info.transpose_const;
-        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(2).get_node_shared_ptr());
+        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(2));
         if (!gather_axis) {
             return false;
         }
@@ -171,8 +171,8 @@ TSGatherBackward::TSGatherBackward() {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
-        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(2).get_node_shared_ptr());
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(2));
         if (!transpose_order || !gather_axis) {
             return false;
         }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_gather.cpp
@@ -33,7 +33,7 @@ TSGatherForward::TSGatherForward() {
         }
 
         auto transpose_order = transpose_info.transpose_const;
-        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(2));
+        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(2).get_node_shared_ptr());
         if (!gather_axis) {
             return false;
         }
@@ -171,8 +171,8 @@ TSGatherBackward::TSGatherBackward() {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
-        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(2));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        auto gather_axis = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(2).get_node_shared_ptr());
         if (!transpose_order || !gather_axis) {
             return false;
         }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
@@ -47,7 +47,7 @@ TSReductionForward::TSReductionForward() {
                                                             const TransposeInputsInfo& transpose_info) -> bool {
         auto keep_dims = get_keep_dims(main_node);
         auto transpose_order = transpose_info.transpose_const;
-        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
+        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
         if (!transpose_order || !reduction_axes)
             return false;
 
@@ -110,8 +110,8 @@ TSReductionBackward::TSReductionBackward() {
 
         auto keep_dims = get_keep_dims(main_node);
 
-        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
-        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
         if (!transpose_order || !reduction_axes)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_reduction.cpp
@@ -47,7 +47,7 @@ TSReductionForward::TSReductionForward() {
                                                             const TransposeInputsInfo& transpose_info) -> bool {
         auto keep_dims = get_keep_dims(main_node);
         auto transpose_order = transpose_info.transpose_const;
-        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
+        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !reduction_axes)
             return false;
 
@@ -110,8 +110,8 @@ TSReductionBackward::TSReductionBackward() {
 
         auto keep_dims = get_keep_dims(main_node);
 
-        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
-        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto reduction_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !reduction_axes)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
@@ -56,7 +56,7 @@ OutputTranspose GetOutputTransposes(const NodePtr& node) {
 template <typename NodeT>
 std::shared_ptr<ov::Node> FindInputNode(ov::Node* node) {
     for (size_t input_idx = 0; input_idx < node->get_input_size(); ++input_idx) {
-        std::shared_ptr<ov::Node> input_node = node->input_value(input_idx).get_node_shared_ptr();
+        std::shared_ptr<ov::Node> input_node = node->get_input_node_shared_ptr(input_idx);
         auto target_node = ov::as_type_ptr<NodeT>(input_node);
         if (target_node)
             return target_node;

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_split.cpp
@@ -56,7 +56,7 @@ OutputTranspose GetOutputTransposes(const NodePtr& node) {
 template <typename NodeT>
 std::shared_ptr<ov::Node> FindInputNode(ov::Node* node) {
     for (size_t input_idx = 0; input_idx < node->get_input_size(); ++input_idx) {
-        std::shared_ptr<ov::Node> input_node = node->get_input_node_shared_ptr(input_idx);
+        std::shared_ptr<ov::Node> input_node = node->input_value(input_idx).get_node_shared_ptr();
         auto target_node = ov::as_type_ptr<NodeT>(input_node);
         if (target_node)
             return target_node;

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
@@ -111,7 +111,7 @@ TSSqueezeForward::TSSqueezeForward() {
         std::vector<size_t> non_negative_axes;
         std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
-            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
+            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
             if (!squeeze_axes) {
                 return false;
             }
@@ -209,7 +209,7 @@ TSSqueezeBackward::TSSqueezeBackward() {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
 
         if (!transpose_order) {
             return false;
@@ -218,7 +218,7 @@ TSSqueezeBackward::TSSqueezeBackward() {
         std::vector<size_t> non_negative_axes;
         std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
-            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
+            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
             if (!squeeze_axes) {
                 return false;
             }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_squeeze.cpp
@@ -111,7 +111,7 @@ TSSqueezeForward::TSSqueezeForward() {
         std::vector<size_t> non_negative_axes;
         std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
-            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
+            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
             if (!squeeze_axes) {
                 return false;
             }
@@ -209,7 +209,7 @@ TSSqueezeBackward::TSSqueezeBackward() {
             return false;
         }
 
-        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto transpose_order = as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
 
         if (!transpose_order) {
             return false;
@@ -218,7 +218,7 @@ TSSqueezeBackward::TSSqueezeBackward() {
         std::vector<size_t> non_negative_axes;
         std::shared_ptr<ov::op::v0::Constant> squeeze_axes;
         if (main_node->get_input_size() > 1) {
-            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
+            squeeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
             if (!squeeze_axes) {
                 return false;
             }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -111,7 +111,7 @@ TSUnaryBackward::TSUnaryBackward() {
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
-        auto unary = transpose->input_value(0).get_node_shared_ptr();
+        auto unary = transpose->get_input_node_shared_ptr(0);
         if (transformation_callback(unary)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unary.cpp
@@ -111,7 +111,7 @@ TSUnaryBackward::TSUnaryBackward() {
         auto transpose_const =
             as_type_ptr<ov::op::v0::Constant>(pattern_to_output.at(transpose_const_label).get_node_shared_ptr());
         auto transpose = pattern_to_output.at(transpose_label).get_node_shared_ptr();
-        auto unary = transpose->get_input_node_shared_ptr(0);
+        auto unary = transpose->input_value(0).get_node_shared_ptr();
         if (transformation_callback(unary)) {
             return false;
         }

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
@@ -123,7 +123,7 @@ TSUnsqueezeForward::TSUnsqueezeForward() {
 
     auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
                                                             const TransposeInputsInfo& transpose_info) -> bool {
-        auto unsqueeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
+        auto unsqueeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!unsqueeze_axes) {
             return false;
         }
@@ -214,8 +214,8 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
             return false;
         }
 
-        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
-        auto unsqueeze_axes = ov::as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
+        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+        auto unsqueeze_axes = ov::as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
         if (!transpose_order || !unsqueeze_axes)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_unsqueeze.cpp
@@ -123,7 +123,7 @@ TSUnsqueezeForward::TSUnsqueezeForward() {
 
     auto sinking_transformation = [OV_CAPTURE_CPY_AND_THIS](const std::shared_ptr<Node>& main_node,
                                                             const TransposeInputsInfo& transpose_info) -> bool {
-        auto unsqueeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
+        auto unsqueeze_axes = as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
         if (!unsqueeze_axes) {
             return false;
         }
@@ -214,8 +214,8 @@ TSUnsqueezeBackward::TSUnsqueezeBackward() {
             return false;
         }
 
-        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
-        auto unsqueeze_axes = ov::as_type_ptr<ov::op::v0::Constant>(main_node->get_input_node_shared_ptr(1));
+        auto transpose_order = ov::as_type_ptr<ov::op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
+        auto unsqueeze_axes = ov::as_type_ptr<ov::op::v0::Constant>(main_node->input_value(1).get_node_shared_ptr());
         if (!transpose_order || !unsqueeze_axes)
             return false;
 

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -91,7 +91,7 @@ TransposeInputsInfo GetFirstTransposeInput(
     }
 
     for (const auto& input_idx : indices_to_check) {
-        NodePtr input_node = node->input_value(input_idx).get_node_shared_ptr();
+        NodePtr input_node = node->get_input_node_shared_ptr(input_idx);
         auto transpose_node = as_type_ptr<ov::op::v1::Transpose>(input_node);
         if (!transpose_node)
             continue;

--- a/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
+++ b/src/common/transformations/src/transformations/transpose_sinking/ts_utils.cpp
@@ -91,7 +91,7 @@ TransposeInputsInfo GetFirstTransposeInput(
     }
 
     for (const auto& input_idx : indices_to_check) {
-        NodePtr input_node = node->get_input_node_shared_ptr(input_idx);
+        NodePtr input_node = node->input_value(input_idx).get_node_shared_ptr();
         auto transpose_node = as_type_ptr<ov::op::v1::Transpose>(input_node);
         if (!transpose_node)
             continue;

--- a/src/common/transformations/tests/type_relaxed_tests.cpp
+++ b/src/common/transformations/tests/type_relaxed_tests.cpp
@@ -354,7 +354,7 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck) {
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::ConstantFolding>();
         OV_ASSERT_NO_THROW(manager.run_passes(f));
-        auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
+        auto layer_before_result = f->get_result()->input_value(0).get_node_shared_ptr();
         ASSERT_TRUE(ov::is_type<ov::opset1::Constant>(layer_before_result));
     }
 }
@@ -372,7 +372,7 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck1) {
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::ConstantFolding>();
         OV_ASSERT_NO_THROW(manager.run_passes(f));
-        auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
+        auto layer_before_result = f->get_result()->input_value(0).get_node_shared_ptr();
         ASSERT_TRUE(ov::is_type<ov::opset1::Constant>(layer_before_result));
     }
 }
@@ -394,7 +394,7 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck2) {
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::ConstantFolding>();
         OV_ASSERT_NO_THROW(manager.run_passes(f));
-        auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
+        auto layer_before_result = f->get_result()->input_value(0).get_node_shared_ptr();
         ASSERT_TRUE(ov::is_type<ov::opset1::Constant>(layer_before_result));
     }
 }
@@ -414,7 +414,7 @@ TEST_F(TypeRelaxedTests, ConstantFoldingCheck3) {
         ov::pass::Manager manager;
         manager.register_pass<ov::pass::ConstantFolding>();
         OV_ASSERT_NO_THROW(manager.run_passes(f));
-        auto layer_before_result = f->get_result()->get_input_node_shared_ptr(0);
+        auto layer_before_result = f->get_result()->input_value(0).get_node_shared_ptr();
         ASSERT_TRUE(ov::is_type<ov::opset1::Constant>(layer_before_result));
     }
 }

--- a/src/core/shape_inference/include/broadcast_shape_inference.hpp
+++ b/src/core/shape_inference/include/broadcast_shape_inference.hpp
@@ -186,7 +186,7 @@ std::vector<TRShape> broadcast_base_shape_infer(const ov::op::util::BroadcastBas
     auto target_as_shape = get_input_const_data_as_shape<TRShape>(op, 1, ta);
 
     if (!target_as_shape) {
-        if (auto concat = ov::as_type_ptr<ov::op::v0::Concat>(op->get_input_node_shared_ptr(1))) {
+        if (auto concat = ov::as_type_ptr<ov::op::v0::Concat>(op->input_value(1).get_node_shared_ptr())) {
             const auto concat_inputs = concat->input_values();
             if (concat->get_output_partial_shape(0).is_static() && concat->get_shape().size() == 1 &&
                 concat_inputs.size() == shape_size(concat->get_shape())) {

--- a/src/core/shape_inference/include/string_tensor_unpack_shape_inference.hpp
+++ b/src/core/shape_inference/include/string_tensor_unpack_shape_inference.hpp
@@ -17,7 +17,7 @@ namespace util {
 static inline Tensor get_string_tensor(const Node* op, const ITensorAccessor& tensor_accessor) {
     if (auto t = tensor_accessor(0)) {
         return t;
-    } else if (const auto& constant = as_type_ptr<v0::Constant>(op->get_input_node_shared_ptr(0))) {
+    } else if (const auto& constant = as_type_ptr<v0::Constant>(op->input_value(0).get_node_shared_ptr())) {
         return constant->get_tensor_view();
     } else {
         return {};

--- a/src/core/shape_inference/include/utils.hpp
+++ b/src/core/shape_inference/include/utils.hpp
@@ -212,7 +212,7 @@ std::optional<TRes> get_input_const_data_as(const ov::Node* op,
     if (auto t = tensor_accessor(idx)) {
         return {get_tensor_data_as<TData, TRes>(t, std::forward<UnaryOperation>(func))};
     } else {
-        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(idx));
+        const auto& constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(idx).get_node_shared_ptr());
         NODE_VALIDATION_CHECK(op, constant != nullptr, "Static shape inference lacks constant data on port ", idx);
         const auto& et = constant->get_element_type();
         const auto& shape = constant->get_shape();
@@ -313,7 +313,7 @@ std::optional<TShape> get_input_const_data_as_shape(const ov::Node* op,
         shape.emplace(get_tensor_data_as<TDimValue>(t, std::forward<UnaryOperation>(func)));
     } else if (port < op->get_input_size()) {
         PartialShape s;
-        if (auto c = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(port))) {
+        if (auto c = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(port).get_node_shared_ptr())) {
             shape.emplace(get_raw_data_as<TDimValue>(c->get_element_type(),
                                                      c->get_data_ptr(),
                                                      shape_size(c->get_shape()),

--- a/src/core/src/pass/stateful_to_stateless.cpp
+++ b/src/core/src/pass/stateful_to_stateless.cpp
@@ -98,7 +98,8 @@ bool ov::pass::StatefulToStateless::run_on_model(const std::shared_ptr<ov::Model
     if (beam_idx) {
         for (const ov::Input<ov::Node>& input : beam_idx->get_output_target_inputs(0)) {
             if (auto gather = ov::as_type_ptr<op::util::GatherBase>(input.get_node()->shared_from_this())) {
-                auto read_value = ov::as_type_ptr<op::util::ReadValueBase>(gather->get_input_node_shared_ptr(0));
+                auto read_value =
+                    ov::as_type_ptr<op::util::ReadValueBase>(gather->input_value(0).get_node_shared_ptr());
                 OPENVINO_ASSERT(read_value,
                                 "Unexpected model topology in StatefulToStateless: no ReadValue is found at the first "
                                 "input of Gather by `beam_idx` parameter");

--- a/src/core/tests/model.cpp
+++ b/src/core/tests/model.cpp
@@ -1423,7 +1423,7 @@ TEST(model, add_output_ordered_ops) {
             relu_found = true;
             EXPECT_FALSE(relu_result_found);
         } else if (ov::as_type_ptr<ov::op::v0::Result>(node) &&
-                   ov::as_type_ptr<ov::op::v0::Relu>(node->get_input_node_shared_ptr(0))) {
+                   ov::as_type_ptr<ov::op::v0::Relu>(node->input_value(0).get_node_shared_ptr())) {
             relu_result_found = true;
             EXPECT_TRUE(relu_found);
         }
@@ -1472,7 +1472,7 @@ TEST(model, add_output_clear_cached_tensor_name_by_ordered_ops) {
     EXPECT_EQ(ops_after.size(), ops_before.size());
     // 6. Expect: Add_output to 'B' - output to node 'C' shall be added on step 4
     auto b_output = model->add_output("B");
-    std::string b_type = b_output.get_node_shared_ptr()->get_input_node_shared_ptr(0)->get_type_name();
+    std::string b_type = b_output.get_node_shared_ptr()->input_value(0).get_node_shared_ptr()->get_type_name();
     EXPECT_EQ(b_type, op3->get_type_name());
 }
 
@@ -1512,7 +1512,7 @@ TEST(model, add_output_clear_cached_op_name_by_ordered_ops) {
     EXPECT_EQ(ops_after.size(), ops_before.size());
     // 6. Expect: Add_output to 'B' - output to node 'C' shall be added on step 4
     auto b_output = model->add_output("B", 0);
-    std::string b_type = b_output.get_node_shared_ptr()->get_input_node_shared_ptr(0)->get_type_name();
+    std::string b_type = b_output.get_node_shared_ptr()->input_value(0).get_node_shared_ptr()->get_type_name();
     EXPECT_EQ(b_type, op3->get_type_name());
 }
 

--- a/src/core/tests/pass/constant_folding.cpp
+++ b/src/core/tests/pass/constant_folding.cpp
@@ -740,7 +740,7 @@ TEST(constant_folding, shape_of_dynamic_v0) {
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -757,7 +757,7 @@ TEST(constant_folding, shape_of_dynamic_v3) {
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -774,7 +774,7 @@ TEST(constant_folding, shape_of_dynamic_i32_v3) {
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -792,7 +792,7 @@ TEST(constant_folding, shape_of_dynamic_double_folding_v0) {
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -809,7 +809,7 @@ TEST(constant_folding, shape_of_dynamic_double_folding_v3) {
 
     ASSERT_EQ(f->get_ops().size(), 3);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -829,7 +829,7 @@ TEST(constant_folding, shape_of_rank_dynamic_v0) {
     ASSERT_EQ(count_ops_of_type<op::v0::ShapeOf>(f), 1);
     ASSERT_EQ(count_ops_of_type<ov::op::v0::Constant>(f), 0);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -847,7 +847,7 @@ TEST(constant_folding, shape_of_rank_dynamic_v3) {
     ASSERT_EQ(count_ops_of_type<op::v3::ShapeOf>(f), 1);
     ASSERT_EQ(count_ops_of_type<ov::op::v0::Constant>(f), 0);
 
-    auto result_shape_of = f->get_results().at(0)->get_input_node_shared_ptr(0);
+    auto result_shape_of = f->get_results().at(0)->input_value(0).get_node_shared_ptr();
     ASSERT_EQ(result_shape_of, shape_of);
     check_names(result_shape_of, {"test"});
 }
@@ -3650,7 +3650,7 @@ TEST(constant_folding, disable_constant_folding) {
     run_constant_folding(f);
 
     // After we enabled CF the sub-graph will be folded to Constant
-    ASSERT_TRUE(ov::is_type<ov::op::v0::Constant>(interpolate->get_input_node_shared_ptr(1)));
+    ASSERT_TRUE(ov::is_type<ov::op::v0::Constant>(interpolate->input_value(1).get_node_shared_ptr()));
 
     // Check that DisableConstantFolding attribute wasn't propagated to some other nodes during CF
     for (auto node : f->get_ordered_ops()) {
@@ -3680,7 +3680,7 @@ TEST(constant_folding, disable_constant_folding_simple) {
     run_constant_folding(f);
 
     // After we enabled CF the sub-graph will be folded to Constant
-    ASSERT_TRUE(ov::is_type<ov::op::v0::Constant>(divide->get_input_node_shared_ptr(1)));
+    ASSERT_TRUE(ov::is_type<ov::op::v0::Constant>(divide->input_value(1).get_node_shared_ptr()));
 
     // Check that DisableConstantFolding attribute wasn't propagated to some other nodes during CF
     for (auto node : f->get_ordered_ops()) {
@@ -3712,7 +3712,7 @@ TEST(constant_folding, disable_constant_folding_check) {
     ASSERT_TRUE(shapeof2->get_rt_info().count("can_be_folded"));
     ASSERT_TRUE(shapeof2->get_rt_info().at("can_be_folded").as<bool>());
 
-    ASSERT_TRUE(ov::is_type<ov::op::v0::Constant>(reshape2->get_input_node_shared_ptr(1)));
+    ASSERT_TRUE(ov::is_type<ov::op::v0::Constant>(reshape2->input_value(1).get_node_shared_ptr()));
 }
 
 TEST(constant_folding, constant_loop) {

--- a/src/core/tests/replace_node.cpp
+++ b/src/core/tests/replace_node.cpp
@@ -98,23 +98,23 @@ TEST(replace_node, replace_nodes) {
     ASSERT_EQ(f->get_results().size(), 1);
 
     // Result node should be sub (unchanged).
-    ASSERT_EQ(f->get_results()[0]->get_input_node_shared_ptr(0), sub);
+    ASSERT_EQ(f->get_results()[0]->input_value(0).get_node_shared_ptr(), sub);
 
     // sub's arguments should be mul (unchanged) and z_replacement.
-    ASSERT_EQ(sub->get_input_node_shared_ptr(0), mul);
-    ASSERT_EQ(sub->get_input_node_shared_ptr(1), z_replacement);
+    ASSERT_EQ(sub->input_value(0).get_node_shared_ptr(), mul);
+    ASSERT_EQ(sub->input_value(1).get_node_shared_ptr(), z_replacement);
 
     // mul's arguments should be add (unchanged) and k_replacement.
-    ASSERT_EQ(mul->get_input_node_shared_ptr(0), add);
-    ASSERT_EQ(mul->get_input_node_shared_ptr(1), k_replacement);
+    ASSERT_EQ(mul->input_value(0).get_node_shared_ptr(), add);
+    ASSERT_EQ(mul->input_value(1).get_node_shared_ptr(), k_replacement);
 
     // add's arguments should be x_replacement and y_replacement.
-    ASSERT_EQ(add->get_input_node_shared_ptr(0), x_replacement);
-    ASSERT_EQ(add->get_input_node_shared_ptr(1), y_replacement);
+    ASSERT_EQ(add->input_value(0).get_node_shared_ptr(), x_replacement);
+    ASSERT_EQ(add->input_value(1).get_node_shared_ptr(), y_replacement);
 
     // z_replacement's arguments should be x_replacement and mul.
-    ASSERT_EQ(z_replacement->get_input_node_shared_ptr(0), x_replacement);
-    ASSERT_EQ(z_replacement->get_input_node_shared_ptr(1), mul);
+    ASSERT_EQ(z_replacement->input_value(0).get_node_shared_ptr(), x_replacement);
+    ASSERT_EQ(z_replacement->input_value(1).get_node_shared_ptr(), mul);
 }
 
 TEST(replace_node, simple_node_replacement) {

--- a/src/frontends/onnx/frontend/src/core/graph.cpp
+++ b/src/frontends/onnx/frontend/src/core/graph.cpp
@@ -310,7 +310,7 @@ std::shared_ptr<ov::Model> Graph::create_model() {
         const auto& result_node = model->get_output_op(i);
         const std::string onnx_output_name = onnx_outputs.Get(static_cast<int>(i)).name();
         result_node->set_friendly_name(onnx_output_name + "/sink_port_0");
-        const auto& previous_operation = result_node->get_input_node_shared_ptr(0);
+        const auto& previous_operation = result_node->input_value(0).get_node_shared_ptr();
         previous_operation->set_friendly_name(onnx_output_name);
     }
     return model;

--- a/src/frontends/paddle/src/internal/pass/transform_fakequantize.cpp
+++ b/src/frontends/paddle/src/internal/pass/transform_fakequantize.cpp
@@ -62,7 +62,7 @@ ov::frontend::paddle::pass::TransformFakeQuantize::TransformFakeQuantize() {
         }
         // get the input
         const auto& sub_node = opsMap.at(q_sub_label).get_node_shared_ptr();
-        if (!sub_node->get_input_node_shared_ptr(0)) {
+        if (!sub_node->input_value(0).get_node_shared_ptr()) {
             return false;
         }
         const auto& input_item = sub_node->get_input_source_output(0);
@@ -95,7 +95,7 @@ ov::frontend::paddle::pass::TransformFakeQuantize::TransformFakeQuantize() {
 
         // get the scale
         const auto& scale_node_cast = ov::as_type_ptr<Constant>(
-            opsMap.at(q_real_scale_label).get_node_shared_ptr()->get_input_node_shared_ptr(0));
+            opsMap.at(q_real_scale_label).get_node_shared_ptr()->input_value(0).get_node_shared_ptr());
         float scale;
         if (!scale_node_cast || !ov::op::util::get_single_value(scale_node_cast, scale)) {
             return false;

--- a/src/frontends/paddle/src/internal/pass/transform_if.cpp
+++ b/src/frontends/paddle/src/internal/pass/transform_if.cpp
@@ -26,7 +26,7 @@ ov::frontend::paddle::pass::TransformIf::TransformIf(std::vector<std::shared_ptr
     matcher_pass_callback callback = [funcs](pattern::Matcher& m) -> bool {
         const auto conditional_block = ov::as_type_ptr<ov::op::internal::ConditionalBlock>(m.get_match_root());
         const auto mask_idx = conditional_block->get_input_size() - 1;
-        const auto cond = conditional_block->get_input_node_shared_ptr(mask_idx);
+        const auto cond = conditional_block->input_value(mask_idx).get_node_shared_ptr();
 
         if (!conditional_block || !cond) {
             return false;

--- a/src/frontends/paddle/src/internal/pass/transform_tensorarray.cpp
+++ b/src/frontends/paddle/src/internal/pass/transform_tensorarray.cpp
@@ -30,8 +30,8 @@ ov::frontend::paddle::pass::TransformTensorArray::TransformTensorArray(std::vect
         const auto& shape_node = opsMap.at(shape_label).get_node_shared_ptr();
         if (!write_node || !shape_node)
             return false;
-        const auto& new_item = write_node->get_input_node_shared_ptr(0);
-        const auto& list = shape_node->get_input_node_shared_ptr(0);
+        const auto& new_item = write_node->input_value(0).get_node_shared_ptr();
+        const auto& list = shape_node->input_value(0).get_node_shared_ptr();
         const auto& new_item_unsqueeze = std::make_shared<Unsqueeze>(
             new_item->output(0),
             Constant::create(element::i32, {1}, {0}));  // unsqueeze in order to handyfully slice a tensorarray

--- a/src/frontends/pytorch/src/transforms/dict_resolver.cpp
+++ b/src/frontends/pytorch/src/transforms/dict_resolver.cpp
@@ -31,8 +31,8 @@ bool DictParameterResolver::run_on_model(const std::shared_ptr<Model>& model) {
             for (const auto inp : targets) {
                 const auto getitem_node = cast_fw_node(inp.get_node()->shared_from_this(), "aten::__getitem__");
                 if (getitem_node) {
-                    const auto index_node =
-                        ov::as_type_ptr<ov::op::util::FrameworkNode>(getitem_node->get_input_node_shared_ptr(1));
+                    const auto index_node = ov::as_type_ptr<ov::op::util::FrameworkNode>(
+                        getitem_node->input_value(1).get_node_shared_ptr());
                     if (!index_node) {
                         at_least_one_unused = true;
                         continue;
@@ -73,7 +73,7 @@ bool DictResultResolver::run_on_model(const std::shared_ptr<Model>& model) {
     bool changed = false;
     const auto results = model->get_results();
     for (const auto& res : results) {
-        if (auto dict_construct_node = cast_fw_node(res->get_input_node_shared_ptr(0), "prim::DictConstruct")) {
+        if (auto dict_construct_node = cast_fw_node(res->input_value(0).get_node_shared_ptr(), "prim::DictConstruct")) {
             const auto inputs = dict_construct_node->input_values();
             if (inputs.size() % 2) {
                 // inputs must be divisible by 2

--- a/src/frontends/pytorch/src/transforms/prim_list_tuple_construct_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_tuple_construct_replacer.cpp
@@ -30,7 +30,7 @@ bool DecomposeListTupleResults::run_on_model(const std::shared_ptr<Model>& model
     while (!results.empty()) {
         auto result = results.front();
         results.pop_front();
-        auto input_node = result->get_input_node_shared_ptr(0);
+        auto input_node = result->input_value(0).get_node_shared_ptr();
         auto tuple_construct = cast_fw_node(input_node, "prim::TupleConstruct");
         auto list_construct = cast_fw_node(input_node, "prim::ListConstruct");
         if (!tuple_construct && !list_construct) {

--- a/src/frontends/pytorch/src/transforms/reverseprop_resolver.cpp
+++ b/src/frontends/pytorch/src/transforms/reverseprop_resolver.cpp
@@ -38,7 +38,7 @@ ReversepropResolver::ReversepropResolver() {
     ov::matcher_pass_callback callback = [](pattern::Matcher& m) {
         auto base_op = m.get_match_root();
         // Apply this transformation only to starting reverse operation
-        if (ov::as_type_ptr<InternalReverseOperation>(base_op->get_input_node_shared_ptr(1)))
+        if (ov::as_type_ptr<InternalReverseOperation>(base_op->input_value(1).get_node_shared_ptr()))
             return false;
 
         auto curr_op = base_op;

--- a/src/frontends/pytorch/src/transforms/torchfx_gptq_pattern_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/torchfx_gptq_pattern_replacer.cpp
@@ -69,14 +69,18 @@ GPTQDecompressionReplacer::GPTQDecompressionReplacer() {
         }
         const auto& pattern_map = m.get_pattern_value_map();
         auto unsqueeze_1_node = pattern_map.at(unsqueeze_1).get_node_shared_ptr();
-        auto unsqueeze_1_in0_const = ov::as_type_ptr<v0::Constant>(unsqueeze_1_node->get_input_node_shared_ptr(0));
-        auto unsqueeze_1_in1_const = ov::as_type_ptr<v0::Constant>(unsqueeze_1_node->get_input_node_shared_ptr(1));
+        auto unsqueeze_1_in0_const =
+            ov::as_type_ptr<v0::Constant>(unsqueeze_1_node->input_value(0).get_node_shared_ptr());
+        auto unsqueeze_1_in1_const =
+            ov::as_type_ptr<v0::Constant>(unsqueeze_1_node->input_value(1).get_node_shared_ptr());
         auto abs_node = pattern_map.at(abs).get_node_shared_ptr();
-        auto abs_in_const = ov::as_type_ptr<v0::Constant>(abs_node->get_input_node_shared_ptr(0));
+        auto abs_in_const = ov::as_type_ptr<v0::Constant>(abs_node->input_value(0).get_node_shared_ptr());
         auto broadcast_node = pattern_map.at(broadcast).get_node_shared_ptr();
         auto unsqueeze_2_node = pattern_map.at(unsqueeze_2).get_node_shared_ptr();
-        auto unsqueeze_2_in0_const = ov::as_type_ptr<v0::Constant>(unsqueeze_2_node->get_input_node_shared_ptr(0));
-        auto unsqueeze_2_in1_const = ov::as_type_ptr<v0::Constant>(unsqueeze_2_node->get_input_node_shared_ptr(1));
+        auto unsqueeze_2_in0_const =
+            ov::as_type_ptr<v0::Constant>(unsqueeze_2_node->input_value(0).get_node_shared_ptr());
+        auto unsqueeze_2_in1_const =
+            ov::as_type_ptr<v0::Constant>(unsqueeze_2_node->input_value(1).get_node_shared_ptr());
 
         OutputVector outputs_1(unsqueeze_1_node->get_output_size());
         OutputVector unsqueeze_1_inputs(2);
@@ -153,7 +157,8 @@ GPTQDecompressionReplacer::GPTQDecompressionReplacer() {
         } else {
             auto convert_3_node = pattern_map.at(convert_3).get_node_shared_ptr();
             auto convert_4_node = pattern_map.at(convert_4).get_node_shared_ptr();
-            auto convert_4_in_const = ov::as_type_ptr<v0::Constant>(convert_4_node->get_input_node_shared_ptr(0));
+            auto convert_4_in_const =
+                ov::as_type_ptr<v0::Constant>(convert_4_node->input_value(0).get_node_shared_ptr());
             auto add_node = pattern_map.at(add).get_node_shared_ptr();
             OutputVector outputs_5(convert_3_node->get_output_size());
             if (!convert_3_node->constant_fold(outputs_5, shifted_const->outputs())) {
@@ -173,7 +178,7 @@ GPTQDecompressionReplacer::GPTQDecompressionReplacer() {
         }
 
         auto convert_2_node = pattern_map.at(convert_2).get_node_shared_ptr();
-        auto convert_2_in_const = ov::as_type_ptr<v0::Constant>(convert_2_node->get_input_node_shared_ptr(0));
+        auto convert_2_in_const = ov::as_type_ptr<v0::Constant>(convert_2_node->input_value(0).get_node_shared_ptr());
 
         OutputVector outputs_8(convert_2_node->get_output_size());
         if (!convert_2_node->constant_fold(outputs_8, convert_2_in_const->outputs())) {
@@ -254,14 +259,15 @@ GPTQMultPatternReplacer::GPTQMultPatternReplacer() {
         auto reshape3_node = pattern_map.at(reshape_3).get_node_shared_ptr();
         // auto mult_node = pattern_map.at(mult).get_node_shared_ptr();
 
-        auto add_input0_const = ov::as_type_ptr<v0::Constant>(convert_1_node->get_input_node_shared_ptr(0));
+        auto add_input0_const = ov::as_type_ptr<v0::Constant>(convert_1_node->input_value(0).get_node_shared_ptr());
         if (add_input0_const->get_element_type() != element::u4) {
             return false;
         }
         auto add_in0_ptr = add_input0_const->get_data_ptr<uint8_t>();
         uint32_t add_val = 0;
         if (convert_2_node) {
-            auto convert_2_input_const = ov::as_type_ptr<v0::Constant>(convert_2_node->get_input_node_shared_ptr(0));
+            auto convert_2_input_const =
+                ov::as_type_ptr<v0::Constant>(convert_2_node->input_value(0).get_node_shared_ptr());
             auto add_in1_ptr = convert_2_input_const->get_data_ptr<uint8_t>();
             if (!add_in1_ptr)
                 return false;
@@ -284,7 +290,7 @@ GPTQMultPatternReplacer::GPTQMultPatternReplacer() {
         }
 
         const auto& static_shape_2 = reshape2_node->get_shape();
-        auto reshape2_in0_const = ov::as_type_ptr<v0::Constant>(convert_4_node->get_input_node_shared_ptr(0));
+        auto reshape2_in0_const = ov::as_type_ptr<v0::Constant>(convert_4_node->input_value(0).get_node_shared_ptr());
         auto sub_replace_const = std::make_shared<v0::Constant>(reshape2_in0_const->get_element_type(),
                                                                 static_shape_2,
                                                                 reshape2_in0_const->get_data_ptr<uint8_t>());
@@ -292,7 +298,7 @@ GPTQMultPatternReplacer::GPTQMultPatternReplacer() {
         auto new_sub_node = std::make_shared<v1::Subtract>(new_convert_node, add_replace_const);
 
         const auto& static_shape_3 = reshape3_node->get_shape();
-        auto reshape3_in0_const = ov::as_type_ptr<v0::Constant>(reshape3_node->get_input_node_shared_ptr(0));
+        auto reshape3_in0_const = ov::as_type_ptr<v0::Constant>(reshape3_node->input_value(0).get_node_shared_ptr());
         auto mult_scale_const = std::make_shared<v0::Constant>(reshape3_in0_const->get_element_type(),
                                                                static_shape_3,
                                                                reshape3_in0_const->get_data_ptr<uint8_t>());

--- a/src/frontends/pytorch/src/transforms/tuple_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/tuple_unpack_replacer.cpp
@@ -29,7 +29,7 @@ PrimTupleUnpackReplacer::PrimTupleUnpackReplacer() {
         if (!tuple_unpack)
             return false;
         OutputVector outputs;
-        auto input_node = tuple_unpack->get_input_node_shared_ptr(0);
+        auto input_node = tuple_unpack->input_value(0).get_node_shared_ptr();
         if (cast_fw_node(input_node, "prim::TupleConstruct")) {
             for (const auto& input : input_node->inputs()) {
                 const auto& out = input.get_source_output();

--- a/src/frontends/pytorch/src/utils_quantize.cpp
+++ b/src/frontends/pytorch/src/utils_quantize.cpp
@@ -242,8 +242,8 @@ std::shared_ptr<Node> u4_compression_stack(const OutputVector& list_elems, int64
     if (!bitwise_shift)
         return nullptr;
 
-    auto weights_u8 = ov::as_type_ptr<v0::Constant>(bitwise_and->get_input_node_shared_ptr(0));
-    auto weights_u8_bitwise_shift = ov::as_type_ptr<v0::Constant>(bitwise_shift->get_input_node_shared_ptr(0));
+    auto weights_u8 = ov::as_type_ptr<v0::Constant>(bitwise_and->input_value(0).get_node_shared_ptr());
+    auto weights_u8_bitwise_shift = ov::as_type_ptr<v0::Constant>(bitwise_shift->input_value(0).get_node_shared_ptr());
     if (weights_u8->get_data_ptr() != weights_u8_bitwise_shift->get_data_ptr())
         return nullptr;
 
@@ -257,7 +257,7 @@ std::shared_ptr<Node> u4_compression_stack(const OutputVector& list_elems, int64
                                                     0x0F))
         return nullptr;
 
-    if (!ov::op::util::has_constant_value<uint64_t>(bitwise_shift->get_input_node_shared_ptr(1), 4))
+    if (!ov::op::util::has_constant_value<uint64_t>(bitwise_shift->input_value(1).get_node_shared_ptr(), 4))
         return nullptr;
 
     // Pattern detected, weights_u8 is target u8 packed constant with weights

--- a/src/frontends/tensorflow/src/transformations/switch_merge_resolve.cpp
+++ b/src/frontends/tensorflow/src/transformations/switch_merge_resolve.cpp
@@ -136,7 +136,7 @@ void insert_result_before_merge(const shared_ptr<Merge>& merge_node,
     // and retrive branch index for it
     const auto& merge_input = merge_node->input(input_ind);
     const auto& input_value = merge_node->input_value(input_ind);
-    const shared_ptr<const Node>& merge_producer = merge_node->get_input_node_shared_ptr(input_ind);
+    const shared_ptr<const Node>& merge_producer = merge_node->input_value(input_ind).get_node_shared_ptr();
     auto producer_cf_marker = get_cf_marker(merge_producer);
     FRONT_END_GENERAL_CHECK(
         producer_cf_marker.existing_markers_with_branches.count(eliminated_marker) > 0,

--- a/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
+++ b/src/frontends/tensorflow_common/src/helper_transforms/const_to_result_remover.cpp
@@ -22,8 +22,8 @@ bool ConstToResultRemover::run_on_model(const std::shared_ptr<ov::Model>& m) {
     // look for isolated UnsupportedConst->Result sub-graphs to remove
     // also, find isolated Constant->Result sub-graphs to remove
     for (const auto& result : m->get_results()) {
-        auto unsupported_const = as_type_ptr<UnsupportedConstant>(result->get_input_node_shared_ptr(0));
-        auto const_node = as_type_ptr<v0::Constant>(result->get_input_node_shared_ptr(0));
+        auto unsupported_const = as_type_ptr<UnsupportedConstant>(result->input_value(0).get_node_shared_ptr());
+        auto const_node = as_type_ptr<v0::Constant>(result->input_value(0).get_node_shared_ptr());
         if (unsupported_const || const_node) {
             results_to_remove.push_back(result);
         }

--- a/src/frontends/tensorflow_common/src/helper_transforms/saved_model_unused_remover.cpp
+++ b/src/frontends/tensorflow_common/src/helper_transforms/saved_model_unused_remover.cpp
@@ -33,7 +33,7 @@ bool SavedModelUnusedRemover::run_on_model(const std::shared_ptr<ov::Model>& m) 
             continue;
         }
 
-        auto param = as_type_ptr<v0::Parameter>(result->get_input_node_shared_ptr(0));
+        auto param = as_type_ptr<v0::Parameter>(result->input_value(0).get_node_shared_ptr());
         if (param) {
             isUsed = false;
             for (size_t i = 0; i < param->get_output_size(); ++i) {

--- a/src/frontends/tensorflow_common/src/helper_transforms/tensor_list_ops_resolver.cpp
+++ b/src/frontends/tensorflow_common/src/helper_transforms/tensor_list_ops_resolver.cpp
@@ -110,7 +110,7 @@ void update_parameter_to_slice_input(const std::shared_ptr<ov::Node>& node,
     if (!tensor_list_get_item) {
         return;
     }
-    auto tensor_list = ov::as_type_ptr<v0::Parameter>(tensor_list_get_item->get_input_node_shared_ptr(0));
+    auto tensor_list = ov::as_type_ptr<v0::Parameter>(tensor_list_get_item->input_value(0).get_node_shared_ptr());
     if (!tensor_list) {
         return;
     }
@@ -147,7 +147,7 @@ void update_result_to_concat_output(const std::shared_ptr<ov::Node>& node,
     if (!tensor_list_set_item) {
         return;
     }
-    auto tensor_list = ov::as_type_ptr<v0::Parameter>(tensor_list_set_item->get_input_node_shared_ptr(0));
+    auto tensor_list = ov::as_type_ptr<v0::Parameter>(tensor_list_set_item->input_value(0).get_node_shared_ptr());
     if (!tensor_list) {
         return;
     }
@@ -169,7 +169,7 @@ void update_result_to_concat_output(const std::shared_ptr<ov::Node>& node,
     }
 
     uint64_t result_idx = merged_input_desc->m_body_value_index;
-    if (results[result_idx]->get_input_node_shared_ptr(0) != tensor_list_set_item) {
+    if (results[result_idx]->input_value(0).get_node_shared_ptr() != tensor_list_set_item) {
         return;
     }
 
@@ -454,7 +454,7 @@ ov::frontend::tensorflow::pass::TensorListInLoopOptimization::TensorListInLoopOp
             }
 
             // get initial value of counter
-            if (!get_constant_value(loop->get_input_node_shared_ptr(input_idx), initial_counter)) {
+            if (!get_constant_value(loop->input_value(input_idx).get_node_shared_ptr(), initial_counter)) {
                 return false;
             }
 
@@ -492,17 +492,19 @@ ov::frontend::tensorflow::pass::TensorListInLoopOptimization::TensorListInLoopOp
         std::vector<uint64_t> update_result_last_iter_ids;
         for (uint64_t result_idx = 0; result_idx < body_results.size(); ++result_idx) {
             const auto& result = body_results[result_idx];
-            auto tensor_list_set_item = ov::as_type_ptr<TensorListSetItem>(result->get_input_node_shared_ptr(0));
+            auto tensor_list_set_item =
+                ov::as_type_ptr<TensorListSetItem>(result->input_value(0).get_node_shared_ptr());
             if (!tensor_list_set_item) {
                 continue;
             }
             int64_t index_value = -1;
-            if (!get_constant_value(tensor_list_set_item->get_input_node_shared_ptr(1), index_value) ||
+            if (!get_constant_value(tensor_list_set_item->input_value(1).get_node_shared_ptr(), index_value) ||
                 (index_value != 0)) {
                 continue;
             }
 
-            auto tensor_list = ov::as_type_ptr<v0::Parameter>(tensor_list_set_item->get_input_node_shared_ptr(0));
+            auto tensor_list =
+                ov::as_type_ptr<v0::Parameter>(tensor_list_set_item->input_value(0).get_node_shared_ptr());
             if (!tensor_list) {
                 continue;
             }
@@ -529,7 +531,8 @@ ov::frontend::tensorflow::pass::TensorListInLoopOptimization::TensorListInLoopOp
                                      update_result_last_iter_ids.end());
         for (auto update_result_idx : all_update_result_ids) {
             const auto& body_result = body_results[update_result_idx];
-            auto tensor_list_set_item = ov::as_type_ptr<TensorListSetItem>(body_result->get_input_node_shared_ptr(0));
+            auto tensor_list_set_item =
+                ov::as_type_ptr<TensorListSetItem>(body_result->input_value(0).get_node_shared_ptr());
             FRONT_END_GENERAL_CHECK(tensor_list_set_item,
                                     "[TensorFlow Frontend] internal error: tensor_list_set_item is nullptr in "
                                     "TensorListInLoopOptimization");

--- a/src/frontends/tensorflow_lite/src/tflite_transformations/tflite_quantize_resolver.cpp
+++ b/src/frontends/tensorflow_lite/src/tflite_transformations/tflite_quantize_resolver.cpp
@@ -127,7 +127,7 @@ pass::TFLQuantizeReplacer::TFLQuantizeReplacer() {
         const auto out_type = tfl_quantize->get_type();
 
         const auto is_constant =
-            ov::is_type<v0::Constant>(tfl_quantize->get_input_node_shared_ptr(0));  // for Constant case
+            ov::is_type<v0::Constant>(tfl_quantize->input_value(0).get_node_shared_ptr());  // for Constant case
 
         FRONT_END_GENERAL_CHECK(in_type == out_type || in_type == element::f32 || out_type == element::f32,
                                 "TFLQuantized types do not match: in_type = ",

--- a/src/inference/src/check_network_batchable.cpp
+++ b/src/inference/src/check_network_batchable.cpp
@@ -17,7 +17,7 @@ bool model_has_suitable_do(const std::shared_ptr<const ov::Model>& model) {
         std::shared_ptr<ov::Node> convert_node;
         if (ov::is_type<ov::op::v0::Convert>(do_node)) {  // cases with do->convert->result
             convert_node = do_node;
-            do_node = convert_node->get_input_node_shared_ptr(0);
+            do_node = convert_node->input_value(0).get_node_shared_ptr();
         }
         auto detectionOutputBase = ov::as_type_ptr<ov::op::util::DetectionOutputBase>(do_node);
         if (detectionOutputBase) {
@@ -79,7 +79,7 @@ std::shared_ptr<const ov::Model> apply_batch_affinity(const std::shared_ptr<cons
         std::shared_ptr<ov::Node> convert_node;
         if (ov::is_type<ov::op::v0::Convert>(do_node)) {  // cases with do->convert->result
             convert_node = do_node;
-            do_node = convert_node->get_input_node_shared_ptr(0);
+            do_node = convert_node->input_value(0).get_node_shared_ptr();
         }
         // the code below doesn't need to separate the versions (opsets) of the DetectionOutput
         // so base class  check is enough

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -189,7 +189,7 @@ void Graph::Replicate(const std::shared_ptr<const ov::Model>& model,
         op2node[op] = node;
 
         for (size_t port = 0; port < op->get_input_size(); port++) {
-            auto parentOp = op->get_input_node_shared_ptr(port);
+            auto parentOp = op->input_value(port).get_node_shared_ptr();
             auto parentNode = op2node[parentOp];
 
             CreateEdge(parentNode, node, getParentOutputPort(op, parentOp, port), static_cast<int>(port));

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -256,7 +256,7 @@ Deconvolution::Deconvolution(const std::shared_ptr<ov::Node>& op, const GraphCon
     externOutShape = inputShapes.size() == 3;
     biasPort = externOutShape ? 3 : 2;
     if (externOutShape) {
-        isConstOutShape = ov::is_type<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+        isConstOutShape = ov::is_type<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
         if (isConstOutShape) {
             lastOutputSpatialDims =
                 ov::as_type<ov::op::v0::Constant>(op->get_input_node_ptr(2))->cast_vector<int32_t>();

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -68,8 +68,8 @@ using namespace dnnl::impl::cpu::aarch64;
 namespace ov::intel_cpu::node {
 
 Eltwise::BroadcastingPolicy Eltwise::determineBroadcastingPolicy(const std::shared_ptr<ov::Node>& op) {
-    const auto const1 = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(0));
-    const auto const2 = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    const auto const1 = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(0).get_node_shared_ptr());
+    const auto const2 = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     int constPort = -1;
     if (const2) {
         constPort = 1;

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1021,7 +1021,7 @@ bool FakeQuantize::isSupportedOperation(const std::shared_ptr<const ov::Node>& o
             }
         }
         for (size_t i = 1; i < fq->get_input_size(); i++) {
-            if (!ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(i))) {
+            if (!ov::as_type_ptr<const ov::opset1::Constant>(fq->input_value(i).get_node_shared_ptr())) {
                 errorMessage = "Has non const 'range' input on " + std::to_string(i) + " port";
                 return false;
             }
@@ -1173,16 +1173,19 @@ FakeQuantize::FakeQuantize(const std::shared_ptr<ov::Node>& op, const GraphConte
             THROW_CPU_NODE_ERR("has different quantization axis size on 'data' and 'range' inputs");
         }
 
-        const auto inputLowNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(1));
+        const auto inputLowNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->input_value(1).get_node_shared_ptr());
         auto inputLowData = inputLowNode->cast_vector<float>();
 
-        const auto inputHighNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(2));
+        const auto inputHighNode =
+            ov::as_type_ptr<const ov::opset1::Constant>(fq->input_value(2).get_node_shared_ptr());
         auto inputHighData = inputHighNode->cast_vector<float>();
 
-        const auto outputLowNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(3));
+        const auto outputLowNode =
+            ov::as_type_ptr<const ov::opset1::Constant>(fq->input_value(3).get_node_shared_ptr());
         auto outputLowData = outputLowNode->cast_vector<float>();
 
-        const auto outputHighNode = ov::as_type_ptr<const ov::opset1::Constant>(fq->get_input_node_shared_ptr(4));
+        const auto outputHighNode =
+            ov::as_type_ptr<const ov::opset1::Constant>(fq->input_value(4).get_node_shared_ptr());
         auto outputHighData = outputHighNode->cast_vector<float>();
 
         binarization = levels == 2;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -1820,7 +1820,7 @@ bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
             }
 
             if (interp->get_input_size() > 3 &&
-                ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID)) == nullptr) {
+                ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID).get_node_shared_ptr()) == nullptr) {
                 errorMessage = "Only const 'axes' input is supported in Interpolate-4";
                 return false;
             }
@@ -1849,7 +1849,7 @@ bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
                 return false;
             }
             if (interp->get_input_size() > 2 && ov::as_type_ptr<const ov::op::v0::Constant>(
-                                                    interp->get_input_node_shared_ptr(AXES_ID_V11)) == nullptr) {
+                                                    interp->input_value(AXES_ID_V11).get_node_shared_ptr()) == nullptr) {
                 errorMessage = "Only const 'axes' input is supported in Interpolate-11";
                 return false;
             }
@@ -1992,14 +1992,14 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             }
 
             const auto scalesNode =
-                ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(SCALES_ID));
+                ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(SCALES_ID).get_node_shared_ptr());
             if (scalesNode) {
                 scales = scalesNode->cast_vector<float>();
                 isScaleConstant = true;
             }
 
             if (isAxesSpecified) {
-                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID))
+                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID).get_node_shared_ptr())
                            ->cast_vector<int>();
             } else {
                 axes.resize(dataRank);
@@ -2037,7 +2037,7 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             if (interpShapeCalcMode == ngInterpShapeCalcMode::SCALES) {
                 interpAttrs.shapeCalcMode = InterpolateShapeCalcMode::scales;
                 const auto scalesNode = ov::as_type_ptr<const ov::op::v0::Constant>(
-                    interp->get_input_node_shared_ptr(SIZE_OR_SCALE_ID_V11));
+                    interp->input_value(SIZE_OR_SCALE_ID_V11).get_node_shared_ptr());
                 if (scalesNode) {
                     scales = scalesNode->cast_vector<float>();
                     isScaleConstant = true;
@@ -2067,7 +2067,7 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             }
 
             if (isAxesSpecified) {
-                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->get_input_node_shared_ptr(AXES_ID_V11))
+                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID_V11).get_node_shared_ptr())
                            ->cast_vector<int>();
                 if (dataRank == 4 && axes.size() == 2 && axes[0] == 1 && axes[1] == 2) {
                     interpAttrs.NCHWAsNHWC = true;

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -1819,8 +1819,8 @@ bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
                 return false;
             }
 
-            if (interp->get_input_size() > 3 &&
-                ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID).get_node_shared_ptr()) == nullptr) {
+            if (interp->get_input_size() > 3 && ov::as_type_ptr<const ov::op::v0::Constant>(
+                                                    interp->input_value(AXES_ID).get_node_shared_ptr()) == nullptr) {
                 errorMessage = "Only const 'axes' input is supported in Interpolate-4";
                 return false;
             }
@@ -1848,8 +1848,9 @@ bool Interpolate::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
                 errorMessage = "Only const 'scales_or_sizes' input is supported for static shapes in Interpolate-11";
                 return false;
             }
-            if (interp->get_input_size() > 2 && ov::as_type_ptr<const ov::op::v0::Constant>(
-                                                    interp->input_value(AXES_ID_V11).get_node_shared_ptr()) == nullptr) {
+            if (interp->get_input_size() > 2 &&
+                ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID_V11).get_node_shared_ptr()) ==
+                    nullptr) {
                 errorMessage = "Only const 'axes' input is supported in Interpolate-11";
                 return false;
             }
@@ -2067,8 +2068,9 @@ Interpolate::Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext
             }
 
             if (isAxesSpecified) {
-                axes = ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID_V11).get_node_shared_ptr())
-                           ->cast_vector<int>();
+                axes =
+                    ov::as_type_ptr<const ov::op::v0::Constant>(interp->input_value(AXES_ID_V11).get_node_shared_ptr())
+                        ->cast_vector<int>();
                 if (dataRank == 4 && axes.size() == 2 && axes[0] == 1 && axes[1] == 2) {
                     interpAttrs.NCHWAsNHWC = true;
                     axes[0] = 2;

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -76,7 +76,7 @@ bool Lrn::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
             errorMessage = "Doesn't support 'data' input with rank: " + std::to_string(dataDims.size());
             return false;
         }
-        auto axesNode = ov::as_type_ptr<const ov::opset1::Constant>(lrn->get_input_node_shared_ptr(1));
+        auto axesNode = ov::as_type_ptr<const ov::opset1::Constant>(lrn->input_value(1).get_node_shared_ptr());
         if (!axesNode) {
             errorMessage = "Only Constant operation on 'axis' input is supported";
             return false;
@@ -114,8 +114,8 @@ Lrn::Lrn(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
     std::string errorMessage;
     if (isSupportedOperation(op, errorMessage)) {
         auto lrn = ov::as_type_ptr<const ov::opset1::LRN>(op);
-        auto axes =
-            ov::as_type_ptr<const ov::opset1::Constant>(lrn->get_input_node_shared_ptr(1))->cast_vector<int64_t>();
+        auto axes = ov::as_type_ptr<const ov::opset1::Constant>(lrn->input_value(1).get_node_shared_ptr())
+                        ->cast_vector<int64_t>();
         bool isAcrossMaps = (axes.size() == 1 && axes[0] == 1);
         alg = isAcrossMaps ? dnnl::algorithm::lrn_across_channels : dnnl::algorithm::lrn_within_channel;
         alpha = static_cast<float>(lrn->get_alpha());

--- a/src/plugins/intel_cpu/src/nodes/mathematics.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.cpp
@@ -43,8 +43,8 @@ bool Math::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::
         if (one_of(op->get_type_info(),
                    ov::op::v0::HardSigmoid::get_type_info_static(),
                    ov::op::v0::Selu::get_type_info_static())) {
-            auto firstConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
-            auto secondConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto firstConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
+            auto secondConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             if (!firstConst || !secondConst) {
                 errorMessage = "Constant expected as the second and third inputs.";
                 return false;
@@ -221,91 +221,90 @@ bool Math::created() const {
 std::map<const ov::DiscreteTypeInfo, std::function<void(const std::shared_ptr<ov::Node>&, Math& node)>>&
 Math::getInitializers() {
     static std::map<const ov::DiscreteTypeInfo, std::function<void(const std::shared_ptr<ov::Node>&, Math& node)>>
-        initializers{
-            {ov::op::v0::Abs::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAbs;
-             }},
-            {ov::op::v0::Acos::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAcos;
-             }},
-            {ov::op::v3::Acosh::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAcosh;
-             }},
-            {ov::op::v0::Asin::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAsin;
-             }},
-            {ov::op::v3::Asinh::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAsinh;
-             }},
-            {ov::op::v0::Atan::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAtan;
-             }},
-            {ov::op::v0::Ceiling::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathCeiling;
-             }},
-            {ov::op::v0::Cos::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathCos;
-             }},
-            {ov::op::v0::Cosh::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathCosh;
-             }},
-            {ov::op::v0::Floor::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathFloor;
-             }},
-            {ov::op::v0::HardSigmoid::get_type_info_static(),
-             [](const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathHardSigmoid;
-                 node.alpha =
-                     ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1))->cast_vector<float>()[0];
-                 node.beta =
-                     ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2))->cast_vector<float>()[0];
-             }},
-            {ov::op::v0::Negative::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathNegative;
-             }},
-            {ov::op::v0::Selu::get_type_info_static(),
-             [](const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathSelu;
-                 node.alpha =
-                     ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1))->cast_vector<float>()[0];
-                 node.gamma =
-                     ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2))->cast_vector<float>()[0];
-             }},
-            {ov::op::v0::Sign::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathSign;
-             }},
-            {ov::op::v0::Sin::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathSin;
-             }},
-            {ov::op::v0::Sinh::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathSinh;
-             }},
-            {ov::op::v4::SoftPlus::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathSoftPlus;
-             }},
-            {ov::op::v0::Tan::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathTan;
-             }},
-            {ov::op::v3::Atanh::get_type_info_static(),
-             []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
-                 node.algorithm = Algorithm::MathAtanh;
-             }}};
+        initializers{{ov::op::v0::Abs::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAbs;
+                      }},
+                     {ov::op::v0::Acos::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAcos;
+                      }},
+                     {ov::op::v3::Acosh::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAcosh;
+                      }},
+                     {ov::op::v0::Asin::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAsin;
+                      }},
+                     {ov::op::v3::Asinh::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAsinh;
+                      }},
+                     {ov::op::v0::Atan::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAtan;
+                      }},
+                     {ov::op::v0::Ceiling::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathCeiling;
+                      }},
+                     {ov::op::v0::Cos::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathCos;
+                      }},
+                     {ov::op::v0::Cosh::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathCosh;
+                      }},
+                     {ov::op::v0::Floor::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathFloor;
+                      }},
+                     {ov::op::v0::HardSigmoid::get_type_info_static(),
+                      [](const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathHardSigmoid;
+                          node.alpha = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr())
+                                           ->cast_vector<float>()[0];
+                          node.beta = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr())
+                                          ->cast_vector<float>()[0];
+                      }},
+                     {ov::op::v0::Negative::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathNegative;
+                      }},
+                     {ov::op::v0::Selu::get_type_info_static(),
+                      [](const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathSelu;
+                          node.alpha = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr())
+                                           ->cast_vector<float>()[0];
+                          node.gamma = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr())
+                                           ->cast_vector<float>()[0];
+                      }},
+                     {ov::op::v0::Sign::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathSign;
+                      }},
+                     {ov::op::v0::Sin::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathSin;
+                      }},
+                     {ov::op::v0::Sinh::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathSinh;
+                      }},
+                     {ov::op::v4::SoftPlus::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathSoftPlus;
+                      }},
+                     {ov::op::v0::Tan::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathTan;
+                      }},
+                     {ov::op::v3::Atanh::get_type_info_static(),
+                      []([[maybe_unused]] const std::shared_ptr<ov::Node>& op, Math& node) {
+                          node.algorithm = Algorithm::MathAtanh;
+                      }}};
     return initializers;
 }
 

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -1849,7 +1849,7 @@ bool MVN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
         }
 
         if (auto mvnOp = ov::as_type_ptr<const ov::op::v6::MVN>(op)) {
-            auto axesOp = ov::as_type_ptr<ov::op::v0::Constant>(mvnOp->get_input_node_shared_ptr(1));
+            auto axesOp = ov::as_type_ptr<ov::op::v0::Constant>(mvnOp->input_value(1).get_node_shared_ptr());
             if (!axesOp) {
                 errorMessage = "Constant expected as the second input.";
                 return false;

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -740,7 +740,7 @@ bool NormalizeL2::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
             return false;
         }
 
-        auto axesNode = ov::as_type_ptr<const ov::op::v0::Constant>(norm->get_input_node_shared_ptr(AXES));
+        auto axesNode = ov::as_type_ptr<const ov::op::v0::Constant>(norm->input_value(AXES).get_node_shared_ptr());
         if (!axesNode) {
             errorMessage = "Supports only constant 'axes' input";
             return false;

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -26,11 +26,12 @@ bool OneHot::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
             errorMessage = "Only opset1 OneHot operation is supported";
             return false;
         }
-        if (ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(ON_VALUE_ID)) == nullptr) {
+        if (ov::as_type_ptr<const ov::opset1::Constant>(oneHot->input_value(ON_VALUE_ID).get_node_shared_ptr()) ==
+            nullptr) {
             errorMessage = "Only const 'on_value' input is supported";
             return false;
         }
-        if (ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(OFF_VALUEAXES_ID)) ==
+        if (ov::as_type_ptr<const ov::opset1::Constant>(oneHot->input_value(OFF_VALUEAXES_ID).get_node_shared_ptr()) ==
             nullptr) {
             errorMessage = "Only const 'off_value' input is supported";
             return false;
@@ -49,7 +50,8 @@ OneHot::OneHot(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
     }
 
     const auto oneHot = ov::as_type_ptr<const ov::opset1::OneHot>(op);
-    const auto depthNode = ov::as_type_ptr<const ov::opset1::Constant>(oneHot->get_input_node_shared_ptr(DEPTH_ID));
+    const auto depthNode =
+        ov::as_type_ptr<const ov::opset1::Constant>(oneHot->input_value(DEPTH_ID).get_node_shared_ptr());
     if (depthNode) {
         depth = depthNode->cast_vector<uint32_t>()[0];
     }

--- a/src/plugins/intel_cpu/src/nodes/reduce.cpp
+++ b/src/plugins/intel_cpu/src/nodes/reduce.cpp
@@ -1985,7 +1985,7 @@ bool Reduce::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
         }
         if (const auto reduce = ov::as_type_ptr<const ov::op::util::ArithmeticReductionKeepDims>(op)) {
             auto reduceConst =
-                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->input_value(REDUCE_INDEXES).get_node_shared_ptr());
             if (!reduceConst) {
                 errorMessage = "Second tensor is not constant";
                 return false;
@@ -1993,7 +1993,7 @@ bool Reduce::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
         }
         if (const auto reduce = ov::as_type_ptr<const ov::op::util::LogicalReductionKeepDims>(op)) {
             auto reduceConst =
-                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->input_value(REDUCE_INDEXES).get_node_shared_ptr());
             if (!reduceConst) {
                 errorMessage = "Second tensor is not constant";
                 return false;
@@ -2003,7 +2003,7 @@ bool Reduce::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
             errorMessage = "Doesn't support Reduce algorithm: " + std::string(op->get_type_info().name);
             return false;
         }
-        if (ov::as_type_ptr<ov::opset1::Constant>(op->get_input_node_shared_ptr(REDUCE_INDEXES)) == nullptr) {
+        if (ov::as_type_ptr<ov::opset1::Constant>(op->input_value(REDUCE_INDEXES).get_node_shared_ptr()) == nullptr) {
             errorMessage = "Only const 'reduce_indexes' input is supported";
             return false;
         }
@@ -2021,7 +2021,7 @@ Reduce::Reduce(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
         if (const auto reduce = ov::as_type_ptr<ov::op::util::ArithmeticReductionKeepDims>(op)) {
             keep_dims = reduce->get_keep_dims();
             auto reduceConst =
-                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->input_value(REDUCE_INDEXES).get_node_shared_ptr());
             if (!reduceConst) {
                 THROW_CPU_NODE_ERR("second tensor is not constant!");
             }
@@ -2029,7 +2029,7 @@ Reduce::Reduce(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
         } else if (const auto reduce = ov::as_type_ptr<ov::op::util::LogicalReductionKeepDims>(op)) {
             keep_dims = reduce->get_keep_dims();
             auto reduceConst =
-                ov::as_type_ptr<const ov::opset1::Constant>(reduce->get_input_node_shared_ptr(REDUCE_INDEXES));
+                ov::as_type_ptr<const ov::opset1::Constant>(reduce->input_value(REDUCE_INDEXES).get_node_shared_ptr());
             if (!reduceConst) {
                 THROW_CPU_NODE_ERR("second tensor is not constant!");
             }

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -336,8 +336,8 @@ bool RNN::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::s
                 return false;
             }
 
-            if (ov::op::util::is_seq_len_provided(op->get_input_node_shared_ptr(0),
-                                                  op->get_input_node_shared_ptr(seqLenIdx))) {
+            if (ov::op::util::is_seq_len_provided(op->input_value(0).get_node_shared_ptr(),
+                                                  op->input_value(seqLenIdx).get_node_shared_ptr())) {
                 errorMessage = "Unsupported sequence length.";
                 return false;
             }

--- a/src/plugins/intel_cpu/src/nodes/split.cpp
+++ b/src/plugins/intel_cpu/src/nodes/split.cpp
@@ -31,7 +31,7 @@ bool Split::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std:
             errorMessage = "Only opset1 Split and VariadicSplit operations are supported";
             return false;
         }
-        auto axisOp = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto axisOp = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         if (!axisOp) {
             errorMessage = "Constant expected as the axis input.";
             return false;
@@ -57,14 +57,14 @@ Split::Split(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& cont
         INPUTS_NUM = 2;
     } else if (ov::as_type_ptr<const ov::op::v1::VariadicSplit>(op)) {
         INPUTS_NUM = 3;
-        if (!ov::is_type<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2))) {
+        if (!ov::is_type<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr())) {
             this->splitLengths.resize(op->get_input_shape(2)[0]);
             this->constSplitLengths = false;
         }
     }
 
     const auto inRank = getInputShapeAtPort(0).getRank();
-    auto axisOp = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto axisOp = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     auto axis = axisOp->cast_vector<int64_t>()[0];
     if (axis < 0) {
         axis += inRank;

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.cpp
@@ -75,7 +75,7 @@ StridedSlice::StridedSlice(const std::shared_ptr<ov::Node>& op, const GraphConte
     }
 
     for (size_t i = 0lu; i < op->get_input_size(); i++) {
-        isConstantInput[i] = ov::is_type<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
+        isConstantInput[i] = ov::is_type<ov::op::v0::Constant>(op->input_value(i).get_node_shared_ptr());
         if (!isConstantInput[i] && one_of(i, attrs.BEGIN_ID, attrs.END_ID, attrs.STRIDE_ID) &&
             !attrs.isSliceScatterOp) {
             shapeHasDataDependency = true;
@@ -147,7 +147,7 @@ StridedSlice::StridedSlice(const std::shared_ptr<ov::Node>& op, const GraphConte
             return;
         }
 
-        const auto constNode = ov::as_type_ptr<const ov::opset1::Constant>(op->get_input_node_shared_ptr(type));
+        const auto constNode = ov::as_type_ptr<const ov::opset1::Constant>(op->input_value(type).get_node_shared_ptr());
         parameter = constNode->cast_vector<int>();
 
         auto size = constNode->get_shape()[0];

--- a/src/plugins/intel_cpu/src/nodes/topk.cpp
+++ b/src/plugins/intel_cpu/src/nodes/topk.cpp
@@ -1869,7 +1869,8 @@ bool TopK::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::
 
         auto topKOp = ov::as_type_ptr<const ov::op::util::TopKBase>(op);
         if (!isDynamicNgraphNode(op)) {
-            auto topKConst = ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
+            auto topKConst =
+                ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->input_value(TOPK_K).get_node_shared_ptr());
             if (!topKConst) {
                 errorMessage = "Second tensor is not constant in static shape mode";
                 return false;
@@ -1905,7 +1906,8 @@ TopK::TopK(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& contex
         auto in_dims_size = in_dims.size();
 
         if (!isDynamicNgraphNode(op)) {
-            auto topKConst = ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->get_input_node_shared_ptr(TOPK_K));
+            auto topKConst =
+                ov::as_type_ptr<const ov::op::v0::Constant>(topKOp->input_value(TOPK_K).get_node_shared_ptr());
             if (!topKConst) {
                 THROW_CPU_NODE_ERR("gets non-constant second tensor in static shape mode!");
             }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/transpose.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/transpose.cpp
@@ -31,7 +31,7 @@ Result TransposeShapeInfer::infer(const std::vector<std::reference_wrapper<const
 }
 ShapeInferPtr TransposeShapeInferFactory::makeShapeInfer() const {
     if (const auto order = ov::as_type_ptr<const ov::op::v0::Constant>(
-            m_op->get_input_node_shared_ptr(ov::op::v1::Transpose::ORDER))) {
+            m_op->input_value(ov::op::v1::Transpose::ORDER).get_node_shared_ptr())) {
         const auto axes_vec = order->cast_vector<size_t>();
         return std::make_shared<TransposeShapeInfer>(m_op->get_output_partial_shape(0).rank().get_length(), axes_vec);
     }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
@@ -229,10 +229,10 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
             // dequantize with subtract
             if (subtract_it != pattern_map.end()) {
                 const auto subtract = ov::as_type_ptr<op::v1::Subtract>(subtract_it->second.get_node_shared_ptr());
-                multiply_input = subtract->clone_with_new_inputs({multiply_input, subtract->input_value(1)});
+                multiply_input = subtract->clone_with_new_inputs({multiply_input->output(0), subtract->input_value(1)});
             }
 
-            auto new_multiply = multiply->clone_with_new_inputs({multiply_input, multiply->input_value(1)});
+            auto new_multiply = multiply->clone_with_new_inputs({multiply_input->output(0), multiply->input_value(1)});
             new_multiply->set_friendly_name(rnn_quantized->get_friendly_name() + ".1");
 
             for (auto output : H_outputs) {

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_fq_rnn_to_quantized_rnn.cpp
@@ -222,7 +222,7 @@ ov::intel_cpu::ConvertFqRnnToQuantizedRnn::ConvertFqRnnToQuantizedRnn() {
         if (hidden_state_it != pattern_map.end()) {
             const auto& convert = pattern_map.at(convert_H).get_node_shared_ptr();
             const auto subtract_it = pattern_map.find(subtract_H);
-            const auto& multiply = rnn->get_input_node_shared_ptr(1);
+            const auto& multiply = rnn->input_value(1).get_node_shared_ptr();
 
             auto new_convert = convert->clone_with_new_inputs({rnn_quantized->output(1)});
             std::shared_ptr<Node> multiply_input = new_convert;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_leaky_relu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_leaky_relu.cpp
@@ -23,7 +23,7 @@ ov::intel_cpu::ConvertToLeakyRelu::ConvertToLeakyRelu() {
         if (!prelu) {
             return false;
         }
-        auto slopeNode = ov::as_type_ptr<ov::opset1::Constant>(prelu->get_input_node_shared_ptr(1));
+        auto slopeNode = ov::as_type_ptr<ov::opset1::Constant>(prelu->input_value(1).get_node_shared_ptr());
         if (slopeNode != nullptr && ov::shape_size(slopeNode->get_shape()) == 1) {
             const float slope = slopeNode->cast_vector<float>()[0];
             const auto leakyRelu = std::make_shared<ov::intel_cpu::LeakyReluNode>(prelu->input(0).get_source_output(),

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_swish_cpu.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/convert_to_swish_cpu.cpp
@@ -23,7 +23,7 @@ ov::intel_cpu::ConvertToSwishCPU::ConvertToSwishCPU() {
         }
         float beta_value = 1.0;
         if (swish->input_values().size() == 2) {
-            auto beta = ov::as_type_ptr<ov::opset4::Constant>(swish->get_input_node_shared_ptr(1));
+            auto beta = ov::as_type_ptr<ov::opset4::Constant>(swish->input_value(1).get_node_shared_ptr());
 
             if (!beta || ov::shape_size(swish->get_input_shape(1)) != 1) {
                 return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_rms_norm.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/decompose_rms_norm.cpp
@@ -29,9 +29,9 @@ DecomposeRMSNorm::DecomposeRMSNorm() {
         if (node == nullptr || transformation_callback(node)) {
             return false;
         }
-        auto data = node->get_input_node_shared_ptr(0);
+        auto data = node->input_value(0);
         auto data_precision = node->get_input_element_type(0);
-        auto scale = node->get_input_node_shared_ptr(1);
+        auto scale = node->input_value(1);
 
         auto power_const = ov::opset10::Constant::create(data_precision, {}, std::vector<float>{2.f});
         auto power = std::make_shared<ov::opset10::Power>(data, power_const);

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_fc_reshape_to_weights.cpp
@@ -55,18 +55,18 @@ ov::intel_cpu::MoveFCReshapeToWeights::MoveFCReshapeToWeights() {
 
     ov::matcher_pass_callback callback = [&](ov::pass::pattern::Matcher& m) {
         const auto fully_connected = m.get_match_root();
-        const auto weights_path = fully_connected->get_input_node_shared_ptr(1);
+        const auto weights_path = fully_connected->input_value(1).get_node_shared_ptr();
         const bool with_transpose = ov::is_type<ov::op::v1::Transpose>(weights_path);
         if (with_transpose) {
             const auto transpose_const =
-                ov::as_type_ptr<ov::op::v0::Constant>(weights_path->get_input_node_shared_ptr(1));
+                ov::as_type_ptr<ov::op::v0::Constant>(weights_path->input_value(1).get_node_shared_ptr());
             if (transpose_const->cast_vector<int>() != std::vector<int>{1, 0}) {
                 return false;
             }
         }
 
         const auto& fc_input_shape = fully_connected->get_input_shape(1);
-        const auto reshape = with_transpose ? weights_path->get_input_node_shared_ptr(0) : weights_path;
+        const auto reshape = with_transpose ? weights_path->input_value(0).get_node_shared_ptr() : weights_path;
 
         auto check_decompression_shape = [&](const std::shared_ptr<ov::Node>& node) {
             ov::Shape expected_shape(3, 1);
@@ -84,18 +84,18 @@ ov::intel_cpu::MoveFCReshapeToWeights::MoveFCReshapeToWeights() {
                    });
         };
 
-        const auto mul = reshape->get_input_node_shared_ptr(0);
-        if (!check_decompression_shape(mul->get_input_node_shared_ptr(1))) {
+        const auto mul = reshape->input_value(0).get_node_shared_ptr();
+        if (!check_decompression_shape(mul->input_value(1).get_node_shared_ptr())) {
             return false;
         }
-        const auto mul_parent = mul->get_input_node_shared_ptr(0);
+        const auto mul_parent = mul->input_value(0).get_node_shared_ptr();
         const bool with_subtract = ov::is_type<ov::op::v1::Subtract>(mul_parent);
-        if (with_subtract && !check_decompression_shape(mul_parent->get_input_node_shared_ptr(1))) {
+        if (with_subtract && !check_decompression_shape(mul_parent->input_value(1).get_node_shared_ptr())) {
             return false;
         }
 
-        const auto convert = with_subtract ? mul_parent->get_input_node_shared_ptr(0) : mul_parent;
-        const auto weights = convert->get_input_node_shared_ptr(0);
+        const auto convert = with_subtract ? mul_parent->input_value(0).get_node_shared_ptr() : mul_parent;
+        const auto weights = convert->input_value(0).get_node_shared_ptr();
         ov::Shape expected_weights_shape(3, 1);
         expected_weights_shape[1] = fc_input_shape[with_transpose ? 1 : 0];
         expected_weights_shape[2] = fc_input_shape[with_transpose ? 0 : 1];
@@ -118,12 +118,12 @@ ov::intel_cpu::MoveFCReshapeToWeights::MoveFCReshapeToWeights() {
 
         // We can remove 3D->2D reshape if we manually reshape all constants in the weights subgraph
         ov::replace_output_update_name(reshape->output(0), reshape->input_value(0));
-        squeeze_constant(mul->get_input_node_shared_ptr(1));
+        squeeze_constant(mul->input_value(1).get_node_shared_ptr());
         squeeze_constant(weights);
         if (with_subtract) {
-            auto sub_const = mul_parent->get_input_node_shared_ptr(1);
+            auto sub_const = mul_parent->input_value(1).get_node_shared_ptr();
             if (ov::is_type<ov::op::v0::Convert>(sub_const)) {
-                sub_const = sub_const->get_input_node_shared_ptr(0);
+                sub_const = sub_const->input_value(0).get_node_shared_ptr();
             }
             squeeze_constant(sub_const);
         }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
@@ -144,7 +144,7 @@ ov::intel_cpu::MoveReadValueInputsToSubgraph::MoveReadValueInputsToSubgraph() {
         }
 
         // Subgraph's output
-        auto last_node = readvalue->get_input_node_shared_ptr(0);
+        auto last_node = readvalue->input_value(0);
         auto output = std::make_shared<ov::op::v0::Result>(last_node);
         auto func = std::make_shared<Model>(ov::ResultVector({output}), params, "state_init_submodel");
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/move_readvalue_inputs_to_subgraph.cpp
@@ -118,12 +118,12 @@ ov::intel_cpu::MoveReadValueInputsToSubgraph::MoveReadValueInputsToSubgraph() {
             subgraph_nodes.emplace_back(node);
 
             for (size_t i = 0; i < node->get_input_size(); i++) {
-                reverse_dfs(node->get_input_node_shared_ptr(i));
+                reverse_dfs(node->input_value(i).get_node_shared_ptr());
             }
         };
 
         // Reverse DFS ReadValue, find all suitable nodes and move them to subgraph_nodes.
-        reverse_dfs(readvalue->get_input_node_shared_ptr(0));
+        reverse_dfs(readvalue->input_value(0).get_node_shared_ptr());
 
         if (inputs.empty() || subgraph_nodes.empty()) {
             return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
@@ -188,10 +188,12 @@ ov::intel_cpu::ConvertInteractionInt8::ConvertInteractionInt8() {
         }
         // check whether the inputs to concat have same fakequantize parameters
         for (size_t i = 1; i < dense_fq_node->get_input_size(); i++) {
-            auto dense_const = ov::as_type_ptr<ov::opset8::Constant>(dense_fq_node->get_input_node_shared_ptr(i))
-                                   ->cast_vector<float>();
-            auto sparse_const = ov::as_type_ptr<ov::opset8::Constant>(sparse_fq_node->get_input_node_shared_ptr(i))
-                                    ->cast_vector<float>();
+            auto dense_const =
+                ov::as_type_ptr<ov::opset8::Constant>(dense_fq_node->input_value(i).get_node_shared_ptr())
+                    ->cast_vector<float>();
+            auto sparse_const =
+                ov::as_type_ptr<ov::opset8::Constant>(sparse_fq_node->input_value(i).get_node_shared_ptr())
+                    ->cast_vector<float>();
             if (dense_const.size() != sparse_const.size() || dense_const != sparse_const) {
                 return false;
             }

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/convert_to_interaction.cpp
@@ -200,10 +200,10 @@ ov::intel_cpu::ConvertInteractionInt8::ConvertInteractionInt8() {
         auto interaction_node = std::make_shared<InteractionNode>(features_node);
         interaction_node->set_friendly_name(final_concat_node->get_friendly_name());
         auto fq_inter_node = dense_fq_node->clone_with_new_inputs({interaction_node,
-                                                                   dense_fq_node->get_input_node_shared_ptr(1),
-                                                                   dense_fq_node->get_input_node_shared_ptr(2),
-                                                                   dense_fq_node->get_input_node_shared_ptr(3),
-                                                                   dense_fq_node->get_input_node_shared_ptr(4)});
+                                                                   dense_fq_node->input_value(1),
+                                                                   dense_fq_node->input_value(2),
+                                                                   dense_fq_node->input_value(3),
+                                                                   dense_fq_node->input_value(4)});
         fq_inter_node->set_friendly_name(final_concat_node->get_friendly_name());
         replace_node(final_concat_node, fq_inter_node);
         return true;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/sdpa_fuse_transpose_reshape.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/sdpa_fuse_transpose_reshape.cpp
@@ -147,9 +147,7 @@ intel_cpu::SDPAFuseTransposeReshape::SDPAFuseTransposeReshape() {
             return false;
         }
 
-        OutputVector args = {q_reshape->input_value(0),
-                             k_reshape->input_value(0),
-                             v_reshape->input_value(0)};
+        OutputVector args = {q_reshape->input_value(0), k_reshape->input_value(0), v_reshape->input_value(0)};
 
         // Config
         intel_cpu::SDPAWithTransposeReshape::Config config;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/sdpa_fuse_transpose_reshape.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/sdpa_fuse_transpose_reshape.cpp
@@ -147,9 +147,9 @@ intel_cpu::SDPAFuseTransposeReshape::SDPAFuseTransposeReshape() {
             return false;
         }
 
-        OutputVector args = {q_reshape->get_input_node_shared_ptr(0),
-                             k_reshape->get_input_node_shared_ptr(0),
-                             v_reshape->get_input_node_shared_ptr(0)};
+        OutputVector args = {q_reshape->input_value(0),
+                             k_reshape->input_value(0),
+                             v_reshape->input_value(0)};
 
         // Config
         intel_cpu::SDPAWithTransposeReshape::Config config;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/sdpa_fuse_transpose_reshape.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/sdpa_fuse_transpose_reshape.cpp
@@ -69,7 +69,7 @@ intel_cpu::SDPAFuseTransposeReshape::SDPAFuseTransposeReshape() {
         // Order=[0, 2, 1, 3]
         auto is_expected_transpose = [&](std::shared_ptr<op::v1::Transpose>& transpose) {
             if (transpose) {
-                const auto orders = as_type_ptr<op::v0::Constant>(transpose->get_input_node_shared_ptr(1));
+                const auto orders = as_type_ptr<op::v0::Constant>(transpose->input_value(1).get_node_shared_ptr());
                 return orders && (std::vector<int32_t>({0, 2, 1, 3}) == orders->cast_vector<int32_t>());
             }
             return false;
@@ -109,13 +109,13 @@ intel_cpu::SDPAFuseTransposeReshape::SDPAFuseTransposeReshape() {
             return false;
         }
         // K,V Reshape's order should be same node.
-        auto k_reshape_order = as_type_ptr<op::v0::Constant>(k_reshape->get_input_node_shared_ptr(1));
-        auto v_reshape_order = as_type_ptr<op::v0::Constant>(v_reshape->get_input_node_shared_ptr(1));
+        auto k_reshape_order = as_type_ptr<op::v0::Constant>(k_reshape->input_value(1).get_node_shared_ptr());
+        auto v_reshape_order = as_type_ptr<op::v0::Constant>(v_reshape->input_value(1).get_node_shared_ptr());
         if (k_reshape_order && v_reshape_order) {
             if (k_reshape_order->cast_vector<int32_t>() != v_reshape_order->cast_vector<int32_t>()) {
                 return false;
             }
-        } else if (k_reshape->get_input_node_shared_ptr(1) != v_reshape->get_input_node_shared_ptr(1)) {
+        } else if (k_reshape->input_value(1).get_node_shared_ptr() != v_reshape->input_value(1).get_node_shared_ptr()) {
             return false;
         }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/simplify_fakequantize.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/pass/simplify_fakequantize.hpp
@@ -13,13 +13,14 @@ namespace ov::intel_cpu {
 inline std::vector<float> simplifyToScale(const std::shared_ptr<ov::op::v0::FakeQuantize>& fq_node,
                                           float threshold = 0.0001f) {
     auto levels = fq_node->get_levels();
-    auto input_low = ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(1))->cast_vector<float>();
+    auto input_low =
+        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(1).get_node_shared_ptr())->cast_vector<float>();
     auto input_high =
-        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(2))->cast_vector<float>();
+        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(2).get_node_shared_ptr())->cast_vector<float>();
     auto output_low =
-        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(3))->cast_vector<float>();
+        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(3).get_node_shared_ptr())->cast_vector<float>();
     auto output_high =
-        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->get_input_node_shared_ptr(4))->cast_vector<float>();
+        ov::as_type_ptr<ov::op::v0::Constant>(fq_node->input_value(4).get_node_shared_ptr())->cast_vector<float>();
 
     std::vector<float> cl, ch, isc, ish, osc, osh;
     for (float i : input_low) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/aarch64/pass/snippets_mark_skipped.cpp
@@ -226,7 +226,7 @@ auto is_skipped_op(const std::shared_ptr<ov::Node>& op) -> bool {
 
 bool isSuitableMatMulWithConstantPath(const std::shared_ptr<Node>& node) {
     return ov::is_type<ov::opset1::MatMul>(node) &&
-           !ov::is_type<ov::opset1::Constant>(node->get_input_node_shared_ptr(1)) &&
+           !ov::is_type<ov::opset1::Constant>(node->input_value(1).get_node_shared_ptr()) &&
            ov::op::util::is_on_constant_path(node->input_value(1));
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/enforce_precision.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/enforce_precision.cpp
@@ -93,7 +93,7 @@ bool EnforcePrecision::run_on_model(const std::shared_ptr<ov::Model>& f) {
         for (auto index = 0ull; index < supported_precisions_to_enforce.size(); ++index) {
             if ((supported_precisions_to_enforce[index] == target) || (actual_precisions[index] == source)) {
                 const auto op_parent =
-                    ov::as_type_ptr<snippets::op::ConvertSaturation>(op->get_input_node_shared_ptr(index));
+                    ov::as_type_ptr<snippets::op::ConvertSaturation>(op->input_value(index).get_node_shared_ptr());
                 if ((op_parent != nullptr) && (op_parent->get_input_element_type(0) == target) &&
                     // we can remove existing convertion only if precisions before and after are appropriate for removal
                     snippets::pass::PropagatePrecision::can_be_removed(op_parent->get_input_element_type(0),

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/fuse_tpp_to_equations.cpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/pass/fuse_tpp_to_equations.cpp
@@ -112,7 +112,7 @@ bool FuseTPPToEquations::run_on_model(const std::shared_ptr<ov::Model>& m) {
         to_visit.pop_back();
         const size_t in_size = node->get_input_size();
         for (size_t i = 0; i < in_size; i++) {
-            to_visit.push_back(node->get_input_node_shared_ptr(in_size - i - 1));
+            to_visit.push_back(node->input_value(in_size - i - 1).get_node_shared_ptr());
         }
     }
     return modified;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
@@ -112,7 +112,7 @@ std::shared_ptr<ov::Node> ConvolutionLayerCPUTest::modifyGraph(const ov::element
                     ov::OutputVector inputsForShapeInfer;
                     for (size_t j = 0; j < lastNode->get_input_size(); j++) {
                         if (ov::is_type<ov::op::v0::Constant>(lastNode->get_input_node_ptr(j))) {
-                            inputsForShapeInfer.push_back(lastNode->get_input_node_shared_ptr(j));
+                            inputsForShapeInfer.push_back(lastNode->input_value(j));
                         } else {
                             inputsForShapeInfer.push_back(
                                 std::make_shared<ov::op::v0::Parameter>(lastNode->get_input_element_type(j),

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
@@ -131,7 +131,7 @@ protected:
                         ov::OutputVector inputsForShapeInfer;
                         for (size_t j = 0; j < lastNode->get_input_size(); j++) {
                             if (ov::is_type<ov::op::v0::Constant>(lastNode->get_input_node_ptr(j))) {
-                                inputsForShapeInfer.push_back(lastNode->get_input_node_shared_ptr(j));
+                                inputsForShapeInfer.push_back(lastNode->input_value(j));
                             } else {
                                 inputsForShapeInfer.push_back(
                                     std::make_shared<ov::op::v0::Parameter>(lastNode->get_input_element_type(j),

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.cpp
@@ -150,11 +150,11 @@ void MatmulWeightsDecompression::check_results() {
 
     const auto runtime_model = compiledModel.get_runtime_model();
     const auto result = runtime_model->get_result();
-    auto fc = result->get_input_node_shared_ptr(0);
+    auto fc = result->input_value(0).get_node_shared_ptr();
     // Handle precision conversion before output
     auto type = fc->get_rt_info().at(ov::exec_model_info::LAYER_TYPE).as<std::string>();
     if (type == "Reorder" || type == "Convert" || type == "Subgraph")
-        fc = fc->get_input_node_shared_ptr(0);
+        fc = fc->input_value(0).get_node_shared_ptr();
 
     type = fc->get_rt_info().at(ov::exec_model_info::LAYER_TYPE).as<std::string>();
     EXPECT_EQ(type, "FullyConnected");

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/broadcast_eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/broadcast_eltwise.cpp
@@ -76,7 +76,7 @@ protected:
 
     void CheckLastNode(const ov::CompiledModel& execNet) {
         const auto model = execNet.get_runtime_model();
-        const auto last_node = model->get_result()->get_input_node_shared_ptr(0);
+        const auto last_node = model->get_result()->input_value(0).get_node_shared_ptr();
         const auto& rt_info = last_node->get_rt_info();
         const auto layer_type = rt_info.find("layerType")->second.as<std::string>();
         EXPECT_EQ(layer_type, "Broadcast");

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/matmul_decompress_convert.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/matmul_decompress_convert.cpp
@@ -150,7 +150,7 @@ protected:
         ASSERT_NE(nullptr, execFunction);
         for (const auto& fcNode : execFunction->get_ops()) {
             if (getExecValue(fcNode->get_rt_info(), ov::exec_model_info::LAYER_TYPE) == "FullyConnected") {
-                const auto& constNode = fcNode->get_input_node_shared_ptr(1);
+                const auto& constNode = fcNode->input_value(1).get_node_shared_ptr();
                 ov::element::Type expectedType(
                     getExecValue(constNode->get_rt_info(), ov::exec_model_info::OUTPUT_PRECISIONS));
                 ASSERT_EQ(expectedType, expectedWeiElemType);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/merge_transpose_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/merge_transpose_reorder.cpp
@@ -123,7 +123,7 @@ protected:
                                                                               ov::Strides{1, 1});
         // It's necessary to force acdb layout to be sure that the reorder, which changes dims order, will be inserted
         // (by default acdb layout is chosen only on >= AVX512 platforms)
-        const auto conv = conv_with_bias->get_input_node_shared_ptr(0);
+        const auto conv = conv_with_bias->input_value(0).get_node_shared_ptr();
         const auto acdb_format = CPUTestUtils::cpu_memory_format_t::acdb;
         conv->get_rt_info() = makeCPUInfo({acdb_format}, {acdb_format}, {});
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/disable_gathercompressed_quantized_model.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/disable_gathercompressed_quantized_model.cpp
@@ -87,7 +87,7 @@ protected:
         const auto compressed_weights_precision = std::get<0>(test_param);
 
         const auto runtime_model = compiledModel.get_runtime_model();
-        const auto matmul = runtime_model->get_result()->get_input_node_shared_ptr(0);
+        const auto matmul = runtime_model->get_result()->input_value(0).get_node_shared_ptr();
 
         bool have_gather = false;
         bool have_gather_compressed = false;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/memory_sharing_test.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/memory_sharing_test.cpp
@@ -52,7 +52,7 @@ TEST_F(EdgeWithSameNameInTwoModels, smoke_CompareWithRef) {
                                                    autoPad,
                                                    convOutCh1);
     conv1->set_friendly_name(convName);
-    conv1->get_input_node_shared_ptr(1)->set_friendly_name(weightName);
+    conv1->input_value(1).get_node_shared_ptr()->set_friendly_name(weightName);
     auto model1 = makeNgraphFunction(type, params1, conv1, "Model1");
 
     // second model
@@ -72,7 +72,7 @@ TEST_F(EdgeWithSameNameInTwoModels, smoke_CompareWithRef) {
                                                    autoPad,
                                                    convOutCh2);
     conv2->set_friendly_name(convName);
-    conv2->get_input_node_shared_ptr(1)->set_friendly_name(weightName);
+    conv2->input_value(1).get_node_shared_ptr()->set_friendly_name(weightName);
     auto model2 = makeNgraphFunction(type, params2, conv2, "Model2");
 
     // model compilation

--- a/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
@@ -84,7 +84,7 @@ postFunctionMgr::addPostOps(const ov::element::Type &ngPrc, ov::ParameterVector 
     auto clonedPostFunction = _pFunction->clone();
     clonedPostFunction->set_friendly_name(_pFunction->get_friendly_name());
     clonedPostFunction->replace_node(clonedPostFunction->get_parameters()[0], lastNode);
-    return clonedPostFunction->get_result()->get_input_node_shared_ptr(0);
+    return clonedPostFunction->get_result()->input_value(0).get_node_shared_ptr();
 }
 
 std::string postFunctionMgr::getFusedOpsNames() const {

--- a/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
@@ -22,7 +22,7 @@ static void CreateBatchToSpaceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
 
     bool constant_shape = true;
     for (size_t i = 1; i < 4; ++i) {
-        auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
+        auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(i).get_node_shared_ptr());
         if (!inConst) {
             constant_shape = false;
             break;
@@ -34,7 +34,7 @@ static void CreateBatchToSpaceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         auto rank = op->get_input_partial_shape(0).size();
         auto format = cldnn::format::get_default_format(rank);
         for (size_t i = 1; i < 4; ++i) {
-            auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
+            auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(i).get_node_shared_ptr());
 
             std::vector<int32_t> sizes = inConst->cast_vector<int32_t>();
             int32_t default_size = i == 1 ? 1 : 0;

--- a/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/broadcast.cpp
@@ -97,7 +97,7 @@ static void CreateCommonBroadcastOp(ProgramBuilder& p, const std::shared_ptr<ov:
 static void CreateBroadcastOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v1::Broadcast>& op) {
     validate_inputs_count(op, {2, 3});
     if (op->get_broadcast_spec().m_type == ov::op::AutoBroadcastType::NONE && op->get_input_size() == 3) {
-        auto axis_mapping_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+        auto axis_mapping_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
         OPENVINO_ASSERT(axis_mapping_node != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
         auto axis_mapping = axis_mapping_node->get_axis_set_val();
@@ -112,7 +112,7 @@ static void CreateBroadcastOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v
     validate_inputs_count(op, {2, 3});
     ov::AxisSet axis_mapping;
     if (op->get_input_size() == 3) {
-        auto axis_mapping_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+        auto axis_mapping_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
         OPENVINO_ASSERT(axis_mapping_node != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
         axis_mapping = axis_mapping_node->get_axis_set_val();

--- a/src/plugins/intel_gpu/src/plugin/ops/col2im.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/col2im.cpp
@@ -33,11 +33,11 @@ static void CreateCol2ImOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v15:
     for (auto p : op->get_pads_end())
         padding_end.push_back(p);
 
-    auto output_shape_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto output_shape_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     auto vec_output_shape = output_shape_const->cast_vector<size_t>();
     ov::Shape output_shape(vec_output_shape);
 
-    auto kernel_size_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+    auto kernel_size_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
     auto kernel_size = kernel_size_const->cast_vector<size_t>();
     ov::Shape kernel_shape(kernel_size);
 

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -161,7 +161,7 @@ static void CreateConvolutionBackpropDataOp(ProgramBuilder& p, const std::shared
                                                output_padding,
                                                weights_have_group_dim);
         if (op->get_input_size() == 3) {
-            auto output_shape_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto output_shape_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             if (output_shape_constant) {
                 auto output_shape = output_shape_constant->cast_vector<int64_t>();
                 ov::Shape shape(output_shape.begin(), output_shape.end());
@@ -253,7 +253,7 @@ static void CreateGroupConvolutionBackpropDataOp(ProgramBuilder& p, const std::s
                                                output_padding,
                                                weights_have_group_dim);
         if (op->get_input_size() == 3) {
-            auto output_shape_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto output_shape_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             if (output_shape_constant) {
                 auto output_shape = output_shape_constant->cast_vector<int64_t>();
                 ov::Shape shape(output_shape.begin(), output_shape.end());

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -103,7 +103,6 @@ static void CreateConvolutionBackpropDataOp(ProgramBuilder& p, const std::shared
     }
 
     auto weightsName = inputs[1];
-    auto weights_node = op->get_input_node_shared_ptr(1);
     // WA: For the cases like Const(weights)->Sub(zp)->Deconv. And also for the cases with real runtime weights.
     // Dimensions order of weights blob is IOYX, but
     // the selected format is OIYX by default. So we need to swap (and transpose) I and O dimensions to match the format
@@ -192,7 +191,6 @@ static void CreateGroupConvolutionBackpropDataOp(ProgramBuilder& p, const std::s
     uint32_t groups = static_cast<uint32_t>(op->get_input_shape(1)[0]);
 
     auto weightsName = inputs[1];
-    auto weights_node = op->get_input_node_shared_ptr(1);
     // WA: For the cases like Const(weights)->Sub(zp)->Deconv. And also for the cases with real runtime weights.
     // Dimensions order of weights blob is IOYX, but
     // the selected format is OIYX by default. So we need to swap I and O dimensions to match the format.

--- a/src/plugins/intel_gpu/src/plugin/ops/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/ctc_greedy_decoder.cpp
@@ -45,7 +45,7 @@ static void CreateCommonCTCGreedyDecoderOp(ProgramBuilder& p, const std::shared_
     if (p.use_new_shape_infer()) {
         uint32_t blank_index = UINT32_MAX;
         if (reordered_inputs.size() == 3) {
-            auto blank_index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto blank_index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             if (!blank_index_node) {
                 OPENVINO_THROW("Unsupported blank_index node type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
             }
@@ -69,7 +69,7 @@ static void CreateCommonCTCGreedyDecoderOp(ProgramBuilder& p, const std::shared_
     } else {
         uint32_t blank_index = static_cast<uint32_t>(op->get_input_shape(0).back() - 1);
         if (reordered_inputs.size() == 3) {
-            auto blank_index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto blank_index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             if (!blank_index_node) {
                 OPENVINO_THROW("Unsupported blank_index node type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
             }

--- a/src/plugins/intel_gpu/src/plugin/ops/cum_sum.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/cum_sum.cpp
@@ -21,7 +21,7 @@ static void CreateCumSumOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::
 
     int64_t axis = 0;
     if (op->get_input_size() == 2) {
-        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
         axis = axes_constant->cast_vector<int64_t>()[0];
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/dft.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/dft.cpp
@@ -29,7 +29,7 @@ void createDft(ProgramBuilder& p,
 
     if (op->is_dynamic() && p.use_new_shape_infer()) {
         std::vector<int64_t> axes;
-        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         if (axes_constant != nullptr) {
             axes = axes_constant->cast_vector<int64_t>();
             uint8_t axis_correction = static_cast<uint8_t>(op->get_input_partial_shape(0).size());
@@ -41,7 +41,7 @@ void createDft(ProgramBuilder& p,
 
         if (op->get_input_size() == 3) {
             std::vector<int64_t> signal_size;
-            auto signal_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto signal_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             if (signal_size_constant != nullptr) {
                 signal_size = signal_size_constant->cast_vector<int64_t>();
             }
@@ -55,7 +55,7 @@ void createDft(ProgramBuilder& p,
     } else {
         const auto& out_shape = op->get_output_shape(0);
 
-        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", friendly_name, " (", op->get_type_name(), ")");
         auto axes = axes_constant->cast_vector<int64_t>();
         uint8_t axis_correction = static_cast<uint8_t>(op->get_input_shape(0).size());
@@ -66,7 +66,7 @@ void createDft(ProgramBuilder& p,
 
         std::vector<int64_t> signal_size;
         if (op->get_input_size() == 3) {
-            auto signal_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+            auto signal_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
             OPENVINO_ASSERT(signal_size_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", friendly_name, " (", op->get_type_name(), ")");
             signal_size = signal_size_constant->cast_vector<int64_t>();
         }

--- a/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/eltwise.cpp
@@ -165,7 +165,7 @@ static void CreateLogicalXorOp(ProgramBuilder& p, const std::shared_ptr<ov::op::
 
 static void CreatePowerOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v1::Power>& op) {
     validate_inputs_count(op, {2});
-    auto power_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto power_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     if (power_node) {
         if (ov::shape_size(power_node->get_output_shape(0)) == 1) {
             float pow;

--- a/src/plugins/intel_gpu/src/plugin/ops/embedding_bag.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/embedding_bag.cpp
@@ -23,7 +23,7 @@ static void CreateEmbeddingBagOffsetsSumOp(ProgramBuilder& p, const std::shared_
 
     int32_t defaultIndex = -1;
     if (inputs.size() > 3) {
-        auto index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
+        auto index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(3).get_node_shared_ptr());
         OPENVINO_ASSERT(index_node != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
         float val;
@@ -107,7 +107,7 @@ static void CreateEmbeddingSegmentsSumOp(ProgramBuilder& p, const std::shared_pt
     int32_t defaultIndex = -1;
     // port of default_index is 4 by default, but we removed "num_segments" above, so now it's equal to 3
     if (inputs.size() > 4) {
-        auto index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(4));
+        auto index_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(4).get_node_shared_ptr());
         OPENVINO_ASSERT(index_node != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
         float val;

--- a/src/plugins/intel_gpu/src/plugin/ops/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/fully_connected.cpp
@@ -43,7 +43,7 @@ static void CreateFullyConnectedCompressedOp(ProgramBuilder& p, const std::share
     float zp_value = 0.0f;
     bool has_scalar_zp = false;
     if (zp_name.size() > 0) {
-        auto zp_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(W_ZP_IDX));
+        auto zp_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(W_ZP_IDX).get_node_shared_ptr());
         if (zp_const && ov::shape_size(zp_const->get_output_shape(0)) == 1) {
             has_scalar_zp = true;
             zp_value = zp_const->cast_vector<float>()[0];

--- a/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/gather.cpp
@@ -148,7 +148,7 @@ void CreateGatherOpBase(ProgramBuilder& p, const std::shared_ptr<T>& op, const i
             float zp_value = 0.0f;
             bool has_scalar_zp = false;
             if (op->get_input_size() == 5) {
-                std::shared_ptr<ov::op::v0::Constant> zp_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(4));
+                std::shared_ptr<ov::op::v0::Constant> zp_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(4).get_node_shared_ptr());
                 if (zp_const && ov::shape_size(zp_const->get_output_shape(0)) == 1) {
                     has_scalar_zp = true;
                     zp_value = zp_const->cast_vector<float>()[0];

--- a/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/interpolate.cpp
@@ -17,7 +17,7 @@ static std::vector<int64_t> ExtractAxes(const std::shared_ptr<ov::op::util::Inte
     std::vector<int64_t> axes;
     auto inputRank = op->get_input_partial_shape(0).size();
     if (op->get_input_size() == axes_index + 1) {
-        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(axes_index));
+        auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(axes_index).get_node_shared_ptr());
         OPENVINO_ASSERT(axes_constant, "Unsupported parameter node type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
         axes = axes_constant->cast_vector<int64_t>();
@@ -75,10 +75,10 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
 
     auto attrs = op->get_attrs();
 
-    auto sizes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(SIZES_INDEX));
+    auto sizes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(SIZES_INDEX).get_node_shared_ptr());
     std::vector<int64_t> sizes = sizes_constant ? sizes_constant->cast_vector<int64_t>() : std::vector<int64_t>{};
 
-    auto scales_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(SCALES_INDEX));
+    auto scales_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(SCALES_INDEX).get_node_shared_ptr());
     std::vector<float> scales = scales_constant ? scales_constant->cast_vector<float>() : std::vector<float>{};
 
     std::vector<int64_t> axes = ExtractAxes(op, AXES_INDEX);
@@ -155,7 +155,7 @@ static void CreateInterpolateOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
 
     auto attrs = op->get_attrs();
 
-    auto scales_or_sizes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(eScalesOrSizesIndex));
+    auto scales_or_sizes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(eScalesOrSizesIndex).get_node_shared_ptr());
     std::vector<float> scales = scales_or_sizes_constant && attrs.shape_calculation_mode == ov::op::v11::Interpolate::ShapeCalcMode::SCALES ?
         scales_or_sizes_constant->cast_vector<float>() : std::vector<float>{};
     std::vector<int64_t> sizes = scales_or_sizes_constant && attrs.shape_calculation_mode == ov::op::v11::Interpolate::ShapeCalcMode::SIZES ?

--- a/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/loop.cpp
@@ -233,15 +233,15 @@ static void CreateCommonLoopOp(ProgramBuilder& p, const std::shared_ptr<ov::op::
 
         if (special_body_ports.body_condition_output_idx >= 0) {
             const auto& body_outputs = loop_op->get_function()->get_results();
-            auto body_condition_output = body_outputs.at(special_body_ports.body_condition_output_idx)->get_input_node_shared_ptr(0);
+            auto body_condition_output = body_outputs.at(special_body_ports.body_condition_output_idx)->input_value(0).get_node_shared_ptr();
             body_execution_condition_id = layer_type_name_ID(body_condition_output);
         }
 
-        trip_count_id = layer_type_name_ID(loop_op->get_input_node_shared_ptr(0));
+        trip_count_id = layer_type_name_ID(loop_op->input_value(0).get_node_shared_ptr());
         // Update trip_count_id for cached constant primitive
         if (trip_count_id != p.primitive_ids[trip_count_id])
             trip_count_id = p.primitive_ids[trip_count_id];
-        first_execution_condition_id = layer_type_name_ID(loop_op->get_input_node_shared_ptr(1));
+        first_execution_condition_id = layer_type_name_ID(loop_op->input_value(1).get_node_shared_ptr());
     }
 
     // setup input_primitive_maps/ output_primitive_maps and back_edges

--- a/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/lrn.cpp
@@ -25,7 +25,7 @@ static void CreateLRNOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::LRN
     auto inputs = p.GetInputInfo(op);
     std::string layerName = layer_type_name_ID(op);
 
-    auto axis_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto axis_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(axis_const != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
     auto axis_value = axis_const->cast_vector<int64_t>();
     auto localSize = static_cast<uint32_t>(op->get_nsize());

--- a/src/plugins/intel_gpu/src/plugin/ops/multinomial.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/multinomial.cpp
@@ -121,7 +121,7 @@ static void CreateMultinomialOp(ProgramBuilder& p, const std::shared_ptr<ov::op:
     };
     p.add_primitive(*op, random_prim);
 
-    auto const_num_samples = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto const_num_samples = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(const_num_samples != nullptr, "[GPU] Unsupported num_samples node type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
     std::int64_t num_samples{};

--- a/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/mvn.cpp
@@ -49,7 +49,7 @@ static void CreateMVNOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::MVN
 static void CreateMVNOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v6::MVN>& op) {
     validate_inputs_count(op, {2});
 
-    auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(inConst != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
     std::vector<int64_t> axes = inConst->cast_vector<int64_t>();

--- a/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/normalize_l2.cpp
@@ -19,7 +19,7 @@ static void CreateNormalizeL2Op(ProgramBuilder& p, const std::shared_ptr<ov::op:
     std::string layerName = layer_type_name_ID(op);
 
     // params
-    auto const_axis = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto const_axis = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(const_axis != nullptr, "[GPU] Unsupported axis node type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
     auto axis = const_axis->cast_vector<size_t>();

--- a/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/one_hot.cpp
@@ -17,9 +17,9 @@ static void CreateOneHotOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v1::
     std::string layerName = layer_type_name_ID(op);
 
     int64_t axis = op->get_axis();
-    auto depth_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
-    auto on_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
-    auto off_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
+    auto depth_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
+    auto on_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
+    auto off_value_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(3).get_node_shared_ptr());
 
     OPENVINO_ASSERT(on_value_node != nullptr || off_value_node != nullptr || depth_value_node != nullptr,
                     "[GPU] Unsupported on/off/depth nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");

--- a/src/plugins/intel_gpu/src/plugin/ops/pad.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/pad.cpp
@@ -41,7 +41,7 @@ static void CreatePadOpInternal(ProgramBuilder& p, const std::shared_ptr<op::uti
     float pad_value = 0.f;
     bool is_value_const = false;
     if (op->get_pad_mode() == ov::op::PadMode::CONSTANT && op->get_input_size() == 4) {
-        auto const_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
+        auto const_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(3).get_node_shared_ptr());
         if (const_node) {
             const bool check_value_range = false;  // Allows the usage of infinity value as pad_value
             OPENVINO_ASSERT(ov::op::util::get_single_value(const_node, pad_value, check_value_range),

--- a/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
@@ -48,7 +48,7 @@ static void CreatePagedAttentionExtensionOp(ProgramBuilder& p, const std::shared
     if (query_merged_dim.is_static()) {
         heads_num = query_merged_dim.get_length() / k_head_size;
     } else {
-        auto reshape_input = op->get_input_node_shared_ptr(0)->get_input_partial_shape(0);
+        auto reshape_input = op->input_value(0).get_node_shared_ptr()->get_input_partial_shape(0);
         heads_num = reshape_input[2].get_length();
     }
 
@@ -61,7 +61,7 @@ static void CreatePagedAttentionExtensionOp(ProgramBuilder& p, const std::shared
     const size_t sliding_window_idx = 10;
     const size_t alibi_idx = 11;
 
-    std::shared_ptr<ov::op::v0::Constant> scale_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(scale_idx));
+    std::shared_ptr<ov::op::v0::Constant> scale_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(scale_idx).get_node_shared_ptr());
     if (scale_const) {
         OPENVINO_ASSERT(ov::shape_size(scale_const->get_output_shape(0)) == 1);
         prim.scale_val = scale_const->cast_vector<float>()[0];
@@ -69,13 +69,13 @@ static void CreatePagedAttentionExtensionOp(ProgramBuilder& p, const std::shared
         prim.scale_val = std::optional<float>();
     }
 
-    std::shared_ptr<ov::op::v0::Constant> sliding_windows_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(sliding_window_idx));
+    std::shared_ptr<ov::op::v0::Constant> sliding_windows_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(sliding_window_idx).get_node_shared_ptr());
     if (sliding_windows_const) {
         OPENVINO_ASSERT(ov::shape_size(sliding_windows_const->get_output_shape(0)) == 1);
         prim.sliding_window = sliding_windows_const->cast_vector<size_t>()[0];
     }
 
-    std::shared_ptr<ov::op::v0::Constant> alibi_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(alibi_idx));
+    std::shared_ptr<ov::op::v0::Constant> alibi_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(alibi_idx).get_node_shared_ptr());
     OPENVINO_ASSERT(alibi_const != nullptr);
     prim.has_alibi = ov::shape_size(alibi_const->get_output_shape(0)) > 0;
     prim.has_rotated_blocks = op->get_input_size() == 16;

--- a/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/paged_attention.cpp
@@ -69,7 +69,8 @@ static void CreatePagedAttentionExtensionOp(ProgramBuilder& p, const std::shared
         prim.scale_val = std::optional<float>();
     }
 
-    std::shared_ptr<ov::op::v0::Constant> sliding_windows_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(sliding_window_idx).get_node_shared_ptr());
+    std::shared_ptr<ov::op::v0::Constant> sliding_windows_const =
+        ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(sliding_window_idx).get_node_shared_ptr());
     if (sliding_windows_const) {
         OPENVINO_ASSERT(ov::shape_size(sliding_windows_const->get_output_shape(0)) == 1);
         prim.sliding_window = sliding_windows_const->cast_vector<size_t>()[0];

--- a/src/plugins/intel_gpu/src/plugin/ops/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/prior_box.cpp
@@ -110,8 +110,8 @@ static void CreatePriorBoxOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
     OPENVINO_ASSERT(img_pshape.is_static(), "Dynamic shapes are not supported for PriorBox operation yet");
 
     if (!output_pshape.is_dynamic()) {
-        const auto output_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(0));
-        const auto image_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        const auto output_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(0).get_node_shared_ptr());
+        const auto image_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
 
         // output_size should be constant to be static output shape
         OPENVINO_ASSERT(output_size_constant,
@@ -182,8 +182,8 @@ static void CreatePriorBoxOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v8
     auto output_pshape = op->get_output_partial_shape(0);
 
     if (!output_pshape.is_dynamic()) {
-        const auto output_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(0));
-        const auto image_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        const auto output_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(0).get_node_shared_ptr());
+        const auto image_size_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
 
         // output_size should be constant to be static output shape
         OPENVINO_ASSERT(output_size_constant,

--- a/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reduce.cpp
@@ -29,7 +29,7 @@ static void CreateReduceOp(ProgramBuilder& p, const std::shared_ptr<ov::Node>& o
     auto input_pshape = op->get_input_partial_shape(0);
     int64_t rank = input_pshape.size();
 
-    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
     std::vector<int64_t> axes = axes_constant->cast_vector<int64_t>();

--- a/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/reshape.cpp
@@ -26,7 +26,7 @@ static void CreateCommonReshapeOp(ProgramBuilder& p, const std::shared_ptr<ov::N
 
     if (p.use_new_shape_infer() || op->is_dynamic()) {
         std::shared_ptr<cldnn::reshape> reshape_prim = nullptr;
-        auto second_const_input = op->get_input_size() == 2 ? ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1)) : nullptr;
+        auto second_const_input = op->get_input_size() == 2 ? ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr()) : nullptr;
         std::vector<int64_t> output_pattern = {};
         if (second_const_input != nullptr) {
             output_pattern = second_const_input->cast_vector<int64_t>();

--- a/src/plugins/intel_gpu/src/plugin/ops/result.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/result.cpp
@@ -18,7 +18,7 @@ namespace ov::intel_gpu {
 static void CreateResultOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Result>& op) {
     validate_inputs_count(op, {1});
 
-    auto prev = op->get_input_node_shared_ptr(0);
+    auto prev = op->input_value(0).get_node_shared_ptr();
     auto input_id = prev->get_friendly_name();
     if (prev->get_output_size() > 1) {
         input_id += "." + std::to_string(op->get_input_source_output(0).get_index());

--- a/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
@@ -21,11 +21,11 @@ void CreateRollOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v7::Roll>& op
     const auto& op_friendly_name = op->get_friendly_name();
     const auto& input_pshape = op->get_input_partial_shape(0);
 
-    auto shift_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto shift_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     OPENVINO_ASSERT(shift_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
     const auto shift_raw = shift_constant->cast_vector<int32_t>();
 
-    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
     OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
     auto axes_raw = axes_constant->cast_vector<int32_t>();
 

--- a/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scaled_dot_product_attention.cpp
@@ -29,7 +29,7 @@ const size_t scale_idx = 4;
 static std::shared_ptr<ov::op::v0::Constant> GetScalarConstInput(const std::shared_ptr<ov::op::Op>& op, size_t idx) {
     std::shared_ptr<ov::op::v0::Constant> constOp = nullptr;
     if (op->get_input_size() > idx && !op->get_input_partial_shape(idx).is_dynamic() && ov::shape_size(op->get_input_shape(idx)) == 1) {
-        constOp = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(idx));
+        constOp = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(idx).get_node_shared_ptr());
     }
     return constOp;
 }

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_elements_update.cpp
@@ -16,7 +16,7 @@ static void CreateScatterElementsUpdateOp(ProgramBuilder& p, const std::shared_p
     auto inputs = p.GetInputInfo(op);
     std::string layerName = layer_type_name_ID(op);
 
-    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
+    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(3).get_node_shared_ptr());
     OPENVINO_ASSERT(axes_constant, "Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
 
     int64_t axis = ov::util::try_normalize_axis(axes_constant->cast_vector<int64_t>()[0],

--- a/src/plugins/intel_gpu/src/plugin/ops/scatter_update.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/scatter_update.cpp
@@ -17,7 +17,7 @@ static void CreateScatterUpdateOp(ProgramBuilder& p, const std::shared_ptr<ov::o
     auto inputs = p.GetInputInfo(op);
     std::string layerName = layer_type_name_ID(op);
 
-    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(3));
+    auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(3).get_node_shared_ptr());
     OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
     int64_t axis = axes_constant->cast_vector<int64_t>()[0];
     auto primitive = cldnn::scatter_update(layerName,

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
@@ -22,7 +22,7 @@ static void CreateSpaceToBatchOp(ProgramBuilder& p, const std::shared_ptr<ov::op
 
     bool constant_shape = true;
     for (size_t i = 1; i < 4; ++i) {
-        auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
+        auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(i).get_node_shared_ptr());
         if (!inConst) {
             constant_shape = false;
             break;
@@ -34,7 +34,7 @@ static void CreateSpaceToBatchOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         auto rank = op->get_input_partial_shape(0).size();
         auto format = cldnn::format::get_default_format(rank);
         for (size_t i = 1; i < 4; ++i) {
-            auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
+            auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(i).get_node_shared_ptr());
 
             std::vector<int32_t> sizes = inConst->cast_vector<int32_t>();
             int32_t default_size = i == 1 ? 1 : 0;

--- a/src/plugins/intel_gpu/src/plugin/ops/split.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/split.cpp
@@ -58,7 +58,7 @@ static void CreateCommonSplitOp(ProgramBuilder& p, const std::shared_ptr<ov::Nod
         }
 
         int64_t axis = -1;
-        auto const_axis = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto const_axis = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         if (const_axis) {
             axis = ov::util::try_normalize_axis(const_axis->cast_vector<int64_t>()[0],
                                                 op->get_input_partial_shape(0).rank(),

--- a/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/tile.cpp
@@ -16,7 +16,7 @@ static void CreateTileOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Ti
     validate_inputs_count(op, {2});
     auto inputs = p.GetInputInfo(op);
     std::string layerName = layer_type_name_ID(op);
-    if (auto repeats_const = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1))) {
+    if (auto repeats_const = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr())) {
         std::vector<int64_t> repeats = repeats_const->cast_vector<int64_t>();
 
         // TODO: Remove code below once new shape infer is enabled

--- a/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/transpose.cpp
@@ -18,7 +18,7 @@ static void CreateTransposeOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v
 
     std::vector<uint16_t> order;
     if (op->get_input_size() == 2) {
-        auto order_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto order_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         OPENVINO_ASSERT(order_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
         order = order_constant->cast_vector<uint16_t>();
     }

--- a/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/unary.cpp
@@ -75,7 +75,7 @@ static void CreateReluOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Re
 static void CreatePReluOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::PRelu>& op) {
     validate_inputs_count(op, {2});
 
-    auto slope_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+    auto slope_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
     auto slope_shape = op->get_input_partial_shape(1);
     auto out_shape = op->get_output_partial_shape(0);
 
@@ -164,8 +164,8 @@ static void CreateErfOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Erf
 
 static void CreateHardSigmoidOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::HardSigmoid>& op) {
     validate_inputs_count(op, {3});
-    auto alpha_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
-    auto beta_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+    auto alpha_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
+    auto beta_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
     if (!alpha_node || !beta_node) {
         OPENVINO_THROW("[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
     }
@@ -190,8 +190,8 @@ static void CreateNegativeOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
 
 static void CreateSeluOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Selu>& op) {
     validate_inputs_count(op, {3});
-    auto alpha_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
-    auto lambda_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
+    auto alpha_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
+    auto lambda_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(2).get_node_shared_ptr());
     if (!alpha_node || !lambda_node) {
         OPENVINO_THROW("Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
     }
@@ -235,7 +235,7 @@ static void CreateCoshOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0::Co
 static void CreateSwishOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v4::Swish>& op) {
     validate_inputs_count(op, {1, 2});
     if (op->get_input_size() == 2) {
-        auto beta_node = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto beta_node = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         if (beta_node) {
             if (ov::shape_size(beta_node->get_output_shape(0)) == 1) {
                 float beta;

--- a/src/plugins/intel_gpu/src/plugin/ops/unique.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/unique.cpp
@@ -18,7 +18,7 @@ void CreateUniqueOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v10::Unique
     bool flattened = true;
     int64_t axis{};
     if (op->get_input_size() == 2) {
-        auto axis_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
+        auto axis_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->input_value(1).get_node_shared_ptr());
         OPENVINO_ASSERT(axis_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op->get_friendly_name(), " (", op->get_type_name(), ")");
         axis = axis_constant->cast_vector<int64_t>().at(0);
         axis = ov::util::try_normalize_axis(axis, op->get_input_partial_shape(0).rank(), *op);

--- a/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/variable.cpp
@@ -65,7 +65,7 @@ void CreateReadValueOp(ProgramBuilder& p, const std::shared_ptr<ov::intel_gpu::o
 
 void CreateAssignOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v3::Assign>& op) {
     validate_inputs_count(op, {1});
-    if (IsReadValueOp(op->get_input_node_shared_ptr(0))) {
+    if (IsReadValueOp(op->input_value(0).get_node_shared_ptr())) {
         return;
     }
     CreateVariableAccessPrimitive<cldnn::assign>(p, op, op->get_variable_id());
@@ -78,7 +78,7 @@ void CreateReadValueOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v6::Read
 
 void CreateAssignOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v6::Assign>& op) {
     validate_inputs_count(op, {1});
-    if (IsReadValueOp(op->get_input_node_shared_ptr(0))) {
+    if (IsReadValueOp(op->input_value(0).get_node_shared_ptr())) {
         return;
     }
     CreateVariableAccessPrimitive<cldnn::assign>(p, op, op->get_variable_id());

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -64,12 +64,12 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected() {
         bool is_convert = false;
         if (auto convert_node = ov::as_type_ptr<ov::op::v0::Convert>(fc_input_b.get_node_shared_ptr())) {
             is_convert = true;
-            fc_input_b = convert_node->get_input_node_shared_ptr(0);
+            fc_input_b = convert_node->input_value(0);
         }
 
         auto transpose_node = ov::as_type_ptr<ov::op::v1::Transpose>(fc_input_b.get_node_shared_ptr());
         if (transpose_node) {
-            fc_input_b = transpose_node->get_input_node_shared_ptr(0);
+            fc_input_b = transpose_node->input_value(0);
         }
 
         auto shape_a = fc_input_a.get_partial_shape();

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_matmul_to_fc.cpp
@@ -52,8 +52,8 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected() {
             if (user != matmul && ov::is_type<ov::op::v0::MatMul>(user) && ov::is_type<ov::op::v0::Convert>(input_b)) {
                 auto other_matmul = ov::as_type_ptr<ov::op::v0::MatMul>(user);
                 // Transpose for input_b generates invalid input for other sibling matmul
-                if (input_b == other_matmul->get_input_node_shared_ptr(0) || fc_input_b == fc_input_a ||
-                    (input_b == other_matmul->get_input_node_shared_ptr(1) && matmul->get_transpose_b() != other_matmul->get_transpose_b())) {
+                if (input_b == other_matmul->input_value(0).get_node_shared_ptr() || fc_input_b == fc_input_a ||
+                    (input_b == other_matmul->input_value(1).get_node_shared_ptr() && matmul->get_transpose_b() != other_matmul->get_transpose_b())) {
                     return false;
                 }
             }
@@ -159,7 +159,7 @@ ConvertMatMulToFullyConnected::ConvertMatMulToFullyConnected() {
         bool can_reuse_transpose = false;
         if (!matmul->get_transpose_b()) {
             if (transpose_node && transpose_node->get_input_size() == 2) {
-                auto order_constant = ov::as_type_ptr<ov::op::v0::Constant>(transpose_node->get_input_node_shared_ptr(1));
+                auto order_constant = ov::as_type_ptr<ov::op::v0::Constant>(transpose_node->input_value(1).get_node_shared_ptr());
                 if (order_constant) {
                     std::vector<size_t> order = order_constant->cast_vector<size_t>();
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
@@ -86,7 +86,7 @@ ConvertStridedSlicesToVariadicSplit::ConvertStridedSlicesToVariadicSplit() {
                     }
                     return true;
                 };
-                auto begin_node = strided_slice_node->get_input_node_shared_ptr(1);
+                auto begin_node = strided_slice_node->input_value(1);
                 if (const auto& begin_constant_node = ov::util::get_constant_from_source(begin_node)) {
                     auto values = begin_constant_node->cast_vector<int64_t>();
                     auto begin_mask = strided_slice_node->get_begin_mask();
@@ -100,9 +100,9 @@ ConvertStridedSlicesToVariadicSplit::ConvertStridedSlicesToVariadicSplit() {
                     return false;
                 }
 
-                auto end_node = strided_slice_node->get_input_node_shared_ptr(2);
+                auto end_node = strided_slice_node->input_value(2);
                 if (const auto& end_constant_node = ov::util::get_constant_from_source(end_node)) {
-                    int64_t max_value = end_node->get_element_type() == ov::element::i32 ? std::numeric_limits<int32_t>::max()
+                    int64_t max_value = end_node.get_node()->get_element_type() == ov::element::i32 ? std::numeric_limits<int32_t>::max()
                                                                                          : std::numeric_limits<int64_t>::max();
                     auto values = end_constant_node->cast_vector<int64_t>();
                     auto end_mask = strided_slice_node->get_end_mask();

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_stridedslices_to_variadicsplit.cpp
@@ -130,7 +130,7 @@ ConvertStridedSlicesToVariadicSplit::ConvertStridedSlicesToVariadicSplit() {
             auto& strided_slice_node = strided_slice_nodes[i];
             for (const auto& user : strided_slice_node->get_users()) {
                 for (size_t idx = 0; idx < user->inputs().size(); ++idx) {
-                    if (user->get_input_node_shared_ptr(idx) == strided_slice_node) {
+                    if (user->input_value(idx).get_node_shared_ptr() == strided_slice_node) {
                         user->input(idx).replace_source_output(variadic_split->output(i));
                     }
                 }

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -71,10 +71,10 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
             output_type = m_fc->get_input_element_type(0);
 
         auto new_fc = std::make_shared<op::FullyConnectedCompressed>(dyn_quan->output(0),
-                                                                     m_fc->get_input_node_shared_ptr(1),
-                                                                     m_fc->get_input_node_shared_ptr(2),
-                                                                     m_fc->get_input_node_shared_ptr(3),
-                                                                     optional_w_zp,
+                                                                     m_fc->input_value(1),
+                                                                     m_fc->input_value(2),
+                                                                     m_fc->input_value(3),
+                                                                     optional_w_zp->output(0),
                                                                      dyn_quan->output(1),
                                                                      optional_a_zp,
                                                                      output_type);

--- a/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/dynamic_quantize_fully_connected.cpp
@@ -62,7 +62,7 @@ DynamicQuantizeFullyConnected::DynamicQuantizeFullyConnected(uint64_t group_size
         }
 
         auto dyn_quan = std::make_shared<ov::op::internal::DynamicQuantize>(m_data, config);
-        auto optional_w_zp = m_fc->get_input_size() > 4 ? m_fc->get_input_node_shared_ptr(4) : std::make_shared<ov::intel_gpu::op::Placeholder>();
+        auto optional_w_zp = m_fc->get_input_size() > 4 ? m_fc->input_value(4).get_node_shared_ptr() : std::make_shared<ov::intel_gpu::op::Placeholder>();
         auto optional_a_zp = config.quantization_type == QuantizationType::Symmetric ?
                                 std::make_shared<ov::intel_gpu::op::Placeholder>() : dyn_quan->output(2);
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/fc_horizontal_fusion.cpp
@@ -139,7 +139,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
         }
         ov::OutputVector weight_nodes_as_output_vector;
         for (size_t i = 0; i < weight_nodes.size(); ++i) {
-            weight_nodes_as_output_vector.push_back(weight_nodes[i]);
+            weight_nodes_as_output_vector.push_back(weight_nodes[i]->output(0));
         }
         auto fused_weight = std::make_shared<ov::op::v0::Concat>(weight_nodes_as_output_vector, 0);
         fused_weight->set_friendly_name(weight_nodes[0]->get_friendly_name() + "_fused_weight");
@@ -147,7 +147,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
 
         ov::OutputVector scales_as_output_vector;
         for (size_t i = 0; i < scale_nodes.size(); ++i) {
-            scales_as_output_vector.push_back(scale_nodes[i]);
+            scales_as_output_vector.push_back(scale_nodes[i]->output(0));
         }
 
         auto fused_scale = std::make_shared<ov::op::v0::Concat>(scales_as_output_vector, 0);
@@ -218,7 +218,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
         if (bias_nodes.size() == fc_nodes.size()) {
             ov::OutputVector bias_nodes_as_output_vector;
             for (size_t i = 0; i < bias_nodes.size(); ++i) {
-                bias_nodes_as_output_vector.push_back(bias_nodes[i]);
+                bias_nodes_as_output_vector.push_back(bias_nodes[i]->output(0));
             }
             fused_bias = std::make_shared<ov::op::v0::Concat>(bias_nodes_as_output_vector, bias_rank - 1);
             fused_bias->set_friendly_name(bias_nodes[0]->get_friendly_name() + "_fused_bias");
@@ -264,7 +264,7 @@ FullyConnectedHorizontalFusion::FullyConnectedHorizontalFusion(bool fuse_mlp_swi
             } else {
                 ov::OutputVector zp_nodes_as_output_vector;
                 for (size_t i = 0; i < zp_nodes.size(); ++i) {
-                    zp_nodes_as_output_vector.push_back(zp_nodes[i]);
+                    zp_nodes_as_output_vector.push_back(zp_nodes[i]->output(0));
                 }
                 fused_zps = std::make_shared<ov::op::v0::Concat>(zp_nodes_as_output_vector, 0);
                 fused_zps->set_friendly_name(zp_nodes[0]->get_friendly_name() + "_fused_zps");

--- a/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/indirect_kv_cache.cpp
@@ -92,8 +92,8 @@ IndirectGemmOpt::IndirectGemmOpt() {
         auto order_in1 = gemm_node->get_input1_transpose_order();
         auto order_out = gemm_node->get_output_transpose_order();
 
-        auto indirect_gemm = std::make_shared<ov::intel_gpu::op::IndirectGemm>(gemm_node->get_input_node_shared_ptr(0),
-                                                                               gemm_node->get_input_node_shared_ptr(1),
+        auto indirect_gemm = std::make_shared<ov::intel_gpu::op::IndirectGemm>(gemm_node->input_value(0),
+                                                                               gemm_node->input_value(1),
                                                                                indirect_kv_cache->output(1), // beam table
                                                                                matmul_kv_cache_index == 0,
                                                                                matmul_kv_cache_index == 1,
@@ -190,9 +190,9 @@ IndirectSDPAOpt::IndirectSDPAOpt() {
         auto is_causal = sdpa->get_causal();
 
         OutputVector data_inputs;
-        data_inputs.push_back(sdpa->get_input_node_shared_ptr(0)); // Q
-        data_inputs.push_back(sdpa->get_input_node_shared_ptr(1)); // K
-        data_inputs.push_back(sdpa->get_input_node_shared_ptr(2)); // V
+        data_inputs.push_back(sdpa->input_value(0)); // Q
+        data_inputs.push_back(sdpa->input_value(1)); // K
+        data_inputs.push_back(sdpa->input_value(2)); // V
 
         if (pattern_map.find(sdpa_with_attn_mask_m) != pattern_map.end()) {
             data_inputs.push_back(sdpa->get_input_source_output(3));

--- a/src/plugins/intel_gpu/src/plugin/transformations/kv_cache_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/kv_cache_fusion.cpp
@@ -74,7 +74,7 @@ KVCacheFusionMatcher::KVCacheFusionMatcher() {
         }
 
         // Replace common ReadValue op with a custom one as common one expects paired Assign operation which is removed by this transform
-        auto new_read_value_node = variable_initializer ? std::make_shared<ov::intel_gpu::op::ReadValue>(variable_initializer, variable)
+        auto new_read_value_node = variable_initializer ? std::make_shared<ov::intel_gpu::op::ReadValue>(variable_initializer->output(0), variable)
                                                         : std::make_shared<ov::intel_gpu::op::ReadValue>(variable);
         new_read_value_node->set_friendly_name(past_node->get_friendly_name());
         ov::copy_runtime_info(past_node, new_read_value_node);

--- a/src/plugins/intel_gpu/src/plugin/transformations/kv_cache_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/kv_cache_fusion.cpp
@@ -70,7 +70,7 @@ KVCacheFusionMatcher::KVCacheFusionMatcher() {
         std::shared_ptr<ov::Node> variable_initializer = nullptr;
         std::shared_ptr<ov::Node> kv_cache_node = nullptr;
         if (past_node->get_input_size() == 1) {
-            variable_initializer = past_node->get_input_node_shared_ptr(0);
+            variable_initializer = past_node->input_value(0).get_node_shared_ptr();
         }
 
         // Replace common ReadValue op with a custom one as common one expects paired Assign operation which is removed by this transform

--- a/src/plugins/intel_gpu/src/plugin/transformations/lora_horizontal_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/lora_horizontal_fusion.cpp
@@ -77,42 +77,40 @@ LoRAHorizontalFusion::LoRAHorizontalFusion() {
 
         ov::NodeVector add_nodes;
         ov::NodeVector multiply_nodes;
-        ov::NodeVector variable_a_nodes;
-        ov::NodeVector variable_b_nodes;
-        ov::NodeVector variable_alpha_nodes;
+        ov::OutputVector variable_a_nodes;
+        ov::OutputVector variable_alpha_nodes;
         ov::NodeVector matmul1_nodes;
-        ov::NodeVector matmul2_nodes;
+        ov::OutputVector matmul2_nodes;
 
         for (const auto& add : split->get_users()) {
             add_nodes.emplace_back(add);
 
             size_t matmul2_idx = ov::is_type<ov::op::v0::MatMul>(add->get_input_node_shared_ptr(0)) ? 0 : 1;
-            matmul2_nodes.emplace_back(add->get_input_node_shared_ptr(matmul2_idx));
+            matmul2_nodes.emplace_back(add->input_value(matmul2_idx));
         }
         for (const auto& matmul2 : matmul2_nodes) {
-            multiply_nodes.emplace_back(matmul2->get_input_node_shared_ptr(0));
-            variable_b_nodes.emplace_back(matmul2->get_input_node_shared_ptr(1));
+            multiply_nodes.emplace_back(matmul2.get_node()->get_input_node_shared_ptr(0));
         }
         for (const auto& multiply : multiply_nodes) {
             size_t matmul1_idx = ov::is_type<ov::op::v0::MatMul>(multiply->get_input_node_shared_ptr(0)) ? 0 : 1;
             matmul1_nodes.emplace_back(multiply->get_input_node_shared_ptr(matmul1_idx));
 
             size_t alpha_idx = (matmul1_idx + 1) % 2;
-            variable_alpha_nodes.emplace_back(multiply->get_input_node_shared_ptr(alpha_idx));
+            variable_alpha_nodes.emplace_back(multiply->input_value(alpha_idx));
         }
         for (const auto& matmul1 : matmul1_nodes) {
-            variable_a_nodes.emplace_back(matmul1->get_input_node_shared_ptr(1));
+            variable_a_nodes.emplace_back(matmul1->input_value(1));
         }
 
         auto fused_variable_a = std::make_shared<ov::op::v0::Concat>(variable_a_nodes, 0);
-        fused_variable_a->set_friendly_name(variable_a_nodes[0]->get_friendly_name() +
+        fused_variable_a->set_friendly_name(variable_a_nodes[0].get_node()->get_friendly_name() +
                                             "_fused_" + std::to_string(variable_a_nodes.size()) + "_ReadValues");
-        ov::copy_runtime_info(variable_a_nodes, fused_variable_a);
+        ov::copy_output_runtime_info(variable_a_nodes, {fused_variable_a->output(0)});
 
         auto fused_variable_alpha = std::make_shared<ov::op::v0::Concat>(variable_alpha_nodes, 1);
-        fused_variable_alpha->set_friendly_name(variable_alpha_nodes[0]->get_friendly_name() +
+        fused_variable_alpha->set_friendly_name(variable_alpha_nodes[0].get_node()->get_friendly_name() +
                                                 "_fused_" + std::to_string(variable_alpha_nodes.size()) + "_ReadValues");
-        ov::copy_runtime_info(variable_alpha_nodes, fused_variable_alpha);
+        ov::copy_output_runtime_info(variable_alpha_nodes, {fused_variable_alpha->output(0)});
 
         bool transpose_a1 = ov::as_type_ptr<ov::op::v0::MatMul>(matmul1_nodes[0])->get_transpose_a();
         bool transpose_b1 = ov::as_type_ptr<ov::op::v0::MatMul>(matmul1_nodes[0])->get_transpose_b();
@@ -138,13 +136,13 @@ LoRAHorizontalFusion::LoRAHorizontalFusion() {
         copy_runtime_info(fused_multiply, output_split);
         output_split->set_friendly_name(split_name);
         for (size_t i = 0; i < matmul2_nodes.size(); ++i) {
-            matmul2_nodes[i]->input(0).replace_source_output(output_split->output(i));
+            matmul2_nodes[i].get_node()->input(0).replace_source_output(output_split->output(i));
         }
 
-        auto fused_matmul2 = std::make_shared<ov::op::v0::Concat>(matmul2_nodes, matmul2_nodes[0]->get_output_partial_shape(0).size() - 1);
-        auto matmul2_name = matmul2_nodes[0]->get_friendly_name() + "_fused_" + std::to_string(matmul2_nodes.size()) + "_MatMuls_output";
+        auto fused_matmul2 = std::make_shared<ov::op::v0::Concat>(matmul2_nodes, matmul2_nodes[0].get_node()->get_output_partial_shape(0).size() - 1);
+        auto matmul2_name = matmul2_nodes[0].get_node()->get_friendly_name() + "_fused_" + std::to_string(matmul2_nodes.size()) + "_MatMuls_output";
         fused_matmul2->set_friendly_name(matmul2_name);
-        ov::copy_runtime_info(matmul2_nodes, fused_matmul2);
+        ov::copy_output_runtime_info(matmul2_nodes, {fused_matmul2->output(0)});
 
         auto fused_add = std::make_shared<ov::op::v1::Add>(split->get_input_node_shared_ptr(0), fused_matmul2);
         auto fused_add_name = add_nodes[0]->get_friendly_name() + "_fused_" + std::to_string(add_nodes.size()) + "_Adds";

--- a/src/plugins/intel_gpu/src/plugin/transformations/sink_reshape.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/sink_reshape.cpp
@@ -45,7 +45,7 @@ SinkReshape::SinkReshape() {
         auto supported_conv_eltwise_post_ops_for_fuse = [](const std::shared_ptr<const Node>& node) -> bool {
             if (ov::is_type<v1::Add>(node) || ov::is_type<v1::Subtract>(node) || ov::is_type<v1::Multiply>(node) ||
                 ov::is_type<v1::Divide>(node))
-                return std::dynamic_pointer_cast<v0::Constant>(node->get_input_node_shared_ptr(1)) != nullptr;
+                return std::dynamic_pointer_cast<v0::Constant>(node->input_value(1).get_node_shared_ptr()) != nullptr;
             return ov::is_type<v0::Exp>(node);
         };
         std::function<bool(const std::shared_ptr<ov::Node>&)> is_suitable_parent;
@@ -55,7 +55,7 @@ SinkReshape::SinkReshape() {
             if (ov::as_type_ptr<op::Convolution>(node))
                 return true;
             for (size_t idx = 0; idx < node->get_input_size(); idx++) {
-                auto input = node->get_input_node_shared_ptr(idx);
+                auto input = node->input_value(idx).get_node_shared_ptr();
                 if (ov::as_type_ptr<v0::Constant>(node))
                     continue;
                 if (supported_conv_eltwise_post_ops_for_fuse(node)) {
@@ -86,7 +86,7 @@ SinkReshape::SinkReshape() {
             return mismatch_count == 1;
         };
         const auto reshape = ov::as_type_ptr<v1::Reshape>(output.get_node_shared_ptr());
-        return is_suitable_reshape(reshape) && is_suitable_parent(reshape->get_input_node_shared_ptr(0));
+        return is_suitable_reshape(reshape) && is_suitable_parent(reshape->input_value(0).get_node_shared_ptr());
     };
 
     auto reshape_m = wrap_type<v1::Reshape>(reshape_predicate && consumers_count(1));

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -37,7 +37,7 @@ bool has_optimized_version(const ov::Output<ov::Node>& output, bool supports_imm
     if (output.get_partial_shape().is_static() && !supports_immad)
         return false;
 
-    auto order_node = output.get_node()->get_input_node_shared_ptr(1);
+    auto order_node = output.get_node()->input_value(1).get_node_shared_ptr();
     if (!ov::is_type<ov::op::v0::Constant>(order_node))
         return false;
 

--- a/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_matmul_fusion.cpp
@@ -53,7 +53,7 @@ UnsqueezeBroadcastReshapeMatmulFusion::UnsqueezeBroadcastReshapeMatmulFusion() {
             return std::count_if(target_shape.begin(), target_shape.end(), [](int32_t s) { return s != 1; }) == 1;
         };
         auto broadcast = ov::as_type_ptr<ov::op::v3::Broadcast>(pattern_map.at(broadcast_m).get_node_shared_ptr());
-        auto target_shape_constant = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->get_input_node_shared_ptr(1));
+        auto target_shape_constant = ov::as_type_ptr<ov::op::v0::Constant>(broadcast->input_value(1).get_node_shared_ptr());
         if (target_shape_constant) {
             auto target_shape_val = target_shape_constant->cast_vector<int32_t>();
             if (!valid_broadcast_target_shape(target_shape_val))

--- a/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/unsqueeze_broadcast_reshape_sdpa_fusion.cpp
@@ -70,7 +70,7 @@ UnsqueezeBroadcastReshapeSDPAFusion::UnsqueezeBroadcastReshapeSDPAFusion() {
         auto broadcast_c = ov::as_type_ptr<ov::op::v3::Broadcast>(pattern_map.at(broadcast_c_m).get_node_shared_ptr());
 
         std::vector<int32_t> target_shape_val_b;
-        auto target_shape_constant_b = ov::as_type_ptr<ov::op::v0::Constant>(broadcast_c->get_input_node_shared_ptr(1));
+        auto target_shape_constant_b = ov::as_type_ptr<ov::op::v0::Constant>(broadcast_c->input_value(1).get_node_shared_ptr());
         if (target_shape_constant_b) {
             target_shape_val_b = target_shape_constant_b->cast_vector<int32_t>();
             if (!valid_broadcast_target_shape(target_shape_val_b)) {
@@ -79,7 +79,7 @@ UnsqueezeBroadcastReshapeSDPAFusion::UnsqueezeBroadcastReshapeSDPAFusion() {
         }
 
         std::vector<int32_t> target_shape_val_c;
-        auto target_shape_constant_c = ov::as_type_ptr<ov::op::v0::Constant>(broadcast_b->get_input_node_shared_ptr(1));
+        auto target_shape_constant_c = ov::as_type_ptr<ov::op::v0::Constant>(broadcast_b->input_value(1).get_node_shared_ptr());
         if (target_shape_constant_c) {
             target_shape_val_c = target_shape_constant_c->cast_vector<int32_t>();
             if (!valid_broadcast_target_shape(target_shape_val_c)) {

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -728,8 +728,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return lstm_seq->get_clip() == 0.0f &&
                        lstm_seq->get_activations() == std::vector<std::string>{"sigmoid", "tanh", "tanh"} &&
                        max_seq_len != 1 &&
-                       !ov::op::util::is_seq_len_provided(lstm_seq->get_input_node_shared_ptr(0),
-                                                          lstm_seq->get_input_node_shared_ptr(3));
+                       !ov::op::util::is_seq_len_provided(lstm_seq->input_value(0).get_node_shared_ptr(),
+                                                          lstm_seq->input_value(3).get_node_shared_ptr());
             }
             return false;
         };
@@ -801,7 +801,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             // Condition to filter out axes such as [0, 1, 2] which is not supported currently.
             const auto norm = ov::as_type_ptr<const ov::op::v0::NormalizeL2>(node);
             const auto inputRank = norm->get_input_partial_shape(0).size();
-            auto axesNode = ov::as_type_ptr<const ov::op::v0::Constant>(norm->get_input_node_shared_ptr(1));
+            auto axesNode = ov::as_type_ptr<const ov::op::v0::Constant>(norm->input_value(1).get_node_shared_ptr());
             const auto axes = axesNode->cast_vector<size_t>();
             const auto isSupportedAxes = [](const std::vector<size_t> &axes, const size_t inputRank) {
                 if (axes.size() == 1 && axes[0] == 1) {
@@ -980,9 +980,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 const auto constantNode = NetworkHelper::getConstantInput(node);
                 const auto constant = constantNode == nullptr ? nullptr : ov::as_type_ptr<ov::op::v0::Constant>(constantNode);
                 if (constant != nullptr) {
-                    auto parent = node->get_input_node_shared_ptr(0);
+                    auto parent = node->input_value(0).get_node_shared_ptr();
                     if (parent == constant) {
-                        parent = node->get_input_node_shared_ptr(1);
+                        parent = node->input_value(1).get_node_shared_ptr();
                     }
                 }
             }
@@ -1195,8 +1195,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             bool asymmetric_dyn_quant = config.get_asym_dynamic_quantization();
             auto dynamic_quantization_group_size = config.get_dynamic_quantization_group_size();
             pass_config->set_callback<ov::intel_gpu::DynamicQuantizeFullyConnected>([=](const_node_ptr& root) -> bool {
-                for (size_t i = 0 ; i < root->get_input_node_shared_ptr(0)->get_output_size(); ++i) {
-                    if (root->get_input_node_shared_ptr(0)->get_output_element_type(i) == ov::element::Type_t::f32) {
+                for (size_t i = 0 ; i < root->input_value(0).get_node_shared_ptr()->get_output_size(); ++i) {
+                    if (root->input_value(0).get_node_shared_ptr()->get_output_element_type(i) == ov::element::Type_t::f32) {
                         GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off: input type is not supported" << std::endl;
                         return true;
                     }

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/broadcast_eltwise.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/broadcast_eltwise.cpp
@@ -82,13 +82,13 @@ TEST_P(BroadcastEltwise, smoke_CompareWithRefs) {
 
     const auto model = compiledModel.get_runtime_model();
 
-    const auto last_node = model->get_result()->get_input_node_shared_ptr(0);
+    const auto last_node = model->get_result()->input_value(0).get_node_shared_ptr();
     const auto& last_rt_info = last_node->get_rt_info();
     const auto last_layer_type = last_rt_info.find("layerType")->second.as<std::string>();
     EXPECT_EQ(last_layer_type, "Reorder");
 
     // Check that BroadcastTransition transformation was applied and broadcast is after eltwise now.
-    const auto last_node_input = last_node->get_input_node_shared_ptr(0);
+    const auto last_node_input = last_node->input_value(0).get_node_shared_ptr();
     const auto& last_input_rt_info = last_node_input->get_rt_info();
     const auto last_input_layer_type = last_input_rt_info.find("layerType")->second.as<std::string>();
     EXPECT_EQ(last_input_layer_type, "broadcast");

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/kv_cache.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/dynamic/kv_cache.cpp
@@ -182,7 +182,7 @@ class KVCacheTests: public ::testing::Test {
                 for (size_t j = 0; j < results.size(); j++) {
                     const auto result = results[j];
                     for (size_t i = 0; i < result->get_input_size(); ++i) {
-                        std::shared_ptr<ov::Node> inputNode = result->get_input_node_shared_ptr(i);
+                        std::shared_ptr<ov::Node> inputNode = result->input_value(i).get_node_shared_ptr();
                         auto it = compareMap.find(inputNode->get_type_info());
                         ASSERT_NE(it, compareMap.end());
                         it->second(inputNode, i, inference_precision, expected[j], actual[j], 1e-4f, 1e-4f, 1.f, 1.f);
@@ -357,7 +357,7 @@ class KVCacheTests: public ::testing::Test {
             for (size_t j = 0; j < results.size(); j++) {
                 const auto result = results[j];
                 for (size_t i = 0; i < result->get_input_size(); ++i) {
-                    std::shared_ptr<ov::Node> inputNode = result->get_input_node_shared_ptr(i);
+                    std::shared_ptr<ov::Node> inputNode = result->input_value(i).get_node_shared_ptr();
                     auto it = compareMap.find(inputNode->get_type_info());
                     ASSERT_NE(it, compareMap.end());
                     it->second(inputNode, i, inference_precision, expected[j], actual[j], 1e-4f, 1e-4f, 1.f, 1.f);

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/include/utils/model.hpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/include/utils/model.hpp
@@ -80,7 +80,7 @@ generate_model(ov::NodeVector& nodes,
                     for (const auto& orig_node_to_check : orig_in_node->output(out_idx).get_target_inputs()) {
                         if (orig_node_to_check.get_node()->shared_from_this() == node) {
                             auto orig_in_node_name = orig_in_node->get_friendly_name();
-                            auto cloned_in_node = cloned_node->get_input_node_shared_ptr(in_idx);
+                            auto cloned_in_node = cloned_node->input_value(in_idx).get_node_shared_ptr();
                             // if op input node is in subgraph replace parameters
                             // in cloned node by other nodes from the map
                             if (cloned_node_map.count(orig_in_node_name)) {
@@ -162,7 +162,7 @@ generate_model(ov::NodeVector& nodes,
         result << op->get_type_info();
         for (size_t i = 0; i < op->inputs().size(); ++i) {
             const auto& in = op->input(i);
-            if (!is_node_to_skip(op->get_input_node_shared_ptr(i))) {
+            if (!is_node_to_skip(op->input_value(i).get_node_shared_ptr())) {
                 is_erase_node |= true;
             }
             result << in.get_element_type();

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/single_op/single_op.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/single_op/single_op.cpp
@@ -65,8 +65,8 @@ bool SingleOpMatcher::match_inputs(const std::shared_ptr<ov::Node> &node,
             return false;
         }
         if (is_match_in_types) {
-            const auto& in_node = node->get_input_node_shared_ptr(port_id);
-            const auto& in_node_ref = ref->get_input_node_shared_ptr(port_id);
+            const auto& in_node = node->input_value(port_id).get_node_shared_ptr();
+            const auto& in_node_ref = ref->input_value(port_id).get_node_shared_ptr();
             if (ov::util::is_node_to_skip(in_node) || ov::util::is_node_to_skip(in_node_ref)) {
                 continue;
             } else if (in_node->get_type_info() != in_node_ref->get_type_info()) {

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/subgraph/repeat_pattern.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/matchers/subgraph/repeat_pattern.cpp
@@ -47,7 +47,7 @@ RepeatPatternExtractor::get_repeat_pattern_borders(const std::shared_ptr<ov::Mod
                     }
                 }
                 for (size_t in_idx = 0; in_idx < node->inputs().size(); ++in_idx) {
-                    auto in_node = node->get_input_node_shared_ptr(in_idx);
+                    auto in_node = node->input_value(in_idx).get_node_shared_ptr();
                     if (std::find(node_vector.begin(), node_vector.end(), in_node) == node_vector.end()) {
                         in_vec.push_back(node->input(in_idx));
                     }
@@ -174,8 +174,8 @@ RepeatPatternExtractor::get_patterns_by_nodes(const std::vector<size_t>& start_o
                         if (j != 0) {
                             bool is_input_matched = false;
                             for (size_t input_idx = 0; input_idx < patterns[i_orig][j]->inputs().size(); ++input_idx) {
-                                auto in_orig = patterns[i_orig][j]->get_input_node_shared_ptr(input_idx);
-                                auto in_ref = patterns[i_ref][j]->get_input_node_shared_ptr(input_idx);
+                                auto in_orig = patterns[i_orig][j]->input_value(input_idx).get_node_shared_ptr();
+                                auto in_ref = patterns[i_ref][j]->input_value(input_idx).get_node_shared_ptr();
                                 if (std::find(pattern_orig.begin(), pattern_orig.end(), in_orig) != pattern_orig.end() &&
                                     std::find(pattern_ref.begin(), pattern_ref.end(), in_ref) != pattern_ref.end()) {
                                     is_input_matched = true;

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/utils/model_comparator.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/utils/model_comparator.cpp
@@ -140,8 +140,8 @@ ModelComparator::get_matched_ops_in_graphs(const std::shared_ptr<ov::Model>& sub
                 checked_op.insert(graph_op->get_friendly_name());
                 if (is_check_inputs) {
                     for (size_t idx = 0; idx < graph_op->inputs().size(); ++idx) {
-                        auto graph_in = graph_op->get_input_node_shared_ptr(idx);
-                        auto subgraph_in = subgraph_op->get_input_node_shared_ptr(idx);
+                        auto graph_in = graph_op->input_value(idx).get_node_shared_ptr();
+                        auto subgraph_in = subgraph_op->input_value(idx).get_node_shared_ptr();
                         if (ov::util::is_node_to_skip(graph_in) && ov::util::is_node_to_skip(subgraph_in)) {
                             if (match(subgraph_in, graph_in)) {
                                 matched_op_names.insert({subgraph_in->get_friendly_name(), graph_in->get_friendly_name()});

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/utils/node.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/utils/node.cpp
@@ -80,7 +80,7 @@ std::map<std::string, ov::conformance::InputInfo>
 get_input_info_by_node(const std::shared_ptr<ov::Node>& node) {
     std::map<std::string, ov::conformance::InputInfo> input_info;
     for (size_t port_id = 0; port_id < node->get_input_size(); ++port_id) {
-        std::shared_ptr<ov::Node> input_node = node->get_input_node_shared_ptr(port_id);
+        std::shared_ptr<ov::Node> input_node = node->input_value(port_id).get_node_shared_ptr();
         if (!ov::op::util::is_parameter(input_node) && !ov::op::util::is_constant(input_node)) {
             continue;
         }
@@ -147,7 +147,7 @@ std::shared_ptr<ov::Node> clone_node(std::shared_ptr<ov::Node> node,
                                                              cloned_node->get_input_partial_shape(0));
         std::string param_name = node_name + "_0";
         param->set_friendly_name(param_name);
-        auto node_to_replace = cloned_node->get_input_node_shared_ptr(0);
+        auto node_to_replace = cloned_node->input_value(0).get_node_shared_ptr();
         ov::replace_node(node_to_replace, param);
     } else {
         cloned_node = node->clone_with_new_inputs(inputs);

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/utils/node.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/tests/utils/node.cpp
@@ -52,7 +52,7 @@ TEST_F(NodeUtilsTest, clone_node) {
 
     {
         auto cloned_node = ov::util::clone_node(add_node_1);
-        ASSERT_TRUE(ov::op::util::is_parameter(cloned_node->get_input_node_shared_ptr(0)));
+        ASSERT_TRUE(ov::op::util::is_parameter(cloned_node->input_value(0).get_node_shared_ptr()));
         ASSERT_TRUE(ov::op::util::is_parameter(cloned_node->get_input_node_ptr(1)));
     }
     {

--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/utils/generate_static_shapes.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/utils/generate_static_shapes.cpp
@@ -52,7 +52,7 @@ namespace {
 
 InputShape generate(const std::shared_ptr<ov::Node>& node,
                     size_t in_port_id) {
-    const auto& param = ov::as_type_ptr<ov::op::v0::Parameter>(node->get_input_node_shared_ptr(in_port_id));
+    const auto& param = ov::as_type_ptr<ov::op::v0::Parameter>(node->input_value(in_port_id).get_node_shared_ptr());
     std::vector<ov::Shape> staticShapes = { param->get_partial_shape().get_min_shape(),
                                             generate_mid_shape(param->get_partial_shape()),
                                             param->get_partial_shape().get_max_shape() };
@@ -75,7 +75,7 @@ InputShape generate(const std::shared_ptr<ov::op::v1::Convolution>& node,
     std::map<size_t, size_t> restrict_dims;
     for (size_t port = 0; port < node->get_input_size(); ++port) {
         if (port != in_port_id) {
-            auto kernel_ptr = node->get_input_node_shared_ptr(port);
+            auto kernel_ptr = node->input_value(port).get_node_shared_ptr();
             // Layout of kernel is [C_OUT, C_IN, Z, Y, X], layout of input is [N, C_IN, Z, Y, X]
             for (size_t dim = kernel_ptr->get_shape().size() - 1; dim >= 2; --dim) {
                 restrict_dims.insert({dim, kernel_ptr->get_shape()[dim]});
@@ -94,7 +94,7 @@ InputShape generate(const std::shared_ptr<ov::op::v1::ConvolutionBackpropData>& 
     std::map<size_t, size_t> restrict_dims;
     for (size_t port = 0; port < node->get_input_size(); ++port) {
         if (port != in_port_id) {
-            auto kernel_ptr = node->get_input_node_shared_ptr(port);
+            auto kernel_ptr = node->input_value(port).get_node_shared_ptr();
             // Layout of kernel is [C_OUT, C_IN, Z, Y, X], layout of input is [N, C_IN, Z, Y, X]
             for (size_t dim = kernel_ptr->get_shape().size() - 1; dim >= 2; --dim) {
                 restrict_dims.insert({dim, kernel_ptr->get_shape()[dim]});

--- a/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/ov_subgraph.cpp
@@ -257,7 +257,7 @@ void SubgraphBaseTest::compare(const std::vector<ov::Tensor>& expected,
     for (size_t j = 0; j < results.size(); j++) {
         const auto result = results[j];
         for (size_t i = 0; i < result->get_input_size(); ++i) {
-            std::shared_ptr<ov::Node> inputNode = result->get_input_node_shared_ptr(i);
+            std::shared_ptr<ov::Node> inputNode = result->input_value(i).get_node_shared_ptr();
             auto it = compareMap.find(inputNode->get_type_info());
             ASSERT_NE(it, compareMap.end());
             it->second(inputNode, i, inference_precision,
@@ -568,8 +568,8 @@ void SubgraphBaseTest::compare_nodes(const std::shared_ptr<ov::Node>& node1, con
                     << node2->get_friendly_name() << " Input(" << i << ") " << node2->input(i).get_element_type() << std::endl;
         }
 
-        const auto const_in_1 = ov::as_type_ptr<ov::op::v0::Constant>(node1->get_input_node_shared_ptr(i));
-        const auto const_in_2 = ov::as_type_ptr<ov::op::v0::Constant>(node2->get_input_node_shared_ptr(i));
+        const auto const_in_1 = ov::as_type_ptr<ov::op::v0::Constant>(node1->input_value(i).get_node_shared_ptr());
+        const auto const_in_2 = ov::as_type_ptr<ov::op::v0::Constant>(node2->input_value(i).get_node_shared_ptr());
         const auto equal_value = ::attributes::detail::equal::Equal<std::shared_ptr<ov::op::v0::Constant>>::equal_value;
         if (const_in_1 && const_in_2 && !equal_value(const_in_1, const_in_2)) {
             err_log << "Different Constant values detected\n"

--- a/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/generate_inputs.cpp
@@ -186,13 +186,13 @@ bool get_fq_scalar_range(const std::shared_ptr<ov::op::v0::FakeQuantize> &node, 
     auto get_min_value = [](const Vec& v) {
         return std::min_element(v.begin(), v.end());
     };
-    if (!get_const_value(node->get_input_node_shared_ptr(1), min_value, get_min_value))
+    if (!get_const_value(node->input_value(1).get_node_shared_ptr(), min_value, get_min_value))
         return false;
 
     auto get_max_value = [](const Vec& v) {
         return std::max_element(v.begin(), v.end());
     };
-    if (!get_const_value(node->get_input_node_shared_ptr(2), max_value, get_max_value))
+    if (!get_const_value(node->input_value(2).get_node_shared_ptr(), max_value, get_max_value))
         return false;
 
     return true;

--- a/src/tests/functional/shared_test_classes/src/base/utils/ranges.cpp
+++ b/src/tests/functional/shared_test_classes/src/base/utils/ranges.cpp
@@ -37,7 +37,7 @@ ov::Tensor ModelRange::generate_input(std::shared_ptr<ov::Node> node, size_t por
         throw std::runtime_error("Couln't find Operation in inputMap: " + std::string(node->get_type_name()));
     }
 
-    std::string range_id = get_range_id(node->get_input_node_shared_ptr(port));
+    std::string range_id = get_range_id(node->input_value(port).get_node_shared_ptr());
     return it->second(node, port, node->get_input_element_type(port), targetShape, node_ranges[range_id]);
 }
 

--- a/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_gather_weights_decompression.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_gather_weights_decompression.cpp
@@ -103,10 +103,10 @@ void SharedMatmulAndGatherWeightsDecompression::check_results() {
 
     const auto results = compiledModel.get_runtime_model()->get_results();
     EXPECT_EQ(results.size(), 2);
-    const auto gather_node = results[0]->get_input_node_shared_ptr(0);
+    const auto gather_node = results[0]->input_value(0).get_node_shared_ptr();
     EXPECT_EQ(gather_node->get_input_element_type(0), compressed_weights_precision);
 
-    const auto matmul_node = results[1]->get_input_node_shared_ptr(0);
+    const auto matmul_node = results[1]->input_value(0).get_node_shared_ptr();
     const auto& expected_mm_weights_precision = use_matmul_decompression_impl
                                                     ? compressed_weights_precision
                                                     : matmul_node->get_input_element_type(0);

--- a/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_weights_decompression.cpp
+++ b/src/tests/functional/shared_test_classes/src/subgraph/shared_matmul_weights_decompression.cpp
@@ -121,7 +121,7 @@ void SharedMatmulWeightsDecompression::check_results() {
 
     const auto results = compiledModel.get_runtime_model()->get_results();
     for (const auto& result : results) {
-        const auto last_layer = result->get_input_node_shared_ptr(0);
+        const auto last_layer = result->input_value(0).get_node_shared_ptr();
         const auto& expected_weights_precision = use_matmul_decompression_impl
                                                      ? compressed_weights_precision
                                                      : last_layer->get_input_element_type(0);

--- a/src/tests/ov_helpers/ov_lpt_models/src/concat.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/concat.cpp
@@ -1495,11 +1495,11 @@ std::shared_ptr<ov::Model> ConcatFunction::getReferenceWithSplitedIntermediate(
 
     const auto fakeQuantize2 = makeFakeQuantizeTypeRelaxed(input2, precision, fqOnData2);
     replace_node(
-        fakeQuantize2->get_input_node_shared_ptr(3),
-        ov::pass::low_precision::NetworkHelper::toScalarIfPossible(fakeQuantize2->get_input_node_shared_ptr(3)));
+        fakeQuantize2->input_value(3).get_node_shared_ptr(),
+        ov::pass::low_precision::NetworkHelper::toScalarIfPossible(fakeQuantize2->input_value(3).get_node_shared_ptr()));
     replace_node(
-        fakeQuantize2->get_input_node_shared_ptr(4),
-        ov::pass::low_precision::NetworkHelper::toScalarIfPossible(fakeQuantize2->get_input_node_shared_ptr(4)));
+        fakeQuantize2->input_value(4).get_node_shared_ptr(),
+        ov::pass::low_precision::NetworkHelper::toScalarIfPossible(fakeQuantize2->input_value(4).get_node_shared_ptr()));
 
     fakeQuantize2->set_friendly_name("fakeQuantize2");
     ov::pass::low_precision::NetworkHelper::setOutDataPrecisionForTypeRelaxed(fakeQuantize2, precisionAfterOperation);

--- a/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_two_output_branches_with_convolution.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/fake_quantize_and_two_output_branches_with_convolution.cpp
@@ -141,12 +141,12 @@ std::shared_ptr<ov::Model> FakeQuantizeAndTwoOutputBranchesWithConvolutionFuncti
     const std::shared_ptr<ov::opset1::Concat> concat = std::make_shared<ov::opset1::Concat>(NodeVector{ deqAfter1, deqAfter2 }, 1ul);
     ov::pass::low_precision::NetworkHelper::setOutDataPrecision(concat, precisionAfterOp);
     if (params.updatePrecisions) {
-        replace_node(convolution1->get_input_node_shared_ptr(1),
-                     ov::pass::low_precision::fold<ov::opset1::Convert>(convolution1->get_input_node_shared_ptr(1),
+        replace_node(convolution1->input_value(1).get_node_shared_ptr(),
+                     ov::pass::low_precision::fold<ov::opset1::Convert>(convolution1->input_value(1).get_node_shared_ptr(),
                                                                         ov::element::i8));
 
-        replace_node(convolution2->get_input_node_shared_ptr(1),
-                     ov::pass::low_precision::fold<ov::opset1::Convert>(convolution2->get_input_node_shared_ptr(1),
+        replace_node(convolution2->input_value(1).get_node_shared_ptr(),
+                     ov::pass::low_precision::fold<ov::opset1::Convert>(convolution2->input_value(1).get_node_shared_ptr(),
                                                                         ov::element::i8));
     }
 

--- a/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
+++ b/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
@@ -99,8 +99,8 @@ bool less_by_friendly_name(const std::shared_ptr<ov::op::v0::Result>& l, const s
 
 bool less_by_parent_friendly_name(const std::shared_ptr<ov::op::v0::Result>& l,
                                   const std::shared_ptr<ov::op::v0::Result>& r) {
-    const auto& l_name = l->get_input_node_shared_ptr(0)->get_friendly_name();
-    const auto& r_name = r->get_input_node_shared_ptr(0)->get_friendly_name();
+    const auto& l_name = l->input_value(0).get_node_shared_ptr()->get_friendly_name();
+    const auto& r_name = r->input_value(0).get_node_shared_ptr()->get_friendly_name();
     return l_name.size() < r_name.size() || (l_name.size() == r_name.size() && l_name < r_name);
 }
 
@@ -679,11 +679,11 @@ Comparator::Result Comparator::compare(const std::shared_ptr<ov::Model>& f, cons
 
         for (size_t i = 0; i < f_results.size(); ++i) {
             if (should_compare(CmpValues::NAMES)) {
-                if (name(f_results[i]->get_input_node_shared_ptr(0)) !=
-                    name(f_ref_results[i]->get_input_node_shared_ptr(0))) {
+                if (name(f_results[i]->input_value(0).get_node_shared_ptr()) !=
+                    name(f_ref_results[i]->input_value(0).get_node_shared_ptr())) {
                     return Result::error(
-                        "Different output node names: " + name(f_results[i]->get_input_node_shared_ptr(0)) + " and " +
-                        name(f_ref_results[i]->get_input_node_shared_ptr(0)));
+                        "Different output node names: " + name(f_results[i]->input_value(0).get_node_shared_ptr()) +
+                        " and " + name(f_ref_results[i]->input_value(0).get_node_shared_ptr()));
                 }
             }
             q.push({f_results[i].get(), f_ref_results[i].get()});
@@ -771,8 +771,8 @@ void Comparator::compare_inputs(ov::Node* node1, ov::Node* node2, std::ostream& 
             using Constant = ov::op::v0::Constant;
             const auto equal_value = ::attributes::detail::equal::Equal<std::shared_ptr<Constant>>::equal_value;
 
-            auto const1 = ov::as_type_ptr<Constant>(node1->get_input_node_shared_ptr(i));
-            auto const2 = ov::as_type_ptr<Constant>(node2->get_input_node_shared_ptr(i));
+            auto const1 = ov::as_type_ptr<Constant>(node1->input_value(i).get_node_shared_ptr());
+            auto const2 = ov::as_type_ptr<Constant>(node2->input_value(i).get_node_shared_ptr());
             if (const1 && const2 && !equal_value(const1, const2)) {
                 err_log << "Different Constant values detected\n"
                         << const1->get_friendly_name() << " & " << const2->get_friendly_name() << "\n"


### PR DESCRIPTION
### Details:
 - fix get_input_node_shared_ptr() to input_value(), since get_input_node_shared_ptr() causes a lot of bugs

### Tickets:
 - CVS-165972
