### PR TITLE
Transformation for marking a new type format

### DIFF
--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -109,5 +109,28 @@ public:
     explicit KeepDequantizationPrecision(const element::TypeVector& precisions);
 };
 
+/**
+ * Marks subgraphs where Gather receives:
+ *   - data: FP Constant → (optional Convert)
+ *   - indices: INT/UINT Constant → (optional Convert)
+ * Disables constant folding for Converts, enables keep-precision for Constants.
+ *
+ * Pattern:
+ *
+ *      [FP Constant]      [INT Constant]       [Axis]
+ *            |                  |                |
+ *      (optional Convert) (optional Convert)     |
+ *            |                  |                |
+ *            +--------+---------+--------+-------+
+ *                     |         |        |
+ *              Gather (data, indices, axis)
+ */
+class TRANSFORMATIONS_API MarkGatherSubgraph : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("MarkGatherSubgraph")
+    MarkGatherSubgraph(const element::TypeVector& fp_precisions_to_mark,
+                       const element::TypeVector& int_precisions_to_mark);
+};
+
 }  // namespace pass
 }  // namespace ov

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -131,6 +131,9 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     using namespace ov::pass;
     REGISTER_PASS(manager, InitNodeInfo)
     if (m_low_precision_enabled) {
+        // Transformation call example, to check with the real model
+        manager.register_pass<MarkGatherSubgraph>(element::TypeVector{element::f8e4m3},
+                                                  element::TypeVector{element::u4});
         manager.register_pass<ov::pass::MarkDequantization>(element::TypeVector{ov::element::i32,
                                                                                 ov::element::u32,
                                                                                 ov::element::i16,

--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -81,6 +81,8 @@ void transformation_pipeline(std::shared_ptr<ov::Model>& model) {
     REGISTER_PASS(manager, SharedOpOptimization)
 
     // 1. Set "disable_const_folding" attribute
+    // we have to add a call into the PrePostProcessing, it runs before compile_model call
+    REGISTER_PASS(manager, MarkGatherSubgraph, element::TypeVector{element::f8e4m3}, element::TypeVector{element::u4});
     REGISTER_PASS(manager,
                   MarkDequantization,
                   TypeVector{i32, u32, i16, u16, i8, u8, i4, u4, nf4, f4e2m1, f8e4m3, f8e5m2, f8e8m0});

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -22,6 +22,7 @@
 #include "openvino/opsets/opset4_decl.hpp"
 #include "openvino/opsets/opset5_decl.hpp"
 #include "openvino/opsets/opset6_decl.hpp"
+#include "openvino/pass/serialize.hpp"
 
 // Common transformations
 #include "transformations/common_optimizations/add_fake_quantize_fusion.hpp"
@@ -366,6 +367,13 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     CPU_REGISTER_PASS_ARM(decompression_handling_manager, ov::pass::TransposeMatMul);
     const auto& decompression_precisions =
         ov::intel_cpu::node::FullyConnected::getSupportedCompressedWeightsTypes(true);
+
+    // Transformation call example, to check with the real model
+    CPU_REGISTER_PASS_COMMON(decompression_handling_manager,
+                             ov::pass::MarkGatherSubgraph,
+                             element::TypeVector{element::f8e4m3},
+                             element::TypeVector{element::u4});
+
     CPU_REGISTER_PASS_COMMON(decompression_handling_manager,
                              ov::pass::MarkDequantization,
                              decompression_precisions,
@@ -402,6 +410,11 @@ void Transformations::PreLpt(const std::vector<ov::element::Type>& defaultPrecis
     ov::pass::Manager manager("Plugin:CPU");
     manager.set_per_pass_validation(false);
     if (useLpt) {
+        // Transformation call example, to check with the real model
+        CPU_REGISTER_PASS_COMMON(manager,
+                                 ov::pass::MarkGatherSubgraph,
+                                 element::TypeVector{element::f8e4m3},
+                                 element::TypeVector{element::u4});
         CPU_REGISTER_PASS_COMMON(manager, ov::pass::MarkDequantization, defaultPrecisions);
     }
 
@@ -1063,6 +1076,9 @@ void Transformations::PostLpt() {
     auto symbolic_pipeline = CPU_REGISTER_PASS_COMMON(postLPTPassManager, ov::pass::SymbolicOptimizations, false);
     symbolic_pipeline->get_manager()->register_pass<NgramFusion>();
 
+    // DEBUG: Serialize to check the model
+    // postLPTPassManager.register_pass<ov::pass::Serialize>(std::string("/workspace/buffer/codebook_xxx.xml"),
+    //                                                       "/workspace/buffer/codebook_xxx.bin");
     postLPTPassManager.run_passes(model);
 }
 


### PR DESCRIPTION
### Details:
 Marks subgraphs where Gather receives:
   - data: FP Constant → (optional Convert)
   - indices: INT/UINT Constant → (optional Convert)
 Disables constant folding for Converts, enables keep-precision for Constants.

Pattern matched by MarkGatherSubgraph

```text
[FP Constant]      [INT/UINT Constant]      [Axis]
 (keep_const_prec)  (keep_const_prec)         |
      |                   |                   |
(optional Convert)  (optional Convert)        |
  (disable_cf)        (disable_cf)            |
      |                   |                   |
      +---------+---------+---------+---------+
                |         |         |
                    Gather
           (data, indices, axis)
```

### Tickets:
 - *CVS-167084*
