### PR TITLE
[Experiment][NPU] Dynamic batching via BatchMode::PLUGIN

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -89,6 +89,7 @@ private:
     std::unique_ptr<Pipeline> _pipeline;
 
     bool _pipelineIsCreated = false;
+    bool _pipelineNeedsReallocation = false;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -19,7 +19,8 @@ public:
              const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
              const std::shared_ptr<IGraph>& graph,
              const std::vector<std::vector<std::shared_ptr<ov::ITensor>>>& input_tensors,
-             const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors);
+             const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors,
+             size_t batch_size = 1);
 
     Pipeline(const Pipeline&) = delete;
     Pipeline& operator=(const Pipeline&) = delete;

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -95,8 +95,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
             continue;
         }
 
-        get_level_zero_input(ioIndex) =
-            allocate_tensor(inputDescriptor, ioIndex, INPUT, *_inputAllocator, batchSize);
+        get_level_zero_input(ioIndex) = allocate_tensor(inputDescriptor, ioIndex, INPUT, *_inputAllocator, batchSize);
 
         ++ioIndex;
     }
@@ -128,15 +127,15 @@ void ZeroInferRequest::create_pipeline() {
             //     _logger.debug("ZeroInferRequest::create_pipeline - tensors %s were already allocated",
             //                   _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
             // } else {
-                for (size_t i = 0; i < get_user_inputs(inputIndex).size(); i++) {
-                    get_level_zero_inputs(inputIndex).resize(get_user_inputs(inputIndex).size());
+            for (size_t i = 0; i < get_user_inputs(inputIndex).size(); i++) {
+                get_level_zero_inputs(inputIndex).resize(get_user_inputs(inputIndex).size());
 
-                    _logger.debug("ZeroInferRequest::create_pipeline - allocate new input tensor for batched input: %s",
-                                  _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
+                _logger.debug("ZeroInferRequest::create_pipeline - allocate new input tensor for batched input: %s",
+                              _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
 
-                    get_level_zero_input(inputIndex, i) =
-                        allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator, batch_size);
-                }
+                get_level_zero_input(inputIndex, i) =
+                    allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator, batch_size);
+            }
             // }
             continue;
         }
@@ -149,11 +148,8 @@ void ZeroInferRequest::create_pipeline() {
 
         _logger.debug("ZeroInferRequest::create_pipeline - allocate new input tensor %s",
                       _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
-        get_level_zero_input(inputIndex) = allocate_tensor(_metadata.inputs.at(inputIndex),
-                                                           inputIndex,
-                                                           INPUT,
-                                                           *_inputAllocator,
-                                                           batch_size);
+        get_level_zero_input(inputIndex) =
+            allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, INPUT, *_inputAllocator, batch_size);
     }
 
     for (size_t outputIndex = 0; outputIndex < _metadata.outputs.size(); ++outputIndex) {
@@ -164,11 +160,8 @@ void ZeroInferRequest::create_pipeline() {
         }
         _logger.debug("ZeroInferRequest::create_pipeline - allocate new output tensor %s",
                       _metadata.outputs.at(outputIndex).nodeFriendlyName.c_str());
-        _levelZeroOutputTensors.at(outputIndex) = allocate_tensor(_metadata.outputs.at(outputIndex),
-                                                                  outputIndex,
-                                                                  OUTPUT,
-                                                                  *_outputAllocator,
-                                                                  batch_size);
+        _levelZeroOutputTensors.at(outputIndex) =
+            allocate_tensor(_metadata.outputs.at(outputIndex), outputIndex, OUTPUT, *_outputAllocator, batch_size);
     }
     _logger.debug("ZeroInferRequest::create_pipeline - init completed");
 
@@ -198,8 +191,12 @@ void ZeroInferRequest::create_pipeline() {
     _logger.debug("ZeroInferRequest::create_pipeline - constructing pipeline");
 
     // Construct pipeline
-    _pipeline =
-        std::make_unique<Pipeline>(_config, _initStructs, _graph, _levelZeroInputTensors, _levelZeroOutputTensors, batch_size.has_value() ? batch_size.value() : 1);
+    _pipeline = std::make_unique<Pipeline>(_config,
+                                           _initStructs,
+                                           _graph,
+                                           _levelZeroInputTensors,
+                                           _levelZeroOutputTensors,
+                                           batch_size.has_value() ? batch_size.value() : 1);
 
     _logger.debug("ZeroInferRequest::create_pipeline - SyncInferRequest completed");
 }
@@ -379,8 +376,11 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                         _logger.debug("ZeroInferRequest::set_tensors - tensor wasn't created in the same L0 context, "
                                       "create a L0 tensor");
 
-                        get_level_zero_input(foundPort.idx, i) =
-                            allocate_tensor(_metadata.inputs.at(foundPort.idx), foundPort.idx, true, *_inputAllocator, batch_size);
+                        get_level_zero_input(foundPort.idx, i) = allocate_tensor(_metadata.inputs.at(foundPort.idx),
+                                                                                 foundPort.idx,
+                                                                                 true,
+                                                                                 *_inputAllocator,
+                                                                                 batch_size);
                     }
 
                     data = get_level_zero_input(foundPort.idx, i)->data();
@@ -439,11 +439,8 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
     std::vector<ov::SoPtr<ov::ITensor>> tensorVector = {userTensors};
     auto batch_size = _graph->get_batch_size(_metadata, tensorVector);
 
-    levelZeroTensors = allocate_tensor(metadata,
-                                       ioIndex,
-                                       isInput,
-                                       isInput ? *_inputAllocator : *_outputAllocator,
-                                       batch_size);
+    levelZeroTensors =
+        allocate_tensor(metadata, ioIndex, isInput, isInput ? *_inputAllocator : *_outputAllocator, batch_size);
 
     auto zeroTensor = std::dynamic_pointer_cast<ZeroTensor>(levelZeroTensors);
     if (zeroTensor != nullptr) {
@@ -560,9 +557,9 @@ void ZeroInferRequest::infer_async() {
 
         if (!_pipelineIsCreated || _pipelineNeedsReallocation) {
             OV_ITT_TASK_NEXT(ZERO_INFER, "create_pipeline");
-            create_pipeline(); // Reallocate pipeline if necessary
+            create_pipeline();  // Reallocate pipeline if necessary
             _pipelineIsCreated = true;
-            _pipelineNeedsReallocation = false; // Reset reallocation flag
+            _pipelineNeedsReallocation = false;  // Reset reallocation flag
         } else {
             if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
                 update_pipeline_if_memory_changed();

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -86,6 +86,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
     _logger.debug("ZeroInferRequest::ZeroInferRequest - checking level zero attributes and allocating tensors");
 
     size_t ioIndex = 0;
+    auto batchSize = _graph->get_batch_size(_metadata, _userInputTensors.at(0));
     for (const IODescriptor& inputDescriptor : _metadata.inputs) {
         check_level_zero_attributes_match(inputDescriptor, _graphInputDescriptors.at(ioIndex));
 
@@ -95,7 +96,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
         }
 
         get_level_zero_input(ioIndex) =
-            allocate_tensor(inputDescriptor, ioIndex, INPUT, *_inputAllocator, _graph->get_batch_size());
+            allocate_tensor(inputDescriptor, ioIndex, INPUT, *_inputAllocator, batchSize);
 
         ++ioIndex;
     }
@@ -110,7 +111,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
         }
 
         _levelZeroOutputTensors.at(ioIndex) =
-            allocate_tensor(outputDescriptor, ioIndex, OUTPUT, *_outputAllocator, _graph->get_batch_size());
+            allocate_tensor(outputDescriptor, ioIndex, OUTPUT, *_outputAllocator, batchSize);
 
         ++ioIndex;
     }
@@ -119,12 +120,14 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
 }
 
 void ZeroInferRequest::create_pipeline() {
+    _logger.debug("ZeroInferRequest::create_pipeline");
+    auto batch_size = _graph->get_batch_size(_metadata, _userInputTensors.at(0));
     for (size_t inputIndex = 0; inputIndex < _metadata.inputs.size(); ++inputIndex) {
-        if (is_batched_input(inputIndex) && _graph->get_batch_size().has_value()) {
-            if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
-                _logger.debug("ZeroInferRequest::create_pipeline - tensors %s were already allocated",
-                              _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
-            } else {
+        if (batch_size.has_value()) {
+            // if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
+            //     _logger.debug("ZeroInferRequest::create_pipeline - tensors %s were already allocated",
+            //                   _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
+            // } else {
                 for (size_t i = 0; i < get_user_inputs(inputIndex).size(); i++) {
                     get_level_zero_inputs(inputIndex).resize(get_user_inputs(inputIndex).size());
 
@@ -132,9 +135,9 @@ void ZeroInferRequest::create_pipeline() {
                                   _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
 
                     get_level_zero_input(inputIndex, i) =
-                        allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator);
+                        allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator, batch_size);
                 }
-            }
+            // }
             continue;
         }
 
@@ -150,7 +153,7 @@ void ZeroInferRequest::create_pipeline() {
                                                            inputIndex,
                                                            INPUT,
                                                            *_inputAllocator,
-                                                           _graph->get_batch_size());
+                                                           batch_size);
     }
 
     for (size_t outputIndex = 0; outputIndex < _metadata.outputs.size(); ++outputIndex) {
@@ -165,7 +168,7 @@ void ZeroInferRequest::create_pipeline() {
                                                                   outputIndex,
                                                                   OUTPUT,
                                                                   *_outputAllocator,
-                                                                  _graph->get_batch_size());
+                                                                  batch_size);
     }
     _logger.debug("ZeroInferRequest::create_pipeline - init completed");
 
@@ -196,7 +199,7 @@ void ZeroInferRequest::create_pipeline() {
 
     // Construct pipeline
     _pipeline =
-        std::make_unique<Pipeline>(_config, _initStructs, _graph, _levelZeroInputTensors, _levelZeroOutputTensors);
+        std::make_unique<Pipeline>(_config, _initStructs, _graph, _levelZeroInputTensors, _levelZeroOutputTensors, batch_size.has_value() ? batch_size.value() : 1);
 
     _logger.debug("ZeroInferRequest::create_pipeline - SyncInferRequest completed");
 }
@@ -220,11 +223,15 @@ void ZeroInferRequest::set_tensor_data(const std::shared_ptr<ov::ITensor>& tenso
             _logger.debug("ZeroInferRequest::set_tensor_data - create locally L0 tensor");
             OV_ITT_TASK_NEXT(ZERO_SET_TENSOR, "allocate tensor");
 
+            ov::SoPtr<ov::ITensor> soPtrTensor(tensor);
+            std::vector<ov::SoPtr<ov::ITensor>> tensorVector = {soPtrTensor};
+            auto batch = _graph->get_batch_size(_metadata, tensorVector);
+
             levelZeroTensors = allocate_tensor(isInput ? _metadata.inputs.at(index) : _metadata.outputs.at(index),
                                                index,
                                                isInput,
                                                isInput ? *_inputAllocator : *_outputAllocator,
-                                               _graph->get_batch_size());
+                                               batch);
 
             updateCommandListArg = true;
         }
@@ -287,7 +294,8 @@ void ZeroInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
             _logger.debug("ZeroInferRequest::set_tensor - got the same tensor, do nothing");
             return;
         }
-        if (is_batched_input(foundPort.idx)) {
+        std::vector<ov::SoPtr<ov::ITensor>> tensorVector = {tensor};
+        if (is_batched_input(foundPort.idx) || _graph->get_batch_size(_metadata, tensorVector).has_value()) {
             // resize vector size to 1 if set_tensor is called after set_tensors
             get_level_zero_inputs(foundPort.idx).resize(1);
             get_level_zero_inputs(foundPort.idx).shrink_to_fit();
@@ -337,8 +345,11 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
     get_user_inputs(foundPort.idx).resize(tensors.size());
     get_user_inputs(foundPort.idx) = tensors;
 
+    _logger.debug("ZeroInferRequest::set_tensors");
+    auto batch_size = _graph->get_batch_size(_metadata, tensors);
+
     if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
-        if (_graph->get_batch_size().has_value()) {
+        if (batch_size) {
             for (size_t i = 0; i < tensors.size(); i++) {
                 auto remoteTensor = std::dynamic_pointer_cast<ZeroRemoteTensor>(tensors[i]._ptr);
 
@@ -362,7 +373,7 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                                       "create a L0 tensor");
 
                         get_level_zero_input(foundPort.idx, i) =
-                            allocate_tensor(_metadata.inputs.at(foundPort.idx), foundPort.idx, true, *_inputAllocator);
+                            allocate_tensor(_metadata.inputs.at(foundPort.idx), foundPort.idx, true, *_inputAllocator, batch_size);
                     }
 
                     data = get_level_zero_input(foundPort.idx, i)->data();
@@ -418,11 +429,13 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
 
     auto& levelZeroTensors = isInput ? get_level_zero_input(ioIndex) : _levelZeroOutputTensors.at(ioIndex);
 
+    auto batch_size = _graph->get_batch_size(_metadata, _userOutputTensors);
+
     levelZeroTensors = allocate_tensor(metadata,
                                        ioIndex,
                                        isInput,
                                        isInput ? *_inputAllocator : *_outputAllocator,
-                                       _graph->get_batch_size());
+                                       batch_size);
 
     auto zeroTensor = std::dynamic_pointer_cast<ZeroTensor>(levelZeroTensors);
     if (zeroTensor != nullptr) {
@@ -565,8 +578,9 @@ void ZeroInferRequest::infer_async() {
             }
         }
 
-        if (is_batched_input(inputIndex)) {
-            if (_graph->get_batch_size().has_value()) {
+        auto batch_size = _graph->get_batch_size(_metadata, _userInputTensors.at(inputIndex));
+        if (is_batched_input(inputIndex) || batch_size.has_value()) {
+            if (batch_size.has_value()) {
                 for (size_t i = 0; i < userTensor.size(); i++) {
                     if (!is_remote_tensor(get_level_zero_input(inputIndex, i))) {
                         void* levelZeroBuffer = get_level_zero_input(inputIndex, i)->data();

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -348,6 +348,13 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
     _logger.debug("ZeroInferRequest::set_tensors");
     auto batch_size = _graph->get_batch_size(_metadata, tensors);
 
+    // Check if any tensor has a greater shape than expected
+    if (tensors.size() > _levelZeroInputTensors.at(foundPort.idx).size() && batch_size.value() != tensors.size()) {
+        batch_size = tensors.size();
+        _graph->set_batch_size(tensors.size());
+        _pipelineNeedsReallocation = true;
+    }
+
     if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
         if (batch_size) {
             for (size_t i = 0; i < tensors.size(); i++) {
@@ -429,7 +436,8 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
 
     auto& levelZeroTensors = isInput ? get_level_zero_input(ioIndex) : _levelZeroOutputTensors.at(ioIndex);
 
-    auto batch_size = _graph->get_batch_size(_metadata, _userOutputTensors);
+    std::vector<ov::SoPtr<ov::ITensor>> tensorVector = {userTensors};
+    auto batch_size = _graph->get_batch_size(_metadata, tensorVector);
 
     levelZeroTensors = allocate_tensor(metadata,
                                        ioIndex,
@@ -550,11 +558,11 @@ void ZeroInferRequest::infer_async() {
     {
         std::lock_guard<std::mutex> lock(_graph->get_mutex());
 
-        if (!_pipelineIsCreated) {
+        if (!_pipelineIsCreated || _pipelineNeedsReallocation) {
             OV_ITT_TASK_NEXT(ZERO_INFER, "create_pipeline");
-            create_pipeline();
-
+            create_pipeline(); // Reallocate pipeline if necessary
             _pipelineIsCreated = true;
+            _pipelineNeedsReallocation = false; // Reset reallocation flag
         } else {
             if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
                 update_pipeline_if_memory_changed();

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -35,7 +35,7 @@ Pipeline::Pipeline(const Config& config,
         _graph->resize_last_submitted_event(_number_of_command_lists);
     }
 
-    _logger.debug("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
+    _logger.info("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||
                         _init_structs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -34,7 +34,7 @@ Pipeline::Pipeline(const Config& config,
         _config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
         _graph->resize_last_submitted_event(_number_of_command_lists);
     }
-    
+
     _logger.debug("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -20,7 +20,8 @@ Pipeline::Pipeline(const Config& config,
                    const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                    const std::shared_ptr<IGraph>& graph,
                    const std::vector<std::vector<std::shared_ptr<ov::ITensor>>>& input_tensors,
-                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors, size_t batch_size)
+                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors,
+                   size_t batch_size)
     : _init_structs(init_structs),
       _graph(graph),
       _config(config),
@@ -35,7 +36,9 @@ Pipeline::Pipeline(const Config& config,
         _graph->resize_last_submitted_event(_number_of_command_lists);
     }
 
-    _logger.info("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
+    _logger.info("Pipeline - initialize started, batch %i, number_of_command_lists %i",
+                 batch,
+                 _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||
                         _init_structs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -16,20 +16,26 @@
 #include "intel_npu/utils/zero/zero_types.hpp"
 
 namespace intel_npu {
-
 Pipeline::Pipeline(const Config& config,
                    const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                    const std::shared_ptr<IGraph>& graph,
                    const std::vector<std::vector<std::shared_ptr<ov::ITensor>>>& input_tensors,
-                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors)
+                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors, size_t batch_size)
     : _init_structs(init_structs),
       _graph(graph),
       _config(config),
       _id(_graph->get_unique_id()),
-      _number_of_command_lists(_graph->get_batch_size().has_value() ? *_graph->get_batch_size() : 1),
+      _number_of_command_lists(_graph->get_batch_size().has_value() ? *_graph->get_batch_size() : batch_size),
       _logger("Pipeline", _config.get<LOG_LEVEL>()) {
     OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "Zero_infer_request::Pipeline::Pipeline");
-    _logger.debug("Pipeline - initialize started");
+    auto batch = _graph->get_batch_size().has_value() ? *_graph->get_batch_size() : batch_size;
+
+    if (_init_structs->getCommandQueueDdiTable().version() < ZE_MAKE_VERSION(1, 1) &&
+        _config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
+        _graph->resize_last_submitted_event(_number_of_command_lists);
+    }
+    
+    _logger.debug("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||
                         _init_structs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),
@@ -81,7 +87,7 @@ Pipeline::Pipeline(const Config& config,
     for (size_t i = 0; i < _number_of_command_lists; i++) {
         size_t io_index = 0;
         for (const auto& desc : graph->get_input_descriptors()) {
-            if (input_tensors.at(io_index).size() > 1) {
+            if (io_index < input_tensors.size() && input_tensors.at(io_index).size() > 1) {
                 void* data = nullptr;
                 auto remote_tensor = std::dynamic_pointer_cast<ZeroRemoteTensor>(input_tensors.at(io_index).at(i));
                 if (remote_tensor == nullptr) {

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -50,6 +50,7 @@ public:
     void set_last_submitted_event(const std::shared_ptr<Event>& event, size_t indexOfCommandList);
     const std::shared_ptr<Event>& get_last_submitted_event(size_t indexOfCommandList) const;
     void resize_last_submitted_event(size_t batch);
+    void set_batch_size(std::size_t batch);
 
     uint32_t get_unique_id();
     void set_last_submitted_id(uint32_t id_index);

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -13,6 +13,9 @@
 #include "intel_npu/utils/zero/zero_wrappers.hpp"
 #include "openvino/runtime/profiling_info.hpp"
 
+#include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
 namespace intel_npu {
 
 class IGraph : public std::enable_shared_from_this<IGraph> {
@@ -46,12 +49,16 @@ public:
 
     void set_last_submitted_event(const std::shared_ptr<Event>& event, size_t indexOfCommandList);
     const std::shared_ptr<Event>& get_last_submitted_event(size_t indexOfCommandList) const;
+    void resize_last_submitted_event(size_t batch);
 
     uint32_t get_unique_id();
     void set_last_submitted_id(uint32_t id_index);
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
+    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors) const;
+
+    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors);
 
 protected:
     /**
@@ -71,7 +78,6 @@ protected:
      * @returns The batch size deduced by the algorithm or the default value of 1 if batching cannot be performed inside
      * the plugin.
      */
-    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata);
 
     ze_graph_handle_t _handle = nullptr;
     NetworkMetadata _metadata;

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -83,6 +83,10 @@ void IGraph::resize_last_submitted_event(size_t batch) {
     _last_submitted_event.resize(batch);
 }
 
+void IGraph::set_batch_size(std::size_t batch) {
+    _batch_size = batch;
+}
+
 uint32_t IGraph::get_unique_id() {
     return _unique_id++;
 }
@@ -96,6 +100,10 @@ uint32_t IGraph::get_last_submitted_id() const {
 }
 
 std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& tensors) const {
+    if (get_batch_size() > 1) {
+        return get_batch_size();
+    }
+
     if (tensors.empty()) {
         return std::nullopt; // Return std::nullopt if no input tensors are set
     }

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -105,30 +105,30 @@ std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<o
     }
 
     if (tensors.empty()) {
-        return std::nullopt; // Return std::nullopt if no input tensors are set
+        return std::nullopt;  // Return std::nullopt if no input tensors are set
     }
 
     const auto& first_tensor = tensors.at(0);
     if (!first_tensor) {
-        return std::nullopt; // Return std::nullopt if the first tensor is null
+        return std::nullopt;  // Return std::nullopt if the first tensor is null
     }
 
     const auto& first_shape = first_tensor->get_shape();
     if (first_shape.empty()) {
-        return std::nullopt; // Return std::nullopt if the shape is empty
+        return std::nullopt;  // Return std::nullopt if the shape is empty
     }
 
-    const size_t candidateBatchSize = first_shape.at(0); // Assume batch size is the first dimension
+    const size_t candidateBatchSize = first_shape.at(0);  // Assume batch size is the first dimension
 
     auto checkBatchSizeConsistency = [candidateBatchSize](const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
         for (const auto& tensor : tensors) {
             if (!tensor) {
-                return false; // Tensor is null
+                return false;  // Tensor is null
             }
 
             const auto& shape = tensor->get_shape();
             if (shape.empty() || shape.at(0) != candidateBatchSize) {
-                return false; // Inconsistent batch size
+                return false;  // Inconsistent batch size
             }
         }
         return true;
@@ -136,7 +136,7 @@ std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<o
 
     if (!checkBatchSizeConsistency(tensors)) {
         _logger.info("Inconsistent batch sizes in input tensors");
-        return std::nullopt; // Return std::nullopt if batch sizes are inconsistent
+        return std::nullopt;  // Return std::nullopt if batch sizes are inconsistent
     }
 
     _logger.debug("Dynamic Batching is handled by the plugin");
@@ -144,7 +144,8 @@ std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<o
     return candidateBatchSize;
 }
 
-std::optional<size_t> IGraph::get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
+std::optional<size_t> IGraph::get_batch_size(const NetworkMetadata& metadata,
+                                             const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
     if (!metadata.outputs.at(0).shapeFromIRModel.has_value()) {
         _logger.debug("Batching on the plugin is not used, batching is handled by the compiler");
         return std::nullopt;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -159,7 +159,13 @@ void Graph::initialize(const Config& config) {
     //  releasing it here to avoid unnecessary memory usage.
     _blobIsReleased = release_blob(config);
 
-    _batch_size = get_batch_size(_metadata);
+    _batch_size = get_batch_size(_metadata, {});
+
+    const ov::PartialShape& firstOutputShape = *_metadata.outputs.at(0).shapeFromIRModel;
+    if (firstOutputShape[0].is_dynamic()) {
+        _logger.debug("Dynamic batch, will initialize command_lists later");
+        return;
+    }
 
     if (_zeroInitStruct->getCommandQueueDdiTable().version() < ZE_MAKE_VERSION(1, 1) &&
         config.get<RUN_INFERENCES_SEQUENTIALLY>()) {

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -19,3 +19,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(batchedConfigs)),
                          BatchedTensorsRunTests::getTestCaseName);
+
+const std::vector<ov::AnyMap> DynamicBatchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         DynamicBatchedTensorsRunTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(DynamicBatchedConfigs)),
+                         BatchedTensorsRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -128,6 +128,10 @@ public:
     }
 };
 
+// Second test group inheriting from the first
+class DynamicBatchedTensorsRunTests : public BatchedTensorsRunTests {
+};
+
 TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
@@ -420,7 +424,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentRemoteTensorsMultipleInferMCL) {
     }
 }
 
-TEST_P(BatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer) {
+TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
@@ -467,7 +471,7 @@ TEST_P(BatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer) {
     }
 }
 
-TEST_P(BatchedTensorsRunTests, DynamicSetInputDifferentTensorsMultipleInfer) {
+TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputDifferentTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 


### PR DESCRIPTION
### Details:
#### Dynamic batch case

Managed to infer this case:
`./benchmark_app.exe -m <resnet-v1-50.xml> -d NPU -load_config plugin_batch_dynamic.json -shape [1..3,3,244,244] -data_shape [2,3,244,244] `
Where _plugin_batch_dynamic.json_:
```
{
        "NPU": {"NPU_BATCH_MODE": "PLUGIN"}
} 
```
Compiled with batch resized to 1:
```
func.func @main(%arg0: tensor<1x3x244x244xui8>) -> tensor<1x1000xf32> {
```

Result:
```
[ INFO ] data  ([N,C,H,W], u8, [2,3,244,244], dyn:[1..3,3,244,244]):    random (image/numpy array is expected)

...

[WARNING] 12:13:57.69 [IGraph] Networks using dynamic batch are handled by the plugin
IGraph::determine_batch_size tensors candidateBatchSize 2
[DEBUG] 12:13:57.69 [IGraph] Batching is handled by the plugin

...

[Pipeline] Pipeline - initialize started, batch 2, _number_of_command_lists 2
[Step 4/11] Reading model files
[ INFO ] Loading model files
[ INFO ] Read model took 11.37 ms
[ INFO ] Original model I/O parameters:
[ INFO ] Network inputs:
[ INFO ]     data (node: data) : f32 / [...] / [?,3,224,224]
[ INFO ] Network outputs:
[ INFO ]     prob (node: prob) : f32 / [...] / [?,1000]
[Step 5/11] Resizing model to match image sizes and given batch
[ INFO ] Number of test configurations is calculated basing on -data_shape parameter
[ WARNING ] data: layout is not set explicitly, so it is defaulted to NCHW. It is STRONGLY recommended to set layout manually to avoid further issues.
[ INFO ] Reshaping model: 'data': [1..3,3,244,244]
[ INFO ] Reshape model took 1.84 ms
[Step 6/11] Configuring input of the model
[ INFO ] Model batch size: 2
[ INFO ] Network inputs:
[ INFO ]     data (node: data) : u8 / [N,C,H,W] / [1..3,3,244,244]
[ INFO ] Network outputs:
[ INFO ]     prob (node: prob) : f32 / [...] / [1..3,1000]

...

[Step 11/11] Dumping statistics report
[ INFO ] Execution Devices: [ NPU ]
[ INFO ] Count:               18352 iterations
[ INFO ] Duration:            60048.31 ms
[ INFO ] Latency:
[ INFO ]    Median:           26.00 ms
[ INFO ]    Average:          26.11 ms
[ INFO ]    Min:              13.24 ms
[ INFO ]    Max:              104.34 ms
[ INFO ] Throughput:          611.24 FPS
```

#### Static batch case

Performance results for comparison:
```
./benchmark_app.exe -m <resnet-v1-50.xml> -d NPU -load_config plugin_batch_dynamic.json -shape [2,3,244,244]  
```
Compiled with batch resized to 1:
```
func.func @main(%arg0: tensor<1x3x244x244xui8>) -> tensor<1x1000xf32> {
```

Result:
```
[ INFO ] data  ([N,C,H,W], u8, [2,3,244,244], static):  random (image/numpy array is expected)
[Step 11/11] Dumping statistics report
[ INFO ] Execution Devices: [ NPU ]
[ INFO ] Count:               18336 iterations
[ INFO ] Duration:            60044.19 ms
[ INFO ] Latency:
[ INFO ]    Median:           26.14 ms
[ INFO ]    Average:          26.16 ms
[ INFO ]    Min:              23.99 ms
[ INFO ]    Max:              135.00 ms
[ INFO ] Throughput:          610.75 FPS
```

### Tickets:
 - E#168772
