### PR TITLE
[CPU][BUG] Random incorrect score value for PagedAttention if `score_aggregation_window` enabled

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -2538,7 +2538,7 @@ struct MHAHelper {
                             score_block_ptr,
                             reinterpret_cast<DATA_TYPE*>(score),
                             1,
-                            rnd_up(cur_kv_len, _block_size),
+                            cur_kv_len,
                             0,
                             0,
                             0);


### PR DESCRIPTION
### Details:
 - *Wrong padding value may result the `cvt_add` to override next header's score value, in multithread environment if next header is slower than current header the score will be incorrect. Since the `cvt_add` handles tails, the padding is removed.*
 - *Port from #30692*

### Tickets:
 - *ticket-id*
