### PR TITLE
[IE TESTS] Add input/output descriptor dumps for subgraph descriptions debugging

### DIFF
--- a/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
+++ b/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
@@ -230,6 +230,12 @@ public:
         return equal_parameters(lhs.m_parameter, rhs.m_parameter);
     }
 
+#ifndef NDEBUG
+    const Parameter* get_parameter() const {
+        return m_parameter;
+    }
+#endif
+
 private:
     const InputNode m_input;
     const Parameter* m_parameter;
@@ -528,6 +534,22 @@ private:
 
         if (lhs_sub_inputs.size() != rhs_sub_inputs.size() ||
             !std::is_permutation(begin(lhs_sub_inputs), end(lhs_sub_inputs), begin(rhs_sub_inputs))) {
+#ifndef NDEBUG
+            std::stringstream ss;
+            if (lhs_sub_inputs.size() != rhs_sub_inputs.size()) {
+                ss << "Different number of inputs: lhs_sub_inputs.size() = " << lhs_sub_inputs.size()
+                   << ", rhs_sub_inputs.size() == " << rhs_sub_inputs.size() << '\n';
+            }
+            ss << "Left subgraph inputs (" << lhs_sub_inputs.size() << "):\n";
+            for (size_t i = 0; i < lhs_sub_inputs.size(); i++) {
+                ss << "  " << i << ": " << lhs_sub_inputs[i].get_parameter()->get_partial_shape() << '\n';
+            }
+            ss << "Right subgraph inputs (" << rhs_sub_inputs.size() << "):\n";
+            for (size_t i = 0; i < rhs_sub_inputs.size(); i++) {
+                ss << "  " << i << ": " << rhs_sub_inputs[i].get_parameter()->get_partial_shape() << '\n';
+            }
+            std::cerr << ss.str() << std::endl;
+#endif
             return Result::error("different SubGraph InputDescription");
         }
         return Result::ok();

--- a/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
+++ b/src/tests/test_utils/common_test_utils/src/graph_comparator.cpp
@@ -327,6 +327,12 @@ public:
         return equal_results(lhs.m_result, rhs.m_result);
     }
 
+#ifndef NDEBUG
+    const Result* get_result() const {
+        return m_result;
+    }
+#endif
+
 private:
     const OutputNode m_output;
     const Result* m_result;
@@ -572,6 +578,22 @@ private:
 
         if (lhs_sub_outputs.size() != rhs_sub_outputs.size() ||
             !std::is_permutation(begin(lhs_sub_outputs), end(lhs_sub_outputs), begin(rhs_sub_outputs))) {
+#ifndef NDEBUG
+            std::stringstream ss;
+            if (lhs_sub_outputs.size() != rhs_sub_outputs.size()) {
+                ss << "Different number of outputs: lhs_sub_outputs.size() = " << lhs_sub_outputs.size()
+                   << ", rhs_sub_outputs.size() == " << rhs_sub_outputs.size() << '\n';
+            }
+            ss << "Left subgraph outputs (" << lhs_sub_outputs.size() << "):\n";
+            for (size_t i = 0; i < lhs_sub_outputs.size(); i++) {
+                ss << "  " << i << ": " << lhs_sub_outputs[i].get_result()->output(0).get_partial_shape() << '\n';
+            }
+            ss << "Right subgraph outputs (" << rhs_sub_outputs.size() << "):\n";
+            for (size_t i = 0; i < rhs_sub_outputs.size(); i++) {
+                ss << "  " << i << ": " << rhs_sub_outputs[i].get_result()->output(0).get_partial_shape() << '\n';
+            }
+            std::cerr << ss.str() << std::endl;
+#endif
             return Result::error("different SubGraph OutputDescription");
         }
         return Result::ok();


### PR DESCRIPTION
### Details:
Add debug log for `NodeAndInputDescription` parameters and and `NodeAndOutputDescription` result debugging when two subgraphs are being compared

### Tickets:
 - N/A
