### PR TITLE
[ONNX] Added handling of MatMulNBits with uint8 zero point packed case

### DIFF
--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -179,10 +179,10 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                 int64_t num_per_byte = 8 / bits;
                 int64_t num_byte = (n_blocks_per_col + (num_per_byte - 1)) / num_per_byte;
                 int64_t num_elements_aligned = num_byte * num_per_byte;
-                ov::Shape casted_zp_shape = ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
-                auto casted_zp_org = std::make_shared<v0::Constant>(zp_element_type,
-                                                                    casted_zp_shape,
-                                                                    zero_points_const->get_data_ptr());
+                ov::Shape casted_zp_shape =
+                    ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
+                auto casted_zp_org =
+                    std::make_shared<v0::Constant>(zp_element_type, casted_zp_shape, zero_points_const->get_data_ptr());
                 converted_zero_points = std::make_shared<v0::Convert>(casted_zp_org, a.get_element_type());
                 if (n_blocks_per_col != num_elements_aligned) {
                     // if not align
@@ -192,7 +192,8 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                     const auto num_elements = std::make_shared<v0::Constant>(ov::element::i32,
                                                                              Shape{1},
                                                                              static_cast<int32_t>(n_blocks_per_col));
-                    converted_zero_points = std::make_shared<v8::Slice>(converted_zero_points, zero, num_elements, one, axis);
+                    converted_zero_points =
+                        std::make_shared<v8::Slice>(converted_zero_points, zero, num_elements, one, axis);
                 }
             }
         }

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -176,9 +176,9 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                                                                        zero_points_const->get_data_ptr());
             } else if (zero_points.get_element_type() == ov::element::u8) {
                 // for alignment, n_blocks_per_col might not aligned to num_per_byte
-                int64_t num_per_byte = 8 / bits;
-                int64_t num_byte = (n_blocks_per_col + (num_per_byte - 1)) / num_per_byte;
-                int64_t num_elements_aligned = num_byte * num_per_byte;
+                uint64_t num_per_byte = 8 / bits;
+                uint64_t num_byte = (n_blocks_per_col + (num_per_byte - 1)) / num_per_byte;
+                uint64_t num_elements_aligned = num_byte * num_per_byte;
                 ov::Shape casted_zp_shape =
                     ov::Shape{static_cast<size_t>(N), static_cast<size_t>(num_elements_aligned), 1};
                 auto casted_zp_org =

--- a/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
+++ b/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp
@@ -171,13 +171,12 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
             // no matter which package method, the outputs of casted_zp will be
             //   {A type or uint2/4/8, [N, n_blocks_per_col, 1]}
             const auto zero_points_const = ov::as_type_ptr<v0::Constant>(zero_points.get_node_shared_ptr());
-            ov::Shape casted_zp_shape = ov::Shape{static_cast<size_t>(N),
-                                                  static_cast<size_t>(n_blocks_per_col),
-                                                  1};
+            ov::Shape casted_zp_shape = ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1};
 
             if (zero_points.get_element_type() == a.get_element_type()) {
                 casted_zp = std::make_shared<v0::Constant>(a.get_element_type(),
-                                                           casted_zp_shape, zero_points_const->get_data_ptr());
+                                                           casted_zp_shape,
+                                                           zero_points_const->get_data_ptr());
                 converted_zero_points = casted_zp;
             } else if (zero_points.get_element_type() == ov::element::u8) {
                 if (n_blocks_per_col * bits % 8) {
@@ -188,16 +187,18 @@ ov::OutputVector matmulnbits(const ov::frontend::onnx::Node& node) {
                         ov::Shape{static_cast<size_t>(N),
                                   static_cast<size_t>(std::ceil(n_blocks_per_col * bits / 8.0f) * (8 / bits)),
                                   1};
-                    auto casted_zp_org =
-                        std::make_shared<v0::Constant>(zp_element_type,
-                                                       casted_zp_shape_org, zero_points_const->get_data_ptr());
+                    auto casted_zp_org = std::make_shared<v0::Constant>(zp_element_type,
+                                                                        casted_zp_shape_org,
+                                                                        zero_points_const->get_data_ptr());
                     casted_zp = std::make_shared<v0::Convert>(casted_zp_org, a.get_element_type());
-                    const auto element_nums =
-                        std::make_shared<v0::Constant>(ov::element::i32, Shape{1}, static_cast<int32_t>(n_blocks_per_col));
+                    const auto element_nums = std::make_shared<v0::Constant>(ov::element::i32,
+                                                                             Shape{1},
+                                                                             static_cast<int32_t>(n_blocks_per_col));
                     converted_zero_points = std::make_shared<v8::Slice>(casted_zp, zero, element_nums, one, axis);
                 } else {
                     casted_zp = std::make_shared<v0::Constant>(zp_element_type,
-                                                               casted_zp_shape, zero_points_const->get_data_ptr());
+                                                               casted_zp_shape,
+                                                               zero_points_const->get_data_ptr());
                     converted_zero_points = std::make_shared<v0::Convert>(casted_zp, a.get_element_type());
                 }
             }

--- a/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_3x32_zp.prototxt
+++ b/src/frontends/onnx/tests/models/com.microsoft/matmulnbits_3x32_zp.prototxt
@@ -1,0 +1,106 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+producer_version: ""
+model_version: 0
+graph {
+  name: "test_matmul_2d"
+  node {
+    input: "a"
+    input: "b_Q4"
+    input: "b_scales"
+    input: "b_zp"
+    output: "c"
+    op_type: "MatMulNBits"
+    attribute {
+      name: "K"
+      i: 32
+      type: INT
+    }
+    attribute {
+      name: "N"
+      i: 3
+      type: INT
+    }
+    attribute {
+      name: "accuracy_level"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "bits"
+      i: 4
+      type: INT
+    }
+    attribute {
+      name: "block_size"
+      i: 16
+      type: INT
+    }
+    domain: "com.microsoft"
+  }
+  initializer {
+    dims: 3
+    dims: 2
+    dims: 8
+    data_type: 2
+    name: "b_Q4"
+    raw_data: "\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87\x21\x43\x65\x87"
+  }
+  initializer {
+    dims: 3
+    data_type: 2
+    name: "b_zp"
+    raw_data: "\x23\x45\x56"
+  }
+  input {
+    name: "a"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "b_scales"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "c"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 7
+}
+opset_import {
+  version: 1
+}

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -1335,14 +1335,12 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_3x32_zp) {
     const auto model = convert_model("com.microsoft/matmulnbits_3x32_zp.onnx");
     auto test_case = ov::test::TestCase(model, s_device);
 
-    test_case.add_input<float>({1, 2, 3, 4,  5, 6, 7,  8, 9, 10, 1, 2, 3, 4,  5, 6, 7, 8, 9, 10, 1, 2, 3, 4,  5, 6,
-                                7, 8, 9, 10, 1, 2, 3,  4, 5, 6,  7, 8, 9, 10, 1, 2, 3, 4, 5, 6,  7, 8, 9, 10, 1, 2,
-                                3, 4, 5, 6,  7, 8, 9, 10, 1, 2, 3, 4});
+    test_case.add_input<float>({1, 2, 3, 4, 5, 6,  7, 8,  9, 10, 1, 2, 3, 4, 5, 6,  7, 8,  9, 10, 1, 2,
+                                3, 4, 5, 6, 7, 8,  9, 10, 1, 2,  3, 4, 5, 6, 7, 8,  9, 10, 1, 2,  3, 4,
+                                5, 6, 7, 8, 9, 10, 1, 2,  3, 4,  5, 6, 7, 8, 9, 10, 1, 2,  3, 4});
     test_case.add_input<float>({1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
 
-    test_case.add_expected_output<float>(
-        Shape{2, 3},
-        {312, -24, -192, 370, 26, -146});
+    test_case.add_expected_output<float>(Shape{2, 3}, {312, -24, -192, 370, 26, -146});
     test_case.run();
 }
 

--- a/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_com_microsoft.in.cpp
@@ -1331,6 +1331,21 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_3x17) {
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_matmulnbits_3x32_zp) {
+    const auto model = convert_model("com.microsoft/matmulnbits_3x32_zp.onnx");
+    auto test_case = ov::test::TestCase(model, s_device);
+
+    test_case.add_input<float>({1, 2, 3, 4,  5, 6, 7,  8, 9, 10, 1, 2, 3, 4,  5, 6, 7, 8, 9, 10, 1, 2, 3, 4,  5, 6,
+                                7, 8, 9, 10, 1, 2, 3,  4, 5, 6,  7, 8, 9, 10, 1, 2, 3, 4, 5, 6,  7, 8, 9, 10, 1, 2,
+                                3, 4, 5, 6,  7, 8, 9, 10, 1, 2, 3, 4});
+    test_case.add_input<float>({1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f});
+
+    test_case.add_expected_output<float>(
+        Shape{2, 3},
+        {312, -24, -192, 370, 26, -146});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_com_microsoft_quickgelu) {
     const auto model = convert_model("com.microsoft/quick_gelu.onnx");
     auto test_case = ov::test::TestCase(model, s_device);


### PR DESCRIPTION
JIRA ID: CVS-166707

As the ONNXRuntime spec said, when input zero_points is stored as uint8_t, it has the same packing method as input B. - [N * CeilDiv(n_blocks_per_col * bits, 8)]. If zero_points has the same type as A, it's not packed and has the same shape as Scales.

For example, if we support 4-bit MatMulNbits, zero_point is uint8, its shape should be [ N * Ceildiv(n_blocks_per_col *4), 8)].  However, for openvino onnx frontend MatMulNbits implement, it insert a reshape with output_shape = 
ov::Shape{static_cast<size_t>(N), static_cast<size_t>(n_blocks_per_col), 1}

it will throw an error when doing shape infer for reshape op, when zero point is packed as uint8.

[1] [onnxruntime/docs/ContribOperators.md at main · microsoft/onnxruntime](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftmatmulnbits)

[2] [openvino/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp at master · openvinotoolkit/openvino](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/onnx/frontend/src/op/com.microsoft/matmulnbits.cpp#L152)
