### PR TITLE
Use any to store post ops

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -638,8 +638,8 @@ ExecutorPtr Convolution::createFallbackExecutor() {
     PostOps& fallbackPostOps = fallbackAttrs.postOps;
     // remove sum post-op from fallback post-ops
     auto sumPostOp =
-        std::find_if(fallbackPostOps.begin(), fallbackPostOps.end(), [](const std::shared_ptr<PostOp>& postOp) {
-            return std::dynamic_pointer_cast<SumPostOp>(postOp);
+        std::find_if(fallbackPostOps.begin(), fallbackPostOps.end(), [](const auto& postOp) {
+            return typeid(SumPostOp) == postOp.type();
         });
 
     fallbackPostOps.erase(sumPostOp, fallbackPostOps.end());

--- a/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
@@ -58,8 +58,8 @@ struct RequiresFallbackDefault {
 template <typename PostOpType>
 [[maybe_unused]] static inline bool hasPostOp(const ConvConfig& config) {
     const auto& postOps = config.attrs.postOps;
-    return any_of(postOps.begin(), postOps.end(), [](const std::shared_ptr<PostOp>& postOp) {
-        return std::dynamic_pointer_cast<PostOpType>(postOp);
+    return any_of(postOps.begin(), postOps.end(), [](const auto& postOp) {
+        return postOp.type() == typeid(PostOpType);
     });
 }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.cpp
@@ -815,7 +815,7 @@ std::shared_ptr<DnnlConvolutionPrimitive> DnnlConvolutionPrimitive::create(
 
     auto getPaddings = [&attrs](const VectorDims& dataShape, const VectorDims& weightsShape) {
         const bool fusedDWconv = std::any_of(attrs.postOps.begin(), attrs.postOps.end(), [](const auto& p) {
-            return std::dynamic_pointer_cast<DepthwiseConvolutionPostOp>(p) != nullptr;
+            return p.type() == typeid(DepthwiseConvolutionPostOp);
         });
 
         if (attrs.autoPadding == AutoPaddingType::None ||  // auto padding disabled

--- a/src/plugins/intel_cpu/src/post_ops.cpp
+++ b/src/plugins/intel_cpu/src/post_ops.cpp
@@ -174,21 +174,21 @@ PostOps getPostOps(const std::vector<NodePtr>& fused, ov::element::Type_t sumDat
     PostOps ops;
 
     auto makeActivationPostOp = [](const std::shared_ptr<node::Eltwise>& eltwise) {
-        return std::make_shared<ActivationPostOp>(convertToActivationPostOpt(eltwise->getAlgorithm()),
-                                                  eltwise->getAlpha(),
-                                                  eltwise->getBeta(),
-                                                  eltwise->getGamma());
+        return std::make_any<ActivationPostOp>(convertToActivationPostOpt(eltwise->getAlgorithm()),
+                                               eltwise->getAlpha(),
+                                               eltwise->getBeta(),
+                                               eltwise->getGamma());
     };
 
     auto makeScaleShiftPostOp = [](const std::shared_ptr<node::Eltwise>& eltwise) {
-        return std::make_shared<ScaleShiftPostOp>(convertToScaleShiftOpt(eltwise->getAlgorithm()),
-                                                  eltwise->getScales(),
-                                                  eltwise->getShifts());
+        return std::make_any<ScaleShiftPostOp>(convertToScaleShiftOpt(eltwise->getAlgorithm()),
+                                               eltwise->getScales(),
+                                               eltwise->getShifts());
     };
 
     auto makeSumPostOp = [&](const std::shared_ptr<node::Eltwise>& eltwise) {
         OPENVINO_ASSERT(sumDataType != ov::element::dynamic, "Sum data type is not defined ", eltwise->getName());
-        return std::make_shared<SumPostOp>(1.0, 0, sumDataType);
+        return std::make_any<SumPostOp>(1.0, 0, sumDataType);
     };
 
     for (const auto& node : fused) {
@@ -209,16 +209,16 @@ PostOps getPostOps(const std::vector<NodePtr>& fused, ov::element::Type_t sumDat
         }
 
         if (const auto fq = std::dynamic_pointer_cast<node::FakeQuantize>(node)) {
-            ops.push_back(std::make_shared<FakeQuantizePostOp>(convertToFqPostOp(fq->getAlgorithm()),
-                                                               fq->getCropLow(),
-                                                               fq->getCropHigh(),
-                                                               fq->getInputScale(),
-                                                               fq->getInputShift(),
-                                                               fq->getOutputScale(),
-                                                               fq->getOutputShift(),
-                                                               fq->getLevels(),
-                                                               fq->isInputLowBroadcast(),
-                                                               fq->isOutputHighBroadcast()));
+            ops.push_back(std::make_any<FakeQuantizePostOp>(convertToFqPostOp(fq->getAlgorithm()),
+                                                            fq->getCropLow(),
+                                                            fq->getCropHigh(),
+                                                            fq->getInputScale(),
+                                                            fq->getInputShift(),
+                                                            fq->getOutputScale(),
+                                                            fq->getOutputShift(),
+                                                            fq->getLevels(),
+                                                            fq->isInputLowBroadcast(),
+                                                            fq->isOutputHighBroadcast()));
         }
 
         if (const auto conv = std::dynamic_pointer_cast<node::Convolution>(node)) {
@@ -233,7 +233,7 @@ PostOps getPostOps(const std::vector<NodePtr>& fused, ov::element::Type_t sumDat
                                              dwWeightsDims[dwWeightsDims.size() - 2]};
             const auto& strides = conv->getStride();
 
-            ops.push_back(std::make_shared<DepthwiseConvolutionPostOp>(ih, iw, kernel, strides));
+            ops.push_back(std::make_any<DepthwiseConvolutionPostOp>(ih, iw, kernel, strides));
         }
     }
 

--- a/src/plugins/intel_cpu/src/post_ops.hpp
+++ b/src/plugins/intel_cpu/src/post_ops.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
+#include <any>
 
 #include "cpu_types.h"
 #include "node.h"
@@ -16,12 +17,7 @@
 
 namespace ov::intel_cpu {
 
-struct PostOp;
-using PostOps = std::vector<std::shared_ptr<PostOp>>;
-
-struct PostOp {
-    virtual ~PostOp() = default;
-};
+using PostOps = std::vector<std::any>;
 
 struct ActivationPostOp;
 using eltwiseExecutorCreatingStrategy = std::function<ExecutorPtr(const ActivationPostOp&,
@@ -30,7 +26,7 @@ using eltwiseExecutorCreatingStrategy = std::function<ExecutorPtr(const Activati
                                                                   std::vector<MemoryDescPtr>,
                                                                   const PostOps&)>;
 
-struct ActivationPostOp : PostOp {
+struct ActivationPostOp {
     enum class Type : uint8_t {
         relu,
         tanh,
@@ -87,7 +83,7 @@ private:
     const float m_gamma;
 };
 
-struct ScaleShiftPostOp : PostOp {
+struct ScaleShiftPostOp {
     enum class Type : uint8_t {
         add,
         subtract,
@@ -120,7 +116,7 @@ private:
     const std::vector<float> m_shifts;
 };
 
-struct FakeQuantizePostOp : PostOp {
+struct FakeQuantizePostOp {
     enum class Type : uint8_t { binarization, quantization_only, quantization_dequantization };
 
     FakeQuantizePostOp(const Type type,
@@ -198,7 +194,7 @@ private:
     bool m_isOutputHighBroadcasted;
 };
 
-struct DepthwiseConvolutionPostOp : PostOp {
+struct DepthwiseConvolutionPostOp {
     DepthwiseConvolutionPostOp(size_t ih, size_t iw, std::vector<size_t> kernel, std::vector<size_t> strides)
         : m_ih(ih),
           m_iw(iw),
@@ -228,7 +224,7 @@ private:
     std::vector<size_t> m_strides;
 };
 
-struct SumPostOp : PostOp {
+struct SumPostOp {
     SumPostOp(float scale, int32_t zero_point, ov::element::Type_t dataType)
         : m_scale(scale),
           m_zero_point(zero_point),
@@ -257,8 +253,6 @@ enum class EltwiseKind : uint8_t {
     ScaleShift,
     // @todo Binary?
 };
-
-using PostOps = std::vector<std::shared_ptr<PostOp>>;
 
 EltwiseKind getEltwiseKind(const Algorithm alg);
 


### PR DESCRIPTION
### Details:
Use `std::any` to store post ops instead of a base type. The main reason of this change is that the base `PostOp` type doesn't have an interface, and it looks it doesn't need to. Using `std::any` provide more flexible and less expensive mechanism to serve this purpose. 

### Tickets:
 - N/A
