### PR TITLE
[CPU][DEBUG CAPS] Remove extra '0x' in blob dumping

### DIFF
--- a/src/plugins/intel_cpu/src/utils/blob_dump.cpp
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.cpp
@@ -174,7 +174,7 @@ void BlobDumper::dumpAsTxt(std::ostream& stream) const {
         stream << d << " ";
     }
     stream << "(" << data_size << ")"
-           << " by address 0x" << std::hex << memory->getDataAs<const int64_t>() << std::dec << '\n';
+           << " by address" << std::hex << memory->getDataAs<const int64_t>() << std::dec << '\n';
 
     const void* ptr = memory->getData();
 


### PR DESCRIPTION
### Details:

Fix blob dumping output issues like:
```
u8 1D shape: 75 (75) by address 0x0x13f6a1380
```

### Tickets:
 - N/A
