### PR TITLE
[GPU] Add support of dynamic paddings to rms_bfyx_opt kernel for Qwen3 model

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/rms_gpu_bfyx_opt.cl
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "include/batch_headers/fetch_data.cl"
+#include "include/fetch_utils.cl"
 #include "include/batch_headers/sub_group_block_read.cl"
 #include "include/batch_headers/sub_group_block_write.cl"
 
@@ -41,7 +41,31 @@ KERNEL(rms_gpu_bfyx_opt)(
     const uint items_num = data_size / workers_per_data;
     const uint leftovers = data_size % workers_per_data;
 
-    const uint data_offset = data_idx * data_size;
+    #if HAS_DYNAMIC_PADDING
+        uint b_idx = 0;
+        uint f_idx = 0;
+        uint z_idx = 0;
+        uint y_idx = 0;
+        uint x_idx = 0;
+        #if INPUT_RANK == 2
+            b_idx = (data_idx);
+        #elif INPUT_RANK == 3
+            f_idx = (data_idx % (INPUT0_FEATURE_NUM));
+            b_idx = (data_idx / (INPUT0_FEATURE_NUM));
+        #else
+            y_idx = (data_idx % (INPUT0_SIZE_Y));
+            z_idx = (data_idx / (INPUT0_SIZE_Y)) % INPUT0_SIZE_Z;
+            f_idx = (data_idx / (INPUT0_SIZE_Y * INPUT0_SIZE_Z)) % INPUT0_FEATURE_NUM;
+            b_idx = (data_idx / (INPUT0_SIZE_Y * INPUT0_SIZE_Z * INPUT0_FEATURE_NUM)) % INPUT0_BATCH_NUM;
+        #endif
+
+        const uint input_data_offset = FUNC_CALL(get_input_index)(OPTIONAL_SHAPE_INFO_TENSOR b_idx, f_idx, 0, z_idx, y_idx, x_idx);
+    #else
+        const uint input_data_offset = data_idx * data_size;
+    #endif
+
+    const uint output_data_offset = data_idx * data_size;
+
     const uint subgroup_offset = get_sub_group_id() * get_sub_group_size() * items_num;
 
     ACCUMULATOR_TYPE data[STACK_SIZE];
@@ -54,7 +78,7 @@ KERNEL(rms_gpu_bfyx_opt)(
     {
         for (; i < items_num - (items_num % SUBGROUP_BLOCK_SIZE); i += SUBGROUP_BLOCK_SIZE)
         {
-            ACC_TYPE vec_tmp = TO_ACC_TYPE(BLOCK_READ(input, data_offset + subgroup_offset + i * get_sub_group_size()));
+            ACC_TYPE vec_tmp = TO_ACC_TYPE(BLOCK_READ(input, input_data_offset + subgroup_offset + i * get_sub_group_size()));
 #if SUBGROUP_BLOCK_SIZE == 1
             rms += native_powr(vec_tmp, 2);
             data[i] = vec_tmp;
@@ -71,14 +95,14 @@ KERNEL(rms_gpu_bfyx_opt)(
 
     for (; i < items_num; i++)
     {
-        ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[data_offset + subgroup_offset + get_sub_group_local_id() + i * get_sub_group_size()]);
+        ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[input_data_offset + subgroup_offset + get_sub_group_local_id() + i * get_sub_group_size()]);
         rms += native_powr(tmp, 2);
         data[i] = tmp;
     }
 
     if (in_data_idx < leftovers)
     {
-        ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[data_offset + workers_per_data * items_num + in_data_idx]);
+        ACCUMULATOR_TYPE tmp = TO_ACCUMULATOR_TYPE(input[input_data_offset + workers_per_data * items_num + in_data_idx]);
         rms += native_powr(tmp, 2);
         data[items_num] = tmp;
     }
@@ -152,7 +176,7 @@ KERNEL(rms_gpu_bfyx_opt)(
                 vec_tmp[j] = normalized;
             }
 #endif
-            BLOCK_WRITE(output, data_offset + subgroup_offset + i * get_sub_group_size(), vec_tmp);
+            BLOCK_WRITE(output, output_data_offset + subgroup_offset + i * get_sub_group_size(), vec_tmp);
         }
     }
 
@@ -165,7 +189,7 @@ KERNEL(rms_gpu_bfyx_opt)(
             FUSED_OPS;
             normalized = FUSED_OPS_RESULT;
         #endif
-        output[data_offset + subgroup_offset + get_sub_group_local_id() + i * get_sub_group_size()] = normalized;
+        output[output_data_offset + subgroup_offset + get_sub_group_local_id() + i * get_sub_group_size()] = normalized;
     }
 
     if (in_data_idx < leftovers)
@@ -177,7 +201,7 @@ KERNEL(rms_gpu_bfyx_opt)(
             FUSED_OPS;
             normalized = FUSED_OPS_RESULT;
         #endif
-        output[data_offset + workers_per_data * items_num + in_data_idx] = normalized;
+        output[output_data_offset + workers_per_data * items_num + in_data_idx] = normalized;
     }
 }
 #undef USE_BLOCK_WRITE

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -54,6 +54,13 @@ DeviceFeaturesKey RMSKernelBfyxOpt::get_required_device_features_key(const Param
 JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, DispatchData dispatchData) const {
     auto jit = Parent::GetJitConstants(params, dispatchData);
 
+    bool has_dynamic_padding = false;
+    for (const auto& dim : params.inputs[0].GetDims())
+        has_dynamic_padding |= dim.pad.is_dynamic;
+
+    if (has_dynamic_padding)
+        jit.AddConstant(MakeJitConstant("HAS_DYNAMIC_PADDING", 1));
+
     if (params.has_dynamic_tensors()) {
         const auto& input = params.inputs[0];
         DimensionAccessHelperJit dims(input);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.cpp
@@ -102,10 +102,10 @@ JitConstants RMSKernelBfyxOpt::GetJitConstants(const rms_params& params, Dispatc
             MakeJitConstant("STACK_SIZE", dispatchData.itemsNum + 1)
         });
     }
+    jit.AddConstant(MakeJitConstant("INPUT_RANK", params.ov_input_rank));
     jit.AddConstant(MakeJitConstant("SUB_GROUP_SIZE", subgroup_size));
     jit.AddConstant(MakeJitConstant("SUBGROUP_BLOCK_SIZE", dispatchData.subgroupBlockSize));
     if (!params.fused_ops.empty()) {
-        jit.AddConstant(MakeJitConstant("INPUT_RANK", params.ov_input_rank));
         switch (params.ov_input_rank) {
             case 1 :
                 jit.AddConstant(MakeJitConstant("LAST_DIM", "b"));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -362,3 +362,54 @@ TEST(rms_gpu_test, rms_test_bfyx_opt_unaligned_dyn) {
         EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-3);
     }
 }
+
+TEST(rms_gpu_test, rms_test_bfyx_opt_padding) {
+    auto& engine = get_test_engine();
+
+    auto input = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx, cldnn::padding({0,0,2}, {0,0,4}, 0x4)});
+    auto input_ref = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx});
+    auto gamma = engine.allocate_memory({ov::PartialShape{1, 16}, data_types::f32, format::bfyx});
+    auto output_ref = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx});
+
+    set_values(input,  {
+        0.0f,       0.0f,      0.001839f,  -0.003815f, 0.000961f,  0.002930f, -0.003998f, -0.008057f, -0.005402f, -0.002945f, 0.006744f,
+        -0.000004f, 0.004303f, -0.002380f, 0.000072f,  0.001404f,  0.000568f, 0.002579f,  0.0f,       0.0f,       0.0f,       0.0f,
+        0.0f,       0.0f,      0.003098f,  -0.006989f, -0.000244f, 0.010193f, 0.002899f,  -0.005798f, -0.026978f, 0.008789f,  0.002258f,
+        0.006500f,  0.003159f, -0.012329f, 0.026245f,  -0.001839f, 0.000259f, 0.002670f,  0.0f,       0.0f,       0.0f,       0.0f,
+    });
+
+    set_values(input_ref, {
+        0.001839f, -0.003815f, 0.000961f, 0.002930f, -0.003998f, -0.008057f, -0.005402f, -0.002945f,
+        0.006744f, -0.000004f, 0.004303f, -0.002380f, 0.000072f, 0.001404f, 0.000568f, 0.002579f,
+        0.003098f, -0.006989f, -0.000244f, 0.010193f, 0.002899f, -0.005798f, -0.026978f, 0.008789f,
+        0.002258f, 0.006500f, 0.003159f, -0.012329f, 0.026245f, -0.001839f, 0.000259f, 0.002670f
+    });
+    set_values(gamma, {
+        0.029785f, 0.014038f, 0.003098f, 0.013123f, 0.015137f, 0.009399f, 0.008362f, 0.008179f,
+        0.018188f, 0.021973f, 0.005249f, 0.004639f, 0.004272f, 0.020264f, 0.013489f, 0.008789f
+    });
+
+    rms_ref<float>(input_ref, gamma, output_ref, 1e-5f);
+
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("gamma", gamma->get_layout()));
+    topology.add(rms("rms", input_info("input"), input_info("gamma"), 1e-5f));
+
+    network network(engine, topology, get_test_default_config(engine));
+
+    network.set_input_data("input", input);
+    network.set_input_data("gamma", gamma);
+
+    auto outputs = network.execute();
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "rms");
+
+    auto output = outputs.begin()->second.get_memory();
+    cldnn::mem_lock<float> output_ptr(output, get_test_stream());
+    cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
+
+    for (unsigned int i = 0; i < output_ref->count(); ++i) {
+        EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-3);
+    }
+}

--- a/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/rms_gpu_test.cpp
@@ -366,7 +366,9 @@ TEST(rms_gpu_test, rms_test_bfyx_opt_unaligned_dyn) {
 TEST(rms_gpu_test, rms_test_bfyx_opt_padding) {
     auto& engine = get_test_engine();
 
-    auto input = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx, cldnn::padding({0,0,2}, {0,0,4}, 0x4)});
+    auto input_layout_dynamic = layout{ov::PartialShape{-1, 2, 16}, data_types::f32, format::bfyx, cldnn::padding({0,0,2}, {0,0,4}, 0x4)};
+
+    auto input = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx, cldnn::padding({0,0,2}, {0,0,4})});
     auto input_ref = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx});
     auto gamma = engine.allocate_memory({ov::PartialShape{1, 16}, data_types::f32, format::bfyx});
     auto output_ref = engine.allocate_memory({ov::PartialShape{1, 2, 16}, data_types::f32, format::bfyx});
@@ -392,11 +394,14 @@ TEST(rms_gpu_test, rms_test_bfyx_opt_padding) {
     rms_ref<float>(input_ref, gamma, output_ref, 1e-5f);
 
     topology topology;
-    topology.add(input_layout("input", input->get_layout()));
+    topology.add(input_layout("input", input_layout_dynamic));
     topology.add(input_layout("gamma", gamma->get_layout()));
     topology.add(rms("rms", input_info("input"), input_info("gamma"), 1e-5f));
 
-    network network(engine, topology, get_test_default_config(engine));
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    network network(engine, topology, config);
 
     network.set_input_data("input", input);
     network.set_input_data("gamma", gamma);
@@ -410,6 +415,6 @@ TEST(rms_gpu_test, rms_test_bfyx_opt_padding) {
     cldnn::mem_lock<float> output_ref_ptr(output_ref, get_test_stream());
 
     for (unsigned int i = 0; i < output_ref->count(); ++i) {
-        EXPECT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-3);
+        ASSERT_NEAR(output_ptr[i], output_ref_ptr[i], 1e-3) << " index=" << i;
     }
 }


### PR DESCRIPTION
### Details:
 - Add support of dynamic input paddings to rms_bfyx_opt kernel for Qwen3 model
 - Test case borrowed from https://github.com/openvinotoolkit/openvino/pull/29835 

### Tickets:
 - *CVS-165116*
