### PR TITLE
[CMAKE] Disable clang-tidy by default for all the platforms

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -74,19 +74,13 @@ else()
     set(STYLE_CHECKS_DEFAULT ON)
 endif()
 
-if(NOT CMAKE_CROSSCOMPILING AND NOT WIN32 AND (X86 OR X86_64))
-    set(TIDY_CHECKS_DEFAULT ON)
-else()
-    set(TIDY_CHECKS_DEFAULT OFF)
-endif()
-
 ov_option (ENABLE_CPPLINT "Enable cpplint checks during the build" ${STYLE_CHECKS_DEFAULT})
 
 ov_dependent_option (ENABLE_CPPLINT_REPORT "Build cpplint report instead of failing the build" OFF "ENABLE_CPPLINT" OFF)
 
 ov_option (ENABLE_CLANG_FORMAT "Enable clang-format checks during the build" ${STYLE_CHECKS_DEFAULT})
 
-ov_option (ENABLE_CLANG_TIDY "Enable clang-tidy checks during the build" ${TIDY_CHECKS_DEFAULT})
+ov_option (ENABLE_CLANG_TIDY "Enable clang-tidy checks during the build" OFF)
 
 ov_option (ENABLE_NCC_STYLE "Enable ncc style check" ${STYLE_CHECKS_DEFAULT})
 


### PR DESCRIPTION
The checks take too long to be enabled by default