### PR TITLE
[GPU] onednn rls-3.9pc integration

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/sdpa/sdpa_kernel_micro.cpp
@@ -312,7 +312,7 @@ void SDPAKernelMicro::init_microkernels(const sdpa_params& params, micro::Packag
     if (params.conf.is_kv_compressed && !kq_common_scales) {
         const auto scale_dt = convert_type(params.key_cache_comp_scale.GetDType());
         problem_kq.Ta_scale = scale_dt;
-        problem_kq.A_scale.alignment = micro::data_type_size(scale_dt);
+        problem_kq.A_scale.alignment = scale_dt.size();
 
         problem_kq.A_scale.layout = micro::MatrixLayout::T;
         problem_kq.aScale2D = true;
@@ -321,7 +321,7 @@ void SDPAKernelMicro::init_microkernels(const sdpa_params& params, micro::Packag
     if (params.conf.is_kv_compressed && params.conf.use_asymmetric_quantization) {
         const auto zp_dt = convert_type(params.key_cache_comp_zp.GetDType());
         problem_kq.Tao = zp_dt;
-        problem_kq.AO.alignment = micro::data_type_size(zp_dt);
+        problem_kq.AO.alignment = zp_dt.size();
         problem_kq.AO.layout = micro::MatrixLayout::T;
         problem_kq.aoPtrDims = kq_common_zp ? 0 : 2;
         problem_kq.aOffset = micro::ABOffset::Calc;
@@ -378,7 +378,7 @@ void SDPAKernelMicro::init_microkernels(const sdpa_params& params, micro::Packag
     if (params.conf.is_kv_compressed && !vs_common_scales) {
         auto scale_dt = convert_type(params.value_cache_comp_scale.GetDType());
         problem_vs.Ta_scale = scale_dt;
-        problem_vs.A_scale.alignment = micro::data_type_size(scale_dt);
+        problem_vs.A_scale.alignment = scale_dt.size();
         problem_vs.A_scale.layout = micro::MatrixLayout::N;
         problem_vs.aScale2D = true;
     }
@@ -386,7 +386,7 @@ void SDPAKernelMicro::init_microkernels(const sdpa_params& params, micro::Packag
     if (params.conf.is_kv_compressed && params.conf.use_asymmetric_quantization) {
         auto zp_dt = convert_type(params.value_cache_comp_zp.GetDType());
         problem_vs.Tao = zp_dt;
-        problem_vs.AO.alignment = micro::data_type_size(zp_dt);
+        problem_vs.AO.alignment = zp_dt.size();
         problem_vs.AO.layout = micro::MatrixLayout::N;
         problem_vs.aoPtrDims = vs_common_zp ? 0 : 2;
         problem_vs.aOffset = micro::ABOffset::Calc;

--- a/src/plugins/intel_gpu/src/kernel_selector/micro_utils.hpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/micro_utils.hpp
@@ -18,22 +18,22 @@
 #endif
 
 #include "gpu/intel/microkernels/package.hpp"
-#include "gpu/intel/jit/gemm/include/microkernel_provider.hpp"
+#include "gpu/intel/jit/gemm/include/gemmstone/microkernel_provider.hpp"
 #include "gpu/intel/microkernels/shim.hpp"
 #include "common/utils.hpp"
 
 namespace micro {
 
 using Package = dnnl::impl::gpu::intel::micro::Package;
-using HWInformation = dnnl::impl::gpu::intel::jit::HWInformation;
-using GEMMProblem = dnnl::impl::gpu::intel::jit::GEMMProblem;
-using ABOffset = dnnl::impl::gpu::intel::jit::ABOffset;
-using GEMMStrategy = dnnl::impl::gpu::intel::jit::GEMMStrategy;
+using HWInformation = gemmstone::HWInformation;
+using GEMMProblem = gemmstone::GEMMProblem;
+using ABOffset = gemmstone::ABOffset;
+using GEMMStrategy = gemmstone::GEMMStrategy;
 using GEMMProtocol = dnnl::impl::gpu::intel::micro::GEMMProtocol;
-using MatrixLayout = dnnl::impl::gpu::intel::jit::MatrixLayout;
-using Type = dnnl::impl::gpu::intel::jit::Type;
-using SizeParams = dnnl::impl::gpu::intel::jit::SizeParams;
-using StrategyRequirement = dnnl::impl::gpu::intel::jit::StrategyRequirement;
+using MatrixLayout = gemmstone::MatrixLayout;
+using Type = gemmstone::Type;
+using SizeParams = gemmstone::SizeParams;
+using StrategyRequirement = gemmstone::StrategyRequirement;
 using ShimOptions = dnnl::impl::gpu::intel::micro::ShimOptions;
 using HostLanguage = dnnl::impl::gpu::intel::micro::HostLanguage;
 using Setting = dnnl::impl::gpu::intel::micro::Setting;
@@ -74,15 +74,11 @@ struct MicroKernelPackage {
 inline Package select_gemm_microkernel(GEMMProtocol protocol, HWInformation hw_info, SizeParams sizes, const GEMMProblem &problem,
                                         const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                         void (*strategyAdjuster)(GEMMStrategy &strategy) = nullptr) {
-    return dnnl::impl::gpu::intel::jit::selectGEMMMicrokernel(protocol, hw_info, sizes, problem, reqs, strategyAdjuster);
+    return gemmstone::selectGEMMMicrokernel(protocol, hw_info, sizes, problem, reqs, strategyAdjuster);
 }
 
 static inline int alignment_for_ld(int ld) {
-    return  dnnl::impl::gpu::intel::jit::alignmentForLD(ld);
-}
-
-static inline uint8_t data_type_size(micro::Type dt) {
-    return uint8_t(dnnl::impl::types::data_type_size(micro::Type(dt).get_dnnl_type()));
+    return  gemmstone::alignmentForLD(ld);
 }
 
 }  // namespace micro

--- a/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
+++ b/src/plugins/intel_gpu/thirdparty/CMakeLists.txt
@@ -156,13 +156,19 @@ if(ENABLE_ONEDNN_FOR_GPU)
             )
         endif()
 
-        set(LIB_INCLUDE_DIRS "${ONEDNN_INSTALL_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/src" "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/src/gpu/intel/jit/ngen" "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/third_party/ngen")
+        set(LIB_INCLUDE_DIRS "${ONEDNN_INSTALL_DIR}/include"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/src"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/src/gpu/intel/jit/ngen"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/src/gpu/intel/jit/config"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/src/gpu/intel/jit/gemm/include"
+                             "${CMAKE_CURRENT_SOURCE_DIR}/onednn_gpu/third_party/ngen")
         set(LIB_DEFINITIONS ENABLE_ONEDNN_FOR_GPU
                             DNNL_DLL
                             DNNL_DLL_EXPORTS
                             DNNL_ENABLE_CPU_ISA_HINTS
                             DNNL_ENABLE_MAX_CPU_ISA
-                            DNNL_X64=1)
+                            DNNL_X64=1
+                            NGEN_CONFIG)
         add_library(onednn_gpu_tgt INTERFACE)
         set_target_properties(onednn_gpu_tgt PROPERTIES
             INTERFACE_LINK_LIBRARIES $<BUILD_INTERFACE:${ONEDNN_GPU_LIB_PATH}>


### PR DESCRIPTION
### Details:
- onednn commit a42b47ff2c (origin/rls-v3.9-pc)
- fix build issue: ngen
-- update cmake: add definition: NGEN_CONFIG
-- update cmake: add include directory src/gpu/intel/jit/configm, src/gpu/intel/jit/gemm/include
-- update header path from gpu/intel/jit/gemm/include to gpu/intel/jit/gemm/include/gemmstone
-- replace namespace from dnnl::impl::gpu::intel::jit to gemmstone
-- data_type_size() to size() of gemmstone::Type


### Tickets:
 - 165696