### PR TITLE
[GPU] Prevent output reorder optimization for oneDNN sum post-op fusions

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -148,6 +148,7 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
             && (dep_node.get_users().size() == 1 || is_direct_ancestor(p_node, dep_node))
             && !dep_node.is_constant()
             && !p_node.is_type<pooling>()
+            && !p_node.is_output()
             && !(dep_node.get_program().is_body_program() && dep_node.is_type<input_layout>())) {
             return add_fusing_type::sum;
         } else if (p_layout.get_tensor() == d_layout.get_tensor()) {

--- a/src/plugins/intel_gpu/tests/functional/subgraph_tests/matmul_sum_fusion.cpp
+++ b/src/plugins/intel_gpu/tests/functional/subgraph_tests/matmul_sum_fusion.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "openvino/core/coordinate_diff.hpp"
+#include "openvino/core/strides.hpp"
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/constant.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/relu.hpp"
+#include "openvino/op/result.hpp"
+
+namespace {
+// Input and Weights shapes
+typedef std::pair<ov::Shape, ov::Shape> MatMulParams;
+
+class MatMulSumFusion : public testing::WithParamInterface<MatMulParams>,
+                        virtual public ov::test::SubgraphBaseStaticTest {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<MatMulParams>& params) {
+        std::pair<ov::Shape, ov::Shape> shapes;
+        shapes = params.param;
+
+        std::ostringstream result;
+        const char separator = '_';
+        result << "IS=(";
+        result << ov::test::utils::partialShape2str({shapes.first}) << separator;
+        result << ov::test::utils::partialShape2str({shapes.second}) << separator;
+        result << ")";
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = ov::test::utils::DEVICE_GPU;
+        auto type = ov::element::f16;
+        ov::Shape matmul_input_shape;
+        ov::Shape weights_shape;
+        std::pair<ov::Shape, ov::Shape> shapes;
+        shapes = GetParam();
+        matmul_input_shape = shapes.first;
+        weights_shape = shapes.second;
+
+        auto matmul_input = std::make_shared<ov::op::v0::Parameter>(type, matmul_input_shape);
+        auto weights = ov::op::v0::Constant::create(type, weights_shape, {1});
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(matmul_input, weights, false, true);
+        auto sum_input = std::make_shared<ov::op::v0::Parameter>(type, matmul->get_output_shape(0));
+        auto activation = std::make_shared<ov::op::v0::Relu>(sum_input);
+        auto sum = std::make_shared<ov::op::v1::Add>(matmul, activation);
+
+        function = std::make_shared<ov::Model>(ov::OutputVector{sum}, ov::ParameterVector{matmul_input, sum_input});
+    }
+};
+
+TEST_P(MatMulSumFusion, Inference) {
+    run();
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_GPU_MatMul, MatMulSumFusion,
+                            ::testing::Values(std::make_pair(ov::Shape{2, 32}, ov::Shape{8, 32}),
+                                              std::make_pair(ov::Shape{10, 17}, ov::Shape{5, 17})),
+                         MatMulSumFusion::getTestCaseName);
+
+}  // namespace

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -89,11 +89,14 @@ public:
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
 class FullyConnectedFusingTestOneDNN : public BaseFusingTest<fully_connected_test_params> {
+protected:
+    std::unordered_map<std::string, layout> extra_inputs;
+
 public:
     void execute(fully_connected_test_params& p, bool is_caching_test = false, bool is_dynamic = false) {
         // Onednn post operation has issue in a machine that does not support imad.
         if (!engine.get_device_info().supports_immad)
-            return;
+            GTEST_SKIP();
 
         auto input_prim = p.data_type == data_types::u8 ? get_mem(get_input_layout(p), 0, 10) : get_mem(get_input_layout(p), -1, 1);
 
@@ -111,6 +114,12 @@ public:
         network::ptr network_fused = get_network(this->engine, this->topology_fused, cfg_fused, get_test_stream_ptr(cfg_fused), is_caching_test);
         network_fused->set_input_data("input", input_prim);
         network_not_fused->set_input_data("input", input_prim);
+
+        for (const auto& [input_id, data_layout] : extra_inputs) {
+            auto data_mem = get_mem(data_layout, -1, 1);
+            network_fused->set_input_data(input_id, data_mem);
+            network_not_fused->set_input_data(input_id, data_mem);
+        }
 
         compare(*network_not_fused, *network_fused, p);
     }
@@ -598,6 +607,41 @@ INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_eltwise_add, ::testing::ValuesIn(s
     fully_connected_test_params{ CASE_FC_FP16_7, 2, 3 },
     fully_connected_test_params{ CASE_FC_FP16_3D_1, 2, 3 },
     fully_connected_test_params{ CASE_FC_FP16_3D_2, 2, 3 },
+}));
+
+class fc_fp16_eltwise_add_full_tensor : public FullyConnectedFusingTestOneDNN {
+public:
+    void run_test(bool is_caching_test = false) {
+        auto p = GetParam();
+        create_topologies(
+            input_layout("input", get_input_layout(p)),
+            input_layout("input2", get_output_layout(p)),
+            data("weights", get_mem(get_weights_layout(p), -1, 1)),
+            data("bias", get_mem(get_bias_layout(p), -2, 2)),
+            activation("activation", input_info("input2"), activation_func::relu),
+            fully_connected("fc_prim", input_info("input"), "weights", "bias", get_output_dim_size(p)),
+            eltwise("eltwise", { input_info("fc_prim"), input_info("activation") }, eltwise_mode::sum),
+            reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f16)
+        );
+
+        extra_inputs["input2"] = get_output_layout(p);
+
+        tolerance = 1e-2f;
+        execute(p, is_caching_test);
+    }
+};
+
+TEST_P(fc_fp16_eltwise_add_full_tensor, basic) {
+    run_test(false);
+}
+
+TEST_P(fc_fp16_eltwise_add_full_tensor, basic_cached) {
+    run_test(true);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_fp16_eltwise_add_full_tensor, ::testing::ValuesIn(std::vector<fully_connected_test_params>{
+    fully_connected_test_params{ CASE_FC_FP16_2, 4, 5 },
+    fully_connected_test_params{ CASE_FC_FP16_3D_1, 4, 5 },
 }));
 
 class fc_fp16_eltwise_add_dynamic : public FullyConnectedFusingTestOneDNN {};


### PR DESCRIPTION
### Details:
 - This patch prevents optimizing out reorder when a sum post-op is used, as it relies on replacing the original primitive's output buffer with a dependency input. If the output reorder is removed, it may result in reading from an incorrect memory buffer during infer request output processing

### Tickets:
 - [CVS-167293](https://jira.devtools.intel.com/browse/CVS-167293)
