### PR TITLE
[CI] [GHA] Pin Python 3.13.3 version on Windows

### DIFF
--- a/.github/workflows/job_build_windows.yml
+++ b/.github/workflows/job_build_windows.yml
@@ -232,7 +232,7 @@ jobs:
         if: ${{ inputs.build-additional-python-wheels }}
         uses: ./openvino/.github/actions/setup_python
         with:
-          version: '3.13'
+          version: '3.13.3'
           pip-cache-path: ${{ env.PIP_CACHE_PATH }}
           should-setup-pip-paths: 'true'
           self-hosted-runner: 'true'


### PR DESCRIPTION
The problem is that free-threaded builds are enabled by default in 3.13.4. [Ref](https://discuss.python.org/t/heads-up-3-13-5-release-coming-soon/94535).

