### PR TITLE
[GPU] turn-off dyn_quan when the shape is not supported from kernel

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/dynamic_quantize/dynamic_quantize_kernel_opt.cpp
@@ -191,26 +191,32 @@ KernelsPriority DynamicQuantizeKernelOpt::GetKernelsPriority(const Params& /*par
     return FORCE_PRIORITY_2;
 }
 
+#define LOG_AND_RETURN_FALSE(params) do { \
+    GPU_DEBUG_TRACE_DETAIL << (params).layerID << " : dynamic_quantize_opt is not supported" << std::endl; \
+    return false; \
+} while (0)
+
+
 bool DynamicQuantizeKernelOpt::Validate(const Params& params) const {
     if (!KernelBaseOpenCL::Validate(params))
-        return false;
+        LOG_AND_RETURN_FALSE(params);
 
     const auto& dq_params = static_cast<const dynamic_quantize_params&>(params);
 
 
     auto bf = get_input_bf_size(dq_params);
     if (((bf.second) % (simd * 2)) != 0)
-        return false;
+        LOG_AND_RETURN_FALSE(params);
 
     if (dq_params.inputs[0].GetPaddedVal() != 0 || dq_params.outputs[0].GetPaddedVal() != 0)
-        return false;
+        LOG_AND_RETURN_FALSE(params);
 
     if (dq_params.append_axis != -1)
-        return false;
+        LOG_AND_RETURN_FALSE(params);
 
     for (size_t i = 0; i < dq_params.group_sizes.size() - 1; i++) {
         if (dq_params.group_sizes[i] != 1)
-            return false;
+            LOG_AND_RETURN_FALSE(params);
     }
 
     // Allow only default scales order
@@ -218,14 +224,14 @@ bool DynamicQuantizeKernelOpt::Validate(const Params& params) const {
     if (!scales_output_order.empty()) {
         for (size_t i = 0; i < scales_output_order.size(); i++)
             if (scales_output_order[i] != i)
-                return false;
+                LOG_AND_RETURN_FALSE(params);
     }
 
     if (dq_params.use_asymmetric_quantization) {
         if (dq_params.combine_scales_and_zp)
-            return false;
+            LOG_AND_RETURN_FALSE(params);
         if (dq_params.outputs[0].GetDType() != Datatype::UINT8)
-            return false;
+            LOG_AND_RETURN_FALSE(params);
     }
 
     return true;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1231,8 +1231,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
 
                 auto weight_shape = root->get_input_partial_shape(1);
                 const size_t innermost_size = weight_shape[weight_shape.size() - 1].get_length();
-                if (innermost_size < 32) {
-                    GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off: shape is too small - " << innermost_size << std::endl;
+                const size_t simd = 16;
+                if (innermost_size < 32 || (innermost_size % (simd * 2) != 0)) {
+                    GPU_DEBUG_TRACE << root->get_friendly_name()
+                                    << "  dyn_quan is turned off: inner shape is not supported. It is too small or not aligned with simd*2 " << innermost_size << std::endl;
                     return true;
                 }
 


### PR DESCRIPTION
### Details:
 - Kernel support is limited for the case where inner-most shape is multiple of simd*2
 - Do not allow dynamic quantization for such case.

### Tickets:
 - 167988
