### PR TITLE
[intel-npu] Molding NPU_TURBO into a shared option between driver and compiler

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -792,7 +792,7 @@ struct TURBO final : OptionBase<TURBO, bool> {
     }
 
     static OptionMode mode() {
-        return OptionMode::RunTime;
+        return OptionMode::Both;
     }
 
     static ov::PropertyMutability mutability() {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -501,8 +501,8 @@ std::string DriverCompilerAdapter::serializeConfig(const Config& config,
             std::ostringstream turbostr;
             turbostr << ov::intel_npu::turbo.name() << KEY_VALUE_SEPARATOR << VALUE_DELIMITER << "\\S+"
                      << VALUE_DELIMITER;
-            logger.warning("NPU_TURBO property is not supported by this compiler. Removing from "
-                           "parameters");
+            logger.info("NPU_TURBO property is not supported by this compiler. Removing from "
+                        "parameters");
             content = std::regex_replace(content, std::regex(turbostr.str()), "");
         }
     }

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -307,6 +307,14 @@ void Plugin::filter_config_by_compiler_support(FilteredConfig& cfg) const {
         // update enable flag
         cfg.enable(key, isEnabled);
     });
+
+    // Special case for NPU_TURBO which might not be supported by compiler, but driver will still use it
+    // if it exists in config = driver supports it
+    // if compiler->is_option_suported is false = compiler doesn't support it and gets marked disabled by default logic
+    // however, if driver supports it, we still need it (and will skip giving it to compiler) = force-enable
+    if (cfg.hasOpt(ov::intel_npu::turbo.name())) {
+        cfg.enable(ov::intel_npu::turbo.name(), true);
+    }
 }
 
 FilteredConfig Plugin::fork_local_config(const std::map<std::string, std::string>& rawConfig,


### PR DESCRIPTION
### Details:
- Molding NPU_TURBO into a shared option between driver and compiler compiler. 
If compiler supports it, will send it to compiler too. Else we send it to driver only.
Changes required to obtain this:
- changing OptionMode for Turbo to OptionMode::Both
- optionMode::Both will make Turbo to be included in compiler arguments even if it doesn't support it > need to add compiler argument string filtering with compiler support verification to remove it if the compiler doesn't support it (but without effecting setting it in driver)
- since Turbo became OptionMode::Both, it will fall into properties initialization (and reinitialization) logic, which will ask about compiler support for it. If compiler doesn't report it supported, the logic marks it disabled. However, we still want to use it for driver, so we force-enable it (it will be filtered out in cid adapter anyway).

### Tickets:
 - CVS-167348
