### PR TITLE
[ONNX] Added support for float16 and bfloat16 for DequantizeLinear

### DIFF
--- a/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
+++ b/src/frontends/onnx/frontend/src/op/dequantize_linear.cpp
@@ -27,35 +27,38 @@ namespace ov {
 namespace frontend {
 namespace onnx {
 namespace ai_onnx {
+namespace opset_1 {
 namespace detail {
 std::shared_ptr<ov::Node> get_zero_point(const ov::OutputVector& inputs) {
     if (inputs.size() == 3 && !ov::op::util::is_null(inputs[2])) {
+        const auto& scale = inputs[1];
         const auto& zero_point = inputs[2];
 
-        if (zero_point.get_element_type() != ov::element::f32) {
-            return std::make_shared<v0::Convert>(zero_point, ov::element::f32);
+        if (zero_point.get_element_type() != scale.get_element_type()) {
+            return std::make_shared<v0::Convert>(zero_point, scale.get_element_type());
         }
 
         return zero_point.get_node_shared_ptr();
     }
     return nullptr;
 }
-}  // namespace detail
-namespace opset_1 {
-ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
-    const ov::OutputVector inputs{node.get_ov_inputs()};
 
-    FRONT_END_GENERAL_CHECK(2 <= inputs.size() && inputs.size() <= 3,
-                            "The DequantizeLinear op expects 2 required and one optional input. Got: ",
-                            inputs.size());
+ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node, int64_t opset) {
+    const ov::OutputVector inputs{node.get_ov_inputs()};
 
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
     const auto zero_point = detail::get_zero_point(inputs);
 
-    common::validate_scalar_input("Dequantization scale", scale.get_node_shared_ptr(), {ov::element::f32});
+    std::set<ov::element::Type> valid_types = {ov::element::f32};
+    if (opset >= 13) {
+        valid_types.emplace(ov::element::f16);
+        valid_types.emplace(ov::element::bf16);
+    }
 
-    const auto converted_x = std::make_shared<v0::Convert>(x, ov::element::f32);
+    common::validate_scalar_input("Dequantization scale", scale.get_node_shared_ptr(), valid_types);
+
+    const auto converted_x = std::make_shared<v0::Convert>(x, scale.get_element_type());
 
     if (zero_point) {
         common::validate_scalar_input("Zero point", zero_point);
@@ -64,6 +67,14 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
         return {std::make_shared<v1::Multiply>(converted_x, scale)};
     }
 }
+}  // namespace detail
+
+ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
+    common::default_op_checks(node, 2);
+
+    return detail::dequantize_linear(node, 1);
+}
+
 ONNX_OP("DequantizeLinear", {1, 12}, ai_onnx::opset_1::dequantize_linear);
 }  // namespace opset_1
 
@@ -154,7 +165,7 @@ ov::OutputVector dequantize_linear(const ov::Output<ov::Node>& x,
 
     validate_scale(scale, x, axis);
     const auto scale_reshaped = reshape_input(scale, axis, x_shape);
-    const auto converted_x = std::make_shared<v0::Convert>(x, ov::element::f32);
+    const auto converted_x = std::make_shared<v0::Convert>(x, scale.get_element_type());
 
     if (zero_point) {
         validate_zero_point(zero_point, x, axis);
@@ -176,19 +187,19 @@ ov::OutputVector dequantize_linear(const ov::frontend::onnx::Node& node) {
                             inputs.size());
     const auto& x = inputs[0];
     const auto& scale = inputs[1];
-    const auto zero_point = ai_onnx::detail::get_zero_point(inputs);
+    const auto zero_point = ai_onnx::opset_1::detail::get_zero_point(inputs);
 
     const auto& scale_shape = scale.get_partial_shape();
     // per-tensor quantization, axis attribute ignored
     if ((scale_shape.rank().is_static() && scale_shape.size() == 0) ||
         (scale_shape.is_static() && shape_size(scale_shape.get_shape()) == 1)) {
         if (!zero_point) {
-            return ai_onnx::opset_1::dequantize_linear(node);
+            return ai_onnx::opset_1::detail::dequantize_linear(node, 13);
         }
         const auto& zero_point_shape = zero_point->get_output_partial_shape(0);
         if ((zero_point_shape.rank().is_static() && zero_point_shape.size() == 0) ||
             (zero_point_shape.is_static() && shape_size(zero_point_shape.get_shape()) == 1)) {
-            return ai_onnx::opset_1::dequantize_linear(node);
+            return ai_onnx::opset_1::detail::dequantize_linear(node, 13);
         }
     }
     // these reshapes make sure that dequantization happens over the specified axis

--- a/src/frontends/onnx/tests/models/dequantize_linear_0_bf16.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_0_bf16.prototxt
@@ -1,0 +1,62 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "x_scale"
+    input: "x_zero_point"
+    output: "y"
+    name: "node1"
+    op_type: "DequantizeLinear"
+  }
+  name: "test"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 2
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "x_scale"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "x_zero_point"
+    type {
+      tensor_type {
+        elem_type: 2
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 16
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 19
+}

--- a/src/frontends/onnx/tests/models/dequantize_linear_0_fp16.prototxt
+++ b/src/frontends/onnx/tests/models/dequantize_linear_0_fp16.prototxt
@@ -1,0 +1,62 @@
+ir_version: 3
+producer_name: "OpenVINO ONNX Frontend"
+graph {
+  node {
+    input: "x"
+    input: "x_scale"
+    input: "x_zero_point"
+    output: "y"
+    name: "node1"
+    op_type: "DequantizeLinear"
+  }
+  name: "test"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 2
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "x_scale"
+    type {
+      tensor_type {
+        elem_type: 10
+        shape {
+        }
+      }
+    }
+  }
+  input {
+    name: "x_zero_point"
+    type {
+      tensor_type {
+        elem_type: 2
+        shape {
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 10
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 19
+}

--- a/src/frontends/onnx/tests/onnx_import_quant.in.cpp
+++ b/src/frontends/onnx/tests/onnx_import_quant.in.cpp
@@ -214,6 +214,30 @@ OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_ui
     test_case.run();
 }
 
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_fp16_zero_scale_uint8) {
+    auto model = convert_model("dequantize_linear_0_fp16.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input(std::vector<uint8_t>{0, 3, 128, 255});  // x
+    test_case.add_input(std::vector<ov::float16>{2.0f});        // scale
+    test_case.add_input(std::vector<uint8_t>{128});             // zero_point
+
+    test_case.add_expected_output<ov::float16>({4}, std::vector<ov::float16>{-256.0f, -250.0f, 0.0f, 254.0f});
+    test_case.run();
+}
+
+OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_bf16_zero_scale_uint8) {
+    auto model = convert_model("dequantize_linear_0_bf16.onnx");
+
+    auto test_case = ov::test::TestCase(model, s_device);
+    test_case.add_input(std::vector<uint8_t>{0, 3, 128, 255});  // x
+    test_case.add_input(std::vector<ov::bfloat16>{2.0f});        // scale
+    test_case.add_input(std::vector<uint8_t>{128});             // zero_point
+
+    test_case.add_expected_output<ov::bfloat16>({4}, std::vector<ov::bfloat16>{-256.0f, -250.0f, 0.0f, 254.0f});
+    test_case.run();
+}
+
 OPENVINO_TEST(${BACKEND_NAME}, onnx_model_dequantize_linear_scalar_zero_scale_uint16) {
     auto model = convert_model("dequantize_linear_u16.onnx");
 


### PR DESCRIPTION
### Details:
 - Added native support of float16 and bfloat16 scale/output for DequantizeLinear opset 13 and higher

### Tickets:
 - 165534
