### PR TITLE
[AUTO] Correct the description for AUTO property ov::execution_devices

### DIFF
--- a/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.rst
+++ b/docs/articles_en/openvino-workflow/running-inference/inference-devices-and-modes/auto-device-selection.rst
@@ -155,7 +155,7 @@ the following setup options:
 | ``ov::execution_devices``                    | Lists the runtime target devices on which the inferences are being |
 |                                              | executed.                                                          |
 |                                              |                                                                    |
-|                                              | Examples of returning results could be ``(CPU)``(``CPU`` is a      |
+|                                              | Examples of returning results could be ``(CPU)``. (``CPU`` is a    |
 |                                              | temporary device, indicating that CPU is used for acceleration at  |
 |                                              | the model compilation stage), ``CPU``, ``GPU``, ``CPU GPU``,       |
 |                                              | ``GPU.0``, etc.                                                    |


### PR DESCRIPTION
### Details:
 - Correct the description of property `ov::execution_devices` in AUTO document.
 - *...*

### Tickets:
 - *ticket-id*
