### PR TITLE
[releases/2025/1] Backporting: WA for cmake >= 4.0 (#29856)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ if(POLICY CMP0177)
     cmake_policy(SET CMP0177 NEW)
 endif()
 
+# set CMAKE_POLICY_VERSION_MINIMUM to avoid errors from 3rd party dependencies
+# after cmake is updated to 4.0
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+
 project(OpenVINO
         DESCRIPTION "OpenVINO toolkit"
         HOMEPAGE_URL "https://docs.openvino.ai/2025/index.html"


### PR DESCRIPTION
### Details:
Backporting https://github.com/openvinotoolkit/openvino/pull/29856 to releases/2025/1