### PR TITLE
[GPU] Fix sdpa_micro kernel crash in BMG

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_micro.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_micro.cl
@@ -327,8 +327,8 @@ KERNEL(micro_sdpa)(OPTIONAL_SHAPE_INFO_ARG
     /* Prefetch first K tile. */
     cooperative_prefetch_2d_k(
             /* ptr */ K,
-            /* r */ k,
-            /* c */ d,
+            /* r */ d,
+            /* c */ k,
             /* rmax */ ugemm_kq_wg_tile_m,
             /* cmax */ PREFETCH_D_MAX,
             /* ld */ ldk,


### PR DESCRIPTION
When using with paged_attention option, the sdpa_micro kernel crash with out of resources.

CVS-162044

