### PR TITLE
[GPU] Enable per-token dynamic quantization by default

### DIFF
--- a/docs/articles_en/openvino-workflow-generative/inference-with-optimum-intel.rst
+++ b/docs/articles_en/openvino-workflow-generative/inference-with-optimum-intel.rst
@@ -241,8 +241,10 @@ includes **Dynamic quantization** of activations of 4/8-bit quantized MatMuls an
   parameters. Larger group sizes lead to faster inference but lower accuracy. Recommended
   group size values are ``0``, ``32``, ``64``, or ``128``.
 
-  On Intel CPU, dynamic quantization is enabled **by default**.
-  On Intel GPU without XMX support, dynamic quantization is enabled by default.
+  On Intel CPU and Intel GPU, dynamic quantization is enabled **by default**.
+  * For Intel CPU and Intel GPU without XMX support, the default group size is ``32``.
+  * For Intel GPU with XMX support, the only supported group size is ``innermost axis`` and
+    it is turned on **by default**.
 
   To disable dynamic quantization you can either:
 

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -161,7 +161,7 @@ static constexpr Property<bool, ov::PropertyMutability::RW> disable_horizontal_f
 static constexpr Property<bool, ov::PropertyMutability::RW> disable_fc_swiglu_fusion{"GPU_DISABLE_FC_SWIGLU_FUSION"};
 static constexpr Property<bool, ov::PropertyMutability::RW> disable_fake_alignment{"GPU_DISABLE_FAKE_ALIGNMENT"};
 static constexpr Property<bool, ov::PropertyMutability::RW> disable_runtime_skip_reorder{"GPU_DISABLE_RUNTIME_SKIP_REORDER"};
-static constexpr Property<bool, ov::PropertyMutability::RW> apply_dynamic_quantization_b1{"GPU_APPLY_DYNAMIC_QUANTIZATION_B1"};
+static constexpr Property<size_t, ov::PropertyMutability::RW> dynamic_quantization_threshold{"GPU_DYNAMIC_QUANTIZATION_THRESHOLD"};
 static constexpr Property<size_t, ov::PropertyMutability::RW> usm_policy{"GPU_USM_POLICY"};
 static constexpr Property<bool, ov::PropertyMutability::RW> asym_dynamic_quantization{"GPU_ASYM_DYNAMIC_QUANTIZATION"};
 static constexpr Property<ShapePredictor::Settings, ov::PropertyMutability::RW> shape_predictor_settings{"GPU_SHAPE_PREDICTOR_SETTINGS"};

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -51,6 +51,7 @@ OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, max_kernels_per_batch, 8, "Cont
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, impls_cache_capacity, 300, "Controls capacity of LRU implementations cache that is created for each program object for dynamic models")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, asym_dynamic_quantization, false, "Enforce asymmetric mode for dynamically quantized activations")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, could_use_flashattn_v2, true, "Enable/Disable SDPA primitive executing with FlashAttenV2 online softmax tricks.")
+OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, dynamic_quantization_threshold, 64, "Apply dynamic quantization only when batch size is larger than this value in OneDNN")
 
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, help, false, "Print help message for all config options")
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, verbose, 0, "Enable logging for debugging purposes. The higher value the more verbose output. 0 - Disabled, 4 - Maximum verbosity")
@@ -82,7 +83,6 @@ OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_fc_swiglu_fusion, false, "Disable 
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_fake_alignment, false, "Disable fake alignment feature which tries to keep gpu friendly memory alignment for arbitrary tensor shapes")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_memory_reuse, false, "Disable memory reuse for activation tensors")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, disable_runtime_skip_reorder, false, "Disable skip reorder optimization applied in runtime")
-OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, apply_dynamic_quantization_b1, false, "Apply dynamic quantization for batch=1 case if dynamic quantization is turned on for OneDNN")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, load_dump_raw_binary, std::vector<std::string>{}, "List of layers to load raw binary")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, start_after_processes, std::vector<std::string>{}, "Start inference after specified list of processes")
 OV_CONFIG_DEBUG_OPTION(ov::intel_gpu, dry_run_path, "", "Enables mode which partially compiles a model and stores runtime model into specified directory")

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -20,10 +20,6 @@ static bool should_skip_execution(dynamic_quantize_node const& node, const layou
         || !act_layout.is_static())
         return false;
 
-    GPU_DEBUG_IF(node.get_program().get_config().get_apply_dynamic_quantization_b1()) {
-        return false;
-    }
-
     // Do not skip dynamic quantization if next node is not fully connected.(such as SDPA)
     OPENVINO_ASSERT(node.get_users().size() == node.get_outputs_count(),
                     "Dynamic quantization is supposed to have only one user-node with duplicated connection: ", node.id());
@@ -37,8 +33,11 @@ static bool should_skip_execution(dynamic_quantize_node const& node, const layou
         input_batch = act_layout.batch() * act_layout.feature();
     }
 
-    if (input_batch <= 64)
+    if (node.get_program().get_config().get_dynamic_quantization_threshold() >= input_batch) {
+        GPU_DEBUG_TRACE << node.id() << "  dyn_quan is turned off: input batch size is too small - " << input_batch << " / "
+                        << node.get_program().get_config().get_dynamic_quantization_threshold() << std::endl;
         return true;
+    }
 
     return false;
 }

--- a/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
+++ b/src/plugins/intel_gpu/src/graph/dynamic_quantize.cpp
@@ -37,9 +37,9 @@ static bool should_skip_execution(dynamic_quantize_node const& node, const layou
         input_batch = act_layout.batch() * act_layout.feature();
     }
 
-    if (input_batch <= 1) {
+    if (input_batch <= 64)
         return true;
-    }
+
     return false;
 }
 

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -220,8 +220,11 @@ void ExecutionConfig::finalize_impl(const IRemoteContext* context) {
     }
 
     // Enable dynamic quantization by default for non-systolic platforms
-    if (!is_set_by_user(ov::hint::dynamic_quantization_group_size) && get_dynamic_quantization_group_size() == 0 && !info.supports_immad) {
-        m_dynamic_quantization_group_size = 32;
+    if (!is_set_by_user(ov::hint::dynamic_quantization_group_size) && get_dynamic_quantization_group_size() == 0) {
+         if (info.supports_immad)
+            m_dynamic_quantization_group_size = std::numeric_limits<uint64_t>::max();
+         else
+            m_dynamic_quantization_group_size = 32;
     }
 
     if (!get_force_implementations().empty()) {

--- a/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/fully_connected_fusion_test.cpp
@@ -215,7 +215,8 @@ public:
 
 #define CASE_FC_FP16_INT4_COMP_1 { 1, 128 }, { 1, 128 }, { 128, 128 }, data_types::f16, format::bfyx, data_types::u4, format::oiyx, data_types::f16, format::bfyx
 #define CASE_FC_FP16_INT4_COMP_3D_1 { 1, 1, 128 }, { 1, 1, 128 }, { 128, 128 }, data_types::f16, format::bfyx, data_types::i4, format::oiyx, data_types::f16, format::bfyx
-#define CASE_FC_FP16_INT4_COMP_3D_2 { 1, 64, 128}, { 1, 64, 128}, { 128, 128 }, data_types::f16, format::bfyx, data_types::i4, format::oiyx, data_types::f16, format::bfyx
+#define CASE_FC_FP16_INT4_COMP_3D_2 { 1, 32, 128 }, { 1, 32, 128 }, { 128, 128 }, data_types::f16, format::bfyx, data_types::i4, format::oiyx, data_types::f16, format::bfyx
+#define CASE_FC_FP16_INT4_COMP_3D_3 { 1, 96, 128}, { 1, 96, 128}, { 128, 128 }, data_types::f16, format::bfyx, data_types::i4, format::oiyx, data_types::f16, format::bfyx
 
 #define CASE_FC_FP16_INT8_COMP_1 { 1, 128 }, { 1, 128 }, { 128, 128 }, data_types::f16, format::bfyx, data_types::u8, format::oiyx, data_types::f16, format::bfyx
 #define CASE_FC_FP16_3D_INT8_COMP_1 { 2, 32, 4 }, { 2, 32, 16 }, { 16, 4 }, data_types::f16, format::bfyx, data_types::u8, format::oiyx, data_types::f16, format::bfyx
@@ -905,8 +906,9 @@ TEST_P(fc_compressed_int8_bias_prod_unfused_dynamic_onednn, basic) {
 }
 
 INSTANTIATE_TEST_SUITE_P(fusings_gpu, fc_compressed_int8_bias_prod_unfused_dynamic_onednn, ::testing::ValuesIn(std::vector<fully_connected_test_params>{
-    fully_connected_test_params{ CASE_FC_FP16_INT4_COMP_3D_1, 2, 3 },
-    fully_connected_test_params{ CASE_FC_FP16_INT4_COMP_3D_2, 3, 3 },
+    fully_connected_test_params{ CASE_FC_FP16_INT4_COMP_3D_1, 2, 3 },   // dyn_quan is skipeed at runtime
+    fully_connected_test_params{ CASE_FC_FP16_INT4_COMP_3D_2, 2, 3 },   // dyn_quan is skipped at runtime
+    fully_connected_test_params{ CASE_FC_FP16_INT4_COMP_3D_3, 3, 3 },   // dyn_quan is not skipped
 }));
 
 class fc_fp16_eltwise_sub : public FullyConnectedFusingTestOneDNN {


### PR DESCRIPTION
### Details:
 - Enable per-token dynamic quantization on GPU with systolic array
 - Skip dynamic quantization when batch size <= 64 because it has performance overhead.

### Tickets:
 - 152994
