### PR TITLE
[NPU] Single Image Test - Add possibility to pass input files using input layer names

### DIFF
--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -2222,19 +2222,6 @@ static int runSingleImageTest() {
             }
             inputFilesForOneInfer.push_back(std::move(entireModelFiles));
         }
-        // Log what is in inputFilesForOneInfer
-        std::cout << "[Debug] Parsed input files for model: " << std::endl;
-        for (size_t i = 0; i < inputFilesForOneInfer.size(); ++i) {
-            std::cout << "Input " << i << ": ";
-            for (const auto& files : inputFilesForOneInfer[i]) {
-                std::cout << "[";
-                for (const auto& file : files) {
-                    std::cout << file << " ";
-                }
-                std::cout << "]";
-            }
-            std::cout << std::endl;
-        }
 
         // Declare output file / reference file variables
         std::vector<std::string> refFilesPerCase;

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -749,7 +749,6 @@ std::string parseInputFiles(const ov::OutputVector& inputInfo, const std::string
             auto it = inputFileMap.find(name);
             if (it != inputFileMap.end()) {
                 inputValues[i] = it->second;
-                std::cout << "--- Matched input: " << name << " with value: " << it->second << std::endl;
                 break;
             }
         }
@@ -776,7 +775,6 @@ std::string parseInputFiles(const ov::OutputVector& inputInfo, const std::string
         }
         result += inputValues[i];
     }
-    std::cout << "--- Final input files: " << result << std::endl;
 
     return result;
 }
@@ -2060,6 +2058,7 @@ static int runSingleImageTest() {
 
             // Parse input files string (matching of node names - if given)
             std::string fileMatch = parseInputFiles(inputInfo, FLAGS_input);
+            std::cout << "--- Parsed input files: " << fileMatch << std::endl;
 
             inputFilesPerCase = splitStringList(fileMatch, ';');
             for (const auto& images : inputFilesPerCase) {

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -719,19 +719,25 @@ std::map<RegexPtr, ov::Layout> parseLayoutRegex(std::string layouts) {
 }
 
 /**
- * @brief Parses input file specifications and matches them to model input names.
+ * @brief Parses and processes input files and matches them to model input names.
  *
- * This function takes a vector of model input information and a string representing
- * input file specifications (in key-value format), then matches each model input
- * to its corresponding file value. It ensures that all inputs are specified or none,
- * and detects duplicate specifications for the same input.
- * The final returned string is semicolon-delimited and ordered to match the inputInfo.
+ * This function processes input file specifications for multiple test cases. It supports both 
+ * the simple format (same file for all inputs) and the mapped format (specific files for specific inputs).
  *
- * @param inputInfo      A vector of OpenVINO output objects representing model inputs.
- * @param inputFiles     A string containing input file specifications, typically as key-value pairs.
- * @return               A semicolon-delimited string of input file values, ordered to match inputInfo.
+ * The input format supports:
+ * - Multiple test cases separated by semicolons (';')
+ * - Within each test case, input mappings separated by commas (',')
+ * - Optional batched inputs separated by pipe ('|') are ignored
+ * - Each mapping in the format "input_name:file_path1|file_path2"
  *
- * @throws               Throws an assertion if duplicate or incomplete input specifications are found.
+ * @param inputInfo     Vector of model input information objects
+ * @param inputFiles    String containing input file specifications
+ *
+ * @return A string with processed input files, maintaining the test case structure (semicolon-separated)
+ *         with each test case containing comma-separated input files.
+ *
+ * @throws OpenVINO::AssertionFailure If input specification is incomplete or contains duplicates within the
+ *         same test case.
  */
 std::string parseInputFiles(const std::vector<ov::Output<const ov::Node>> inputInfo, const std::string& inputFiles) {
     // Splits input files into test cases (delimited by ';')

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -2216,8 +2216,8 @@ static int runSingleImageTest() {
         auto inputInfo = compiledModel.inputs();
 
         // Parse input files string (matching of node names - if given)
-        std::string fileMatch = parseInputFiles(inputInfo, FLAGS_input);
-        inputFilesPerCase = splitStringList(fileMatch, ';');
+        std::string processedFileInputs = parseInputFiles(inputInfo, FLAGS_input);
+        inputFilesPerCase = splitStringList(processedFileInputs, ';');
         for (const auto& images : inputFilesPerCase) {
             std::vector<std::string> filesPerModel = splitStringList(images, ',');
             FilesForModelInputs entireModelFiles;
@@ -2278,6 +2278,25 @@ static int runSingleImageTest() {
             }
         }
         std::cout << "[Debug] Image bin precision processed!" << std::endl;
+
+        // Parse reference files
+        if (!FLAGS_ref_results.empty()) {
+            refFilesPerCase = splitStringList(FLAGS_ref_results, ';');
+            // Make sure that the number of test cases (separated by ;) is the same as number of test cases given in
+            // input files
+            if (refFilesPerCase.size() != inputFilesPerCase.size()) {
+                std::cout << "The number of test cases in reference files is not equal to the number of test cases"
+                    << " given in input files. "
+                    << "  Number of test cases in reference files: " << refFilesPerCase.size()
+                    << "  Number of test cases in input files: " << inputFilesPerCase.size() << std::endl;
+                return EXIT_FAILURE;
+            }
+
+            for (const auto& refResult : refFilesPerCase) {
+                std::vector<std::string> refFilesPerModel = splitStringList(refResult, ',');
+                refFilesForOneInfer.push_back(std::move(refFilesPerModel));
+            }
+        }
 
         // store compiled model, if required
         if (!FLAGS_compiled_blob.empty()) {

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -747,7 +747,6 @@ std::string parseInputFiles(const std::vector<ov::Output<const ov::Node>> inputI
 
     for (size_t testCaseIndex = 0; testCaseIndex < inputFileList.size(); ++testCaseIndex) {
         const auto& inputFile = inputFileList[testCaseIndex];
-        std::cout << "TEST CASE " << testCaseIndex << " --> " << inputFile << std::endl;
         std::map<std::string, std::string> newInputFileMap = parseArgMap(inputFile, ',');
         std::vector<std::string> processedInputFilesPerCase(inputInfo.size());
 
@@ -775,12 +774,6 @@ std::string parseInputFiles(const std::vector<ov::Output<const ov::Node>> inputI
             std::cout << "No input files specified. Using default input file -->" << inputFile << std::endl;
             processedInputFiles[testCaseIndex] = inputFile;
             continue;
-        }
-        // Log what is in processedInputFilesPerCase
-        std::cout << " ---------- " << std::endl;
-        std::cout << "Processed input file map for test case " << testCaseIndex << ": " << std::endl;
-        for (const auto& pair : processedInputFilesPerCase) {
-            std::cout << "  " << pair << std::endl;
         }
         // Concatenate processedInputFilesPerCase results with , delimiter, then store in processedInputFiles at index
         std::string result;
@@ -2220,20 +2213,10 @@ static int runSingleImageTest() {
             compiledModel = core.import_model(file, FLAGS_device);
         }
 
-        // Debug
-        std::cout << "[Debug] Compiled model:" << std::endl;
-        auto modelInputs = compiledModel.inputs();
-        std::cout << "[Debug] Model inputs:" << std::endl;
-        for (const auto& input : modelInputs) {
-            std::cout << " - " << input.get_any_name() << ": " << input.get_element_type() << " " << input.get_shape() << std::endl;
-        }
-
         auto inputInfo = compiledModel.inputs();
 
         // Parse input files string (matching of node names - if given)
         std::string fileMatch = parseInputFiles(inputInfo, FLAGS_input);
-        std::cout << "--- Parsed input files: " << fileMatch << std::endl;
-
         inputFilesPerCase = splitStringList(fileMatch, ';');
         for (const auto& images : inputFilesPerCase) {
             std::vector<std::string> filesPerModel = splitStringList(images, ',');

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -786,14 +786,14 @@ std::string parseInputFiles(const std::vector<ov::Output<const ov::Node>> inputs
     }
 
     // Concatenate processedInputCasesList results with ; delimiter
-    std::string inputFilesConcatenated;
+    std::string processedInputCases;
     for (size_t i = 0; i < processedInputCasesList.size(); ++i) {
         if (i > 0) {
-            inputFilesConcatenated += ";";
+            processedInputCases += ";";
         }
-        inputFilesConcatenated += processedInputCasesList[i];
+        processedInputCases += processedInputCasesList[i];
     }
-    return inputFilesConcatenated;
+    return processedInputCases;
 }
 
 template <class T>

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -764,6 +764,7 @@ std::string parseInputFiles(const ov::OutputVector& inputInfo, const std::string
     }
     // If there are no matches, valueCount will be 0. Hence we directly return the inputFiles string.
     if (valueCount == 0) {
+        std::cout << "No input files specified. Using default input files -->" << inputFiles << std::endl;
         return inputFiles;
     }
 
@@ -775,7 +776,7 @@ std::string parseInputFiles(const ov::OutputVector& inputInfo, const std::string
         }
         result += inputValues[i];
     }
-
+    std::cout << "Input files: " << result << std::endl;
     return result;
 }
 
@@ -2071,6 +2072,19 @@ static int runSingleImageTest() {
                 }
                 inputFilesForOneInfer.push_back(std::move(entireModelFiles));
             }
+            // Log what is in inputFilesForOneInfer
+            std::cout << "[Debug] Parsed input files for model: " << std::endl;
+            for (size_t i = 0; i < inputFilesForOneInfer.size(); ++i) {
+                std::cout << "Input " << i << ": ";
+                for (const auto& files : inputFilesForOneInfer[i]) {
+                    std::cout << "[";
+                    for (const auto& file : files) {
+                        std::cout << file << " ";
+                    }
+                    std::cout << "]";
+                }
+                std::cout << std::endl;
+            }
 
             // Input precision
             if (!FLAGS_ip.empty()) {
@@ -2246,6 +2260,7 @@ static int runSingleImageTest() {
                 ++inferIdx;
             }
         }
+        std::cout << "[Debug] Image bin precision processed!" << std::endl;
 
         // store compiled model, if required
         if (!FLAGS_compiled_blob.empty()) {

--- a/src/plugins/intel_npu/tools/single-image-test/main.cpp
+++ b/src/plugins/intel_npu/tools/single-image-test/main.cpp
@@ -771,7 +771,6 @@ std::string parseInputFiles(const std::vector<ov::Output<const ov::Node>> inputI
                                 "Check if there are duplicate input names in the input file map.");
         }
         if (valueCount == 0) {
-            std::cout << "No input files specified. Using default input file -->" << inputFile << std::endl;
             processedInputFiles[testCaseIndex] = inputFile;
             continue;
         }
@@ -2283,7 +2282,6 @@ static int runSingleImageTest() {
                 ++inferIdx;
             }
         }
-        std::cout << "[Debug] Image bin precision processed!" << std::endl;
 
         // store compiled model, if required
         if (!FLAGS_compiled_blob.empty()) {


### PR DESCRIPTION
### Details:
* Introduced a new function `parseInputFiles` to match model input names with input file specifications. This ensures all inputs are specified or none, and detects duplicates. The function returns a semicolon-delimited string of input file values ordered to match the model inputs. 

### Tickets:
 - E-166781