### PR TITLE
[core] Expand RuntimeAttribute with member is_deterministic()

### DIFF
--- a/src/common/snippets/src/pass/hash.cpp
+++ b/src/common/snippets/src/pass/hash.cpp
@@ -319,7 +319,7 @@ void ovfunction_2_hash(uint64_t& hash,
             hash = hash_combine(hash, AttrType::rt_info);
             for (const auto& [name, attribute] : attributes) {
                 if (attribute.is<ov::RuntimeAttribute>()) {
-                    if (const auto& rt_attribute = attribute.as<ov::RuntimeAttribute>(); rt_attribute.is_hashable()) {
+                    if (const auto& rt_attribute = attribute.as<ov::RuntimeAttribute>(); rt_attribute.is_deterministic()) {
                         const auto& type_info = rt_attribute.get_type_info();
                         hash = hash_combine(hash, AttrType::attribute);
                         hash = hash_combine(hash_combine(hash, AttrType::name), type_info.name);

--- a/src/common/snippets/src/pass/hash.cpp
+++ b/src/common/snippets/src/pass/hash.cpp
@@ -317,19 +317,17 @@ void ovfunction_2_hash(uint64_t& hash,
         hash = hash_combine(hash, AttrType::data);
         auto append_runtime_info = [&](uint64_t& hash, ov::RTMap& attributes) {
             hash = hash_combine(hash, AttrType::rt_info);
-            for (auto& item : attributes) {
-                if (item.second.is<ov::RuntimeAttribute>()) {
-                    auto& rt_attribute = item.second.as<ov::RuntimeAttribute>();
-                    const auto& type_info = rt_attribute.get_type_info();
-                    if (!strcmp(type_info.name, "fused_names")) {
-                        continue;
-                    }
-                    hash = hash_combine(hash, AttrType::attribute);
-                    hash = hash_combine(hash_combine(hash, AttrType::name), type_info.name);
-                    hash = hash_combine(hash_combine(hash, AttrType::version), type_info.get_version());
+            for (const auto& [name, attribute] : attributes) {
+                if (attribute.is<ov::RuntimeAttribute>()) {
+                    if (const auto& rt_attribute = attribute.as<ov::RuntimeAttribute>(); rt_attribute.is_hashable()) {
+                        const auto& type_info = rt_attribute.get_type_info();
+                        hash = hash_combine(hash, AttrType::attribute);
+                        hash = hash_combine(hash_combine(hash, AttrType::name), type_info.name);
+                        hash = hash_combine(hash_combine(hash, AttrType::version), type_info.get_version());
 
-                    rt_info::RTInfoHasher rt_info_visitor(hash);
-                    rt_attribute.visit_attributes(rt_info_visitor);
+                        rt_info::RTInfoHasher rt_info_visitor(hash);
+                        rt_attribute.visit_attributes(rt_info_visitor);
+                    }
                 }
             }
         };

--- a/src/common/transformations/include/transformations/rt_info/fused_names_attribute.hpp
+++ b/src/common/transformations/include/transformations/rt_info/fused_names_attribute.hpp
@@ -61,7 +61,7 @@ public:
      */
     std::vector<std::string> getVectorNames() const;
 
-    bool is_hashable() const override;
+    bool is_deterministic() const override;
 
     ov::Any merge(const ov::NodeVector& nodes) const override;
 

--- a/src/common/transformations/include/transformations/rt_info/fused_names_attribute.hpp
+++ b/src/common/transformations/include/transformations/rt_info/fused_names_attribute.hpp
@@ -61,6 +61,8 @@ public:
      */
     std::vector<std::string> getVectorNames() const;
 
+    bool is_hashable() const override;
+
     ov::Any merge(const ov::NodeVector& nodes) const override;
 
     ov::Any init(const std::shared_ptr<ov::Node>& node) const override;

--- a/src/common/transformations/src/transformations/rt_info/fused_names_attribute.cpp
+++ b/src/common/transformations/src/transformations/rt_info/fused_names_attribute.cpp
@@ -82,7 +82,7 @@ std::string FusedNames::to_string() const {
     return getNames();
 }
 
-bool FusedNames::is_hashable() const {
+bool FusedNames::is_deterministic() const {
     // the names stored by this attribute can be auto generated which are not deterministic
     // and should not impact on cache hash
     return false;

--- a/src/common/transformations/src/transformations/rt_info/fused_names_attribute.cpp
+++ b/src/common/transformations/src/transformations/rt_info/fused_names_attribute.cpp
@@ -81,3 +81,9 @@ bool FusedNames::visit_attributes(AttributeVisitor& visitor) {
 std::string FusedNames::to_string() const {
     return getNames();
 }
+
+bool FusedNames::is_hashable() const {
+    // the names stored by this attribute can be auto generated which are not deterministic
+    // and should not impact on cache hash
+    return false;
+}

--- a/src/core/include/openvino/core/runtime_attribute.hpp
+++ b/src/core/include/openvino/core/runtime_attribute.hpp
@@ -27,11 +27,11 @@ public:
     virtual bool is_copyable() const;
     virtual bool is_copyable(const std::shared_ptr<Node>& to) const;
     /**
-     * @brief If attribute is hashable should be included in cache hash computation.
+     * @brief If attribute is deterministic it should be included in cache hash computation.
      *
-     * @return true if hashable otherwise false.
+     * @return true if deterministic otherwise false.
      */
-    virtual bool is_hashable() const;
+    virtual bool is_deterministic() const;
     virtual Any init(const std::shared_ptr<Node>& node) const;
     virtual Any merge(const ov::NodeVector& nodes) const;
     virtual Any merge(const ov::OutputVector& outputs) const;

--- a/src/core/include/openvino/core/runtime_attribute.hpp
+++ b/src/core/include/openvino/core/runtime_attribute.hpp
@@ -26,6 +26,12 @@ public:
     virtual ~RuntimeAttribute();
     virtual bool is_copyable() const;
     virtual bool is_copyable(const std::shared_ptr<Node>& to) const;
+    /**
+     * @brief If attribute is hashable should be included in cache hash computation.
+     *
+     * @return true if hashable otherwise false.
+     */
+    virtual bool is_hashable() const;
     virtual Any init(const std::shared_ptr<Node>& node) const;
     virtual Any merge(const ov::NodeVector& nodes) const;
     virtual Any merge(const ov::OutputVector& outputs) const;

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1072,17 +1072,13 @@ void ngfunction_2_ir(pugi::xml_node& netXml,
         // <layers/data> general attributes
         pugi::xml_node data = layer.append_child("data");
 
-        const auto is_rt_info_deterministic = deterministic ? [](const ov::RuntimeAttribute& rt_attribute){
-            return rt_attribute.is_deterministic();
-            } : [](const ov::RuntimeAttribute&) {return true;};
-
-        auto append_runtime_info = [&is_rt_info_deterministic](pugi::xml_node& node, ov::RTMap& attributes) {
+        auto append_runtime_info = [&deterministic](pugi::xml_node& node, ov::RTMap& attributes) {
             pugi::xml_node rt_node = node.append_child("rt_info");
             bool has_attrs = false;
             for (auto& item : attributes) {
                 if (item.second.is<ov::RuntimeAttribute>()) {
                     auto& rt_attribute = item.second.as<ov::RuntimeAttribute>();
-                    if (is_rt_info_deterministic(rt_attribute)) {
+                    if (!deterministic || rt_attribute.is_deterministic()) {
                         auto attribute_node = rt_node.append_child("attribute");
                         const auto& type_info = rt_attribute.get_type_info();
                         attribute_node.append_attribute("name").set_value(type_info.name);

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1072,17 +1072,17 @@ void ngfunction_2_ir(pugi::xml_node& netXml,
         // <layers/data> general attributes
         pugi::xml_node data = layer.append_child("data");
 
-        const auto is_rt_info_hashable = deterministic ? [](const ov::RuntimeAttribute& rt_attribute){
-            return rt_attribute.is_hashable();
+        const auto is_rt_info_deterministic = deterministic ? [](const ov::RuntimeAttribute& rt_attribute){
+            return rt_attribute.is_deterministic();
             } : [](const ov::RuntimeAttribute&) {return true;};
 
-        auto append_runtime_info = [&is_rt_info_hashable](pugi::xml_node& node, ov::RTMap& attributes) {
+        auto append_runtime_info = [&is_rt_info_deterministic](pugi::xml_node& node, ov::RTMap& attributes) {
             pugi::xml_node rt_node = node.append_child("rt_info");
             bool has_attrs = false;
             for (auto& item : attributes) {
                 if (item.second.is<ov::RuntimeAttribute>()) {
                     auto& rt_attribute = item.second.as<ov::RuntimeAttribute>();
-                    if (is_rt_info_hashable(rt_attribute)) {
+                    if (is_rt_info_deterministic(rt_attribute)) {
                         auto attribute_node = rt_node.append_child("attribute");
                         const auto& type_info = rt_attribute.get_type_info();
                         attribute_node.append_attribute("name").set_value(type_info.name);

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -1072,21 +1072,27 @@ void ngfunction_2_ir(pugi::xml_node& netXml,
         // <layers/data> general attributes
         pugi::xml_node data = layer.append_child("data");
 
-        auto append_runtime_info = [](pugi::xml_node& node, ov::RTMap& attributes) {
+        const auto is_rt_info_hashable = deterministic ? [](const ov::RuntimeAttribute& rt_attribute){
+            return rt_attribute.is_hashable();
+            } : [](const ov::RuntimeAttribute&) {return true;};
+
+        auto append_runtime_info = [&is_rt_info_hashable](pugi::xml_node& node, ov::RTMap& attributes) {
             pugi::xml_node rt_node = node.append_child("rt_info");
             bool has_attrs = false;
             for (auto& item : attributes) {
                 if (item.second.is<ov::RuntimeAttribute>()) {
-                    auto attribute_node = rt_node.append_child("attribute");
                     auto& rt_attribute = item.second.as<ov::RuntimeAttribute>();
-                    const auto& type_info = rt_attribute.get_type_info();
-                    attribute_node.append_attribute("name").set_value(type_info.name);
-                    attribute_node.append_attribute("version").set_value(type_info.get_version().c_str());
-                    rt_info::RTInfoSerializer serializer(attribute_node);
-                    if (!rt_attribute.visit_attributes(serializer)) {
-                        rt_node.remove_child(attribute_node);
-                    } else {
-                        has_attrs = true;
+                    if (is_rt_info_hashable(rt_attribute)) {
+                        auto attribute_node = rt_node.append_child("attribute");
+                        const auto& type_info = rt_attribute.get_type_info();
+                        attribute_node.append_attribute("name").set_value(type_info.name);
+                        attribute_node.append_attribute("version").set_value(type_info.get_version().c_str());
+                        rt_info::RTInfoSerializer serializer(attribute_node);
+                        if (!rt_attribute.visit_attributes(serializer)) {
+                            rt_node.remove_child(attribute_node);
+                        } else {
+                            has_attrs = true;
+                        }
                     }
                 }
             }

--- a/src/core/src/runtime_attribute.cpp
+++ b/src/core/src/runtime_attribute.cpp
@@ -42,7 +42,7 @@ std::ostream& operator<<(std::ostream& os, const RuntimeAttribute& attrubute) {
     return os << attrubute.to_string();
 }
 
-bool RuntimeAttribute::is_hashable() const {
+bool RuntimeAttribute::is_deterministic() const {
     return true;
 }
 

--- a/src/core/src/runtime_attribute.cpp
+++ b/src/core/src/runtime_attribute.cpp
@@ -42,4 +42,8 @@ std::ostream& operator<<(std::ostream& os, const RuntimeAttribute& attrubute) {
     return os << attrubute.to_string();
 }
 
+bool RuntimeAttribute::is_hashable() const {
+    return true;
+}
+
 }  // namespace ov

--- a/src/inference/src/dev/compilation_context.cpp
+++ b/src/inference/src/dev/compilation_context.cpp
@@ -72,7 +72,7 @@ std::string ModelCache::compute_hash(const std::shared_ptr<const ov::Model>& mod
     for (const auto& op : model->get_ordered_ops()) {
         // Skip runtime attributes which are not hash-able
         for (const auto& [name, attribute] : op->get_rt_info()) {
-            if (!attribute.is<ov::RuntimeAttribute>() || attribute.as<ov::RuntimeAttribute>().is_hashable()) {
+            if (!attribute.is<ov::RuntimeAttribute>() || attribute.as<ov::RuntimeAttribute>().is_deterministic()) {
                 seed = hash_combine(seed, name);
                 std::stringstream strm;
                 attribute.print(strm);

--- a/src/inference/src/dev/compilation_context.cpp
+++ b/src/inference/src/dev/compilation_context.cpp
@@ -70,7 +70,7 @@ std::string ModelCache::compute_hash(const std::shared_ptr<const ov::Model>& mod
 
     // 3. Add runtime information which may not be serialized
     for (const auto& op : model->get_ordered_ops()) {
-        // Skip runtime attributes which are not cashable
+        // Skip runtime attributes which are not hash-able
         for (const auto& [name, attribute] : op->get_rt_info()) {
             if (!attribute.is<ov::RuntimeAttribute>() || attribute.as<ov::RuntimeAttribute>().is_hashable()) {
                 seed = hash_combine(seed, name);

--- a/src/inference/src/dev/compilation_context.cpp
+++ b/src/inference/src/dev/compilation_context.cpp
@@ -64,18 +64,20 @@ std::string ModelCache::compute_hash(const std::shared_ptr<const ov::Model>& mod
     m.run_passes(std::const_pointer_cast<ov::Model>(model));
 
     // 2. Compute hash on serialized data and options
-    for (const auto& kvp : compileOptions) {
-        seed = hash_combine(seed, kvp.first + kvp.second.as<std::string>());
+    for (const auto& [name, option] : compileOptions) {
+        seed = hash_combine(seed, name + option.as<std::string>());
     }
 
     // 3. Add runtime information which may not be serialized
     for (const auto& op : model->get_ordered_ops()) {
-        const auto& rt = op->get_rt_info();
-        for (const auto& rtMapData : rt) {
-            seed = hash_combine(seed, rtMapData.first);
-            std::stringstream strm;
-            rtMapData.second.print(strm);
-            seed = hash_combine(seed, strm.str());
+        // Skip runtime attributes which are not cashable
+        for (const auto& [name, attribute] : op->get_rt_info()) {
+            if (!attribute.is<ov::RuntimeAttribute>() || attribute.as<ov::RuntimeAttribute>().is_hashable()) {
+                seed = hash_combine(seed, name);
+                std::stringstream strm;
+                attribute.print(strm);
+                seed = hash_combine(seed, strm.str());
+            }
         }
     }
 

--- a/src/inference/tests/unit/compilation_context_test.cpp
+++ b/src/inference/tests/unit/compilation_context_test.cpp
@@ -201,7 +201,27 @@ TEST(NetworkContext, HashWithFusedNames) {
     auto setFused = [&](Node::RTMap& rtInfo, const std::string& name) {
         rtInfo[ov::FusedNames::get_type_info_static()] = ov::FusedNames(name);
     };
-    checkCustomRt(setFusedEmpty, setFused);
+
+    auto model1 = create_simple_model();
+    auto model2 = create_simple_model();
+    auto& op1 = model1->get_ops().front()->get_rt_info();
+    auto& op2 = model2->get_ops().front()->get_rt_info();
+
+    // Fused names are excluded from hash
+    setFusedEmpty(op2);
+    EXPECT_EQ(ov::ModelCache::compute_hash(model1, {}), ov::ModelCache::compute_hash(model2, {}));
+
+    setFusedEmpty(op1);
+    EXPECT_EQ(ov::ModelCache::compute_hash(model1, {}), ov::ModelCache::compute_hash(model2, {}));
+
+    setFused(op1, "test");
+    EXPECT_EQ(ov::ModelCache::compute_hash(model1, {}), ov::ModelCache::compute_hash(model2, {}));
+
+    setFused(op2, "test");
+    EXPECT_EQ(ov::ModelCache::compute_hash(model1, {}), ov::ModelCache::compute_hash(model2, {}));
+
+    setFused(op1, "test2");
+    EXPECT_EQ(ov::ModelCache::compute_hash(model1, {}), ov::ModelCache::compute_hash(model2, {}));
 }
 
 TEST(NetworkContext, HashWithPrimitivesPriorityType) {


### PR DESCRIPTION
### Details:
 - Add new member to RuntimeAttribute to give information if attribute should be taken into hash calculation. Default value is true which means it should be used for hash. 
 - Some runtime attribute if have no deterministic values (base on some auto/random values) or have no impact on model behavior maybe considered to exclude from hash calculation to avoid multiple entries of same model in cache. The new attribute will allow OpenVINO internal or defined by user attributes to be include or excluded from hash computation.
 - Set `FusedNames` attribute to be not deterministic as stored names can be auto generated names and will not change model but will cause generating multiple entries in cache of same model.

### Tickets:
 - CVS-167799
