### PR TITLE
[GPU] Match sliding window calculation between pagedAttention and SDPA

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
@@ -1306,7 +1306,7 @@ KERNEL(sdpa_opt)(
 #if IS_CAUSAL
                     // casual mask: valid only if m >= n
 #if defined(IS_PAGED_ATTENTION) && SLIDING_WINDOW_SIZE != 0
-                    if ((seq_len + i <= target_seq_idx + sglid) && (target_seq_idx + sglid < SLIDING_WINDOW_SIZE || seq_len + i >= target_seq_idx + sglid - SLIDING_WINDOW_SIZE)) {
+                    if ((seq_len + i <= target_seq_idx + sglid) && (target_seq_idx + sglid < SLIDING_WINDOW_SIZE || seq_len + i > target_seq_idx + sglid - SLIDING_WINDOW_SIZE)) {
 #else
                     if (seq_len + i <= target_seq_idx + sglid) {
 #endif


### PR DESCRIPTION
There is some mismatch between sliding window implementation in pagedAttention with SDPA attention mask.  The pagedAttention for multi token is off by one row.
