### PR TITLE
[GPU] updates group_normalization_fsv16 to use SIMD32

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cl
@@ -67,6 +67,7 @@ KERNEL(calc_mean_sqr_mean_per_feature)(
     }
 }
 #elif GROUP_NORM_KERNEL_GROUP_MEAN_VARIANCE
+REQD_SUB_GROUP_SIZE(SIMD)
 KERNEL(calc_mean_variance_per_group)(
     __global ACCUMULATOR_TYPE* internal_mean,
     __global ACCUMULATOR_TYPE* internal_variance
@@ -111,7 +112,7 @@ KERNEL(group_normalization_b_fs_yx_fsv16)(
     const __global ACCUMULATOR_TYPE* internal_variance
 ) {
     const uint b = get_global_id(1) % OUTPUT_BATCH_NUM;
-    const uint f = get_global_id(1) / OUTPUT_BATCH_NUM * FSV + get_sub_group_local_id();
+    const uint f = get_global_id(1) / OUTPUT_BATCH_NUM * FSV + (get_sub_group_local_id() % FSV);
     const uint yx = get_global_id(0) / FSV;
     const uint y = yx / OUTPUT_SIZE_X;
     const uint x = yx % OUTPUT_SIZE_X;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
@@ -42,11 +42,10 @@ public:
     explicit GroupNormalizationGeneratorBase(std::string_view name, std::string_view suffix) : KernelGenerator(name, suffix) {}
     [[nodiscard]] JitConstants get_jit_constants(const RuntimeParams& params) const override {
         auto get_max_simd_size = [](const RuntimeParams& params) {
-            size_t max_simd_size = 16;
+            size_t max_simd_size = fsv;
             for (auto& simd_size : params.get_device_info().supported_simd_sizes) {
                 max_simd_size = std::max(max_simd_size, simd_size);
             }
-            std::cout << "max_simd_size: " << max_simd_size << std::endl;
             return max_simd_size;
         };
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/group_normalization_fsv16.cpp
@@ -18,7 +18,6 @@ namespace ov::intel_gpu::ocl {
 namespace {
 
 constexpr size_t fsv = 16;
-constexpr size_t simd = fsv;
 
 ov::element::Type get_activation_type(const RuntimeParams& params) {
     if (params.get_input_layout(0).data_type == ov::element::f16) {
@@ -42,11 +41,20 @@ class GroupNormalizationGeneratorBase : public KernelGenerator {
 public:
     explicit GroupNormalizationGeneratorBase(std::string_view name, std::string_view suffix) : KernelGenerator(name, suffix) {}
     [[nodiscard]] JitConstants get_jit_constants(const RuntimeParams& params) const override {
+        auto get_max_simd_size = [](const RuntimeParams& params) {
+            size_t max_simd_size = 16;
+            for (auto& simd_size : params.get_device_info().supported_simd_sizes) {
+                max_simd_size = std::max(max_simd_size, simd_size);
+            }
+            std::cout << "max_simd_size: " << max_simd_size << std::endl;
+            return max_simd_size;
+        };
+
         auto jit = KernelGenerator::get_jit_constants(params);
         auto desc = params.typed_desc<group_normalization>();
         jit.make("EPSILON", static_cast<float>(desc->epsilon));
         jit.make("NUM_GROUPS", desc->num_groups);
-        jit.make("SIMD", simd);
+        jit.make("SIMD", get_max_simd_size(params));
         jit.make("FSV", fsv);
 
         if (params.is_dynamic()) {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -163,7 +163,6 @@ INSTANTIATE_TEST_SUITE_P(
 
 } // anonymous namespace
 
-#ifdef ENABLE_ONEDNN_FOR_GPU
 TEST(group_normalization, input_bfyx_output_fsv16) {
     GTEST_SKIP();
     auto& engine = get_test_engine();
@@ -240,12 +239,9 @@ TEST(group_normalization, input_bfyx_output_fsv16) {
         ASSERT_NEAR(output_mem_t[i], output_mem_g[i], 0.0001);
     }
 }
-#endif // ENABLE_ONEDNN_FOR_GPU
 
 TEST(group_normalization, basic_b_fs_yx_fsv16) {
     auto& engine = get_test_engine();
-    if (engine.get_device_info().supports_immad)
-        return;
 
     const ov::Shape input_shape = {1, 128, 256, 256};
     const ov::Shape param_shape = {128, 1, 1, 1};
@@ -298,11 +294,11 @@ TEST(group_normalization, basic_b_fs_yx_fsv16) {
 
     auto outputs = network.execute();
     auto output = outputs.at("output_bfyx_f32").get_memory();
-    cldnn::mem_lock<float> output_mem_lock(output, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> output_mem_lock(output, get_test_stream());
 
-    cldnn::mem_lock<float> input_mem_lock(input_mem, get_test_stream());
-    cldnn::mem_lock<float> scale_mem_lock(scale_mem, get_test_stream());
-    cldnn::mem_lock<float> bias_mem_lock(bias_mem, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> input_mem_lock(input_mem, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> scale_mem_lock(scale_mem, get_test_stream());
+    cldnn::mem_lock<float, mem_lock_type::read> bias_mem_lock(bias_mem, get_test_stream());
 
     std::vector<float> reference_output(output_mem_lock.size());
     ov::reference::group_normalization(input_mem_lock.data(),


### PR DESCRIPTION
### Details:
 - This PR updates group_normalization_fsv16 to use SIMD32 for better performance.

### Tickets:
 - 161941
