### PR TITLE
[NPU] protopipe: add missing headers for GCC 15

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/src/graph.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/graph.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <any>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <typeindex>

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/criterion.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/criterion.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 struct ITermCriterion {


### PR DESCRIPTION
### Details:
 - *The [`<cstdint>`](https://en.cppreference.com/w/cpp/header/cstdint) C++ header needs to be explicitly included when building with GCC 15 for using fixed width integer types. For details, see the [porting to GCC 15 documentation](https://gcc.gnu.org/gcc-15/porting_to.html#cxx).*

### Tickets:
 - *No tickets currently exists reporting a build error in the protopipe component when using GCC 15*
