### PR TITLE
[GPU] KeepDequantizationPrecision pass fix

### DIFF
--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -868,3 +868,52 @@ TEST_F(TransformationTests, KeepDequantizationPrecisionTransformationFolding) {
     auto result = func_comparator(model_ref, model);
     ASSERT_TRUE(result.valid) << result.message;
 }
+
+TEST_F(TransformationTests, KeepDequantizationPrecisionTransformationFoldingWithConvert) {
+    // This test uses the legacy TransformationTests class because ConvertPrecision pass
+    // internally inserts additional nodes for data type consistency, which causes the
+    // check_unique_names() function to fail with a "Tensor name: N is missing in ..." error.
+    // Once this issue is fixed, the test should be migrated to the new TransformationTestsF infrastructure.
+
+    // After KeepDequantizationPrecision all Convert, Subtract, and Multiply nodes
+    // are marked with the 'disable_fp16_compression' attribute, and dequantization subgraph is folded
+    // during Constant Folding (called from ConvertPrecision pass), using f32 data type and finally
+    // converted to the f16 data type.
+
+    std::shared_ptr<Model> model, model_ref;
+    pass::Manager manager;
+
+    auto quantization_dt = element::u16;
+    auto dequantization_dt = element::f32;
+
+    {
+        auto parameter = std::make_shared<opset10::Parameter>(dequantization_dt, Shape{1});
+        auto weights = opset10::Constant::create(quantization_dt, Shape{4, 16, 1, 1}, {3});
+        auto convert = std::make_shared<opset10::Convert>(weights, dequantization_dt);
+        auto zero_point = opset10::Constant::create(quantization_dt, Shape{}, {127});
+        auto convert_on_zero_point = std::make_shared<opset10::Convert>(zero_point, dequantization_dt);
+        auto subtract = std::make_shared<opset10::Subtract>(convert, convert_on_zero_point);
+        auto scale = opset10::Constant::create(dequantization_dt, Shape{}, {0.2});
+        auto multiply = std::make_shared<opset10::Multiply>(subtract, scale);
+        auto add = std::make_shared<opset10::Add>(parameter, multiply);
+        model = std::make_shared<ov::Model>(ov::OutputVector{add});
+
+        const auto keep_precision_sensitive_in_fp32 = true;
+        const auto add_precision_sensitive_convert = true;
+        manager.register_pass<pass::KeepDequantizationPrecision>(element::TypeVector{quantization_dt}, add_precision_sensitive_convert);
+        manager.register_pass<pass::ConvertPrecision>(element::f32, element::f16, type_to_fuse_map{}, keep_precision_sensitive_in_fp32);
+        manager.run_passes(model);
+    }
+
+    {
+        auto weights_dt = element::f16;
+        auto parameter = std::make_shared<opset10::Parameter>(element::f16, Shape{1});
+        auto weights = opset10::Constant::create(weights_dt, Shape{4, 16, 1, 1}, {3});
+        auto add = std::make_shared<opset10::Add>(parameter, weights);
+        model_ref = std::make_shared<ov::Model>(ov::OutputVector{add});
+    }
+
+    auto func_comparator = FunctionsComparator::with_default();
+    auto result = func_comparator(model_ref, model);
+    ASSERT_TRUE(result.valid) << result.message;
+}

--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -106,7 +106,8 @@ public:
 class TRANSFORMATIONS_API KeepDequantizationPrecision : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("KeepDequantizationPrecision");
-    explicit KeepDequantizationPrecision(const element::TypeVector& precisions);
+    explicit KeepDequantizationPrecision(const element::TypeVector& precisions,
+                                         bool add_precision_sensitive_convert = false);
 };
 
 }  // namespace pass

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -310,21 +310,22 @@ ov::pass::KeepConstPrecision::KeepConstPrecision(const element::TypeVector& prec
     auto m = std::make_shared<Matcher>(multiply_pattern, "KeepConstPrecision");
     this->register_matcher(m, callback);
 }
+
 ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element::TypeVector& precisions,
                                                                    bool add_precision_sensitive_convert) {
     MATCHER_SCOPE(KeepDequantizationPrecision);
 
-    auto input_pattern = any_input(pattern::type_matches_any(precisions));
+    auto input_pattern = pattern::wrap_type<v0::Constant>(pattern::type_matches_any(precisions));
     auto convert_pattern = pattern::wrap_type<v0::Convert>({input_pattern}, pattern::consumers_count(1));
 
     // zero points:
-    auto zp_pattern = any_input();
+    auto zp_pattern = pattern::wrap_type<v0::Constant>();
     auto zp_convert_pattern = pattern::optional<v0::Convert>(zp_pattern);
     auto zp_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({zp_convert_pattern, any_input()});
     auto subtract_pattern = pattern::optional<v1::Subtract>({convert_pattern, zp_reshape_pattern});
 
     // scale:
-    auto scale_pattern = any_input();
+    auto scale_pattern = pattern::wrap_type<v0::Constant>();
     auto scale_convert_pattern = pattern::optional<v0::Convert>(scale_pattern);
     auto scale_reshape_pattern = pattern::optional<v1::Reshape, v0::Unsqueeze>({scale_convert_pattern, any_input()});
     auto multiply_pattern = pattern::wrap_type<v1::Multiply>({subtract_pattern, scale_reshape_pattern});

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -464,9 +464,10 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
         const bool keep_precision_sensitive_in_fp32_1 = true;
         const bool convert_input_output_precision = false;
         const bool store_original_precision_as_rt_attribute = true;
+        const auto add_precision_sensitive_convert = true;
 
         manager.register_pass<ov::pass::KeepDequantizationPrecision>(
-            ov::element::TypeVector{ov::element::i32, ov::element::u32, ov::element::u16});
+            ov::element::TypeVector{ov::element::i32, ov::element::u32, ov::element::u16}, add_precision_sensitive_convert);
 
         manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
                                                           empty_fuse_map,


### PR DESCRIPTION
### Details:
 - This PR updates the matching logic of KeepDequantizationPrecision transformation pass to be applied only to constant nodes and adds optional `add_precision_sensitive_convert` flag to insert Convert nodes for reordering folded subgraphs to selected inference precision
