### PR TITLE
[NPU] Remove unnecessary type conversions

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -44,7 +44,7 @@ void check_level_zero_attributes_match(const IODescriptor& ioDescriptor, const A
                     " vs. ",
                     zeDescriptorName,
                     ". The I/O order may have been altered, which could lead to an erroneous behavior.");
-    OPENVINO_ASSERT(zeroUtils::getZePrecision(ioDescriptor.precision) == zeDescriptor.info.devicePrecision,
+    OPENVINO_ASSERT(ioDescriptor.precision == zeroUtils::toOVElementType(zeDescriptor.info.devicePrecision),
                     "Precision mismatch for input/output named " + ioDescriptor.nameFromCompiler);
 
     const std::vector<size_t>& ovDimensions = ioDescriptor.shapeFromCompiler.get_max_shape();

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -11,6 +11,7 @@
 #include "intel_npu/prefix.hpp"
 #include "intel_npu/utils/zero/zero_api.hpp"
 #include "intel_npu/utils/zero/zero_result.hpp"
+#include "intel_npu/utils/zero/zero_utils.hpp"
 #include "intel_npu/utils/zero/zero_wrappers.hpp"
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/model.hpp"
@@ -34,61 +35,6 @@
 #define NotSupportArgumentMetadata(T) (T < ZE_GRAPH_EXT_VERSION_1_6)
 
 #define UseCopyForNativeBinary(T) (T < ZE_GRAPH_EXT_VERSION_1_7)
-
-namespace {
-
-ov::element::Type_t toOVElementType(const ze_graph_argument_precision_t zeElementType) {
-    switch (zeElementType) {
-    case ZE_GRAPH_ARGUMENT_PRECISION_UNKNOWN:
-        return ov::element::Type_t::dynamic;
-    case ZE_GRAPH_ARGUMENT_PRECISION_DYNAMIC:
-        return ov::element::Type_t::dynamic;
-    case ZE_GRAPH_ARGUMENT_PRECISION_BOOLEAN:
-        return ov::element::Type_t::boolean;
-    case ZE_GRAPH_ARGUMENT_PRECISION_NF4:
-        return ov::element::Type_t::nf4;
-    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E4M3:
-        return ov::element::Type_t::f8e4m3;
-    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E5M2:
-        return ov::element::Type_t::f8e5m2;
-    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E8M0:
-        return ov::element::Type_t::f8e8m0;
-    case ZE_GRAPH_ARGUMENT_PRECISION_BF16:
-        return ov::element::Type_t::bf16;
-    case ZE_GRAPH_ARGUMENT_PRECISION_FP16:
-        return ov::element::Type_t::f16;
-    case ZE_GRAPH_ARGUMENT_PRECISION_FP32:
-        return ov::element::Type_t::f32;
-    case ZE_GRAPH_ARGUMENT_PRECISION_FP64:
-        return ov::element::Type_t::f64;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT4:
-        return ov::element::Type_t::i4;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT8:
-        return ov::element::Type_t::i8;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT16:
-        return ov::element::Type_t::i16;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT32:
-        return ov::element::Type_t::i32;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT64:
-        return ov::element::Type_t::i64;
-    case ZE_GRAPH_ARGUMENT_PRECISION_BIN:
-        return ov::element::Type_t::u1;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT4:
-        return ov::element::Type_t::u4;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT8:
-        return ov::element::Type_t::u8;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT16:
-        return ov::element::Type_t::u16;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT32:
-        return ov::element::Type_t::u32;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT64:
-        return ov::element::Type_t::u64;
-    default:
-        return ov::element::Type_t::dynamic;
-    }
-}
-
-}  // namespace
 
 namespace intel_npu {
 
@@ -402,7 +348,7 @@ ze_graph_handle_t ZeGraphExtWrappers::getGraphHandle(const uint8_t& blobData, si
  */
 static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                                     const std::optional<ze_graph_argument_metadata_t>& metadata) {
-    ov::element::Type_t precision = toOVElementType(arg.devicePrecision);
+    ov::element::Type_t precision = zeroUtils::toOVElementType(arg.devicePrecision);
     ov::Shape shapeFromCompiler;
     ov::PartialShape shapeFromIRModel;
     std::unordered_set<std::string> outputTensorNames;

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -63,129 +63,55 @@ static inline ze_command_queue_priority_t toZeQueuePriority(const ov::hint::Prio
     }
 }
 
-static inline std::size_t precisionToSize(const ze_graph_argument_precision_t val) {
-    switch (val) {
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT4:
-        return 4;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT4:
-        return 4;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT8:
-        return 8;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT8:
-        return 8;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT16:
-        return 16;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT16:
-        return 16;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT32:
-        return 32;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT32:
-        return 32;
-    case ZE_GRAPH_ARGUMENT_PRECISION_INT64:
-        return 64;
-    case ZE_GRAPH_ARGUMENT_PRECISION_UINT64:
-        return 64;
+static inline ov::element::Type_t toOVElementType(const ze_graph_argument_precision_t zeElementType) {
+    switch (zeElementType) {
+    case ZE_GRAPH_ARGUMENT_PRECISION_UNKNOWN:
+        return ov::element::Type_t::dynamic;
+    case ZE_GRAPH_ARGUMENT_PRECISION_DYNAMIC:
+        return ov::element::Type_t::dynamic;
+    case ZE_GRAPH_ARGUMENT_PRECISION_BOOLEAN:
+        return ov::element::Type_t::boolean;
     case ZE_GRAPH_ARGUMENT_PRECISION_NF4:
-        return 4;
+        return ov::element::Type_t::nf4;
+    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E4M3:
+        return ov::element::Type_t::f8e4m3;
+    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E5M2:
+        return ov::element::Type_t::f8e5m2;
+    case ZE_GRAPH_ARGUMENT_PRECISION_FP8_E8M0:
+        return ov::element::Type_t::f8e8m0;
     case ZE_GRAPH_ARGUMENT_PRECISION_BF16:
-        return 16;
+        return ov::element::Type_t::bf16;
     case ZE_GRAPH_ARGUMENT_PRECISION_FP16:
-        return 16;
+        return ov::element::Type_t::f16;
     case ZE_GRAPH_ARGUMENT_PRECISION_FP32:
-        return 32;
+        return ov::element::Type_t::f32;
     case ZE_GRAPH_ARGUMENT_PRECISION_FP64:
-        return 64;
+        return ov::element::Type_t::f64;
+    case ZE_GRAPH_ARGUMENT_PRECISION_INT4:
+        return ov::element::Type_t::i4;
+    case ZE_GRAPH_ARGUMENT_PRECISION_INT8:
+        return ov::element::Type_t::i8;
+    case ZE_GRAPH_ARGUMENT_PRECISION_INT16:
+        return ov::element::Type_t::i16;
+    case ZE_GRAPH_ARGUMENT_PRECISION_INT32:
+        return ov::element::Type_t::i32;
+    case ZE_GRAPH_ARGUMENT_PRECISION_INT64:
+        return ov::element::Type_t::i64;
     case ZE_GRAPH_ARGUMENT_PRECISION_BIN:
-        return 1;
+        return ov::element::Type_t::u1;
+    case ZE_GRAPH_ARGUMENT_PRECISION_UINT4:
+        return ov::element::Type_t::u4;
+    case ZE_GRAPH_ARGUMENT_PRECISION_UINT8:
+        return ov::element::Type_t::u8;
+    case ZE_GRAPH_ARGUMENT_PRECISION_UINT16:
+        return ov::element::Type_t::u16;
+    case ZE_GRAPH_ARGUMENT_PRECISION_UINT32:
+        return ov::element::Type_t::u32;
+    case ZE_GRAPH_ARGUMENT_PRECISION_UINT64:
+        return ov::element::Type_t::u64;
     default:
-        OPENVINO_THROW("precisionToSize switch->default reached");
+        return ov::element::Type_t::dynamic;
     }
-}
-
-static inline ze_graph_argument_precision_t getZePrecision(const ov::element::Type_t precision) {
-    switch (precision) {
-    case ov::element::Type_t::i4:
-        return ZE_GRAPH_ARGUMENT_PRECISION_INT4;
-    case ov::element::Type_t::u4:
-        return ZE_GRAPH_ARGUMENT_PRECISION_UINT4;
-    case ov::element::Type_t::i8:
-        return ZE_GRAPH_ARGUMENT_PRECISION_INT8;
-    case ov::element::Type_t::u8:
-        return ZE_GRAPH_ARGUMENT_PRECISION_UINT8;
-    case ov::element::Type_t::i16:
-        return ZE_GRAPH_ARGUMENT_PRECISION_INT16;
-    case ov::element::Type_t::u16:
-        return ZE_GRAPH_ARGUMENT_PRECISION_UINT16;
-    case ov::element::Type_t::i32:
-        return ZE_GRAPH_ARGUMENT_PRECISION_INT32;
-    case ov::element::Type_t::u32:
-        return ZE_GRAPH_ARGUMENT_PRECISION_UINT32;
-    case ov::element::Type_t::i64:
-        return ZE_GRAPH_ARGUMENT_PRECISION_INT64;
-    case ov::element::Type_t::u64:
-        return ZE_GRAPH_ARGUMENT_PRECISION_UINT64;
-    case ov::element::Type_t::nf4:
-        return ZE_GRAPH_ARGUMENT_PRECISION_NF4;
-    case ov::element::Type_t::f8e4m3:
-        return ZE_GRAPH_ARGUMENT_PRECISION_FP8_E4M3;
-    case ov::element::Type_t::f8e5m2:
-        return ZE_GRAPH_ARGUMENT_PRECISION_FP8_E5M2;
-    case ov::element::Type_t::f8e8m0:
-        return ZE_GRAPH_ARGUMENT_PRECISION_FP8_E8M0;
-    case ov::element::Type_t::bf16:
-        return ZE_GRAPH_ARGUMENT_PRECISION_BF16;
-    case ov::element::Type_t::f16:
-        return ZE_GRAPH_ARGUMENT_PRECISION_FP16;
-    case ov::element::Type_t::f32:
-        return ZE_GRAPH_ARGUMENT_PRECISION_FP32;
-    case ov::element::Type_t::f64:
-        return ZE_GRAPH_ARGUMENT_PRECISION_FP64;
-    case ov::element::Type_t::u1:
-        return ZE_GRAPH_ARGUMENT_PRECISION_BIN;
-    default:
-        return ZE_GRAPH_ARGUMENT_PRECISION_UNKNOWN;
-    }
-}
-
-static inline std::size_t layoutCount(const ze_graph_argument_layout_t val) {
-    switch (val) {
-    case ZE_GRAPH_ARGUMENT_LAYOUT_NCHW:
-        return 4;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_NHWC:
-        return 4;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_NCDHW:
-        return 5;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_NDHWC:
-        return 5;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_OIHW:
-        return 4;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_C:
-        return 1;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_CHW:
-        return 3;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_HW:
-        return 2;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_NC:
-        return 2;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_CN:
-        return 2;
-    case ZE_GRAPH_ARGUMENT_LAYOUT_ANY:
-        // When input has empty shape, val is ZE_GRAPH_ARGUMENT_LAYOUT_ANY
-        // Add this to pass Single Layer Test on Windows
-        return 0;
-    default:
-        OPENVINO_THROW("layoutCount switch->default reached");
-    }
-}
-
-static inline std::size_t getSizeIOBytes(const ze_graph_argument_properties_3_t& argument) {
-    std::size_t num_elements = 1;
-    for (std::size_t i = 0; i < layoutCount(argument.deviceLayout); ++i) {
-        num_elements *= argument.dims[i];
-    }
-    const std::size_t size_in_bits = num_elements * precisionToSize(argument.devicePrecision);
-    const std::size_t size_in_bytes = (size_in_bits + (CHAR_BIT - 1)) / CHAR_BIT;
-    return size_in_bytes;
 }
 
 static inline uint32_t findCommandQueueGroupOrdinal(


### PR DESCRIPTION
### Details:
- *If ZE_GRAPH_ARGUMENT_PRECISION_BOOLEAN is reported by the driver, the plugin will fail to convert to an element type*
 - *Too many type conversions to keep updated when a new type is supported. Removing unnecessary conversions*

### Tickets:
 - *E#167996*
