### PR TITLE
[Core][Unicode] read_model supports std::filesystem::path initialized with type std::wstring

### DIFF
--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -84,6 +84,12 @@ public:
     std::shared_ptr<ov::Model> read_model(const std::wstring& model_path,
                                           const std::wstring& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
+    template <class Path,
+              std::enable_if_t<std::is_same_v<Path, std::filesystem::path> &&
+                               std::is_same_v<typename Path::value_type, wchar_t>>* = nullptr>
+    auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
+        return read_model(model_path.wstring(), bin_path.wstring(), properties);
+    }
 #endif
 
     /**
@@ -106,7 +112,9 @@ public:
                                           const std::string& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
 
-    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    template <class Path,
+              std::enable_if_t<std::is_same_v<Path, std::filesystem::path> &&
+                               std::is_same_v<typename Path::value_type, char>>* = nullptr>
     auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
         return read_model(model_path.string(), bin_path.string(), properties);
     }

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -27,17 +27,7 @@ protected:
                                      ov::util::string_to_wstring(name);
             auto model_file_path_w = postfix_w + L".xml";
             auto weight_file_path_w = postfix_w + L".bin";
-            bool is_copy_successfully = ov::test::utils::copyFile(model_file_name, model_file_path_w);
-            if (!is_copy_successfully) {
-                FAIL() << "Unable to copy from '" << model_file_name << "' to '"
-                       << ov::util::wstring_to_string(model_file_path_w) << "'";
-            }
-            is_copy_successfully = ov::test::utils::copyFile(weight_file_name, weight_file_path_w);
-            if (!is_copy_successfully) {
-                FAIL() << "Unable to copy from '" << weight_file_name << "' to '"
-                       << ov::util::wstring_to_string(weight_file_path_w) << "'";
-            }
-            // ov::test::utils::generate_test_model(model_path_w, weight_path_w);
+            ov::test::utils::generate_test_model(model_file_path_w, weight_file_path_w);
             model_files_name_w.push_back(model_file_path_w);
             weight_files_name_w.push_back(weight_file_path_w);
         }
@@ -156,7 +146,7 @@ TEST_F(CoreBaseTest, read_model_with_std_fs_path_unicode) {
         std::wstring model_file_name_w = model_files_name_w[testIndex];
         std::wstring weight_file_name_w = weight_files_name_w[testIndex];
         std::filesystem::path model_path, weight_path;
-#    ifdef WIN32
+#    ifdef _WIN32
         model_path = std::filesystem::path(model_file_name_w);
         weight_path = std::filesystem::path(weight_file_name_w);
 #    else

--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/test_model/test_model.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/test_model/test_model.hpp
@@ -14,6 +14,21 @@ namespace ov {
 namespace test {
 namespace utils {
 
+#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+/**
+ * @brief generates IR files (XML and BIN files) with the test model.
+ *        Passed reference vector is filled with OpenVINO operations to validate after the network reading.
+ * @param model_path used to serialize the generated network
+ * @param weights_path used to serialize the generated weights
+ * @param input_type input element type of the generated model
+ * @param input_shape dims on the input layer of the generated model
+ */
+void generate_test_model(const std::wstring& model_path,
+                         const std::wstring& weights_path,
+                         const ov::element::Type& input_type = ov::element::f32,
+                         const ov::PartialShape& input_shape = {1, 3, 227, 227});
+#endif
+
 /**
  * @brief generates IR files (XML and BIN files) with the test model.
  *        Passed reference vector is filled with OpenVINO operations to validate after the network reading.

--- a/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
@@ -12,7 +12,16 @@
 namespace ov {
 namespace test {
 namespace utils {
-
+#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+void generate_test_model(const std::wstring& model_path,
+                         const std::wstring& weights_path,
+                         const ov::element::Type& input_type,
+                         const ov::PartialShape& input_shape) {
+    ov::pass::Manager manager;
+    manager.register_pass<ov::pass::Serialize>(model_path, weights_path);
+    manager.run_passes(ov::test::utils::make_conv_pool_relu(input_shape.to_shape(), input_type));
+}
+#endif
 void generate_test_model(const std::string& model_path,
                          const std::string& weights_path,
                          const ov::element::Type& input_type,

--- a/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
@@ -8,6 +8,7 @@
 #include "openvino/core/partial_shape.hpp"
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/serialize.hpp"
+#include "openvino/util/wstring_convert_util.hpp"
 
 namespace ov {
 namespace test {
@@ -18,7 +19,12 @@ void generate_test_model(const std::wstring& model_path,
                          const ov::element::Type& input_type,
                          const ov::PartialShape& input_shape) {
     ov::pass::Manager manager;
+#    ifdef _WIN32
     manager.register_pass<ov::pass::Serialize>(model_path, weights_path);
+#    else
+    manager.register_pass<ov::pass::Serialize>(ov::util::wstring_to_string(model_path),
+                                               ov::util::wstring_to_string(weights_path));
+#    endif
     manager.run_passes(ov::test::utils::make_conv_pool_relu(input_shape.to_shape(), input_type));
 }
 #endif


### PR DESCRIPTION
### Details:
 - Enhance read_model function overloads to support wchar_t paths

### Tickets:
 - [CVS-168219](https://jira.devtools.intel.com/browse/CVS-168219)
