### PR TITLE
scalar_tensor.default op name support (non aten version)

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/op_support.py
@@ -258,6 +258,7 @@ class OperatorSupport(OpSupport):
             "torch.ops.aten.zero.default": None,
             "torch.ops.aten.zeros.default": None,
             "torch.ops.aten.zeros_like.default": None,
+            "torch.ops.scalar_tensor.default": None,
             "torch.ops.torchvision.deform_conv2d.default": None,
             "torch.ops.torchvision.roi_align.default": None,
             "torch.ops.quantized_decomposed.quantize_per_tensor.default": None,

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -1082,6 +1082,7 @@ const std::unordered_map<std::string, CreatorFunction> get_supported_ops_fx() {
         {"aten.zeros.names", op::translate_zeros_fx},
         {"aten.zeros_like.default", op::translate_zeros_like_fx},
         {"get_attr", op::translate_constant},
+        {"scalar_tensor.default", op::translate_scalar_tensor_fx},
         {"torchvision.deform_conv2d.default", op::translate_deform_conv},
         {"torchvision.roi_align.default", op::translate_roi_align},
         {"quantized_decomposed.quantize_per_tensor.default", op::translate_quantize_per_tensor_fx},


### PR DESCRIPTION
### Details:
- "aten.scalar_tensor.default" is already supported by pytorch frontend. But some ops seems to have "scalar_tensor.default" ops in executorch flow which uses same translation as "aten.scalar_tensor.default". The PR only adds "scalar_tensor.default" into the supported ops list and op translation table.
- This PR impacts executorch llama support with export llama lib.

### Tickets:
 - https://jira.devtools.intel.com/browse/CVS-165750
