### PR TITLE
[JS] Fix the tar-fs vulnerability for release branch

### DIFF
--- a/src/bindings/js/node/package-lock.json
+++ b/src/bindings/js/node/package-lock.json
@@ -2381,9 +2381,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/src/bindings/js/node/package.json
+++ b/src/bindings/js/node/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "gunzip-maybe": "^1.4.2",
     "https-proxy-agent": "^7.0.2",
-    "tar-fs": "^3.0.8"
+    "tar-fs": "^3.0.9"
   },
   "binary": {
     "module_path": "./bin/",


### PR DESCRIPTION
These changes were cherry-picked from #30853.
These changes are necessary for correctly publishing the NPM package.

### Details:
 - Update the `tar-fs` dependency in the `openvino-node` package from `3.0.8` to `3.0.9`.

### Tickets:
 - CVS-168859
 