### PR TITLE
[`intel-npu`] [`Functional Shared Behavior Tests`] Activate skipped core threading tests

### DIFF
--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/blob_compatibility.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/blob_compatibility.cpp
@@ -9,6 +9,8 @@
 #include <map>
 #include <string>
 
+#include "common/utils.hpp"
+
 using namespace ov::test::behavior;
 
 const auto all_models = []() -> std::vector<std::string> {

--- a/src/plugins/intel_npu/tests/functional/behavior/compiled_model/import_export.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/compiled_model/import_export.cpp
@@ -9,7 +9,7 @@
 #include <map>
 #include <string>
 
-#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
 
 using namespace ov::test::behavior;
 

--- a/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/ov_plugin/internal_properties_tests.cpp
@@ -5,7 +5,7 @@
 
 #include "overload/ov_plugin/internal_properties_tests.hpp"
 
-#include "common/npu_test_env_cfg.hpp"
+#include "common/utils.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 
 namespace ov::test::behavior {

--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "base/ov_behavior_test_utils.hpp"
-#include "common/utils.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 
 using namespace ov::test::behavior;

--- a/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/npu_test_env_cfg.hpp
@@ -56,17 +56,6 @@ std::string getDeviceNameTestCase(const std::string& str);
 std::string getDeviceName();
 std::string getDeviceNameID(const std::string& str);
 
-// Current version of gtest seems to fail when parsing template functions for getTestCaseName
-// To overcome this issue, programmer must make sure to wrap in paratheses this function when
-// it is given at INSTANTIATE_TEST_SUITE_P macros
-// e.g. INSTANTIATE_TEST_SUITE_P(TEST_SUITE_NAME, TEST_SUITE_CLASS, params,
-// (appendPlatformTypeTestName<TEST_SUITE_CLASS>))
-template <typename T>
-std::string appendPlatformTypeTestName(testing::TestParamInfo<typename T::ParamType> obj) {
-    const std::string& test_name = GenericTestCaseNameClass::getTestCaseName<T>(obj);
-    return test_name + "_targetPlatform=" + getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU);
-}
-
 }  // namespace ov::test::utils
 
 namespace InferRequestParamsAnyMapTestName {

--- a/src/plugins/intel_npu/tests/functional/common/utils.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.hpp
@@ -8,6 +8,7 @@
 #include <openvino/runtime/core.hpp>
 
 #include "common_test_utils/unicode_utils.hpp"
+#include "npu_test_env_cfg.hpp"
 
 std::string getBackendName(const ov::Core& core);
 
@@ -80,3 +81,29 @@ constexpr bool
                                                  std::void_t<decltype(std::declval<T>().getTestCaseName(
                                                      std::declval<testing::TestParamInfo<typename T::ParamType>>()))>> =
         true;
+
+namespace ov {
+
+namespace test {
+
+namespace utils {
+
+template <typename T>
+std::string appendPlatformTypeTestName(testing::TestParamInfo<typename T::ParamType> obj) {
+    const std::string& test_name = GenericTestCaseNameClass::getTestCaseName<T>(obj);
+    return test_name + "_targetPlatform=" + getTestsPlatformFromEnvironmentOr(ov::test::utils::DEVICE_NPU);
+}
+
+template <typename T>
+std::string appendDriverVersionTestName(testing::TestParamInfo<typename T::ParamType> obj) {
+    const auto& pluginCacheCore = ov::test::utils::PluginCache::get().core(ov::test::utils::DEVICE_NPU);
+    auto driverVersion =
+        pluginCacheCore->get_property(ov::test::utils::DEVICE_NPU, ov::intel_npu::driver_version.name());
+    return ov::test::utils::appendPlatformTypeTestName<T>(obj) + "_driverVersion=" + driverVersion.as<std::string>();
+}
+
+}  // namespace utils
+
+}  // namespace test
+
+}  // namespace ov

--- a/src/plugins/intel_npu/tests/functional/common/utils.hpp
+++ b/src/plugins/intel_npu/tests/functional/common/utils.hpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <openvino/runtime/core.hpp>
+#include <openvino/runtime/intel_npu/properties.hpp>
 
 #include "common_test_utils/unicode_utils.hpp"
 #include "npu_test_env_cfg.hpp"

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
@@ -23,12 +23,21 @@ const Params params_disable_umd_cache[] = {std::tuple<Device, Config>{
 
 const Params params_cached[] = {std::tuple<Device, Config>{ov::test::utils::DEVICE_NPU, {}}};
 
+template <typename T>
+std::string appendDriverVestionTestName(testing::TestParamInfo<typename T::ParamType> obj) {
+    const auto& pluginCacheCore = ov::test::utils::PluginCache::get().core(ov::test::utils::DEVICE_NPU);
+    auto driverVersion =
+        pluginCacheCore->get_property(ov::test::utils::DEVICE_NPU, ov::intel_npu::driver_version.name());
+    return ov::test::utils::appendPlatformTypeTestName<T>(obj) + "_driverVersion=" + driverVersion.as<std::string>();
+}
+
 }  // namespace
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU,
                          CoreThreadingTest,
                          testing::ValuesIn(params),
-                         (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTest>));
+                         (appendDriverVestionTestName<CoreThreadingTest>));  // need to get also driver version to skip
+                                                                             // failing tests with PV driver
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
                          CoreThreadingTestsWithIter,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_plugin/core_threading_tests.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "behavior/ov_plugin/core_threading.hpp"
-#include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
 #include "intel_npu/npu_private_properties.hpp"
 
@@ -23,35 +22,28 @@ const Params params_disable_umd_cache[] = {std::tuple<Device, Config>{
 
 const Params params_cached[] = {std::tuple<Device, Config>{ov::test::utils::DEVICE_NPU, {}}};
 
-template <typename T>
-std::string appendDriverVestionTestName(testing::TestParamInfo<typename T::ParamType> obj) {
-    const auto& pluginCacheCore = ov::test::utils::PluginCache::get().core(ov::test::utils::DEVICE_NPU);
-    auto driverVersion =
-        pluginCacheCore->get_property(ov::test::utils::DEVICE_NPU, ov::intel_npu::driver_version.name());
-    return ov::test::utils::appendPlatformTypeTestName<T>(obj) + "_driverVersion=" + driverVersion.as<std::string>();
-}
-
 }  // namespace
 
-INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU,
-                         CoreThreadingTest,
-                         testing::ValuesIn(params),
-                         (appendDriverVestionTestName<CoreThreadingTest>));  // need to get also driver version to skip
-                                                                             // failing tests with PV driver
+INSTANTIATE_TEST_SUITE_P(
+    compatibility_smoke_BehaviorTests_CoreThreadingTest_NPU,
+    CoreThreadingTest,
+    testing::ValuesIn(params),
+    ov::test::utils::appendDriverVersionTestName<CoreThreadingTest>);  // need to get also driver version to skip
+                                                                       // failing tests with PV driver
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
                          CoreThreadingTestsWithIter,
                          testing::Combine(testing::ValuesIn(params), testing::Values(15), testing::Values(50)),
-                         (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>));
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_NPU,
                          CoreThreadingTestsWithCacheEnabled,
                          testing::Combine(testing::ValuesIn(params_cached), testing::Values(10), testing::Values(30)),
-                         (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithCacheEnabled>));
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithCacheEnabled>);
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests_CoreThreadingTest_UmdCacheDisabled_NPU,
                          CoreThreadingTestsWithIter,
                          testing::Combine(testing::ValuesIn(params_disable_umd_cache),
                                           testing::Values(8),
                                           testing::Values(20)),
-                         (ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>));
+                         ov::test::utils::appendPlatformTypeTestName<CoreThreadingTestsWithIter>);

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -656,6 +656,19 @@ Example:
 
     <!-- EISW 112064 -->
     <skip_config>
+        <message>Failing common core threading tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <!-- INFERENCE_PRECISION_HINT = FP32 not supported on NPU -->
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 112064 -->
+    <skip_config>
         <message>Failing Linux core threading tests</message>
         <enable_rules>
             <backend>LEVEL0</backend>
@@ -663,19 +676,6 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel/.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- EISW 112064 -->
-    <skip_config>
-        <message>Failing Windows core threading tests</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*</filter>
-            <filter>.*smoke_BehaviorTests_CoreThreadingTest_NPU/CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*</filter>
         </filters>
     </skip_config>
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -662,7 +662,7 @@ Example:
             <operating_system>linux</operating_system>
         </enable_rules>
         <filters>
-            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel/.*</filter>
         </filters>
     </skip_config>
 
@@ -675,6 +675,7 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*</filter>
+            <filter>.*smoke_BehaviorTests_CoreThreadingTest_NPU/CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*</filter>
         </filters>
     </skip_config>
 
@@ -690,7 +691,7 @@ Example:
             <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
         </filters>
     </skip_config>
-    
+
     <!-- EISW 117582 -->
     <skip_config>
         <message>Failing core threading test with cache enabled</message>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -677,6 +677,7 @@ Example:
         <filters>
             <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel/.*</filter>
             <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_MultipleCores/.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput/.*</filter>
         </filters>
     </skip_config>
 
@@ -685,7 +686,7 @@ Example:
         <message>Failing Windows PV Driver core threading tests</message>
         <enable_rules>
             <backend>LEVEL0</backend>
-            <operating_system>linux</operating_system>
+            <operating_system>windows</operating_system>
         </enable_rules>
         <filters>
             <filter>.*CoreThreadingTest.smoke_QueryModel/.*_driverVersion=1688.*</filter>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -654,34 +654,6 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- EISW 112064 -->
-    <skip_config>
-        <message>Failing core threading tests</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-        </enable_rules>
-        <filters>
-            <filter>.*CoreThreadingTest.smoke_QueryModel.*</filter>
-            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel.*</filter>
-            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*</filter>
-            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*</filter>
-            <filter>.*CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput.*</filter>
-        </filters>
-    </skip_config>
-
-    <skip_config>
-        <message>Failing properties tests</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-        </enable_rules>
-        <filters>
-            <!-- EISW 108600 -->
-            <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
-            <!-- EISW 133153 -->
-            <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
-        </filters>
-    </skip_config>
-
     <!-- EISW 117582 -->
     <skip_config>
         <message>Failing core threading test with cache enabled</message>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -676,6 +676,19 @@ Example:
         </enable_rules>
         <filters>
             <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel/.*</filter>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_MultipleCores/.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 112064 -->
+    <skip_config>
+        <message>Failing Windows PV Driver core threading tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <operating_system>linux</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*CoreThreadingTest.smoke_QueryModel/.*_driverVersion=1688.*</filter>
         </filters>
     </skip_config>
 

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -654,6 +654,43 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- EISW 112064 -->
+    <skip_config>
+        <message>Failing Linux core threading tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <operating_system>linux</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel.*</filter>
+        </filters>
+    </skip_config>
+
+    <!-- EISW 112064 -->
+    <skip_config>
+        <message>Failing Windows core threading tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+            <operating_system>windows</operating_system>
+        </enable_rules>
+        <filters>
+            <filter>.*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*</filter>
+        </filters>
+    </skip_config>
+
+    <skip_config>
+        <message>Failing properties tests</message>
+        <enable_rules>
+            <backend>LEVEL0</backend>
+        </enable_rules>
+        <filters>
+            <!-- EISW 108600 -->
+            <filter>.*OVSpecificDeviceSetConfigTest.GetConfigSpecificDeviceNoThrow.*</filter>
+            <!-- EISW 133153 -->
+            <filter>.*OVPropertiesIncorrectTests.SetPropertiesWithIncorrectKey.*DEVICE_ID.*</filter>
+        </filters>
+    </skip_config>
+    
     <!-- EISW 117582 -->
     <skip_config>
         <message>Failing core threading test with cache enabled</message>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -746,16 +746,6 @@ std::vector<std::string> disabledTestPatterns() {
                 ".*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*",
         });
 
-        // [Tracking number: E#112064]
-        _skipRegistry.addPatterns(backendName.isZero(),
-                "Failing core threading tests", {
-                ".*CoreThreadingTest.smoke_QueryModel.*",
-                ".*CoreThreadingTestsWithIter.smoke_CompileModel.*",
-                ".*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*",
-                ".*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*",
-                ".*CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput.*"
-        });
-
         // [Tracking number: E#108600]
         _skipRegistry.addPatterns(backendName.isZero(),
                 "Failing properties tests", {

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -746,6 +746,16 @@ std::vector<std::string> disabledTestPatterns() {
                 ".*smoke_OVClassLoadNetworkTest/OVClassLoadNetworkTestNPU.*",
         });
 
+        // [Tracking number: E#112064]
+        _skipRegistry.addPatterns(backendName.isZero(),
+                "Failing core threading tests", {
+                ".*CoreThreadingTest.smoke_QueryModel.*",
+                ".*CoreThreadingTestsWithIter.smoke_CompileModel.*",
+                ".*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_SingleCore.*",
+                ".*CoreThreadingTestsWithIter.smoke_CompileModel_Accuracy_MultipleCores.*",
+                ".*CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput.*"
+        });
+
         // [Tracking number: E#108600]
         _skipRegistry.addPatterns(backendName.isZero(),
                 "Failing properties tests", {


### PR DESCRIPTION
### Details:
 - *The following tests will be activated:*
 - *`CoreThreadingTest.smoke_QueryModel` (Windows + Linux, but not Windows with PV driver)*
 - *`CoreThreadingTestsWithIter.smoke_CompileModel` (Windows only)*
 - *`CoreThreadingTestsWithIter.nightly_AsyncInfer_ShareInput` (Windows only)*

### Tickets:
 - *112064*
