### PR TITLE
[NPU] Add FP8 precision support in NPU plugin

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -693,6 +693,12 @@ void ZeroInferRequest::check_network_precision(const ov::element::Type_t precisi
         break;
     case ov::element::Type_t::bf16:
         break;
+    case ov::element::Type_t::f8e4m3:
+        break;
+    case ov::element::Type_t::f8e5m2:
+        break;
+    case ov::element::Type_t::f8e8m0:
+        break;
     case ov::element::Type_t::nf4:
         break;
     case ov::element::Type_t::u4:
@@ -720,7 +726,7 @@ void ZeroInferRequest::check_network_precision(const ov::element::Type_t precisi
     default:
         OPENVINO_THROW(
             "Unsupported tensor precision: " + ov::element::Type(precision).get_type_name() +
-            "! Supported precisions: FP32, FP16, BF16, NF4, U4, I4, U8, I8, U16, I16, U32, I32, U64, I64, FP64");
+            "! Supported precisions: FP32, FP16, BF16, FP8, NF4, U4, I4, U8, I8, U16, I16, U32, I32, U64, I64, FP64");
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -75,6 +75,12 @@ std::string ovPrecisionToLegacyPrecisionString(const ov::element::Type& precisio
         return "FP64";
     case ov::element::Type_t::bf16:
         return "BF16";
+    case ov::element::Type_t::f8e4m3:
+        return "FP8_E4M3";
+    case ov::element::Type_t::f8e5m2:
+        return "FP8_E5M2";
+    case ov::element::Type_t::f8e8m0:
+        return "FP8_E8M0";
     case ov::element::Type_t::nf4:
         return "NF4";
     case ov::element::Type_t::i4:

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -47,6 +47,12 @@ ov::element::Type_t toOVElementType(const ze_graph_argument_precision_t zeElemen
         return ov::element::Type_t::boolean;
     case ZE_GRAPH_ARGUMENT_PRECISION_NF4:
         return ov::element::Type_t::nf4;
+    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E4M3:
+        return ov::element::Type_t::f8e4m3;
+    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E5M2:
+        return ov::element::Type_t::f8e5m2;
+    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E8M0:
+        return ov::element::Type_t::f8e8m0;
     case ZE_GRAPH_ARGUMENT_PRECISION_BF16:
         return ov::element::Type_t::bf16;
     case ZE_GRAPH_ARGUMENT_PRECISION_FP16:

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -126,6 +126,12 @@ static inline ze_graph_argument_precision_t getZePrecision(const ov::element::Ty
         return ZE_GRAPH_ARGUMENT_PRECISION_UINT64;
     case ov::element::Type_t::nf4:
         return ZE_GRAPH_ARGUMENT_PRECISION_NF4;
+    case ov::element::Type_t::f8e4m3:
+        return ZE_GRAPH_ARGUMENT_PRECISION_FP8_E4M3;
+    case ov::element::Type_t::f8e5m2:
+        return ZE_GRAPH_ARGUMENT_PRECISION_FP8_E5M2;
+    case ov::element::Type_t::f8e8m0:
+        return ZE_GRAPH_ARGUMENT_PRECISION_FP8_E8M0;
     case ov::element::Type_t::bf16:
         return ZE_GRAPH_ARGUMENT_PRECISION_BF16;
     case ov::element::Type_t::f16:


### PR DESCRIPTION
### Details:
 - *Add FP8 precision support for NPU.*
 - *Update L0 extension which include FP8 graph arg precision.*
 - *Tests can't be enabled because FP8 is not fully supported in NPU compiler at this moment.*


### Tickets:
 - *E-163770*
