### PR TITLE
[GPU] Limit KeepDequantizationPrecision transformation to subgraphs containing only constant nodes

### DIFF
--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -843,19 +843,6 @@ TEST_F(TransformationTestsF, KeepDequantizationPrecisionTransformationMarkupNonC
 
     manager.register_pass<pass::KeepDequantizationPrecision>(element::TypeVector{quantization_dt});
 
-    {
-        auto parameter = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{1});
-        auto weights = opset10::Constant::create(quantization_dt, Shape{4, 16, 1, 1}, {3});
-        auto convert = std::make_shared<opset10::Convert>(weights, dequantization_dt);
-        auto zero_point = opset10::Constant::create(quantization_dt, Shape{}, {127});
-        auto convert_on_zero_point = std::make_shared<opset10::Convert>(zero_point, dequantization_dt);
-        auto subtract = std::make_shared<opset10::Subtract>(convert, convert_on_zero_point);
-        auto scale = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{});
-        auto multiply = std::make_shared<opset10::Multiply>(subtract, scale);
-        auto add = std::make_shared<opset10::Add>(parameter, multiply);
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{add});
-    }
-
     comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
     comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
 }

--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -821,6 +821,45 @@ TEST_F(TransformationTestsF, KeepDequantizationPrecisionTransformationMarkup) {
     comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
 }
 
+TEST_F(TransformationTestsF, KeepDequantizationPrecisionTransformationMarkupNonConst) {
+    // KeepDequantizationPrecision pass should not match the specified subgraph,
+    // as it only targets constant weights, scales, and zero points.
+
+    auto quantization_dt = element::u16;
+    auto dequantization_dt = element::f32;
+
+    {
+        auto parameter = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{1});
+        auto weights = opset10::Constant::create(quantization_dt, Shape{4, 16, 1, 1}, {3});
+        auto convert = std::make_shared<opset10::Convert>(weights, dequantization_dt);
+        auto zero_point = opset10::Constant::create(quantization_dt, Shape{}, {127});
+        auto convert_on_zero_point = std::make_shared<opset10::Convert>(zero_point, dequantization_dt);
+        auto subtract = std::make_shared<opset10::Subtract>(convert, convert_on_zero_point);
+        auto scale = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{});
+        auto multiply = std::make_shared<opset10::Multiply>(subtract, scale);
+        auto add = std::make_shared<opset10::Add>(parameter, multiply);
+        model = std::make_shared<ov::Model>(ov::OutputVector{add});
+    }
+
+    manager.register_pass<pass::KeepDequantizationPrecision>(element::TypeVector{quantization_dt});
+
+    {
+        auto parameter = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{1});
+        auto weights = opset10::Constant::create(quantization_dt, Shape{4, 16, 1, 1}, {3});
+        auto convert = std::make_shared<opset10::Convert>(weights, dequantization_dt);
+        auto zero_point = opset10::Constant::create(quantization_dt, Shape{}, {127});
+        auto convert_on_zero_point = std::make_shared<opset10::Convert>(zero_point, dequantization_dt);
+        auto subtract = std::make_shared<opset10::Subtract>(convert, convert_on_zero_point);
+        auto scale = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{});
+        auto multiply = std::make_shared<opset10::Multiply>(subtract, scale);
+        auto add = std::make_shared<opset10::Add>(parameter, multiply);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{add});
+    }
+
+    comparator.enable(FunctionsComparator::CmpValues::CONST_VALUES);
+    comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
+}
+
 TEST_F(TransformationTests, KeepDequantizationPrecisionTransformationFolding) {
     // This test uses the legacy TransformationTests class because ConvertPrecision pass
     // internally inserts additional nodes for data type consistency, which causes the

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -310,6 +310,7 @@ ov::pass::KeepConstPrecision::KeepConstPrecision(const element::TypeVector& prec
     auto m = std::make_shared<Matcher>(multiply_pattern, "KeepConstPrecision");
     this->register_matcher(m, callback);
 }
+
 ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element::TypeVector& precisions,
                                                                    bool add_precision_sensitive_convert) {
     MATCHER_SCOPE(KeepDequantizationPrecision);

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -314,17 +314,17 @@ ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element
                                                                    bool add_precision_sensitive_convert) {
     MATCHER_SCOPE(KeepDequantizationPrecision);
 
-    auto input_pattern = any_input(pattern::type_matches_any(precisions));
+    auto input_pattern = pattern::wrap_type<v0::Constant>(pattern::type_matches_any(precisions));
     auto convert_pattern = pattern::wrap_type<v0::Convert>({input_pattern}, pattern::consumers_count(1));
 
     // zero points:
-    auto zp_pattern = any_input();
+    auto zp_pattern = pattern::wrap_type<v0::Constant>();
     auto zp_convert_pattern = pattern::optional<v0::Convert>(zp_pattern);
     auto zp_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({zp_convert_pattern, any_input()});
     auto subtract_pattern = pattern::optional<v1::Subtract>({convert_pattern, zp_reshape_pattern});
 
     // scale:
-    auto scale_pattern = any_input();
+    auto scale_pattern = pattern::wrap_type<v0::Constant>();
     auto scale_convert_pattern = pattern::optional<v0::Convert>(scale_pattern);
     auto scale_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({scale_convert_pattern, any_input()});
     auto multiply_pattern = pattern::wrap_type<v1::Multiply>({subtract_pattern, scale_reshape_pattern});


### PR DESCRIPTION
### Details:
 - This PR updates the matching logic of KeepDequantizationPrecision transformation pass to be applied only to constant nodes
