### PR TITLE
[GPU] Prevent u16/i16 dequantization subgraphs folding during model conversion, allowing Plugins to handle subgraphs on their own

### DIFF
--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -76,5 +76,19 @@ public:
                                 bool fold_multiply_const = true);
 };
 
+/**
+ * @ingroup ov_transformation_common_api
+ *
+ * @brief KeepDequantizationPrecision matches Dequantization subgraphs and, if precision matches with
+ * specified, Convert, Multiply (and Subtract) nodes might be marked with disable_fp16_compression attribute.
+ * This prevents precision loss when the original precision is lowered during ConstantFolding execution.
+ *
+ */
+class TRANSFORMATIONS_API KeepDequantizationPrecision : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("KeepDequantizationPrecision");
+    explicit KeepDequantizationPrecision(const element::TypeVector& precisions);
+};
+
 }  // namespace pass
 }  // namespace ov

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -131,7 +131,9 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     using namespace ov::pass;
     REGISTER_PASS(manager, InitNodeInfo)
     if (m_low_precision_enabled) {
-        manager.register_pass<ov::pass::MarkDequantization>(element::TypeVector{ov::element::i8,
+        manager.register_pass<ov::pass::MarkDequantization>(element::TypeVector{ov::element::i16,
+                                                                                ov::element::u16,
+                                                                                ov::element::i8,
                                                                                 ov::element::u8,
                                                                                 ov::element::i4,
                                                                                 ov::element::u4,

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -309,3 +309,55 @@ ov::pass::KeepConstPrecision::KeepConstPrecision(const element::TypeVector& prec
     auto m = std::make_shared<Matcher>(multiply_pattern, "KeepConstPrecision");
     this->register_matcher(m, callback);
 }
+
+ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element::TypeVector& precisions) {
+    MATCHER_SCOPE(KeepDequantizationPrecision);
+
+    auto input_pattern = pattern::any_input(pattern::type_matches_any(precisions));
+    auto convert_pattern = pattern::wrap_type<v0::Convert>({input_pattern}, pattern::consumers_count(1));
+
+    // zero points:
+    auto zp_pattern = pattern::any_input();
+    auto zp_convert_pattern = pattern::optional<v0::Convert>(zp_pattern);
+    auto zp_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({zp_convert_pattern, pattern::any_input()});
+    auto subtract_pattern = pattern::optional<v1::Subtract>({convert_pattern, zp_reshape_pattern});
+
+    // scale:
+    auto scale_pattern = pattern::any_input();
+    auto scale_convert_pattern = pattern::optional<v0::Convert>(scale_pattern);
+    auto scale_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({scale_convert_pattern, pattern::any_input()});
+    auto multiply_pattern = pattern::wrap_type<v1::Multiply>({subtract_pattern, scale_reshape_pattern});
+
+    matcher_pass_callback callback = [=](Matcher& m) {
+        const auto& pt_map = m.get_pattern_value_map();
+        auto convert = pt_map.at(convert_pattern).get_node_shared_ptr();
+        auto multiply = m.get_match_root();
+
+        if (transformation_callback(multiply)) {
+            return false;
+        }
+
+        disable_fp16_compression(convert);
+        disable_fp16_compression(multiply);
+
+        if (pt_map.count(subtract_pattern)) {
+            auto subtract = pt_map.at(subtract_pattern).get_node_shared_ptr();
+            disable_fp16_compression(subtract);
+        }
+
+        if (pt_map.count(zp_convert_pattern)) {
+            auto zp_convert = pt_map.at(zp_convert_pattern).get_node_shared_ptr();
+            disable_fp16_compression(zp_convert);
+        }
+
+        if (pt_map.count(scale_convert_pattern)) {
+            auto scale_convert = pt_map.at(scale_convert_pattern).get_node_shared_ptr();
+            disable_fp16_compression(scale_convert);
+        }
+
+        return false;
+    };
+
+    auto m = std::make_shared<Matcher>(multiply_pattern, "KeepDequantizationPrecision");
+    this->register_matcher(m, callback);
+}

--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -81,7 +81,7 @@ void transformation_pipeline(std::shared_ptr<ov::Model>& model) {
     REGISTER_PASS(manager, SharedOpOptimization)
 
     // 1. Set "disable_const_folding" attribute
-    REGISTER_PASS(manager, MarkDequantization, TypeVector{i8, u8, i4, u4, nf4, f4e2m1, f8e4m3, f8e5m2, f8e8m0});
+    REGISTER_PASS(manager, MarkDequantization, TypeVector{i16, u16, i8, u8, i4, u4, nf4, f4e2m1, f8e4m3, f8e5m2, f8e8m0});
     REGISTER_PASS(manager, DisableShapeOfConstantFolding, false);
     REGISTER_PASS(manager, DisableRandomUniformConstantFolding)
     // Mark quantized and f16/bf16 compressed constants to prevent CF for them,

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -463,6 +463,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         const bool convert_input_output_precision = false;
         const bool store_original_precision_as_rt_attribute = true;
 
+        manager.register_pass<ov::pass::KeepDequantizationPrecision>(ov::element::TypeVector{ ov::element::u16 });
+
         manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
                                                           empty_fuse_map,
                                                           keep_precision_sensitive_in_fp32_1,


### PR DESCRIPTION
### Details:
 - Currently, all u16/i16 dequantization subgraphs are folded during model conversion. This patch modifies that behavior by preserving the original dequantization subgraphs, allowing plugins to handle them independently.
 - Since GPU Plugin currently doesn't have any optimizations for u16 data type, such subgraphs should still be folded. However, during the ConvertPrecision pass, these folded f32 constants are converted to f16, which lead to overflow due to the limited representable range of f16 data type for u16 values. This patch introduces an additional KeepDequantizationPrecision pass, which helps preserve the original data type of dequantized subgraphs, preventing their lowering during ConvertPrecision.

Dequantization subgraph after model conversion:
![image](https://github.com/user-attachments/assets/561d3075-0770-43ee-bd7a-c9991b4105ce)
Fused dequantization subgraph of transformed model (original f32 precision is preserved for the constant):
![image](https://github.com/user-attachments/assets/96f6b0d8-4f6d-4ada-a65a-d85f5c093162)


### Tickets:
 - [CVS-167293](https://jira.devtools.intel.com/browse/CVS-167293)
