### PR TITLE
[RISCV64] Implement CPU plugin just-in-time emitter for Sqrt operation

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -172,7 +172,16 @@ void jit_divide_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const 
     VReg src1 = VReg(in_vec_idxs[1]);
     VReg dst = VReg(out_vec_idxs[0]);
 
-    h->vfdiv_vv(dst, src0, src1);
+    switch (exec_prc_) {
+    case ov::element::f32:
+        h->vfdiv_vv(dst, src0, src1);
+        break;
+    case ov::element::i32:
+        h->vdiv_vv(dst, src0, src1);
+        break;
+    default:
+        OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
+    }
 }
 
 std::set<std::vector<element::Type>> jit_divide_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
@@ -844,22 +853,11 @@ void jit_sqrt_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const st
     VReg src = VReg(in_vec_idxs[0]);
     VReg dst = VReg(out_vec_idxs[0]);
 
-    switch (exec_prc_) {
-    case ov::element::f32:
-        h->vfsqrt_v(dst, src);
-        break;
-    case ov::element::i32:
-        h->vfcvt_f_x_v(dst, src);
-        h->vfsqrt_v(dst, dst);
-        h->vfcvt_x_f_v(dst, dst);
-        break;
-    default:
-        OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
-    }
+    h->vfsqrt_v(dst, src);
 }
 
 std::set<std::vector<element::Type>> jit_sqrt_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
-    return {{element::f32}, {element::i32}};
+    return {{element::f32}};
 }
 
 /// SUB ///

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -818,6 +818,50 @@ std::set<std::vector<element::Type>> jit_sigmoid_emitter::get_supported_precisio
     return {{element::f32}};
 }
 
+/// SQRT ///
+jit_sqrt_emitter::jit_sqrt_emitter(ov::intel_cpu::riscv64::jit_generator* host, ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                   const std::shared_ptr<ov::Node>& node)
+    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {}
+
+jit_sqrt_emitter::jit_sqrt_emitter(ov::intel_cpu::riscv64::jit_generator* host, ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                   const ov::element::Type exec_prc)
+    : jit_emitter(host, host_isa, exec_prc) {}
+
+size_t jit_sqrt_emitter::get_inputs_num() const {
+    return 1;
+}
+
+void jit_sqrt_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
+    if (host_isa_ == ov::intel_cpu::riscv64::cpu_isa_t::gv) {
+        emit_isa<ov::intel_cpu::riscv64::cpu_isa_t::gv>(in_vec_idxs, out_vec_idxs);
+    } else {
+        OPENVINO_THROW("Can't create jit eltwise kernel");
+    }
+}
+
+template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+void jit_sqrt_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const {
+    VReg src = VReg(in_vec_idxs[0]);
+    VReg dst = VReg(out_vec_idxs[0]);
+
+    switch (exec_prc_) {
+    case ov::element::f32:
+        h->vfsqrt_v(dst, src);
+        break;
+    case ov::element::i32:
+        h->vfcvt_f_x_v(dst, src);
+        h->vfsqrt_v(dst, dst);
+        h->vfcvt_x_f_v(dst, dst);
+        break;
+    default:
+        OV_CPU_JIT_EMITTER_THROW("Unsupported precision");
+    }
+}
+
+std::set<std::vector<element::Type>> jit_sqrt_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
+    return {{element::f32}, {element::i32}};
+}
+
 /// SUB ///
 jit_subtract_emitter::jit_subtract_emitter(ov::intel_cpu::riscv64::jit_generator* host, ov::intel_cpu::riscv64::cpu_isa_t host_isa,
                                            const std::shared_ptr<ov::Node>& node)

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -185,7 +185,7 @@ void jit_divide_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs, const 
 }
 
 std::set<std::vector<element::Type>> jit_divide_emitter::get_supported_precisions(const std::shared_ptr<ov::Node>& node) {
-    return {{element::f32, element::f32}};
+    return {{element::f32, element::f32}, {element::i32, element::i32}};
 }
 
 /// Exp ///

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
@@ -264,6 +264,24 @@ private:
     std::unique_ptr<jit_exp_emitter> jit_exp_emitter_ {nullptr};
 };
 
+class jit_sqrt_emitter : public jit_emitter {
+public:
+    jit_sqrt_emitter(ov::intel_cpu::riscv64::jit_generator* host, ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                     const ov::element::Type exec_prc = ov::element::f32);
+    jit_sqrt_emitter(ov::intel_cpu::riscv64::jit_generator* host, ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                     const std::shared_ptr<ov::Node>& node);
+
+    size_t get_inputs_num() const override;
+
+    static std::set<std::vector<element::Type>> get_supported_precisions(
+        const std::shared_ptr<ov::Node>& node = nullptr);
+
+private:
+    void emit_impl(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const override;
+    template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
+};
+
 class jit_subtract_emitter : public jit_emitter {
 public:
     jit_subtract_emitter(ov::intel_cpu::riscv64::jit_generator* host, ov::intel_cpu::riscv64::cpu_isa_t host_isa,

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -815,6 +815,7 @@ public:
                     Algorithm::EltwisePrelu,
                     Algorithm::EltwiseRelu,
                     Algorithm::EltwiseSigmoid,
+                    Algorithm::EltwiseSqrt,
                     Algorithm::EltwiseSubtract)) {
             return false;
         }

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -276,7 +276,7 @@ void jit_uni_eltwise_generic<isa>::load_vector(size_t vec_idx, const Xbyak_riscv
         vfcvt_f_x_v(src_vec(vec_idx), src_vec(vec_idx)); // int32 -> fp32
 
     if (one_of(dst_prc, ov::element::i32) && one_of(src_prc, ov::element::f16, ov::element::f32))
-        vfcvt_rtz_x_f_v(src_vec(vec_idx), src_vec(vec_idx)); // fp32 -> int32 (round-toward-zero)
+        vfcvt_x_f_v(src_vec(vec_idx), src_vec(vec_idx)); // fp32 -> int32
 }
 
 template <ov::intel_cpu::riscv64::cpu_isa_t isa>
@@ -285,7 +285,7 @@ void jit_uni_eltwise_generic<isa>::store_vector(const Xbyak_riscv::Reg& gpr_work
     OPENVINO_ASSERT(one_of(src_prc, ov::element::f32, ov::element::i32), "Unsupported src prc");
 
     if (one_of(src_prc, ov::element::f32) && one_of(dst_prc, ov::element::i8, ov::element::u8, ov::element::i32))
-        vfcvt_rtz_x_f_v(dst_vec(), dst_vec()); // fp32 -> int32 (round-toward-zero)
+        vfcvt_x_f_v(dst_vec(), dst_vec()); // fp32 -> int32
 
     if (one_of(src_prc, ov::element::i32) && one_of(dst_prc, ov::element::f16, ov::element::f32))
         vfcvt_f_x_v(dst_vec(), dst_vec()); // int32 -> fp32

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -419,6 +419,7 @@ std::shared_ptr<jit_emitter> jit_uni_eltwise_generic<isa>::create_eltwise_emitte
         OV_CASE(Algorithm::EltwisePrelu, jit_prelu_emitter),
         OV_CASE(Algorithm::EltwiseRelu, jit_relu_emitter),
         OV_CASE(Algorithm::EltwiseSigmoid, jit_sigmoid_emitter),
+        OV_CASE(Algorithm::EltwiseSqrt, jit_sqrt_emitter),
         OV_CASE(Algorithm::EltwiseSubtract, jit_subtract_emitter));
 
     if (!ctx.emitter) {
@@ -546,6 +547,7 @@ std::set<std::vector<element::Type>> eltwise_precision_helper::get_supported_pre
               OV_CASE(Algorithm::EltwisePrelu, jit_prelu_emitter),
               OV_CASE(Algorithm::EltwiseRelu, jit_relu_emitter),
               OV_CASE(Algorithm::EltwiseSigmoid, jit_sigmoid_emitter),
+              OV_CASE(Algorithm::EltwiseSqrt, jit_sqrt_emitter),
               OV_CASE(Algorithm::EltwiseSubtract, jit_subtract_emitter));
 
     if (precisions.empty()) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -236,7 +236,8 @@ std::string ActivationLayerCPUTest::getPrimitiveType(const utils::ActivationType
             (activation_type == utils::ActivationTypes::LeakyRelu) ||
             (activation_type == utils::ActivationTypes::Relu) ||
             (activation_type == utils::ActivationTypes::PReLu) ||
-            (activation_type == utils::ActivationTypes::Sigmoid) )
+            (activation_type == utils::ActivationTypes::Sigmoid) ||
+            (activation_type == utils::ActivationTypes::Sqrt))
             return "jit";
     }
 #if defined(OV_CPU_WITH_SHL)


### PR DESCRIPTION
### Details:
 - *Create fp32 Sqrt operation JIT Emitter for RISCV64 platform with RVV1.0 support*
 - *Implement JIT Emitter in the JIT Executor*
 - *Modify RISCV64 kernel to apply developed JIT emitter*

### Testing:
- ***Pass**: Verified with QEMU test ../bin/riscv64/Release/ov_cpu_func_tests --gtest_filter="*smoke*Activation*Sqrt*"
![image](https://github.com/user-attachments/assets/926c5b1b-37dd-423f-8b34-1439a902899a)

### Related Issue:
https://github.com/openvinotoolkit/openvino/issues/30246
