### PR TITLE
[GPU] WA: SD3.5 accuracy fix with dynamic quantization

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -493,6 +493,7 @@ void primitive_inst::update_shape() {
                         *output_shape.begin() = 0;
                         new_layouts[i].set_partial_shape(output_shape);
                     }
+                    break;
                 }
             }
         }

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -462,6 +462,41 @@ void primitive_inst::update_shape() {
     _impl_params->memory_deps = memory_deps;
 
     auto new_layouts = get_node().type()->calc_output_layouts(*_node, *_impl_params);
+
+    // WA: Skip dynamic quantization for the case where OneDNN has accuracy issue with post-op fusion
+    // This is a temporal workaround that should be removed in next release
+    if (get_node().is_type<dynamic_quantize>()) {
+        // if user instance is fully_connected, print user's input layouts
+        auto user = get_node().get_users().front();
+        if (user->is_type<fully_connected>()) {
+            auto fc_inst = _users[0];
+            auto fc_impl_params = fc_inst->get_impl_params();
+            for (auto& fd : fc_impl_params->fused_desc) {
+                if (!fd.has_outer_dep())
+                    continue;
+                const auto &layout_post_op = fc_inst->get_input_layout(fd.outer_dep_start_idx);
+                const auto &shape_post_op = layout_post_op.get_partial_shape();;
+                const auto &layout_input = _impl_params->get_input_layout(0);
+                const auto &shape_input = layout_input.get_partial_shape();
+
+                // If binary post-op is fused and its f-axis is broadcasted, skip dynamic quantization
+                if (shape_post_op.rank().is_static() && shape_post_op.rank().get_length() >= 3 &&
+                    shape_post_op[1].is_static() && shape_post_op[1].get_length() == 1 &&
+                    shape_input.rank().get_length() >= 3 &&
+                    shape_input[1].is_static() && shape_input[1].get_length() > 1 &&
+                    shape_input[0].is_static() && shape_input[0].get_length() > 1) {
+                    GPU_DEBUG_TRACE_DETAIL << fc_inst->id() << ": skip dynamic quantization because of unsupported broadcast - "
+                                    << layout_input.to_short_string() << ", " << layout_post_op.to_short_string() << std::endl;
+                    new_layouts[0] = _impl_params->get_input_layout(0);
+                    for (size_t i = 1; i < new_layouts.size(); i++) {
+                        auto output_shape = new_layouts[i].get_partial_shape();
+                        *output_shape.begin() = 0;
+                        new_layouts[i].set_partial_shape(output_shape);
+                    }
+                }
+            }
+        }
+    }
     for (size_t idx = 0; idx != new_layouts.size(); ++idx) {
         auto& new_layout = new_layouts[idx];
         if (!get_node().is_type<reshape>() || (!get_node().get_input_layout(0).data_padding.is_dynamic() && !get_node().can_be_optimized())) {
@@ -2588,6 +2623,7 @@ std::string primitive_inst::generic_to_string(program_node const& node, const ch
 cldnn::network::ptr primitive_inst::get_unfused_subgraph() {
     GPU_DEBUG_TRACE_DETAIL << id() << ": Use unfused subgraph due to unexpected fusions\n";
     if (!_unfused_subgraph) {
+        GPU_DEBUG_INFO << id() << ": [WARNING] Create unfused subgraph due to unexpected fusions\n";
         const auto has_primitive_id = [](std::vector<primitive_id> arr, const auto& target_pid) {
             return std::any_of(arr.cbegin(), arr.cend(), [&](const auto& pid) {
                 return pid == target_pid;


### PR DESCRIPTION
### Details:
 - Skip dyn_quan for unsupported case from onednn
 - When FC has binary post op and it has broadcasting in f-axis, gemm generates incorrect result

### Tickets:
 - 152994
