### PR TITLE
NPUW: Lift logging levels and fix Scalar matching

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/compiled_model.cpp
@@ -111,6 +111,13 @@ void pre_load_transform(const std::shared_ptr<ov::Model>& model, const ov::AnyMa
         rewr.run_on_model(model);
     }
 
+    if (cfg_get<::intel_npu::NPUW_FOLD>(props)) {
+        // Having folding enabled assumes Scalar bank matching,
+        // make this procedure a little bit more reliable by untangling
+        // the excess tiny Const connections
+        ov::npuw::patterns::opt::untangleConst(model);
+    }
+
     if (cfg_get<::intel_npu::NPUW_SLICE_OUT>(props)) {
         // Add Slice before last MatMul for the prefill model
         ov::pass::GraphRewrite rewr;

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/compiler.cpp
@@ -458,7 +458,8 @@ public:
         for (const auto& nh : graph->sorted()) {
             LOG_BLOCK();
             Group::GPtr group = graph->meta(nh).get<Group::GPtr>();
-            LOG_VERB("Group " << group->getId() << ", size " << group->size() << ", tag " << group->specialTags() << ", rep " << group->repeated());
+            LOG_VERB("Group " << group->getId() << ", size " << group->size() << ", tag " << group->specialTags()
+                              << ", rep " << group->repeated());
         }
 
         LOG_INFO("Done");

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/compiler.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/compiler.cpp
@@ -453,12 +453,12 @@ public:
             break;
         }
 
-        LOG_DEBUG("Online partitioning: group sizes after compilation:");
+        LOG_VERB("Online partitioning: group sizes after compilation (in topological order):");
         auto graph = m_snapshot->getGraph();
         for (const auto& nh : graph->sorted()) {
             LOG_BLOCK();
             Group::GPtr group = graph->meta(nh).get<Group::GPtr>();
-            LOG_DEBUG("Group " << group->getId() << ", size " << group->size() << ", tag " << group->specialTags());
+            LOG_VERB("Group " << group->getId() << ", size " << group->size() << ", tag " << group->specialTags() << ", rep " << group->repeated());
         }
 
         LOG_INFO("Done");

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/online/snapshot.cpp
@@ -33,9 +33,10 @@ bool isOp(const std::shared_ptr<ov::Node>& node) {
         return false;
     }
     if (ov::is_type<ov::opset1::Convert>(node)) {
-        if (node->inputs().size() != 1) {
-            // can occur only in Const->Convert->Node case
-            return false;
+        if (node->output(0).get_target_inputs().size() > 1) {
+            // If a Convert node has > 1 reader(s), it is not a simple straight Weight
+            // convert we could discard from the partitioning
+            return true;
         }
         auto target_input = node->get_input_source_output(0);
         auto parent_node = target_input.get_node()->shared_from_this();
@@ -1070,8 +1071,8 @@ bool Snapshot::cleanUpUniquesImpl(const GPtrSet& gptrs) {
     for (const auto& gptr : gptrs) {
         if (!gptr->avoidedTargets().empty() || gptr->isNoFold()) {
             auto block_layer_size = (*(gptrs.begin()))->size();
-            LOG_DEBUG("Keeping a repeated block of " << gptrs.size() << " groups with " << block_layer_size
-                                                     << " layers - has AVOIDs");
+            LOG_VERB("Keeping a repeated block of " << gptrs.size() << " groups with " << block_layer_size
+                                                    << " layers - has AVOIDs");
             // Special case - keep it
             for (const auto& g : gptrs) {
                 g->freeze();
@@ -1084,7 +1085,7 @@ bool Snapshot::cleanUpUniquesImpl(const GPtrSet& gptrs) {
     // FIXME: slightly different from Ensemble since we don't check flops and keep it by size only
     auto block_layer_size = (*(gptrs.begin()))->size();
     if (gptrs.size() >= m_ctx.keep_blocks && block_layer_size >= m_ctx.keep_block_size) {
-        LOG_DEBUG("Keeping a repeated block of " << gptrs.size() << " groups with " << block_layer_size << " layers.");
+        LOG_VERB("Keeping a repeated block of " << gptrs.size() << " groups with " << block_layer_size << " layers.");
         for (const auto& g : gptrs) {
             g->freeze();
         }
@@ -1095,8 +1096,7 @@ bool Snapshot::cleanUpUniquesImpl(const GPtrSet& gptrs) {
     for (const auto& gptr : gptrs) {
         gptr->setRepeated(nullptr);
     }
-
-    LOG_DEBUG("Repeated block of " << gptrs.size() << " groups with " << block_layer_size << " layers is dropped.");
+    LOG_VERB("Repeated block of " << gptrs.size() << " groups with " << block_layer_size << " layers is dropped.");
 
     return false;
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/opt.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/opt.cpp
@@ -1847,6 +1847,33 @@ ConvToMatmul::ConvToMatmul(Context::Ref ctx) {
     register_matcher(std::make_shared<opp::Matcher>(transpose_out, "ConvToMatmul"), std::move(callback));
 }
 
+void untangleConst(std::shared_ptr<ov::Model> model) {
+    // Duplicate small Constants which are consumed by multiple operators
+    // to simplify match bank validation in the future
+    for (const auto& ov_node : model->get_ordered_ops()) {
+        if (!ov::op::util::is_constant(ov_node)) {
+            continue;
+        }
+        const auto readers = ov_node->output(0).get_target_inputs();
+        if (readers.size() <= 1) {
+            continue;
+        }
+        auto this_const = std::static_pointer_cast<ov::op::v0::Constant>(ov_node);
+        auto this_type = this_const->get_element_type();
+        auto this_shape = ov_node->output(0).get_shape();
+        if (this_type == ov::element::i64 && this_shape.size() == 0) {
+            // Keep the first reader with the original const, but redirect
+            // all others to use their individual instance
+            auto this_val = this_const->get_tensor_view();
+            auto it = readers.begin();
+            while (++it != readers.end()) {
+                auto new_const = std::make_shared<ov::op::v0::Constant>(this_val);
+                it->replace_source_output(new_const);
+            }
+        }
+    }
+}
+
 }  // namespace opt
 }  // namespace patterns
 }  // namespace npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/opt.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/patterns/opt.hpp
@@ -216,6 +216,9 @@ public:
     ConvToMatmul(Context::Ref ctx);
 };
 
+// UntangleConst
+void untangleConst(std::shared_ptr<ov::Model> model);
+
 }  // namespace opt
 }  // namespace patterns
 }  // namespace npuw

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.cpp
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "openvino/op/util/op_types.hpp"
 #include "traits.hpp"
+
+#include "openvino/op/util/op_types.hpp"
 
 namespace ov {
 namespace npuw {
 
-bool partitioning::traits::is_tiny_shape(const ov::Shape &shape) {
+bool partitioning::traits::is_tiny_shape(const ov::Shape& shape) {
     const auto total = std::accumulate(shape.begin(), shape.end(), std::size_t{1}, std::multiplies<std::size_t>());
 
     // The initial check
@@ -18,7 +19,7 @@ bool partitioning::traits::is_tiny_shape(const ov::Shape &shape) {
     return false;
 }
 
-bool partitioning::traits::is_tiny_scalar(const std::shared_ptr<ov::Node> &node) {
+bool partitioning::traits::is_tiny_scalar(const std::shared_ptr<ov::Node>& node) {
     if (!ov::op::util::is_constant(node)) {
         return false;
     }

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.cpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/op/util/op_types.hpp"
+#include "traits.hpp"
+
+namespace ov {
+namespace npuw {
+
+bool partitioning::traits::is_tiny_shape(const ov::Shape &shape) {
+    const auto total = std::accumulate(shape.begin(), shape.end(), std::size_t{1}, std::multiplies<std::size_t>());
+
+    // The initial check
+    if ((shape.size() == 0 || (shape.size() == 1 && shape[0] <= 10)) || (total <= 10)) {
+        return true;
+    }
+    return false;
+}
+
+bool partitioning::traits::is_tiny_scalar(const std::shared_ptr<ov::Node> &node) {
+    if (!ov::op::util::is_constant(node)) {
+        return false;
+    }
+    return is_tiny_shape(node->output(0).get_shape());
+}
+
+}  // namespace npuw
+}  // namespace ov

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+
 #include "openvino/openvino.hpp"
 
 namespace ov {
@@ -12,9 +13,9 @@ namespace npuw {
 namespace partitioning {
 namespace traits {
 
-bool is_tiny_shape(const ov::Shape &shape);
+bool is_tiny_shape(const ov::Shape& shape);
 
-bool is_tiny_scalar(const std::shared_ptr<ov::Node> &node);
+bool is_tiny_scalar(const std::shared_ptr<ov::Node>& node);
 
 }  // namespace traits
 }  // namespace partitioning

--- a/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/partitioning/traits.hpp
@@ -1,0 +1,22 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include "openvino/openvino.hpp"
+
+namespace ov {
+namespace npuw {
+namespace partitioning {
+namespace traits {
+
+bool is_tiny_shape(const ov::Shape &shape);
+
+bool is_tiny_scalar(const std::shared_ptr<ov::Node> &node);
+
+}  // namespace traits
+}  // namespace partitioning
+}  // namespace npuw
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Move too verbose logs into debug level, and some important information from debug to verbose
 - Help partitioning algorithm deal with scalar matching by untangling some odd connections (implemented for a reduced number of cases)

### Tickets:
 - EISW-170681
