### PR TITLE
[GPU] support for 4bit qdq models

### DIFF
--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -442,6 +442,8 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                 return !is_type<ov::op::v0::MatMul>(next_node);
             });
 
+        manager.register_pass<ov::pass::CommonOptimizations>();
+
         // Disable subtract folding only for the dGPUs to meet the requirements of oneDNN:
         // it expects to have the same data type for weights and zero points (apply it only for u8 data type, since other compression
         // types are not supported by oneDNN)
@@ -473,8 +475,6 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                                                           keep_precision_sensitive_in_fp32_1,
                                                           convert_input_output_precision,
                                                           store_original_precision_as_rt_attribute);
-
-        manager.register_pass<ov::pass::CommonOptimizations>();
 
         ov::pass::ConvertPagedAttnInputs::KVCacheConfig kv_cache_config;
         kv_cache_config.keyCachePrecision = config.get_kv_cache_precision();

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -476,7 +476,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
         manager.register_pass<ov::pass::CommonOptimizations>();
 
-        // In the case of "input -> reshape -> convert -> multiply", 
+        // In the case of "input -> reshape -> convert -> multiply",
         // the "input -> reshape" subgraph is constant-folded in the above "CommonOptimizations"
         // To handle this case, "KeepConstPrecision" is executed again.
         manager.register_pass<ov::pass::KeepConstPrecision>(supported_woq_types, !device_info.supports_immad);

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -642,7 +642,7 @@ TEST(OVRemoteTensorTests, smoke_MixedTensorTypes) {
     cl_context ctx = gpu_context;
     auto ocl_instance = std::make_shared<OpenCL>(ctx);
 
-    ov::Shape output_shape_allocated{1, 4, 32, 32};
+    ov::Shape output_shape_allocated{1, 3, 32, 32};
     auto user_output_tensor = gpu_context.create_tensor(output->get_element_type(), output_shape_allocated);
     ov::Tensor output_tensor_copy_0(output->get_element_type(), output_shape_allocated);
     ov::Tensor output_tensor_copy_1(output->get_element_type(), output_shape_allocated);
@@ -674,8 +674,8 @@ TEST(OVRemoteTensorTests, smoke_MixedTensorTypes) {
             // Keep same output, but use larger input
             // In that case user tensor is not enough to store the result and set shape will be called on the user
             // tensor
-            ov::Shape input_shape{1, 6, 32, 32};
-            ov::Shape output_shape_actual{1, 6, 32, 32};
+            ov::Shape input_shape{1, 4, 32, 32};
+            ov::Shape output_shape_actual{1, 4, 32, 32};
             auto input_tensor = gpu_context.create_tensor(input->get_element_type(), input_shape);
 
             infer_request.set_tensor(input, input_tensor);
@@ -687,8 +687,8 @@ TEST(OVRemoteTensorTests, smoke_MixedTensorTypes) {
         {
             // Now try to increase buffer size comparing to the 1st run
             // User output buffer is supposed to be the same
-            ov::Shape input_shape{1, 4, 32, 32};
-            ov::Shape output_shape_actual{1, 4, 32, 32};
+            ov::Shape input_shape{1, 3, 32, 32};
+            ov::Shape output_shape_actual{1, 3, 32, 32};
             auto input_tensor_1 = gpu_context.create_tensor(input->get_element_type(), input_shape);
             auto data = ov::test::utils::create_and_fill_tensor(input->get_element_type(), input_shape);
             ASSERT_TRUE(input_tensor_1.is<ov::intel_gpu::ocl::ClBufferTensor>());

--- a/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
+++ b/src/plugins/intel_gpu/tests/functional/remote_tensor_tests/gpu_remote_tensor_tests.cpp
@@ -642,7 +642,7 @@ TEST(OVRemoteTensorTests, smoke_MixedTensorTypes) {
     cl_context ctx = gpu_context;
     auto ocl_instance = std::make_shared<OpenCL>(ctx);
 
-    ov::Shape output_shape_allocated{1, 3, 32, 32};
+    ov::Shape output_shape_allocated{1, 4, 32, 32};
     auto user_output_tensor = gpu_context.create_tensor(output->get_element_type(), output_shape_allocated);
     ov::Tensor output_tensor_copy_0(output->get_element_type(), output_shape_allocated);
     ov::Tensor output_tensor_copy_1(output->get_element_type(), output_shape_allocated);
@@ -674,8 +674,8 @@ TEST(OVRemoteTensorTests, smoke_MixedTensorTypes) {
             // Keep same output, but use larger input
             // In that case user tensor is not enough to store the result and set shape will be called on the user
             // tensor
-            ov::Shape input_shape{1, 4, 32, 32};
-            ov::Shape output_shape_actual{1, 4, 32, 32};
+            ov::Shape input_shape{1, 6, 32, 32};
+            ov::Shape output_shape_actual{1, 6, 32, 32};
             auto input_tensor = gpu_context.create_tensor(input->get_element_type(), input_shape);
 
             infer_request.set_tensor(input, input_tensor);
@@ -687,8 +687,8 @@ TEST(OVRemoteTensorTests, smoke_MixedTensorTypes) {
         {
             // Now try to increase buffer size comparing to the 1st run
             // User output buffer is supposed to be the same
-            ov::Shape input_shape{1, 3, 32, 32};
-            ov::Shape output_shape_actual{1, 3, 32, 32};
+            ov::Shape input_shape{1, 4, 32, 32};
+            ov::Shape output_shape_actual{1, 4, 32, 32};
             auto input_tensor_1 = gpu_context.create_tensor(input->get_element_type(), input_shape);
             auto data = ov::test::utils::create_and_fill_tensor(input->get_element_type(), input_shape);
             ASSERT_TRUE(input_tensor_1.is<ov::intel_gpu::ocl::ClBufferTensor>());


### PR DESCRIPTION
### Details:
   - Some models have a dequantization pattern like
     input(constant) --> reshape --> convert --> multiply
     - `KeepConstPrecision` pass cannot work for the input due to the reshape.
   - So, this PR updated to execute `KeepConstPrecision` one more time after `ConstantFolding`

### Tickets:
 - 167671
