### PR TITLE
[CORE] Fix ov::util::create_directory_recursive on relative path

### DIFF
--- a/src/common/util/src/file_util.cpp
+++ b/src/common/util/src/file_util.cpp
@@ -293,7 +293,8 @@ void ov::util::create_directory_recursive(const std::wstring& path) {
 
 void ov::util::create_directory_recursive(const std::filesystem::path& path) {
     namespace fs = std::filesystem;
-    auto dir_path = fs::weakly_canonical(path);
+
+    auto dir_path = path;
     if (!dir_path.has_filename() || dir_path.has_extension()) {
         dir_path = get_directory(dir_path);
     }


### PR DESCRIPTION
### Details:
Fix cases when `fs::weakly_canonical` fails with an error
E.g.:
```cpp
ov::util::create_directory_recursive("dir_name")
```

### Tickets:
 - N/A
