### PR TITLE
[CPU] Fix Convolution primitive creation when dw conv post op is fused

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -286,6 +286,7 @@ const std::vector<impl_desc_type>& Convolution::getDefaultImplPriority() {
         impl_desc_type::brgconv_avx2_dw,
         impl_desc_type::brgconv_avx2_1x1,
         impl_desc_type::brgconv_avx2,
+        impl_desc_type::jit_avx2_1x1_dw,
         impl_desc_type::jit_uni_dw,
         impl_desc_type::jit_uni_1x1,
         impl_desc_type::jit_uni,

--- a/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
@@ -7,6 +7,7 @@
 #include "memory_desc/dnnl_blocked_memory_desc.h"
 #include "memory_format_filter.hpp"
 #include "nodes/executors/convolution_config.hpp"
+#include "nodes/executors/debug_messages.hpp"
 #include "nodes/executors/dnnl/dnnl_convolution_primitive.hpp"
 #include "nodes/executors/executor.hpp"
 #include "nodes/executors/executor_implementation.hpp"
@@ -53,6 +54,14 @@ struct RequiresFallbackDefault {
 
     LayoutConfig layoutConfig;
 };
+
+template <typename PostOpType>
+[[maybe_unused]] static inline bool hasPostOp(const ConvConfig& config) {
+    const auto& postOps = config.attrs.postOps;
+    return any_of(postOps.begin(), postOps.end(), [](const std::shared_ptr<PostOp>& postOp) {
+        return std::dynamic_pointer_cast<PostOpType>(postOp);
+    });
+}
 
 template <typename Attrs>
 bool MatchesMemoryFormatFilter(const executor::Config<Attrs>& config,
@@ -102,8 +111,11 @@ const std::vector<ExecutorImplementation<ConvAttrs>>& getImplementations() {
                                                memoryFormatFilter)) {
                     return false;
                 }
-                // nspc shows better performance only with brgconv implementation
-                return DnnlConvolutionPrimitive::isBrgConvAvailable(config);
+
+                VERIFY(!hasPostOp<DepthwiseConvolutionPostOp>(config), UNSUPPORTED_POST_OPS);
+                VERIFY(DnnlConvolutionPrimitive::isBrgConvAvailable(config), "brgemm convolution is not available");
+
+                return true;
             },
             RequiresFallbackDefault{{LayoutType::nspc, LayoutType::ncsp, LayoutType::nspc, LayoutType::nspc}},
             AcceptsAnyShape<ConvAttrs>{},
@@ -118,6 +130,8 @@ const std::vector<ExecutorImplementation<ConvAttrs>>& getImplementations() {
                     return false;
                 }
 
+                // fork kernel with dw conv post ops supports only src: (ncsp | nCsp8c), dst: nCsp8c
+                VERIFY(!hasPostOp<DepthwiseConvolutionPostOp>(config), UNSUPPORTED_POST_OPS);
                 const auto [groupNum, groupIC, IC, groupOC] = DnnlConvolutionPrimitive::getChannelParams(config);
 
                 return IC == 1 && groupOC == 1;
@@ -134,6 +148,9 @@ const std::vector<ExecutorImplementation<ConvAttrs>>& getImplementations() {
                                                memoryFormatFilter)) {
                     return false;
                 }
+
+                // fork kernel with dw conv post ops supports only src: (ncsp | nCsp8c), dst: nCsp8c
+                VERIFY(!hasPostOp<DepthwiseConvolutionPostOp>(config), UNSUPPORTED_POST_OPS);
 
                 const auto [groupNum, groupIC, IC, groupOC] = DnnlConvolutionPrimitive::getChannelParams(config);
 
@@ -169,6 +186,9 @@ const std::vector<ExecutorImplementation<ConvAttrs>>& getImplementations() {
                     return false;
                 }
 
+                // fork kernel with dw conv post ops supports only src: (ncsp | nCsp8c), dst: nCsp8c
+                VERIFY(!hasPostOp<DepthwiseConvolutionPostOp>(config), UNSUPPORTED_POST_OPS);
+
                 const auto [groupNum, groupIC, IC, groupOC] = DnnlConvolutionPrimitive::getChannelParams(config);
 
                 return IC > 4;
@@ -202,6 +222,9 @@ const std::vector<ExecutorImplementation<ConvAttrs>>& getImplementations() {
                                                memoryFormatFilter)) {
                     return false;
                 }
+
+                // fork kernel with dw conv post ops supports only src: (ncsp | nCsp8c), dst: nCsp8c
+                VERIFY(!hasPostOp<DepthwiseConvolutionPostOp>(config), UNSUPPORTED_POST_OPS);
 
                 return true;
             },

--- a/src/plugins/intel_cpu/src/onednn/iml_type_mapper.cpp
+++ b/src/plugins/intel_cpu/src/onednn/iml_type_mapper.cpp
@@ -121,6 +121,7 @@ const char* impl_type_to_string(impl_desc_type type) {
     CASE(jit_avx512_amx);
     CASE(jit_avx512_amx_1x1);
     CASE(jit_avx512_amx_dw);
+    CASE(jit_avx2_1x1_dw);
     CASE(brgconv_avx512);
     CASE(brgconv_avx2);
     CASE(brgconv_avx);

--- a/src/plugins/intel_cpu/src/onednn/iml_type_mapper.h
+++ b/src/plugins/intel_cpu/src/onednn/iml_type_mapper.h
@@ -88,6 +88,8 @@ enum impl_desc_type : int64_t {
     jit_uni_dw = jit | uni | _dw,
     jit_avx512_amx_dw = jit | avx512 | amx | _dw,
 
+    jit_avx2_1x1_dw = jit | avx2 | _1x1 | _dw,
+
     brgconv_avx512 = brgconv | avx512,
     brgconv_avx2 = brgconv | avx2,
     brgconv_avx = brgconv | avx,


### PR DESCRIPTION
Before refactoring:
- Convolution was created with 8c blocking right away
After refactoring:
1) Convolution was created with 'any' layout, then some primitive implementation (not fork dw conv) returned 8c layout
2) 8c layout is used to create fork dw conv implementation (not the one, which returned this layout).
3) Essentially the same primitive is created but performance is worse

Solution - prevent fallback to 'any' layout in the first place

### Ticket
- 166651