### PR TITLE
[GPU] Fix typos in layer info keys in GPU graphs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/convolution.cpp
+++ b/src/plugins/intel_gpu/src/graph/convolution.cpp
@@ -178,8 +178,8 @@ std::string convolution_inst::to_string(convolution_node const& node) {
     conv_info.add("dilation", cldnn::to_string(dilation));
     conv_info.add("deformable_groups", desc->deformable_groups);
     conv_info.add("groups", desc->groups);
-    conv_info.add("has zero points for weights: ", w_zp);
-    conv_info.add("has zero points for activations: ", a_zp);
+    conv_info.add("has zero points for weights", w_zp);
+    conv_info.add("has zero points for activations", a_zp);
     node_info->add("convolution info", conv_info);
     node_info->dump(primitive_description);
 

--- a/src/plugins/intel_gpu/src/graph/detection_output.cpp
+++ b/src/plugins/intel_gpu/src/graph/detection_output.cpp
@@ -143,7 +143,7 @@ std::string detection_output_inst::to_string(detection_output_node const& node) 
     detec_out_info.add("input location id", input_location.id());
     detec_out_info.add("input confidence id", input_confidence.id());
     detec_out_info.add("input prior box id", input_prior_box.id());
-    detec_out_info.add("num_classes:", desc->num_classes);
+    detec_out_info.add("num_classes", desc->num_classes);
     detec_out_info.add("keep_top_k", desc->keep_top_k);
     detec_out_info.add("share_location", share_location);
     detec_out_info.add("background_label_id", desc->background_label_id);

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -314,13 +314,13 @@ std::string gemm_inst::to_string(gemm_node const& node) {
     gemm_info.add("beam_table", (desc->beam_table.is_valid() ? desc->beam_table.pid : "N/A"));
     gemm_info.add("alpha", alpha);
     gemm_info.add("beta", beta);
-    gemm_info.add("trasnpose_input0", transpose_input0);
+    gemm_info.add("transpose_input0", transpose_input0);
     gemm_info.add("transpose_input1", transpose_input1);
     gemm_info.add("indirect_input0", indirect_input0);
     gemm_info.add("indirect_input1", indirect_input1);
-    gemm_info.add("trasnpose_order_input0", desc->input0_transpose_order);
-    gemm_info.add("trasnpose_order_input1", desc->input1_transpose_order);
-    gemm_info.add("trasnpose_order_output", desc->output_transpose_order);
+    gemm_info.add("transpose_order_input0", desc->input0_transpose_order);
+    gemm_info.add("transpose_order_input1", desc->input1_transpose_order);
+    gemm_info.add("transpose_order_output", desc->output_transpose_order);
     node_info->add("gemm info", gemm_info);
     node_info->dump(primitive_description);
 

--- a/src/plugins/intel_gpu/src/graph/random_uniform.cpp
+++ b/src/plugins/intel_gpu/src/graph/random_uniform.cpp
@@ -72,7 +72,7 @@ std::string random_uniform_inst::to_string(random_uniform_node const &node) {
     json_composite random_uniform_info;
     random_uniform_info.add("input id", node.input().id());
     random_uniform_info.add("min_value id", node.input(1).id());
-    random_uniform_info.add("max_value  id", node.input(2).id());
+    random_uniform_info.add("max_value id", node.input(2).id());
     random_uniform_info.add("global_seed", node.get_primitive()->global_seed);
     random_uniform_info.add("op_seed", node.get_primitive()->op_seed);
     node_info->add("random uniform info", random_uniform_info);


### PR DESCRIPTION
### Details:
- This small PR fixes several typos in keys used to add layer-specific info to GPU plugin debug graphs