### PR TITLE
[GPU] Allow setting primitive's dependencies using index

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/adaptive_pooling.hpp
@@ -79,14 +79,14 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
 
     adaptive_pooling_mode mode;
     tensor output_size;
-    primitive_id indices_output;
+    input_info indices_output;
     data_types index_element_type{data_types::i64};
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, mode);
         seed = hash_combine(seed, index_element_type);
-        seed = hash_combine(seed, indices_output.empty());
+        seed = hash_combine(seed, indices_output.is_valid());
         return seed;
     }
 
@@ -118,10 +118,13 @@ struct adaptive_pooling : public primitive_base<adaptive_pooling> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!indices_output.empty())
-            ret.push_back(indices_output);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (indices_output.is_valid())
+            ret[idx++] = &indices_output;
+
         return ret;
     }
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/condition.hpp
@@ -111,9 +111,6 @@ struct condition : public primitive_base<condition> {
         ib >> branch_true;
         ib >> branch_false;
     }
-
-protected:
-    std::vector<input_info> get_dependencies() const override { return {}; }
 };
 
 static inline std::ostream& operator<< (std::ostream& os, condition::branch& info) {

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -187,15 +187,15 @@ struct convolution : public primitive_base<convolution> {
     /// @param grouped_weights_shape Defines if weights tensor has explicit group dimension.
     bool grouped_weights_shape {false};
     /// @brief Primitive id containing weights data.
-    const primitive_id weights;
+    const input_info weights;
     /// @brief Primitive id containing bias data.
-    const primitive_id bias;
+    const input_info bias;
     /// @brief Primitive id containing weights zero points.
-    const primitive_id weights_zero_points;
+    const input_info weights_zero_points;
     /// @brief Primitive id containing activations zero points.
-    const primitive_id activations_zero_points;
+    const input_info activations_zero_points;
     /// @brief Primitive id containing compensation.
-    const primitive_id compensation;
+    const input_info compensation;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
@@ -210,11 +210,11 @@ struct convolution : public primitive_base<convolution> {
         seed = hash_combine(seed, bilinear_interpolation_pad);
         seed = hash_combine(seed, transposed);
         seed = hash_combine(seed, grouped_weights_shape);
-        seed = hash_combine(seed, !weights.empty());
-        seed = hash_combine(seed, !bias.empty());
-        seed = hash_combine(seed, !weights_zero_points.empty());
-        seed = hash_combine(seed, !activations_zero_points.empty());
-        seed = hash_combine(seed, !compensation.empty());
+        seed = hash_combine(seed, !weights.is_valid());
+        seed = hash_combine(seed, !bias.is_valid());
+        seed = hash_combine(seed, !weights_zero_points.is_valid());
+        seed = hash_combine(seed, !activations_zero_points.is_valid());
+        seed = hash_combine(seed, !compensation.is_valid());
         return seed;
     }
 
@@ -236,11 +236,11 @@ struct convolution : public primitive_base<convolution> {
                cmp_fields(bilinear_interpolation_pad) &&
                cmp_fields(transposed) &&
                cmp_fields(grouped_weights_shape) &&
-               cmp_fields(weights.empty()) &&
-               cmp_fields(bias.empty()) &&
-               cmp_fields(weights_zero_points.empty()) &&
-               cmp_fields(activations_zero_points.empty()) &&
-               cmp_fields(compensation.empty());
+               cmp_fields(weights.is_valid()) &&
+               cmp_fields(bias.is_valid()) &&
+               cmp_fields(weights_zero_points.is_valid()) &&
+               cmp_fields(activations_zero_points.is_valid()) &&
+               cmp_fields(compensation.is_valid());
         #undef cmp_fields
     }
 
@@ -277,27 +277,31 @@ struct convolution : public primitive_base<convolution> {
         ib >> bilinear_interpolation_pad;
         ib >> transposed;
         ib >> grouped_weights_shape;
-        ib >> *const_cast<primitive_id*>(&weights);
-        ib >> *const_cast<primitive_id*>(&bias);
-        ib >> *const_cast<primitive_id*>(&weights_zero_points);
-        ib >> *const_cast<primitive_id*>(&activations_zero_points);
-        ib >> *const_cast<primitive_id*>(&compensation);
+        ib >> *const_cast<input_info*>(&weights);
+        ib >> *const_cast<input_info*>(&bias);
+        ib >> *const_cast<input_info*>(&weights_zero_points);
+        ib >> *const_cast<input_info*>(&activations_zero_points);
+        ib >> *const_cast<input_info*>(&compensation);
     }
 
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret = {weights};
-        if (!bias.empty()) {
-            ret.push_back(bias);
-        }
-        if (!weights_zero_points.empty()) {
-            ret.push_back(weights_zero_points);
-        }
-        if (!activations_zero_points.empty()) {
-            ret.push_back(activations_zero_points);
-        }
-        if (!compensation.empty()) {
-            ret.push_back(compensation);
-        }
+protected:
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        ret[idx++] = &weights;
+
+        if (bias.is_valid())
+            ret[idx++] = &bias;
+
+        if (weights_zero_points.is_valid())
+            ret[idx++] = &weights_zero_points;
+
+        if (activations_zero_points.is_valid())
+            ret[idx++] = &activations_zero_points;
+
+        if (compensation.is_valid())
+            ret[idx++] = &compensation;
 
         return ret;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/convolution.hpp
@@ -187,15 +187,15 @@ struct convolution : public primitive_base<convolution> {
     /// @param grouped_weights_shape Defines if weights tensor has explicit group dimension.
     bool grouped_weights_shape {false};
     /// @brief Primitive id containing weights data.
-    const input_info weights;
+    input_info weights;
     /// @brief Primitive id containing bias data.
-    const input_info bias;
+    input_info bias;
     /// @brief Primitive id containing weights zero points.
-    const input_info weights_zero_points;
+    input_info weights_zero_points;
     /// @brief Primitive id containing activations zero points.
-    const input_info activations_zero_points;
+    input_info activations_zero_points;
     /// @brief Primitive id containing compensation.
-    const input_info compensation;
+    input_info compensation;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
@@ -277,11 +277,11 @@ struct convolution : public primitive_base<convolution> {
         ib >> bilinear_interpolation_pad;
         ib >> transposed;
         ib >> grouped_weights_shape;
-        ib >> *const_cast<input_info*>(&weights);
-        ib >> *const_cast<input_info*>(&bias);
-        ib >> *const_cast<input_info*>(&weights_zero_points);
-        ib >> *const_cast<input_info*>(&activations_zero_points);
-        ib >> *const_cast<input_info*>(&compensation);
+        ib >> weights;
+        ib >> bias;
+        ib >> weights_zero_points;
+        ib >> activations_zero_points;
+        ib >> compensation;
     }
 
 protected:
@@ -289,6 +289,7 @@ protected:
         auto ret = std::map<size_t, const input_info*>{};
         auto idx = input.size();
 
+        OPENVINO_ASSERT(weights.is_valid());
         ret[idx++] = &weights;
 
         if (bias.is_valid())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
@@ -31,8 +31,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param activation_slp Relu activation slope.
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
-                  const std::vector<primitive_id>& bias,
+                  const primitive_id& weights,
+                  const primitive_id& bias,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
                   ov::Strides dilations = {1, 1})
@@ -62,8 +62,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param activation_slp Relu activation slope.
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
-                  const std::vector<primitive_id>& bias,
+                  const primitive_id& weights,
+                  const primitive_id& bias,
                   uint32_t groups,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
@@ -93,7 +93,7 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param activation_slp Relu activation slope.
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
+                  const primitive_id& weights,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
                   ov::Strides dilations = {1, 1})
@@ -110,7 +110,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           output_partial_shape({}),
           output_shape_id(""),
           weights(weights),
-          bias(std::vector<primitive_id>(0)) {}
+          bias("") {}
 
     /// @brief Constructs deconvolution primitive (w/o bias).
     /// @param id This primitive id.
@@ -123,7 +123,7 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param activation_slp Relu activation slope.
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id> &weights,
+                  const primitive_id& weights,
                   uint32_t groups,
                   ov::Strides stride = {1, 1},
                   ov::CoordinateDiff pad = {0, 0},
@@ -141,7 +141,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           output_partial_shape({}),
           output_shape_id(""),
           weights(weights),
-          bias(std::vector<primitive_id>(0)) {}
+          bias("") {}
 
     /// @brief Constructs deconvolution primitive (computes input paddings to match output size).
     /// @param id This primitive id.
@@ -155,8 +155,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param output_size User-defined output data size of the primitive (w/o padding).
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
-                  const std::vector<primitive_id>& bias,
+                  const primitive_id& weights,
+                  const primitive_id& bias,
                   ov::Strides stride,
                   ov::CoordinateDiff pad,
                   ov::Strides dilations,
@@ -190,8 +190,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param output_size User-defined output data size of the primitive (w/o padding).
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
-                  const std::vector<primitive_id>& bias,
+                  const primitive_id& weights,
+                  const primitive_id& bias,
                   uint32_t groups,
                   ov::Strides stride,
                   ov::CoordinateDiff pad,
@@ -227,8 +227,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param output_size User-defined output data size of the primitive (w/o padding).
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
-                  const std::vector<primitive_id>& bias,
+                  const primitive_id& weights,
+                  const primitive_id& bias,
                   uint32_t groups,
                   ov::Strides stride,
                   ov::CoordinateDiff pad,
@@ -263,7 +263,7 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @param output_size User-defined output data size of the primitive (w/o padding).
     deconvolution(const primitive_id& id,
                   const input_info& input,
-                  const std::vector<primitive_id>& weights,
+                  const primitive_id& weights,
                   ov::Strides stride,
                   ov::CoordinateDiff pad,
                   ov::Strides dilations,
@@ -280,7 +280,7 @@ struct deconvolution : public primitive_base<deconvolution> {
           out_padding(pad.size(), 0),
           grouped_weights_shape(false),
           weights(weights),
-          bias(std::vector<primitive_id>(0)) {}
+          bias("") {}
 
     /// @brief Constructs deconvolution primitive (computes input paddings to match output size).
     /// @param id This primitive id.
@@ -295,8 +295,8 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @return Deconvolution primitive with specified settings.
     static deconvolution create_with_output_size(const primitive_id& id,
                                                  const input_info& input,
-                                                 const std::vector<primitive_id>& weights,
-                                                 const std::vector<primitive_id>& bias,
+                                                 const primitive_id& weights,
+                                                 const primitive_id& bias,
                                                  tensor output_size,
                                                  ov::Strides stride = {1, 1},
                                                  ov::CoordinateDiff pad = {0, 0},
@@ -323,7 +323,7 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @return Deconvolution primitive with specified settings.
     static deconvolution create_with_output_size(const primitive_id& id,
                                                  const input_info& input,
-                                                 const std::vector<primitive_id>& weights,
+                                                 const primitive_id& weights,
                                                  tensor output_size,
                                                  ov::Strides stride = {1, 1},
                                                  ov::CoordinateDiff pad = {0, 0},
@@ -360,11 +360,11 @@ struct deconvolution : public primitive_base<deconvolution> {
     /// @brief Defines spatial shape of the output.
     ov::PartialShape output_partial_shape;
     /// @brief Data primitive id containing spatial shape of the output.
-    primitive_id output_shape_id;
+    input_info output_shape_id;
     /// @brief List of primitive ids containing weights data.
-    const primitive_id_arr weights;
+    input_info weights;
     /// @brief List of primitive ids containing bias data.
-    const primitive_id_arr bias;
+    input_info bias;
 
     size_t hash() const override {
         size_t seed = primitive::hash();
@@ -372,9 +372,9 @@ struct deconvolution : public primitive_base<deconvolution> {
         seed = hash_range(seed, stride.begin(), stride.end());
         seed = hash_combine(seed, groups);
         seed = hash_combine(seed, grouped_weights_shape);
-        seed = hash_combine(seed, weights.size());
-        seed = hash_combine(seed, bias.size());
-        seed = hash_combine(seed, output_shape_id.empty());
+        seed = hash_combine(seed, weights.is_valid());
+        seed = hash_combine(seed, bias.is_valid());
+        seed = hash_combine(seed, output_shape_id.is_valid());
         return seed;
     }
 
@@ -393,9 +393,9 @@ struct deconvolution : public primitive_base<deconvolution> {
                cmp_fields(pads_end) &&
                cmp_fields(out_padding) &&
                cmp_fields(grouped_weights_shape) &&
-               cmp_fields(weights.size()) &&
-               cmp_fields(bias.size()) &&
-               cmp_fields(output_shape_id.empty());
+               cmp_fields(weights.is_valid()) &&
+               cmp_fields(bias.is_valid()) &&
+               cmp_fields(output_shape_id.is_valid());
         #undef cmp_fields
     }
 
@@ -431,17 +431,23 @@ struct deconvolution : public primitive_base<deconvolution> {
         ib >> grouped_weights_shape;
         ib >> output_partial_shape;
         ib >> output_shape_id;
-        ib >> *const_cast<primitive_id_arr*>(&weights);
-        ib >> *const_cast<primitive_id_arr*>(&bias);
+        ib >> weights;
+        ib >> bias;
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        ret.reserve(weights.size() + bias.size() + (output_shape_id.empty() ? 0 : 1));
-        for (auto& w : weights) ret.push_back(w);
-        for (auto& b : bias) ret.push_back(b);
-        if (!output_shape_id.empty()) ret.push_back(output_shape_id);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (weights.is_valid())
+            ret[idx++] = &weights;
+
+        if (bias.is_valid())
+            ret[idx++] = &bias;
+
+        if (output_shape_id.is_valid())
+            ret[idx++] = &output_shape_id;
 
         return ret;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/deconvolution.hpp
@@ -440,8 +440,8 @@ protected:
         auto ret = std::map<size_t, const input_info*>{};
         auto idx = input.size();
 
-        if (weights.is_valid())
-            ret[idx++] = &weights;
+        OPENVINO_ASSERT(weights.is_valid());
+        ret[idx++] = &weights;
 
         if (bias.is_valid())
             ret[idx++] = &bias;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_detection_output.hpp
@@ -86,8 +86,8 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
           max_delta_log_wh{max_delta_log_wh},
           deltas_weights{std::move(deltas_weights)} {}
 
-    primitive_id output_classes;
-    primitive_id output_scores;
+    input_info output_classes;
+    input_info output_scores;
     float score_threshold = 0.0f;
     float nms_threshold = 0.0f;
     int num_classes = 0;
@@ -107,8 +107,8 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
         seed = hash_combine(seed, class_agnostic_box_regression);
         seed = hash_combine(seed, max_delta_log_wh);
         seed = hash_range(seed, deltas_weights.begin(), deltas_weights.end());
-        seed = hash_combine(seed, output_classes.empty());
-        seed = hash_combine(seed, output_scores.empty());
+        seed = hash_combine(seed, output_classes.is_valid());
+        seed = hash_combine(seed, output_scores.is_valid());
         return seed;
     }
 
@@ -127,8 +127,8 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
                cmp_fields(class_agnostic_box_regression) &&
                cmp_fields(max_delta_log_wh) &&
                cmp_fields(deltas_weights) &&
-               cmp_fields(output_classes.empty()) &&
-               cmp_fields(output_scores.empty());
+               cmp_fields(output_classes.is_valid()) &&
+               cmp_fields(output_scores.is_valid());
         #undef cmp_fields
     }
 
@@ -161,13 +161,15 @@ struct experimental_detectron_detection_output : public primitive_base<experimen
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!output_classes.empty())
-            ret.emplace_back(output_classes);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
 
-        if (!output_scores.empty())
-            ret.emplace_back(output_scores);
+        if (output_classes.is_valid())
+            ret[idx++] = &output_classes;
+
+        if (output_scores.is_valid())
+            ret[idx++] = &output_scores;
 
         return ret;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/experimental_detectron_generate_proposals_single_image.hpp
@@ -59,7 +59,7 @@ struct experimental_detectron_generate_proposals_single_image
             pre_nms_count{pre_nms_count},
             post_nms_count{post_nms_count} {}
 
-    primitive_id output_roi_scores;
+    input_info output_roi_scores;
     float min_size = 0.0f;
     float nms_threshold = 0.0f;
     int64_t pre_nms_count = 0;
@@ -71,7 +71,7 @@ struct experimental_detectron_generate_proposals_single_image
         seed = hash_combine(seed, nms_threshold);
         seed = hash_combine(seed, pre_nms_count);
         seed = hash_combine(seed, post_nms_count);
-        seed = hash_combine(seed, output_roi_scores.empty());
+        seed = hash_combine(seed, output_roi_scores.is_valid());
         return seed;
     }
 
@@ -85,7 +85,7 @@ struct experimental_detectron_generate_proposals_single_image
                nms_threshold == rhs_casted.nms_threshold &&
                pre_nms_count == rhs_casted.pre_nms_count &&
                post_nms_count == rhs_casted.post_nms_count &&
-               output_roi_scores.empty() == rhs_casted.output_roi_scores.empty();
+               output_roi_scores.is_valid() == rhs_casted.output_roi_scores.is_valid();
     }
 
     void save(BinaryOutputBuffer& ob) const override {
@@ -107,10 +107,13 @@ struct experimental_detectron_generate_proposals_single_image
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!output_roi_scores.empty())
-            ret.push_back(output_roi_scores);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (output_roi_scores.is_valid())
+            ret[idx++] = &output_roi_scores;
+
         return ret;
     }
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -246,6 +246,7 @@ protected:
         auto ret = std::map<size_t, const input_info*>{};
         auto idx = input.size();
 
+        OPENVINO_ASSERT(weights.is_valid());
         ret[idx++] = &weights;
 
         if (bias.is_valid())

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/fully_connected.hpp
@@ -143,13 +143,13 @@ struct fully_connected : public primitive_base<fully_connected> {
     }
 
     /// @brief Primitive id containing weights data.
-    primitive_id weights;
+    input_info weights;
     /// @brief Primitive id containing bias data.
-    primitive_id bias;
+    input_info bias;
 
     bool compressed_weights = false;
-    primitive_id decompression_scale = "";
-    primitive_id decompression_zero_point = "";
+    input_info decompression_scale = {};
+    input_info decompression_zero_point = {};
     bool dynamic_quantized_activation = false;
     bool dynamic_quantized_activation_zp = false;
     input_info activation_scale = {"", 0};
@@ -165,10 +165,10 @@ struct fully_connected : public primitive_base<fully_connected> {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, input_size);
         seed = hash_combine(seed, weights_rank);
-        seed = hash_combine(seed, bias.empty());
+        seed = hash_combine(seed, bias.is_valid());
         seed = hash_combine(seed, compressed_weights);
-        seed = hash_combine(seed, !decompression_scale.empty());
-        seed = hash_combine(seed, !decompression_zero_point.empty());
+        seed = hash_combine(seed, !decompression_scale.is_valid());
+        seed = hash_combine(seed, !decompression_zero_point.is_valid());
         seed = hash_combine(seed, activation_scale.is_valid());
         seed = hash_combine(seed, activation_zero_point.is_valid());
         seed = hash_combine(seed, decompression_zero_point_scalar.has_value());
@@ -184,10 +184,10 @@ struct fully_connected : public primitive_base<fully_connected> {
 
         return input_size == rhs_casted.input_size &&
                weights_rank == rhs_casted.weights_rank &&
-               bias.empty() == rhs_casted.bias.empty() &&
+               bias.is_valid() == rhs_casted.bias.is_valid() &&
                compressed_weights == rhs_casted.compressed_weights &&
-               decompression_scale.empty() == rhs_casted.decompression_scale.empty() &&
-               decompression_zero_point.empty() == rhs_casted.decompression_zero_point.empty() &&
+               decompression_scale.is_valid() == rhs_casted.decompression_scale.is_valid() &&
+               decompression_zero_point.is_valid() == rhs_casted.decompression_zero_point.is_valid() &&
                activation_scale.is_valid() == rhs_casted.activation_scale.is_valid() &&
                activation_zero_point.is_valid() == rhs_casted.activation_zero_point.is_valid() &&
                decompression_zero_point_scalar.value_or(0.0f) == rhs_casted.decompression_zero_point_scalar.value_or(0.0f);
@@ -242,24 +242,26 @@ struct fully_connected : public primitive_base<fully_connected> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        ret.push_back(weights);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
 
-        if (!bias.empty())
-            ret.push_back(bias);
+        ret[idx++] = &weights;
 
-        if (!decompression_scale.empty())
-            ret.push_back(decompression_scale);
+        if (bias.is_valid())
+            ret[idx++] = &bias;
 
-        if (!decompression_zero_point.empty())
-            ret.push_back(decompression_zero_point);
+        if (decompression_scale.is_valid())
+            ret[idx++] = &decompression_scale;
+
+        if (decompression_zero_point.is_valid())
+            ret[idx++] = &decompression_zero_point;
 
         if (activation_scale.is_valid())
-            ret.push_back(activation_scale);
+            ret[idx++] = &activation_scale;
 
         if (activation_zero_point.is_valid())
-            ret.push_back(activation_zero_point);
+            ret[idx++] = &activation_zero_point;
 
         return ret;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gather.hpp
@@ -167,14 +167,15 @@ struct gather : public primitive_base<gather> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
 
         if (decompression_scale.is_valid())
-            ret.push_back(decompression_scale.pid);
+            ret[idx++] = &decompression_scale;
 
         if (decompression_zero_point.is_valid())
-            ret.push_back(decompression_zero_point.pid);
+            ret[idx++] = &decompression_zero_point;
 
         return ret;
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/gemm.hpp
@@ -231,10 +231,15 @@ struct gemm : public primitive_base<gemm> {
         ib >> beam_table.idx;
     }
 
-    std::vector<input_info> get_dependencies() const override {
+protected:
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
         if (beam_table.is_valid())
-            return { beam_table };
-        return {};
+            ret[idx++] = &beam_table;
+
+        return ret;
     }
 
 private:

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/generate_proposals.hpp
@@ -60,8 +60,8 @@ struct generate_proposals
 
     ov::op::v9::GenerateProposals::Attributes attrs;
 
-    primitive_id output_rois_scores;
-    primitive_id output_rois_num;
+    input_info output_rois_scores;
+    input_info output_rois_num;
     data_types roi_num_type = data_types::dynamic;
 
     size_t hash() const override {
@@ -73,8 +73,8 @@ struct generate_proposals
         seed = hash_combine(seed, attrs.normalized);
         seed = hash_combine(seed, attrs.nms_eta);
         seed = hash_combine(seed, roi_num_type);
-        seed = hash_combine(seed, output_rois_scores.empty());
-        seed = hash_combine(seed, output_rois_num.empty());
+        seed = hash_combine(seed, output_rois_scores.is_valid());
+        seed = hash_combine(seed, output_rois_num.is_valid());
         return seed;
     }
 
@@ -92,8 +92,8 @@ struct generate_proposals
                cmp_fields(attrs.normalized) &&
                cmp_fields(attrs.nms_eta) &&
                cmp_fields(roi_num_type) &&
-               cmp_fields(output_rois_scores.empty()) &&
-               cmp_fields(output_rois_num.empty());
+               cmp_fields(output_rois_scores.is_valid()) &&
+               cmp_fields(output_rois_num.is_valid());
         #undef cmp_fields
     }
 
@@ -124,12 +124,16 @@ struct generate_proposals
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!output_rois_scores.empty())
-            ret.push_back(output_rois_scores);
-        if (!output_rois_num.empty())
-            ret.push_back(output_rois_num);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (output_rois_scores.is_valid())
+            ret[idx++] = &output_rois_scores;
+
+        if (output_rois_num.is_valid())
+            ret[idx++] = &output_rois_num;
+
         return ret;
     }
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/loop.hpp
@@ -273,17 +273,19 @@ struct loop : public primitive_base<loop> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        // add external_id in dependencies if not exist
-        for (const auto& mapping : input_primitive_maps) {
-            auto target = std::find_if(input.begin(), input.end(),
-                                    [&](const input_info& info) {
-                                        return info.pid == mapping.external_id.pid;});
-            if (target == input.end()) {
-                ret.push_back(mapping.external_id.pid);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        for (auto& mapping : input_primitive_maps) {
+            auto found = std::any_of(input.begin(), input.end(), [&](const input_info& info) {
+                return info.pid == mapping.external_id.pid;
+            });
+            if (!found) {
+                ret[idx++] = &mapping.external_id;
             }
         }
+
         return ret;
     }
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/multiclass_nms.hpp
@@ -37,8 +37,8 @@ struct multiclass_nms : public primitive_base<multiclass_nms> {
         }
     }
 
-    primitive_id output_selected_indices{};
-    primitive_id output_selected_num{};
+    input_info output_selected_indices{};
+    input_info output_selected_num{};
     ov::op::util::MulticlassNmsBase::Attributes attrs;
     bool has_roisnum{false};
 
@@ -102,12 +102,16 @@ struct multiclass_nms : public primitive_base<multiclass_nms> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!output_selected_indices.empty())
-            ret.emplace_back(output_selected_indices);
-        if (!output_selected_num.empty())
-            ret.emplace_back(output_selected_num);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (output_selected_indices.is_valid())
+            ret[idx++] = &output_selected_indices;
+
+        if (output_selected_num.is_valid())
+            ret[idx++] = &output_selected_num;
+
         return ret;
     }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/non_max_suppression.hpp
@@ -68,24 +68,24 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
     int selected_indices_num;
     bool center_point_box;
     bool sort_result_descending;
-    primitive_id num_select_per_class;
-    primitive_id iou_threshold;
-    primitive_id score_threshold;
-    primitive_id soft_nms_sigma;
-    primitive_id second_output;
-    primitive_id third_output;
+    input_info num_select_per_class;
+    input_info iou_threshold;
+    input_info score_threshold;
+    input_info soft_nms_sigma;
+    input_info second_output;
+    input_info third_output;
     Rotation rotation{Rotation::NONE};
 
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, center_point_box);
         seed = hash_combine(seed, sort_result_descending);
-        seed = hash_combine(seed, num_select_per_class.empty());
-        seed = hash_combine(seed, iou_threshold.empty());
-        seed = hash_combine(seed, score_threshold.empty());
-        seed = hash_combine(seed, soft_nms_sigma.empty());
-        seed = hash_combine(seed, second_output.empty());
-        seed = hash_combine(seed, third_output.empty());
+        seed = hash_combine(seed, num_select_per_class.is_valid());
+        seed = hash_combine(seed, iou_threshold.is_valid());
+        seed = hash_combine(seed, score_threshold.is_valid());
+        seed = hash_combine(seed, soft_nms_sigma.is_valid());
+        seed = hash_combine(seed, second_output.is_valid());
+        seed = hash_combine(seed, third_output.is_valid());
         seed = hash_combine(seed, rotation);
         return seed;
     }
@@ -100,32 +100,14 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
         return cmp_fields(selected_indices_num) &&
                cmp_fields(center_point_box) &&
                cmp_fields(sort_result_descending) &&
-               cmp_fields(num_select_per_class.empty()) &&
-               cmp_fields(iou_threshold.empty()) &&
-               cmp_fields(score_threshold.empty()) &&
-               cmp_fields(soft_nms_sigma.empty()) &&
-               cmp_fields(second_output.empty()) &&
-               cmp_fields(third_output.empty()) &&
+               cmp_fields(num_select_per_class.is_valid()) &&
+               cmp_fields(iou_threshold.is_valid()) &&
+               cmp_fields(score_threshold.is_valid()) &&
+               cmp_fields(soft_nms_sigma.is_valid()) &&
+               cmp_fields(second_output.is_valid()) &&
+               cmp_fields(third_output.is_valid()) &&
                cmp_fields(rotation);
         #undef cmp_fields
-    }
-
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!num_select_per_class.empty())
-            ret.push_back(num_select_per_class);
-        if (!iou_threshold.empty())
-            ret.push_back(iou_threshold);
-        if (!score_threshold.empty())
-            ret.push_back(score_threshold);
-        if (!soft_nms_sigma.empty())
-            ret.push_back(soft_nms_sigma);
-        if (!second_output.empty())
-            ret.push_back(second_output);
-        if (!third_output.empty())
-            ret.push_back(third_output);
-
-        return ret;
     }
 
     void save(BinaryOutputBuffer& ob) const override {
@@ -154,6 +136,32 @@ struct non_max_suppression : public primitive_base<non_max_suppression> {
         ib >> second_output;
         ib >> third_output;
         ib >> make_data(&rotation, sizeof(rotation));
+    }
+
+protected:
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (num_select_per_class.is_valid())
+            ret[idx++] = &num_select_per_class;
+
+        if (iou_threshold.is_valid())
+            ret[idx++] = &iou_threshold;
+
+        if (score_threshold.is_valid())
+            ret[idx++] = &score_threshold;
+
+        if (soft_nms_sigma.is_valid())
+            ret[idx++] = &soft_nms_sigma;
+
+        if (second_output.is_valid())
+            ret[idx++] = &second_output;
+
+        if (third_output.is_valid())
+            ret[idx++] = &third_output;
+
+        return ret;
     }
 };
 

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/normalize.hpp
@@ -50,7 +50,7 @@ struct normalize : public primitive_base<normalize> {
     /// @brief Scale input primitive id with values needed for scaling after the normalization.
     /// Scale x dimension should be 1 (if all channels have the same scale) or equal to input feature size (one scale per channel).
     /// All other dimensions should be 1.
-    primitive_id scale_input;
+    input_info scale_input;
     /// @brief Determines if the normalization is done across or within spatial (see documentation above).
     bool across_spatial = true;
     /// @brief Epsilon for not dividing by zero while normalizing.
@@ -88,6 +88,13 @@ struct normalize : public primitive_base<normalize> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override { return {scale_input}; }
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        ret[idx++] = &scale_input;
+
+        return ret;
+    }
 };
 }  // namespace cldnn

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/pooling.hpp
@@ -131,7 +131,7 @@ struct pooling : public primitive_base<pooling> {
               maxPoolOpset8Features(true) {}
 
     /// @brief Primitive id which contains indices output.
-    primitive_id indices_output;
+    input_info indices_output;
     /// @brief Pooling mode.
     pooling_mode mode = pooling_mode::max;
     /// @brief Pooling kernel size.
@@ -171,7 +171,7 @@ struct pooling : public primitive_base<pooling> {
         seed = hash_combine(seed, axis);
         seed = hash_combine(seed, index_element_type);
         seed = hash_combine(seed, maxPoolOpset8Features);
-        seed = hash_combine(seed, indices_output.empty());
+        seed = hash_combine(seed, indices_output.is_valid());
         return seed;
     }
 
@@ -193,7 +193,7 @@ struct pooling : public primitive_base<pooling> {
                cmp_fields(axis) &&
                cmp_fields(index_element_type) &&
                cmp_fields(maxPoolOpset8Features) &&
-               cmp_fields(indices_output.empty());
+               cmp_fields(indices_output.is_valid());
         #undef cmp_fields
     }
 
@@ -234,10 +234,13 @@ struct pooling : public primitive_base<pooling> {
     }
 
 protected:
-    std::vector<input_info> get_dependencies() const override {
-        std::vector<input_info> ret;
-        if (!indices_output.empty())
-            ret.push_back(indices_output);
+    std::map<size_t, const input_info*> get_dependencies_map() const override {
+        auto ret = std::map<size_t, const input_info*>{};
+        auto idx = input.size();
+
+        if (indices_output.is_valid())
+            ret[idx++] = &indices_output;
+
         return ret;
     }
 };

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/primitive.hpp
@@ -300,6 +300,7 @@ public:
         }
     }
 
+    /// @brief Returns mutable reference to input dependency at given index.
     input_info& get_dependency(size_t idx) {
         if (idx < input.size())
             return input[idx];
@@ -321,6 +322,7 @@ public:
         return *const_cast<input_info*>(dependencies_map[idx]);
     }
 
+    /// @brief Returns const reference to input dependency at given index.
     const input_info& get_dependency(size_t idx) const {
         if (idx < input.size())
             return input[idx];
@@ -339,6 +341,7 @@ public:
     }
 
 protected:
+    /// @brief This method returns additional dependencies those are not maintained from primitive::input.
     virtual std::map<size_t, const input_info*> get_dependencies_map() const { return {}; }
     class condition;
     friend struct primitive_info;

--- a/src/plugins/intel_gpu/src/graph/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/convolution.cpp
@@ -166,8 +166,8 @@ std::string convolution_inst::to_string(convolution_node const& node) {
 
     std::stringstream primitive_description;
 
-    std::string w_zp = desc->weights_zero_points.empty() ? "false" : "true";
-    std::string a_zp = desc->activations_zero_points.empty() ? "false" : "true";
+    std::string w_zp = desc->weights_zero_points.is_valid() ? "true" : "false";
+    std::string a_zp = desc->activations_zero_points.is_valid() ? "true" : "false";
 
     json_composite conv_info;
     conv_info.add("stride", cldnn::to_string(strd));

--- a/src/plugins/intel_gpu/src/graph/deconvolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/deconvolution.cpp
@@ -207,7 +207,7 @@ std::vector<layout> deconvolution_inst::calc_output_layouts(deconvolution_node c
             op.set_output_shape(output_partial_shape.to_shape());
             input_shapes.push_back(ov::Shape{output_partial_shape.size()});
             output_shapes = ov::op::v1::shape_infer(&op, input_shapes, pads_begin, pads_end);
-        } else if ((desc->output_shape_id != "" || desc->output_partial_shape.size() > 0) && memory_deps.count(2)) {
+        } else if ((desc->output_shape_id.is_valid() || desc->output_partial_shape.size() > 0) && memory_deps.count(2)) {
             auto mem = memory_deps.at(2);
             auto dims = read_vector<int64_t>(mem, impl_param.get_stream());
             auto dims_shape = ov::Shape{dims.size()};
@@ -292,7 +292,7 @@ deconvolution_inst::typed_primitive_inst(network& network, deconvolution_node co
 
     auto filter_inst = node.weights().get_output_layout().convert_to_weights_layout(argument->grouped_weights_shape);
 
-    if (argument->bias.size() != 0) {
+    if (argument->bias.is_valid()) {
         auto bias_inst = node.bias().get_output_layout();
         CLDNN_ERROR_NOT_EQUAL(node.id(),
                                 "Bias batch[0]",

--- a/src/plugins/intel_gpu/src/graph/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/fully_connected.cpp
@@ -330,7 +330,7 @@ template std::vector<layout> fully_connected_inst::calc_output_layouts<ov::Parti
 std::string fully_connected_inst::to_string(fully_connected_node const& node) {
     auto desc = node.get_primitive();
     auto node_info = node.desc_to_json();
-    auto bias_id = desc->bias != "" ? desc->bias : "no bias";
+    auto bias_id = desc->bias.is_valid() ? desc->bias.pid : "no bias";
     auto weights_id = desc->weights;
 
     std::stringstream primitive_description;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/pre_replace_deconv.cpp
@@ -75,15 +75,12 @@ void pre_replace_deconv::run(program& p) {
                 // remove deconvolution node and its connections to weights and biases, rename it and move to the optimized list
                 p.remove_connection(input_node, deconv_node);
                 std::vector<std::shared_ptr<program_node>> weight_connections;
-                for (auto& weights_id : weights_nodes_id) {
-                    auto weights_iter = p.nodes_map.find(weights_id);
-                    if (weights_iter == p.nodes_map.end())
-                        continue;
+                auto weights_iter = p.nodes_map.find(weights_nodes_id.pid);
+                OPENVINO_ASSERT(weights_iter != p.nodes_map.end());
 
-                    auto weights_node_ptr = weights_iter->second;
-                    weight_connections.push_back(weights_node_ptr);
-                    p.remove_connection(*weights_node_ptr, deconv_node);
-                }
+                auto weights_node_ptr = weights_iter->second;
+                weight_connections.push_back(weights_node_ptr);
+                p.remove_connection(*weights_node_ptr, deconv_node);
 
                 ov::CoordinateDiff pad_begin(spatial_rank, 0);
                 ov::CoordinateDiff pad_end(spatial_rank, 0);
@@ -98,8 +95,8 @@ void pre_replace_deconv::run(program& p) {
                 }
 
                 std::vector<std::shared_ptr<program_node>> bias_connections;
-                for (auto& bias_id : biases_nodes_id) {
-                    auto bias_iter = p.nodes_map.find(bias_id);
+                if (biases_nodes_id.is_valid()) {
+                    auto bias_iter = p.nodes_map.find(biases_nodes_id.pid);
                     if (bias_iter == p.nodes_map.end())
                         continue;
 
@@ -119,8 +116,8 @@ void pre_replace_deconv::run(program& p) {
                 // create convolution primitive
                 auto conv_prim = std::make_shared<convolution>(deconv_node_id,
                                                                input_node_id,
-                                                               weights_nodes_id[0],
-                                                               biases_nodes_id.empty() ? "" : biases_nodes_id[0],
+                                                               weights_nodes_id.pid,
+                                                               biases_nodes_id.is_valid() ? biases_nodes_id.pid : "",
                                                                groups,
                                                                stride,
                                                                dilation,
@@ -169,17 +166,16 @@ void pre_replace_deconv::run(program& p) {
                deconv_prim->stride[deconv_prim->stride.size() - 1] == 2 && deconv_prim->stride[deconv_prim->stride.size() - 2] == 2 &&
                filter_layout.spatial(0) == 9 && filter_layout.spatial(1) == 9 &&
                deconv_prim->pad[deconv_prim->pad.size() - 1] == 4 && deconv_prim->pad[deconv_prim->pad.size() - 2]  == 4 &&
-               weights_nodes_id.size() == 1 && biases_nodes_id.size() == 1 &&
                input_node.get_output_layout().format == format::bfyx) {
                 const auto scale_factor = deconv_prim->stride[deconv_prim->stride.size() - 1];
                 auto spatial_rank = deconv_node.get_output_layout().get_spatial_rank();
 
-                const auto& weight_node_id = weights_nodes_id.front();
+                const auto& weight_node_id = weights_nodes_id.pid;
                 auto weights_node_ptr = p.nodes_map.find(weight_node_id)->second;
                 const auto& weights_layout = weights_node_ptr->get_output_layout();
                 const auto& weights_data_type = weights_layout.data_type;
 
-                const auto& bias_node_id = biases_nodes_id.front();
+                const auto& bias_node_id = biases_nodes_id.pid;
                 auto bias_id_node_ptr = p.nodes_map.find(bias_node_id)->second;
                 const auto bias_data_type = bias_id_node_ptr->get_output_layout().data_type;
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -394,11 +394,11 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
 
             auto conv_with_bias_prim = std::make_shared<convolution>(desc->id + "_tmp",
                                                                      desc->input[0],
-                                                                     desc->weights,
+                                                                     desc->weights.pid,
                                                                      biases,
-                                                                     desc->weights_zero_points,
-                                                                     desc->activations_zero_points,
-                                                                     desc->compensation,
+                                                                     desc->weights_zero_points.pid,
+                                                                     desc->activations_zero_points.pid,
+                                                                     desc->compensation.pid,
                                                                      desc->groups,
                                                                      desc->stride,
                                                                      desc->dilation,
@@ -416,7 +416,6 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
         } else if (replace_candidate.is_type<deconvolution>()) {
             auto& deconv = replace_candidate.as<deconvolution>();
             auto desc = deconv.get_primitive();
-            std::vector<primitive_id> biases = {bias_name};
 
             // If the primitive has biases, then we try to combine the values, or do nothing and keep as fused sum.
             if (deconv.bias_term()) {
@@ -433,8 +432,8 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
 
             auto deconv_with_bias_prim = std::make_shared<deconvolution>(desc->id + "_tmp",
                                                                          desc->input[0],
-                                                                         desc->weights,
-                                                                         biases,
+                                                                         desc->weights.pid,
+                                                                         bias_name,
                                                                          desc->groups,
                                                                          desc->stride,
                                                                          desc->pad,
@@ -733,7 +732,7 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 if (input.is_type<reshape>() || input.is_type<concatenation>())
                     return;
                 auto additional_params_input = activation_node.get_primitive()->additional_params_input;
-                if (activation_func == cldnn::activation_func::relu_negative_slope && !additional_params_input.empty() &&
+                if (activation_func == cldnn::activation_func::relu_negative_slope && additional_params_input.is_valid() &&
                     (input.is_type<fully_connected>() || input.is_type<gemm>())) {
                     // prelu fusion is not implemented in oneDNN3.1 (CVS-108233)
                     return;
@@ -1286,7 +1285,7 @@ void prepare_primitive_fusing::fuse_constant_transposes(program& p) {
                 if (desc->compressed_weights) {
                     size_t scale_idx = weights_offset + (fc.bias_term() ? 2 : 1);
                     valid_weights_indices.push_back(scale_idx);
-                    if (!desc->decompression_zero_point.empty()) {
+                    if (desc->decompression_zero_point.is_valid()) {
                         valid_weights_indices.push_back(scale_idx + 1);
                     }
                 }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -528,7 +528,7 @@ static void optimize_weights_decompression_parameters(fully_connected_node& fc_n
         reorder_bfyx_to_fbyx(decompression_scale_idx);
     }
 
-    if (!fc_prim->decompression_zero_point.empty()) {
+    if (fc_prim->decompression_zero_point.is_valid()) {
         auto decompression_zp_idx = decompression_scale_idx + 1;
         if (need_reorder(decompression_zp_idx)) {
             reorder_bfyx_to_fbyx(decompression_zp_idx);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/reorder_inputs.cpp
@@ -808,7 +808,7 @@ void reorder_inputs::run(program& p, reorder_factory& rf) {
 
                 auto activation_desc = fused_desc.typed_desc<activation>();
                 if (activation_desc->activation_function == cldnn::activation_func::relu_negative_slope &&
-                    !activation_desc->additional_params_input.empty()) {
+                    activation_desc->additional_params_input.is_valid()) {
                     const auto expected_dt = data_types::f32;
                     const auto dep_idx = fused_desc.outer_dep_start_idx;
                     const auto orig_layout = node->get_dependency(dep_idx).get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/activation.cpp
@@ -56,7 +56,7 @@ struct activation_impl : typed_primitive_impl_ocl<activation> {
 
         convert_new_activation_func(*primitive, params.activations);
 
-        bool is_parameterized = !primitive->additional_params_input.empty();
+        bool is_parameterized = primitive->additional_params_input.is_valid();
         if (is_parameterized) {
             const auto& slope_layout = impl_param.input_layouts[1];
             const auto& output_layout = impl_param.get_output_layout();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/convolution.cpp
@@ -146,16 +146,16 @@ public:
         if ((impl_param.input_layouts[0].data_type == data_types::u8 ||
              impl_param.input_layouts[0].data_type == data_types::i8 ||
              (impl_param.input_layouts[0].data_type == data_types::f32 &&
-              (!primitive->weights_zero_points.empty() ||
-               !primitive->activations_zero_points.empty() ||
-               !primitive->compensation.empty())))
+              (primitive->weights_zero_points.is_valid() ||
+               primitive->activations_zero_points.is_valid() ||
+               primitive->compensation.is_valid())))
             && (impl_param.input_layouts[1].data_type == data_types::i8 ||
                 impl_param.input_layouts[1].data_type == data_types::u8)) {
-            if (!primitive->weights_zero_points.empty() && !primitive->activations_zero_points.empty()) {
+            if (primitive->weights_zero_points.is_valid() && primitive->activations_zero_points.is_valid()) {
                 conv_params.quantization = kernel_selector::QuantizationType::ASYMMETRIC_DATA_AND_WEIGHTS;
-            } else if (!primitive->weights_zero_points.empty()) {
+            } else if (primitive->weights_zero_points.is_valid()) {
                 conv_params.quantization = kernel_selector::QuantizationType::ASYMMETRIC_WEIGHTS;
-            } else if (!primitive->activations_zero_points.empty()) {
+            } else if (primitive->activations_zero_points.is_valid()) {
                 conv_params.quantization = kernel_selector::QuantizationType::ASYMMETRIC_DATA;
             } else {
                 conv_params.quantization = kernel_selector::QuantizationType::SYMMETRIC;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/fully_connected.cpp
@@ -67,10 +67,10 @@ protected:
 
         args.inputs = { instance.input_memory_ptr(0) };
         size_t in_id = instance.bias_term() ? 3 : 2;
-        if (!desc->decompression_scale.empty())
+        if (desc->decompression_scale.is_valid())
             args.inputs.push_back(instance.dep_memory_ptr(in_id++));
 
-        if (!desc->decompression_zero_point.empty())
+        if (desc->decompression_zero_point.is_valid())
             args.inputs.push_back(instance.dep_memory_ptr(in_id));
 
         return args;
@@ -115,10 +115,10 @@ public:
 
             std::vector<layout> layouts{input0_layout, input1_layout};
 
-            bool has_zp = !primitive->decompression_zero_point.empty();
-            bool has_scale = !primitive->decompression_scale.empty();
+            bool has_zp = primitive->decompression_zero_point.is_valid();
+            bool has_scale = primitive->decompression_scale.is_valid();
 
-            size_t offset = primitive->bias.empty() ? 2 : 3;
+            size_t offset = primitive->bias.is_valid() ? 3 : 2;
             if (has_scale) {
                 auto scale_layout = input_layouts[offset++];
                 layouts.push_back(scale_layout);
@@ -175,8 +175,8 @@ public:
         auto params = get_weights_bias_default_params<kernel_selector::fully_connected_params>(updated_impl_param, false, is_shape_agnostic);
         params.allowInputReordering = true;
 
-        bool commpressed = !primitive->decompression_scale.empty();
-        bool with_zp = !primitive->decompression_zero_point.empty();
+        bool commpressed = primitive->decompression_scale.is_valid();
+        bool with_zp = primitive->decompression_zero_point.is_valid();
         if (commpressed) {
             params.compressed = true;
             params.decompression_scale = convert_data_tensor(updated_impl_param.input_layouts[2]);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/reorder.cpp
@@ -57,7 +57,7 @@ public:
         auto params = get_default_params<kernel_selector::reorder_params>(impl_param, is_shape_agnostic);
 
         auto inputs_count = primitive->input.size();
-        bool has_mean = !primitive->mean.empty();
+        bool has_mean = primitive->mean.is_valid();
         for (size_t i = 1; i < inputs_count; i++) {
             params.inputs.push_back(convert_data_tensor(impl_param.get_input_layout(i)));
         }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -82,7 +82,7 @@ static std::shared_ptr<dnnl::convolution_forward::primitive_desc> get_convolutio
         pad_r.insert(pad_r.end(), insert_count, 0);
     }
 
-    if (!prim->bias.empty()) {
+    if (prim->bias.is_valid()) {
         auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, true);
         return std::make_shared<dnnl::convolution_forward::primitive_desc>(
             engine.get_onednn_engine(),
@@ -273,7 +273,7 @@ public:
 
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ob.getKernelImplParams());
         auto prim = impl_params->typed_desc<convolution>();
-        bool has_wzp = !prim->weights_zero_points.empty();
+        bool has_wzp = prim->weights_zero_points.is_valid();
         if (has_wzp) {
             ob << make_data(&_wzp_data_type, sizeof(dnnl::memory::data_type));
         }
@@ -312,7 +312,7 @@ public:
         ib >> zero_bias;
 
         auto prim = impl_params->typed_desc<convolution>();
-        bool has_wzp = !prim->weights_zero_points.empty();
+        bool has_wzp = prim->weights_zero_points.is_valid();
         if (has_wzp) {
             ib >> make_data(&_wzp_data_type, sizeof(dnnl::memory::data_type));
             _attrs->set_zero_points(DNNL_ARG_WEIGHTS, 0, dnnl::memory::dims{}, _wzp_data_type);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -54,7 +54,7 @@ static std::shared_ptr<dnnl::deconvolution_forward::primitive_desc> get_deconvol
         pad_r.insert(pad_r.end(), insert_count, 0);
     }
 
-    if (!prim->bias.empty()) {
+    if (prim->bias.is_valid()) {
         auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, true);
         return std::make_shared<dnnl::deconvolution_forward::primitive_desc>(
             engine.get_onednn_engine(),

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -63,16 +63,16 @@ protected:
             const auto weights_dt = instance.get_input_layout(1).data_type;
             auto weight_bitwidth = ov::element::Type(weights_dt).bitwidth();
             OPENVINO_ASSERT(weight_bitwidth == 8 || weight_bitwidth == 4, "[GPU] oneDNN supports only 4bit/8bit compressed weights");
-            int idx = prim->bias.empty() ? 2 : 3;
+            int idx = prim->bias.is_valid() ? 3 : 2;
 
-            if (!prim->decompression_scale.empty()) {
+            if (prim->decompression_scale.is_valid()) {
                 auto decompression_scale_idx = idx++;
                 auto scale_mem = instance.dep_memory_ptr(decompression_scale_idx);
                 dnnl::memory::desc desc = onednn::layout_to_memory_desc(scale_mem->get_layout(), dnnl::memory::format_tag::a, true);
                 args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, scale_mem->get_onednn_memory(desc)});
             }
 
-            if (!prim->decompression_zero_point.empty()) {
+            if (prim->decompression_zero_point.is_valid()) {
                 auto decompression_zp_idx = idx++;
                 auto zp_mem = instance.dep_memory_ptr(decompression_zp_idx);
                 dnnl::memory::desc desc = onednn::layout_to_memory_desc(zp_mem->get_layout(), dnnl::memory::format_tag::a, true);
@@ -240,7 +240,7 @@ public:
         auto prim = impl_params->typed_desc<fully_connected>();
         size_t input_size = prim->input_size;
         size_t weights_rank = prim->weights_rank;
-        bool has_bias = !prim->bias.empty();
+        bool has_bias = prim->bias.is_valid();
         bool is_compressed = prim->compressed_weights;
         ob << input_size;
         ob << weights_rank;
@@ -249,13 +249,13 @@ public:
         ob << prim->dynamic_quantized_activation;
         ob << prim->dynamic_quantized_activation_zp;
 
-        bool has_decompression_scale = !prim->decompression_scale.empty();
+        bool has_decompression_scale = prim->decompression_scale.is_valid();
         if (has_decompression_scale) {
             ob << _ds_group_size;
             ob << make_data(&_ds_data_type, sizeof(dnnl::memory::data_type));
         }
 
-        bool has_decompression_zp = !prim->decompression_zero_point.empty() || prim->decompression_zero_point_scalar.has_value();
+        bool has_decompression_zp = prim->decompression_zero_point.is_valid() || prim->decompression_zero_point_scalar.has_value();
         if (has_decompression_zp) {
             ob << make_data(&_dzp_data_type, sizeof(dnnl::memory::data_type));
         }
@@ -291,7 +291,7 @@ public:
         int per_oc = PER_OC << shift_size;
         int grouped = GROUPED << shift_size;
 
-        bool has_decompression_scale = !prim->decompression_scale.empty();
+        bool has_decompression_scale = prim->decompression_scale.is_valid();
         if (has_decompression_scale) {
             ib >> _ds_group_size;
             ib >> make_data(&_ds_data_type, sizeof(dnnl::memory::data_type));
@@ -301,7 +301,7 @@ public:
                 _attrs->set_scales(DNNL_ARG_WEIGHTS, grouped, {_ds_group_size, 1}, _ds_data_type);
         }
 
-        bool has_decompression_zp = !prim->decompression_zero_point.empty() || prim->decompression_zero_point_scalar.has_value();
+        bool has_decompression_zp = prim->decompression_zero_point.is_valid() || prim->decompression_zero_point_scalar.has_value();
         auto& arg = impl_params->get_program().get_node(impl_params->desc->id).as<fully_connected>();
         int idx = !arg.bias_term() ? 2 : 3;
 
@@ -374,7 +374,7 @@ public:
             int per_oc = PER_OC << shift_size;
             int grouped = GROUPED << shift_size;
 
-            if (!prim->decompression_scale.empty()) {
+            if (prim->decompression_scale.is_valid()) {
                 auto decompression_scale_idx = ++idx;
                 auto scale_layout = arg.get_dependency(decompression_scale_idx).get_output_layout();
                 ds_data_type = convert_data_type(scale_layout.data_type);
@@ -392,7 +392,7 @@ public:
                 }
             }
 
-            if (!prim->decompression_zero_point.empty()) {
+            if (prim->decompression_zero_point.is_valid()) {
                 auto decompression_zp_idx = ++idx;
                 auto dzp_layout = arg.get_dependency(decompression_zp_idx).get_output_layout();
                 dzp_data_type = convert_data_type(dzp_layout.data_type);
@@ -426,7 +426,7 @@ public:
 
 
             auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
-                                                             prim->input_size, prim->weights_rank, !prim->bias.empty(), *attr);
+                                                             prim->input_size, prim->weights_rank, prim->bias.is_valid(), *attr);
 
             auto prim_onednn = std::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
             prim_onednn->_ds_group_size = group_size;
@@ -435,7 +435,7 @@ public:
             return prim_onednn;
         } else {
             auto prim_desc = get_matmul_primitive_descriptor(impl_params, impl_params.prog->get_engine(),
-                                                             prim->input_size, prim->weights_rank, !prim->bias.empty(), *attr);
+                                                             prim->input_size, prim->weights_rank, prim->bias.is_valid(), *attr);
 
             return std::make_unique<fully_connected_onednn>(engine, config, attr, *prim_desc);
         }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.hpp
@@ -64,8 +64,8 @@ struct FullyConnectedImplementationManager : public ImplementationManager {
             LOG_AND_RETURN_FALSE(node);
 
         if (fc_prim->compressed_weights) {
-            if (!fc_prim->decompression_zero_point.empty()) {
-                auto decompression_zp_idx = fc_prim->bias.empty() ? 3 : 4;
+            if (fc_prim->decompression_zero_point.is_valid()) {
+                auto decompression_zp_idx = fc_prim->bias.is_valid() ? 4 : 3;
                 auto decompression_zp_dt = fc_node.get_input_layout(decompression_zp_idx).data_type;
                 if ((wei_dt != ov::element::Type_t::u4 && wei_dt != ov::element::Type_t::u8) ||
                     (decompression_zp_dt != ov::element::Type_t::u8 && decompression_zp_dt != ov::element::Type_t::i8)) {

--- a/src/plugins/intel_gpu/src/graph/impls/sycl/impl_example.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/sycl/impl_example.cpp
@@ -155,10 +155,10 @@ struct fully_connected_sycl_example : typed_primitive_sycl_impl<fully_connected>
 
         std::vector<memory::ptr> inputs = { instance.input_memory_ptr(0) };
         size_t in_id = instance.bias_term() ? 3 : 2;
-        if (!desc->decompression_scale.empty())
+        if (desc->decompression_scale.is_valid())
             inputs.push_back(instance.dep_memory_ptr(in_id++));
 
-        if (!desc->decompression_zero_point.empty())
+        if (desc->decompression_zero_point.is_valid())
             inputs.push_back(instance.dep_memory_ptr(in_id));
 
         OPENVINO_ASSERT(!instance.bias_term() && !instance.get_node().has_fused_primitives());

--- a/src/plugins/intel_gpu/src/graph/include/activation_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/activation_inst.h
@@ -34,7 +34,7 @@ public:
 
     std::vector<size_t> get_shape_infer_dependencies() const override { return {}; }
 
-    bool is_parameterized() const { return !typed_desc()->additional_params_input.empty(); }
+    bool is_parameterized() const { return typed_desc()->additional_params_input.is_valid(); }
 
     std::shared_ptr<NodeFuseParams> get_fuse_params() const override {
         return std::make_shared<ActivationFuseParams>(typed_desc());
@@ -61,7 +61,7 @@ public:
 
     memory::ptr slope_memory() const { return dep_memory_ptr(1); }
 
-    bool is_parameterized() const { return !get_typed_desc<activation>()->additional_params_input.empty(); }
+    bool is_parameterized() const { return get_typed_desc<activation>()->additional_params_input.is_valid(); }
 };
 
 using activation_inst = typed_primitive_inst<activation>;

--- a/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/convolution_inst.h
@@ -85,10 +85,10 @@ public:
         return deformable_mode;
     }
 
-    bool bias_term() const { return get_primitive()->bias.size() > 0; }
-    bool weights_zero_points_term() const { return get_primitive()->weights_zero_points.size() > 0; }
-    bool compensation_term() const { return get_primitive()->compensation.size() > 0; }
-    bool activations_zero_points_term() const { return get_primitive()->activations_zero_points.size() > 0; }
+    bool bias_term() const { return get_primitive()->bias.is_valid(); }
+    bool weights_zero_points_term() const { return get_primitive()->weights_zero_points.is_valid(); }
+    bool compensation_term() const { return get_primitive()->compensation.is_valid(); }
+    bool activations_zero_points_term() const { return get_primitive()->activations_zero_points.is_valid(); }
     bool use_explicit_padding() const { return get_primitive()->auto_pad == ov::op::PadType::EXPLICIT; }
 
     // Currently convolution with constant weight is only supported for dynamic shape

--- a/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/deconvolution_inst.h
@@ -30,7 +30,7 @@ public:
     program_node& weights() const { return get_dependency(1);}
     program_node& bias() const { return get_dependency(2);}
 
-    bool bias_term() const { return !get_primitive()->bias.empty();}
+    bool bias_term() const { return get_primitive()->bias.is_valid();}
 
     std::vector<size_t> get_shape_infer_dependencies() const override { return {2}; }
 

--- a/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/fully_connected_inst.h
@@ -22,7 +22,7 @@ public:
     program_node& input() const { return get_dependency(0); }
     program_node& weights() const { return get_dependency(1); }
     program_node& bias() const { return get_dependency(2); }
-    bool bias_term() const { return !get_primitive()->bias.empty(); }
+    bool bias_term() const { return get_primitive()->bias.is_valid(); }
 
     std::vector<size_t> get_shape_infer_dependencies() const override { return {}; }
 

--- a/src/plugins/intel_gpu/src/graph/include/non_max_suppression_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/non_max_suppression_inst.h
@@ -30,19 +30,19 @@ public:
         return get_dependency(1);
     }
 
-    bool has_num_select_per_class() const { return !get_primitive()->num_select_per_class.empty(); }
+    bool has_num_select_per_class() const { return get_primitive()->num_select_per_class.is_valid(); }
     program_node& num_select_per_class_node() const {
         return get_dependency(2);
     }
 
-    bool has_iou_threshold() const { return !get_primitive()->iou_threshold.empty(); }
+    bool has_iou_threshold() const { return get_primitive()->iou_threshold.is_valid(); }
     program_node& iou_threshold_node() const {
         size_t offset = 2;
         offset += has_num_select_per_class();
         return get_dependency(offset);
     }
 
-    bool has_score_threshold() const { return !get_primitive()->score_threshold.empty(); }
+    bool has_score_threshold() const { return get_primitive()->score_threshold.is_valid(); }
     program_node& score_threshold_node() const {
         size_t offset = 2;
         offset += has_num_select_per_class();
@@ -50,7 +50,7 @@ public:
         return get_dependency(offset);
     }
 
-    bool has_soft_nms_sigma() const { return !get_primitive()->soft_nms_sigma.empty(); }
+    bool has_soft_nms_sigma() const { return get_primitive()->soft_nms_sigma.is_valid(); }
     program_node& soft_nms_sigma_node() const {
         size_t offset = 2;
         offset += has_num_select_per_class();
@@ -59,7 +59,7 @@ public:
         return get_dependency(offset);
     }
 
-    bool has_second_output() const { return !get_primitive()->second_output.empty(); }
+    bool has_second_output() const { return get_primitive()->second_output.is_valid(); }
     program_node& second_output_node() const {
         size_t offset = 2;
         offset += has_num_select_per_class();
@@ -69,7 +69,7 @@ public:
         return get_dependency(offset);
     }
 
-    bool has_third_output() const { return !get_primitive()->third_output.empty(); }
+    bool has_third_output() const { return get_primitive()->third_output.is_valid(); }
     program_node& third_output_node() const {
         size_t offset = 2;
         offset += has_num_select_per_class();
@@ -130,7 +130,7 @@ public:
         return dep_memory_ptr(1);
     }
 
-    bool has_num_select_per_class() const { return !get_typed_desc<non_max_suppression>()->num_select_per_class.empty(); }
+    bool has_num_select_per_class() const { return get_typed_desc<non_max_suppression>()->num_select_per_class.is_valid(); }
     memory::ptr num_select_per_class_mem() const {
         return dep_memory_ptr(2);
     }
@@ -138,7 +138,7 @@ public:
         return dependencies().at(2).first;
     }
 
-    bool has_iou_threshold() const { return !get_typed_desc<non_max_suppression>()->iou_threshold.empty(); }
+    bool has_iou_threshold() const { return get_typed_desc<non_max_suppression>()->iou_threshold.is_valid(); }
     memory::ptr iou_threshold_mem() const {
         return dep_memory_ptr(get_iou_threshold_offset());
     }
@@ -146,7 +146,7 @@ public:
         return dependencies().at(get_iou_threshold_offset()).first;
     }
 
-    bool has_score_threshold() const { return !get_typed_desc<non_max_suppression>()->score_threshold.empty(); }
+    bool has_score_threshold() const { return get_typed_desc<non_max_suppression>()->score_threshold.is_valid(); }
     memory::ptr score_threshold_mem() const {
         return dep_memory_ptr(get_score_threshold_offset());
     }
@@ -154,7 +154,7 @@ public:
         return dependencies().at(get_score_threshold_offset()).first;
     }
 
-    bool has_soft_nms_sigma() const { return !get_typed_desc<non_max_suppression>()->soft_nms_sigma.empty(); }
+    bool has_soft_nms_sigma() const { return get_typed_desc<non_max_suppression>()->soft_nms_sigma.is_valid(); }
     memory::ptr soft_nms_sigma_mem() const {
         return dep_memory_ptr(get_soft_nms_sigma_offset());
     }
@@ -162,7 +162,7 @@ public:
         return dependencies().at(get_soft_nms_sigma_offset()).first;
     }
 
-    bool has_second_output() const { return !get_typed_desc<non_max_suppression>()->second_output.empty(); }
+    bool has_second_output() const { return get_typed_desc<non_max_suppression>()->second_output.is_valid(); }
     memory::ptr second_output_mem() const {
         size_t offset = 2;
         offset += has_num_select_per_class();
@@ -172,7 +172,7 @@ public:
         return dep_memory_ptr(offset);
     }
 
-    bool has_third_output() const { return !get_typed_desc<non_max_suppression>()->third_output.empty(); }
+    bool has_third_output() const { return get_typed_desc<non_max_suppression>()->third_output.is_valid(); }
     memory::ptr third_output_mem() const {
         size_t offset = 2;
         offset += has_num_select_per_class();

--- a/src/plugins/intel_gpu/src/graph/include/reorder_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/reorder_inst.h
@@ -33,7 +33,7 @@ public:
     program_node& input(size_t idx = 0) const { return get_dependency(idx); }
     program_node& mean() const { return get_dependency(1); }
 
-    bool has_mean() const { return !typed_desc()->mean.empty(); }
+    bool has_mean() const { return typed_desc()->mean.is_valid(); }
 
     bool requires_reinterpret() const { return req_reinterpr; }
     void requires_reinterpret(bool val) { req_reinterpr = (optimized && val); }
@@ -92,7 +92,7 @@ public:
     memory::ptr mean_nv12_memory() const { return dep_memory_ptr(2); }
     memory::ptr mean_memory() const { return dep_memory_ptr(1); }
 
-    bool has_mean() const { return !get_typed_desc<reorder>()->mean.empty(); }
+    bool has_mean() const { return get_typed_desc<reorder>()->mean.is_valid(); }
 
     void update_output_memory() override;
     bool requires_reinterpret() const {

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -257,8 +257,8 @@ bool layout_optimizer::can_fuse_reorder(program_node& prev, program_node& next, 
             fmt_prev == format::bfyx &&
             (fmt_next == format::b_fs_yx_fsv16 || fmt_next == format::bs_fs_yx_bsv32_fsv16) &&
             next_output_layout.feature() >= 16 && prev_output_layout.feature() <= 4 &&
-            next.as<convolution>().get_primitive()->activations_zero_points.empty() &&
-            next.as<convolution>().get_primitive()->weights_zero_points.empty())
+            !next.as<convolution>().get_primitive()->activations_zero_points.is_valid() &&
+            !next.as<convolution>().get_primitive()->weights_zero_points.is_valid())
             return true;
 
         if (next.is_type<convolution>() &&
@@ -691,7 +691,7 @@ bool layout_optimizer::convolution_bs_fs_yx_bsv16_fsv16_opt(const layout& input_
     if (int8_sup)
         correct_batch = input_layout.batch() >= 16;
     int8_sup &= (input_layout.batch() % 16 == 0 && weights_layout.data_type == data_types::i8 &&
-                 conv->activations_zero_points.empty() && conv->weights_zero_points.empty());
+                 !conv->activations_zero_points.is_valid() && !conv->weights_zero_points.is_valid());
     auto ks_x = weights_layout.spatial(0);
     auto ks_y = weights_layout.spatial(1);
     int8_sup &= (input_layout.spatial(2) == 1 && ((ks_x == 1 && ks_y == 1) || (ks_x == 3 && ks_y == 3) || (ks_x == 7 && ks_y == 7)) &&

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1528,7 +1528,7 @@ void program_node::create_onednn_primitive_attributes(
             auto fused_desc = desc.typed_desc<activation>();
             bool allow_new_shape_infer = get_program().is_new_shape_infer();
             if (fused_desc->activation_function == cldnn::activation_func::relu_negative_slope
-                && !fused_desc->additional_params_input.empty()) {
+                && fused_desc->additional_params_input.is_valid()) {
                 auto dep_idx = cldnn_post_ops[idx].outer_dep_start_idx;
                 int oc_dim = 1;
                 if (allow_new_shape_infer)

--- a/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/convolution.cpp
@@ -123,7 +123,6 @@ static void CreateConvolutionBackpropDataOp(ProgramBuilder& p, const std::shared
         weightsName.pid = permuteName;
     }
 
-    std::vector<cldnn::primitive_id> weights = {weightsName.pid};
     const bool weights_have_group_dim = false;
 
     auto strides = op->get_strides();
@@ -138,7 +137,7 @@ static void CreateConvolutionBackpropDataOp(ProgramBuilder& p, const std::shared
         pads_begin.resize(std::max<size_t>(2, pads_begin.size()), 0);
         auto deconvPrim = cldnn::deconvolution(layerName,
                                                inputs[0],
-                                               weights,
+                                               weightsName.pid,
                                                {},
                                                1,
                                                strides,
@@ -150,7 +149,7 @@ static void CreateConvolutionBackpropDataOp(ProgramBuilder& p, const std::shared
     } else {
         auto deconvPrim = cldnn::deconvolution(layerName,
                                                inputs[0],
-                                               weights,
+                                               weightsName.pid,
                                                {},
                                                1,
                                                strides,
@@ -211,7 +210,6 @@ static void CreateGroupConvolutionBackpropDataOp(ProgramBuilder& p, const std::s
         weightsName.pid = permuteName;
     }
 
-    std::vector<cldnn::primitive_id> weights = {weightsName.pid};
     const bool weights_have_group_dim = true;
 
     auto strides = op->get_strides();
@@ -227,7 +225,7 @@ static void CreateGroupConvolutionBackpropDataOp(ProgramBuilder& p, const std::s
 
         auto deconvPrim = cldnn::deconvolution(layerName,
                                                inputs[0],
-                                               weights,
+                                               weightsName.pid,
                                                {},
                                                groups,
                                                strides,
@@ -242,7 +240,7 @@ static void CreateGroupConvolutionBackpropDataOp(ProgramBuilder& p, const std::s
     } else {
         auto deconvPrim = cldnn::deconvolution(layerName,
                                                inputs[0],
-                                               weights,
+                                               weightsName.pid,
                                                {},
                                                groups,
                                                strides,

--- a/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
@@ -314,7 +314,7 @@ TEST_P(deconv_actv, basic) {
     create_topologies(
         input_layout("input", get_input_layout(p)),
         data("weights", get_mem(get_weights_layout(p))),
-        deconvolution("deconv", input_info("input"), { "weights" }, p.groups, p.stride, p.pad),
+        deconvolution("deconv", input_info("input"), "weights", p.groups, p.stride, p.pad),
         activation("act", input_info("deconv"), activation_func::relu),
         reorder("out", input_info("act"), p.default_format, data_types::f32)
     );

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/deconvolution_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/deconvolution_si_test.cpp
@@ -42,8 +42,8 @@ TEST_P(deconvolution_si_test, shape_infer) {
     auto input_data_layout = layout{p.input_shape, data_types::f32, format::bfyx};
     auto weight_layout = layout{p.weight_shape, data_types::f32, format::bfyx};
 
-    std::vector<cldnn::primitive_id> weights = {"weight"};
-    std::vector<cldnn::primitive_id> bias = {};
+    cldnn::primitive_id weights = "weight";
+    cldnn::primitive_id bias = "";
 
     auto input_prim = std::make_shared<input_layout>("data", input_data_layout);
     auto weight_prim = std::make_shared<input_layout>("weight", weight_layout);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -1559,7 +1559,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz3x3x3_in1x1x4x4x4_nopad) {
         input_layout("input", input->get_layout()),
         data("weights", weights),
         reorder("reordered_input", input_info("input"), this->input_layout_format, data_types::f32),
-        deconvolution("deconv", input_info("reordered_input"), { "weights" }, {1, 1, 1}, {0, 0, 0}),
+        deconvolution("deconv", input_info("reordered_input"), "weights", ov::Strides{1, 1, 1}, {0, 0, 0}),
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
@@ -1653,7 +1653,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x2_in1x1x2x2x2_stride2_nopad) 
         input_layout("input", input->get_layout()),
         data("weights", weights),
         reorder("reordered_input", input_info("input"), this->input_layout_format, data_types::f32),
-        deconvolution("deconv", input_info("reordered_input"), { "weights" }, { 2,2,2 }, {0, 0, 0}),
+        deconvolution("deconv", input_info("reordered_input"), "weights", ov::Strides{ 2,2,2 }, {0, 0, 0}),
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
@@ -1726,7 +1726,7 @@ TYPED_TEST(deconvolution_basic_3d, basic3D_wsiz2x2x2_in1x1x2x2x2_stride2_pad1) {
         input_layout("input", input->get_layout()),
         data("weights", weights),
         reorder("reordered_input", input_info("input"), this->input_layout_format, data_types::f32),
-        deconvolution("deconv", input_info("reordered_input"), { "weights" }, { 2,2,2 }, { 1, 1, 1 }),
+        deconvolution("deconv", input_info("reordered_input"), "weights", ov::Strides{ 2,2,2 }, { 1, 1, 1 }),
         reorder("plane_output", input_info("deconv"), format::bfzyx, cldnn::data_types::f32)
     );
 
@@ -2373,7 +2373,7 @@ TEST(deconvolution_f32_fw_gpu, bs_fs_zyx_bsv16_fsv16_wsiz2x2x2_in1x1x2x2x2_strid
     topology topology(
             input_layout("input", input->get_layout()),
             data("weights", weights),
-            deconvolution("deconv", input_info("input"), { "weights" }, { 2,2,2 }, { 1, 1, 1 }),
+            deconvolution("deconv", input_info("input"), "weights", ov::Strides{ 2,2,2 }, { 1, 1, 1 }),
             reorder("out", input_info("deconv"), format::bfzyx, data_types::f32)
     );
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/fully_connected_gpu_test.cpp
@@ -3769,7 +3769,7 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
 
         if (is_wzp_test) {
             fc_prim.compressed_weights = true;
-            fc_prim.decompression_zero_point = is_wzp_test ? "wzp" : "";
+            fc_prim.decompression_zero_point = is_wzp_test ? input_info("wzp") : input_info();
         }
 
         // Implemented dynamic quantize kernel
@@ -3895,7 +3895,7 @@ void test_compressed_int4_scale_dynamic_batch_gemv(bool is_caching_test,
 
         if (is_wzp_test) {
             fc_prim.compressed_weights = true;
-            fc_prim.decompression_zero_point = is_wzp_test ? "wzp" : "";
+            fc_prim.decompression_zero_point = is_wzp_test ? input_info("wzp") : input_info();
         }
 
         // Implemented dynamic quantize kernel

--- a/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/hash_key_gpu_test.cpp
@@ -71,11 +71,11 @@ public:
         const auto primitive_hash = primitve->hash();
         const auto params_hash = primitve->type->get_fake_aligned_params(*prim_inst->get_impl_params()).hash();
         if (!engine.get_device_info().supports_immad) {
-            ASSERT_EQ(primitive_hash, 9510988594087947885UL);
-            ASSERT_EQ(params_hash, 1095272671134235967UL);
+            ASSERT_EQ(primitive_hash, 9450288823768808646UL);
+            ASSERT_EQ(params_hash, 4379838024983679385UL);
         } else {
-            ASSERT_EQ(primitive_hash, 9510988594087947885UL);
-            ASSERT_EQ(params_hash, 12994953567935633205UL);
+            ASSERT_EQ(primitive_hash, 9450288823768808646UL);
+            ASSERT_EQ(params_hash, 4312197244449972103UL);
         }
     }
 
@@ -175,8 +175,8 @@ public:
         const auto primitive_hash = primitve->hash();
         const auto params_hash = prim_inst->get_impl_params()->hash();
 
-        ASSERT_EQ(primitive_hash, 16293979194373117693UL);
-        ASSERT_EQ(params_hash, 3897060862531064919UL);
+        ASSERT_EQ(primitive_hash, 16293979194373117692UL);
+        ASSERT_EQ(params_hash, 3897060862522441010UL);
     }
 
     void test_reshape_basic(bool is_caching_test) {
@@ -226,8 +226,8 @@ public:
         const auto primitive_hash = primitve->hash();
         const auto params_hash = prim_inst->get_impl_params()->hash();
 
-        ASSERT_EQ(primitive_hash, 13549661972131371304UL);
-        ASSERT_EQ(params_hash, 4514788296955089688UL);
+        ASSERT_EQ(primitive_hash, 13549661971645339528UL);
+        ASSERT_EQ(params_hash, 2317969473793675238UL);
     }
 
     void test_quantize_basic(bool is_caching_test) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -2920,7 +2920,7 @@ public:
     memory::ptr generate_reference_typed(const std::vector<cldnn::memory::ptr>& inputs)
     {
         auto reorder = std::static_pointer_cast<cldnn::reorder>(layer_params);
-        primitive_id mean = reorder->mean;
+        primitive_id mean = reorder->mean.pid;
         std::vector<float> subtract_per_feature = reorder->subtract_per_feature;
         assert(mean == "");
         assert(subtract_per_feature.size() == 0);


### PR DESCRIPTION
### Details:
 - This patch is preliminary work for updating the unfusion logic. It adds an additional method `primitive::get_dependency(size_t idx)`, which returns a mutable reference to the input_info associated with the specified dependency index, allowing to reconfigure it

