### PR TITLE
Pass output shape efficiently by value

### DIFF
--- a/src/core/reference/include/openvino/reference/interpolate_pil.hpp
+++ b/src/core/reference/include/openvino/reference/interpolate_pil.hpp
@@ -163,18 +163,21 @@ void imaging_resample_horizontal(T* im_out,
     double ss;
     int x, xmin, xmax;
     double* k;
+    const auto im_out_shape_d0 = im_out_shape[0];
+    const auto im_out_shape_d1 = im_out_shape[1];
+    const auto im_in_shape_d1 = im_in_shape[1];
 
-    for (size_t yy = 0; yy < im_out_shape[0]; yy++) {
-        for (size_t xx = 0; xx < im_out_shape[1]; xx++) {
+    for (size_t yy = 0; yy < im_out_shape_d0; yy++) {
+        for (size_t xx = 0; xx < im_out_shape_d1; xx++) {
             xmin = bounds[xx * 2 + 0];
             xmax = bounds[xx * 2 + 1];
             k = &kk[xx * ksize];
             ss = 0.0;
             for (x = 0; x < xmax; x++) {
-                size_t in_idx = (yy + offset) * im_in_shape[1] + (x + xmin);
+                size_t in_idx = (yy + offset) * im_in_shape_d1 + (x + xmin);
                 ss += im_in[in_idx] * k[x];
             }
-            size_t out_idx = yy * im_out_shape[1] + xx;
+            size_t out_idx = yy * im_out_shape_d1 + xx;
             if (std::is_integral<T>()) {
                 im_out[out_idx] = T(clip<T, int64_t>(round_up<int64_t, double>(ss)));
             } else {
@@ -196,18 +199,21 @@ void imaging_resample_vertical(T* im_out,
     double ss;
     int y, ymin, ymax;
     double* k;
+    const auto im_out_shape_d0 = im_out_shape[0];
+    const auto im_out_shape_d1 = im_out_shape[1];
+    const auto im_in_shape_d1 = im_in_shape[1];
 
-    for (size_t yy = 0; yy < im_out_shape[0]; yy++) {
+    for (size_t yy = 0; yy < im_out_shape_d0; yy++) {
         ymin = bounds[yy * 2 + 0];
         ymax = bounds[yy * 2 + 1];
         k = &kk[yy * ksize];
-        for (size_t xx = 0; xx < im_out_shape[1]; xx++) {
+        for (size_t xx = 0; xx < im_out_shape_d1; xx++) {
             ss = 0.0;
             for (y = 0; y < ymax; y++) {
-                size_t in_idx = (y + ymin) * im_in_shape[1] + xx;
+                size_t in_idx = (y + ymin) * im_in_shape_d1 + xx;
                 ss += im_in[in_idx] * k[y];
             }
-            size_t out_idx = yy * im_out_shape[1] + xx;
+            size_t out_idx = yy * im_out_shape_d1 + xx;
             if (std::is_integral<T>()) {
                 im_out[out_idx] = T(clip<T, int64_t>(round_up<int64_t, double>(ss)));
             } else {

--- a/src/core/reference/include/openvino/reference/prior_box_clustered.hpp
+++ b/src/core/reference/include/openvino/reference/prior_box_clustered.hpp
@@ -41,6 +41,7 @@ void prior_box_clustered(const T* data,
     }
 
     size_t var_size = variances.size();
+    const auto out_shape_d1 = out_shape[1];
     for (int64_t h = 0; h < layer_height; ++h) {
         for (int64_t w = 0; w < layer_width; ++w) {
             float center_x = (w + attrs.offset) * step_w;
@@ -79,10 +80,10 @@ void prior_box_clustered(const T* data,
                 // 2. 4 variance values
                 if (var_size == 1) {
                     for (size_t j = 0; j < 4; j++)
-                        dst_data[idx + j + out_shape[1]] = variances[0];
+                        dst_data[idx + j + out_shape_d1] = variances[0];
                 } else {
                     for (size_t j = 0; j < var_size; j++)
-                        dst_data[idx + j + out_shape[1]] = variances[j];
+                        dst_data[idx + j + out_shape_d1] = variances[j];
                 }
             }
         }

--- a/src/core/reference/src/op/reshape.cpp
+++ b/src/core/reference/src/op/reshape.cpp
@@ -44,20 +44,22 @@ void reshape_2D(const char* in,
                 const AxisVector& axes_order,
                 const Shape& out_shape,
                 size_t elem_size) {
-    size_t num_elements = shape_size(in_shape);
+    const auto num_elements = shape_size(in_shape);
+    const auto out_shape_d0 = out_shape[0];
+    const auto out_shape_d1 = out_shape[1];
     if (num_elements <= get_threshold()) {
-        for (size_t i = 0; i < out_shape[0]; i++) {
+        for (size_t i = 0; i < out_shape_d0; i++) {
             size_t off = i;
-            for (size_t j = 0; j < out_shape[1]; j++) {
+            for (size_t j = 0; j < out_shape_d1; j++) {
                 copy_element(out, in + off * elem_size, elem_size);
                 out += elem_size;
-                off += out_shape[0];
+                off += out_shape_d0;
             }
         }
     } else {
-        ov::parallel_for2d_dynamic(out_shape[0], out_shape[1], [in, out, &out_shape, elem_size](size_t i, size_t j) {
-            size_t in_off = j * out_shape[0] + i;
-            size_t out_off = i * out_shape[1] + j;
+        ov::parallel_for2d_dynamic(out_shape_d0, out_shape_d1, [in, out, out_shape_d0, out_shape_d1, elem_size](size_t i, size_t j) {
+            size_t in_off = j * out_shape_d0 + i;
+            size_t out_off = i * out_shape_d1 + j;
             copy_element(out + out_off * elem_size, in + in_off * elem_size, elem_size);
         });
     }
@@ -84,16 +86,21 @@ void reshape_3D(const char* in,
                 const AxisVector& axes_order,
                 const Shape& out_shape,
                 size_t elem_size) {
-    size_t num_elements = shape_size(in_shape);
+    const auto num_elements = shape_size(in_shape);
+    const auto out_shape_d0 = out_shape[0];
+    const auto out_shape_d1 = out_shape[1];
+    const auto out_shape_d2 = out_shape[2];
+    const auto in_shape_d1 = in_shape[1];
+    const auto in_shape_d2 = in_shape[2];
     if (num_elements <= get_threshold()) {
         const auto strides = get_strides(3, elem_size, axes_order, in_shape);
 
         size_t off_0 = 0;
-        for (size_t i = 0; i < out_shape[0]; i++) {
+        for (size_t i = 0; i < out_shape_d0; i++) {
             size_t off_1 = off_0;
-            for (size_t j = 0; j < out_shape[1]; j++) {
+            for (size_t j = 0; j < out_shape_d1; j++) {
                 size_t in_off = off_1;
-                for (size_t k = 0; k < out_shape[2]; k++) {
+                for (size_t k = 0; k < out_shape_d2; k++) {
                     copy_element(out, in + in_off, elem_size);
                     out += elem_size;
                     in_off += strides[2];
@@ -103,17 +110,17 @@ void reshape_3D(const char* in,
             off_0 += strides[0];
         }
     } else {
-        ov::parallel_for3d(out_shape[0],
-                           out_shape[1],
-                           out_shape[2],
-                           [in, out, axes_order, &in_shape, &out_shape, elem_size](size_t i, size_t j, size_t k) {
+        ov::parallel_for3d(out_shape_d0,
+                           out_shape_d1,
+                           out_shape_d2,
+                           [in, out, axes_order, in_shape_d1, in_shape_d2, out_shape_d1, out_shape_d2, elem_size](size_t i, size_t j, size_t k) {
                                size_t in_indexes[3];
                                in_indexes[axes_order[0]] = i;
                                in_indexes[axes_order[1]] = j;
                                in_indexes[axes_order[2]] = k;
                                size_t in_off =
-                                   (in_indexes[0] * in_shape[1] + in_indexes[1]) * in_shape[2] + in_indexes[2];
-                               size_t out_off = (i * out_shape[1] + j) * out_shape[2] + k;
+                                   (in_indexes[0] * in_shape_d1 + in_indexes[1]) * in_shape_d2 + in_indexes[2];
+                               size_t out_off = (i * out_shape_d1 + j) * out_shape_d2 + k;
                                copy_element(out + out_off * elem_size, in + in_off * elem_size, elem_size);
                            });
     }
@@ -125,18 +132,25 @@ void reshape_4D(const char* in,
                 const AxisVector& axes_order,
                 const Shape& out_shape,
                 size_t elem_size) {
-    size_t num_elements = shape_size(in_shape);
+    const auto num_elements = shape_size(in_shape);
+    const auto out_shape_d0 = out_shape[0];
+    const auto out_shape_d1 = out_shape[1];
+    const auto out_shape_d2 = out_shape[2];
+    const auto out_shape_d3 = out_shape[3];
+    const auto in_shape_d1 = in_shape[1];
+    const auto in_shape_d2 = in_shape[2];
+    const auto in_shape_d3 = in_shape[3];
     if (num_elements <= get_threshold()) {
         const auto strides = get_strides(4, elem_size, axes_order, in_shape);
 
         size_t off_0 = 0;
-        for (size_t i = 0; i < out_shape[0]; i++) {
+        for (size_t i = 0; i < out_shape_d0; i++) {
             size_t off_1 = off_0;
-            for (size_t j = 0; j < out_shape[1]; j++) {
+            for (size_t j = 0; j < out_shape_d1; j++) {
                 size_t off_2 = off_1;
-                for (size_t k = 0; k < out_shape[2]; k++) {
+                for (size_t k = 0; k < out_shape_d2; k++) {
                     size_t in_off = off_2;
-                    for (size_t l = 0; l < out_shape[3]; l++) {
+                    for (size_t l = 0; l < out_shape_d3; l++) {
                         copy_element(out, in + in_off, elem_size);
                         out += elem_size;
                         in_off += strides[3];
@@ -149,20 +163,20 @@ void reshape_4D(const char* in,
         }
     } else {
         ov::parallel_for4d(
-            out_shape[0],
-            out_shape[1],
-            out_shape[2],
-            out_shape[3],
-            [in, out, axes_order, &in_shape, &out_shape, elem_size](size_t i, size_t j, size_t k, size_t l) {
+            out_shape_d0,
+            out_shape_d1,
+            out_shape_d2,
+            out_shape_d3,
+            [in, out, axes_order, in_shape_d1, in_shape_d2, in_shape_d3, out_shape_d1, out_shape_d2, out_shape_d3, elem_size](size_t i, size_t j, size_t k, size_t l) {
                 size_t in_indexes[4];
                 in_indexes[axes_order[0]] = i;
                 in_indexes[axes_order[1]] = j;
                 in_indexes[axes_order[2]] = k;
                 in_indexes[axes_order[3]] = l;
                 size_t in_off =
-                    ((in_indexes[0] * in_shape[1] + in_indexes[1]) * in_shape[2] + in_indexes[2]) * in_shape[3] +
+                    ((in_indexes[0] * in_shape_d1 + in_indexes[1]) * in_shape_d2 + in_indexes[2]) * in_shape_d3 +
                     in_indexes[3];
-                size_t out_off = ((i * out_shape[1] + j) * out_shape[2] + k) * out_shape[3] + l;
+                size_t out_off = ((i * out_shape_d1 + j) * out_shape_d2 + k) * out_shape_d3 + l;
                 copy_element(out + out_off * elem_size, in + in_off * elem_size, elem_size);
             });
     }
@@ -174,20 +188,29 @@ void reshape_5D(const char* in,
                 const AxisVector& axes_order,
                 const Shape& out_shape,
                 size_t elem_size) {
-    size_t num_elements = shape_size(in_shape);
+    const auto num_elements = shape_size(in_shape);
+    const auto out_shape_d0 = out_shape[0];
+    const auto out_shape_d1 = out_shape[1];
+    const auto out_shape_d2 = out_shape[2];
+    const auto out_shape_d3 = out_shape[3];
+    const auto out_shape_d4 = out_shape[4];
+    const auto in_shape_d1 = in_shape[1];
+    const auto in_shape_d2 = in_shape[2];
+    const auto in_shape_d3 = in_shape[3];
+    const auto in_shape_d4 = in_shape[4];
     if (num_elements <= get_threshold()) {
         const auto strides = get_strides(5, elem_size, axes_order, in_shape);
 
         size_t off_0 = 0;
-        for (size_t i = 0; i < out_shape[0]; i++) {
+        for (size_t i = 0; i < out_shape_d0; i++) {
             size_t off_1 = off_0;
-            for (size_t j = 0; j < out_shape[1]; j++) {
+            for (size_t j = 0; j < out_shape_d1; j++) {
                 size_t off_2 = off_1;
-                for (size_t k = 0; k < out_shape[2]; k++) {
+                for (size_t k = 0; k < out_shape_d2; k++) {
                     size_t off_3 = off_2;
-                    for (size_t l = 0; l < out_shape[3]; l++) {
+                    for (size_t l = 0; l < out_shape_d3; l++) {
                         size_t in_off = off_3;
-                        for (size_t m = 0; m < out_shape[4]; m++) {
+                        for (size_t m = 0; m < out_shape_d4; m++) {
                             copy_element(out, in + in_off, elem_size);
                             out += elem_size;
                             in_off += strides[4];
@@ -202,12 +225,12 @@ void reshape_5D(const char* in,
         }
     } else {
         ov::parallel_for5d(
-            out_shape[0],
-            out_shape[1],
-            out_shape[2],
-            out_shape[3],
-            out_shape[4],
-            [in, out, axes_order, &in_shape, &out_shape, elem_size](size_t i, size_t j, size_t k, size_t l, size_t m) {
+            out_shape_d0,
+            out_shape_d1,
+            out_shape_d2,
+            out_shape_d3,
+            out_shape_d4,
+            [in, out, axes_order, in_shape_d1, in_shape_d2, in_shape_d3, in_shape_d4, out_shape_d1, out_shape_d2, out_shape_d3, out_shape_d4, elem_size](size_t i, size_t j, size_t k, size_t l, size_t m) {
                 size_t in_indexes[5];
                 in_indexes[axes_order[0]] = i;
                 in_indexes[axes_order[1]] = j;
@@ -215,11 +238,11 @@ void reshape_5D(const char* in,
                 in_indexes[axes_order[3]] = l;
                 in_indexes[axes_order[4]] = m;
                 size_t in_off =
-                    (((in_indexes[0] * in_shape[1] + in_indexes[1]) * in_shape[2] + in_indexes[2]) * in_shape[3] +
+                    (((in_indexes[0] * in_shape_d1 + in_indexes[1]) * in_shape_d2 + in_indexes[2]) * in_shape_d3 +
                      in_indexes[3]) *
-                        in_shape[4] +
+                        in_shape_d4 +
                     in_indexes[4];
-                size_t out_off = (((i * out_shape[1] + j) * out_shape[2] + k) * out_shape[3] + l) * out_shape[4] + m;
+                size_t out_off = (((i * out_shape_d1 + j) * out_shape_d2 + k) * out_shape_d3 + l) * out_shape_d4 + m;
                 copy_element(out + out_off * elem_size, in + in_off * elem_size, elem_size);
             });
     }
@@ -231,22 +254,33 @@ void reshape_6D(const char* in,
                 const AxisVector& axes_order,
                 const Shape& out_shape,
                 size_t elem_size) {
-    size_t num_elements = shape_size(in_shape);
+    const auto num_elements = shape_size(in_shape);
+    const auto out_shape_d0 = out_shape[0];
+    const auto out_shape_d1 = out_shape[1];
+    const auto out_shape_d2 = out_shape[2];
+    const auto out_shape_d3 = out_shape[3];
+    const auto out_shape_d4 = out_shape[4];
+    const auto out_shape_d5 = out_shape[5];
+    const auto in_shape_d1 = in_shape[1];
+    const auto in_shape_d2 = in_shape[2];
+    const auto in_shape_d3 = in_shape[3];
+    const auto in_shape_d4 = in_shape[4];
+    const auto in_shape_d5 = in_shape[5];
     if (num_elements <= get_threshold()) {
         const auto strides = get_strides(6, elem_size, axes_order, in_shape);
 
         size_t off_0 = 0;
-        for (size_t i = 0; i < out_shape[0]; i++) {
+        for (size_t i = 0; i < out_shape_d0; i++) {
             size_t off_1 = off_0;
-            for (size_t j = 0; j < out_shape[1]; j++) {
+            for (size_t j = 0; j < out_shape_d1; j++) {
                 size_t off_2 = off_1;
-                for (size_t k = 0; k < out_shape[2]; k++) {
+                for (size_t k = 0; k < out_shape_d2; k++) {
                     size_t off_3 = off_2;
-                    for (size_t l = 0; l < out_shape[3]; l++) {
+                    for (size_t l = 0; l < out_shape_d3; l++) {
                         size_t off_4 = off_3;
-                        for (size_t m = 0; m < out_shape[4]; m++) {
+                        for (size_t m = 0; m < out_shape_d4; m++) {
                             size_t in_off = off_4;
-                            for (size_t n = 0; n < out_shape[5]; n++) {
+                            for (size_t n = 0; n < out_shape_d5; n++) {
                                 copy_element(out, in + in_off, elem_size);
                                 out += elem_size;
                                 in_off += strides[5];
@@ -263,13 +297,13 @@ void reshape_6D(const char* in,
         }
     } else {
         ov::parallel_for6d(
-            out_shape[0],
-            out_shape[1],
-            out_shape[2],
-            out_shape[3],
-            out_shape[4],
-            out_shape[5],
-            [=, &axes_order, &in_shape, &out_shape](size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) {
+            out_shape_d0,
+            out_shape_d1,
+            out_shape_d2,
+            out_shape_d3,
+            out_shape_d4,
+            out_shape_d5,
+            [=, &axes_order, &in_shape_d1, &in_shape_d2, &in_shape_d3, &in_shape_d4, &in_shape_d5, &out_shape_d1, &out_shape_d2, &out_shape_d3, &out_shape_d4, &out_shape_d5](size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) {
                 size_t in_indexes[6];
                 in_indexes[axes_order[0]] = i;
                 in_indexes[axes_order[1]] = j;
@@ -278,14 +312,14 @@ void reshape_6D(const char* in,
                 in_indexes[axes_order[4]] = m;
                 in_indexes[axes_order[5]] = n;
                 size_t in_off =
-                    ((((in_indexes[0] * in_shape[1] + in_indexes[1]) * in_shape[2] + in_indexes[2]) * in_shape[3] +
+                    ((((in_indexes[0] * in_shape_d1 + in_indexes[1]) * in_shape_d2 + in_indexes[2]) * in_shape_d3 +
                       in_indexes[3]) *
-                         in_shape[4] +
+                        in_shape_d4 +
                      in_indexes[4]) *
-                        in_shape[5] +
+                        in_shape_d5 +
                     in_indexes[5];
-                size_t out_off = ((((i * out_shape[1] + j) * out_shape[2] + k) * out_shape[3] + l) * out_shape[4] + m) *
-                                     out_shape[5] +
+                size_t out_off = ((((i * out_shape_d1 + j) * out_shape_d2 + k) * out_shape_d3 + l) * out_shape_d4 + m) *
+                                 out_shape_d5 +
                                  n;
                 copy_element(out + out_off * elem_size, in + in_off * elem_size, elem_size);
             });

--- a/src/core/reference/src/op/slice.cpp
+++ b/src/core/reference/src/op/slice.cpp
@@ -44,8 +44,10 @@ void slice(const char* data,
     const auto in_data_strides = row_major_strides(data_shape);
     const auto out_data_strides = row_major_strides(out_shape);
     std::vector<int64_t> in_data_coord(aligned_starts);
-    for (size_t out_idx = 0; out_idx < shape_size(out_shape); ++out_idx) {
-        for (size_t i = 0; i < in_data_coord.size(); ++i) {
+    const auto out_shape_size = shape_size(out_shape);
+    const auto in_data_coord_size = in_data_coord.size();
+    for (size_t out_idx = 0; out_idx < out_shape_size; ++out_idx) {
+        for (size_t i = 0; i < in_data_coord_size; ++i) {
             in_data_coord[i] = aligned_starts[i] + (out_idx / out_data_strides[i] % out_shape[i]) * aligned_steps[i];
         }
         const auto in_idx =

--- a/src/core/reference/src/op/stft.cpp
+++ b/src/core/reference/src/op/stft.cpp
@@ -36,6 +36,8 @@ void stft(const float* signal,
     std::copy(window, window + window_shape[0], pad_window.begin() + (frame_size_dim - window_length) / 2);
 
     const auto fft_out_shape_size = shape_size(fft_out_shape);
+    const auto fft_out_shape_d0 = fft_out_shape[0];
+    const auto fft_out_shape_d1 = fft_out_shape[1];
     for (size_t batch = 0, batch_in_start = 0, batch_frames_out = 0; batch < batch_size; ++batch) {
         for (size_t frame_idx = 0; frame_idx < num_frames; ++frame_idx) {
             const auto frame_start = batch_in_start + frame_idx * frame_step;
@@ -58,11 +60,11 @@ void stft(const float* signal,
         batch_frames_out += num_frames;
     }
     if (transpose_frames) {
-        const auto stft_transp_out_shape = Shape{batch_size, fft_out_shape[0], num_frames, fft_out_shape[1]};
+        const auto stft_transp_out_shape = Shape{batch_size, fft_out_shape_d0, num_frames, fft_out_shape_d1};
         std::vector<float> signal_t(rdft_result, rdft_result + shape_size(stft_transp_out_shape));
         transpose(reinterpret_cast<const char*>(signal_t.data()),
                   reinterpret_cast<char*>(rdft_result),
-                  Shape{batch_size, num_frames, fft_out_shape[0], fft_out_shape[1]},
+                  Shape{batch_size, num_frames, fft_out_shape_d0, fft_out_shape_d1},
                   sizeof(float),
                   {0, 2, 1, 3},
                   stft_transp_out_shape);

--- a/src/core/src/op/transpose.cpp
+++ b/src/core/src/op/transpose.cpp
@@ -98,13 +98,15 @@ bool Transpose::evaluate(TensorVector& outputs, const TensorVector& inputs) cons
         auto out_ptr = int4_iterator(static_cast<uint8_t*>(out.data()));
         // The int4_iterator not supports const pointer but these data are not modified
         auto in_ptr = int4_iterator(static_cast<uint8_t*>(const_cast<void*>(arg.data())));
+        const auto out_shape_d0 = out_shape[0];
+        const auto out_shape_d1 = out_shape[1];
         if ((arg_type == ov::element::i4 || arg_type == ov::element::u4) && arg.get_shape().size() == 2) {
-            for (size_t i = 0; i < out_shape[0]; i++) {
+            for (size_t i = 0; i < out_shape_d0; i++) {
                 size_t off = i;
-                for (size_t j = 0; j < out_shape[1]; j++) {
+                for (size_t j = 0; j < out_shape_d1; j++) {
                     out_ptr.copy_from(in_ptr + off);
                     ++out_ptr;
-                    off += out_shape[0];
+                    off += out_shape_d0;
                 }
             }
         } else {


### PR DESCRIPTION
### Details:
In current implementation, for operations that will frequently called out_shape to get row and column value of output shape, like the reshape_2D implementation in following code:
```
void reshape_2D(const char* in,
                char* out,
                const Shape& in_shape,
                const AxisVector& axes_order,
                const Shape& out_shape,
                size_t elem_size) {
    size_t num_elements = shape_size(in_shape);
    if (num_elements <= get_threshold()) {
        for (size_t i = 0; i < out_shape[0]; i++) {
            size_t off = i;
            for (size_t j = 0; j < out_shape[1]; j++) {
                copy_element(out, in + off * elem_size, elem_size);
                out += elem_size;
                off += out_shape[0];
            }
        }
    } else {
        ov::parallel_for2d_dynamic(out_shape[0], out_shape[1], [in, out, &out_shape, elem_size](size_t i, size_t j) {
            size_t in_off = j * out_shape[0] + i;
            size_t out_off = i * out_shape[1] + j;
            copy_element(out + out_off * elem_size, in + in_off * elem_size, elem_size);
        });
    }
}
```
```out_shape[0]``` needs to call "util::normalize" to do the boundary check for each element, when the element size is huge, it will become the hotspot.

```
typename Shape::const_reference Shape::operator[](std::ptrdiff_t i) const {
    return std::vector<size_t>::operator[](util::normalize(i, size()));
}
```
We can pass get the output shape value outside and pass it to the lambda, that's what we did in the PR.

### Tickets:
 - *CVS-166899*
