### PR TITLE
[CORE] Check Windows version for fn GetProcessMitigationPolicy

### DIFF
--- a/src/common/util/include/openvino/util/common_util.hpp
+++ b/src/common/util/include/openvino/util/common_util.hpp
@@ -198,14 +198,6 @@ constexpr std::array<std::conditional_t<std::is_void_v<T>, std::common_type_t<Ar
     return {std::forward<Args>(args)...};
 }
 
-#if defined(_WIN32)
-bool may_i_use_dynamic_code();
-#else
-constexpr bool may_i_use_dynamic_code() {
-    return true;
-}
-#endif
-
 /**
  * @brief A custom stream buffer that provides read-only access to a string view.
  *

--- a/src/common/util/include/openvino/util/os.hpp
+++ b/src/common/util/include/openvino/util/os.hpp
@@ -8,16 +8,7 @@
 #    include <windows.h>
 #endif
 
-namespace ov {
-namespace util {
-
-#if defined(_WIN32)
-size_t get_os_encoded_version();
-#else
-constexpr size_t get_os_encoded_version() {
-    return 0;
-}
-#endif
+namespace ov::util {
 
 // The GetProcessMitigationPolicy function has been implemented since Windows 8 (0x0602),
 // so don't compile it on a lower version.
@@ -29,5 +20,4 @@ constexpr bool may_i_use_dynamic_code() {
 }
 #endif
 
-}  // namespace util
-}  // namespace ov
+}  // namespace ov::util

--- a/src/common/util/include/openvino/util/os.hpp
+++ b/src/common/util/include/openvino/util/os.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#if defined(_WIN32)
+#    include <windows.h>
+#endif
+
+namespace ov {
+namespace util {
+
+#if defined(_WIN32)
+size_t get_os_encoded_version();
+#else
+constexpr size_t get_os_encoded_version() {
+    return 0;
+}
+#endif
+
+// The GetProcessMitigationPolicy function has been implemented since Windows 8 (0x0602),
+// so don't compile it on a lower version.
+#if defined(_WIN32) && (_WIN32_WINNT >= 0x0602)
+bool may_i_use_dynamic_code();
+#else
+constexpr bool may_i_use_dynamic_code() {
+    return true;
+}
+#endif
+
+}  // namespace util
+}  // namespace ov

--- a/src/common/util/src/common_util.cpp
+++ b/src/common/util/src/common_util.cpp
@@ -6,10 +6,6 @@
 
 #include <algorithm>
 
-#if defined(_WIN32)
-#    include <windows.h>
-#endif
-
 std::string ov::util::to_lower(const std::string& s) {
     std::string rc = s;
     std::transform(rc.begin(), rc.end(), rc.begin(), ::tolower);
@@ -56,12 +52,3 @@ std::string ov::util::filter_lines_by_prefix(const std::string& str, const std::
     }
     return res.str();
 }
-
-#if defined(_WIN32)
-bool ov::util::may_i_use_dynamic_code() {
-    HANDLE handle = GetCurrentProcess();
-    PROCESS_MITIGATION_DYNAMIC_CODE_POLICY dynamic_code_policy = {0};
-    GetProcessMitigationPolicy(handle, ProcessDynamicCodePolicy, &dynamic_code_policy, sizeof(dynamic_code_policy));
-    return dynamic_code_policy.ProhibitDynamicCode != TRUE;
-}
-#endif

--- a/src/common/util/src/os/win/os.cpp
+++ b/src/common/util/src/os/win/os.cpp
@@ -6,57 +6,28 @@
 
 namespace ov::util {
 
-size_t get_os_encoded_version(void) {
-    static size_t os_encoded_version = 0lu;
-
-    if (os_encoded_version == 0lu) {
-        OSVERSIONINFOEXW os_version_info = {};
-        ZeroMemory(&os_version_info, sizeof(OSVERSIONINFOEX));
-
-        // Extended OS detection. We need it because of changed OS detection
-        // mechanism on Windows 11
-        // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion
-        HMODULE hNTOSKRNL = LoadLibrary("ntoskrnl.exe");
-        typedef NTSTATUS (*fnRtlGetVersion)(PRTL_OSVERSIONINFOW lpVersionInformation);
-        fnRtlGetVersion RtlGetVersion = nullptr;
-        if (hNTOSKRNL) {
-            RtlGetVersion = (fnRtlGetVersion)GetProcAddress(hNTOSKRNL, "RtlGetVersion");
-        }
-
-        // On Windows 11 GetVersionExW returns wrong information (like a Windows 8, build 9200)
-        // Because of that we update inplace information if RtlGetVersion is available
-        os_version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
-        if (RtlGetVersion && SUCCEEDED(RtlGetVersion((PRTL_OSVERSIONINFOW)&os_version_info))) {
-            os_encoded_version = (os_version_info.dwMajorVersion << 8) | os_version_info.dwMinorVersion;
-            return os_encoded_version;
-        }
-
-        os_version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEXW);
-        #pragma warning(push)
-#pragma warning(disable : 4996)
-        if (FAILED(GetVersionExW((LPOSVERSIONINFOW)&os_version_info))) {
-            return 0lu;
-        }
-#pragma warning(pop)
-
-        os_encoded_version = (os_version_info.dwMajorVersion << 8) | os_version_info.dwMinorVersion;
-    }
-
-    return os_encoded_version;
-}
-
 #if (_WIN32_WINNT >= 0x0602)
-bool ov::util::may_i_use_dynamic_code() {
-    // Need to check OS version, due to the binary could have been built on different platform.
-    if (get_os_encoded_version() >= 0x0602) {
-        HANDLE handle = GetCurrentProcess();
-        PROCESS_MITIGATION_DYNAMIC_CODE_POLICY dynamic_code_policy = {0};
-        auto res = GetProcessMitigationPolicy(handle, ProcessDynamicCodePolicy, &dynamic_code_policy, sizeof(dynamic_code_policy));
+bool may_i_use_dynamic_code() {
+    // The function GetProcessMitigationPolicy may not be available in the kernel32 library. It depends on the Windows version.
+    // Need to check this at runtime if the project was built on a different platform.
+    if (HMODULE kernel32 = LoadLibrary("kernel32")) {
+        typedef BOOL (*fnGetProcessMitigationPolicy)(HANDLE, _PROCESS_MITIGATION_POLICY, PVOID, SIZE_T);
+        fnGetProcessMitigationPolicy get_process_mitigation_policy =
+            (fnGetProcessMitigationPolicy)GetProcAddress(kernel32, "GetProcessMitigationPolicy");
 
-        return dynamic_code_policy.ProhibitDynamicCode != TRUE;
-    } else {
-        return true;
+        if (get_process_mitigation_policy) {
+            HANDLE handle = GetCurrentProcess();
+            PROCESS_MITIGATION_DYNAMIC_CODE_POLICY dynamic_code_policy = {0};
+            if (SUCCEEDED(get_process_mitigation_policy(handle,
+                                                        ProcessDynamicCodePolicy,
+                                                        &dynamic_code_policy,
+                                                        sizeof(dynamic_code_policy)))) {
+                return dynamic_code_policy.ProhibitDynamicCode != TRUE;
+            }
+        }
     }
+
+    return true;
 }
 #endif
 

--- a/src/common/util/src/os/win/os.cpp
+++ b/src/common/util/src/os/win/os.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/util/os.hpp"
+
+namespace ov::util {
+
+size_t get_os_encoded_version(void) {
+    static size_t os_encoded_version = 0lu;
+
+    if (os_encoded_version == 0lu) {
+        OSVERSIONINFOEXW os_version_info = {};
+        ZeroMemory(&os_version_info, sizeof(OSVERSIONINFOEX));
+
+        // Extended OS detection. We need it because of changed OS detection
+        // mechanism on Windows 11
+        // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion
+        HMODULE hNTOSKRNL = LoadLibrary("ntoskrnl.exe");
+        typedef NTSTATUS (*fnRtlGetVersion)(PRTL_OSVERSIONINFOW lpVersionInformation);
+        fnRtlGetVersion RtlGetVersion = nullptr;
+        if (hNTOSKRNL) {
+            RtlGetVersion = (fnRtlGetVersion)GetProcAddress(hNTOSKRNL, "RtlGetVersion");
+        }
+
+        // On Windows 11 GetVersionExW returns wrong information (like a Windows 8, build 9200)
+        // Because of that we update inplace information if RtlGetVersion is available
+        os_version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
+        if (RtlGetVersion && SUCCEEDED(RtlGetVersion((PRTL_OSVERSIONINFOW)&os_version_info))) {
+            os_encoded_version = (os_version_info.dwMajorVersion << 8) | os_version_info.dwMinorVersion;
+            return os_encoded_version;
+        }
+
+        os_version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEXW);
+        #pragma warning(push)
+#pragma warning(disable : 4996)
+        if (FAILED(GetVersionExW((LPOSVERSIONINFOW)&os_version_info))) {
+            return 0lu;
+        }
+#pragma warning(pop)
+
+        os_encoded_version = (os_version_info.dwMajorVersion << 8) | os_version_info.dwMinorVersion;
+    }
+
+    return os_encoded_version;
+}
+
+#if (_WIN32_WINNT >= 0x0602)
+bool ov::util::may_i_use_dynamic_code() {
+    // Need to check OS version, due to the binary could have been built on different platform.
+    if (get_os_encoded_version() >= 0x0602) {
+        HANDLE handle = GetCurrentProcess();
+        PROCESS_MITIGATION_DYNAMIC_CODE_POLICY dynamic_code_policy = {0};
+        auto res = GetProcessMitigationPolicy(handle, ProcessDynamicCodePolicy, &dynamic_code_policy, sizeof(dynamic_code_policy));
+
+        return dynamic_code_policy.ProhibitDynamicCode != TRUE;
+    } else {
+        return true;
+    }
+}
+#endif
+
+}  // namespace ov::util

--- a/src/core/reference/src/op/convert.cpp
+++ b/src/core/reference/src/op/convert.cpp
@@ -8,7 +8,7 @@
 
 #ifdef OV_CORE_USE_XBYAK_JIT
 #    include "openvino/reference/utils/jit_generator.hpp"
-#    include "openvino/util/common_util.hpp"
+#    include "openvino/util/os.hpp"
 #endif
 
 #ifdef OV_CORE_USE_INTRINSICS

--- a/src/core/src/runtime/compute_hash.cpp
+++ b/src/core/src/runtime/compute_hash.cpp
@@ -21,7 +21,7 @@
 #ifdef OV_CORE_USE_XBYAK_JIT
 #    include "openvino/core/parallel.hpp"
 #    include "openvino/reference/utils/registers_pool.hpp"
-#    include "openvino/util/common_util.hpp"
+#    include "openvino/util/os.hpp"
 #endif  // OV_CORE_USE_XBYAK_JIT
 
 namespace ov {


### PR DESCRIPTION
### Details:
 - *The GetProcessMitigationPolicy  function has been implemented since Windows 8, thus need to check Windows version first.*

### Tickets:
 - *CVS-166811*
