### PR TITLE
[GPU] Use sdpa_opt kernel for 3D SDPA and num_heads=1

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -451,7 +451,7 @@ public:
     static std::unique_ptr<primitive_impl> create(const typed_program_node<scaled_dot_product_attention>& arg, const kernel_impl_params& impl_param) {
         std::vector<kernel_selector::kernel_data> kernels_data;
         auto& kernel_selector = kernel_selector_t::Instance();
-        bool is_output_rank_4d = impl_param.output_layouts[0].get_partial_shape().size() == 4;
+        const bool is_output_rank_4d = impl_param.output_layouts[0].get_partial_shape().size() == 4;
         auto params = is_output_rank_4d ? impl_param : static_canonicalize_shapes(impl_param);
 
         auto sdpa_kernel_params = get_kernel_params(params, params.is_dynamic());


### PR DESCRIPTION
### Details:
 - This is a follow up PR from https://github.com/openvinotoolkit/openvino/pull/30303
 - Through the above PR, shape canonicalization was implemented for 3D SDPA support. However, there is an accuracy issue when `sdpa_micro` kernel is selected instead of `sdpa_opt`.
 - Therefore, it is currently restricted to execute `sdpa_opt` kernel for 3D SDPA and `num_heads`=1

### Tickets:
 - 167451
