### PR TITLE
[GPU] select bfyx for OneDNN convolution when feature size is 4

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -935,7 +935,8 @@ format layout_optimizer::get_expected_format(convolution_node const& node) {
 
     // Use planar format for dynamic convolution with small input channel(IC <= 3)
     if (node.is_dynamic() && use_onednn_impls && onednn_valid_post_ops &&
-        input_layout.get_partial_shape()[1].is_static() && input_layout.get_partial_shape()[1].get_length() <= 3) {
+        input_layout.get_partial_shape()[1].is_static() &&
+        (input_layout.get_partial_shape()[1].get_length() <= 4 || output_layout.get_partial_shape()[1].get_length() <= 4)) {
         return format::get_default_format(input_layout.get_partial_shape().size());
     }
 


### PR DESCRIPTION
### Details:
 - Currently, when feature size of convolution's input or output is 4, OneDNN's ocl_ref kernel is used, and it degrades performance of some models (e.g. Stable Diffusion 1.5)
 - This PR updates `layout_optimizer` to select `bfyx` and makes the convolution layers to use OneDNN's jit kernel in this case.

### Tickets:
 - 161941
