### PR TITLE
[intel-npu] marking defer_weights_load property public 

### DIFF
--- a/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
+++ b/src/plugins/intel_npu/src/al/include/intel_npu/config/options.hpp
@@ -615,7 +615,7 @@ struct DEFER_WEIGHTS_LOAD final : OptionBase<DEFER_WEIGHTS_LOAD, bool> {
     }
 #endif
     static bool isPublic() {
-        return false;
+        return true;
     }
     static OptionMode mode() {
         return OptionMode::RunTime;


### PR DESCRIPTION
### Details:
 - marking defer_weights_load property public (made private by mistake)

### Tickets:
 - *ticket-id*
