### PR TITLE
[CPU][ARM] Check Convert output precision before fusing with Eltwise

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -2367,7 +2367,7 @@ bool Eltwise::canFuseConvert(const NodePtr& convertNode) const {
     }
 // Convert can be fused into Eltwise only if jit implementation is supported
 #if defined(OPENVINO_ARCH_ARM64)
-    return EltwiseJitExecutor::isSupportedOp(this, getAlpha(), getBeta(), getGamma());
+    return EltwiseJitExecutor::isSupportedOp(this, getAlpha(), getBeta(), getGamma(), {}, {convertNode->getOriginalOutputPrecisionAtPort(0)});
 #else
     return false;
 #endif


### PR DESCRIPTION
### Details:
 - Recently additional check of input and output Eltwise precisions was implemented in `EltwiseJitExecutor::isSupportedOp`: https://github.com/openvinotoolkit/openvino/pull/29875
 - This method contains also a WA: jit implementation of Eltwise Floor uses f16 and f32 only (CVS-138629).
 - There is a transformation `MergeEltwiseAndConvert` that can set Eltwise output precision different from f16 and f32. The transformation calls `Eltwise::canFuseConvert`, however `Eltwise::canFuseConvert` didn't pass Convert output precision to `EltwiseJitExecutor::isSupportedOp` for validation.

### Tickets:
 - CVS-165704
