### PR TITLE
[GPU] Skip ReadValue execution if its already set

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1876,6 +1876,15 @@ void primitive_inst::prepare_primitive() {
             return;
         }
 
+        if (_node->is_type<read_value>()) {
+            auto prim = get_node().as<read_value>().get_primitive();
+            auto& variable = get_network().get_variable(prim->variable_id);
+
+            if (variable.is_set() && can_be_optimized()) {
+                set_flag(ExecutionFlags::SKIP);
+            }
+        }
+
         // Check successor reorder if layouts are same
         // Need to set can_be_optimized for user reorder at predecessor because
         // if the user is can_be_optimized and output node then current nodes' output should be allocated to host.


### PR DESCRIPTION
### Details:
 - *Slight speedup for LoRA, which uses a huge amount of `read_value`*
 - *With the same checks, when executing a impl, nothing happens except overheads, which means we can skip execution in advance*