### PR TITLE
Keep dequantization subgraph output as inference precision for GPU plugin

### DIFF
--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -9,7 +9,6 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/unsqueeze.hpp"
-#include "openvino/op/util/precision_sensitive_attribute.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
@@ -351,19 +350,8 @@ ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element
                 disable_fp16_compression(node_ptr);
             }
         }
-        
-        auto multiply_users = multiply->get_users();
-        for (const auto& user : multiply_users) {
-            for (size_t idx = 0; idx < user->inputs().size(); ++idx) {
-                if (user->get_input_node_shared_ptr(idx) == multiply) {
-                    auto new_convert = std::make_shared<v0::Convert>(multiply, multiply->get_output_element_type(0));
-                    ov::mark_as_precision_sensitive(new_convert->input(0));
-                    user->input(idx).replace_source_output(new_convert->output(0));
-                }
-            }
-        }
 
-        return true;
+        return false;
     };
 
     auto m = std::make_shared<Matcher>(multiply_pattern, "KeepDequantizationPrecision");

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -9,6 +9,7 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/precision_sensitive_attribute.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/pattern.hpp"
@@ -350,8 +351,19 @@ ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element
                 disable_fp16_compression(node_ptr);
             }
         }
+        
+        auto multiply_users = multiply->get_users();
+        for (const auto& user : multiply_users) {
+            for (size_t idx = 0; idx < user->inputs().size(); ++idx) {
+                if (user->get_input_node_shared_ptr(idx) == multiply) {
+                    auto new_convert = std::make_shared<v0::Convert>(multiply, multiply->get_output_element_type(0));
+                    ov::mark_as_precision_sensitive(new_convert->input(0));
+                    user->input(idx).replace_source_output(new_convert->output(0));
+                }
+            }
+        }
 
-        return false;
+        return true;
     };
 
     auto m = std::make_shared<Matcher>(multiply_pattern, "KeepDequantizationPrecision");

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_dequantization_fp16.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_dequantization_fp16.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "convert_dequantization_fp16.hpp"
+
+#include "openvino/op/multiply.hpp"
+#include "openvino/op/reshape.hpp"
+#include "openvino/op/subtract.hpp"
+#include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/precision_sensitive_attribute.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/pass/pattern/op/optional.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "transformations/rt_info/dequantization_node.hpp"
+#include "transformations/rt_info/disable_constant_folding.hpp"
+#include "transformations/rt_info/keep_const_precision.hpp"
+#include "transformations/utils/utils.hpp"
+
+namespace ov::intel_gpu {
+
+ConvertDequantizationFP16::ConvertDequantizationFP16(const element::TypeVector& precisions) {
+    add_matcher<ConvertDequantizationFP16Matcher>(precisions);
+}
+
+ConvertDequantizationFP16Matcher::ConvertDequantizationFP16Matcher(const element::TypeVector& precisions) {
+    using namespace ov::op;
+    using namespace ov::pass::pattern;
+
+    auto input_pattern = any_input(type_matches_any(precisions));
+    auto convert_pattern = wrap_type<v0::Convert>({input_pattern}, consumers_count(1));
+
+    // zero points:
+    auto zp_pattern = any_input();
+    auto zp_convert_pattern = optional<v0::Convert>(zp_pattern);
+    auto zp_reshape_pattern = optional<v1::Reshape, v0::Unsqueeze>({zp_convert_pattern, any_input()});
+    auto subtract_pattern = optional<v1::Subtract>({convert_pattern, zp_reshape_pattern});
+
+    // scale:
+    auto scale_pattern = any_input();
+    auto scale_convert_pattern = optional<v0::Convert>(scale_pattern);
+    auto scale_reshape_pattern = optional<v1::Reshape, v0::Unsqueeze>({scale_convert_pattern, any_input()});
+    auto multiply_pattern = wrap_type<v1::Multiply>({subtract_pattern, scale_reshape_pattern});
+
+    ov::matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
+        const auto& pattern_map = m.get_pattern_value_map();
+        auto multiply = m.get_match_root();
+        
+        auto multiply_users = multiply->get_users();
+        for (const auto& user : multiply_users) {
+            for (size_t idx = 0; idx < user->inputs().size(); ++idx) {
+                if (user->get_input_node_shared_ptr(idx) == multiply) {
+                    auto new_convert = std::make_shared<v0::Convert>(multiply, multiply->get_output_element_type(0));
+                    ov::mark_as_precision_sensitive(new_convert->input(0));
+                    user->input(idx).replace_source_output(new_convert->output(0));
+                }
+            }
+        }
+
+        return true;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(multiply_pattern, "ConvertDequantizationFP16Matcher");
+    this->register_matcher(m, callback);
+}
+
+}  // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations/convert_dequantization_fp16.hpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/convert_dequantization_fp16.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov::intel_gpu {
+
+class ConvertDequantizationFP16: public ov::pass::GraphRewrite {
+public:
+    OPENVINO_GRAPH_REWRITE_RTTI("ConvertDequantizationFP16");
+    ConvertDequantizationFP16(const element::TypeVector& precisions);
+};
+
+/**
+ * @brief 
+
+ */
+class ConvertDequantizationFP16Matcher: public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("ConvertDequantizationFP16Matcher");
+    ConvertDequantizationFP16Matcher(const element::TypeVector& precisions);
+};
+
+}   // namespace ov::intel_gpu

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -68,6 +68,7 @@
 #include "plugin/transformations/binary_conv_to_conv.hpp"
 #include "plugin/transformations/clamp_fp16_output.hpp"
 #include "plugin/transformations/convert_convolution.hpp"
+#include "plugin/transformations/convert_dequantization_fp16.hpp"
 #include "plugin/transformations/convert_fc_to_compressed.hpp"
 #include "plugin/transformations/convert_matmul_to_fc.hpp"
 #include "plugin/transformations/convert_stridedslices_to_variadicsplit.hpp"
@@ -466,6 +467,9 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         const bool store_original_precision_as_rt_attribute = true;
 
         manager.register_pass<ov::pass::KeepDequantizationPrecision>(
+            ov::element::TypeVector{ov::element::i32, ov::element::u32, ov::element::u16});
+
+        manager.register_pass<ov::intel_gpu::ConvertDequantizationFP16>(
             ov::element::TypeVector{ov::element::i32, ov::element::u32, ov::element::u16});
 
         manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,


### PR DESCRIPTION
### Details:
 - Insert convert op as subgraph endpoint for identified u16, i32, u32 dequantization subgraph, in order to keep constant folding to compute in fp32 but output as the current inference precision (fp16) for GPU plugin.

### Tickets:
 - [CVS-167484](https://jira.devtools.intel.com/browse/CVS-167484)