### PR TITLE
[GPU] Prevent using usm_device write lock_type in Loop

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/common/loop.cpp
@@ -20,22 +20,22 @@ static int64_t read_scalar_value(memory::ptr mem, stream& stream) {
 
     switch (prim_layout.data_type) {
     case data_types::u8: {
-        mem_lock<uint8_t> lock_prim_output{mem, stream};
+        mem_lock<uint8_t, mem_lock_type::read> lock_prim_output{mem, stream};
         trip_count = *lock_prim_output.data();
         break;
     }
     case data_types::i8: {
-        mem_lock<int8_t> lock_prim_output{mem, stream};
+        mem_lock<int8_t, mem_lock_type::read> lock_prim_output{mem, stream};
         trip_count = *lock_prim_output.data();
         break;
     }
     case data_types::i32: {
-        mem_lock<int32_t> lock_prim_output{mem, stream};
+        mem_lock<int32_t, mem_lock_type::read> lock_prim_output{mem, stream};
         trip_count = *lock_prim_output.data();
         break;
     }
     case data_types::i64: {
-        mem_lock<int64_t> lock_prim_output{mem, stream};
+        mem_lock<int64_t, mem_lock_type::read> lock_prim_output{mem, stream};
         trip_count = *lock_prim_output.data();
         break;
     }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/loop_gpu_test.cpp
@@ -548,7 +548,7 @@ static void test_loop_gpu_wo_trip_count(ov::PartialShape body_input_layout,
     ASSERT_EQ(output_layout.spatial(1), e_output_layout.spatial(1));
     // value check
     {
-        mem_lock<float> output_ptr{ output_mem, get_test_stream() };
+        mem_lock<float, mem_lock_type::read> output_ptr{ output_mem, get_test_stream() };
         for (size_t i = 0, iend = output_layout.count(); i < iend; ++i) {
             ASSERT_FLOAT_EQ(output_ptr[i], expected.at(i));
         }
@@ -753,7 +753,7 @@ static void test_loop_gpu_wo_trip_count_w_multiple_shapes(ov::PartialShape body_
         ASSERT_EQ(output_layout.spatial(1), e_output_layout.spatial(1));
         // value check
         {
-            mem_lock<float> output_ptr{ output_mem, get_test_stream() };
+            mem_lock<float, mem_lock_type::read> output_ptr{ output_mem, get_test_stream() };
             for (size_t i = 0, iend = output_layout.count(); i < iend; ++i) {
                 ASSERT_FLOAT_EQ(output_ptr[i], expected.at(i));
             }
@@ -1194,7 +1194,7 @@ static void test_loop_gpu_wo_trip_count_update_primitive_id(ov::PartialShape bod
         ASSERT_EQ(output_layout.spatial(1), e_output_layout.spatial(1));
         // value check
         {
-            mem_lock<float> output_ptr{ output_mem, get_test_stream() };
+            mem_lock<float, mem_lock_type::read> output_ptr{ output_mem, get_test_stream() };
             for (size_t i = 0, iend = output_layout.count(); i < iend; ++i) {
                 ASSERT_FLOAT_EQ(output_ptr[i], expected.at(i));
             }


### PR DESCRIPTION
### Details:
 - *Use mem_lock type read for loop read_scalar*

### Tickets:
 - *167031*
