### PR TITLE
[TF FE] Reenable TestSwitchMergeWithVariablePredicate test on GPU

### DIFF
--- a/tests/layer_tests/tensorflow_tests/test_tf_SwitchMerge.py
+++ b/tests/layer_tests/tensorflow_tests/test_tf_SwitchMerge.py
@@ -100,7 +100,5 @@ class TestSwitchMergeWithVariablePredicate(CommonTFLayerTest):
     @pytest.mark.nightly
     def test_switch_merge_with_variable_predicate(self, x_shape, cond_shape, cond_value,
                                                   ie_device, precision, ir_version, temp_dir):
-        if ie_device == 'GPU':
-            pytest.skip("156244: accuracy error on GPU")
         self._test(*self.switch_merge_with_variable_predicate_net(x_shape, cond_shape, cond_value),
                    ie_device, precision, ir_version, temp_dir=temp_dir)


### PR DESCRIPTION
### Details:
- *Enables test that was previously skipped on GPU, because it is no longer failing.*

### Tickets:
- *156244*
