### PR TITLE
update mem_bandwidth_pressure_tolerance() for CPU plugin

### DIFF
--- a/src/inference/dev_api/openvino/runtime/performance_heuristics.hpp
+++ b/src/inference/dev_api/openvino/runtime/performance_heuristics.hpp
@@ -34,6 +34,7 @@ struct MemBandwidthPressure {
 OPENVINO_RUNTIME_API MemBandwidthPressure mem_bandwidth_pressure_tolerance(
     const std::shared_ptr<ov::Model> model,
     const float cache_size,
-    const float memThresholdAssumeLimited = MemBandwidthPressure::LIMITED);
+    const float memThresholdAssumeLimited = MemBandwidthPressure::LIMITED,
+    const ov::element::Type targetType = ov::element::undefined);
 
 }  // namespace ov

--- a/src/inference/src/dev/performance_heuristics.cpp
+++ b/src/inference/src/dev/performance_heuristics.cpp
@@ -8,7 +8,8 @@ namespace ov {
 
 MemBandwidthPressure mem_bandwidth_pressure_tolerance(const std::shared_ptr<ov::Model> model,
                                                       const float cache_size,
-                                                      const float memThresholdAssumeLimited) {
+                                                      const float memThresholdAssumeLimited,
+                                                      const ov::element::Type targetType) {
     int total_convs = 0, mem_limited_convs = 0, compute_convs = 0, total_gemms = 0, mem_limited_gemms = 0,
         total_deconvs = 0, compute_deconvs = 0, mem_limited_deconvs = 0;
     auto memLimitedFactor = [&](size_t size_data_moved, int datatype_size = 4) -> float {
@@ -35,6 +36,10 @@ MemBandwidthPressure mem_bandwidth_pressure_tolerance(const std::shared_ptr<ov::
             continue;
         }
         auto type1 = node->input_value(1).get_element_type();  // weights
+        type1 =
+            ((type1 == ov::element::f32) && (targetType != ov::element::f32) && (targetType != ov::element::undefined))
+                ? targetType
+                : type1;
         const bool isINT8 = isLowPrecision(type1);
         const bool isBF16orFP16 = isHalfPrecision(type1);
         const int data_type_size = isINT8 ? 1 : isBF16orFP16 ? 2 : 4;

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.cpp
@@ -613,7 +613,10 @@ int get_model_prefer_threads(const int num_streams,
         const float memThresholdAssumeLimitedForISA = ov::MemBandwidthPressure::LIMITED / isaSpecificThreshold;
         const float L2_cache_size = dnnl::utils::get_cache_size(2 /*level*/, true /*per core */);
         ov::MemBandwidthPressure networkToleranceForLowCache =
-            ov::mem_bandwidth_pressure_tolerance(model, L2_cache_size, memThresholdAssumeLimitedForISA);
+            ov::mem_bandwidth_pressure_tolerance(model,
+                                                 L2_cache_size,
+                                                 memThresholdAssumeLimitedForISA,
+                                                 config.inferencePrecision);
 
 #    if (defined(OPENVINO_ARCH_ARM) && defined(__linux__))
         config.modelPreferThreads = 4;


### PR DESCRIPTION
### Details:
 - *When user set inference Precision to bf16, mem_bandwidth_pressure_tolerance() will get f32 from graph during threading scheduling*

### Tickets:
 - *ticket-id*
