### PR TITLE
[GPU][Coverity] Avoid incrementing end() iterator in LayoutJitter

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
@@ -115,10 +115,7 @@ void LayoutJitter::make_definitions(const layout& l, size_t shape_info_offset) {
                 m_strides[i] = JitTerm{to_code_string(strides[channel_index])};
             } else if (format::is_simple_data_format(fmt)) {
                 auto channel_it = std::find(actual_channels_order.begin(), actual_channels_order.end(), target_channel);
-                if (channel_it == actual_channels_order.end()) {
-                    // Skip stride calculation if the target channel is not found in the actual channel order
-                    continue;
-                }
+                OPENVINO_ASSERT(channel_it != actual_channels_order.end());
 
                 m_strides[i] = JitTerm{"1"};
                 for (auto it = std::next(channel_it); it != actual_channels_order.end(); ++it) {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
@@ -115,11 +115,16 @@ void LayoutJitter::make_definitions(const layout& l, size_t shape_info_offset) {
                 m_strides[i] = JitTerm{to_code_string(strides[channel_index])};
             } else if (format::is_simple_data_format(fmt)) {
                 auto channel_it = std::find(actual_channels_order.begin(), actual_channels_order.end(), target_channel);
+                if (channel_it == actual_channels_order.end()) {
+                    // Skip stride calculation if the target channel is not found in the actual channel order
+                    continue;
+                }
+
                 m_strides[i] = JitTerm{"1"};
-                for (channel_it++; channel_it != actual_channels_order.end(); channel_it++) {
+                for (auto it = std::next(channel_it); it != actual_channels_order.end(); ++it) {
                     auto idx =
-                        std::distance(default_channels_order.begin(), std::find(default_channels_order.begin(), default_channels_order.end(), *channel_it));
-                    auto idx_ext = channels_map[*channel_it];
+                        std::distance(default_channels_order.begin(), std::find(default_channels_order.begin(), default_channels_order.end(), *it));
+                    auto idx_ext = channels_map[*it];
                     if (pad._lower_size.at(idx) > 0 || pad._upper_size.at(idx) > 0 || pad._dynamic_dims_mask[idx]) {
                         m_strides[i] = m_strides[i] * (m_dims[idx_ext] + m_pad_lower[idx_ext] + m_pad_upper[idx_ext]);
                     } else {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/jitter.cpp
@@ -122,8 +122,7 @@ void LayoutJitter::make_definitions(const layout& l, size_t shape_info_offset) {
 
                 m_strides[i] = JitTerm{"1"};
                 for (auto it = std::next(channel_it); it != actual_channels_order.end(); ++it) {
-                    auto idx =
-                        std::distance(default_channels_order.begin(), std::find(default_channels_order.begin(), default_channels_order.end(), *it));
+                    auto idx = std::distance(default_channels_order.begin(), std::find(default_channels_order.begin(), default_channels_order.end(), *it));
                     auto idx_ext = channels_map[*it];
                     if (pad._lower_size.at(idx) > 0 || pad._upper_size.at(idx) > 0 || pad._dynamic_dims_mask[idx]) {
                         m_strides[i] = m_strides[i] * (m_dims[idx_ext] + m_pad_lower[idx_ext] + m_pad_upper[idx_ext]);


### PR DESCRIPTION
Fix coverity issue with usage of invalid iterator

### Details:
 - Check for end() iterator before jumping to loop which increments the iterator

### Tickets:
 - 167165
