### PR TITLE
[CI] [GHA] Skip the `handle_docker` step if the pipeline should be skipped

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -68,6 +68,7 @@ jobs:
         timeout-minutes: 15
 
       - uses: ./.github/actions/handle_docker
+        if: ${{ needs.smart_ci.outputs.skip_workflow != 'True' }}
         id: handle_docker
         with:
           images: |


### PR DESCRIPTION
### Details:
 - Should fix https://github.com/openvinotoolkit/openvino/actions/runs/15119713191/job/42499011503#step:6:1

### Tickets:
 - *167893*
