### PR TITLE
[intel-npu] Moving backend options registration up in the init sequence

### DIFF
--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -220,6 +220,8 @@ void Plugin::init_options() {
             REGISTER_OPTION(TURBO);
             REGISTER_OPTION(WORKLOAD_TYPE);
         }
+        // register backend options
+        _backend->registerOptions(*_options);
     }
 
     // parse again env_variables to update registered configs which have env vars set
@@ -227,10 +229,6 @@ void Plugin::init_options() {
 
     // filter out unsupported options
     filter_config_by_compiler_support(_globalConfig);
-
-    if (_backend) {
-        _backend->registerOptions(*_options);
-    }
 }
 
 void Plugin::filter_config_by_compiler_support(FilteredConfig& cfg) const {


### PR DESCRIPTION
### Details:
 - Moving backend options registration upper in the init sequence so it will properly catch env var parsing

### Tickets:
 - *ticket-id*
