### PR TITLE
[Protopipe] Workaround for nameless tensors

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -137,11 +137,19 @@ static void cfgReshape(const std::shared_ptr<ov::Model>& model,
     model->reshape(partial_shapes);
 }
 
+static std::string make_default_tensor_name(const ov::Output<const ov::Node>& output) {
+    auto default_name = output.get_node()->get_friendly_name();
+    if (output.get_node()->get_output_size() > 1) {
+        default_name += ':' + std::to_string(output.get_index());
+    }
+    return default_name;
+}
+
 static std::vector<std::string> extractLayerNames(ov::OutputVector& ouputs) {
     std::vector<std::string> names;
-    std::transform(nodes.begin(), nodes.end(), std::back_inserter(names), [](auto& node) {
+    std::transform(ouputs.begin(), ouputs.end(), std::back_inserter(names), [](auto& node) {
         if (node.get_names().empty()) {
-            node.set_names({node.get_node()->get_friendly_name()});
+            node.set_names({make_default_tensor_name(node)});
         }
         return node.get_any_name();
     });

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -145,9 +145,9 @@ static std::string make_default_tensor_name(const ov::Output<const ov::Node>& ou
     return default_name;
 }
 
-static std::vector<std::string> extractLayerNames(ov::OutputVector& ouputs) {
+static std::vector<std::string> extractLayerNames(ov::OutputVector& outputs) {
     std::vector<std::string> names;
-    std::transform(ouputs.begin(), ouputs.end(), std::back_inserter(names), [](auto& node) {
+    std::transform(outputs.begin(), outputs.end(), std::back_inserter(names), [](auto& node) {
         if (node.get_names().empty()) {
             node.set_names({make_default_tensor_name(node)});
         }

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -137,7 +137,7 @@ static void cfgReshape(const std::shared_ptr<ov::Model>& model,
     model->reshape(partial_shapes);
 }
 
-static std::vector<std::string> extractLayerNames(std::vector<ov::Output<ov::Node>>& nodes) {
+static std::vector<std::string> extractLayerNames(ov::OutputVector& ouputs) {
     std::vector<std::string> names;
     std::transform(nodes.begin(), nodes.end(), std::back_inserter(names), [](auto& node) {
         if (node.get_names().empty()) {


### PR DESCRIPTION
### Details:
 - *Modified 'extractLayerNames' so it also sets a name to tensors in case they don't have one*

### Tickets:
 - *EISW-167740*
