### PR TITLE
[IE] Avoid race condition in IAsyncInferRequest

### DIFF
--- a/src/inference/src/dev/iasync_infer_request.cpp
+++ b/src/inference/src/dev/iasync_infer_request.cpp
@@ -99,6 +99,7 @@ void ov::IAsyncInferRequest::cancel() {
 
 void ov::IAsyncInferRequest::set_callback(std::function<void(std::exception_ptr)> callback) {
     check_state();
+    std::lock_guard<std::mutex> lock{m_mutex};
     m_callback = std::move(callback);
 }
 
@@ -148,11 +149,12 @@ ov::threading::Task ov::IAsyncInferRequest::make_next_stage_task(
 
             if ((itEndStage == itNextStage) || (nullptr != currentException)) {
                 auto lastStageTask = [this, currentException]() mutable {
-                    auto promise = std::move(m_promise);
+                    std::promise<void> promise;
                     std::function<void(std::exception_ptr)> callback;
                     {
                         std::lock_guard<std::mutex> lock{m_mutex};
                         m_state = InferState::IDLE;
+                        promise = std::move(m_promise);
                         std::swap(callback, m_callback);
                     }
                     if (callback) {


### PR DESCRIPTION
### Details:
 - Added missing lock protections
 - Coverity issues: 1530042, 1530340

### Tickets:
 - CVS-165933
