### PR TITLE
[intel-npu] Compiled model properties: include only properties that had been set

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -1286,6 +1286,10 @@ struct RUN_INFERENCES_SEQUENTIALLY final : OptionBase<RUN_INFERENCES_SEQUENTIALL
         return false;
     }
 
+    static bool isPublic() {
+        return true;
+    }
+
     static OptionMode mode() {
         return OptionMode::RunTime;
     }

--- a/src/plugins/intel_npu/src/plugin/include/properties.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/properties.hpp
@@ -61,6 +61,10 @@ private:
     std::map<std::string, std::tuple<bool, ov::PropertyMutability, std::function<ov::Any(const Config&)>>> _properties;
     std::vector<ov::PropertyName> _supportedProperties;
 
+    // internal registration functions basd on client object
+    void registerPluginProperties();
+    void registerCompiledModelProperties();
+
     const std::vector<ov::PropertyName> _cachingProperties = {ov::device::architecture.name(),
                                                               ov::intel_npu::compilation_mode_params.name(),
                                                               ov::intel_npu::compiler_dynamic_quantization.name(),

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -528,7 +528,7 @@ void Properties::registerCompiledModelProperties() {
     TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::qdq_optimization, QDQ_OPTIMIZATION);
     TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::disable_version_check, DISABLE_VERSION_CHECK);
     TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::batch_compiler_mode_settings, BATCH_COMPILER_MODE_SETTINGS);
-    TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::run_inferences_sequentially, RUN_INFERENCES_SEQUENTIALLY, true);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::run_inferences_sequentially, RUN_INFERENCES_SEQUENTIALLY);
 
     TRY_REGISTER_CUSTOM_PROPERTY(ov::workload_type,
                                  WORKLOAD_TYPE,

--- a/src/plugins/intel_npu/src/plugin/src/properties.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/properties.cpp
@@ -49,9 +49,54 @@ namespace intel_npu {
             bool isPublic = _config.getOpt(o_name).isPublic();                                          \
             ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                     \
             if (_pType == PropertiesType::COMPILED_MODEL) {                                             \
-                if (!_config.has(o_name)) {                                                             \
-                    break;                                                                              \
-                }                                                                                       \
+                isMutable = ov::PropertyMutability::RO;                                                 \
+            }                                                                                           \
+            _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, [](const Config& config) { \
+                                    return config.get<OPT_TYPE>();                                      \
+                                }));                                                                    \
+        }                                                                                               \
+    } while (0)
+
+/**
+ * @brief Macro for registering simple get<> properties which have been previously set. For COMPILED_MODEL
+ *
+ * This macro is the same as TRY_REGISTER_SIMPLE_PROPERTY with the added functionality that it first verifies
+ * whether the option was previously set. Basicly it will not register properties which are still on their
+ * default values.
+ * This is useful for Compiled_model properties to avoid reporting settings which were not set at model compilation.
+ * Having properties in compiled_model which report default value can be misleading as those default values might
+ * not even haven been used by compiler, or in extreme cornercases be out of sync with the compiler's default values.
+ *
+ * @param OPT_NAME Class/type of the option (will fetch .name() from it)
+ * @param OPT_TYPE Type (template) of the option
+ *
+ * @details
+ * - It first checks if the config has a previusly set value for this key. If there isn't any value set for this key,
+ *   it will skip registration
+ * - Then checks if the option was registered in the global config. Options not present in the global config
+ *   are not supported in the current configuration and were previously filtered out on plugin level.
+ * - The property visibility (public/private) and mutability (RO/RW) are read from the base option descriptor
+ * (optionBase) the property will map to
+ * - COMPILED_MODEL only: In case the property is registered for a compiled_model, mutability will be automatically
+ * forced to READ-ONLY
+ * - COMPILED_MODEL only: If the configuration has no entry for the option, it means it was not set, which means it will
+ * skip registering it
+ * - A simple config.get<OPT_TYPE> lambda function is defined as the property's callback function
+ *
+ * @note The macro ensures that compiled model properties are marked read-only unless the configuration lacks the
+ * specified option type.
+ * @note TO BE USED FOR COMPILED_MODEL
+ */
+#define TRY_REGISTER_SIMPLE_PROPERTY_IFSET(OPT_NAME, OPT_TYPE)                                          \
+    do {                                                                                                \
+        std::string o_name = OPT_NAME.name();                                                           \
+        if (!_config.has(o_name)) {                                                                     \
+            break;                                                                                      \
+        }                                                                                               \
+        if (_config.isAvailable(o_name)) {                                                              \
+            bool isPublic = _config.getOpt(o_name).isPublic();                                          \
+            ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                     \
+            if (_pType == PropertiesType::COMPILED_MODEL) {                                             \
                 isMutable = ov::PropertyMutability::RO;                                                 \
             }                                                                                           \
             _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, [](const Config& config) { \
@@ -80,9 +125,6 @@ namespace intel_npu {
         if (_config.isAvailable(o_name)) {                                                                     \
             ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();                            \
             if (_pType == PropertiesType::COMPILED_MODEL) {                                                    \
-                if (!_config.has(o_name)) {                                                                    \
-                    break;                                                                                     \
-                }                                                                                              \
                 isMutable = ov::PropertyMutability::RO;                                                        \
             }                                                                                                  \
             _properties.emplace(o_name, std::make_tuple(PROP_VISIBILITY, isMutable, [](const Config& config) { \
@@ -111,9 +153,6 @@ namespace intel_npu {
             bool isPublic = _config.getOpt(o_name).isPublic();                               \
             ov::PropertyMutability isMutable = _config.getOpt(o_name).mutability();          \
             if (_pType == PropertiesType::COMPILED_MODEL) {                                  \
-                if (!_config.has(o_name)) {                                                  \
-                    break;                                                                   \
-                }                                                                            \
                 isMutable = ov::PropertyMutability::RO;                                      \
             }                                                                                \
             _properties.emplace(o_name, std::make_tuple(isPublic, isMutable, PROP_RETFUNC)); \
@@ -269,6 +308,31 @@ void Properties::registerProperties() {
     // Reset
     _properties.clear();
 
+    switch (_pType) {
+    case PropertiesType::PLUGIN:
+        registerPluginProperties();
+        break;
+    case PropertiesType::COMPILED_MODEL:
+        registerCompiledModelProperties();
+        break;
+    default:
+        OPENVINO_THROW("Invalid plugin configuration!");
+        break;
+    }
+
+    // 2.3. Common metrics (exposed same way by both Plugin and CompiledModel)
+    REGISTER_SIMPLE_METRIC(ov::supported_properties, true, _supportedProperties);
+
+    // 3. Populate supported properties list
+    // ========
+    for (auto& property : _properties) {
+        if (std::get<0>(property.second)) {
+            _supportedProperties.emplace_back(ov::PropertyName(property.first, std::get<1>(property.second)));
+        }
+    }
+}
+
+void Properties::registerPluginProperties() {
     // 1. Configs
     // ========
     // 1.1 simple configs which only return value
@@ -289,7 +353,6 @@ void Properties::registerProperties() {
     TRY_REGISTER_SIMPLE_PROPERTY(ov::device::id, DEVICE_ID);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::num_streams, NUM_STREAMS);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::weights_path, WEIGHTS_PATH);
-    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::model_priority, MODEL_PRIORITY);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::internal::exclusive_async_requests, EXCLUSIVE_ASYNC_REQUESTS);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::compilation_mode_params, COMPILATION_MODE_PARAMS);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::dma_engines, DMA_ENGINES);
@@ -304,76 +367,48 @@ void Properties::registerProperties() {
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::backend_compilation_params, BACKEND_COMPILATION_PARAMS);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::batch_mode, BATCH_MODE);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::turbo, TURBO);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::model_priority, MODEL_PRIORITY);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::bypass_umd_caching, BYPASS_UMD_CACHING);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::defer_weights_load, DEFER_WEIGHTS_LOAD);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::compiler_dynamic_quantization, COMPILER_DYNAMIC_QUANTIZATION);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::qdq_optimization, QDQ_OPTIMIZATION);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::disable_version_check, DISABLE_VERSION_CHECK);
     TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::batch_compiler_mode_settings, BATCH_COMPILER_MODE_SETTINGS);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::enable_cpu_pinning, ENABLE_CPU_PINNING);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::workload_type, WORKLOAD_TYPE);
 
-    // 1.2. Special cases
-    // ==================
-    if (_pType == PropertiesType::PLUGIN && _metrics != nullptr) {
-        // These properties require different handling in plugin vs compiled_model
-        TRY_REGISTER_SIMPLE_PROPERTY(ov::workload_type, WORKLOAD_TYPE);
-        // plugin-only
-        TRY_REGISTER_CUSTOMFUNC_PROPERTY(ov::intel_npu::stepping, STEPPING, [&](const Config& config) {
-            if (!config.has<STEPPING>()) {
-                const auto specifiedDeviceName = get_specified_device_name(config);
-                return static_cast<int64_t>(_metrics->GetSteppingNumber(specifiedDeviceName));
-            } else {
-                return config.get<STEPPING>();
-            }
-        });
-        // plugin-only
-        TRY_REGISTER_CUSTOMFUNC_PROPERTY(ov::intel_npu::max_tiles, MAX_TILES, [&](const Config& config) {
-            if (!config.has<MAX_TILES>()) {
-                const auto specifiedDeviceName = get_specified_device_name(config);
-                return static_cast<int64_t>(_metrics->GetMaxTiles(specifiedDeviceName));
-            } else {
-                return config.get<MAX_TILES>();
-            }
-        });
+    TRY_REGISTER_CUSTOMFUNC_PROPERTY(ov::intel_npu::stepping, STEPPING, [&](const Config& config) {
+        if (!config.has<STEPPING>()) {
+            const auto specifiedDeviceName = get_specified_device_name(config);
+            return static_cast<int64_t>(_metrics->GetSteppingNumber(specifiedDeviceName));
+        } else {
+            return config.get<STEPPING>();
+        }
+    });
+    TRY_REGISTER_CUSTOMFUNC_PROPERTY(ov::intel_npu::max_tiles, MAX_TILES, [&](const Config& config) {
+        if (!config.has<MAX_TILES>()) {
+            const auto specifiedDeviceName = get_specified_device_name(config);
+            return static_cast<int64_t>(_metrics->GetMaxTiles(specifiedDeviceName));
+        } else {
+            return config.get<MAX_TILES>();
+        }
+    });
 
-        TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::run_inferences_sequentially, RUN_INFERENCES_SEQUENTIALLY, [&] {
-            if (_backend && _backend->getInitStructs()) {
-                if (_backend->getInitStructs()->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1)) {
-                    return true;
-                }
+    TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::run_inferences_sequentially, RUN_INFERENCES_SEQUENTIALLY, [&] {
+        if (_backend && _backend->getInitStructs()) {
+            if (_backend->getInitStructs()->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1)) {
+                return true;
             }
-            return false;
-        }());
-        TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::enable_cpu_pinning, ENABLE_CPU_PINNING);
-    } else if (_pType == PropertiesType::COMPILED_MODEL) {
-        // These properties require different handling in plugin vs compiled_model
-        TRY_REGISTER_CUSTOM_PROPERTY(ov::workload_type,
-                                     WORKLOAD_TYPE,
-                                     true,
-                                     ov::PropertyMutability::RW,
-                                     [](const Config& config) {
-                                         return config.get<WORKLOAD_TYPE>();
-                                     });
-        // compiled-model only
-        TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::run_inferences_sequentially, RUN_INFERENCES_SEQUENTIALLY, true);
-        TRY_REGISTER_SIMPLE_PROPERTY(ov::loaded_from_cache, LOADED_FROM_CACHE);
-
-        // need to force-skip config.has() for cpu_pinning
-        TRY_REGISTER_CUSTOM_PROPERTY(ov::hint::enable_cpu_pinning,
-                                     ENABLE_CPU_PINNING,
-                                     true,
-                                     ov::PropertyMutability::RO,
-                                     [](const Config& config) {
-                                         return config.get<ENABLE_CPU_PINNING>();
-                                     });
-    }
+        }
+        return false;
+    }());
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::enable_cpu_pinning, ENABLE_CPU_PINNING);
 
     // 2. Metrics (static device and enviroment properties)
     // ========
     // REGISTER_SIMPLE_METRIC format: (property, public true/false, return value)
     // REGISTER_CUSTOM_METRIC format: (property, public true/false, return value function)
-
-    // 2.1 Metrics for Plugin-only (or those which need to be handled differently)
-    if (_pType == PropertiesType::PLUGIN && _metrics != nullptr) {
+    if (_metrics != nullptr) {
         REGISTER_SIMPLE_METRIC(ov::available_devices, true, _metrics->GetAvailableDevicesNames());
         REGISTER_SIMPLE_METRIC(ov::device::capabilities, true, _metrics->GetOptimizationCapabilities());
         REGISTER_SIMPLE_METRIC(
@@ -447,39 +482,87 @@ void Properties::registerProperties() {
             }
             return caching_props;
         });
-    } else if (_pType == PropertiesType::COMPILED_MODEL) {
-        /// 2.2 Metrics for CompiledModel-only (or those which need to be handled differently)
-        REGISTER_CUSTOM_METRIC(ov::model_name, true, [](const Config&) {
-            // TODO: log an error here as the code shouldn't have gotten here
-            // this property is implemented in compiled model directly
-            // this implementation here servers only to publish it in supported_properties
-            return std::string("invalid");
-        });
-        REGISTER_SIMPLE_METRIC(ov::optimal_number_of_infer_requests,
-                               true,
-                               static_cast<uint32_t>(getOptimalNumberOfInferRequestsInParallel(config)));
-        REGISTER_CUSTOM_METRIC(ov::internal::supported_properties, true, [&](const Config&) {
-            static const std::vector<ov::PropertyName> supportedProperty{
-                ov::PropertyName(ov::internal::caching_properties.name(), ov::PropertyMutability::RO)};
-            return supportedProperty;
-        });
-        REGISTER_CUSTOM_METRIC(ov::execution_devices, true, [](const Config&) {
-            // TODO: log an error here as the code shouldn't have gotten here
-            // this property is implemented in compiled model directly
-            // this implementation here servers only to publish it in supported_properties
-            return std::string("NPU");
-        });
     }
-    // 2.3. Common metrics (exposed same way by both Plugin and CompiledModel)
-    REGISTER_SIMPLE_METRIC(ov::supported_properties, true, _supportedProperties);
+}
 
-    // 3. Populate supported properties list
+void Properties::registerCompiledModelProperties() {
+    // 1. Configs
     // ========
-    for (auto& property : _properties) {
-        if (std::get<0>(property.second)) {
-            _supportedProperties.emplace_back(ov::PropertyName(property.first, std::get<1>(property.second)));
-        }
-    }
+    // 1.1 simple configs which only return value
+    // TRY_REGISTER_SIMPLE_PROPERTY format: (property, config_to_return)
+    // TRY_REGISTER_VARPUB_PROPERTY format: (property, config_to_return, dynamic public/private value)
+    // TRY_REGISTER_CUSTOMFUNC_PROPERTY format: (property, custom_return_lambda_function)
+    // TRY_REGISTER_CUSTOM_PROPERTY format: (property, visibility, mutability, custom_return_lambda_function)
+    // FORCE_REGISTER_CUSTOM_PROPERTY format: (property, visibility, mutability, custom_return_lambda_function)
+
+    // Permanent properties
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::enable_cpu_pinning, ENABLE_CPU_PINNING);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::log::level, LOG_LEVEL);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::loaded_from_cache, LOADED_FROM_CACHE);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::intel_npu::turbo, TURBO);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::model_priority, MODEL_PRIORITY);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::performance_mode, PERFORMANCE_HINT);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::execution_mode, EXECUTION_MODE_HINT);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::hint::num_requests, PERFORMANCE_HINT_NUM_REQUESTS);
+    TRY_REGISTER_SIMPLE_PROPERTY(ov::compilation_num_threads, COMPILATION_NUM_THREADS);
+
+    // Properties we shall only enable if they were set prior-to-compilation
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::hint::inference_precision, INFERENCE_PRECISION_HINT);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::hint::model, MODEL_PTR);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::weights_path, WEIGHTS_PATH);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::cache_dir, CACHE_DIR);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::enable_profiling, PERF_COUNT);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::compilation_mode_params, COMPILATION_MODE_PARAMS);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::dma_engines, DMA_ENGINES);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::tiles, TILES);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::compilation_mode, COMPILATION_MODE);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::compiler_type, COMPILER_TYPE);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::platform, PLATFORM);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::dynamic_shape_to_static, DYNAMIC_SHAPE_TO_STATIC);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::profiling_type, PROFILING_TYPE);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::backend_compilation_params, BACKEND_COMPILATION_PARAMS);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::batch_mode, BATCH_MODE);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::bypass_umd_caching, BYPASS_UMD_CACHING);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::defer_weights_load, DEFER_WEIGHTS_LOAD);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::compiler_dynamic_quantization, COMPILER_DYNAMIC_QUANTIZATION);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::qdq_optimization, QDQ_OPTIMIZATION);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::disable_version_check, DISABLE_VERSION_CHECK);
+    TRY_REGISTER_SIMPLE_PROPERTY_IFSET(ov::intel_npu::batch_compiler_mode_settings, BATCH_COMPILER_MODE_SETTINGS);
+    TRY_REGISTER_VARPUB_PROPERTY(ov::intel_npu::run_inferences_sequentially, RUN_INFERENCES_SEQUENTIALLY, true);
+
+    TRY_REGISTER_CUSTOM_PROPERTY(ov::workload_type,
+                                 WORKLOAD_TYPE,
+                                 true,
+                                 ov::PropertyMutability::RW,
+                                 [](const Config& config) {
+                                     return config.get<WORKLOAD_TYPE>();
+                                 });
+
+    // 2. Metrics (static device and enviroment properties)
+    // ========
+    // REGISTER_SIMPLE_METRIC format: (property, public true/false, return value)
+    // REGISTER_CUSTOM_METRIC format: (property, public true/false, return value function)
+
+    REGISTER_CUSTOM_METRIC(ov::model_name, true, [](const Config&) {
+        // TODO: log an error here as the code shouldn't have gotten here
+        // this property is implemented in compiled model directly
+        // this implementation here servers only to publish it in supported_properties
+        return std::string("invalid");
+    });
+    REGISTER_SIMPLE_METRIC(ov::optimal_number_of_infer_requests,
+                           true,
+                           static_cast<uint32_t>(getOptimalNumberOfInferRequestsInParallel(config)));
+    REGISTER_CUSTOM_METRIC(ov::internal::supported_properties, true, [&](const Config&) {
+        static const std::vector<ov::PropertyName> supportedProperty{
+            ov::PropertyName(ov::internal::caching_properties.name(), ov::PropertyMutability::RO)};
+        return supportedProperty;
+    });
+    REGISTER_CUSTOM_METRIC(ov::execution_devices, true, [](const Config&) {
+        // TODO: log an error here as the code shouldn't have gotten here
+        // this property is implemented in compiled model directly
+        // this implementation here servers only to publish it in supported_properties
+        return std::string("NPU");
+    });
 }
 
 ov::Any Properties::get_property(const std::string& name, const ov::AnyMap& arguments) const {

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/property.cpp
@@ -21,8 +21,7 @@ std::vector<std::pair<std::string, ov::Any>> exe_network_supported_properties = 
     {ov::hint::num_requests.name(), ov::Any(8)},
     {ov::hint::enable_cpu_pinning.name(), ov::Any(true)},
     {ov::hint::performance_mode.name(), ov::Any(ov::hint::PerformanceMode::THROUGHPUT)},
-    {ov::enable_profiling.name(), ov::Any(true)},
-    {ov::device::id.name(), ov::Any(ov::test::utils::getDeviceNameID(ov::test::utils::getDeviceName()))},
+    {ov::hint::model_priority.name(), ov::Any(ov::hint::Priority::MEDIUM)},
     {ov::optimal_number_of_infer_requests.name(), ov::Any(2)},
 };
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/compiled_model/properties.cpp
@@ -54,7 +54,6 @@ const std::string& expectedModelName = []() -> std::string {
 }();
 
 const std::vector<ov::AnyMap> compat_PublicCompiledModelConfigs = {
-    {{ov::device::id.name(), ov::Any("")}},
     {{ov::hint::enable_cpu_pinning.name(), ov::Any(false)}},
     {{ov::hint::model_priority.name(), ov::Any(ov::hint::Priority::MEDIUM)}},
     {{ov::execution_devices.name(), ov::Any(ov::test::utils::DEVICE_NPU)}},
@@ -62,12 +61,11 @@ const std::vector<ov::AnyMap> compat_PublicCompiledModelConfigs = {
     {{ov::model_name.name(), ov::Any(expectedModelName)}},
     {{ov::optimal_number_of_infer_requests.name(), ov::Any(1u)}},
     {{ov::hint::performance_mode.name(), ov::Any(ov::hint::PerformanceMode::LATENCY)}},
-    {{ov::hint::num_requests.name(), ov::Any(1u)}},
-    {{ov::enable_profiling.name(), ov::Any(false)}}};
+    {{ov::hint::num_requests.name(), ov::Any(1u)}}};
 
 const std::vector<ov::AnyMap> PublicCompiledModelConfigs = {
     {{ov::hint::execution_mode.name(), ov::Any(ov::hint::ExecutionMode::PERFORMANCE)}},
-    {{ov::hint::inference_precision.name(), ov::Any(ov::element::f16)}},
+    {{ov::hint::model_priority.name(), ov::Any(ov::hint::Priority::MEDIUM)}},
 };
 
 const std::vector<ov::AnyMap> compiledModelIncorrectConfigs = {


### PR DESCRIPTION
### Details:
- breaking unified properties registration function into 2 separate ones, dedicated for Plugin properties and dedicated for Compiled_model properties
- revisiting compiled_model properties
- adding macro to be used with particular properties for compiled_model which checks first if the option was set or is on default value
- for compiled model, all compiler-specific properties are now only registered if they were previously set

### Tickets:
 - EISW-75326
