### PR TITLE
[Snippets] Choose correct Convert op type in precision propagation

### DIFF
--- a/src/common/snippets/src/pass/propagate_precision.cpp
+++ b/src/common/snippets/src/pass/propagate_precision.cpp
@@ -213,9 +213,12 @@ bool ov::snippets::pass::PropagatePrecision::validate_and_infer_types_and_restor
 
         if (output.get_element_type() != op_output_types[i]) {
             was_updated = true;
-            auto convert = std::make_shared<ov::snippets::op::ConvertSaturation>(
-                output,
-                op_output_types[i]);
+            std::shared_ptr<ov::Node> convert;
+            if (ov::is_type<ov::op::v0::FakeQuantize>(output.get_node())) {
+                convert = std::make_shared<ov::snippets::op::ConvertSaturation>(output, op_output_types[i]);
+            } else {
+                convert = std::make_shared<ov::snippets::op::ConvertTruncation>(output, op_output_types[i]);
+            }
             copy_runtime_info(output.get_node_shared_ptr(), convert);
 
             for (auto& input : output.get_target_inputs()) {

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -396,22 +396,11 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(.*fma.*EltwiseLayerCPUTest.*)");
     retVector.emplace_back(R"(.*int_jit.*EltwiseLayerCPUTest.*)");
     retVector.emplace_back(R"(.*dyn.*EltwiseChainTest.*)");
-    retVector.emplace_back(R"(.*smoke_EltwiseChain_MergeConvert_int8/.*InPRC0=i8.*Conversion=i8.*)");
-    retVector.emplace_back(R"(.*smoke_EltwiseChain_MergeConvert_int8/.*InPRC0=u8.*Conversion=i8.*)");
-    retVector.emplace_back(R"(.*smoke_EltwiseChain_MergeConvert_int8/.*InPRC0=i16.*Conversion=i8.*)");
-    retVector.emplace_back(R"(.*smoke_EltwiseChain_MergeConvert_int8/.*InPRC0=u16.*Conversion=i8.*)");
-    retVector.emplace_back(R"(.*smoke_EltwiseChain_MergeConvert_int8/.*InPRC0=i32.*Conversion=i8.*)");
     // by calc abs_threshold with expected value
     retVector.emplace_back(R"(.*smoke_CompareWithRefs_static/EltwiseLayerTest.*_eltwise_op_type=Div_.*_model_type=i32_.*)");
     // int8 / code-generation specific
     retVector.emplace_back(R"(smoke_LPT.*)");
     retVector.emplace_back(R"(.*smoke_RoPETest.*)");
-#endif
-
-#if defined(OPENVINO_ARCH_ARM64)
-    // Issue: 149216. For low precision model from original framework, Snippets PropagatePrecision should insert ConvertTruncation instead
-    // of ConvertSaturation when converting larger integer to smaller integer to align with c++ standard and ngraph reference.
-    retVector.emplace_back(R"(.*smoke_EltwiseChain_MergeConvert_int8/.*Op0=Prod.*Conversion=i8.*)");
 #endif
 
 #if defined(OPENVINO_ARCH_RISCV64)


### PR DESCRIPTION
### Details:
 - Align `Convert` node type with C++ standard and ngraph reference for non FQ output case

### Tickets:
 - 149216
