### PR TITLE
[GPU] Allow kv_cache_precision property to be read from rt_info for PagedAttention models on any GPUs

### DIFF
--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -193,7 +193,9 @@ TRANSFORMATIONS_API bool constantIsEqualTo(const std::shared_ptr<ov::op::v0::Con
 
 TRANSFORMATIONS_API bool has_f16_constants(const std::shared_ptr<const ov::Model>& function);
 
-TRANSFORMATIONS_API bool is_large_language_model(const ov::Model& model);
+TRANSFORMATIONS_API bool is_large_language_model(
+    const ov::Model& model,
+    std::function<bool(std::shared_ptr<ov::Node>)> custom_condition = nullptr);
 
 /**
  * \brief Check if 'other_shape' can be broadcasted to 'ref_shape'

--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -195,7 +195,9 @@ TRANSFORMATIONS_API bool has_f16_constants(const std::shared_ptr<const ov::Model
 
 TRANSFORMATIONS_API bool is_large_language_model(
     const ov::Model& model,
-    std::function<bool(std::shared_ptr<ov::Node>)> custom_condition = nullptr);
+    std::function<bool(std::shared_ptr<ov::Node>)> func = [](std::shared_ptr<ov::Node>) {
+        return false;
+    });
 
 /**
  * \brief Check if 'other_shape' can be broadcasted to 'ref_shape'

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -140,7 +140,7 @@ bool has_f16_constants(const std::shared_ptr<const ov::Model>& function) {
     return false;
 }
 
-bool is_large_language_model(const ov::Model& model, std::function<bool(std::shared_ptr<ov::Node>)> custom_condition) {
+bool is_large_language_model(const ov::Model& model, std::function<bool(std::shared_ptr<ov::Node>)> func) {
     using namespace ov::pass::pattern;
 
     const auto past = wrap_type<ov::op::v6::ReadValue>();
@@ -156,7 +156,7 @@ bool is_large_language_model(const ov::Model& model, std::function<bool(std::sha
     const auto kvcache_matcher = std::make_shared<ov::pass::pattern::Matcher>(present, "KVCacheMatcher");
 
     for (const auto& op : model.get_ops()) {
-        if (custom_condition && custom_condition(op))
+        if (func(op))
             return true;
 
         if (kvcache_matcher->match(op->output(0)) || ov::is_type<ov::op::PagedAttentionExtension>(op))

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -140,7 +140,7 @@ bool has_f16_constants(const std::shared_ptr<const ov::Model>& function) {
     return false;
 }
 
-bool is_large_language_model(const ov::Model& model) {
+bool is_large_language_model(const ov::Model& model, std::function<bool(std::shared_ptr<ov::Node>)> custom_condition) {
     using namespace ov::pass::pattern;
 
     const auto past = wrap_type<ov::op::v6::ReadValue>();
@@ -156,6 +156,9 @@ bool is_large_language_model(const ov::Model& model) {
     const auto kvcache_matcher = std::make_shared<ov::pass::pattern::Matcher>(present, "KVCacheMatcher");
 
     for (const auto& op : model.get_ops()) {
+        if (custom_condition && custom_condition(op))
+            return true;
+
         if (kvcache_matcher->match(op->output(0)) || ov::is_type<ov::op::PagedAttentionExtension>(op))
             return true;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/execution_config.hpp
@@ -36,7 +36,7 @@ struct ExecutionConfig : public ov::PluginConfig {
 protected:
     void finalize_impl(const IRemoteContext* context) override;
     void apply_model_specific_options(const IRemoteContext* context, const ov::Model& model) override;
-    void apply_rt_info(const IRemoteContext* context, const ov::RTMap& rt_info, bool is_llm);
+    void apply_rt_info(const IRemoteContext* context, const ov::RTMap& rt_info, bool is_llm, bool is_paged_attention_model);
 
     void apply_user_properties(const cldnn::device_info& info);
     void apply_hints(const cldnn::device_info& info);


### PR DESCRIPTION
### Details:
 - Allow kv_cache_precision property to be read from rt_info for PagedAttention models on any GPUs
 - Previously, kv_cache_precision was read from rt_info only on non-systolic platforms due to the poor performance of  sdpa_micro kernel. However, since PagedAttention does not use sdpa_micro, this restriction can now be removed

### Tickets:
 - [CVS-165096](https://jira.devtools.intel.com/browse/CVS-165096
)
