### PR TITLE
[transformations][CPU] Add opset version to TypeRelaxed operators rt info

### DIFF
--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -79,6 +79,8 @@ public:
         m_input_data_types[inputIndex] = element_type;
     }
 
+    static constexpr std::string_view version_prefix{"type_relaxed"};
+
 protected:
     void remember_input_data_types(Node& node, element::TypeVector& old_input_types);
 
@@ -95,7 +97,7 @@ protected:
     } init_rt_result;
 
     init_rt_result init_rt_info(Node& node) const {
-        node.get_rt_info()["opset"] = "type_relaxed_opset";
+        node.get_rt_info()["opset"] = std::string(version_prefix) + node.get_type_info().version_id;
         return {};
     }
 

--- a/src/common/transformations/include/ov_ops/type_relaxed.hpp
+++ b/src/common/transformations/include/ov_ops/type_relaxed.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "openvino/op/convert.hpp"
@@ -79,7 +80,7 @@ public:
         m_input_data_types[inputIndex] = element_type;
     }
 
-    static constexpr std::string_view version_prefix{"type_relaxed"};
+    static constexpr std::string_view version_prefix{"type_relaxed_"};
 
 protected:
     void remember_input_data_types(Node& node, element::TypeVector& old_input_types);

--- a/src/common/transformations/include/transformations/utils/print_model.hpp
+++ b/src/common/transformations/include/transformations/utils/print_model.hpp
@@ -21,6 +21,7 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/pass/pass.hpp"
+#include "ov_ops/type_relaxed.hpp"
 #include "transformations/utils/utils.hpp"
 
 namespace ov {
@@ -322,8 +323,10 @@ void dump_cpp_style(std::ostream& os, const std::shared_ptr<ov::Model>& model) {
         auto version_info = std::string(type_info.get_version());
         auto type = version_info + "::" + type_info.name;
         auto& rt_info = op->get_rt_info();
-        if (rt_info.count("opset") && rt_info["opset"] == "type_relaxed_opset") {
-            type = std::string("ov::op::TypeRelaxed<") + type + ">";
+        if (std::dynamic_pointer_cast<ov::op::TypeRelaxedBase>(op)) {
+            if (rt_info.count("opset")) {
+                type = std::string("ov::op::TypeRelaxed<") + type + ">";
+            }
         }
         auto name = opname[op.get()];
         os << prefix << "    ";

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -40,9 +40,7 @@ namespace {
 template <typename Op>
 class TypeRelaxedExtension : public ov::OpExtension<ov::op::TypeRelaxed<Op>> {
 public:
-    TypeRelaxedExtension()
-        : m_version{std::string(ov::op::TypeRelaxedBase::version_prefix) + Op::get_type_info_static().version_id},
-          m_ext_type(Op::get_type_info_static().name, m_version.data()) {}
+    TypeRelaxedExtension() : m_ext_type(Op::get_type_info_static().name, version()) {}
 
     ~TypeRelaxedExtension() override = default;
 
@@ -59,7 +57,12 @@ public:
     }
 
 private:
-    std::string m_version;
+    static const char* version() {
+        static const auto version =
+            std::string(ov::op::TypeRelaxedBase::version_prefix) + Op::get_type_info_static().version_id;
+        return version.data();
+    }
+
     ov::DiscreteTypeInfo m_ext_type;
 };
 

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -40,7 +40,10 @@ namespace {
 template <typename Op>
 class TypeRelaxedExtension : public ov::OpExtension<ov::op::TypeRelaxed<Op>> {
 public:
-    TypeRelaxedExtension() : m_ext_type(Op::get_type_info_static().name, "type_relaxed_opset") {}
+    TypeRelaxedExtension()
+        : m_version{std::string(ov::op::TypeRelaxedBase::version_prefix) + Op::get_type_info_static().version_id},
+          m_ext_type(Op::get_type_info_static().name, m_version.data()) {}
+
     ~TypeRelaxedExtension() override = default;
 
     [[nodiscard]] const ov::DiscreteTypeInfo& get_type_info() const override {
@@ -56,6 +59,7 @@ public:
     }
 
 private:
+    std::string m_version;
     ov::DiscreteTypeInfo m_ext_type;
 };
 

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -28,8 +28,14 @@ const ov::AnyMap empty_property = {};
 
 using ov::op::v0::Parameter, ov::op::v0::Result;
 
-TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
+using smoke_serialization_OVCompiledGraphImportExportTest = OVCompiledNetworkTestBase;
+
+TEST_F(smoke_serialization_OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
     // Create model with interpolate which v0 and v4 are supported by TypeRelaxedExtension
+    constexpr auto elementType = ov::element::f32;
+    auto core = ov::test::utils::PluginCache::get().core();
+    std::shared_ptr<ov::Model> model;
+
     {
         using ov::op::v4::Interpolate;
 
@@ -50,32 +56,82 @@ TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtensio
 
         auto result = std::make_shared<Result>(interpolate);
         result->set_friendly_name("result");
-        function = std::make_shared<ov::Model>(ov::ResultVector{result},
-                                               ov::ParameterVector{data, output_shape, scales},
-                                               "Interpolate");
-        ov::util::set_tensors_names(ov::AUTO, *function);
+        model = std::make_shared<ov::Model>(ov::ResultVector{result},
+                                            ov::ParameterVector{data, output_shape, scales},
+                                            "Interpolate");
+        ov::util::set_tensors_names(ov::AUTO, *model);
     }
 
-    auto execNet = core->compile_model(function, target_device, configuration);
+    auto execNet = core->compile_model(model, ov::test::utils::DEVICE_CPU);
     std::stringstream strm;
     execNet.export_model(strm);
 
-    ov::CompiledModel importedCompiledModel = core->import_model(strm, target_device, configuration);
-    EXPECT_EQ(function->inputs().size(), 3);
-    EXPECT_EQ(function->inputs().size(), importedCompiledModel.inputs().size());
+    auto importedCompiledModel = core->import_model(strm, ov::test::utils::DEVICE_CPU);
+    EXPECT_EQ(model->inputs().size(), 3);
+    EXPECT_EQ(model->inputs().size(), importedCompiledModel.inputs().size());
     EXPECT_NO_THROW(importedCompiledModel.input("data").get_node());
     EXPECT_THROW(importedCompiledModel.input("param"), ov::Exception);
 
-    EXPECT_EQ(function->outputs().size(), 1);
-    EXPECT_EQ(function->outputs().size(), importedCompiledModel.outputs().size());
+    EXPECT_EQ(model->outputs().size(), 1);
+    EXPECT_EQ(model->outputs().size(), importedCompiledModel.outputs().size());
     EXPECT_NO_THROW(importedCompiledModel.output());
-    EXPECT_EQ(function->output(0).get_tensor().get_names(), importedCompiledModel.output(0).get_tensor().get_names());
+    EXPECT_EQ(model->output(0).get_tensor().get_names(), importedCompiledModel.output(0).get_tensor().get_names());
     EXPECT_NO_THROW(importedCompiledModel.output("result").get_node());
     EXPECT_THROW(importedCompiledModel.output("param"), ov::Exception);
 
     EXPECT_EQ(elementType, importedCompiledModel.input("data").get_element_type());
     EXPECT_EQ(elementType, importedCompiledModel.output("result").get_element_type());
-};
+}
+
+// TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
+//     // Create model with interpolate which v0 and v4 are supported by TypeRelaxedExtension
+//     {
+//         using ov::op::v4::Interpolate;
+
+//         ov::ParameterVector inputs;
+//         auto data = std::make_shared<Parameter>(elementType, ov::PartialShape{1, 3, 64, 64});
+//         data->set_friendly_name("data");
+//         auto output_shape = std::make_shared<Parameter>(ov::element::i32, ov::PartialShape{2});
+//         output_shape->set_friendly_name("output_shape");
+//         auto scales = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{2});
+//         scales->set_friendly_name("scales");
+
+//         Interpolate::InterpolateAttrs attrs{};
+//         attrs.antialias = false;
+//         attrs.pads_begin = {0, 0, 0, 0};
+//         attrs.pads_end = {0, 0, 0, 0};
+//         attrs.cube_coeff = -0.75;
+//         auto interpolate = std::make_shared<ov::op::TypeRelaxed<Interpolate>>(data, output_shape, scales, attrs);
+
+//         auto result = std::make_shared<Result>(interpolate);
+//         result->set_friendly_name("result");
+//         function = std::make_shared<ov::Model>(ov::ResultVector{result},
+//                                                ov::ParameterVector{data, output_shape, scales},
+//                                                "Interpolate");
+//         ov::util::set_tensors_names(ov::AUTO, *function);
+//     }
+
+//     auto execNet = core->compile_model(function, target_device, configuration);
+//     std::stringstream strm;
+//     execNet.export_model(strm);
+
+//     ov::CompiledModel importedCompiledModel = core->import_model(strm, target_device, configuration);
+//     EXPECT_EQ(function->inputs().size(), 3);
+//     EXPECT_EQ(function->inputs().size(), importedCompiledModel.inputs().size());
+//     EXPECT_NO_THROW(importedCompiledModel.input("data").get_node());
+//     EXPECT_THROW(importedCompiledModel.input("param"), ov::Exception);
+
+//     EXPECT_EQ(function->outputs().size(), 1);
+//     EXPECT_EQ(function->outputs().size(), importedCompiledModel.outputs().size());
+//     EXPECT_NO_THROW(importedCompiledModel.output());
+//     EXPECT_EQ(function->output(0).get_tensor().get_names(),
+//     importedCompiledModel.output(0).get_tensor().get_names());
+//     EXPECT_NO_THROW(importedCompiledModel.output("result").get_node());
+//     EXPECT_THROW(importedCompiledModel.output("param"), ov::Exception);
+
+//     EXPECT_EQ(elementType, importedCompiledModel.input("data").get_element_type());
+//     EXPECT_EQ(elementType, importedCompiledModel.output("result").get_element_type());
+// };
 
 INSTANTIATE_TEST_SUITE_P(smoke_serialization,
                          OVCompiledGraphImportExportTest,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -26,7 +26,6 @@ const std::vector<ov::element::Type_t> netPrecisions = {
 };
 const ov::AnyMap empty_property = {};
 
-#ifdef OPENVINO_ARCH_X86_64
 using ov::op::v0::Parameter, ov::op::v0::Result;
 
 TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
@@ -77,7 +76,6 @@ TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtensio
     EXPECT_EQ(elementType, importedCompiledModel.input("data").get_element_type());
     EXPECT_EQ(elementType, importedCompiledModel.output("result").get_element_type());
 };
-#endif
 
 INSTANTIATE_TEST_SUITE_P(smoke_serialization,
                          OVCompiledGraphImportExportTest,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -11,7 +11,6 @@
 namespace {
 
 using namespace ov::test::behavior;
-using ov::op::v0::Parameter, ov::op::v0::Result;
 
 const std::vector<ov::element::Type_t> netPrecisions = {
     ov::element::i8,
@@ -27,14 +26,10 @@ const std::vector<ov::element::Type_t> netPrecisions = {
 };
 const ov::AnyMap empty_property = {};
 
-TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
-    const std::vector<ov::element::Type> unsupported_precisions{ov::element::i16, ov::element::u16, ov::element::u32, ov::element::u64};
+#ifdef OPENVINO_ARCH_X86_64
+using ov::op::v0::Parameter, ov::op::v0::Result;
 
-    if (std::find(unsupported_precisions.begin(),
-                  unsupported_precisions.end(),
-                  elementType) != unsupported_precisions.end()) {
-        GTEST_SKIP() << "Element type " << elementType << " is not supported by Interpolate v4";
-    }
+TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
     // Create model with interpolate which v0 and v4 are supported by TypeRelaxedExtension
     {
         using ov::op::v4::Interpolate;
@@ -82,6 +77,7 @@ TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtensio
     EXPECT_EQ(elementType, importedCompiledModel.input("data").get_element_type());
     EXPECT_EQ(elementType, importedCompiledModel.output("result").get_element_type());
 };
+#endif
 
 INSTANTIATE_TEST_SUITE_P(smoke_serialization,
                          OVCompiledGraphImportExportTest,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -28,9 +28,12 @@ const ov::AnyMap empty_property = {};
 
 using ov::op::v0::Parameter, ov::op::v0::Result;
 
-using smoke_serialization_OVCompiledGraphImportExportTest = OVCompiledNetworkTestBase;
+INSTANTIATE_TEST_SUITE_P(smoke_serialization,
+                         OVClassCompiledModelImportExportTestP,
+                         ::testing::Values(ov::test::utils::DEVICE_CPU),
+                         ::testing::PrintToStringParamName());
 
-TEST_F(smoke_serialization_OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
+TEST_P(OVClassCompiledModelImportExportTestP, importExportModelWithTypeRelaxedExtension) {
     // Create model with interpolate which v0 and v4 are supported by TypeRelaxedExtension
     constexpr auto elementType = ov::element::f32;
     auto core = ov::test::utils::PluginCache::get().core();
@@ -62,11 +65,11 @@ TEST_F(smoke_serialization_OVCompiledGraphImportExportTest, importExportModelWit
         ov::util::set_tensors_names(ov::AUTO, *model);
     }
 
-    auto execNet = core->compile_model(model, ov::test::utils::DEVICE_CPU);
+    auto execNet = core->compile_model(model, target_device);
     std::stringstream strm;
     execNet.export_model(strm);
 
-    auto importedCompiledModel = core->import_model(strm, ov::test::utils::DEVICE_CPU);
+    auto importedCompiledModel = core->import_model(strm, target_device);
     EXPECT_EQ(model->inputs().size(), 3);
     EXPECT_EQ(model->inputs().size(), importedCompiledModel.inputs().size());
     EXPECT_NO_THROW(importedCompiledModel.input("data").get_node());

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/behavior/compiled_model/import_export.cpp
@@ -83,56 +83,6 @@ TEST_F(smoke_serialization_OVCompiledGraphImportExportTest, importExportModelWit
     EXPECT_EQ(elementType, importedCompiledModel.output("result").get_element_type());
 }
 
-// TEST_P(OVCompiledGraphImportExportTest, importExportModelWithTypeRelaxedExtension) {
-//     // Create model with interpolate which v0 and v4 are supported by TypeRelaxedExtension
-//     {
-//         using ov::op::v4::Interpolate;
-
-//         ov::ParameterVector inputs;
-//         auto data = std::make_shared<Parameter>(elementType, ov::PartialShape{1, 3, 64, 64});
-//         data->set_friendly_name("data");
-//         auto output_shape = std::make_shared<Parameter>(ov::element::i32, ov::PartialShape{2});
-//         output_shape->set_friendly_name("output_shape");
-//         auto scales = std::make_shared<Parameter>(ov::element::f32, ov::PartialShape{2});
-//         scales->set_friendly_name("scales");
-
-//         Interpolate::InterpolateAttrs attrs{};
-//         attrs.antialias = false;
-//         attrs.pads_begin = {0, 0, 0, 0};
-//         attrs.pads_end = {0, 0, 0, 0};
-//         attrs.cube_coeff = -0.75;
-//         auto interpolate = std::make_shared<ov::op::TypeRelaxed<Interpolate>>(data, output_shape, scales, attrs);
-
-//         auto result = std::make_shared<Result>(interpolate);
-//         result->set_friendly_name("result");
-//         function = std::make_shared<ov::Model>(ov::ResultVector{result},
-//                                                ov::ParameterVector{data, output_shape, scales},
-//                                                "Interpolate");
-//         ov::util::set_tensors_names(ov::AUTO, *function);
-//     }
-
-//     auto execNet = core->compile_model(function, target_device, configuration);
-//     std::stringstream strm;
-//     execNet.export_model(strm);
-
-//     ov::CompiledModel importedCompiledModel = core->import_model(strm, target_device, configuration);
-//     EXPECT_EQ(function->inputs().size(), 3);
-//     EXPECT_EQ(function->inputs().size(), importedCompiledModel.inputs().size());
-//     EXPECT_NO_THROW(importedCompiledModel.input("data").get_node());
-//     EXPECT_THROW(importedCompiledModel.input("param"), ov::Exception);
-
-//     EXPECT_EQ(function->outputs().size(), 1);
-//     EXPECT_EQ(function->outputs().size(), importedCompiledModel.outputs().size());
-//     EXPECT_NO_THROW(importedCompiledModel.output());
-//     EXPECT_EQ(function->output(0).get_tensor().get_names(),
-//     importedCompiledModel.output(0).get_tensor().get_names());
-//     EXPECT_NO_THROW(importedCompiledModel.output("result").get_node());
-//     EXPECT_THROW(importedCompiledModel.output("param"), ov::Exception);
-
-//     EXPECT_EQ(elementType, importedCompiledModel.input("data").get_element_type());
-//     EXPECT_EQ(elementType, importedCompiledModel.output("result").get_element_type());
-// };
-
 INSTANTIATE_TEST_SUITE_P(smoke_serialization,
                          OVCompiledGraphImportExportTest,
                          ::testing::Combine(::testing::ValuesIn(netPrecisions),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -575,7 +575,7 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*EltwiseLayerCPUTest.*IS=\(\[1\.\.10\.2\.5\.6\]_\).*eltwiseOpType=SqDiff.*_configItem=INFERENCE_PRECISION_HINT=f16.*)");
     }
     // Issue 167685
-    retVector.emplace_back(R"(.*importExportModelWithTypeRelaxedExtension.*)");
+    retVector.emplace_back(R"(.*importExportModelWithTypeRelaxedExt.*)");
 #endif
 #if defined(OPENVINO_ARCH_ARM)
     retVector.emplace_back(R"(.*ActivationLayerTest.*Inference.*)");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -328,6 +328,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*CpuReservationTest.*Mutiple_CompiledModel_Reservation.*)",
         // Issue: 163351
         R"(.*CoreThreadingTestsWithIter.*nightly_AsyncInfer_ShareInput.*)",
+        // Interpolate used in the test not support all test precisions
+        R"(.*importExportModelWithTypeRelaxedExtension.*elementType=(i16|u16|u32|u64).*)",
     };
 
     // fp32 floor for bf16 models: conversion issue

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -576,6 +576,8 @@ std::vector<std::string> disabledTestPatterns() {
         retVector.emplace_back(
             R"(.*EltwiseLayerCPUTest.*IS=\(\[1\.\.10\.2\.5\.6\]_\).*eltwiseOpType=SqDiff.*_configItem=INFERENCE_PRECISION_HINT=f16.*)");
     }
+    // Issue 167685
+    retVector.emplace_back(R"(.*importExportModelWithTypeRelaxedExtension.*)");
 #endif
 #if defined(OPENVINO_ARCH_ARM)
     retVector.emplace_back(R"(.*ActivationLayerTest.*Inference.*)");

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -328,8 +328,6 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*CpuReservationTest.*Mutiple_CompiledModel_Reservation.*)",
         // Issue: 163351
         R"(.*CoreThreadingTestsWithIter.*nightly_AsyncInfer_ShareInput.*)",
-        // Interpolate used in the test not support all test precisions
-        R"(.*importExportModelWithTypeRelaxedExtension.*elementType=(i16|u16|u32|u64).*)",
     };
 
     // fp32 floor for bf16 models: conversion issue


### PR DESCRIPTION
### Details:
 - Fix export/import models which has TypeRelaxed operators by adding original operator opset version to TypeRelaxed operator version passed as runtime info
 - The proper info would be set this correct version in TypeRelaxed operator version but it still used in `ov::snippets::TargetMachine ` class in jitter map.

### Tickets:
 - CVS-166815
