### PR TITLE
[Coverity] Medium issues in GPU Plugin

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/op/kv_cache_compressed.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/op/kv_cache_compressed.hpp
@@ -42,7 +42,7 @@ public:
     std::vector<uint64_t> get_scales_zp_output_order() const { return m_quantization_attrs.scales_zp_output_order; }
 
 private:
-    bool m_compressed;
+    bool m_compressed = false;
     QuantizationAttrs m_quantization_attrs = {};
 };
 

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1391,9 +1391,7 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
 
         if (desc->compressed) {
             auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
-            if (!compressed_cache_variable) {
-                OPENVINO_THROW("compressed_cache_variable is null");
-            }
+           OPENVINO_ASSERT(compressed_cache_variable != nullptr, "[GPU] compressed_cache_variable is null");
             auto& present_scales_layout = _impl_params->output_layouts[2];
             const auto sequence_axis = kv_cache_inst::get_scale_zp_sequence_axis();
             kv_cache_inst::update_pad(present_scales_layout, max_pad - new_seq_len, sequence_axis);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1391,7 +1391,7 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
 
         if (desc->compressed) {
             auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
-           OPENVINO_ASSERT(compressed_cache_variable != nullptr, "[GPU] compressed_cache_variable is null");
+            OPENVINO_ASSERT(compressed_cache_variable != nullptr, "[GPU] compressed_cache_variable is null");
             auto& present_scales_layout = _impl_params->output_layouts[2];
             const auto sequence_axis = kv_cache_inst::get_scale_zp_sequence_axis();
             kv_cache_inst::update_pad(present_scales_layout, max_pad - new_seq_len, sequence_axis);

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -1391,6 +1391,9 @@ void primitive_inst::do_runtime_in_place_kv_cache() {
 
         if (desc->compressed) {
             auto compressed_cache_variable = dynamic_cast<ov::intel_gpu::VariableStateIndirectKVCacheCompressed*>(&variable);
+            if (!compressed_cache_variable) {
+                OPENVINO_THROW("compressed_cache_variable is null");
+            }
             auto& present_scales_layout = _impl_params->output_layouts[2];
             const auto sequence_axis = kv_cache_inst::get_scale_zp_sequence_axis();
             kv_cache_inst::update_pad(present_scales_layout, max_pad - new_seq_len, sequence_axis);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/convolution/convolution_kernel_b_fs_zyx_fsv16_imad.cpp
@@ -186,7 +186,7 @@ float Convolution_kernel_b_fs_zyx_fsv16_imad::EstimateBlockParamsRatio(const con
         return -10.f;
     }
 
-    float occupancy_by_logic_size = static_cast<float>(params.outputs[0].LogicalSize() / static_cast<size_t>(params.engineInfo.maxThreadsPerDevice));
+    float occupancy_by_logic_size = static_cast<float>(params.outputs[0].LogicalSize()) / static_cast<float>(params.engineInfo.maxThreadsPerDevice);
     bool increase_max_reg_pressure = occupancy_by_logic_size >= 595.f;
     bool twice_increase_max_reg_pressure = occupancy_by_logic_size >= 595.f * 2.f;
     float max_reg_pressure = twice_increase_max_reg_pressure ? 0.785f : increase_max_reg_pressure ? 0.75f : 0.7f;


### PR DESCRIPTION
### Details:
 - Fixing 1565213, 1565100, 1565332
 - Other issues are already fixed

### Changes:
- Initialized the default `m_compressed` value to false
- Null pointer dereferences: ensure `compressed_cache_variable` is not NULL
- Ensure result is float

### Tickets:
 - *CVS-157248*

