### PR TITLE
[CPU] Enable headers check in clang-tidy

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -119,7 +119,7 @@ Checks: >
 WarningsAsErrors: '*'
 # Use clang-format for applied fixes
 FormatStyle: file
-# HeaderFilterRegex: 'src/plugins/intel_cpu/src/.*'
+HeaderFilterRegex: 'src/plugins/intel_cpu/src/[^/]*\.h(pp)?$'
 CheckOptions:
   - key: cppcoreguidelines-avoid-do-while.IgnoreMacros
     value: true

--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -119,7 +119,7 @@ Checks: >
 WarningsAsErrors: '*'
 # Use clang-format for applied fixes
 FormatStyle: file
-HeaderFilterRegex: 'src/plugins/intel_cpu/src/[^/]*\.h(pp)?$'
+HeaderFilterRegex: 'src/plugins/intel_cpu/src/.*\.h(pp)?$'
 CheckOptions:
   - key: cppcoreguidelines-avoid-do-while.IgnoreMacros
     value: true

--- a/src/plugins/intel_cpu/src/async_infer_request.h
+++ b/src/plugins/intel_cpu/src/async_infer_request.h
@@ -14,16 +14,15 @@
 #include "openvino/runtime/threading/istreams_executor.hpp"
 #include "openvino/runtime/threading/itask_executor.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class AsyncInferRequest : public ov::IAsyncInferRequest {
 public:
     AsyncInferRequest(const std::shared_ptr<IInferRequest>& request,
                       const std::shared_ptr<ov::threading::ITaskExecutor>& task_executor,
                       const std::shared_ptr<ov::threading::ITaskExecutor>& callback_executor,
-                      const bool is_optimized_single_stream = false);
-    ~AsyncInferRequest();
+                      bool is_optimized_single_stream = false);
+    ~AsyncInferRequest() override;
 
     void infer() override;
 
@@ -46,5 +45,4 @@ public:
     std::function<void()> m_infer_func;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cache/cache_entry.h
+++ b/src/plugins/intel_cpu/src/cache/cache_entry.h
@@ -11,14 +11,12 @@
 
 #include "lru_cache.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class CacheEntryBase {
 public:
     enum class LookUpStatus : int8_t { Hit, Miss };
 
-public:
     virtual ~CacheEntryBase() = default;
 };
 
@@ -38,7 +36,6 @@ class CacheEntry : public CacheEntryBase {
 public:
     using ResultType = std::pair<ValType, LookUpStatus>;
 
-public:
     explicit CacheEntry(size_t capacity) : _impl(capacity) {}
 
     /**
@@ -61,15 +58,14 @@ public:
         if (retVal == retEmpty) {
             retStatus = LookUpStatus::Miss;
             retVal = builder(key);
-            if (retVal != retEmpty)
+            if (retVal != retEmpty) {
                 _impl.put(key, retVal);
+            }
         }
         return {retVal, retStatus};
     }
 
-public:
     ImplType _impl;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cache/lru_cache.h
+++ b/src/plugins/intel_cpu/src/cache/lru_cache.h
@@ -18,15 +18,13 @@
  * @attention This cache implementation IS NOT THREAD SAFE!
  */
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 template <typename Key, typename Value>
 class LruCache {
 public:
     using value_type = std::pair<Key, Value>;
 
-public:
     explicit LruCache(size_t capacity) : _capacity(capacity) {}
 
     /**
@@ -84,7 +82,7 @@ public:
      * @brief Returns the current capacity value
      * @return the current capacity value
      */
-    size_t getCapacity() const noexcept {
+    [[nodiscard]] size_t getCapacity() const noexcept {
         return _capacity;
     }
 
@@ -107,5 +105,4 @@ private:
     size_t _capacity;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cache/multi_cache.h
+++ b/src/plugins/intel_cpu/src/cache/multi_cache.h
@@ -12,8 +12,7 @@
 
 #include "cache_entry.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * @brief Class that represent a preemptive cache for different key/value pair types.
@@ -29,7 +28,6 @@ public:
     template <typename KeyType, typename ValueType>
     using EntryPtr = std::shared_ptr<EntryTypeT<KeyType, ValueType>>;
 
-public:
     /**
      * @param capacity here means maximum records limit FOR EACH entry specified by a pair of Key/Value types.
      * @note zero capacity means empty cache so no records are stored and no entries are created
@@ -59,7 +57,6 @@ private:
     template <typename KeyType, typename ValueType>
     EntryPtr<KeyType, ValueType> getEntry();
 
-private:
     static std::atomic_size_t _typeIdCounter;
     size_t _capacity;
     std::unordered_map<size_t, EntryBasePtr> _storage;
@@ -88,5 +85,4 @@ using MultiCacheWeakCPtr = std::weak_ptr<const MultiCache>;
 using MultiCachePtr = std::shared_ptr<MultiCache>;
 using MultiCacheCPtr = std::shared_ptr<const MultiCache>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -26,12 +26,11 @@
 #include "sub_memory_manager.hpp"
 #include "weights_cache.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class CompiledModel : public ov::ICompiledModel {
 public:
-    typedef std::shared_ptr<CompiledModel> Ptr;
+    using Ptr = std::shared_ptr<CompiledModel>;
 
     struct GraphGuard : public Graph {
         std::mutex _mutex;
@@ -41,14 +40,13 @@ public:
         };
     };
 
-public:
     CompiledModel(const std::shared_ptr<ov::Model>& model,
                   const std::shared_ptr<const ov::IPlugin>& plugin,
                   Config cfg,
-                  const bool loaded_from_cache,
+                  bool loaded_from_cache,
                   std::shared_ptr<SubMemoryManager> sub_memory_manager = nullptr);
 
-    ~CompiledModel();
+    ~CompiledModel() override;
 
     std::shared_ptr<ov::IAsyncInferRequest> create_infer_request() const override;
 
@@ -58,7 +56,7 @@ public:
 
     ov::Any get_property(const std::string& name) const override;
 
-    void set_property(const ov::AnyMap& properties) override {
+    void set_property([[maybe_unused]] const ov::AnyMap& properties) override {
         OPENVINO_THROW_NOT_IMPLEMENTED("It's not possible to set property of an already compiled model. "
                                        "Set property to Core::compile_model during compilation");
     };
@@ -131,7 +129,7 @@ public:
     CompiledModelHolder(CompiledModelHolder&&) = default;
     CompiledModelHolder& operator=(CompiledModelHolder&&) = default;
 
-    const Graph& graph() const {
+    [[nodiscard]] const Graph& graph() const {
         return *m_graph;
     }
 
@@ -142,15 +140,15 @@ public:
         return lock;
     }
 
-    std::string name() const {
+    [[nodiscard]] std::string name() const {
         return m_compiled_model->name();
     }
 
-    std::shared_ptr<const ov::ICompiledModel> compiled_model() const {
+    [[nodiscard]] std::shared_ptr<const ov::ICompiledModel> compiled_model() const {
         return m_compiled_model;
     }
 
-    int id() const {
+    [[nodiscard]] int id() const {
         return m_id;
     }
 
@@ -160,5 +158,4 @@ private:
     int m_id;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/config.h
+++ b/src/plugins/intel_cpu/src/config.h
@@ -20,41 +20,40 @@
 #include "openvino/runtime/threading/istreams_executor.hpp"
 #include "utils/debug_caps_config.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 struct Config {
     Config();
 
-    enum LPTransformsMode {
+    enum LPTransformsMode : uint8_t {
         Off,
         On,
     };
 
-    enum DenormalsOptMode {
+    enum DenormalsOptMode : uint8_t {
         DO_Keep,
         DO_Off,
         DO_On,
     };
 
-    enum SnippetsMode {
+    enum SnippetsMode : uint8_t {
         Enable,
         IgnoreCallback,
         Disable,
     };
 
-    enum CacheQuantMode {
+    enum CacheQuantMode : uint8_t {
         AUTO,
         BY_CHANNEL,
         BY_HIDDEN,
     };
 
-    enum class ModelType { CNN, LLM, Unknown };
+    enum class ModelType : uint8_t { CNN, LLM, Unknown };
 
     bool collectPerfCounters = false;
     bool exclusiveAsyncRequests = false;
     SnippetsMode snippetsMode = SnippetsMode::Enable;
-    std::string dumpToDot = {};
-    std::string device_id = {};
+    std::string dumpToDot;
+    std::string device_id;
     float fcSparseWeiDecompressionRate = 1.0f;
     uint64_t fcDynamicQuantizationGroupSize = 32;
     bool fcDynamicQuantizationGroupSizeSetExplicitly = false;
@@ -96,7 +95,7 @@ struct Config {
     bool changedCpuPinning = false;
     bool enableCpuReservation = false;
     ov::hint::SchedulingCoreType schedulingCoreType = ov::hint::SchedulingCoreType::ANY_CORE;
-    std::set<ov::hint::ModelDistributionPolicy> modelDistributionPolicy = {};
+    std::set<ov::hint::ModelDistributionPolicy> modelDistributionPolicy;
     int streamsRankLevel = 1;
     int numSubStreams = 0;
     bool enableNodeSplit = false;
@@ -120,7 +119,7 @@ struct Config {
     // is reserved.
     bool DAZOn = false;
 
-    void readProperties(const ov::AnyMap& prop, const ModelType modelType = ModelType::Unknown);
+    void readProperties(const ov::AnyMap& prop, ModelType modelType = ModelType::Unknown);
 
     void updateProperties();
 
@@ -139,5 +138,4 @@ struct Config {
 #endif
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_map_scheduling.hpp
+++ b/src/plugins/intel_cpu/src/cpu_map_scheduling.hpp
@@ -34,7 +34,7 @@ std::vector<std::vector<int>> apply_scheduling_core_type(ov::hint::SchedulingCor
  * @return     updated proc_type_table which removed unmatched processors
  */
 std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
-                                                    const bool input_ht_changed,
+                                                    bool input_ht_changed,
                                                     const std::string& input_pm_hint,
                                                     const std::vector<std::vector<int>>& proc_type_table);
 
@@ -47,9 +47,9 @@ std::vector<std::vector<int>> apply_hyper_threading(bool& input_ht_hint,
  * @param[in]  streams_info_table indicate streams detail of this model
  * @return     whether pinning threads to cpu cores
  */
-bool check_cpu_pinning(const bool cpu_pinning,
-                       const bool cpu_pinning_changed,
-                       const bool cpu_reservation,
+bool check_cpu_pinning(bool cpu_pinning,
+                       bool cpu_pinning_changed,
+                       bool cpu_reservation,
                        const std::vector<std::vector<int>>& streams_info_table);
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -31,8 +31,7 @@
  *
  */
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Memory;
 class ProxyMemoryBlock;
@@ -50,7 +49,7 @@ public:
      * @brief Accessor to underlying memory buffer
      * @return A pointer to underlying memory
      */
-    virtual void* getRawPtr() const noexcept = 0;
+    [[nodiscard]] virtual void* getRawPtr() const noexcept = 0;
 
     /**
      * @brief Allows to set externally allocated memory buffer. In that case, the object has no control over the
@@ -71,7 +70,7 @@ public:
      * @brief Check if the object has control over underlying memory buffer
      * @return status whether the object has control over underlying memory buffer
      */
-    virtual bool hasExtBuffer() const noexcept = 0;
+    [[nodiscard]] virtual bool hasExtBuffer() const noexcept = 0;
 };
 
 /**
@@ -80,12 +79,12 @@ public:
 class MemoryBlockWithReuse : public IMemoryBlock {
 public:
     MemoryBlockWithReuse(int numa_node = -1) : m_data(nullptr, release), numa_node(numa_node) {}
-    void* getRawPtr() const noexcept override;
+    [[nodiscard]] void* getRawPtr() const noexcept override;
     void setExtBuff(void* ptr, size_t size) override;
     bool resize(size_t size) override;
-    bool hasExtBuffer() const noexcept override;
+    [[nodiscard]] bool hasExtBuffer() const noexcept override;
     void free();
-    size_t size() const;  // in bytes
+    [[nodiscard]] size_t size() const;  // in bytes
 
 private:
     bool m_useExternalStorage = false;
@@ -109,17 +108,16 @@ public:
 class DnnlMemoryBlock : public IMemoryBlockObserver {
 public:
     explicit DnnlMemoryBlock(std::unique_ptr<IMemoryBlock> memBlock) : m_pMemBlock(std::move(memBlock)) {}
-    void* getRawPtr() const noexcept override;
+    [[nodiscard]] void* getRawPtr() const noexcept override;
     void setExtBuff(void* ptr, size_t size) override;
     bool resize(size_t size) override;
-    bool hasExtBuffer() const noexcept override;
+    [[nodiscard]] bool hasExtBuffer() const noexcept override;
     void registerMemory(Memory* memPtr) override;
     void unregisterMemory(Memory* memPtr) override;
 
 private:
     void notifyUpdate();
 
-private:
     std::unordered_set<Memory*> m_setMemPtrs;
     std::unique_ptr<IMemoryBlock> m_pMemBlock;
 };
@@ -154,7 +152,7 @@ public:
         }
     }
 
-    MemoryBlockPtr get() const {
+    [[nodiscard]] MemoryBlockPtr get() const {
         return m_pMemBlock;
     }
 
@@ -171,13 +169,13 @@ class IMemory {
 public:
     virtual ~IMemory() = default;
 
-    virtual const MemoryDesc& getDesc() const = 0;
-    virtual MemoryDescPtr getDescPtr() const = 0;
+    [[nodiscard]] virtual const MemoryDesc& getDesc() const = 0;
+    [[nodiscard]] virtual MemoryDescPtr getDescPtr() const = 0;
 
-    virtual void* getData() const = 0;  // pointer to the actual memory
+    [[nodiscard]] virtual void* getData() const = 0;  // pointer to the actual memory
 
-    template <typename T, typename datatype = typename std::decay<T>::type>
-    T* getDataAs() const {
+    template <typename T, typename datatype = std::decay_t<T>>
+    [[nodiscard]] T* getDataAs() const {
         /** @todo enabling this check requires all the nodes to follow this requirement
          * OPENVINO_ASSERT(element::from<datatype>() == getPrecision(),
          * "Memory data element type ", getPrecision(), " is not representable as ", element::from<datatype>());
@@ -185,9 +183,9 @@ public:
         return static_cast<T*>(getData());
     }
 
-    virtual size_t getSize() const = 0;  // in bytes
-    virtual const Shape& getShape() const = 0;
-    virtual const VectorDims& getStaticDims() const = 0;
+    [[nodiscard]] virtual size_t getSize() const = 0;  // in bytes
+    [[nodiscard]] virtual const Shape& getShape() const = 0;
+    [[nodiscard]] virtual const VectorDims& getStaticDims() const = 0;
 
     // Redefines descriptor. The memory descriptor will be replaced with the new one.
     // Memory will not be reallocated according to the dynamic memory block policy
@@ -196,11 +194,11 @@ public:
 
     virtual void load(const IMemory& src, bool ftz, bool bf16saturation) const = 0;
 
-    virtual MemoryBlockPtr getMemoryBlock() const = 0;
+    [[nodiscard]] virtual MemoryBlockPtr getMemoryBlock() const = 0;
 
     virtual void nullify() = 0;
 
-    bool isDefined() const noexcept {
+    [[nodiscard]] bool isDefined() const noexcept {
         if (auto desc = getDescPtr()) {
             return desc->isDefined();
         }
@@ -208,20 +206,20 @@ public:
     }
 
     // oneDNN specifics for backward compatibility
-    virtual dnnl::memory getPrimitive() const = 0;
+    [[nodiscard]] virtual dnnl::memory getPrimitive() const = 0;
 
-    ov::element::Type getPrecision() const {
+    [[nodiscard]] ov::element::Type getPrecision() const {
         return getDesc().getPrecision();
     }
 
-    dnnl::memory::data_type getDataType() const {
+    [[nodiscard]] dnnl::memory::data_type getDataType() const {
         return DnnlExtensionUtils::ElementTypeToDataType(getDesc().getPrecision());
     }
 
     template <typename T,
-              typename std::enable_if<!std::is_pointer<T>::value && !std::is_reference<T>::value, int>::type = 0,
-              typename std::enable_if<std::is_base_of<MemoryDesc, T>::value, int>::type = 0>
-    std::shared_ptr<T> getDescWithType() const;
+              std::enable_if_t<!std::is_pointer_v<T> && !std::is_reference_v<T>, int> = 0,
+              std::enable_if_t<std::is_base_of_v<MemoryDesc, T>, int> = 0>
+    [[nodiscard]] std::shared_ptr<T> getDescWithType() const;
 };
 
 class StaticMemory final : public IMemory {
@@ -230,10 +228,10 @@ public:
     public:
         explicit StaticMemoryBlock(size_t size);
         StaticMemoryBlock(void* data, size_t size);
-        void* getRawPtr() const noexcept override;
+        [[nodiscard]] void* getRawPtr() const noexcept override;
         void setExtBuff(void* ptr, size_t size) override;
         bool resize(size_t size) override;
-        bool hasExtBuffer() const noexcept override;
+        [[nodiscard]] bool hasExtBuffer() const noexcept override;
         void registerMemory(Memory* memPtr) override;
         void unregisterMemory(Memory* memPtr) override;
 
@@ -244,7 +242,6 @@ public:
 
     using MemBlockPtr = std::shared_ptr<StaticMemoryBlock>;
 
-public:
     StaticMemory(dnnl::engine eng, MemoryDescPtr desc, const void* data = nullptr, bool pads_zeroing = true);
     StaticMemory(dnnl::engine eng, const MemoryDesc& desc, const void* data = nullptr, bool pads_zeroing = true);
 
@@ -254,24 +251,24 @@ public:
     StaticMemory(Memory&&) = delete;
     StaticMemory& operator=(StaticMemory&&) = delete;
 
-    const MemoryDesc& getDesc() const override;
-    MemoryDescPtr getDescPtr() const override;
+    [[nodiscard]] const MemoryDesc& getDesc() const override;
+    [[nodiscard]] MemoryDescPtr getDescPtr() const override;
 
-    void* getData() const override;  // pointer to the actual memory
+    [[nodiscard]] void* getData() const override;  // pointer to the actual memory
 
-    size_t getSize() const override;  // in bytes
-    const Shape& getShape() const override;
-    const VectorDims& getStaticDims() const override;
+    [[nodiscard]] size_t getSize() const override;  // in bytes
+    [[nodiscard]] const Shape& getShape() const override;
+    [[nodiscard]] const VectorDims& getStaticDims() const override;
 
     // Always throws since a static memory descriptor should not be modified
     void redefineDesc(MemoryDescPtr desc) override;
 
     void load(const IMemory& src, bool ftz, bool bf16saturation) const override;
 
-    MemoryBlockPtr getMemoryBlock() const override;
+    [[nodiscard]] MemoryBlockPtr getMemoryBlock() const override;
 
     // oneDNN specifics for backward compatibility
-    dnnl::memory getPrimitive() const override;
+    [[nodiscard]] dnnl::memory getPrimitive() const override;
 
     void nullify() override;
 
@@ -336,13 +333,11 @@ private:
     friend DnnlMemoryBlock;
     friend ProxyMemoryBlock;
 
-private:
     void update();
 
     void create(const MemoryDesc& desc, const void* data = nullptr, bool pads_zeroing = true);
     void create(MemoryDescPtr desc, const void* data = nullptr, bool pads_zeroing = true);
 
-private:
     dnnl::engine m_eng;
     MemoryDescPtr m_pMemDesc;
     DnnlMemBlockHandle m_blockHandle;
@@ -373,13 +368,13 @@ public:
 
     class StringMemoryBlock {
     public:
-        StringMemoryBlock() : m_data(nullptr, release) {}
-        OvString* getStringPtr() const noexcept;
+        StringMemoryBlock() : m_data(nullptr, release){};
+        [[nodiscard]] OvString* getStringPtr() const noexcept;
         void setExtBuff(OvString* ptr, size_t size);
-        size_t getStrLen() const noexcept;
-        void* getRawPtr() const noexcept;
+        [[nodiscard]] size_t getStrLen() const noexcept;
+        [[nodiscard]] void* getRawPtr() const noexcept;
         bool resize(size_t size /* string elements number */);
-        bool hasExtBuffer() const noexcept;
+        [[nodiscard]] bool hasExtBuffer() const noexcept;
 
     private:
         bool m_use_external_storage = false;
@@ -405,23 +400,23 @@ public:
     StringMemory(dnnl::engine engine, const MemoryDesc& desc, StringMemoryBlockPtr block)
         : StringMemory(std::move(engine), desc.clone(), std::move(block)) {}
 
-    const MemoryDesc& getDesc() const override {
+    [[nodiscard]] const MemoryDesc& getDesc() const override {
         return *m_mem_desc;
     }
 
-    MemoryDescPtr getDescPtr() const override {
+    [[nodiscard]] MemoryDescPtr getDescPtr() const override {
         return m_mem_desc;
     }
 
-    void* getData() const override;
+    [[nodiscard]] void* getData() const override;
 
-    size_t getSize() const override;  // In bytes
+    [[nodiscard]] size_t getSize() const override;  // In bytes
 
-    const Shape& getShape() const override {
+    [[nodiscard]] const Shape& getShape() const override {
         return m_mem_desc->getShape();
     }
 
-    const VectorDims& getStaticDims() const override {
+    [[nodiscard]] const VectorDims& getStaticDims() const override {
         return m_mem_desc->getShape().getStaticDims();
     }
 
@@ -429,13 +424,13 @@ public:
 
     void load(const IMemory& src, bool ftz, bool bf16saturation) const override;
 
-    MemoryBlockPtr getMemoryBlock() const override;
+    [[nodiscard]] MemoryBlockPtr getMemoryBlock() const override;
 
-    StringMemoryBlockPtr getStringMemoryBlockPtr() const {
+    [[nodiscard]] StringMemoryBlockPtr getStringMemoryBlockPtr() const {
         return m_memoryBlock;
     }
 
-    dnnl::memory getPrimitive() const override;
+    [[nodiscard]] dnnl::memory getPrimitive() const override;
 
     void nullify() override;
 
@@ -466,5 +461,4 @@ MemoryPtr split_vertical(const dnnl::engine& eng,
                          int w_size,
                          bool need_fill = true);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_shape.h
+++ b/src/plugins/intel_cpu/src/cpu_shape.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 #include <limits>
 #include <string>
@@ -16,8 +17,7 @@
 #include "openvino/core/interval.hpp"
 #include "openvino/core/partial_shape.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Shape {
 public:
@@ -43,7 +43,7 @@ public:
         });
     }
 
-    explicit Shape(const VectorDims& shape) : type(ShapeType::Static), dims(minDims = maxDims = shape) {
+    explicit Shape(const VectorDims& shape) : dims(minDims = maxDims = shape) {
         hasZeroDimensions = std::any_of(dims.begin(), dims.end(), [](size_t dim) {
             return dim == 0;
         });
@@ -71,7 +71,7 @@ public:
         });
     }
 
-    Shape(const std::initializer_list<Dim>& shape) : type(ShapeType::Static) {
+    Shape(const std::initializer_list<Dim>& shape) {
         minDims.reserve(shape.size());
         maxDims.reserve(shape.size());
 
@@ -100,7 +100,7 @@ public:
      * dims = [UNDEFINED_DIM, UNDEFINED_DIM, UNDEFINED_DIM, UNDEFINED_DIM]
      * @return return lower bound of shape = [1, 1, 1, 1]
      */
-    const VectorDims& getMinDims() const {
+    [[nodiscard]] const VectorDims& getMinDims() const {
         return minDims;
     }
 
@@ -117,7 +117,7 @@ public:
      * dims = [UNDEFINED_DIM, UNDEFINED_DIM, UNDEFINED_DIM, UNDEFINED_DIM]
      * @return return upper bound of shape = [6, 6, 6, 6]
      */
-    const VectorDims& getMaxDims() const {
+    [[nodiscard]] const VectorDims& getMaxDims() const {
         return maxDims;
     }
 
@@ -125,7 +125,7 @@ public:
      * @brief return defined shape or throw exception for dynamic case
      * @return return shape
      */
-    const VectorDims& getStaticDims() const {
+    [[nodiscard]] const VectorDims& getStaticDims() const {
         if (type != ShapeType::Static) {
             OPENVINO_THROW("Cannot get dims for non static shape");
         }
@@ -146,41 +146,41 @@ public:
      * dims = [2, 3, UNDEFINED_DIM, UNDEFINED_DIM]
      * @return return shape with defined and undefined dims = [2, 3, UNDEFINED_DIM, UNDEFINED_DIM]
      */
-    const VectorDims& getDims() const {
+    [[nodiscard]] const VectorDims& getDims() const {
         return dims;
     }
 
-    bool isStatic() const {
+    [[nodiscard]] bool isStatic() const {
         return type == ShapeType::Static;
     }
 
-    bool isDynamic() const {
+    [[nodiscard]] bool isDynamic() const {
         return type == ShapeType::Dynamic;
     }
 
-    bool hasZeroDims() const {
+    [[nodiscard]] bool hasZeroDims() const {
         return hasZeroDimensions;
     }
 
-    size_t getRank() const {
+    [[nodiscard]] size_t getRank() const {
         return minDims.size();
     }
 
-    size_t getElementsCount() const {
+    [[nodiscard]] size_t getElementsCount() const {
         if (type != ShapeType::Static) {
             OPENVINO_THROW("Cannot get elements count for non static shape");
         }
 
         size_t size = 1;
 
-        for (size_t i = 0; i < minDims.size(); i++) {
-            size *= minDims[i];
+        for (uint64_t minDim : minDims) {
+            size *= minDim;
         }
 
         return size;
     }
 
-    ov::PartialShape toPartialShape() const {
+    [[nodiscard]] ov::PartialShape toPartialShape() const {
         using ov::Dimension;
         std::vector<Dimension> nGraphDims;
         nGraphDims.reserve(minDims.size());
@@ -189,12 +189,12 @@ public:
             Dimension::value_type maxDim = Shape::UNDEFINED_DIM == maxDims[i] ? -1 : maxDims[i];
             nGraphDims.emplace_back(minDim, maxDim);
         }
-        return ov::PartialShape(nGraphDims);
+        return {nGraphDims};
     }
 
-    bool isCompatible(const VectorDims& vecDims) const;
+    [[nodiscard]] bool isCompatible(const VectorDims& vecDims) const;
 
-    std::string toString() const;
+    [[nodiscard]] std::string toString() const;
 
     bool operator==(const Shape& rhs) const {
         return minDims == rhs.minDims && maxDims == rhs.maxDims;
@@ -204,7 +204,7 @@ public:
         return !(*this == rhs);
     }
 
-    bool hasDefinedUpperBounds() const {
+    [[nodiscard]] bool hasDefinedUpperBounds() const {
         return std::all_of(maxDims.begin(), maxDims.end(), [](Dim dim) {
             return dim != UNDEFINED_DIM;
         });
@@ -220,7 +220,7 @@ private:
         }
     }
 
-    enum class ShapeType { Static, Dynamic } type{ShapeType::Static};
+    enum class ShapeType : uint8_t { Static, Dynamic } type{ShapeType::Static};
 
     bool hasZeroDimensions = false;
 
@@ -241,5 +241,4 @@ private:
 
 Shape mergeShapes(const Shape& lhs, const Shape& rhs);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_streams_calculation.hpp
+++ b/src/plugins/intel_cpu/src/cpu_streams_calculation.hpp
@@ -44,11 +44,11 @@ namespace ov::intel_cpu {
  * @return     streams information table which will be used by StreamsExecutor.
  */
 std::vector<std::vector<int>> get_streams_info_table(
-    const int input_streams,
-    const bool input_streams_changed,
-    const int input_threads,
-    const int input_infer_requests,
-    const int model_prefer_threads,
+    int input_streams,
+    bool input_streams_changed,
+    int input_threads,
+    int input_infer_requests,
+    int model_prefer_threads,
     const std::string& input_perf_hint,
     const std::set<ov::hint::ModelDistributionPolicy>& hint_model_distribution_policy,
     const std::vector<std::vector<int>>& proc_type_table);
@@ -61,7 +61,7 @@ std::vector<std::vector<int>> get_streams_info_table(
  * @return     streams rank table which will be used by StreamsExecutor.
  */
 std::vector<std::vector<int>> get_streams_rank_table(const std::vector<std::vector<int>>& streams_info_table,
-                                                     const int input_rank_level,
+                                                     int input_rank_level,
                                                      int& num_sub_streams);
 
 /**
@@ -75,7 +75,7 @@ std::vector<std::vector<int>> get_streams_rank_table(const std::vector<std::vect
  * @param[in]  config intel cpu configuration
  * @return     model_prefer_threads "0" means generating the optimal threads per stream based on platform
  */
-int get_model_prefer_threads(const int num_streams,
+int get_model_prefer_threads(int num_streams,
                              const std::vector<std::vector<int>>& proc_type_table,
                              const std::shared_ptr<ov::Model>& model,
                              Config& config);
@@ -92,8 +92,8 @@ int get_model_prefer_threads(const int num_streams,
  * @return     candidate processors have benn updated based on user input hints like ov::hint::scheduling_core_type and
  * ov::hint::enable_hyper_threading
  */
-std::vector<std::vector<int>> generate_stream_info(const int streams,
-                                                   const int input_numa_node_id,
+std::vector<std::vector<int>> generate_stream_info(int streams,
+                                                   int input_numa_node_id,
                                                    const std::shared_ptr<ov::Model>& model,
                                                    Config& config,
                                                    std::vector<std::vector<int>>& proc_type_table,
@@ -105,7 +105,7 @@ std::vector<std::vector<int>> generate_stream_info(const int streams,
  * @param[in]  model graph handle
  * @param[in]  config intel cpu configuration
  */
-void get_num_streams(const int streams, const std::shared_ptr<ov::Model>& model, Config& config);
+void get_num_streams(int streams, const std::shared_ptr<ov::Model>& model, Config& config);
 
 /**
  * @brief      Sort proc_type_table by numa node id on which application is running. The numa node will move to first
@@ -113,6 +113,6 @@ void get_num_streams(const int streams, const std::shared_ptr<ov::Model>& model,
  * @param[in]  current_numa_node numa node ID on which application is running.
  * @param[in]  proc_type_table summary table of number of processors per type
  */
-void sort_table_by_numa_node_id(const int current_numa_node, std::vector<std::vector<int>>& proc_type_table);
+void sort_table_by_numa_node_id(int current_numa_node, std::vector<std::vector<int>>& proc_type_table);
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_tensor.h
+++ b/src/plugins/intel_cpu/src/cpu_tensor.h
@@ -14,8 +14,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/runtime/itensor.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Tensor : public ITensor {
 public:
@@ -56,5 +55,4 @@ private:
 
 std::shared_ptr<ITensor> make_tensor(MemoryPtr mem);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/cpu_types.h
+++ b/src/plugins/intel_cpu/src/cpu_types.h
@@ -5,13 +5,13 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <vector>
 
 #include "utils/caseless.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 using Dim = std::size_t;
 using VectorDims = std::vector<Dim>;
@@ -19,7 +19,7 @@ using VectorDims = std::vector<Dim>;
 std::string dim2str(Dim dim);
 std::string dims2str(const VectorDims& dims);
 
-enum class Type {
+enum class Type : uint8_t {
     Unknown,
     If,
     Reorder,
@@ -139,7 +139,7 @@ enum class Type {
     LoRA
 };
 
-enum class Algorithm {
+enum class Algorithm : uint8_t {
     Default,
 
     // Pooling algorithms
@@ -291,9 +291,8 @@ extern const ov::intel_cpu::caseless_unordered_map<std::string, Type> type_to_na
 
 Type TypeFromName(const std::string& type);
 
-std::string NameFromType(const Type type);
+std::string NameFromType(Type type);
 
-std::string algToString(const Algorithm alg);
+std::string algToString(Algorithm alg);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.cpp
@@ -65,7 +65,7 @@ uint8_t DnnlExtensionUtils::sizeOfDataType(dnnl::memory::data_type dataType) {
 
 std::optional<dnnl::memory::data_type> DnnlExtensionUtils::ElementTypeToDataType(
     const ov::element::Type& elementType,
-    DnnlExtensionUtils::nothrow_tag /*unused*/) noexcept {
+    [[maybe_unused]] DnnlExtensionUtils::nothrow_tag tag) noexcept {
     switch (elementType) {
     case ov::element::f32:
         return memory::data_type::f32;
@@ -105,7 +105,7 @@ std::optional<dnnl::memory::data_type> DnnlExtensionUtils::ElementTypeToDataType
 }
 
 dnnl::memory::data_type DnnlExtensionUtils::ElementTypeToDataType(const ov::element::Type& elementType,
-                                                                  DnnlExtensionUtils::throw_tag /*unused*/) {
+                                                                  [[maybe_unused]] DnnlExtensionUtils::throw_tag tag) {
     auto&& result = ElementTypeToDataType(elementType, nothrow_tag{});
     OPENVINO_ASSERT(result, "CPU plugin does not support ", elementType.to_string(), " for use with oneDNN.");
     return result.value();

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.h
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.h
@@ -36,19 +36,18 @@ public:
     struct throw_tag {};
     struct nothrow_tag {};
 
-public:
     static uint8_t sizeOfDataType(dnnl::memory::data_type dataType);
     static dnnl::memory::data_type ElementTypeToDataType(const ov::element::Type& elementType,
                                                          throw_tag tag = throw_tag{});
 
     static std::optional<dnnl::memory::data_type> ElementTypeToDataType(const ov::element::Type& elementType,
-                                                                        nothrow_tag) noexcept;
+                                                                        nothrow_tag /*unused*/) noexcept;
 
     static ov::element::Type DataTypeToElementType(const dnnl::memory::data_type& dataType);
     static Dim convertToDim(const dnnl::memory::dim& dim);
     static dnnl::memory::dim convertToDnnlDim(const Dim& dim);
     static VectorDims convertToVectorDims(const dnnl::memory::dims& dims);
-    static VectorDims convertToVectorDims(const dnnl::impl::dims_t dims, const int ndims);
+    static VectorDims convertToVectorDims(const dnnl::impl::dims_t dims, int ndims);
     static std::vector<dnnl::memory::dim> convertToDnnlDims(const VectorDims& dims);
     static dnnl::memory::format_tag GetPlainFormatByRank(size_t rank);
 
@@ -85,7 +84,7 @@ public:
         while (itpd) {
             const impl_desc_type descImplType = parse_impl_name(itpd.impl_info_str());
 
-            if (comparator(descImplType)) {
+            if (std::forward<T>(comparator)(descImplType)) {
                 return true;
             }
 
@@ -104,8 +103,8 @@ public:
         while (itpd) {
             const impl_desc_type descImplType = parse_impl_name(itpd.impl_info_str());
 
-            if (comparator(descImplType)) {
-                func(itpd);
+            if (std::forward<T>(comparator)(descImplType)) {
+                std::forward<L>(func)(itpd);
                 if (first_match) {
                     break;
                 }
@@ -115,8 +114,6 @@ public:
                 break;
             }
         }
-
-        return;
     }
 
     static bool find_implementation(dnnl::primitive_desc& desc, impl_desc_type impl_type);

--- a/src/plugins/intel_cpu/src/dnnl_extension_utils.h
+++ b/src/plugins/intel_cpu/src/dnnl_extension_utils.h
@@ -41,7 +41,7 @@ public:
                                                          throw_tag tag = throw_tag{});
 
     static std::optional<dnnl::memory::data_type> ElementTypeToDataType(const ov::element::Type& elementType,
-                                                                        nothrow_tag /*unused*/) noexcept;
+                                                                        nothrow_tag tag) noexcept;
 
     static ov::element::Type DataTypeToElementType(const dnnl::memory::data_type& dataType);
     static Dim convertToDim(const dnnl::memory::dim& dim);

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer.h
@@ -22,8 +22,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "post_ops.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 // so far the API only support per-Tensor or per-OC
 class DnnlPostOpsComposer {
@@ -31,11 +30,11 @@ public:
     DnnlPostOpsComposer(const PostOps& postOps,
                         const dnnl::engine& engine,
                         const VectorDims& outputDims,
-                        const size_t indexOfOutputChannelDim,
-                        const bool isINT8,
-                        const int weiScaleMaskPerChannel,
+                        size_t indexOfOutputChannelDim,
+                        bool isINT8,
+                        int weiScaleMaskPerChannel,
                         const MemoryArgs& memory,
-                        const dnnl::memory::data_type outDataType,
+                        dnnl::memory::data_type outDataType,
                         const std::vector<float>& legacyDqScales = {},
                         bool useLegacyPostOps = false,
                         bool useLegacyZeroPoints = false);
@@ -66,8 +65,8 @@ private:
     void appendAttrPostOpsLegacy(const ActivationPostOp& postOp);
     void appendAttrPostOpsLegacy(const ScaleShiftPostOp& postOp);
     void appendAttrPostOpsLegacy(const FakeQuantizePostOp& postOp);
-    void appendBinary(const dnnl::algorithm alg, const std::vector<float>& data);
-    void appendEltwise(const dnnl::algorithm alg, float alpha, float beta);
+    void appendBinary(dnnl::algorithm alg, const std::vector<float>& data);
+    void appendEltwise(dnnl::algorithm alg, float alpha, float beta);
     void appendSum(float scale, int32_t zeroPoint, ov::element::Type dataType);
     void appendRoundHTE();
     bool appendScale(const std::vector<float>& scale, bool isLastPostOp, bool allowBinary = true);
@@ -113,5 +112,4 @@ private:
     void updateDestScales();
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer_legacy.h
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer_legacy.h
@@ -16,8 +16,7 @@
 #include "cpu_memory.h"
 #include "cpu_types.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 // so far the API only support per-Tensor or per-OC
 class DnnlPostOpsComposerLegacy {
@@ -33,8 +32,8 @@ public:
                               const std::vector<float>& DQScales,
                               bool hasBias);
 
-    void appendBinary(const dnnl::algorithm alg, const std::vector<float>& data);
-    void appendEltwise(const dnnl::algorithm alg, float alpha, float beta);
+    void appendBinary(dnnl::algorithm alg, const std::vector<float>& data);
+    void appendEltwise(dnnl::algorithm alg, float alpha, float beta);
     void appendRoundHTE();
     bool appendScale(const std::vector<float>& scale, bool isLastPostOp, bool allowBinary = true);
     bool appendShift(const std::vector<float>& shift, bool allowBinary = true);
@@ -70,5 +69,4 @@ private:
     void updateDestScales();
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
+++ b/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
@@ -13,8 +13,7 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "utils/general_utils.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class DnnlScratchPad {
     MemoryBlockPtr blockPtr;
@@ -32,14 +31,14 @@ public:
         return std::make_shared<Memory>(eng, md, blockPtr);
     }
 
-    size_t size() const {
-        if (baseBlockPtr)
+    [[nodiscard]] size_t size() const {
+        if (baseBlockPtr) {
             return baseBlockPtr->size();
+        }
         return 0;
     }
 };
 
 using DnnlScratchPadPtr = std::shared_ptr<DnnlScratchPad>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -529,7 +529,7 @@ EdgePtr Edge::getSharedEdge() const {
     return memoryFromEdgePtr;
 }
 
-EdgePtr Edge::getSharedEdge(std::nothrow_t /*unused*/) const {
+EdgePtr Edge::getSharedEdge([[maybe_unused]] std::nothrow_t nothrow_tag) const {
     return memoryFromEdge.lock();
 }
 

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -11,6 +11,7 @@
 #include <new>
 #include <ostream>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -511,8 +512,8 @@ void Edge::validate() {
         return;
     }
 
-    getParent();
-    getChild();
+    std::ignore = getParent();
+    std::ignore = getChild();
 
     if (status != Status::Allocated || !memoryPtr) {
         OPENVINO_THROW("Error memory is not allocated for edge: ", *this);

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <new>
@@ -17,8 +18,7 @@
 #include "nodes/node_config.h"
 #include "weights_cache.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Node;
 class Edge;
@@ -30,7 +30,7 @@ class Edge {
 public:
     Edge(const std::shared_ptr<Node>& parent, const std::shared_ptr<Node>& child, int pr_port = 0, int ch_port = 0);
 
-    enum class Status {
+    enum class Status : uint8_t {
         Uninitialized,   // base edge is unknown yet
         NeedAllocation,  // edge is the base edge
         NotAllocated,    // edge references another edge
@@ -38,11 +38,11 @@ public:
         Validated        // edge is validated
     };
 
-    enum class ReorderStatus { Regular = 0, Optimized = 1, No = 2 };
+    enum class ReorderStatus : uint8_t { Regular = 0, Optimized = 1, No = 2 };
 
-    enum LOOK { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN };
+    enum LOOK : uint8_t { LOOK_UP = 1, LOOK_DOWN = 2, LOOK_BOTH = LOOK_UP | LOOK_DOWN };
 
-    inline Status getStatus() const noexcept {
+    [[nodiscard]] Status getStatus() const noexcept {
         return status;
     }
 
@@ -62,7 +62,7 @@ public:
     }
 
     void changeStatus(Status state);
-    bool inPlace(LOOK look = LOOK_BOTH) const;
+    [[nodiscard]] bool inPlace(LOOK look = LOOK_BOTH) const;
 
     void init();
     void allocate(const void* mem_ptr = nullptr);
@@ -71,34 +71,34 @@ public:
     void reuse(MemoryPtr ptr);
     void validate();
 
-    std::shared_ptr<Node> getParent() const;
-    std::shared_ptr<Node> getChild() const;
+    [[nodiscard]] std::shared_ptr<Node> getParent() const;
+    [[nodiscard]] std::shared_ptr<Node> getChild() const;
 
     const IMemory& getMemory();
-    MemoryPtr getMemoryPtr() const;
+    [[nodiscard]] MemoryPtr getMemoryPtr() const;
 
     ReorderStatus needReorder();
-    std::shared_ptr<Node> modifiedInPlace() const;
-    bool isDropped() const;
-    bool isUseExternalMemory() const;
+    [[nodiscard]] std::shared_ptr<Node> modifiedInPlace() const;
+    [[nodiscard]] bool isDropped() const;
+    [[nodiscard]] bool isUseExternalMemory() const;
 
-    int getInputNum() const;
-    int getOutputNum() const;
+    [[nodiscard]] int getInputNum() const;
+    [[nodiscard]] int getOutputNum() const;
 
     void setChildPort(const size_t port) {
         child_port = port;
     }
 
     void sharedMemFrom(const EdgePtr& edge);
-    EdgePtr getSharedEdge() const;
-    EdgePtr getSharedEdge(std::nothrow_t) const;
+    [[nodiscard]] EdgePtr getSharedEdge() const;
+    [[nodiscard]] EdgePtr getSharedEdge(std::nothrow_t /*unused*/) const;
 
-    bool hasDefinedMaxSize() const {
+    [[nodiscard]] bool hasDefinedMaxSize() const {
         return getOriginalDesc().hasDefinedMaxSize();
     }
 
-    std::string hash() const;
-    const MemoryDesc& getOriginalDesc() const;
+    [[nodiscard]] std::string hash() const;
+    [[nodiscard]] const MemoryDesc& getOriginalDesc() const;
 
 private:
     std::weak_ptr<Node> parent;
@@ -111,10 +111,10 @@ private:
     MemoryPtr memoryPtr;
     Status status = Status::Uninitialized;
 
-    const MemoryDesc& getInputDesc() const;
-    const MemoryDesc& getOutputDesc() const;
-    PortDescBaseCPtr getInputPortDesc() const;
-    PortDescBaseCPtr getOutputPortDesc() const;
+    [[nodiscard]] const MemoryDesc& getInputDesc() const;
+    [[nodiscard]] const MemoryDesc& getOutputDesc() const;
+    [[nodiscard]] PortDescBaseCPtr getInputPortDesc() const;
+    [[nodiscard]] PortDescBaseCPtr getOutputPortDesc() const;
 
     bool enforceReorder();
 
@@ -128,5 +128,4 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const Edge& edge);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/edge.h
+++ b/src/plugins/intel_cpu/src/edge.h
@@ -91,7 +91,7 @@ public:
 
     void sharedMemFrom(const EdgePtr& edge);
     [[nodiscard]] EdgePtr getSharedEdge() const;
-    [[nodiscard]] EdgePtr getSharedEdge(std::nothrow_t /*unused*/) const;
+    [[nodiscard]] EdgePtr getSharedEdge(std::nothrow_t nothrow_tag) const;
 
     [[nodiscard]] bool hasDefinedMaxSize() const {
         return getOriginalDesc().hasDefinedMaxSize();

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_bf16_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_bf16_emitters.hpp
@@ -20,7 +20,7 @@ namespace ov::intel_cpu {
 
 class jit_uni_vcvtneps2bf16 : public jit_emitter {
 public:
-    enum class conversion_mode { default_mode, saturation_mode };
+    enum class conversion_mode : uint8_t { default_mode, saturation_mode };
     jit_uni_vcvtneps2bf16(dnnl::impl::cpu::x64::jit_generator* host,
                           dnnl::impl::cpu::x64::cpu_isa_t host_isa,
                           ov::element::Type exec_prc = ov::element::bf16,
@@ -132,7 +132,7 @@ private:
     }
 
     void register_table_entries() override {
-        enum {
+        enum : uint8_t {
             fixup_input_code_qnan_ = 0,
             fixup_input_code_snan_ = 1,
             fixup_input_code_ninf_ = 4,

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_bf16_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_bf16_emitters.hpp
@@ -127,7 +127,7 @@ private:
         }
     }
 
-    inline int encode_fixup_selector(int input, int output) {
+    static int encode_fixup_selector(int input, int output) {
         return ((output) << (4 * (input)));
     }
 

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
@@ -168,8 +168,8 @@ protected:
         }
     }
 
-    virtual void validate_arguments(const std::vector<size_t>& /*unused*/,
-                                    const std::vector<size_t>& /*unused*/) const {}
+    virtual void validate_arguments([[maybe_unused]] const std::vector<size_t>& in,
+                                    [[maybe_unused]] const std::vector<size_t>& out) const {}
 
 #ifdef SNIPPETS_DEBUG_CAPS
     mutable jit_emitter_info_t info_;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
@@ -28,7 +28,7 @@
 
 namespace ov::intel_cpu {
 
-enum emitter_in_out_map {
+enum emitter_in_out_map : uint8_t {
     vec_to_vec,
     vec_to_gpr,
     gpr_to_vec,
@@ -38,6 +38,7 @@ enum emitter_in_out_map {
 // structure for storage of emitter parameters to hash in map
 struct emitter_params {
     [[nodiscard]] virtual size_t hash() const = 0;
+    virtual ~emitter_params() = default;
 };
 
 class jit_emitter : public ov::snippets::Emitter {
@@ -118,7 +119,7 @@ protected:
     mutable Xbyak::Reg64 p_table;
     mutable std::shared_ptr<Xbyak::Label> l_table;
 
-    enum {
+    enum : uint8_t {
         _cmp_eq_oq = dnnl::impl::cpu::x64::jit_generator::_cmp_eq_oq,
         _cmp_neq_uq = dnnl::impl::cpu::x64::jit_generator::_cmp_neq_uq,
         _cmp_lt_os = dnnl::impl::cpu::x64::jit_generator::_cmp_lt_os,

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_emitter.hpp
@@ -46,8 +46,7 @@ public:
                 dnnl::impl::cpu::x64::cpu_isa_t host_isa,
                 ov::element::Type exec_prc = ov::element::f32,
                 emitter_in_out_map in_out_type = emitter_in_out_map::vec_to_vec)
-        : Emitter(),
-          h(host),
+        : h(host),
           host_isa_(host_isa),
           exec_prc_(exec_prc),
           l_table(new Xbyak::Label()),
@@ -98,7 +97,7 @@ protected:
     virtual void register_table_entries() {}
 
     void load_table_addr() const {
-        h->mov(p_table, *l_table.get());
+        h->mov(p_table, *l_table);
     }
 
     // we accept only 32bit hexadecimal table values to avoid any rounding
@@ -168,7 +167,8 @@ protected:
         }
     }
 
-    virtual void validate_arguments(const std::vector<size_t>&, const std::vector<size_t>&) const {}
+    virtual void validate_arguments(const std::vector<size_t>& /*unused*/,
+                                    const std::vector<size_t>& /*unused*/) const {}
 
 #ifdef SNIPPETS_DEBUG_CAPS
     mutable jit_emitter_info_t info_;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_load_store_emitters.hpp
@@ -55,7 +55,7 @@ struct store_emitter_params : public emitter_params {
 };
 
 // Arithmetic modes for data type conversion in store_emitter
-enum arithmetic_mode { saturation, truncation };
+enum arithmetic_mode : uint8_t { saturation, truncation };
 
 class jit_load_emitter : public jit_emitter {
 public:
@@ -89,7 +89,7 @@ public:
 
 private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
-    void emit_isa(const Xbyak::Reg64& reg_src, const int out_vec_idx, const int offset) const;
+    void emit_isa(const Xbyak::Reg64& reg_src, int out_vec_idx, int offset) const;
 
     template <typename Vmm>
     void load_bytes(const Vmm& vmm, const Xbyak::Reg64& reg, int offset, int load_size) const;
@@ -159,7 +159,7 @@ public:
 
 private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
-    void emit_isa(const int in_vec_idx, const Xbyak::Reg64& reg_dst, const int offset) const;
+    void emit_isa(int in_vec_idx, const Xbyak::Reg64& reg_dst, int offset) const;
 
     template <typename Vmm>
     void store_bytes(const Xbyak::Reg64& reg, int offset, int store_size) const;

--- a/src/plugins/intel_cpu/src/emitters/snippets/brgemm_generic.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/brgemm_generic.hpp
@@ -21,8 +21,8 @@ struct BrgemmGenericKernelConfig : public snippets::KernelExecutorBase::GenericC
 public:
     BrgemmGenericKernelConfig() = default;
 
-    bool is_completed() const override;
-    bool is_empty() const;
+    [[nodiscard]] bool is_completed() const override;
+    [[nodiscard]] bool is_empty() const;
 
     virtual void update(int64_t M, int64_t N, int64_t K, int64_t LDA, int64_t LDB, int64_t LDC, float beta);
 
@@ -31,34 +31,34 @@ public:
         return !(*this == rhs);
     }
 
-    int64_t get_M() const {
+    [[nodiscard]] int64_t get_M() const {
         return m_M;
     }
-    int64_t get_N() const {
+    [[nodiscard]] int64_t get_N() const {
         return m_N;
     }
-    int64_t get_K() const {
+    [[nodiscard]] int64_t get_K() const {
         return m_K;
     }
-    float get_beta() const {
+    [[nodiscard]] float get_beta() const {
         return m_beta;
     }
-    int64_t get_LDA() const {
+    [[nodiscard]] int64_t get_LDA() const {
         return m_LDA;
     }
-    int64_t get_LDB() const {
+    [[nodiscard]] int64_t get_LDB() const {
         return m_LDB;
     }
-    int64_t get_LDC() const {
+    [[nodiscard]] int64_t get_LDC() const {
         return m_LDC;
     }
 
 #ifdef SNIPPETS_DEBUG_CAPS
-    virtual std::string to_string() const override;
+    [[nodiscard]] std::string to_string() const override;
 #endif
 
 protected:
-    size_t compute_hash() const;
+    [[nodiscard]] size_t compute_hash() const;
 
     int64_t m_M{0}, m_N{0}, m_K{0}, m_LDA{0}, m_LDB{0}, m_LDC{0};
     float m_beta{0};

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_kernel_executor_table.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_kernel_executor_table.hpp
@@ -41,7 +41,7 @@ protected:
         }
     };
     /** Compile kernel managed by KernelExecutor instance. Will be called only if Kernel is not found in the cache */
-    virtual std::shared_ptr<KernelType> compile_kernel(const Conf& c) const = 0;
+    [[nodiscard]] virtual std::shared_ptr<KernelType> compile_kernel(const Conf& c) const = 0;
     /** CPU plugin cache implementation is used to avoid redundant recompilations */
     ov::intel_cpu::MultiCacheWeakPtr m_kernel_cache;
 };

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -27,15 +27,15 @@ public:
     std::string to_string() const override;
 #endif
 
-    enum class RepackingImplType {
+    enum class RepackingImplType : uint8_t {
         NONE,         // no kernel-outside repacking
         IN_PARALLEL,  // should be executed in parallel_nt by each thread
         SEPARATE,     // should be separathy from kernel executed
     };
     RepackingImplType repacking_impl_type = RepackingImplType::NONE;
 
-    RepackedInputConfig repacked_input_config = {};
-    std::vector<jit_snippets_call_args::loop_args_t> loop_args = {};
+    RepackedInputConfig repacked_input_config;
+    std::vector<jit_snippets_call_args::loop_args_t> loop_args;
 };
 
 class CPURuntimeConfigurator : public ov::snippets::RuntimeConfigurator {

--- a/src/plugins/intel_cpu/src/emitters/snippets/jit_snippets_call_args.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/jit_snippets_call_args.hpp
@@ -36,7 +36,7 @@ struct jit_snippets_call_args {
     ~jit_snippets_call_args();
 
     void register_loops(const std::vector<loop_args_t>& loops);
-    void init_external_ptrs(const size_t size);
+    void init_external_ptrs(size_t size);
 
     const void* src_ptrs[SNIPPETS_MAX_DATA_PTR_COUNT] = {};
     void* dst_ptrs[SNIPPETS_MAX_DATA_PTR_COUNT] = {};
@@ -64,7 +64,7 @@ struct jit_snippets_call_args::loop_args_t {
     loop_args_t& operator=(loop_args_t other);
     friend void swap(loop_args_t& first, loop_args_t& second) noexcept;
 
-    void init_pointers_and_copy_data(const int64_t num_elements,
+    void init_pointers_and_copy_data(int64_t num_elements,
                                      const int64_t* ptr_increments,
                                      const int64_t* finalization_offsets);
 
@@ -75,8 +75,8 @@ struct jit_snippets_call_args::loop_args_t {
 };
 
 struct jit_snippets_compile_args {
-    std::vector<std::vector<size_t>> data_offsets = {};
-    std::vector<size_t> exec_domain = {};
+    std::vector<std::vector<size_t>> data_offsets;
+    std::vector<size_t> exec_domain;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/emitters/snippets/repacked_input.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/repacked_input.hpp
@@ -29,7 +29,7 @@ struct RepackedInput {
                   VectorDims out_offsets);
 
     template <class T = RepackedInputKernel, std::enable_if_t<std::is_base_of_v<RepackedInputKernel, T>, bool> = true>
-    std::shared_ptr<const T> kernel() const {
+    [[nodiscard]] std::shared_ptr<const T> kernel() const {
         const auto ker = std::dynamic_pointer_cast<const T>(m_kernel);
         OPENVINO_ASSERT(ker, "Kernel is empty!");
         return ker;
@@ -42,8 +42,8 @@ struct RepackedInput {
 private:
     std::shared_ptr<const RepackedInputKernel> m_kernel{nullptr};
     CpuBlockedMemoryDescPtr m_desc{nullptr};
-    VectorDims m_in_offsets{};
-    VectorDims m_out_offsets{};
+    VectorDims m_in_offsets;
+    VectorDims m_out_offsets;
 };
 
 using RepackedInputConfig = std::unordered_map<size_t, ov::intel_cpu::RepackedInput>;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.cpp
@@ -497,8 +497,8 @@ bool intel_cpu::CompiledSnippetCPU::empty() const {
     return get_code_size() == 0;
 }
 
-intel_cpu::CPUGenerator::CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa_, ov::intel_cpu::MultiCacheWeakPtr cache)
-    : Generator(std::make_shared<CPUTargetMachine>(isa_, std::move(cache))) {}
+intel_cpu::CPUGenerator::CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr cache)
+    : Generator(std::make_shared<CPUTargetMachine>(host_isa, std::move(cache))) {}
 intel_cpu::CPUGenerator::CPUGenerator(const std::shared_ptr<CPUTargetMachine>& target) : Generator(target) {}
 
 std::shared_ptr<snippets::Generator> intel_cpu::CPUGenerator::clone() const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
@@ -36,7 +36,7 @@ public:
 
 class CPUTargetMachine : public snippets::TargetMachine {
 public:
-    explicit CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr);
+    explicit CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr /*cache*/);
     [[nodiscard]] std::shared_ptr<snippets::TargetMachine> clone() const override;
     [[nodiscard]] bool is_supported() const override;
     snippets::CompiledSnippetPtr get_snippet() override;
@@ -59,7 +59,7 @@ private:
 
 class CPUGenerator : public snippets::Generator {
 public:
-    CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa, ov::intel_cpu::MultiCacheWeakPtr);
+    CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa, ov::intel_cpu::MultiCacheWeakPtr /*cache*/);
     CPUGenerator(const std::shared_ptr<CPUTargetMachine>& target);
     std::shared_ptr<Generator> clone() const override;
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
@@ -36,7 +36,7 @@ public:
 
 class CPUTargetMachine : public snippets::TargetMachine {
 public:
-    explicit CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr /*cache*/);
+    explicit CPUTargetMachine(dnnl::impl::cpu::x64::cpu_isa_t host_isa, ov::intel_cpu::MultiCacheWeakPtr cache);
     [[nodiscard]] std::shared_ptr<snippets::TargetMachine> clone() const override;
     [[nodiscard]] bool is_supported() const override;
     snippets::CompiledSnippetPtr get_snippet() override;
@@ -59,7 +59,7 @@ private:
 
 class CPUGenerator : public snippets::Generator {
 public:
-    CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa, ov::intel_cpu::MultiCacheWeakPtr /*cache*/);
+    CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa, ov::intel_cpu::MultiCacheWeakPtr cache);
     CPUGenerator(const std::shared_ptr<CPUTargetMachine>& target);
     std::shared_ptr<Generator> clone() const override;
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.cpp
@@ -67,7 +67,7 @@ const Xbyak::Reg64& jit_binary_call_emitter::get_call_address_reg() const {
 }
 const Xbyak::Reg64& jit_binary_call_emitter::get_callee_saved_reg() const {
     OV_CPU_JIT_EMITTER_ASSERT(m_regs_initialized, "You should call init_binary_call_regs() before using this method");
-    return get_callee_saved_reg();
+    return m_callee_saved_reg;
 }
 
 const std::set<snippets::Reg>& jit_binary_call_emitter::get_regs_to_spill() const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.cpp
@@ -67,7 +67,7 @@ const Xbyak::Reg64& jit_binary_call_emitter::get_call_address_reg() const {
 }
 const Xbyak::Reg64& jit_binary_call_emitter::get_callee_saved_reg() const {
     OV_CPU_JIT_EMITTER_ASSERT(m_regs_initialized, "You should call init_binary_call_regs() before using this method");
-    return m_callee_saved_reg;
+    return get_callee_saved_reg();
 }
 
 const std::set<snippets::Reg>& jit_binary_call_emitter::get_regs_to_spill() const {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_binary_call_emitter.hpp
@@ -71,7 +71,7 @@ protected:
 private:
     // Note: init_regs() can be called only from emit_impl, since it needs initialized regs
     // init_impl is a constant method, so all these fields have to be mutable
-    mutable std::set<snippets::Reg> m_regs_to_spill{};
+    mutable std::set<snippets::Reg> m_regs_to_spill;
     mutable Xbyak::Reg64 m_callee_saved_reg;
     mutable Xbyak::Reg64 m_call_address_reg;
     mutable bool m_regs_initialized = false;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_copy_b_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_copy_b_emitter.hpp
@@ -41,8 +41,8 @@ private:
     void validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
 
-    std::vector<size_t> m_memory_offsets{};
-    std::vector<size_t> m_buffer_ids{};
+    std::vector<size_t> m_memory_offsets;
+    std::vector<size_t> m_buffer_ids;
     std::shared_ptr<BrgemmCopyBKernelExecutor> m_kernel_executor{nullptr};
     bool m_with_comp{false};
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_brgemm_emitter.hpp
@@ -47,9 +47,9 @@ private:
 
     // Note: offsets order: A, B, C (+ scratchpad, if needed). Values can be dynamic_value if offset is calculated in
     // runtime
-    std::vector<size_t> m_memory_offsets{};
+    std::vector<size_t> m_memory_offsets;
     // Note: cluster ids order: A, B, C (+ scratchpad, if needed). Values can be dynamic_value if there is no buffer
-    std::vector<size_t> m_buffer_ids{};
+    std::vector<size_t> m_buffer_ids;
     std::shared_ptr<x64::BrgemmBaseKernelExecutor> m_kernel_executor = nullptr;
     std::optional<size_t> m_binary_postops_offset = std::nullopt;
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_debug_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_debug_emitter.hpp
@@ -17,7 +17,7 @@ namespace ov::intel_cpu {
 
 class jit_debug_emitter : public jit_emitter {
 public:
-    enum class EmissionLocation { preamble, postamble, both };
+    enum class EmissionLocation : uint8_t { preamble, postamble, both };
     jit_debug_emitter(const std::shared_ptr<jit_emitter>& target_emitter,
                       std::shared_ptr<jit_emitter> decorator_emitter,
                       const EmissionLocation& loc)

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_horizon_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_horizon_emitter.hpp
@@ -46,7 +46,7 @@ private:
     template <typename Vmm>
     void perform_op(const Vmm& vmm1, const Vmm& vmm2, const Vmm& vmm3) const;
 
-    enum class OpType { max, sum };
+    enum class OpType : uint8_t { max, sum };
     OpType m_op_type = OpType::max;
 };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_loop_emitters.hpp
@@ -96,10 +96,10 @@ protected:
     size_t num_outputs = 0;
     size_t work_amount = 0;
     size_t wa_increment = 0;
-    std::vector<bool> is_incremented = {};
-    std::vector<int64_t> ptr_increments = {};
-    std::vector<int64_t> finalization_offsets = {};
-    std::vector<int64_t> data_sizes = {};
+    std::vector<bool> is_incremented;
+    std::vector<int64_t> ptr_increments;
+    std::vector<int64_t> finalization_offsets;
+    std::vector<int64_t> data_sizes;
     size_t loop_id = 0;
     bool evaluate_once = false;
     bool are_ptr_increments_dynamic = false;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_memory_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_memory_emitters.hpp
@@ -66,7 +66,6 @@ private:
 
     void emit_data() const override;
 
-private:
     std::unique_ptr<jit_load_emitter> load_emitter = nullptr;
 };
 
@@ -102,7 +101,6 @@ private:
 
     void emit_data() const override;
 
-private:
     std::unique_ptr<jit_store_emitter> store_emitter = nullptr;
 };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_segfault_detector_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_segfault_detector_emitter.hpp
@@ -16,9 +16,9 @@
 #    include "emitters/plugin/x64/jit_emitter.hpp"
 #    include "openvino/runtime/threading/thread_local.hpp"
 
-using namespace ov::threading;
-
 namespace ov::intel_cpu {
+
+using namespace ov::threading;
 
 class jit_uni_segfault_detector_emitter;
 extern std::shared_ptr<ThreadLocal<jit_uni_segfault_detector_emitter*>> g_custom_segfault_handler;
@@ -43,7 +43,7 @@ private:
     jit_emitter* m_target_emitter = nullptr;
     bool is_target_use_load_emitter = false;
     bool is_target_use_store_emitter = false;
-    std::string m_target_node_name = "";
+    std::string m_target_node_name;
 
     void save_target_emitter() const;
     static void set_local_handler(jit_uni_segfault_detector_emitter* emitter_address);

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_snippets_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/jit_snippets_emitters.hpp
@@ -67,7 +67,6 @@ private:
     template <dnnl::impl::cpu::x64::cpu_isa_t isa>
     void emit_isa(const std::vector<size_t>& in, const std::vector<size_t>& out) const;
 
-private:
     size_t byte_size = 0lu;
 };
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -113,7 +113,7 @@ protected:
 
 struct brgemm_ref_kernel : public dnnl::impl::cpu::x64::brgemm_kernel_t {
     brgemm_ref_kernel(BrgemmKernelConfig c);
-    void operator()(dnnl::impl::cpu::x64::brgemm_kernel_params_t*) const override;
+    void operator()(dnnl::impl::cpu::x64::brgemm_kernel_params_t* /*unused*/) const override;
     dnnl_status_t create_kernel() override {
         return dnnl_status_t::dnnl_success;
     }

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -113,7 +113,7 @@ protected:
 
 struct brgemm_ref_kernel : public dnnl::impl::cpu::x64::brgemm_kernel_t {
     brgemm_ref_kernel(BrgemmKernelConfig c);
-    void operator()(dnnl::impl::cpu::x64::brgemm_kernel_params_t* /*unused*/) const override;
+    void operator()(dnnl::impl::cpu::x64::brgemm_kernel_params_t* args) const override;
     dnnl_status_t create_kernel() override {
         return dnnl_status_t::dnnl_success;
     }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1419,7 +1419,7 @@ public:
         m_completion.store(true, std::memory_order_release);
     }
 
-    void updateDynParams(size_t node_indx, size_t /*unused*/) {
+    void updateDynParams(size_t node_indx, [[maybe_unused]] size_t stop_indx) {
         size_t local_counter = node_indx;
         while (true) {
             const bool completion = m_completion.load(std::memory_order_acquire);
@@ -1453,12 +1453,12 @@ public:
           m_wait(wait),
           m_node_indx(node_indx),
           m_stop_indx(stop_indx) {}
-    task* execute(tbb::detail::d1::execution_data& /*unused*/) override {
+    task* execute([[maybe_unused]] tbb::detail::d1::execution_data& data) override {
         m_body(m_node_indx, m_stop_indx);
         m_wait.release();
         return nullptr;
     }
-    task* cancel(tbb::detail::d1::execution_data& /*unused*/) override {
+    task* cancel([[maybe_unused]] tbb::detail::d1::execution_data& data) override {
         m_wait.release();
         return nullptr;
     }

--- a/src/plugins/intel_cpu/src/graph.cpp
+++ b/src/plugins/intel_cpu/src/graph.cpp
@@ -1953,8 +1953,8 @@ NodePtr Graph::InsertReorder(const EdgePtr& edge,
     // Due to the specificity of GraphOptimizer::MergeTransposeAndReorder() that isOptimized flag uses, we shouldn't
     // do these checks.
     if (!isOptimized) {
-        reorder->getParentEdgeAt(0)->getOriginalDesc();
-        reorder->getChildEdgeAt(0)->getOriginalDesc();
+        std::ignore = reorder->getParentEdgeAt(0)->getOriginalDesc();
+        std::ignore = reorder->getChildEdgeAt(0)->getOriginalDesc();
     }
 
     return reorder;

--- a/src/plugins/intel_cpu/src/graph.h
+++ b/src/plugins/intel_cpu/src/graph.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
@@ -28,8 +29,7 @@
 #include "proxy_mem_blk.h"
 #include "utils/general_utils.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class SyncInferRequest;
 namespace node {
@@ -41,7 +41,7 @@ public:
     using Ptr = std::shared_ptr<Graph>;
     using OutputMemoryBlocks = std::unordered_map<std::size_t, ProxyMemoryBlockPtr>;
 
-    enum class Status {
+    enum class Status : uint8_t {
         NotReady = 0,
         Initialized = 1,
         ReadyStatic = 2,
@@ -111,29 +111,33 @@ public:
 
     NodePtr getInputNodeByIndex(std::size_t index) {
         auto input = inputNodesMap.find(index);
-        if (input == inputNodesMap.end())
+        if (input == inputNodesMap.end()) {
             return nullptr;
+        }
         return input->second;
     }
 
     NodePtr getOutputNodeByIndex(std::size_t index) {
         auto output = outputNodesMap.find(index);
-        if (output == outputNodesMap.end())
+        if (output == outputNodesMap.end()) {
             return nullptr;
+        }
         return output->second;
     }
 
     NodeConstPtr getInputNodeByIndex(std::size_t index) const {
         auto input = inputNodesMap.find(index);
-        if (input == inputNodesMap.end())
+        if (input == inputNodesMap.end()) {
             return nullptr;
+        }
         return input->second;
     }
 
     NodeConstPtr getOutputNodeByIndex(std::size_t index) const {
         auto output = outputNodesMap.find(index);
-        if (output == outputNodesMap.end())
+        if (output == outputNodesMap.end()) {
             return nullptr;
+        }
         return output->second;
     }
 
@@ -354,15 +358,13 @@ protected:
     friend std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph);
 
 private:
-    using event_t = void (Graph::*)(void);
+    using event_t = void (Graph::*)();
 
-private:
     void EnforceInferencePrecision();
     void EnforceBF16();
     void insertReorder(EdgePtr& edge, bool isOptimized, std::unordered_set<std::string>& uniqueLayerNames);
     void insertConvert(EdgePtr& edge);
 
-private:
     // TODO: change std::map to std::unordered_map
     std::map<std::size_t, NodePtr> inputNodesMap;
     std::map<std::size_t, NodePtr> outputNodesMap;
@@ -381,5 +383,4 @@ private:
 
 using GraphPtr = std::shared_ptr<Graph>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/graph_context.h
+++ b/src/plugins/intel_cpu/src/graph_context.h
@@ -17,8 +17,7 @@
 #include "sub_memory_manager.hpp"
 #include "weights_cache.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 namespace node {
 class MemoryStatesRegister;
@@ -29,8 +28,8 @@ class NetworkMemoryControl;
 
 class GraphContext {
 public:
-    typedef std::shared_ptr<GraphContext> Ptr;
-    typedef std::shared_ptr<const GraphContext> CPtr;
+    using Ptr = std::shared_ptr<GraphContext>;
+    using CPtr = std::shared_ptr<const GraphContext>;
 
     GraphContext(Config config,
                  WeightsSharing::Ptr w_cache,
@@ -38,53 +37,53 @@ public:
                  ov::threading::IStreamsExecutor::Ptr streamExecutor = nullptr,
                  std::shared_ptr<SubMemoryManager> sub_memory_manager = nullptr);
 
-    const Config& getConfig() const {
+    [[nodiscard]] const Config& getConfig() const {
         return m_config;
     }
 
-    WeightsSharing::Ptr getWeightsCache() const {
+    [[nodiscard]] WeightsSharing::Ptr getWeightsCache() const {
         return m_weightsCache;
     }
 
-    MultiCachePtr getParamsCache() const {
+    [[nodiscard]] MultiCachePtr getParamsCache() const {
         return m_rtParamsCache;
     }
 
-    DnnlScratchPadPtr getScratchPad() const {
+    [[nodiscard]] DnnlScratchPadPtr getScratchPad() const {
         return m_rtScratchPads[m_numaNodeId];
     }
 
-    const std::vector<DnnlScratchPadPtr>& getScratchPads() const {
+    [[nodiscard]] const std::vector<DnnlScratchPadPtr>& getScratchPads() const {
         return m_rtScratchPads;
     }
 
     static const dnnl::engine& getEngine();
 
-    bool isGraphQuantized() const {
+    [[nodiscard]] bool isGraphQuantized() const {
         return m_isGraphQuantizedFlag;
     }
 
-    ov::threading::CPUStreamsExecutor::Ptr getCPUStreamExecutor() const {
+    [[nodiscard]] ov::threading::CPUStreamsExecutor::Ptr getCPUStreamExecutor() const {
         return m_cpuStreamExecutor;
     }
 
-    std::shared_ptr<SubMemoryManager> getSubMemory() const {
+    [[nodiscard]] std::shared_ptr<SubMemoryManager> getSubMemory() const {
         return m_subMemoryManager;
     }
 
-    int getNumNumaNodes() const {
+    [[nodiscard]] int getNumNumaNodes() const {
         return m_numNumaNodes;
     }
 
-    const std::shared_ptr<node::MemoryStatesRegister>& getMemoryStatesRegister() const {
+    [[nodiscard]] const std::shared_ptr<node::MemoryStatesRegister>& getMemoryStatesRegister() const {
         return m_memoryStatesRegister;
     }
 
-    const std::shared_ptr<MemoryControl>& getMemoryControl() const {
+    [[nodiscard]] const std::shared_ptr<MemoryControl>& getMemoryControl() const {
         return m_memoryControl;
     }
 
-    const std::shared_ptr<NetworkMemoryControl>& getAuxiliaryNetworkMemoryControl() const {
+    [[nodiscard]] const std::shared_ptr<NetworkMemoryControl>& getAuxiliaryNetworkMemoryControl() const {
         return m_auxiliaryNetworkMemoryControl;
     }
 
@@ -131,5 +130,4 @@ private:
     MemoryControl::Ptr m_memoryControl;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/graph_dumper.h
+++ b/src/plugins/intel_cpu/src/graph_dumper.h
@@ -9,8 +9,7 @@
 #include "graph.h"
 #include "openvino/core/model.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 std::shared_ptr<ov::Model> dump_graph_as_ie_ngraph_net(const Graph& graph);
 #ifdef CPU_DEBUG_CAPS
@@ -19,5 +18,4 @@ void summary_perf(const Graph& graph);
 void average_counters(const Graph& graph);
 #endif  // CPU_DEBUG_CAPS
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/graph_optimizer.h
+++ b/src/plugins/intel_cpu/src/graph_optimizer.h
@@ -8,14 +8,12 @@
 #include "graph.h"
 #include "node.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class GraphOptimizer {
 public:
     GraphOptimizer();
 
-public:
     static void ApplyCommonGraphOptimizations(Graph& graph);
     static void ApplyImplSpecificGraphOptimizations(Graph& graph);
     static void ShareReorders(Graph& graph);
@@ -93,8 +91,7 @@ private:
                                              const NodePtr& transposeNode,
                                              const NodePtr& reshapeNode,
                                              const NodePtr& reorderNode,
-                                             const bool reverseOrder);
+                                             bool reverseOrder);
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/hash_builder.hpp
+++ b/src/plugins/intel_cpu/src/hash_builder.hpp
@@ -44,7 +44,7 @@ struct Builder {
         return *this;
     }
 
-    size_t generate() {
+    size_t generate() const {
         return m_seed;
     }
 

--- a/src/plugins/intel_cpu/src/infer_request.h
+++ b/src/plugins/intel_cpu/src/infer_request.h
@@ -27,8 +27,7 @@
 #include "openvino/runtime/so_ptr.hpp"
 #include "proxy_mem_blk.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class AsyncInferRequest;
 
@@ -44,8 +43,7 @@ public:
 
     void set_tensor(const ov::Output<const ov::Node>& port, const ov::SoPtr<ov::ITensor>& tensor) override;
 
-    void set_tensors_impl(const ov::Output<const ov::Node> port,
-                          const std::vector<ov::SoPtr<ov::ITensor>>& tensors) override;
+    void set_tensors_impl(ov::Output<const ov::Node> port, const std::vector<ov::SoPtr<ov::ITensor>>& tensors) override;
 
     ov::SoPtr<ov::ITensor> get_tensor(const ov::Output<const ov::Node>& port) const override;
     std::vector<ov::SoPtr<ov::ITensor>> get_tensors(const ov::Output<const ov::Node>& _port) const override;
@@ -70,7 +68,6 @@ private:
     public:
         using MemBlockPtr = std::shared_ptr<MemoryBlockWithReuse>;
 
-    public:
         OutputControlBlock(const ov::element::Type& precision, const Shape& shape);
 
         OutputControlBlock(const OutputControlBlock&) = delete;
@@ -79,15 +76,15 @@ private:
         OutputControlBlock(OutputControlBlock&&) = default;
         OutputControlBlock& operator=(OutputControlBlock&&) = default;
 
-        std::shared_ptr<Tensor> tensor() const {
+        [[nodiscard]] std::shared_ptr<Tensor> tensor() const {
             return m_tensor;
         }
 
-        const void* rawPtr() const {
+        [[nodiscard]] const void* rawPtr() const {
             return m_tensor->get_memory()->getData();
         }
 
-        MemBlockPtr currentMemBlock() const {
+        [[nodiscard]] MemBlockPtr currentMemBlock() const {
             return m_buffers[m_buffIndx];
         }
 
@@ -110,7 +107,6 @@ private:
         int m_buffIndx = 0;
     };
 
-private:
     void create_infer_request();
     void init_tensor(const std::size_t& port_index, const ov::ISyncInferRequest::FoundPort::Type& type);
 
@@ -123,7 +119,6 @@ private:
 
     void sub_streams_infer();
 
-private:
     std::unordered_map<std::size_t, OutputControlBlock> m_outputControlBlocks;
 
     std::unordered_map<std::size_t, ov::SoPtr<ov::ITensor>> m_input_external_ptr;
@@ -139,5 +134,4 @@ private:
     std::unordered_map<std::size_t, ov::SoPtr<ov::ITensor>> m_outputs;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/internal_properties.hpp
+++ b/src/plugins/intel_cpu/src/internal_properties.hpp
@@ -23,7 +23,7 @@ static constexpr Property<int32_t, PropertyMutability::RW> cpu_runtime_cache_cap
 /**
  * @brief Enum to define possible snippets mode hints.
  */
-enum class SnippetsMode {
+enum class SnippetsMode : uint8_t {
     ENABLE = 0,           //!<  Enable
     IGNORE_CALLBACK = 1,  //!<  Ignore callback
     DISABLE = 2,          //!<  Disable
@@ -70,7 +70,7 @@ static constexpr Property<SnippetsMode, PropertyMutability::RW> snippets_mode{"S
 /**
  * @brief Enum to define possible cache quant schema hints.
  */
-enum class CacheQuantMode {
+enum class CacheQuantMode : uint8_t {
     AUTO,
     BY_CHANNEL,
     BY_HIDDEN,

--- a/src/plugins/intel_cpu/src/memory_control.hpp
+++ b/src/plugins/intel_cpu/src/memory_control.hpp
@@ -51,7 +51,6 @@ public:
     using Ptr = std::shared_ptr<MemoryControl>;
     using CPtr = std::shared_ptr<const MemoryControl>;
 
-public:
     void insert(const MemoryRegions& regions, const std::vector<size_t>& syncInds);
 
     MemorySolution solve();
@@ -63,18 +62,17 @@ public:
     void allocateMemory();
     void releaseMemory();
 
-    const std::string& getId() const {
+    [[nodiscard]] const std::string& getId() const {
         return m_id;
     }
 
 private:
     explicit MemoryControl(std::string id);
     void insert(const MemoryRegion& region, const std::vector<size_t>& syncInds);
-    MemoryStatistics dumpStatistics() const;
+    [[nodiscard]] MemoryStatistics dumpStatistics() const;
 
     friend class NetworkMemoryControl;
 
-private:
     std::string m_id;
     std::vector<RegionHandlerPtr> m_handlers;
     bool m_allocated = false;
@@ -88,9 +86,9 @@ public:
     void allocateMemory();
     void releaseMemory();
 
-    std::vector<std::pair<std::string, MemoryStatistics>> dumpStatistics() const;
+    [[nodiscard]] std::vector<std::pair<std::string, MemoryStatistics>> dumpStatistics() const;
 
-    const std::vector<MemoryControl::Ptr>& controlUnits() const {
+    [[nodiscard]] const std::vector<MemoryControl::Ptr>& controlUnits() const {
         return m_controlUnits;
     }
 

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.h
@@ -12,14 +12,12 @@
 #include "cpu_memory_desc.h"
 #include "cpu_types.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class BlockedMemoryDesc : public virtual MemoryDesc {
 public:
     using CmpMask = std::bitset<32>;
 
-public:
     BlockedMemoryDesc() = default;
 
     static constexpr CmpMask FULL_MASK{0xffffffff};
@@ -103,5 +101,4 @@ protected:
 using BlockedMemoryDescPtr = std::shared_ptr<BlockedMemoryDesc>;
 using BlockedMemoryDescCPtr = std::shared_ptr<const BlockedMemoryDesc>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.h
@@ -13,8 +13,7 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class DnnlBlockedMemoryDesc;
 
@@ -90,7 +89,7 @@ public:
 
     size_t getPaddedElementsCount() const override;
 
-    MemoryDescPtr cloneWithNewPrecision(const ov::element::Type prec) const override;
+    MemoryDescPtr cloneWithNewPrecision(ov::element::Type prec) const override;
 
 private:
     size_t getElementOffset(size_t elemNumber) const override;
@@ -107,7 +106,6 @@ private:
         precision = prc;
     }
 
-private:
     ov::element::Type precision;
     size_t offsetPadding;
 };
@@ -115,5 +113,4 @@ private:
 using CpuBlockedMemoryDescPtr = std::shared_ptr<CpuBlockedMemoryDesc>;
 using CpuBlockedMemoryDescCPtr = std::shared_ptr<const CpuBlockedMemoryDesc>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc.h
@@ -28,9 +28,10 @@
  *
  */
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 namespace node {
+// WA for `friend class`
+// NOLINTNEXTLINE(bugprone-forward-declaration-namespace)
 class Split;
 }  // namespace node
 
@@ -40,7 +41,7 @@ using MemoryDescPtr = std::shared_ptr<MemoryDesc>;
 using MemoryDescCPtr = std::shared_ptr<const MemoryDesc>;
 using VecMemoryDescs = std::vector<MemoryDescPtr>;
 
-enum MemoryDescType {
+enum MemoryDescType : uint8_t {
     Undef = 0,
     Blocked = 1,
     Dnnl = 1 << 1,
@@ -48,7 +49,7 @@ enum MemoryDescType {
     Empty = 1 << 2,
 };
 
-enum class LayoutType : unsigned {
+enum class LayoutType : uint8_t {
     nspc,    // general per channels format
     ncsp,    // general planar
     nCsp8c,  // general channels blocked by 8
@@ -106,7 +107,7 @@ public:
         return cloneWithNewDimsImp(dims);
     }
 
-    virtual MemoryDescPtr cloneWithNewPrecision(const ov::element::Type prec) const = 0;
+    virtual MemoryDescPtr cloneWithNewPrecision(ov::element::Type prec) const = 0;
 
     virtual bool isCompatible(const MemoryDesc& rhs) const = 0;
 
@@ -146,22 +147,24 @@ public:
     }
 
     template <typename T,
-              typename std::enable_if<!std::is_pointer<T>::value && !std::is_reference<T>::value, int>::type = 0,
-              typename std::enable_if<std::is_base_of<MemoryDesc, T>::value, int>::type = 0>
+              std::enable_if_t<!std::is_pointer_v<T> && !std::is_reference_v<T>, int> = 0,
+              std::enable_if_t<std::is_base_of_v<MemoryDesc, T>, int> = 0>
     T* as() {
         T* casted = dynamic_cast<T*>(this);
-        if (!casted)
+        if (!casted) {
             OPENVINO_THROW("Cannot dynamically cast MemoryDesc");
+        }
         return casted;
     }
 
     template <typename T,
-              typename std::enable_if<!std::is_pointer<T>::value && !std::is_reference<T>::value, int>::type = 0,
-              typename std::enable_if<std::is_base_of<MemoryDesc, T>::value, int>::type = 0>
+              std::enable_if_t<!std::is_pointer_v<T> && !std::is_reference_v<T>, int> = 0,
+              std::enable_if_t<std::is_base_of_v<MemoryDesc, T>, int> = 0>
     const T* as() const {
         const T* casted = dynamic_cast<const T*>(this);
-        if (!casted)
+        if (!casted) {
             OPENVINO_THROW("Cannot dynamically cast MemoryDesc");
+        }
         return casted;
     }
 
@@ -204,5 +207,4 @@ protected:
     friend class node::Split;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_memory_desc_utils.h
@@ -13,8 +13,7 @@
 #include "openvino/runtime/itensor.hpp"
 #include "openvino/runtime/so_ptr.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class MemoryDesc;
 class DnnlMemoryDesc;
@@ -109,5 +108,4 @@ public:
     static std::string dims2str(const VectorDims& dims);
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.h
@@ -19,8 +19,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/util/util.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class CpuBlockedMemoryDesc;
 
@@ -70,7 +69,7 @@ public:
 
     size_t getPaddedElementsCount() const override;
 
-    MemoryDescPtr cloneWithNewPrecision(const ov::element::Type prec) const override;
+    MemoryDescPtr cloneWithNewPrecision(ov::element::Type prec) const override;
 
     using DnnlMemoryDesc::getPrecision;
     using DnnlMemoryDesc::setPrecision;
@@ -123,5 +122,4 @@ OPENVINO_DISABLE_WARNING_MSVC_END(4250)
 using DnnlBlockedMemoryDescPtr = std::shared_ptr<DnnlBlockedMemoryDesc>;
 using DnnlBlockedMemoryDescCPtr = std::shared_ptr<const DnnlBlockedMemoryDesc>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
@@ -19,8 +19,7 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class DnnlMemoryDesc;
 
@@ -33,12 +32,12 @@ public:
 
     MemoryDescPtr clone() const override;
 
-    MemoryDescPtr cloneWithNewPrecision(const ov::element::Type prec) const override;
+    MemoryDescPtr cloneWithNewPrecision(ov::element::Type prec) const override;
 
     bool isCompatible(const MemoryDesc& rhs) const override;
     bool isCompatible(const DnnlMemoryDesc& rhs) const;
 
-    bool hasLayoutType(LayoutType layoutType) const override {
+    bool hasLayoutType(LayoutType /*layoutType*/) const override {
         return false;
     }
 
@@ -46,7 +45,7 @@ public:
 
     size_t getMaxMemSize() const override;
 
-    virtual bool isSame(dnnl::memory::format_tag fmt) const {
+    virtual bool isSame(dnnl::memory::format_tag /*fmt*/) const {
         return false;
     }
 
@@ -87,5 +86,4 @@ private:
     friend DnnlMemoryDescPtr DnnlExtensionUtils::makeDescriptor(const_dnnl_memory_desc_t desc);
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_memory_desc.h
@@ -37,7 +37,7 @@ public:
     bool isCompatible(const MemoryDesc& rhs) const override;
     bool isCompatible(const DnnlMemoryDesc& rhs) const;
 
-    bool hasLayoutType(LayoutType /*layoutType*/) const override {
+    bool hasLayoutType([[maybe_unused]] LayoutType layoutType) const override {
         return false;
     }
 
@@ -45,7 +45,7 @@ public:
 
     size_t getMaxMemSize() const override;
 
-    virtual bool isSame(dnnl::memory::format_tag /*fmt*/) const {
+    virtual bool isSame([[maybe_unused]] dnnl::memory::format_tag fmt) const {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/memory_desc/empty_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/empty_memory_desc.h
@@ -48,7 +48,7 @@ public:
         return 0;
     }
 
-    bool hasLayoutType(LayoutType /*layoutType*/) const override {
+    bool hasLayoutType([[maybe_unused]] LayoutType layoutType) const override {
         return false;
     }
 

--- a/src/plugins/intel_cpu/src/memory_desc/empty_memory_desc.h
+++ b/src/plugins/intel_cpu/src/memory_desc/empty_memory_desc.h
@@ -15,8 +15,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "utils/general_utils.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * @brief Represents an empty memory descriptor.
@@ -49,7 +48,7 @@ public:
         return 0;
     }
 
-    bool hasLayoutType(LayoutType layoutType) const override {
+    bool hasLayoutType(LayoutType /*layoutType*/) const override {
         return false;
     }
 
@@ -70,7 +69,7 @@ public:
     }
 
 private:
-    size_t getElementOffset(size_t elemNumber) const override {
+    size_t getElementOffset([[maybe_unused]] size_t elemNumber) const override {
         return 0;
     }
     bool canComputeMemSizeZeroDims() const override {
@@ -79,13 +78,13 @@ private:
     size_t getCurrentMemSizeImp() const override {
         return 0;
     }
-    size_t getOffset(const VectorDims& v) const {
+    static size_t getOffset([[maybe_unused]] const VectorDims& v) {
         return 0;
     }
     bool isDefinedImp() const override {
         return true;
     }
-    MemoryDescPtr cloneWithNewDimsImp(const VectorDims& dims) const override {
+    MemoryDescPtr cloneWithNewDimsImp([[maybe_unused]] const VectorDims& dims) const override {
         OPENVINO_THROW("Clone an empty memory desc with any new dimensions is prohibited");
     }
 
@@ -97,5 +96,4 @@ private:
 using EmptyMemoryDescPtr = std::shared_ptr<EmptyMemoryDesc>;
 using EmptyMemoryDescCPtr = std::shared_ptr<const EmptyMemoryDesc>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/memory_state.h
+++ b/src/plugins/intel_cpu/src/memory_state.h
@@ -18,8 +18,7 @@
 #include "openvino/runtime/tensor.hpp"
 #include "utils/plain_tensor.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class IVariableState : public ov::IVariableState {
 public:
@@ -96,7 +95,6 @@ private:
 
     MemoryPtr internal_state_mem() const override;
 
-private:
     MemoryDescPtr m_internal_desc;  // mem desc required by the graph internal tensor
     std::array<MemoryPtr, 2> m_internal_mem{};
     size_t buffer_num = 0;
@@ -116,7 +114,6 @@ private:
 
     MemoryPtr internal_state_mem() const override;
 
-private:
     MemoryPtr m_internal_mem;
     MemoryDescPtr m_internal_desc;  // mem desc required by the graph internal tensor
 };
@@ -126,8 +123,8 @@ public:
     VariableStateKVcache(const std::string& name,
                          MemoryDescPtr external_desc,
                          BlockedMemoryDescPtr dense_internal_desc,
-                         const bool quant_by_channel,
-                         const size_t group_size = 0);
+                         bool quant_by_channel,
+                         size_t group_size = 0);
 
     // ov::IVariableState
     ov::SoPtr<ov::ITensor> get_state() const override;
@@ -171,7 +168,6 @@ private:
     void reset_impl() override;
     void commit_impl() override;
 
-private:
     MemoryPtr m_internal_mem;  // kv cache
     MemoryPtr m_hidden_state;  // beam access table
     size_t m_internal_mem_max_size = 0;
@@ -188,5 +184,4 @@ private:
 
 using MemStatePtr = std::shared_ptr<IVariableState>;
 using MemStateCPtr = std::shared_ptr<const IVariableState>;
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/mlas/sgemm.hpp
+++ b/src/plugins/intel_cpu/src/mlas/sgemm.hpp
@@ -15,7 +15,7 @@ namespace ov::intel_cpu {
  * @param K       Supplies the number of rows of matrix B.
  * @return        bytes of the packing buffer
  */
-size_t mlas_sgemm_pack_get_size(const int64_t N, const int64_t K);
+size_t mlas_sgemm_pack_get_size(int64_t N, int64_t K);
 
 /**
  * @brief  Packs the contents of matrix B
@@ -28,12 +28,7 @@ size_t mlas_sgemm_pack_get_size(const int64_t N, const int64_t K);
  * @param src     Supplies the address of matrix B
  * @param dst     Supplies pointer to prePacked B buffer
  */
-void mlas_sgemm_pack(const char* transb,
-                     const int64_t N,
-                     const int64_t K,
-                     const int64_t ldb,
-                     const float* src,
-                     float* dst);
+void mlas_sgemm_pack(const char* transb, int64_t N, int64_t K, int64_t ldb, const float* src, float* dst);
 
 /**
  * @brief  SGEMM with planar B matrix
@@ -56,17 +51,17 @@ void mlas_sgemm_pack(const char* transb,
  */
 void mlas_sgemm(const char* transa,
                 const char* transb,
-                const int64_t M,
-                const int64_t N,
-                const int64_t K,
-                const float alpha,
+                int64_t M,
+                int64_t N,
+                int64_t K,
+                float alpha,
                 const float* A,
-                const int64_t lda,
+                int64_t lda,
                 const float* B,
-                const int64_t ldb,
-                const float beta,
+                int64_t ldb,
+                float beta,
                 float* C,
-                const int64_t ldc,
+                int64_t ldc,
                 size_t thread_num = 0);
 
 /**
@@ -91,17 +86,17 @@ void mlas_sgemm(const char* transa,
  */
 void mlas_sgemm_compute(const char* transa,
                         const char* transb,
-                        const int64_t M,
-                        const int64_t N,
-                        const int64_t K,
-                        const float alpha,
+                        int64_t M,
+                        int64_t N,
+                        int64_t K,
+                        float alpha,
                         const float* A,
-                        const int64_t lda,
+                        int64_t lda,
                         const float* B,
-                        const int64_t ldb,
-                        const float beta,
+                        int64_t ldb,
+                        float beta,
                         float* C,
-                        const int64_t ldc,
+                        int64_t ldc,
                         const float* bias = nullptr,
                         size_t thread_num = 0);
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/mlas/thread_pool.hpp
+++ b/src/plugins/intel_cpu/src/mlas/thread_pool.hpp
@@ -15,10 +15,10 @@ class OVMlasThreadPool : public IMlasThreadPool {
 public:
     OVMlasThreadPool() = delete;
     explicit OVMlasThreadPool(const size_t& threadNum) : threadNum(threadNum) {}
+    virtual ~OVMlasThreadPool() = default;
     size_t DegreeOfParallelism() override;
-    void TrySimpleParallelFor(const std::ptrdiff_t total, const std::function<void(std::ptrdiff_t)>& fn) override;
+    void TrySimpleParallelFor(std::ptrdiff_t total, const std::function<void(std::ptrdiff_t)>& fn) override;
 
-public:
     // the actual threads used for sgemm
     size_t threadNum = 0;
 };

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -49,8 +49,7 @@
 #define CPU_NODE_ASSERT(condition, ...) \
     OPENVINO_ASSERT(condition, getTypeStr(), " node with name '", getName(), "' ", __VA_ARGS__)
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 using NodePtr = std::shared_ptr<Node>;
 using NodeConstPtr = std::shared_ptr<const Node>;
@@ -87,7 +86,7 @@ public:
 private:
     static ov::intel_cpu::BlockedDescCreator::CreatorConstPtr getBlockedDescCreator(
         ov::intel_cpu::LayoutType blockedDescType) {
-        auto& creators = ov::intel_cpu::BlockedDescCreator::getCommonCreators();
+        const auto& creators = ov::intel_cpu::BlockedDescCreator::getCommonCreators();
         if (creators.find(blockedDescType) == creators.end()) {
             OPENVINO_THROW("Cannot find tensor descriptor creator");
         }
@@ -107,7 +106,7 @@ public:
           implementationType(type),
           executorFactory(std::move(factory)) {}
 
-    const NodeConfig& getConfig() const {
+    [[nodiscard]] const NodeConfig& getConfig() const {
         return config;
     }
 
@@ -115,7 +114,7 @@ public:
         this->config = config;
     }
 
-    impl_desc_type getImplementationType() const {
+    [[nodiscard]] impl_desc_type getImplementationType() const {
         return implementationType;
     }
 
@@ -123,17 +122,18 @@ public:
         implementationType = type;
     }
 
-    ExecutorFactoryLegacyPtr getExecutorFactory() const {
+    [[nodiscard]] ExecutorFactoryLegacyPtr getExecutorFactory() const {
         return executorFactory;
     }
 
     template <typename T,
-              typename std::enable_if<!std::is_pointer<T>::value && !std::is_reference<T>::value, int>::type = 0,
-              typename std::enable_if<std::is_base_of<ExecutorFactoryLegacy, T>::value, int>::type = 0>
+              std::enable_if_t<!std::is_pointer_v<T> && !std::is_reference_v<T>, int> = 0,
+              std::enable_if_t<std::is_base_of_v<ExecutorFactoryLegacy, T>, int> = 0>
     std::shared_ptr<T> getExecutorFactoryAs() {
         auto casted = std::dynamic_pointer_cast<T>(executorFactory);
-        if (!casted)
+        if (!casted) {
             OPENVINO_THROW("Cannot dynamically cast ExecutorFactory");
+        }
         return casted;
     }
 
@@ -141,14 +141,14 @@ public:
         executorFactory = std::move(factory);
     }
 
-    bool hasZeroInputDims() const {
+    [[nodiscard]] bool hasZeroInputDims() const {
         const auto& inputConfigs = getConfig().inConfs;
         return std::any_of(inputConfigs.begin(), inputConfigs.end(), [](const PortConfig& portConfig) {
             return portConfig.hasZeroDims();
         });
     }
 
-    bool hasZeroInputDimsAtPort(size_t portIdx) const {
+    [[nodiscard]] bool hasZeroInputDimsAtPort(size_t portIdx) const {
         const auto& inputConfigs = getConfig().inConfs;
         OPENVINO_ASSERT(portIdx < inputConfigs.size(),
                         "Attempt to get NodeDesc input configuration for port ",
@@ -158,14 +158,14 @@ public:
         return inputConfigs[portIdx].hasZeroDims();
     }
 
-    bool hasZeroOutputDims() const {
+    [[nodiscard]] bool hasZeroOutputDims() const {
         const auto& outputConfigs = getConfig().outConfs;
         return std::any_of(outputConfigs.begin(), outputConfigs.end(), [](const PortConfig& portConfig) {
             return portConfig.hasZeroDims();
         });
     }
 
-    bool hasZeroOutputDimsAtPort(size_t portIdx) const {
+    [[nodiscard]] bool hasZeroOutputDimsAtPort(size_t portIdx) const {
         const auto& outputConfigs = getConfig().outConfs;
         OPENVINO_ASSERT(portIdx < outputConfigs.size(),
                         "Attempt to get NodeDesc output configuration for port ",
@@ -188,7 +188,6 @@ public:
 
     using AttrPtr = std::shared_ptr<dnnl::primitive_attr>;
 
-public:
     template <typename T, int N>
     struct Tag {};
 
@@ -345,7 +344,7 @@ public:
         return !hasEmptyInputTensors();
     }
 
-    enum class ConstantType {
+    enum class ConstantType : uint8_t {
         Const,          // Node is placed in a constant subgraph
         NoConst,        // Node is placed in a non-constant subgraph
         StrictNoConst,  // Node produces non-constant subgraph: this type can't be changed and it does not depend on the
@@ -442,17 +441,19 @@ public:
         return supportedPrimitiveDescriptors;
     }
 
-    inline const NodeDesc* getSelectedPrimitiveDescriptor() const {
+    const NodeDesc* getSelectedPrimitiveDescriptor() const {
         if (selectedPrimitiveDescriptorIndex < 0 ||
-            static_cast<size_t>(selectedPrimitiveDescriptorIndex) >= supportedPrimitiveDescriptors.size())
+            static_cast<size_t>(selectedPrimitiveDescriptorIndex) >= supportedPrimitiveDescriptors.size()) {
             return nullptr;
+        }
         return &supportedPrimitiveDescriptors[selectedPrimitiveDescriptorIndex];
     }
 
-    inline NodeDesc* getSelectedPrimitiveDescriptor() {
+    NodeDesc* getSelectedPrimitiveDescriptor() {
         if (selectedPrimitiveDescriptorIndex < 0 ||
-            static_cast<size_t>(selectedPrimitiveDescriptorIndex) >= supportedPrimitiveDescriptors.size())
+            static_cast<size_t>(selectedPrimitiveDescriptorIndex) >= supportedPrimitiveDescriptors.size()) {
             return nullptr;
+        }
         return &supportedPrimitiveDescriptors[selectedPrimitiveDescriptorIndex];
     }
 
@@ -486,8 +487,8 @@ public:
      * @return pointer to selected primitive descriptor with type T
      */
     template <typename T,
-              typename std::enable_if<!std::is_pointer<T>::value && !std::is_reference<T>::value, int>::type = 0,
-              typename std::enable_if<std::is_base_of<MemoryDesc, T>::value, int>::type = 0>
+              std::enable_if_t<!std::is_pointer_v<T> && !std::is_reference_v<T>, int> = 0,
+              std::enable_if_t<std::is_base_of_v<MemoryDesc, T>, int> = 0>
     std::shared_ptr<T> getInputMemDescAtPort(size_t portNum) const;
 
     /**
@@ -497,15 +498,16 @@ public:
      * @return pointer to selected primitive descriptor with type T
      */
     template <typename T,
-              typename std::enable_if<!std::is_pointer<T>::value && !std::is_reference<T>::value, int>::type = 0,
-              typename std::enable_if<std::is_base_of<MemoryDesc, T>::value, int>::type = 0>
+              std::enable_if_t<!std::is_pointer_v<T> && !std::is_reference_v<T>, int> = 0,
+              std::enable_if_t<std::is_base_of_v<MemoryDesc, T>, int> = 0>
     std::shared_ptr<T> getOutputMemDescAtPort(size_t portNum) const;
 
     void selectPrimitiveDescriptorByIndex(int index) {
-        if (index < 0 || static_cast<size_t>(index) >= supportedPrimitiveDescriptors.size())
+        if (index < 0 || static_cast<size_t>(index) >= supportedPrimitiveDescriptors.size()) {
             selectedPrimitiveDescriptorIndex = -1;
-        else
+        } else {
             selectedPrimitiveDescriptorIndex = index;
+        }
 
         // Each primitive descriptor has its own InPlace status. So after new primitive descriptor selection
         // we should reset InPlace type to definite new status for node using Node::isInPlace()
@@ -528,7 +530,7 @@ public:
     void updateDynamicParams();
     void executeDynamic(const dnnl::stream& strm, int numaId = -1);
     virtual void redefineOutputMemory(const std::vector<VectorDims>& newOutputShapes);
-    void redefineOutputMemory(const size_t port, const VectorDims& new_output_shape) const;
+    void redefineOutputMemory(size_t port, const VectorDims& new_output_shape) const;
     bool outputShapeDataDependency() const;
 
     virtual void initSupportedPrimitiveDescriptors();
@@ -674,7 +676,7 @@ public:
         algorithm = alg;
     }
 
-    virtual bool canFuse(const NodePtr& node) const {
+    virtual bool canFuse([[maybe_unused]] const NodePtr& node) const {
         return false;
     }
 
@@ -712,7 +714,7 @@ public:
      */
     std::pair<std::vector<float>, std::vector<float>> getScalesAndShifts(const Node* parentNode) const;
 
-    void fuseDQScales(const float* scaleData, const size_t scaleSize);
+    void fuseDQScales(const float* scaleData, size_t scaleSize);
     const std::vector<float>& getDQScales() const {
         return DQScales;
     }
@@ -724,11 +726,11 @@ public:
     virtual void appendPostOps(dnnl::post_ops& ops,
                                const VectorDims& postOpDims,
                                std::unordered_map<int, MemoryPtr>& postOpsMem,
-                               const int channelAxis);
+                               int channelAxis);
     virtual void appendPostOps(dnnl::post_ops& ops,
                                const VectorDims& postOpDims,
                                std::vector<const void*>& postOpsMem,
-                               const int channelAxis);
+                               int channelAxis);
     virtual bool canBeExecutedInInt8() const {
         OPENVINO_THROW_NOT_IMPLEMENTED("canBeExecutedInInt8 not implemented for node with type ",
                                        NameFromType(getType()));
@@ -754,8 +756,7 @@ protected:
         return nullptr;
     }
 
-    typedef std::function<DnnlMemoryDescPtr(dnnl::primitive_desc& primitive_desc_it, size_t idx)>
-        GetPrimitiveMemoryFormatFunc;
+    using GetPrimitiveMemoryFormatFunc = std::function<DnnlMemoryDescPtr(dnnl::primitive_desc&, size_t)>;
     std::vector<GetPrimitiveMemoryFormatFunc> internalBlobDesc;
 
     std::vector<Shape> inputShapes;
@@ -790,7 +791,7 @@ protected:
 
     int selectedPrimitiveDescriptorIndex = -1;
 
-    enum class InPlaceType { Unknown, InPlace, NoInPlace };
+    enum class InPlaceType : uint8_t { Unknown, InPlace, NoInPlace };
     mutable InPlaceType inplace = InPlaceType::Unknown;
     ConstantType constant = ConstantType::NoConst;
     std::vector<MemoryPtr> internalBlobs;
@@ -870,7 +871,7 @@ protected:
     void execute(const dnnl::stream& strm, int numaId);
     virtual void execute(const dnnl::stream& strm) = 0;
     // TODO [DS] : make pure after all nodes support dynamic shapes
-    virtual void executeDynamicImpl(const dnnl::stream& strm) {
+    virtual void executeDynamicImpl([[maybe_unused]] const dnnl::stream& strm) {
         OPENVINO_THROW_NOT_IMPLEMENTED("[DS] executeDynamicImpl not implemented for node with type: ", getTypeStr());
     }
 
@@ -889,7 +890,7 @@ protected:
         return scratchpadMem;
     }
 
-    std::vector<VectorDims> lastInputDims = {};
+    std::vector<VectorDims> lastInputDims;
 
     std::shared_ptr<IShapeInfer> shapeInference;
 
@@ -968,5 +969,4 @@ struct NodeImpl : public NodeType {
     }
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/adaptive_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/adaptive_pooling.h
@@ -17,9 +17,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class AdaptivePooling : public Node {
 public:
@@ -34,7 +32,7 @@ public:
 
 private:
     int spatialDimsCount;
-    mutable std::vector<Dim> spatialDimsValue = {};
+    mutable std::vector<Dim> spatialDimsValue;
     ov::element::Type precision = ov::element::f32;
     static inline void setBinBorders(size_t* startPtr,
                                      size_t* endPtr,
@@ -50,6 +48,4 @@ protected:
     void executeDynamicImpl(const dnnl::stream& strm) override;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/batch_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/batch_to_space.h
@@ -4,19 +4,15 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class BatchToSpace : public Node {
 public:
@@ -25,23 +21,23 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
 
-    bool neverExecute() const override {
+    [[nodiscard]] bool neverExecute() const override {
         const auto& spd = getSelectedPrimitiveDescriptor();
         return spd->hasZeroInputDims() || spd->hasZeroOutputDims();
     }
 
     // output shape can potentially be empty
-    bool isExecutable() const override {
+    [[nodiscard]] bool isExecutable() const override {
         return !hasEmptyInputTensors() && !hasEmptyOutputTensors();
     }
 
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     };
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return true;
     };
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -52,11 +48,8 @@ private:
     template <typename T>
     void batchToSpaceKernel();
 
-private:
     std::vector<size_t> blockShapeIn;
     std::vector<size_t> cropsBeginIn;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.h
@@ -20,9 +20,7 @@
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_bin_conv_params {
     int mb;
@@ -66,9 +64,9 @@ struct jit_bin_conv_call_args {
 };
 
 struct jit_uni_bin_conv_kernel {
-    void (*ker_)(const jit_bin_conv_call_args*);
+    void (*ker_)(const jit_bin_conv_call_args*){nullptr};
 
-    void operator()(const jit_bin_conv_call_args* args) {
+    void operator()(const jit_bin_conv_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
@@ -76,11 +74,10 @@ struct jit_uni_bin_conv_kernel {
     explicit jit_uni_bin_conv_kernel(jit_bin_conv_params jcp,
                                      jit_dw_conv_params jcp_dw_conv,
                                      const dnnl_primitive_attr& attr)
-        : ker_(nullptr),
-          jcp_(jcp),
+        : jcp_(jcp),
           jcp_dw_conv_(jcp_dw_conv),
           attr_(attr) {}
-    virtual ~jit_uni_bin_conv_kernel() {}
+    virtual ~jit_uni_bin_conv_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -145,6 +142,4 @@ private:
                           const std::vector<size_t>& d_str) const;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.h
@@ -64,7 +64,7 @@ struct jit_bin_conv_call_args {
 };
 
 struct jit_uni_bin_conv_kernel {
-    void (*ker_)(const jit_bin_conv_call_args*){nullptr};
+    void (*ker_)(const jit_bin_conv_call_args*) = nullptr;
 
     void operator()(const jit_bin_conv_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/broadcast.h
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.h
@@ -38,7 +38,7 @@ protected:
 private:
     void plainExecute(const dnnl::stream& strm);
 
-    enum AutoBroadcastType { NUMPY, EXPLICIT };
+    enum AutoBroadcastType : uint8_t { NUMPY, EXPLICIT };
     AutoBroadcastType broadcastType = NUMPY;
 
     static constexpr size_t INPUT_DATA_IDX = 0;

--- a/src/plugins/intel_cpu/src/nodes/broadcast.h
+++ b/src/plugins/intel_cpu/src/nodes/broadcast.h
@@ -5,20 +5,16 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "common/tile_broadcast_utils.h"
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Broadcast : public Node, public TileBroadcastCommon {
 public:
@@ -53,6 +49,4 @@ private:
     std::vector<int32_t> axesMapping;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/bucketize.h
+++ b/src/plugins/intel_cpu/src/nodes/bucketize.h
@@ -14,9 +14,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Bucketize : public Node {
 public:
@@ -25,15 +23,15 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override {
         execute(strm);
     }
 
     void prepareParams() override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
@@ -54,6 +52,4 @@ private:
     ov::element::Type output_precision;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/causal_mask_preprocess.h
+++ b/src/plugins/intel_cpu/src/nodes/causal_mask_preprocess.h
@@ -14,9 +14,7 @@
 #include "openvino/core/node.hpp"
 #include "transformations/cpu_opset/common/op/causal_mask_preprocess.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class CausalMaskPreprocess : public Node {
 public:
@@ -49,6 +47,4 @@ private:
     std::shared_ptr<Executor> m_executor;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/col2im.h
+++ b/src/plugins/intel_cpu/src/nodes/col2im.h
@@ -14,9 +14,7 @@
 #include "openvino/core/shape.hpp"
 #include "openvino/core/strides.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Col2Im : public Node {
 public:
@@ -26,8 +24,8 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:
@@ -43,6 +41,4 @@ private:
     ov::Shape padsEnd;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -208,9 +208,9 @@ void jit_uni_converter::yuv_to_rgb(const variable<float[N]>& y,
             return mask;
         };
 
-        r.permute(genPermutationMask(0));
-        g.permute(genPermutationMask(1));
-        b.permute(genPermutationMask(2));
+        r = r.permute(genPermutationMask(0));
+        g = g.permute(genPermutationMask(1));
+        b = b.permute(genPermutationMask(2));
 
         auto blendWithMask = [&](int offset, const variable<float[N]>& result) {
             static const uint32_t blendMasks[2] = {0x92492492, 0x24924924};
@@ -218,8 +218,8 @@ void jit_uni_converter::yuv_to_rgb(const variable<float[N]>& y,
             const auto mask1 = static_cast<const uint16_t>(blendMasks[1] >> ((offset * N) % 3));
 
             result = r;
-            result.blend(g, mask0);
-            result.blend(b, mask1);
+            result = result.blend(g, mask0);
+            result = result.blend(b, mask1);
         };
 
         blendWithMask(0, r0);
@@ -854,8 +854,8 @@ JitConverter<T[N]>::load_yuv(const variable<const T*>& src_y,
 template <typename T, size_t N>
 void JitConverter<T[N]>::unpack_uv(const variable<float[N]>& u, const variable<float[N]>& v) {
     static const uint8_t order[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
-    u.permute(order);
-    v.permute(order);
+    std::ignore = u.permute(order);
+    std::ignore = v.permute(order);
 }
 
 template <typename T>

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -854,8 +854,8 @@ JitConverter<T[N]>::load_yuv(const variable<const T*>& src_y,
 template <typename T, size_t N>
 void JitConverter<T[N]>::unpack_uv(const variable<float[N]>& u, const variable<float[N]>& v) {
     static const uint8_t order[] = {0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7};
-    std::ignore = u.permute(order);
-    std::ignore = v.permute(order);
+    u = u.permute(order);
+    v = v.permute(order);
 }
 
 template <typename T>

--- a/src/plugins/intel_cpu/src/nodes/color_convert.h
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.h
@@ -23,16 +23,13 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ColorConvert : public Node {
 public:
     ColorConvert(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
     class Converter;
 
-public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
@@ -47,7 +44,6 @@ private:
     void initSupportedNV12Impls();
     void initSupportedI420Impls();
 
-private:
     using ConverterBuilder = std::function<Converter*(Node*)>;
     using SupportedImpls = multidim_map<impl_desc_type,       // Implementation type
                                         Algorithm,            // Algorithm: ColorConvertXXX
@@ -77,11 +73,11 @@ public:
 
     Converter(Node* node, const ColorFormat& colorFormat);
     virtual ~Converter() = default;
-    ov::element::Type inputPrecision(size_t idx) const;
-    ov::element::Type outputPrecision(size_t idx) const;
-    const void* input(size_t idx) const;
-    void* output(size_t idx) const;
-    const VectorDims& inputDims(size_t idx) const;
+    [[nodiscard]] ov::element::Type inputPrecision(size_t idx) const;
+    [[nodiscard]] ov::element::Type outputPrecision(size_t idx) const;
+    [[nodiscard]] const void* input(size_t idx) const;
+    [[nodiscard]] void* output(size_t idx) const;
+    [[nodiscard]] const VectorDims& inputDims(size_t idx) const;
     virtual void execute(const dnnl::stream& strm) = 0;
 
 protected:
@@ -89,6 +85,4 @@ protected:
     ColorFormat _colorFormat;  // RGB: {0,1,2}, BGR: {2,1,0}
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/common/arbitrary_order_desc_creator.h
+++ b/src/plugins/intel_cpu/src/nodes/common/arbitrary_order_desc_creator.h
@@ -12,19 +12,18 @@
 #include "memory_desc/cpu_blocked_memory_desc.h"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class ArbitraryOrderDescCreator : public BlockedDescCreator {
 public:
     ArbitraryOrderDescCreator(VectorDims order);
 
-    CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision, const Shape& srcShape) const override;
-    size_t getMinimalRank() const override;
+    [[nodiscard]] CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
+                                                  const Shape& srcShape) const override;
+    [[nodiscard]] size_t getMinimalRank() const override;
 
 private:
     VectorDims m_order;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.h
+++ b/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.h
@@ -17,19 +17,17 @@
 #include "memory_desc/cpu_memory_desc.h"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class CreatorsMapFilterConstIterator;
 
 class BlockedDescCreator {
 public:
-    typedef std::shared_ptr<BlockedDescCreator> CreatorPtr;
-    typedef std::shared_ptr<const BlockedDescCreator> CreatorConstPtr;
-    typedef std::map<LayoutType, CreatorConstPtr> CreatorsMap;
-    typedef std::function<bool(const CreatorsMap::value_type&)> Predicate;
+    using CreatorPtr = std::shared_ptr<BlockedDescCreator>;
+    using CreatorConstPtr = std::shared_ptr<const BlockedDescCreator>;
+    using CreatorsMap = std::map<LayoutType, CreatorConstPtr>;
+    using Predicate = std::function<bool(const CreatorsMap::value_type&)>;
 
-public:
     static const CreatorsMap& getCommonCreators();
     static std::pair<CreatorsMapFilterConstIterator, CreatorsMapFilterConstIterator> makeFilteredRange(
         const CreatorsMap& map,
@@ -39,28 +37,28 @@ public:
     static std::pair<CreatorsMapFilterConstIterator, CreatorsMapFilterConstIterator> makeFilteredRange(
         const CreatorsMap& map,
         Predicate predicate);
-    virtual CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision, const Shape& srcShape) const = 0;
+    [[nodiscard]] virtual CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
+                                                          const Shape& srcShape) const = 0;
 
-    std::shared_ptr<CpuBlockedMemoryDesc> createSharedDesc(const ov::element::Type& precision,
-                                                           const Shape& srcShape) const {
+    [[nodiscard]] std::shared_ptr<CpuBlockedMemoryDesc> createSharedDesc(const ov::element::Type& precision,
+                                                                         const Shape& srcShape) const {
         return std::make_shared<CpuBlockedMemoryDesc>(createDesc(precision, srcShape));
     }
 
-    virtual size_t getMinimalRank() const = 0;
+    [[nodiscard]] virtual size_t getMinimalRank() const = 0;
     virtual ~BlockedDescCreator() = default;
 };
 
 class CreatorsMapFilterConstIterator {
 public:
-    typedef BlockedDescCreator::CreatorsMap::const_iterator Iterator;
-    typedef std::iterator_traits<Iterator>::value_type value_type;
-    typedef std::iterator_traits<Iterator>::reference reference;
-    typedef std::iterator_traits<Iterator>::pointer pointer;
-    typedef std::iterator_traits<Iterator>::difference_type difference_type;
-    typedef std::forward_iterator_tag iterator_category;
-    typedef std::function<bool(const value_type&)> predicate_type;
+    using Iterator = BlockedDescCreator::CreatorsMap::const_iterator;
+    using value_type = std::iterator_traits<Iterator>::value_type;
+    using reference = std::iterator_traits<Iterator>::reference;
+    using pointer = std::iterator_traits<Iterator>::pointer;
+    using difference_type = std::iterator_traits<Iterator>::difference_type;
+    using iterator_category = std::forward_iterator_tag;
+    using predicate_type = std::function<bool(const value_type&)>;
 
-public:
     CreatorsMapFilterConstIterator(predicate_type filter, Iterator begin, Iterator end)
         : _iter(begin),
           _end(end),
@@ -76,8 +74,8 @@ public:
         return *this;
     }
 
-    CreatorsMapFilterConstIterator end() const {
-        return CreatorsMapFilterConstIterator(predicate_type(), _end, _end);
+    [[nodiscard]] CreatorsMapFilterConstIterator end() const {
+        return {predicate_type(), _end, _end};
     }
 
     CreatorsMapFilterConstIterator operator++(int) {
@@ -108,5 +106,4 @@ private:
     predicate_type _filter;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.h
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.h
@@ -6,8 +6,7 @@
 
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * @brief Copy size elements from buffer specified srcPtr pointer to buffer specified dstPtr.
@@ -24,11 +23,7 @@ namespace intel_cpu {
  * number of elements in buffers to be converted
  * @return none.
  */
-void cpu_convert(const void* srcPtr,
-                 void* dstPtr,
-                 ov::element::Type srcPrc,
-                 ov::element::Type dstPrc,
-                 const size_t size);
+void cpu_convert(const void* srcPtr, void* dstPtr, ov::element::Type srcPrc, ov::element::Type dstPrc, size_t size);
 
 /**
  * @brief Copy size elements from buffer specified srcPtr pointer to buffer specified dstPtr.
@@ -52,9 +47,8 @@ void cpu_convert(const void* srcPtr,
                  ov::element::Type srcPrc,
                  ov::element::Type interimPrc,
                  ov::element::Type dstPrc,
-                 const size_t size);
+                 size_t size);
 
 bool is_supported_convert(ov::element::Type srcPrc, ov::element::Type dstPrc);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_memcpy.h
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_memcpy.h
@@ -10,8 +10,7 @@
 #include "onednn/dnnl.h"
 #include "openvino/core/parallel.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * @brief Copies bytes between buffers with security enhancements
@@ -39,7 +38,8 @@ inline void cpu_memcpy(void* dst, const void* src, size_t count) {
 
 inline int cpu_memcpy_s(void* dst, size_t dst_size, const void* src, size_t count) {
     if (!src || count > dst_size ||
-        count > (dst > src ? ((uintptr_t)dst - (uintptr_t)src) : ((uintptr_t)src - (uintptr_t)dst))) {
+        count > (dst > src ? (reinterpret_cast<uintptr_t>(dst) - reinterpret_cast<uintptr_t>(src))
+                           : (reinterpret_cast<uintptr_t>(src) - reinterpret_cast<uintptr_t>(dst)))) {
         // zero out dest if error detected
         std::memset(dst, 0, dst_size);
         return -1;
@@ -56,8 +56,8 @@ inline int cpu_memcpy_s(void* dst, size_t dst_size, const void* src, size_t coun
 inline void cpu_parallel_memcpy(void* dst, const void* src, size_t count) {
     const size_t l2_cache_size = dnnl::utils::get_cache_size(2, true);
     if (count >= l2_cache_size) {
-        auto src_int8 = static_cast<const uint8_t*>(src);
-        auto dst_int8 = static_cast<uint8_t*>(dst);
+        const auto* src_int8 = static_cast<const uint8_t*>(src);
+        auto* dst_int8 = static_cast<uint8_t*>(dst);
         parallel_nt(0, [&](const size_t ithr, const size_t nthr) {
             size_t start = 0, end = 0;
             splitter(count, nthr, ithr, start, end);
@@ -68,5 +68,4 @@ inline void cpu_parallel_memcpy(void* dst, const void* src, size_t count) {
     }
 }
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/dnnl_executor.h
+++ b/src/plugins/intel_cpu/src/nodes/common/dnnl_executor.h
@@ -72,7 +72,6 @@ public:
 protected:
     virtual void reorder_exec(std::unordered_map<int, dnnl::memory> primArgs, const dnnl::stream& strm);
 
-protected:
     dnnl::primitive execPrim;
     // key is the port number for the primitive that needs memory reordering
     std::unordered_map<int, IntermReorder> inputReorders;

--- a/src/plugins/intel_cpu/src/nodes/common/permute_kernel.h
+++ b/src/plugins/intel_cpu/src/nodes/common/permute_kernel.h
@@ -12,8 +12,7 @@
 
 #include "cpu_types.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 struct PermuteParams {
     VectorDims src_block_dims;
@@ -23,7 +22,7 @@ struct PermuteParams {
     VectorDims order;
     size_t data_size;
 
-    size_t hash() const;
+    [[nodiscard]] size_t hash() const;
     bool operator==(const PermuteParams& rhs) const;
 };
 
@@ -44,15 +43,15 @@ struct jit_args_permute {
 };
 
 struct jit_uni_permute_kernel {
-    void (*ker_)(const jit_args_permute*);
+    void (*ker_)(const jit_args_permute*){nullptr};
 
-    void operator()(const jit_args_permute* args) {
+    void operator()(const jit_args_permute* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_permute_kernel(jit_permute_config_params jcp_) : ker_(nullptr), jcp(std::move(jcp_)) {}
-    virtual ~jit_uni_permute_kernel() {}
+    explicit jit_uni_permute_kernel(jit_permute_config_params jcp_) : jcp(std::move(jcp_)) {}
+    virtual ~jit_uni_permute_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -64,18 +63,17 @@ public:
     PermuteKernel(const PermuteParams& params);
 
     void execute(const uint8_t* src_data, uint8_t* dst_data);
-    void execute(const uint8_t* src_data, uint8_t* dst_data, const int mb);
-    const PermuteParams& getPermuteParams() const {
+    void execute(const uint8_t* src_data, uint8_t* dst_data, int mb);
+    [[nodiscard]] const PermuteParams& getPermuteParams() const {
         return params;
     }
 
 private:
-    void optimizedExecute(const uint8_t* src_data, const uint8_t* dst_data, const int mb);
+    void optimizedExecute(const uint8_t* src_data, const uint8_t* dst_data, int mb);
 
     jit_permute_config_params jcp = {};
     std::shared_ptr<jit_uni_permute_kernel> permute_kernel;
     PermuteParams params;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/permute_kernel.h
+++ b/src/plugins/intel_cpu/src/nodes/common/permute_kernel.h
@@ -43,7 +43,7 @@ struct jit_args_permute {
 };
 
 struct jit_uni_permute_kernel {
-    void (*ker_)(const jit_args_permute*){nullptr};
+    void (*ker_)(const jit_args_permute*) = nullptr;
 
     void operator()(const jit_args_permute* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/common/reorder_prim.h
+++ b/src/plugins/intel_cpu/src/nodes/common/reorder_prim.h
@@ -9,13 +9,11 @@
 
 #include "cache/multi_cache.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 dnnl::reorder getReorderPrim(const MultiCachePtr& cache,
                              const dnnl::engine& engine,
                              const dnnl::memory::desc& src,
                              const dnnl::memory::desc& dest);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -46,7 +46,7 @@ struct jit_softmax_config_params {
 };
 
 struct jit_uni_softmax_kernel {
-    void (*ker_)(const jit_args_softmax*){nullptr};
+    void (*ker_)(const jit_args_softmax*) = nullptr;
 
     void operator()(const jit_args_softmax* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.h
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.h
@@ -12,8 +12,7 @@
 #include "openvino/core/parallel.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 struct jit_uni_softmax_kernel;
 
@@ -25,8 +24,9 @@ static inline void softmax_many_batches(const float* src_data, float* dst_data, 
         float max = psrc[i];
         for (int c = 0; c < C; c++) {
             float val = psrc[c * H * W + i];
-            if (val > max)
+            if (val > max) {
                 max = val;
+            }
         }
 
         float expSum = 0;
@@ -51,11 +51,9 @@ private:
     template <typename in_data_t, typename out_data_t>
     void calculate(const in_data_t* src_data, out_data_t* dst_data, int B, int C, int H, int W);
 
-private:
     int block_size;
     ov::element::Type input_prec, output_prec;
     std::shared_ptr<jit_uni_softmax_kernel> softmax_kernel;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.h
+++ b/src/plugins/intel_cpu/src/nodes/common/tile_broadcast_utils.h
@@ -12,8 +12,7 @@
 #include "cpu_memory.h"
 #include "cpu_types.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class TileBroadcastCommon {
 protected:
@@ -35,7 +34,7 @@ private:
                                                VectorDims& optimizedSrcStrides);
     static void broadcastScalar(const char* srcData, char* dstData, size_t elt_cnt, size_t data_size);
 
-    static bool canBeExecutedInBlockedLayout(VectorDims srcBlockedDims, VectorDims repeats, const size_t elemsInBlock);
+    static bool canBeExecutedInBlockedLayout(VectorDims srcBlockedDims, VectorDims repeats, size_t elemsInBlock);
     static bool canBeExecutedInNSPCLayout(VectorDims srcBlockedDims, VectorDims repeats);
 
     struct {
@@ -46,5 +45,4 @@ private:
     } optimizedParams;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/composite.cpp
+++ b/src/plugins/intel_cpu/src/nodes/composite.cpp
@@ -120,7 +120,7 @@ int Composite::registerToAllocationContext(int offset, AllocationContext& contex
     return m_graph.RegisterToAllocationContext(offset, context);
 }
 
-void Composite::execute(const dnnl::stream& /*strm*/) {
+void Composite::execute([[maybe_unused]] const dnnl::stream& strm) {
     m_graph.Infer();
 }
 

--- a/src/plugins/intel_cpu/src/nodes/composite.h
+++ b/src/plugins/intel_cpu/src/nodes/composite.h
@@ -48,7 +48,7 @@ public:
     void getSupportedDescriptors() override{};
     void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
-    void execute(const dnnl::stream& /*strm*/) override;
+    void execute([[maybe_unused]] const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
     int registerToAllocationContext(int offset, AllocationContext& context) override;

--- a/src/plugins/intel_cpu/src/nodes/composite.h
+++ b/src/plugins/intel_cpu/src/nodes/composite.h
@@ -17,9 +17,7 @@
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Composite : public Node {
 public:
@@ -50,7 +48,7 @@ public:
     void getSupportedDescriptors() override{};
     void selectOptimalPrimitiveDescriptor() override;
     void createPrimitive() override;
-    void execute(const dnnl::stream&) override;
+    void execute(const dnnl::stream& /*strm*/) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
     int registerToAllocationContext(int offset, AllocationContext& context) override;
@@ -65,6 +63,4 @@ private:
     std::shared_ptr<Executor> m_executor;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/concat.h
+++ b/src/plugins/intel_cpu/src/nodes/concat.h
@@ -5,12 +5,10 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "edge.h"
@@ -19,9 +17,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Concat : public Node {
 public:
@@ -32,18 +28,18 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void initOptimalPrimitiveDescriptor() override;
     void selectOptimalPrimitiveDescriptor() override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override {
         execute(strm);
     }
     void resolveInPlaceEdges(Edge::LOOK look) override;
 
-    ov::element::Type getRuntimePrecision() const override;
+    [[nodiscard]] ov::element::Type getRuntimePrecision() const override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void prepareParams() override;
 
 private:
@@ -69,6 +65,4 @@ private:
     dnnl::primitive prim;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -191,17 +191,7 @@ bool Convolution::isSupportedOperation(const std::shared_ptr<const ov::Node>& op
 }
 
 Convolution::Convolution(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
-    : Node(op, context, ConvolutionShapeInferFactory(op)),
-      withSum(false),
-      withDWConv(false),
-      dw_conv_oc(0),
-      dw_conv_ih(0),
-      dw_conv_iw(0),
-      dw_conv_in_dt(memory::data_type::undef),
-      groupNum(1LU),
-      IC(1),
-      groupIC(1),
-      groupOC(1) {
+    : Node(op, context, ConvolutionShapeInferFactory(op)) {
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -128,21 +128,21 @@ private:
     ExecutorPtr m_executor = nullptr;
     ExecutorPtr fallbackExecutor = nullptr;
 
-    bool withSum;
-    bool withDWConv;
+    bool withSum{false};
+    bool withDWConv{false};
     bool withSumBroadcast = false;
 
-    size_t dw_conv_oc;
-    size_t dw_conv_ih;
-    size_t dw_conv_iw;
+    size_t dw_conv_oc{0};
+    size_t dw_conv_ih{0};
+    size_t dw_conv_iw{0};
     std::vector<size_t> dw_conv_kernel;
     std::vector<size_t> dw_conv_strides;
-    dnnl::memory::data_type dw_conv_in_dt;
+    dnnl::memory::data_type dw_conv_in_dt{dnnl::impl::data_type::undef};
 
-    size_t groupNum;
-    size_t IC;
-    size_t groupIC;
-    size_t groupOC;
+    size_t groupNum{1LU};
+    size_t IC{1};
+    size_t groupIC{1};
+    size_t groupOC{1};
 
     FusedSubgraphPtr subgraph;
     std::unordered_map<NodePtr, std::vector<NodePtr>> fusedConstNodes;

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -64,21 +64,21 @@ public:
     std::vector<int32_t> legacyOutputCompensation;
     // Hold stock per-tensor input zero point. Pass to onednn to calculate output compensation.
     std::vector<int32_t> inputZeroPoints;
-    void initializeInputZeroPoints(const uint8_t* inputZpData, const size_t inputZpSize);
+    void initializeInputZeroPoints(const uint8_t* inputZpData, size_t inputZpSize);
 
     const VectorDims& getWeightDims() {
         return getInputShapeAtPort(WEIGHTS).getDims();
     }
-    const std::vector<size_t>& getStride() {
+    const std::vector<size_t>& getStride() const {
         return m_attrs.stride;
     }
-    const std::vector<size_t>& getDilation() {
+    const std::vector<size_t>& getDilation() const {
         return m_attrs.dilation;
     }
-    const std::vector<ptrdiff_t>& getPaddingL() {
+    const std::vector<ptrdiff_t>& getPaddingL() const {
         return m_attrs.paddingL;
     }
-    const std::vector<ptrdiff_t>& getPaddingR() {
+    const std::vector<ptrdiff_t>& getPaddingR() const {
         return m_attrs.paddingR;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/conv.h
+++ b/src/plugins/intel_cpu/src/nodes/conv.h
@@ -128,21 +128,21 @@ private:
     ExecutorPtr m_executor = nullptr;
     ExecutorPtr fallbackExecutor = nullptr;
 
-    bool withSum{false};
-    bool withDWConv{false};
+    bool withSum = false;
+    bool withDWConv = false;
     bool withSumBroadcast = false;
 
-    size_t dw_conv_oc{0};
-    size_t dw_conv_ih{0};
-    size_t dw_conv_iw{0};
+    size_t dw_conv_oc = 0;
+    size_t dw_conv_ih = 0;
+    size_t dw_conv_iw = 0;
     std::vector<size_t> dw_conv_kernel;
     std::vector<size_t> dw_conv_strides;
     dnnl::memory::data_type dw_conv_in_dt{dnnl::impl::data_type::undef};
 
-    size_t groupNum{1LU};
-    size_t IC{1};
-    size_t groupIC{1};
-    size_t groupOC{1};
+    size_t groupNum = 1LU;
+    size_t IC = 1;
+    size_t groupIC = 1;
+    size_t groupOC = 1;
 
     FusedSubgraphPtr subgraph;
     std::unordered_map<NodePtr, std::vector<NodePtr>> fusedConstNodes;

--- a/src/plugins/intel_cpu/src/nodes/convert.h
+++ b/src/plugins/intel_cpu/src/nodes/convert.h
@@ -15,11 +15,10 @@
 #include "nodes/executors/convert.hpp"
 #include "nodes/node_config.h"
 #include "openvino/core/node.hpp"
+#include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Convert : public Node {
 public:
@@ -35,8 +34,8 @@ public:
     void prepareParams() override;
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
@@ -49,14 +48,14 @@ public:
         this->output = output.clone();
     }
 
-    const MemoryDesc& getInput() const {
+    [[nodiscard]] const MemoryDesc& getInput() const {
         return *input;
     }
-    const MemoryDesc& getOutput() const {
+    [[nodiscard]] const MemoryDesc& getOutput() const {
         return *output;
     }
 
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needPrepareParams() const override {
         return inputShapesModified();
     }
 
@@ -72,6 +71,4 @@ private:
     NodeConfig config;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.h
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class CTCGreedyDecoder : public Node {
 public:
@@ -24,9 +22,9 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -36,6 +34,4 @@ private:
     bool mergeRepeated;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.h
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder_seq_len.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class CTCGreedyDecoderSeqLen : public Node {
 public:
@@ -24,9 +22,9 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -39,6 +37,4 @@ private:
     bool mergeRepeated;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.h
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class CTCLoss : public Node {
 public:
@@ -23,12 +21,12 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     };
 
@@ -38,6 +36,4 @@ private:
     bool unique;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_memory.h"
 #include "graph_context.h"
@@ -16,9 +15,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class CumSum : public Node {
 public:
@@ -27,9 +24,9 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
@@ -47,7 +44,7 @@ private:
 
     static inline size_t getStartOffset(const std::vector<size_t>& forStartOffset, const std::vector<size_t>& strides);
 
-    size_t getAxis(const IMemory& _axis, const IMemory& _data) const;
+    [[nodiscard]] size_t getAxis(const IMemory& _axis, const IMemory& _data) const;
 
     enum { CUM_SUM_DATA, AXIS, numOfInputs };
     bool exclusive;
@@ -65,6 +62,4 @@ private:
     };
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/cum_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/cum_sum.h
@@ -46,7 +46,7 @@ private:
 
     [[nodiscard]] size_t getAxis(const IMemory& _axis, const IMemory& _data) const;
 
-    enum { CUM_SUM_DATA, AXIS, numOfInputs };
+    enum : uint8_t { CUM_SUM_DATA, AXIS, numOfInputs };
     bool exclusive;
     bool reverse;
     size_t numOfDims;

--- a/src/plugins/intel_cpu/src/nodes/deconv.h
+++ b/src/plugins/intel_cpu/src/nodes/deconv.h
@@ -24,9 +24,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Deconvolution : public Node {
 public:
@@ -100,8 +98,8 @@ private:
     size_t IC = 0;
     size_t OC = 0;
     std::vector<int32_t> lastOutputSpatialDims;
-    VectorDims dnnlCompatibleWeiDims{};
-    VectorDims expectedBiasDims{};
+    VectorDims dnnlCompatibleWeiDims;
+    VectorDims expectedBiasDims;
 
     bool useACL = false;
     DeconvAttrs deconvAttrs;
@@ -129,6 +127,4 @@ private:
     bool isConstOutShape = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/def_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.h
@@ -62,7 +62,7 @@ struct jit_def_conv_call_args {
 };
 
 struct jit_uni_def_conv_kernel {
-    void (*ker_)(const jit_def_conv_call_args*){nullptr};
+    void (*ker_)(const jit_def_conv_call_args*) = nullptr;
 
     void operator()(const jit_def_conv_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/def_conv.h
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.h
@@ -19,9 +19,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_def_conv_params {
     int ndims;
@@ -64,15 +62,15 @@ struct jit_def_conv_call_args {
 };
 
 struct jit_uni_def_conv_kernel {
-    void (*ker_)(const jit_def_conv_call_args*);
+    void (*ker_)(const jit_def_conv_call_args*){nullptr};
 
-    void operator()(const jit_def_conv_call_args* args) {
+    void operator()(const jit_def_conv_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_def_conv_kernel(const jit_def_conv_params& jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_def_conv_kernel() {}
+    explicit jit_uni_def_conv_kernel(const jit_def_conv_params& jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_def_conv_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -100,8 +98,8 @@ public:
         size_t group = 1;
         int deformable_group = 1;
         bool with_bilinear_pad = false;
-        std::vector<ptrdiff_t> stride = {};
-        std::vector<ptrdiff_t> dilation = {};
+        std::vector<ptrdiff_t> stride;
+        std::vector<ptrdiff_t> dilation;
         std::vector<ptrdiff_t> padL;
     } defConvAttr;
 
@@ -178,6 +176,4 @@ private:
     bool autoPadding = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.cpp
@@ -333,7 +333,7 @@ DepthToSpace::DepthToSpaceExecutor::DepthToSpaceExecutor(const DepthToSpaceAttrs
     permuteKernel = std::make_unique<PermuteKernel>(params);
 }
 
-void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const int MB) {
+void DepthToSpace::DepthToSpaceExecutor::exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, int MB) {
     if (!permuteKernel) {
         OPENVINO_THROW("Could not execute. Kernel for Transpose node was not compiled.");
     }

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.h
@@ -17,9 +17,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class DepthToSpace : public Node {
 public:
@@ -30,7 +28,7 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
 
@@ -43,7 +41,7 @@ public:
         size_t dataSize = 1lu;
         size_t nSpatialDims = 0lu;
         VectorDims srcBlockedDims;
-        size_t hash() const;
+        [[nodiscard]] size_t hash() const;
         bool operator==(const DepthToSpaceAttrs& rhs) const;
     };
 
@@ -54,7 +52,7 @@ private:
     DepthToSpaceAttrs attrs;
     struct DepthToSpaceExecutor {
         DepthToSpaceExecutor(const DepthToSpaceAttrs& attrs);
-        void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, const int MB);
+        void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, int MB);
         ~DepthToSpaceExecutor() = default;
 
     private:
@@ -64,6 +62,4 @@ private:
     executorPtr execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.h
@@ -32,7 +32,7 @@ public:
 
     void prepareParams() override;
 
-    enum Mode { BLOCKS_FIRST = 0, DEPTH_FIRST = 1 };
+    enum Mode : uint8_t { BLOCKS_FIRST = 0, DEPTH_FIRST = 1 };
     struct DepthToSpaceAttrs {
         LayoutType layoutType;
         Mode mode;

--- a/src/plugins/intel_cpu/src/nodes/detection_output.h
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.h
@@ -64,7 +64,7 @@ private:
     int coordOffset = 0;
     int cacheSizeL3 = 0;
 
-    enum CodeType {
+    enum CodeType : uint8_t {
         CORNER = 1,
         CENTER_SIZE = 2,
     };

--- a/src/plugins/intel_cpu/src/nodes/detection_output.h
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.h
@@ -7,15 +7,12 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class DetectionOutput : public Node {
 public:
@@ -24,7 +21,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -146,6 +143,4 @@ private:
     std::vector<int> confInfoForPrior;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/dft.h
+++ b/src/plugins/intel_cpu/src/nodes/dft.h
@@ -9,8 +9,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"
@@ -18,12 +16,9 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu::node {
 
-namespace node {
-
-class DFT : public Node {
+class DFT : public ov::intel_cpu::Node {
 public:
     DFT(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
     ~DFT() override = default;
@@ -32,15 +27,15 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     void createPrimitive() override;
-    bool needShapeInfer() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
-    std::vector<int32_t> getAxes() const;
+    [[nodiscard]] std::vector<int32_t> getAxes() const;
     void createJITKernels(bool hasDFT, bool hasFFT);
     void dftNd(float* output,
                const VectorDims& outputShape,
@@ -78,6 +73,4 @@ private:
     bool m_is_signal_size_const = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -1407,8 +1407,7 @@ bool Eltwise::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, st
 }
 
 Eltwise::Eltwise(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
-    : Node(op, context, EltwiseShapeInferFactory()),
-      broadcastingPolicy(Undefined) {
+    : Node(op, context, EltwiseShapeInferFactory()) {
     std::string errorMessage;
     if (!isSupportedOperation(op, errorMessage)) {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);

--- a/src/plugins/intel_cpu/src/nodes/eltwise.h
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.h
@@ -28,7 +28,7 @@
 
 namespace ov::intel_cpu::node {
 
-enum class EltwiseImplType { reference = 0, optimized = 1, optimizedShapeAgnostic = 2 };
+enum class EltwiseImplType : uint8_t { reference = 0, optimized = 1, optimizedShapeAgnostic = 2 };
 class Eltwise : public Node {
 public:
     class IEltwiseExecutor {
@@ -99,7 +99,7 @@ public:
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    enum BroadcastingPolicy {
+    enum BroadcastingPolicy : uint8_t {
         PerChannel,
         PerTensor,
         Undefined,
@@ -113,7 +113,7 @@ public:
 
 private:
     executorPtr execPtr = nullptr;
-    BroadcastingPolicy broadcastingPolicy;
+    BroadcastingPolicy broadcastingPolicy{Undefined};
 
     dnnl::algorithm onednnAlgorithm = dnnl::algorithm::undef;
 

--- a/src/plugins/intel_cpu/src/nodes/eltwise.h
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.h
@@ -26,9 +26,7 @@
 #include "openvino/core/type.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum class EltwiseImplType { reference = 0, optimized = 1, optimizedShapeAgnostic = 2 };
 class Eltwise : public Node {
@@ -37,14 +35,13 @@ public:
     public:
         IEltwiseExecutor() = default;
         virtual void exec(const jit_eltwise_call_args_ptrs& args_ptrs, const VectorDims& dims_out) = 0;
-        virtual size_t getBatchDimIdx() const = 0;
-        virtual const VectorDims& getOutDims() const = 0;
+        [[nodiscard]] virtual size_t getBatchDimIdx() const = 0;
+        [[nodiscard]] virtual const VectorDims& getOutDims() const = 0;
         virtual ~IEltwiseExecutor() = default;
     };
 
     using executorPtr = std::shared_ptr<IEltwiseExecutor>;
 
-public:
     Eltwise(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
 
     void getSupportedDescriptors() override;
@@ -59,11 +56,11 @@ public:
     void appendPostOps(dnnl::post_ops& ops,
                        const VectorDims& postOpDims,
                        std::unordered_map<int, MemoryPtr>& postOpsMem,
-                       const int channelAxis) override;
+                       int channelAxis) override;
     void appendPostOps(dnnl::post_ops& ops,
                        const VectorDims& postOpDims,
                        std::vector<const void*>& postOpsMem,
-                       const int channelAxis) override;
+                       int channelAxis) override;
     bool appendAttrPostOps(DnnlPostOpsComposerLegacy& dnnlpoc,
                            bool isLastPostOp,
                            dnnl::memory::data_type outDataType,
@@ -124,14 +121,14 @@ private:
     std::vector<bool> broadcastPolicy;
     bool specialConvolutionAddFusing = false;
     size_t inputNum = 0;
-    std::vector<ptrdiff_t> start_offset_in = {};
+    std::vector<ptrdiff_t> start_offset_in;
     ptrdiff_t start_offset_out = 0;
 
     std::vector<ov::element::Type> inpPrc;
     ov::element::Type outPrc;
 
     // blocked dims for which kernel compiled and params prepared
-    std::vector<VectorDims> currentInBlkDims = {};
+    std::vector<VectorDims> currentInBlkDims;
 
     // shape agnostic kernel
     struct {
@@ -144,16 +141,16 @@ private:
     float beta = 0;
     float gamma = 0;
 
-    std::vector<float> scales = {};
-    std::vector<float> shifts = {};
+    std::vector<float> scales;
+    std::vector<float> shifts;
     MemoryPtr scalesMemory;
     MemoryPtr shiftsMemory;
 
-    std::vector<float> depthwiseData = {};
+    std::vector<float> depthwiseData;
     MemoryPtr depthwiseMemory;
     size_t depthwiseDataSize = 0;
 
-    std::vector<MemoryPtr> memPtrs = {};
+    std::vector<MemoryPtr> memPtrs;
     std::vector<const void*> fqDataPtrs;
 
     using Initializer = std::function<void(const std::shared_ptr<ov::Node>&, Eltwise& node)>;
@@ -167,7 +164,7 @@ private:
     void appendPostOpsImpl(dnnl::post_ops& ops,
                            const VectorDims& postOpDims,
                            std::vector<T>& postOpsMem,
-                           const int channelAxis = 1);
+                           int channelAxis = 1);
 
     void appendMemory(const std::vector<float>& data, MemoryPtr& memPtr, std::vector<MemoryPtr>& postOpsMem);
     static void appendMemory(const std::vector<float>& data, MemoryPtr& memPtr, std::vector<const void*>& postOpsMem);
@@ -177,6 +174,4 @@ private:
     std::shared_ptr<EltwiseExecutor> eltwiseExecPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/eltwise.h
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.h
@@ -113,7 +113,7 @@ public:
 
 private:
     executorPtr execPtr = nullptr;
-    BroadcastingPolicy broadcastingPolicy{Undefined};
+    BroadcastingPolicy broadcastingPolicy = Undefined;
 
     dnnl::algorithm onednnAlgorithm = dnnl::algorithm::undef;
 

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag.h
@@ -14,9 +14,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class EmbeddingBag {
 public:
@@ -59,6 +57,4 @@ protected:
     std::string _layerName;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag.h
@@ -19,7 +19,7 @@ namespace ov::intel_cpu::node {
 class EmbeddingBag {
 public:
     enum class Reduction : uint8_t { SUM, MEAN };
-    EmbeddingBag([[maybe_unused]] const std::shared_ptr<ov::Node>& op,
+    EmbeddingBag(const std::shared_ptr<ov::Node>& op,
                  size_t requiredInputNum,
                  size_t indicesIdx,
                  size_t perSampleWeightsIdx,

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag.h
@@ -18,8 +18,8 @@ namespace ov::intel_cpu::node {
 
 class EmbeddingBag {
 public:
-    enum class Reduction { SUM, MEAN };
-    EmbeddingBag(const std::shared_ptr<ov::Node>&,
+    enum class Reduction : uint8_t { SUM, MEAN };
+    EmbeddingBag([[maybe_unused]] const std::shared_ptr<ov::Node>& op,
                  size_t requiredInputNum,
                  size_t indicesIdx,
                  size_t perSampleWeightsIdx,
@@ -31,7 +31,7 @@ public:
                  const VectorDims& inDims,
                  const MemoryPtr& outMemory);
 
-    ~EmbeddingBag() = default;
+    virtual ~EmbeddingBag() = default;
 
 protected:
     virtual void initFromInputs() = 0;

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_offsets.h
@@ -14,9 +14,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class EmbeddingBagOffset : public Node, public EmbeddingBag {
 public:
@@ -49,6 +47,4 @@ private:
     size_t _offsetsLen = 0;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_bag_packed.h
@@ -14,9 +14,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class EmbeddingBagPacked : public Node, public EmbeddingBag {
 public:
@@ -44,6 +42,4 @@ private:
     size_t _indicesPerBag = 0;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
+++ b/src/plugins/intel_cpu/src/nodes/embedding_segments_sum.h
@@ -15,9 +15,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class EmbeddingSegmentsSum : public Node, public EmbeddingBag {
 public:
@@ -26,21 +24,21 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 protected:
     void prepareParams() override;
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:
     void initFromInputs() override;
     void getIndices(size_t embIndex, const int*& indices, size_t& size, int& weightsIdx, bool& withWeight) override;
-    int32_t getNumSegments() const;
+    [[nodiscard]] int32_t getNumSegments() const;
 
     static constexpr size_t SEGMENT_ID_IDX = 2lu;
     static constexpr size_t NUM_SEGMENTS_IDX = 3lu;
@@ -54,6 +52,4 @@ private:
     size_t indicesSize_ = 0;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.hpp
@@ -10,7 +10,7 @@
 
 namespace ov::intel_cpu {
 
-enum ACLArgs { ACL_SRC_0, ACL_SRC_1, ACL_SRC_2, ACL_BIAS, ACL_WEI, ACL_DST, ACL_DST_DEQ_SCALE, COUNT_OF_ARGS };
+enum ACLArgs : uint8_t { ACL_SRC_0, ACL_SRC_1, ACL_SRC_2, ACL_BIAS, ACL_WEI, ACL_DST, ACL_DST_DEQ_SCALE, COUNT_OF_ARGS };
 
 using ACLFunction = std::unique_ptr<arm_compute::IFunction>;
 using ACLShapes = std::array<arm_compute::TensorShape, ACLArgs::COUNT_OF_ARGS>;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_common_executor.hpp
@@ -10,7 +10,16 @@
 
 namespace ov::intel_cpu {
 
-enum ACLArgs : uint8_t { ACL_SRC_0, ACL_SRC_1, ACL_SRC_2, ACL_BIAS, ACL_WEI, ACL_DST, ACL_DST_DEQ_SCALE, COUNT_OF_ARGS };
+enum ACLArgs : uint8_t {
+    ACL_SRC_0,
+    ACL_SRC_1,
+    ACL_SRC_2,
+    ACL_BIAS,
+    ACL_WEI,
+    ACL_DST,
+    ACL_DST_DEQ_SCALE,
+    COUNT_OF_ARGS
+};
 
 using ACLFunction = std::unique_ptr<arm_compute::IFunction>;
 using ACLShapes = std::array<arm_compute::TensorShape, ACLArgs::COUNT_OF_ARGS>;

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_utils.hpp
@@ -72,7 +72,7 @@ inline arm_compute::TensorShape shapeCast(const VectorDims& dims) {
     return tensorShape;
 }
 
-enum ACLAxisCastMode { NO_LAYOUT_CONVERSION, NHWC_TO_NCHW, NCHW_TO_NHWC };
+enum ACLAxisCastMode : uint8_t { NO_LAYOUT_CONVERSION, NHWC_TO_NCHW, NCHW_TO_NHWC };
 
 /**
  * @brief Return reverted axis used in ACL. If axis cast mode is

--- a/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/common_utils.hpp
@@ -26,7 +26,7 @@ namespace ov::intel_cpu {
 
     auto scalesMemory = memory.at(ARG_DST_DEQ_SCALE);
 
-    auto scalesData = static_cast<const float*>(scalesMemory->getData());
+    const auto* scalesData = static_cast<const float*>(scalesMemory->getData());
 
     if (!scalesData) {
         return {};

--- a/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/common/ref_transpose.hpp
@@ -23,7 +23,7 @@ public:
     static void referenceExecute(const uint8_t* src_data,
                                  uint8_t* dst_data,
                                  const jit_permute_config_params& jcp,
-                                 const int mb);
+                                 int mb);
     bool init(const TransposeParams& transposeParams,
               const std::vector<MemoryDescPtr>& srcDescs,
               const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/convert.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convert.hpp
@@ -43,7 +43,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const ConvertParams& convertParams,
                                            const MemoryDescPtr& srcDesc,
                                            const MemoryDescPtr& dstDesc) const = 0;
-    [[nodiscard]] virtual ConvertExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual ConvertExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using ConvertExecutorBuilderPtr = std::shared_ptr<ConvertExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/convert_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convert_list.hpp
@@ -31,7 +31,7 @@ public:
                            const MemoryDescPtr& dstDesc,
                            const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getConvertExecutorsList()) {
+        for (const auto& desc : getConvertExecutorsList()) {
             if (desc.builder->isSupported(convertParams, srcDesc, dstDesc)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/deconv.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/deconv.hpp
@@ -60,7 +60,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const DeconvAttrs& convAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual DeconvExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual DeconvExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using DeconvExecutorBuilderPtr = std::shared_ptr<DeconvExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/deconv_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/deconv_list.hpp
@@ -32,7 +32,7 @@ public:
                           const std::vector<MemoryDescPtr>& dstDescs,
                           const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getDeconvExecutorsList()) {
+        for (const auto& desc : getDeconvExecutorsList()) {
             if (desc.builder->isSupported(deconvAttrs, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
@@ -66,7 +66,7 @@ public:
     DnnlConvolutionPrimitive(const Key& key,
                              const dnnl::engine& engine,
                              const std::vector<impl_desc_type>& implPriorities,
-                             const impl_desc_type defaultImplType);
+                             impl_desc_type defaultImplType);
 
     void execute(dnnl_primitive_args& primArgs);
 
@@ -97,13 +97,13 @@ public:
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const ConvAttrs& attrs,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
-                                                            const bool cacheWeights);
+                                                            bool cacheWeights);
 
     // create shape agnostic data using FC attributes (1x1 Convolution as FC executor)
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& fcAttrs,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
-                                                            const bool cacheWeights);
+                                                            bool cacheWeights);
 
     static std::shared_ptr<DnnlConvolutionPrimitive> create(const MemoryArgs& memory,
                                                             const ConvAttrs& attrs,

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected.hpp
@@ -27,12 +27,12 @@ template <typename Primitive, typename Attrs, typename ShapeAgnosticData, typena
 class DnnlExecutor : public Executor {
 public:
     using PrimitivePtr = std::shared_ptr<Primitive>;
-    DnnlExecutor(const Attrs& attrs,
+    DnnlExecutor(Attrs attrs,
                  const MemoryArgs& memory,
                  ExecutorContext::CPtr context,
                  const bool cacheWeights,
                  const bool fc3Das2D = false)
-        : m_attrs(attrs),
+        : m_attrs(std::move(attrs)),
           m_context(std::move(context)),
           m_shapeAgnosticData(Primitive::createShapeAgnosticData(m_attrs, memory, m_context, cacheWeights)),
           m_primArgs(m_shapeAgnosticData->m_primAttrs.dnnlArgs),

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
@@ -64,11 +64,11 @@ public:
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& attrs,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
-                                                            const bool cacheWeights);
+                                                            bool cacheWeights);
 
-    static bool useWeightsDecompressionImpl(const ov::element::Type inputType,
-                                            const ov::element::Type weightsType,
-                                            const Config::ModelType modelType);
+    static bool useWeightsDecompressionImpl(ov::element::Type inputType,
+                                            ov::element::Type weightsType,
+                                            Config::ModelType modelType);
 
     static DnnlMemoryDescPtr makeTransposedWeightDescriptor(const DnnlMemoryDescPtr& srcDesc,
                                                             const DnnlMemoryDescPtr& dstDesc,

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
@@ -59,12 +59,12 @@ public:
         return m_implType;
     }
 
-    static bool useWeightsDecompressionImpl(const ov::element::Type inputType, const ov::element::Type weightsType);
+    static bool useWeightsDecompressionImpl(ov::element::Type inputType, ov::element::Type weightsType);
 
     static DnnlShapeAgnosticDataPtr createShapeAgnosticData(const FCAttrs& attrs,
                                                             const MemoryArgs& memory,
                                                             const ExecutorContext::CPtr& context,
-                                                            const bool cacheWeights);
+                                                            bool cacheWeights);
 
     static DnnlMemoryDescPtr makeTransposedWeightDescriptor(const DnnlMemoryDescPtr& srcDesc,
                                                             const DnnlMemoryDescPtr& dstDesc,
@@ -72,7 +72,7 @@ public:
 
     static std::shared_ptr<DnnlMatMulPrimitive> create(const MemoryArgs& memory,
                                                        const MatMulAttrs& attrs,
-                                                       const ExecutorContext::CPtr context,
+                                                       ExecutorContext::CPtr context,
                                                        const DnnlShapeAgnosticDataPtr& shapeAgnosticData);
 
 private:

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.hpp
@@ -12,9 +12,9 @@
 #include "nodes/executors/executor.hpp"
 
 namespace ov::intel_cpu::utils {
-MemoryPtr prepareWeightsMemory(const DnnlMemoryDescPtr srcWeightDesc,
-                               const DnnlMemoryDescPtr dstWeightDesc,
-                               const MemoryCPtr weightsMem,
-                               const ExecutorContext::CPtr context,
-                               const bool needShiftSignedToUnsigned = false);
+MemoryPtr prepareWeightsMemory(DnnlMemoryDescPtr srcWeightDesc,
+                               DnnlMemoryDescPtr dstWeightDesc,
+                               MemoryCPtr weightsMem,
+                               ExecutorContext::CPtr context,
+                               bool needShiftSignedToUnsigned = false);
 }  // namespace ov::intel_cpu::utils

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise.hpp
@@ -52,7 +52,7 @@ struct EltwiseAttrs {
     }
 };
 
-enum class EltwisePostOpType { Undefined, Eltwise, Dnnl };
+enum class EltwisePostOpType : uint8_t { Undefined, Eltwise, Dnnl };
 
 class EltwisePostOp {
 public:
@@ -115,7 +115,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const EltwiseAttrs& eltwiseAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual EltwiseExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual EltwiseExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using EltwiseExecutorBuilderPtr = std::shared_ptr<EltwiseExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/eltwise_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/eltwise_list.hpp
@@ -34,7 +34,7 @@ public:
                            const std::vector<MemoryDescPtr>& dstDescs,
                            const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getEltwiseExecutorsList()) {
+        for (const auto& desc : getEltwiseExecutorsList()) {
             if (desc.builder->isSupported(eltwiseAttrs, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -26,13 +26,13 @@
 namespace ov::intel_cpu {
 
 // @todo another option is to determine shape relation by executor type
-enum class ShapeTolerance { Agnostic, Dependant };
+enum class ShapeTolerance : uint8_t { Agnostic, Dependant };
 
-enum class ExecutorType { Undefined, Graph, Common, jit_x64, Dnnl, Acl, Mlas, jit_aarch64, Shl, Kleidiai };
+enum class ExecutorType : uint8_t { Undefined, Graph, Common, jit_x64, Dnnl, Acl, Mlas, jit_aarch64, Shl, Kleidiai };
 
-enum class OperationType { FullyConnected, MatMul, Convolution };
+enum class OperationType : uint8_t { FullyConnected, MatMul, Convolution };
 
-std::string ExecutorTypeToString(const ExecutorType type);
+std::string ExecutorTypeToString(ExecutorType type);
 ExecutorType ExecutorTypeFromString(const std::string& typeStr);
 
 class ExecutorContext {

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_factory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_factory.hpp
@@ -34,7 +34,7 @@ public:
                     const MemoryDescArgs& descriptors,
                     const MemoryFormatFilter& memoryFormatFilter = {},
                     const std::string& implementationPriority = {})
-        : m_attrs(attrs),
+        : m_attrs(std::move(attrs)),
           m_context(std::move(context)),
           m_suitableImplementations(filter(m_attrs, descriptors, memoryFormatFilter, implementationPriority)) {
         OPENVINO_ASSERT(!m_suitableImplementations.empty(), "No suitable implementations found");
@@ -70,6 +70,7 @@ public:
         };
 
         std::vector<MemoryDescArgs> memoryDescArgs;
+        memoryDescArgs.reserve(m_suitableImplementations.size());
         for (const auto& impl : m_suitableImplementations) {
             memoryDescArgs.emplace_back(getProperMemoryDescArgs(impl, config));
         }

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
@@ -65,7 +65,8 @@ public:
           m_acceptsShape(std::move(acceptsShape)),
           m_create(std::move(create)) {}
 
-    bool supports(const executor::Config<Attrs>& config, const MemoryFormatFilter& memoryFormatFilter) const {
+    [[nodiscard]] bool supports(const executor::Config<Attrs>& config,
+                                const MemoryFormatFilter& memoryFormatFilter) const {
         if (m_supports) {
             return m_supports(config, memoryFormatFilter);
         }
@@ -73,7 +74,7 @@ public:
         return false;
     }
 
-    std::optional<executor::Config<Attrs>> requiresFallback(const executor::Config<Attrs>& config) const {
+    [[nodiscard]] std::optional<executor::Config<Attrs>> requiresFallback(const executor::Config<Attrs>& config) const {
         if (m_requiresFallback) {
             return m_requiresFallback(config);
         }
@@ -89,7 +90,9 @@ public:
         return false;
     }
 
-    ExecutorPtr create(const Attrs& attrs, const MemoryArgs& memory, const ExecutorContext::CPtr context) const {
+    [[nodiscard]] ExecutorPtr create(const Attrs& attrs,
+                                     const MemoryArgs& memory,
+                                     const ExecutorContext::CPtr context) const {
         DEBUG_LOG("Creating executor using implementation: ", m_name);
 
         if (m_create) {

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -25,15 +25,21 @@ static constexpr int MAX_INPUT_INTERPOLATE = 8;
 
 namespace ov::intel_cpu {
 
-enum InterpolateLayoutType { planar, block, by_channel };
+enum InterpolateLayoutType : uint8_t { planar, block, by_channel };
 
-enum InterpolateMode { nearest, linear, linear_onnx, cubic, bilinear_pillow, bicubic_pillow };
+enum InterpolateMode : uint8_t { nearest, linear, linear_onnx, cubic, bilinear_pillow, bicubic_pillow };
 
-enum InterpolateCoordTransMode { half_pixel, pytorch_half_pixel, asymmetric, tf_half_pixel_for_nn, align_corners };
+enum InterpolateCoordTransMode : uint8_t {
+    half_pixel,
+    pytorch_half_pixel,
+    asymmetric,
+    tf_half_pixel_for_nn,
+    align_corners
+};
 
-enum class InterpolateNearestMode { round_prefer_floor, round_prefer_ceil, floor, ceil, simple };
+enum class InterpolateNearestMode : uint8_t { round_prefer_floor, round_prefer_ceil, floor, ceil, simple };
 
-enum class InterpolateShapeCalcMode { sizes, scales };
+enum class InterpolateShapeCalcMode : uint8_t { sizes, scales };
 
 struct InterpolateAttrs {
     InterpolateShapeCalcMode shapeCalcMode = InterpolateShapeCalcMode::sizes;
@@ -71,7 +77,7 @@ inline VectorDims getPaddedInputShape(const VectorDims& srcDims,
 }
 
 inline int clipCoord(int pos, int length) {
-    return std::max(static_cast<int>(0), std::min(pos, length - 1));
+    return std::max(0, std::min(pos, length - 1));
 }
 
 inline size_t getSpatialDimsNum(const Dim rank) {
@@ -193,7 +199,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const InterpolateAttrs& InterpolateAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual InterpolateExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual InterpolateExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using InterpolateExecutorBuilderPtr = std::shared_ptr<InterpolateExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -21,7 +21,7 @@
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-enum { MAX_INPUT_INTERPOLATE = 8 };
+static constexpr int MAX_INPUT_INTERPOLATE = 8;
 
 namespace ov::intel_cpu {
 

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate_list.hpp
@@ -32,7 +32,7 @@ public:
                                const std::vector<MemoryDescPtr>& dstDescs,
                                const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getInterpolateExecutorsList()) {
+        for (const auto& desc : getInterpolateExecutorsList()) {
             if (desc.builder->isSupported(InterpolateAttrs, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -106,7 +106,7 @@ MlasGemmExecutor::MlasGemmExecutor(const FCAttrs& attrs, const MemoryArgs& memor
     : m_attrs(attrs),
       m_memoryArgs(memory),
       packedWeights(prepareWeightMemory(memory.at(ARG_WEI), context, !attrs.weightsNonTransposed)),
-      M(0),
+
       N(batchDim(memory.at(ARG_WEI)->getStaticDims())),
       K(memory.at(ARG_WEI)->getStaticDims().back()) {}
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
@@ -35,7 +35,7 @@ private:
     const FCAttrs& m_attrs;
     const MemoryArgs& m_memoryArgs;
     const MemoryCPtr packedWeights;
-    int64_t M{0}, N, K;
+    int64_t M = 0, N, K;
     int curNumaNode = -1;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.hpp
@@ -35,7 +35,7 @@ private:
     const FCAttrs& m_attrs;
     const MemoryArgs& m_memoryArgs;
     const MemoryCPtr packedWeights;
-    int64_t M, N, K;
+    int64_t M{0}, N, K;
     int curNumaNode = -1;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_transpose.hpp
@@ -47,7 +47,7 @@ public:
                                    const std::vector<MemoryDescPtr>& srcDescs,
                                    const std::vector<MemoryDescPtr>& dstDescs) const override;
 
-    [[nodiscard]] TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const override;
+    [[nodiscard]] TransposeExecutorPtr makeExecutor(ExecutorContext::CPtr context) const override;
 };
 
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
@@ -17,10 +17,10 @@
 
 namespace ov::intel_cpu {
 
-enum MVNLayoutType { mvn_planar, mvn_block, mvn_by_channel };
+enum MVNLayoutType : uint8_t { mvn_planar, mvn_block, mvn_by_channel };
 
 // Defines way to add epsilon: inside sqrt or outside.
-enum MVNEpsMode { INSIDE_SQRT, OUTSIDE_SQRT };
+enum MVNEpsMode : uint8_t { INSIDE_SQRT, OUTSIDE_SQRT };
 
 struct MVNAttrs {
     MVNLayoutType layout = mvn_planar;
@@ -64,7 +64,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const MVNAttrs& mvnAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual MVNExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual MVNExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using MVNExecutorBuilderPtr = std::shared_ptr<MVNExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/mvn_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mvn_list.hpp
@@ -32,7 +32,7 @@ public:
                        const std::vector<MemoryDescPtr>& dstDescs,
                        const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getMVNExecutorsList()) {
+        for (const auto& desc : getMVNExecutorsList()) {
             if (desc.builder->isSupported(mvnAttrs, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
@@ -75,7 +75,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const PoolingAttrs& poolingAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual PoolingExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual PoolingExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using PoolingExecutorBuilderPtr = std::shared_ptr<PoolingExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/pooling_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/pooling_list.hpp
@@ -32,7 +32,7 @@ public:
                            const std::vector<MemoryDescPtr>& dstDescs,
                            const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getPoolingExecutorsList()) {
+        for (const auto& desc : getPoolingExecutorsList()) {
             if (desc.builder->isSupported(poolingAttrs, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
@@ -51,7 +51,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const ReduceAttrs& reduceAttrs,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual ReduceExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual ReduceExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using ReduceExecutorBuilderPtr = std::shared_ptr<ReduceExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/reduce_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/reduce_list.hpp
@@ -32,7 +32,7 @@ public:
                           const std::vector<MemoryDescPtr>& dstDescs,
                           const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getReduceExecutorsList()) {
+        for (const auto& desc : getReduceExecutorsList()) {
             if (desc.builder->isSupported(reduceAttrs, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/subgraph.hpp
@@ -83,7 +83,7 @@ protected:
     virtual void parallel_for6d(const initializer_functor& initializer, const call_functor& caller);
     virtual void parallel_forNd(const initializer_functor& initializer, const call_functor& caller);
 
-    inline void update_scratchpad_ptr(void*& scratchpad_ptr, size_t ithr) const {
+    void update_scratchpad_ptr(void*& scratchpad_ptr, size_t ithr) const {
         if (m_buffer_scratchpad_size > 0) {
             scratchpad_ptr = m_buffer_scratchpad->getDataAs<uint8_t>() + ithr * m_buffer_scratchpad_size;
         }
@@ -92,7 +92,7 @@ protected:
     std::shared_ptr<snippets::Schedule> m_schedule;
     // Holds index of output used as in execution domain
     // it should be compatible with a schedule's work size
-    std::vector<size_t> m_parallel_exec_domain = {};
+    std::vector<size_t> m_parallel_exec_domain;
     size_t m_harness_work_amount = 0;
 
     // Buffer scratchpad
@@ -106,8 +106,8 @@ protected:
     // Count of threads for parallel_nt
     int m_nthreads = 0;
 
-    std::vector<ptrdiff_t> m_start_offset_in = {};
-    std::vector<ptrdiff_t> m_start_offset_out = {};
+    std::vector<ptrdiff_t> m_start_offset_in;
+    std::vector<ptrdiff_t> m_start_offset_out;
 };
 
 class SubgraphSpecializedBaseExecutor {
@@ -148,11 +148,11 @@ public:
 protected:
     using kernel = void (*)(const void*, const void*);
 
-    inline void init_call_args(jit_snippets_call_args& call_args,
-                               const std::vector<MemoryPtr>& srcMemPtrs,
-                               const std::vector<MemoryPtr>& dstMemPtrs,
-                               const std::vector<ptrdiff_t>& start_offset_in,
-                               const std::vector<ptrdiff_t>& start_offset_out) {
+    void init_call_args(jit_snippets_call_args& call_args,
+                        const std::vector<MemoryPtr>& srcMemPtrs,
+                        const std::vector<MemoryPtr>& dstMemPtrs,
+                        const std::vector<ptrdiff_t>& start_offset_in,
+                        const std::vector<ptrdiff_t>& start_offset_out) {
         call_args.init_external_ptrs(m_external_ptr_mappings.size());
         for (const auto& mapping : m_src_ptr_mappings) {
             call_args.src_ptrs[mapping.postprocessed_idx] =
@@ -184,13 +184,13 @@ public:
 protected:
     using dynamic_kernel = void (*)(const void*);
 
-    inline void init_call_args(jit_snippets_call_args& call_args) {
+    void init_call_args(jit_snippets_call_args& call_args) {
         call_args.register_loops(m_loop_args);
         call_args.init_external_ptrs(m_external_ptr_mappings.size());
         std::copy(m_buffer_offsets.cbegin(), m_buffer_offsets.cend(), call_args.buffer_offsets);
     }
 
-    inline void init_original_ptrs(const std::vector<MemoryPtr>& srcMemPtrs,
+    static void init_original_ptrs(const std::vector<MemoryPtr>& srcMemPtrs,
                                    const std::vector<MemoryPtr>& dstMemPtrs,
                                    std::vector<const uint8_t*>& src_ptrs,
                                    std::vector<uint8_t*>& dst_ptrs,
@@ -210,12 +210,12 @@ protected:
         }
     }
 
-    inline void update_ptrs(jit_snippets_call_args& call_args,
-                            const std::vector<const uint8_t*>& src_ptrs,
-                            const std::vector<uint8_t*>& dst_ptrs,
-                            const std::vector<size_t>& indexes) const {
+    void update_ptrs(jit_snippets_call_args& call_args,
+                     const std::vector<const uint8_t*>& src_ptrs,
+                     const std::vector<uint8_t*>& dst_ptrs,
+                     const std::vector<size_t>& indexes) const {
         for (const auto& mapping : m_src_ptr_mappings) {
-            auto i_ptr = src_ptrs[mapping.original_idx];
+            const auto* i_ptr = src_ptrs[mapping.original_idx];
             for (size_t j = 0; j < indexes.size(); j++) {
                 i_ptr += m_data_offsets[mapping.original_idx][j] * indexes[j];
             }
@@ -223,7 +223,7 @@ protected:
         }
 
         for (const auto& mapping : m_external_ptr_mappings) {
-            auto i_ptr = src_ptrs[mapping.original_idx];
+            const auto* i_ptr = src_ptrs[mapping.original_idx];
             for (size_t j = 0; j < indexes.size(); j++) {
                 i_ptr += m_data_offsets[mapping.original_idx][j] * indexes[j];
             }
@@ -231,7 +231,7 @@ protected:
         }
 
         for (size_t i = 0; i < dst_ptrs.size(); i++) {
-            auto i_ptr = dst_ptrs[i];
+            auto* i_ptr = dst_ptrs[i];
             for (size_t j = 0; j < indexes.size(); j++) {
                 i_ptr += m_data_offsets[i + src_ptrs.size()][j] * indexes[j];
             }
@@ -239,9 +239,9 @@ protected:
         }
     }
 
-    std::vector<size_t> m_buffer_offsets = {};
-    std::vector<std::vector<size_t>> m_data_offsets = {};
-    std::vector<jit_snippets_call_args::loop_args_t> m_loop_args = {};
+    std::vector<size_t> m_buffer_offsets;
+    std::vector<std::vector<size_t>> m_data_offsets;
+    std::vector<jit_snippets_call_args::loop_args_t> m_loop_args;
     std::function<void()> m_reset_exec_table_state;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/executors/transpose.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/transpose.hpp
@@ -41,7 +41,7 @@ public:
     [[nodiscard]] virtual bool isSupported(const TransposeParams& transposeParams,
                                            const std::vector<MemoryDescPtr>& srcDescs,
                                            const std::vector<MemoryDescPtr>& dstDescs) const = 0;
-    [[nodiscard]] virtual TransposeExecutorPtr makeExecutor(const ExecutorContext::CPtr context) const = 0;
+    [[nodiscard]] virtual TransposeExecutorPtr makeExecutor(ExecutorContext::CPtr context) const = 0;
 };
 
 using TransposeExecutorBuilderPtr = std::shared_ptr<TransposeExecutorBuilder>;

--- a/src/plugins/intel_cpu/src/nodes/executors/transpose_list.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/transpose_list.hpp
@@ -31,7 +31,7 @@ public:
                              const std::vector<MemoryDescPtr>& dstDescs,
                              const ExecutorContext::CPtr& context)
         : ExecutorFactoryLegacy(context) {
-        for (auto& desc : getTransposeExecutorsList()) {
+        for (const auto& desc : getTransposeExecutorsList()) {
             if (desc.builder->isSupported(transposeParams, srcDescs, dstDescs)) {
                 supportedDescs.push_back(desc);
             }

--- a/src/plugins/intel_cpu/src/nodes/executors/type_mask.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/type_mask.hpp
@@ -11,7 +11,7 @@
 
 namespace ov::intel_cpu {
 struct TypeMask {
-    enum Value : uint64_t {
+    enum Value : uint32_t {
         _dynamic = 1 << 0,
         _boolean = 1 << 1,
         _bf16 = 1 << 2,
@@ -90,7 +90,7 @@ private:
 
 namespace TypeMaskAlias {
 constexpr ov::element::Type fxx(ov::element::Type_t::dynamic);
-#define DEFINE_TYPE_ALIAS(x) constexpr auto x = TypeMask::Value::x
+#define DEFINE_TYPE_ALIAS(x) constexpr uint64_t x = TypeMask::Value::x
 // use underscore for naming to avoid conflicts with Precision aliases
 DEFINE_TYPE_ALIAS(_dynamic);
 DEFINE_TYPE_ALIAS(_boolean);

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/subgraph.hpp
@@ -54,7 +54,7 @@ protected:
                                    int ithr,
                                    jit_snippets_call_args& call_args);
 
-    inline void* get_external_scratchpad_ptr(size_t ithr, size_t idx) const {
+    void* get_external_scratchpad_ptr(size_t ithr, size_t idx) const {
         if (m_repacked_input_config.empty()) {
             return nullptr;
         }
@@ -72,17 +72,17 @@ protected:
     }
 
     // [ Thread Index -> Index of input with repacking data - > last repacked src_offset ]
-    std::vector<std::vector<size_t>> m_repacked_offsets_by_threads = {};
-    RepackedInputConfig m_repacked_input_config = {};
+    std::vector<std::vector<size_t>> m_repacked_offsets_by_threads;
+    RepackedInputConfig m_repacked_input_config;
 
-    std::function<void(const std::vector<size_t>&, const std::vector<size_t>&, size_t&)> init_offset = {};
+    std::function<void(const std::vector<size_t>&, const std::vector<size_t>&, size_t&)> init_offset;
 
     using RepackingImplType = CPURuntimeConfig::RepackingImplType;
     const RepackingImplType& get_repacking_impl_type() const {
         return m_repacking_impl_type;
     }
 
-    inline void clean_repacked_offsets(size_t ithr) {
+    void clean_repacked_offsets(size_t ithr) {
         m_repacked_offsets_by_threads[ithr].assign(m_repacked_input_config.size(), std::numeric_limits<size_t>::max());
     }
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.h
@@ -7,15 +7,12 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ExperimentalDetectronDetectionOutput : public Node {
 public:
@@ -24,10 +21,10 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needShapeInfer() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override {
         execute(strm);
     }
@@ -52,6 +49,4 @@ private:
     std::vector<float> deltas_weights_;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ExperimentalDetectronGenerateProposalsSingleImage : public Node {
 public:
@@ -57,6 +55,4 @@ private:
     std::vector<int> roi_indices_;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ExperimentalDetectronPriorGridGenerator : public Node {
 public:
@@ -51,6 +49,4 @@ private:
     float stride_h_;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.h
@@ -15,9 +15,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ExperimentalDetectronROIFeatureExtractor : public Node {
 public:
@@ -52,6 +50,4 @@ private:
     bool aligned_ = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_topkrois.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ExperimentalDetectronTopKROIs : public Node {
 public:
@@ -23,12 +21,12 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return false;
     };
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     };
     void executeDynamicImpl(const dnnl::stream& strm) override {
@@ -51,6 +49,4 @@ private:
     int max_rois_num_;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
@@ -64,7 +64,7 @@ public:
     void prepareParams() override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
-    enum class ExtImgPatcherPadType { VALID, SAME_LOWER, SAME_UPPER };
+    enum class ExtImgPatcherPadType : uint8_t { VALID, SAME_LOWER, SAME_UPPER };
 
 private:
     std::vector<size_t> _ksizes;

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
@@ -18,9 +18,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_extract_image_patches_params {
     size_t IW;
@@ -42,15 +40,15 @@ struct jit_extract_image_patches_args {
 };
 
 struct jit_uni_extract_image_patches_kernel {
-    void (*ker_)(const jit_extract_image_patches_args*);
-    void operator()(const jit_extract_image_patches_args* args) {
+    void (*ker_)(const jit_extract_image_patches_args*){nullptr};
+    void operator()(const jit_extract_image_patches_args* args) const {
         assert(ker_);
         ker_(args);
     }
     jit_extract_image_patches_params jpp;
     virtual void create_ker() = 0;
-    explicit jit_uni_extract_image_patches_kernel(jit_extract_image_patches_params jpp) : ker_(nullptr), jpp(jpp) {}
-    virtual ~jit_uni_extract_image_patches_kernel() {}
+    explicit jit_uni_extract_image_patches_kernel(jit_extract_image_patches_params jpp) : jpp(jpp) {}
+    virtual ~jit_uni_extract_image_patches_kernel() = default;
 };
 
 class ExtractImagePatches : public Node {
@@ -84,7 +82,7 @@ private:
                                                  const VectorDims& strides,
                                                  const VectorDims& rates,
                                                  const ExtImgPatcherPadType& padType,
-                                                 const size_t prcSize);
+                                                 size_t prcSize);
         virtual ~ExtractImagePatchesExecutor() = default;
 
     protected:
@@ -107,7 +105,7 @@ private:
                                        const VectorDims& strides,
                                        const VectorDims& rates,
                                        const ExtImgPatcherPadType& padType,
-                                       const size_t prcSize);
+                                       size_t prcSize);
         void exec(void* src, void* dst, const VectorDims& istrides, const VectorDims& ostrides) override;
         void executeOptimizedGeneric(void* src,
                                      void* dst,
@@ -125,7 +123,7 @@ private:
                                        const VectorDims& strides,
                                        const VectorDims& rates,
                                        const ExtImgPatcherPadType& padType,
-                                       const size_t prcSize);
+                                       size_t prcSize);
         void exec(void* src, void* dst, const VectorDims& istrides, const VectorDims& ostrides) override;
         void executeReference(void* src, void* dst, const VectorDims& istrides, const VectorDims& ostrides) const;
 
@@ -134,6 +132,4 @@ private:
     };
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.h
@@ -40,7 +40,7 @@ struct jit_extract_image_patches_args {
 };
 
 struct jit_uni_extract_image_patches_kernel {
-    void (*ker_)(const jit_extract_image_patches_args*){nullptr};
+    void (*ker_)(const jit_extract_image_patches_args*) = nullptr;
     void operator()(const jit_extract_image_patches_args* args) const {
         assert(ker_);
         ker_(args);

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -7,21 +7,16 @@
 #include <node.h>
 
 #include <cstddef>
-#include <functional>
 #include <memory>
-#include <numeric>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "dnnl_extension_utils.h"
 #include "graph_context.h"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Eye : public Node {
 public:
@@ -30,7 +25,6 @@ public:
     static constexpr size_t DIAGONAL_INDEX = 2lu;
     static constexpr size_t BATCH_SHAPE = 3lu;
 
-public:
     Eye(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
 
     void getSupportedDescriptors() override;
@@ -55,49 +49,49 @@ private:
     void executeSpecified();
     template <typename T>
     struct EyeExecute;
-    inline const size_t getRowNum() const {
+    const size_t getRowNum() const {
         auto rowMem = getSrcMemoryAtPort(ROWS_NUM);
-        if (rowMem == nullptr)
+        if (rowMem == nullptr) {
             THROW_CPU_NODE_ERR("doesn't contain row_count data");
-        const int* rowPtr = rowMem->getDataAs<const int>();
+        }
+        const auto* rowPtr = rowMem->getDataAs<const int>();
 
         return rowPtr[0];
     }
-    inline const size_t getColNum() const {
+    const size_t getColNum() const {
         auto colMem = getSrcMemoryAtPort(COLS_NUM);
-        if (colMem == nullptr)
+        if (colMem == nullptr) {
             THROW_CPU_NODE_ERR("doesn't contain col_count data");
-        const int* colPtr = colMem->getDataAs<const int>();
+        }
+        const auto* colPtr = colMem->getDataAs<const int>();
 
         return colPtr[0];
     }
-    inline const int getDiagIndex() const {
+    const int getDiagIndex() const {
         auto diagIndMem = getSrcMemoryAtPort(DIAGONAL_INDEX);
-        if (diagIndMem == nullptr)
+        if (diagIndMem == nullptr) {
             THROW_CPU_NODE_ERR("doesn't contain diag_index data");
-        const int* diagIndexPtr = diagIndMem->getDataAs<const int>();
+        }
+        const auto* diagIndexPtr = diagIndMem->getDataAs<const int>();
 
         return diagIndexPtr[0];
     }
-    inline const std::vector<int> getBatchShape() const {
+    const std::vector<int> getBatchShape() const {
         if (withBatchShape) {
-            const int batchShapeSize =
+            const auto batchShapeSize =
                 static_cast<const int>(getSrcMemoryAtPort(BATCH_SHAPE)->getShape().getElementsCount());
             std::vector<int> batchShape(batchShapeSize);
-            const int* batchShapePtr = getSrcDataAtPortAs<const int>(BATCH_SHAPE);
+            const auto* batchShapePtr = getSrcDataAtPortAs<const int>(BATCH_SHAPE);
             batchShape.assign(batchShapePtr, batchShapePtr + batchShapeSize);
             return batchShape;
-        } else {
-            return std::vector<int>{};
         }
+        return std::vector<int>{};
     }
 
-    inline const size_t getBatchVolume(const std::vector<int>& batchShape) {
+    static const size_t getBatchVolume(const std::vector<int>& batchShape) {
         return std::accumulate(begin(batchShape), end(batchShape), 1, std::multiplies<>());
     }
     bool withBatchShape = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -68,7 +68,7 @@ struct jit_quantize_call_args {
 };
 
 struct jit_uni_quantize_kernel {
-    void (*ker_)(const jit_quantize_call_args*){nullptr};
+    void (*ker_)(const jit_quantize_call_args*) = nullptr;
 
     void operator()(const jit_quantize_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -25,7 +25,15 @@
 
 namespace ov::intel_cpu::node {
 
-enum class FQ_add_input_type { CROP_LOW, CROP_HIGH, INPUT_SCALE, INPUT_SHIFT, OUTPUT_SCALE, OUTPUT_SHIFT, INPUTS_SIZE };
+enum class FQ_add_input_type : uint8_t {
+    CROP_LOW,
+    CROP_HIGH,
+    INPUT_SCALE,
+    INPUT_SHIFT,
+    OUTPUT_SCALE,
+    OUTPUT_SHIFT,
+    INPUTS_SIZE
+};
 
 struct jit_quantize_params {
     bool is_planar;
@@ -98,10 +106,10 @@ public:
     void createPrimitive() override;
 
     const float* getBinarizationTresholdsPtr() const {
-        return &binarizationThresholds[0];
+        return binarizationThresholds.data();
     }
     const float* getBinarizationOutputMaskPtr() const {
-        return reinterpret_cast<const float*>(&binarizationOutputMask[0]);
+        return reinterpret_cast<const float*>(binarizationOutputMask.data());
     }
     size_t getBinarizationTresholdsSize() const {
         return binarizationThresholds.size();
@@ -203,7 +211,7 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    enum BroadcastingPolicy {
+    enum BroadcastingPolicy : uint8_t {
         PerChannel,  // all FQ operations are per channel
         PerTensor,   // all FQ operations are per tensor
         Mixed,       // some per channel, some per tensor

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -13,9 +13,6 @@
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <unordered_map>
-#include <utility>
-#include <vector>
 
 #include "cpu_memory.h"
 #include "cpu_types.h"
@@ -26,9 +23,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum class FQ_add_input_type { CROP_LOW, CROP_HIGH, INPUT_SCALE, INPUT_SHIFT, OUTPUT_SCALE, OUTPUT_SHIFT, INPUTS_SIZE };
 
@@ -65,15 +60,15 @@ struct jit_quantize_call_args {
 };
 
 struct jit_uni_quantize_kernel {
-    void (*ker_)(const jit_quantize_call_args*);
+    void (*ker_)(const jit_quantize_call_args*){nullptr};
 
-    void operator()(const jit_quantize_call_args* args) {
+    void operator()(const jit_quantize_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_quantize_kernel(const jit_quantize_params& jqp) : ker_(nullptr), jqp_(jqp) {}
-    virtual ~jit_uni_quantize_kernel() {}
+    explicit jit_uni_quantize_kernel(const jit_quantize_params& jqp) : jqp_(jqp) {}
+    virtual ~jit_uni_quantize_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -195,11 +190,11 @@ public:
     void appendPostOps(dnnl::post_ops& ops,
                        const VectorDims& postOpDims,
                        std::unordered_map<int, MemoryPtr>& postOpsMem,
-                       const int channelAxis) override;
+                       int channelAxis) override;
     void appendPostOps(dnnl::post_ops& ops,
                        const VectorDims& postOpDims,
                        std::vector<const void*>& postOpsMem,
-                       const int channelAxis) override;
+                       int channelAxis) override;
     bool appendAttrPostOps(DnnlPostOpsComposerLegacy& dnnlpoc,
                            bool isLastPostOp,
                            dnnl::memory::data_type outDataType,
@@ -239,14 +234,14 @@ private:
     };
     void init() override;
     std::vector<LayoutType> getDataFormats() const;
-    void initializePostOpData(const VectorDims& postOpDims, const size_t bufferAlignment, bool doRounding);
-    void initializePostOpDataLegacy(const VectorDims& dims, const size_t bufferAlignment);
+    void initializePostOpData(const VectorDims& postOpDims, size_t bufferAlignment, bool doRounding);
+    void initializePostOpDataLegacy(const VectorDims& dims, size_t bufferAlignment);
     void executeReference();
     void executeBinarization(const std::unique_ptr<jit_uni_quantize_kernel>& pKernel) const;
     void executeQuantization(const std::unique_ptr<jit_uni_quantize_kernel>& pKernel) const;
 
-    void appendMemory(const size_t dataSize, const void* data, MemoryPtr& memPtr, std::vector<MemoryPtr>& postOpsMem);
-    static void appendMemory(const size_t dataSize,
+    void appendMemory(size_t dataSize, const void* data, MemoryPtr& memPtr, std::vector<MemoryPtr>& postOpsMem);
+    static void appendMemory(size_t dataSize,
                              const void* data,
                              MemoryPtr& memPtr,
                              std::vector<const void*>& postOpsMem);
@@ -286,8 +281,9 @@ private:
 
         void shrinkLength() {
             auto _do_shrink = [](std::vector<float>& v) {
-                if (v.size() <= 1)
+                if (v.size() <= 1) {
                     return;
+                }
                 auto ref = v[0];
                 if (std::all_of(v.cbegin(), v.cend(), [&](float val) {
                         return val == ref;
@@ -342,6 +338,4 @@ private:
     BroadcastingPolicy broadcastingPolicy;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -26,9 +26,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "sub_memory_manager.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 // tensor parallel config
 struct FCTensorParallelConfig {
@@ -133,6 +131,4 @@ private:
     FCTensorParallelConfig tp_cfg;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.h
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.h
@@ -63,7 +63,7 @@ public:
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
 
     size_t descInputNumbers() override {
-        return static_cast<size_t>(getOriginalInputsNumber());
+        return getOriginalInputsNumber();
     }
 
     void initSupportedPrimitiveDescriptors() override;

--- a/src/plugins/intel_cpu/src/nodes/gather.h
+++ b/src/plugins/intel_cpu/src/nodes/gather.h
@@ -11,7 +11,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "edge.h"
 #include "graph_context.h"
@@ -19,9 +18,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Gather : public Node {
 public:
@@ -130,6 +127,4 @@ private:
     std::shared_ptr<jitGatherKernelBase> jitKernel;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/gather_elements.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_elements.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class GatherElements : public Node {
 public:
@@ -24,7 +22,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -47,6 +45,4 @@ private:
     void directExecution();
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.h
@@ -15,9 +15,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class GatherND : public Node {
 public:
@@ -26,7 +24,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -93,6 +91,4 @@ private:
     executorPtr execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/gather_tree.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_tree.h
@@ -17,9 +17,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class GatherTree : public Node {
 public:
@@ -28,7 +26,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -69,6 +67,4 @@ private:
     ov::element::Type precision;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/generate_proposals.h
+++ b/src/plugins/intel_cpu/src/nodes/generate_proposals.h
@@ -7,15 +7,12 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class GenerateProposals : public Node {
 public:
@@ -24,10 +21,10 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needShapeInfer() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -59,6 +56,4 @@ private:
     std::vector<int> roi_indices_;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/grid_sample.hpp
@@ -11,7 +11,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "kernels/x64/grid_sample.hpp"

--- a/src/plugins/intel_cpu/src/nodes/grn.h
+++ b/src/plugins/intel_cpu/src/nodes/grn.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class GRN : public Node {
 public:
@@ -23,7 +21,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -38,6 +36,4 @@ private:
     int W = 1;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/if.cpp
+++ b/src/plugins/intel_cpu/src/nodes/if.cpp
@@ -35,8 +35,7 @@ namespace ov::intel_cpu::node {
 
 If::PortMapHelper::PortMapHelper(MemoryPtr from, std::deque<MemoryPtr> to, [[maybe_unused]] const dnnl::engine& eng)
     : srcMemPtr(std::move(from)),
-      dstMemPtrs(std::move(to)),
-      size(0) {
+      dstMemPtrs(std::move(to)) {
     if (srcMemPtr->getDesc().isDefined()) {
         size = srcMemPtr->getShape().getElementsCount();
     }

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -8,11 +8,9 @@
 #include <node.h>
 
 #include <cstddef>
-#include <deque>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "allocation_context.hpp"
 #include "cpu_memory.h"
@@ -21,9 +19,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/op/if.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class If : public Node {
 public:
@@ -54,10 +50,10 @@ protected:
     }
 
 private:
-    void prepareBeforeMappers(const bool isThen, const dnnl::engine& eng);
-    void prepareAfterMappers(const bool isThen, const dnnl::engine& eng);
+    void prepareBeforeMappers(bool isThen, const dnnl::engine& eng);
+    void prepareAfterMappers(bool isThen, const dnnl::engine& eng);
 
-    static std::deque<MemoryPtr> getToMemories(const Node* node, const size_t port);
+    static std::deque<MemoryPtr> getToMemories(const Node* node, size_t port);
 
     struct PortMap {
         int from; /**< Index of external/internal out data */
@@ -93,6 +89,4 @@ private:
     std::shared_ptr<ov::op::v8::If> m_op;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -73,7 +73,7 @@ private:
         std::deque<MemoryPtr> dstMemPtrs;
         std::deque<MemoryDescPtr> originalDstMemDescs;
 
-        ptrdiff_t size;
+        ptrdiff_t size{0};
     };
 
     Graph m_thenGraph;

--- a/src/plugins/intel_cpu/src/nodes/if.h
+++ b/src/plugins/intel_cpu/src/nodes/if.h
@@ -73,7 +73,7 @@ private:
         std::deque<MemoryPtr> dstMemPtrs;
         std::deque<MemoryDescPtr> originalDstMemDescs;
 
-        ptrdiff_t size{0};
+        ptrdiff_t size = 0;
     };
 
     Graph m_thenGraph;

--- a/src/plugins/intel_cpu/src/nodes/input.h
+++ b/src/plugins/intel_cpu/src/nodes/input.h
@@ -10,7 +10,6 @@
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <openvino/op/constant.hpp>
 #include <string>
-#include <utility>
 
 #include "cpu_memory.h"
 #include "cpu_shape.h"
@@ -18,11 +17,10 @@
 #include "graph_context.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "openvino/core/node.hpp"
+#include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Input : public Node {
 public:
@@ -97,7 +95,6 @@ private:
     void initSupportedPdDefault();
     void initSupportedPdFromMemDesc();
 
-private:
     std::shared_ptr<ov::op::v0::Constant> m_constOp;
     MemoryCPtr memoryPtr;
     bool isMeanImage = false;
@@ -106,6 +103,4 @@ private:
     bool m_isInPlace = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/interaction.h
+++ b/src/plugins/intel_cpu/src/nodes/interaction.h
@@ -36,7 +36,7 @@ struct jit_move_scale_call_args {
 };
 
 struct jit_uni_move_scale_kernel {
-    void (*ker_)(const jit_move_scale_call_args*){nullptr};
+    void (*ker_)(const jit_move_scale_call_args*) = nullptr;
 
     void operator()(const jit_move_scale_call_args* call_args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/interaction.h
+++ b/src/plugins/intel_cpu/src/nodes/interaction.h
@@ -19,9 +19,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_move_scale_compile_params {
     ov::element::Type src_prc;
@@ -38,15 +36,15 @@ struct jit_move_scale_call_args {
 };
 
 struct jit_uni_move_scale_kernel {
-    void (*ker_)(const jit_move_scale_call_args*);
+    void (*ker_)(const jit_move_scale_call_args*){nullptr};
 
-    void operator()(const jit_move_scale_call_args* call_args) {
+    void operator()(const jit_move_scale_call_args* call_args) const {
         assert(ker_);
         ker_(call_args);
     }
 
-    explicit jit_uni_move_scale_kernel(const jit_move_scale_compile_params& jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_move_scale_kernel() {}
+    explicit jit_uni_move_scale_kernel(const jit_move_scale_compile_params& jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_move_scale_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -87,6 +85,4 @@ private:
     std::unique_ptr<jit_uni_move_scale_kernel> moveInteractKernel;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/interpolate.h
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.h
@@ -50,7 +50,7 @@ struct jit_interpolate_call_args {
 };
 
 struct jit_uni_interpolate_kernel {
-    void (*ker_)(const jit_interpolate_call_args*){nullptr};
+    void (*ker_)(const jit_interpolate_call_args*) = nullptr;
 
     void operator()(const jit_interpolate_call_args* args) const {
         assert(ker_);
@@ -79,7 +79,6 @@ public:
     static constexpr int CUBIC_GRID_LEN = 4;
     static constexpr float PILLOW_BILINEAR_WINDOW_SCALE = 1.0f;
     static constexpr float PILLOW_BICUBIC_WINDOW_SCALE = 2.0f;
-    static constexpr int MAX_INPUT_INTERPOLATE = 8;
 
     Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
 

--- a/src/plugins/intel_cpu/src/nodes/interpolate.h
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.h
@@ -12,7 +12,6 @@
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "executors/interpolate.hpp"
@@ -21,11 +20,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-#define MAX_INPUT_INTERPOLATE 8
-
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_interpolate_config_params {
     InterpolateLayoutType layout;
@@ -55,18 +50,17 @@ struct jit_interpolate_call_args {
 };
 
 struct jit_uni_interpolate_kernel {
-    void (*ker_)(const jit_interpolate_call_args*);
+    void (*ker_)(const jit_interpolate_call_args*){nullptr};
 
-    void operator()(const jit_interpolate_call_args* args) {
+    void operator()(const jit_interpolate_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
     explicit jit_uni_interpolate_kernel(jit_interpolate_config_params jcp, const dnnl_primitive_attr& attr)
-        : ker_(nullptr),
-          jcp_(jcp),
+        : jcp_(jcp),
           attr_(attr) {}
-    virtual ~jit_uni_interpolate_kernel() {}
+    virtual ~jit_uni_interpolate_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -85,8 +79,8 @@ public:
     static constexpr int CUBIC_GRID_LEN = 4;
     static constexpr float PILLOW_BILINEAR_WINDOW_SCALE = 1.0f;
     static constexpr float PILLOW_BICUBIC_WINDOW_SCALE = 2.0f;
+    static constexpr int MAX_INPUT_INTERPOLATE = 8;
 
-public:
     Interpolate(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
 
     void getSupportedDescriptors() override;
@@ -123,7 +117,7 @@ private:
 
         virtual void exec(const uint8_t* in_ptr_, uint8_t* out_ptr_, const void* post_ops_data_) = 0;
         virtual ~InterpolateExecutorBase() = default;
-        VectorDims getSrcDimPad5d() const {
+        [[nodiscard]] VectorDims getSrcDimPad5d() const {
             return srcDimPad5d;
         }
 
@@ -153,7 +147,7 @@ private:
                             float cubicCoeff,
                             InterpolateLayoutType layout);
 
-        float coordTransToInput(int outCoord, float scale, int inShape, int outShape) const;
+        [[nodiscard]] float coordTransToInput(int outCoord, float scale, int inShape, int outShape) const;
         static int nearestRound(float origin, bool isDownsample, InterpolateNearestMode nearestMode);
         void linearOnnxCF(int outCoord,
                           float scale,
@@ -273,7 +267,6 @@ private:
                              int OH,
                              int OW);
 
-    private:
         std::shared_ptr<jit_uni_interpolate_kernel> interpolateKernel = nullptr;
     };
 
@@ -327,7 +320,6 @@ private:
         static float getValue(const uint8_t* base, size_t offset, ov::element::Type prec);
         static void setValue(uint8_t* base, size_t offset, float value, ov::element::Type prec);
 
-    private:
         bool antialias;
         std::vector<float> dataScales;
         InterpolateAttrs refInterpAttrs;
@@ -339,7 +331,7 @@ private:
                                           const std::vector<int>& padBegin,
                                           const std::vector<int>& padEnd);
     std::vector<float> getScales(const VectorDims& srcDimPad, const VectorDims& dstDim);
-    static size_t getSpatialDimsNum(const Dim rank);
+    static size_t getSpatialDimsNum(Dim rank);
 
     bool hasPad = false;
 
@@ -360,6 +352,4 @@ private:
     std::shared_ptr<InterpolateExecutor> aclExecPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/inverse.hpp
+++ b/src/plugins/intel_cpu/src/nodes/inverse.hpp
@@ -8,7 +8,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"

--- a/src/plugins/intel_cpu/src/nodes/istft.h
+++ b/src/plugins/intel_cpu/src/nodes/istft.h
@@ -22,19 +22,19 @@ public:
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void createPrimitive() override;
 
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
 protected:
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
 
 private:
     /// ISTFT params

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.hpp
@@ -58,7 +58,7 @@ struct jit_eltwise_call_args_indexes {
 struct jit_uni_eltwise_kernel {
     void (*ker_)(const jit_eltwise_call_args_ptrs*, const jit_eltwise_call_args_indexes*){nullptr};
 
-    void operator()(const jit_eltwise_call_args_ptrs* const_args, const jit_eltwise_call_args_indexes* indexes) {
+    void operator()(const jit_eltwise_call_args_ptrs* const_args, const jit_eltwise_call_args_indexes* indexes) const {
         assert(ker_);
         ker_(const_args, indexes);
     }
@@ -73,7 +73,7 @@ struct jit_uni_eltwise_kernel {
 
 class eltwise_precision_helper {
 public:
-    static ov::element::Type get_precision(const size_t inputs_number,
+    static ov::element::Type get_precision(size_t inputs_number,
                                            const ov::element::Type (&src_prc)[MAX_ELTWISE_INPUTS],
                                            const std::vector<EltwiseData>& eltwise_data,
                                            const std::vector<element::Type>& exec_precisions_priority);

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.hpp
@@ -56,7 +56,7 @@ struct jit_eltwise_call_args_indexes {
 };
 
 struct jit_uni_eltwise_kernel {
-    void (*ker_)(const jit_eltwise_call_args_ptrs*, const jit_eltwise_call_args_indexes*){nullptr};
+    void (*ker_)(const jit_eltwise_call_args_ptrs*, const jit_eltwise_call_args_indexes*) = nullptr;
 
     void operator()(const jit_eltwise_call_args_ptrs* const_args, const jit_eltwise_call_args_indexes* indexes) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.cpp
@@ -192,7 +192,7 @@ static void find_params_by_channel(const T* src,
                                    float* zp,
                                    size_t bits) {
     size_t j = 0;
-    float integer_range = static_cast<float>((1 << bits) - 1);
+    auto integer_range = static_cast<float>((1 << bits) - 1);
 #if defined(HAVE_AVX512F)
     for (; j + vec_len_f32_avx512 <= hidden_dims; j += vec_len_f32_avx512) {
         auto v_max = _mm512_set1_ps(-std::numeric_limits<float>::max());

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/attn_quant.hpp
@@ -17,10 +17,10 @@ void attn_quantkv(const ov::intel_cpu::PlainTensor& k_src,
                   const ov::intel_cpu::PlainTensor& v_dst,
                   const ov::intel_cpu::PlainTensor& k_scale_zp,
                   const ov::intel_cpu::PlainTensor& v_scale_zp,
-                  const size_t L0,
-                  const bool quant_k_by_channel,
-                  const size_t k_group_size,
-                  const size_t v_group_size);
+                  size_t L0,
+                  bool quant_k_by_channel,
+                  size_t k_group_size,
+                  size_t v_group_size);
 
 void paged_attn_quantkv(const ov::intel_cpu::PlainTensor& k_src,
                         const ov::intel_cpu::PlainTensor& v_src,
@@ -32,10 +32,10 @@ void paged_attn_quantkv(const ov::intel_cpu::PlainTensor& k_src,
                         const ov::intel_cpu::PlainTensor& block_indices_begins,
                         const ov::intel_cpu::PlainTensor& slot_mapping,
                         ov::intel_cpu::PlainTensor& temp_buffer,
-                        const bool quant_key_by_channel,
-                        const bool quant_value_by_channel,
-                        const size_t key_group_size,
-                        const size_t value_group_size);
+                        bool quant_key_by_channel,
+                        bool quant_value_by_channel,
+                        size_t key_group_size,
+                        size_t value_group_size);
 
 void attn_quant_u8(const float* src, uint8_t* dst, size_t n, float& scale, float& zp);
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa_common.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa_common.hpp
@@ -38,7 +38,7 @@ struct PagedAttentionExecutor {
     static const size_t ID_ROTATION_DELTAS = 15;           // [num_rotated_blocks * block_size || 0], int32
     static const size_t ID_ROTATION_TRIG_LUT = 16;         // [max_context_length * S || 0], f32
     virtual void execute(const std::vector<ov::intel_cpu::MemoryPtr>& inputs,
-                         const std::vector<ov::intel_cpu::MemoryPtr> outputs) = 0;
+                         std::vector<ov::intel_cpu::MemoryPtr> outputs) = 0;
     virtual ~PagedAttentionExecutor() = default;
 };
 
@@ -68,10 +68,9 @@ public:
 };
 
 class JitMatMulVecAMX : public dnnl::impl::cpu::x64::jit_generator {
-    void operator=(const JitMatMulVecAMX&);
-
 public:
     DECLARE_CPU_JIT_AUX_FUNCTIONS(JitMatMulVecAMX)
+    void operator=(const JitMatMulVecAMX&) = delete;
     int m_head_size;
     int m_block_size;
     ov::element::Type m_amx_prec;

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
@@ -888,8 +888,8 @@ template <typename TA>
 static float dot_product_by_channel(TA* a,
                                     uint8_t* b,
                                     size_t n,
-                                    float* scale,
-                                    float* zp,
+                                    const float* scale,
+                                    const float* zp,
                                     [[maybe_unused]] size_t group_size) {
     float sum = 0.0f;
     size_t i = 0;

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/brgemm_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/brgemm_kernel.hpp
@@ -40,13 +40,13 @@ public:
     [[nodiscard]] size_t get_scratch_a_size() const;
     // bytes needed to place scratch buffer b
     [[nodiscard]] size_t get_scratch_b_size() const;
-    [[nodiscard]] const size_t get_mblk_size() const {
+    [[nodiscard]] static const size_t get_mblk_size() {
         return matmulOptimalM;
     }
     [[nodiscard]] const size_t get_k_blk() const {
         return K_blk;
     }
-    [[nodiscard]] const size_t get_wsp_size() const {
+    [[nodiscard]] static const size_t get_wsp_size() {
         return 4 * 1024;
     }
 
@@ -80,7 +80,7 @@ private:
     std::unique_ptr<dnnl::impl::cpu::x64::brgemm_kernel_t> brgKernels[MHA_BRGEMM_KERNELS_NUM];
     std::unique_ptr<dnnl::impl::cpu::x64::matmul::jit_brgemm_matmul_copy_a_t> brgCopyAKernel;
     std::unique_ptr<dnnl::impl::cpu::x64::matmul::jit_brgemm_matmul_copy_b_t> brgCopyBKernel;
-    size_t getBrgIdx(size_t mIdx, size_t kIdx, size_t nIdx) {
+    static size_t getBrgIdx(size_t mIdx, size_t kIdx, size_t nIdx) {
         return mIdx * 4 + kIdx * 2 + nIdx;
     }
     void init_brgemm(brgemmCtx& ctx,

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
@@ -35,7 +35,7 @@ struct jit_args_fft {
 };
 
 struct jit_uni_dft_kernel {
-    void (*ker_)(const jit_args_dft*){nullptr};
+    void (*ker_)(const jit_args_dft*) = nullptr;
 
     void operator()(const jit_args_dft* args) const {
         assert(ker_);
@@ -49,7 +49,7 @@ struct jit_uni_dft_kernel {
 };
 
 struct jit_uni_fft_kernel {
-    void (*ker_)(const jit_args_fft*){nullptr};
+    void (*ker_)(const jit_args_fft*) = nullptr;
 
     void operator()(const jit_args_fft* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/dft_uni_kernel.hpp
@@ -37,7 +37,7 @@ struct jit_args_fft {
 struct jit_uni_dft_kernel {
     void (*ker_)(const jit_args_dft*){nullptr};
 
-    void operator()(const jit_args_dft* args) {
+    void operator()(const jit_args_dft* args) const {
         assert(ker_);
         ker_(args);
     }
@@ -51,7 +51,7 @@ struct jit_uni_dft_kernel {
 struct jit_uni_fft_kernel {
     void (*ker_)(const jit_args_fft*){nullptr};
 
-    void operator()(const jit_args_fft* args) {
+    void operator()(const jit_args_fft* args) const {
         assert(ker_);
         ker_(args);
     }

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
@@ -80,7 +80,7 @@ struct gatherJitExecArgs {
 };
 
 struct jitGatherKernelBase {
-    void (*ker_)(const gatherJitExecArgs*){nullptr};
+    void (*ker_)(const gatherJitExecArgs*) = nullptr;
     void operator()(const gatherJitExecArgs* args) const {
         assert(ker_);
         ker_(args);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/gather_uni_kernel.hpp
@@ -81,7 +81,7 @@ struct gatherJitExecArgs {
 
 struct jitGatherKernelBase {
     void (*ker_)(const gatherJitExecArgs*){nullptr};
-    void operator()(const gatherJitExecArgs* args) {
+    void operator()(const gatherJitExecArgs* args) const {
         assert(ker_);
         ker_(args);
     }
@@ -95,13 +95,13 @@ struct jitGatherKernelBase {
     virtual ~jitGatherKernelBase() = default;
 
     virtual void create_ker() = 0;
-    uint64_t getVecLen() {
+    [[nodiscard]] uint64_t getVecLen() const {
         return vlen;
     }
-    uint64_t getDataElPerVec() {
+    [[nodiscard]] uint64_t getDataElPerVec() const {
         return dataElPerVec;
     }
-    uint64_t getIdxElPerVec() {
+    [[nodiscard]] uint64_t getIdxElPerVec() const {
         return idxElPerVec;
     }
     virtual bool isSupportedConfiguration(uint64_t afterAxisSize) = 0;

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
@@ -18,8 +18,8 @@
 
 namespace ov::intel_cpu {
 
-enum class GridSampleInterpolationMode { BILINEAR, BICUBIC, NEAREST };
-enum class GridSamplePaddingMode { ZEROS, BORDER, REFLECTION };
+enum class GridSampleInterpolationMode : uint8_t { BILINEAR, BICUBIC, NEAREST };
+enum class GridSamplePaddingMode : uint8_t { ZEROS, BORDER, REFLECTION };
 
 namespace kernel {
 
@@ -68,12 +68,12 @@ struct GridSamplesKernelExecArgs {
     uint64_t workAmount = 0lu;
 };
 
-enum coord { w, h };
+enum coord : uint8_t { w, h };
 
 class GridSampleKernelBase : public JitKernelBase {
 public:
     void (*ker_)(const GridSamplesKernelExecArgs*){nullptr};
-    void operator()(const GridSamplesKernelExecArgs* args) {
+    void operator()(const GridSamplesKernelExecArgs* args) const {
         assert(ker_);
         ker_(args);
     }
@@ -91,13 +91,13 @@ public:
           gridElPerVec(vlen / gridTypeSize) {}
 
     virtual void create_ker() = 0;
-    uint64_t getVecLen() {
+    uint64_t getVecLen() const {
         return vlen;
     }
-    uint64_t getDataElPerVec() {
+    uint64_t getDataElPerVec() const {
         return dataElPerVec;
     }
-    uint64_t getGridElPerVec() {
+    uint64_t getGridElPerVec() const {
         return gridElPerVec;
     }
 
@@ -189,9 +189,9 @@ private:
     void zerosPadding(const Vmask& kDst, const Vmm& vHCoord, const Vmm& vWCoord);
     void zerosPaddingW(const Vmask& kDst, const Vmm& vCoord);
     void zerosPaddingH(const Vmask& kDst, const Vmm& vCoord, const Vmask& kMaskW);
-    void borderPadding(const Vmm& vCoordDst, const Vmm& vCoordOrigin, const coord dim);
-    void reflectionPadding(const Vmm& vCoordDst, const Vmm& vCoordOrigin, const coord dim);
-    void bicubicCoefficients(const Vmm& vCoef, const Vmm& vDX, const uint8_t idx);
+    void borderPadding(const Vmm& vCoordDst, const Vmm& vCoordOrigin, coord dim);
+    void reflectionPadding(const Vmm& vCoordDst, const Vmm& vCoordOrigin, coord dim);
+    void bicubicCoefficients(const Vmm& vCoef, const Vmm& vDX, uint8_t idx);
     void tail();
 
     // Aux

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/grid_sample.hpp
@@ -72,7 +72,7 @@ enum coord : uint8_t { w, h };
 
 class GridSampleKernelBase : public JitKernelBase {
 public:
-    void (*ker_)(const GridSamplesKernelExecArgs*){nullptr};
+    void (*ker_)(const GridSamplesKernelExecArgs*) = nullptr;
     void operator()(const GridSamplesKernelExecArgs* args) const {
         assert(ker_);
         ker_(args);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
@@ -90,7 +90,15 @@ struct reg_traits : public reg_traits_by_size<sizeof(T)> {};
 
 template <size_t N>
 struct vec_min_size {
-    constexpr static size_t size = N <= 16 ? 16 : N <= 32 ? 32 : 64;
+    constexpr static size_t size = []() constexpr -> size_t {
+        if (N <= 16) {
+            return 16;
+        }
+        if (N <= 32) {
+            return 32;
+        }
+        return 64;
+    }();
 };
 
 template <typename T, size_t N>
@@ -149,7 +157,7 @@ class boolean_expression {
 public:
     using reg_type = const typename reg_traits<T>::type;
 
-    enum class type {
+    enum class type : uint8_t {
         eq,   // ==
         neq,  // !=
         ls,   // <
@@ -202,7 +210,7 @@ public:
         using namespace Xbyak;
 
         _expr.cmp(_else);
-        fn();
+        std::forward<F>(fn)();
         _expr._kernel.jmp(_exit, Xbyak::CodeGenerator::T_NEAR);
         _expr._kernel.L(_else);
 
@@ -231,8 +239,8 @@ public:
 
     variable_base& operator=(const variable_base&) = delete;
 
-    variable_base(const variable_base&);
-    variable_base(variable_base&&) noexcept;
+    variable_base([[maybe_unused]] const variable_base& rhs);
+    variable_base([[maybe_unused]] variable_base&& rhs) noexcept;
 
     [[nodiscard]] reg_type& reg() const {
         return *_reg;
@@ -265,8 +273,8 @@ public:
 
     variable_base& operator=(const variable_base&) = delete;
 
-    variable_base(const variable_base&);
-    variable_base(variable_base&&) noexcept;
+    variable_base([[maybe_unused]] const variable_base& rhs);
+    variable_base([[maybe_unused]] variable_base&& rhs) noexcept;
 
     reg_type& reg() const {
         return *_addr;
@@ -300,6 +308,7 @@ public:
         return variable<std::remove_pointer_t<T>, memory_tag>(base::_kernel, base::shreg());
     }
 
+    // NOLINTBEGIN(cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator)
     const variable& operator=(reg_type& rhs) const {
         base::_kernel.mov(base::reg(), rhs);
         return *this;
@@ -524,12 +533,12 @@ public:
         return *this;
     }
 
-    const variable& blend(reg_type& rhs, uint16_t mask) const {
+    [[nodiscard]] const variable& blend(reg_type& rhs, uint16_t mask) const {
         base::_kernel.uni_vblendps(base::reg(), rhs, mask);
         return *this;
     }
 
-    const variable& permute(const std::array<uint8_t, N>& order) const {
+    [[nodiscard]] const variable& permute(const std::array<uint8_t, N>& order) const {
         base::_kernel.uni_vpermps(base::reg(), order.data(), base::reg());
         return *this;
     }
@@ -937,7 +946,7 @@ then_expression<T>::then_expression(if_expression<T>& expr) : _if_expr(expr) {}
 template <typename T>
 template <typename F>
 void then_expression<T>::_else(F&& fn) {
-    fn();
+    std::forward<F>(fn)();
     _if_expr._expr._kernel.L(_if_expr._exit);
     _if_expr._is_exit_valid = true;
 }
@@ -996,6 +1005,8 @@ variable<T[N], register_tag>::variable(jit_kernel& krnl)
 
 template <typename T, size_t N>
 variable<T[N], register_tag>::variable(jit_kernel& krnl, const shared_reg<reg_type>& reg) : base(krnl, reg) {}
+
+// NOLINTEND(cppcoreguidelines-c-copy-assignment-signature, misc-unconventional-assign-operator)
 
 }  // namespace internal
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
@@ -239,8 +239,8 @@ public:
 
     variable_base& operator=(const variable_base&) = delete;
 
-    variable_base([[maybe_unused]] const variable_base& rhs);
-    variable_base([[maybe_unused]] variable_base&& rhs) noexcept;
+    variable_base(const variable_base& rhs);
+    variable_base(variable_base&& rhs) noexcept;
 
     [[nodiscard]] reg_type& reg() const {
         return *_reg;
@@ -273,8 +273,8 @@ public:
 
     variable_base& operator=(const variable_base&) = delete;
 
-    variable_base([[maybe_unused]] const variable_base& rhs);
-    variable_base([[maybe_unused]] variable_base&& rhs) noexcept;
+    variable_base(const variable_base& rhs);
+    variable_base(variable_base&& rhs) noexcept;
 
     reg_type& reg() const {
         return *_addr;

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel_base.hpp
@@ -41,7 +41,7 @@ public:
         return m_isa;
     }
 
-    size_t getVectorLen() {
+    size_t getVectorLen() const {
         return vlen;
     }
 
@@ -101,7 +101,7 @@ public:
 
     void uni_vpbroadcastq(const Xbyak::Xmm& x, const Xbyak::Operand& op);
 
-    void uni_vroundpd(const Xbyak::Xmm& v_dst, const Xbyak::Operand& op, const uint8_t imm);
+    void uni_vroundpd(const Xbyak::Xmm& v_dst, const Xbyak::Operand& op, uint8_t imm);
 
     void uni_vcvtdq2pd(const Xbyak::Xmm& v_dst, const Xbyak::Operand& op);
 
@@ -115,50 +115,50 @@ public:
                   const Xbyak::Reg64& rSrcPtr,
                   const Xbyak::Xmm& vSrcShift,
                   const Xbyak::Opmask& kReadMask,
-                  const bool useMask = true,
-                  const bool zeroFill = false);
+                  bool useMask = true,
+                  bool zeroFill = false);
 
     void gatherdd(const Xbyak::Xmm& v_dst,
                   const Xbyak::Reg64& rSrcPtr,
                   const Xbyak::Xmm& vSrcShift,
                   const Xbyak::Xmm& vReadMask,
-                  const bool useMask = true,
-                  const bool zeroFill = false);
+                  bool useMask = true,
+                  bool zeroFill = false);
 
     void gatherdd(const Xbyak::Ymm& v_dst,
                   const Xbyak::Reg64& rSrcPtr,
                   const Xbyak::Ymm& vSrcShift,
                   const Xbyak::Ymm& vReadMask,
-                  const bool useMask = true,
-                  const bool zeroFill = false);
+                  bool useMask = true,
+                  bool zeroFill = false);
 
     void fillRestWorkMask(const Xbyak::Opmask& kDstMask, const Xbyak::Reg64& rWorkRest);
 
-    void fillRestWorkMask(const Xbyak::Xmm& xmmDstMask, const Xbyak::Reg64& rWorkRest, const uint64_t typeSize = 4);
+    void fillRestWorkMask(const Xbyak::Xmm& xmmDstMask, const Xbyak::Reg64& rWorkRest, uint64_t typeSize = 4);
 
-    void fillRestWorkMask(const Xbyak::Ymm& ymmDstMask, const Xbyak::Reg64& rWorkRest, const uint64_t typeSize = 4);
+    void fillRestWorkMask(const Xbyak::Ymm& ymmDstMask, const Xbyak::Reg64& rWorkRest, uint64_t typeSize = 4);
 
     void load(const Xbyak::Xmm& v_dst,
               const Xbyak::Address& srcAddr,
               const Xbyak::Reg64& rLoadNum,
-              const size_t typeSize,
-              const bool zeroFill = false);
+              size_t typeSize,
+              bool zeroFill = false);
 
     void load(const Xbyak::Ymm& v_dst,
               const Xbyak::Address& srcAddr,
               const Xbyak::Reg64& rLoadNum,
-              const size_t typeSize,
-              const bool zeroFill = false);
+              size_t typeSize,
+              bool zeroFill = false);
 
     void store(const Xbyak::Address& dstAddr,
                const Xbyak::Xmm& v_src,
                const Xbyak::Reg64& rToStoreNum,
-               const size_t typeSize);
+               size_t typeSize);
 
     void store(const Xbyak::Address& dstAddr,
                const Xbyak::Ymm& v_src,
                const Xbyak::Reg64& rToStoreNum,
-               const size_t typeSize);
+               size_t typeSize);
 
     // Makes gather from memory under the vReadMask and writes to the memory m128.
     void memMovDD(const Xbyak::Reg64& rDst,
@@ -166,8 +166,8 @@ public:
                   const Xbyak::Xmm& vReadMask,
                   const Xbyak::Xmm& vSrcShift,
                   const Xbyak::Reg64& rToStoreNum,
-                  const bool useMask = true,
-                  const bool zeroFill = false);
+                  bool useMask = true,
+                  bool zeroFill = false);
 
     // Makes gather from the memory under the vReadMask and writes to the memory m256.
     void memMovDD(const Xbyak::Reg64& rDst,
@@ -175,11 +175,11 @@ public:
                   const Xbyak::Ymm& vReadMask,
                   const Xbyak::Ymm& vSrcShift,
                   const Xbyak::Reg64& rToStoreNum,
-                  const bool useMask = true,
-                  const bool zeroFill = false);
+                  bool useMask = true,
+                  bool zeroFill = false);
 
 protected:
-    inline bool isValidIsa(dnnl::impl::cpu::x64::cpu_isa_t isa) {
+    static bool isValidIsa(dnnl::impl::cpu::x64::cpu_isa_t isa) {
         return dnnl::impl::cpu::x64::mayiuse(isa);
     }
 
@@ -187,7 +187,7 @@ protected:
     RegistersPool::Ptr registersPool;
     size_t vlen;
 
-    enum {
+    enum : uint8_t {
         // Comparison predicate operand (immediate byte) for single-precision floating-point values.
         CMP_EQ_PS = 0,  // Equal (ordered, non-signaling)
         CMP_LT_PS,      // Less-than (ordered, signaling)

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_uni_eltwise_generic.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_uni_eltwise_generic.hpp
@@ -46,19 +46,19 @@ private:
                                                          Xbyak::Ymm,
                                                          Xbyak::Zmm>::type;
 
-    inline Xbyak::Reg64 get_src_reg(int idx) {
+    Xbyak::Reg64 get_src_reg(int idx) {
         return Xbyak::Reg64(r8.getIdx() + idx);
     }
 
-    inline Vmm get_vmm_reg(int idx) {
+    Vmm get_vmm_reg(int idx) {
         return Vmm(1 + idx);
     }
 
-    inline Vmm get_aux_vmm(int idx) {
+    Vmm get_aux_vmm(int idx) {
         return Vmm(10 + idx);
     }
 
-    inline Xbyak::Xmm get_xmm_reg(int idx) {
+    Xbyak::Xmm get_xmm_reg(int idx) {
         return Xbyak::Xmm(get_vmm_reg(idx).getIdx());
     }
 
@@ -91,10 +91,9 @@ private:
     std::shared_ptr<jit_uni_vcvtneps2bf16> uni_vcvtneps2bf16;
 
     std::shared_ptr<jit_emitter> eltwise_emitter = nullptr;
-    std::vector<std::shared_ptr<jit_emitter>> post_op_emitters = {};
+    std::vector<std::shared_ptr<jit_emitter>> post_op_emitters;
 
-    std::vector<std::shared_ptr<dnnl::impl::cpu::x64::jit_uni_quantization_injector_f32<isa>>> quantization_injectors =
-        {};
+    std::vector<std::shared_ptr<dnnl::impl::cpu::x64::jit_uni_quantization_injector_f32<isa>>> quantization_injectors;
 
     const std::vector<EltwiseData>& eltwise_data_;
     const std::vector<ov::intel_cpu::Type>& ops_list_;

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
@@ -246,7 +246,6 @@ struct Work {
     // input : weight [N, K], setup repacks range of N [n_start, n_end)
     template <typename Tsrc, typename Tdst>
     void setup(Tdst* dst, Tsrc* p_weight, int stride_in_bytes, bool do_sum_per_oc = false) {
-        auto& mkernel = get_MKernel();
         auto num_blk_K = (k1 - k0 + blk_K_size - 1) / blk_K_size;
         auto* pw = p_weight + n0 * stride_in_bytes / sizeof(Tsrc);
 
@@ -282,7 +281,6 @@ struct Work {
     // in each Bpair, p_weight1 stored in B0, p_weight2 stored in B1
     template <typename Tsrc, typename Tdst>
     void setup(Tdst* dst, Tsrc* p_weight1, Tsrc* p_weight2, int stride_in_bytes, bool do_sum_per_oc = false) {
-        auto& mkernel = get_MKernel();
         auto num_blk_K = (k1 - k0 + blk_K_size - 1) / blk_K_size;
         auto* pw1 = p_weight1 + (n0 / 2) * stride_in_bytes / sizeof(Tsrc);
         auto* pw2 = p_weight2 + (n0 / 2) * stride_in_bytes / sizeof(Tsrc);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
@@ -55,7 +55,7 @@ private:
     void* last_cfg = nullptr;
 };
 
-enum class TMUL_TYPE { SSD = 1, USD = 2, SUD = 3, UUD = 4, FP16 = 5, BF16 = 6 };
+enum class TMUL_TYPE : uint8_t { SSD = 1, USD = 2, SUD = 3, UUD = 4, FP16 = 5, BF16 = 6 };
 
 class MKernel : public dnnl::impl::cpu::x64::jit_generator {
 public:
@@ -209,14 +209,14 @@ struct Work {
     int blk_K_size = 0;
     int output_id;
     void* p_raw_weights;
-    operator bool() {
+    operator bool() const {
         return BN > 0;
     }
 
     bool quant_i8 = false;
     bool is_f16 = false;
 
-    MKernel& get_MKernel() {
+    [[nodiscard]] MKernel& get_MKernel() const {
         constexpr int BM = 256;
         static MKernel jit_amx_bf16(BM, TMUL_TYPE::BF16);
         static MKernel jit_amx_f16(BM, TMUL_TYPE::FP16);
@@ -230,7 +230,7 @@ struct Work {
         return jit_amx_bf16;
     }
 
-    MKernel& get_MKernel_1x2() {
+    [[nodiscard]] MKernel& get_MKernel_1x2() const {
         static MKernel jit_amx_bf16(16, TMUL_TYPE::BF16);
         static MKernel jit_amx_f16(16, TMUL_TYPE::FP16);
         static MKernel jit_amx_i8(16, TMUL_TYPE::SSD);
@@ -274,7 +274,7 @@ struct Work {
         }
 
         for (int Mtails = 0; Mtails < 32; Mtails++) {
-            mkernel.tile_config_M(m_tcfg[Mtails], Mtails == 0 ? 32 : Mtails);
+            ov::intel_cpu::MKernel::tile_config_M(m_tcfg[Mtails], Mtails == 0 ? 32 : Mtails);
         }
     }
 
@@ -322,7 +322,7 @@ struct Work {
         }
 
         for (int Mtails = 0; Mtails < 32; Mtails++) {
-            mkernel.tile_config_M(m_tcfg[Mtails], Mtails == 0 ? 32 : Mtails);
+            ov::intel_cpu::MKernel::tile_config_M(m_tcfg[Mtails], Mtails == 0 ? 32 : Mtails);
         }
     }
 
@@ -350,7 +350,7 @@ struct Work {
 
         auto C_stride_bytes = BN * sizeof(float);
         OPENVINO_ASSERT(C_M * C_stride_bytes <= m_C.stride_bytes(0) * m_C.size(0));
-        auto pC = reinterpret_cast<uint8_t*>(m_C.ptr_v());
+        auto* pC = reinterpret_cast<uint8_t*>(m_C.ptr_v());
 
         auto element_size = quant_i8 ? sizeof(int8_t) : sizeof(ov::bfloat16);
 
@@ -399,7 +399,7 @@ struct Work {
             // else
             //      firstK: 0 1 0(skip store, tilezero, skip load), the otherK except last: 0 0 0(skip all),
             //      lastK: 1 0 0(store, skip tile zero, skip load)
-            int do_accumulation;
+            int do_accumulation = 0;
             MKernel::call_args args;
             args.strideA = strideA;
             args.strideC = C_stride_bytes;
@@ -457,7 +457,7 @@ struct ScratchBuffAllocator {
         m_total_size += size;
         m_sizes.push_back(size);
     }
-    size_t size() {
+    [[nodiscard]] size_t size() const {
         return m_total_size;
     }
     void finalize(void* base) {
@@ -480,12 +480,12 @@ struct MatrixDynQuantPerRow {
 
     MatrixDynQuantPerRow() = default;
 
-    size_t size() {
+    [[nodiscard]] size_t size() const {
         // size of data & scale & zp
         return M * K + M * sizeof(float) * 2;
     }
 
-    size_t stride() {
+    [[nodiscard]] size_t stride() const {
         return K;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/non_max_suppression.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/non_max_suppression.hpp
@@ -23,7 +23,7 @@
 
 namespace ov::intel_cpu {
 
-enum class NMSBoxEncodeType { CORNER, CENTER };
+enum class NMSBoxEncodeType : uint8_t { CORNER, CENTER };
 
 #if defined(OPENVINO_ARCH_X86_64)
 
@@ -137,7 +137,7 @@ private:
 
     inline void horizontal_mul();
 
-    inline void prepare_table() {
+    void prepare_table() {
         auto broadcast_d = [&](int val) {
             for (size_t d = 0; d < vlen / sizeof(int); ++d) {
                 dd(val);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rdft_kernel.hpp
@@ -17,7 +17,7 @@
 
 namespace ov::intel_cpu {
 
-enum dft_type {
+enum dft_type : uint8_t {
     real_to_complex,
     complex_to_complex,
     complex_to_real,
@@ -44,7 +44,7 @@ struct jit_dft_kernel {
 
     void (*ker_)(const jit_dft_args*) = nullptr;
 
-    void operator()(const jit_dft_args* args) {
+    void operator()(const jit_dft_args* args) const {
         assert(ker_);
         ker_(args);
     }

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/rms_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/rms_kernel.hpp
@@ -69,16 +69,16 @@ private:
     void reduce_ymm_to_xmm(const Xmm& acc, const Xmm& tmp);
     void reduce_xmm_to_scalar(const Xmm& acc,
                               const Xmm& tmp,
-                              const std::size_t number_of_values_to_reduce = number_of_f32_in_xmm_);
+                              std::size_t number_of_values_to_reduce = number_of_f32_in_xmm_);
     void reduce_ymm_to_scalar(const Xbyak::Xmm& acc,
                               const Xbyak::Xmm& tmp1,
                               const Xbyak::Xmm& tmp2,
-                              const std::size_t number_of_values_to_reduce = number_of_f32_in_ymm_);
+                              std::size_t number_of_values_to_reduce = number_of_f32_in_ymm_);
     void reduce_vmm_to_scalar(const Xbyak::Xmm& acc,
                               const Xbyak::Xmm& tmp1,
                               const Xbyak::Xmm& tmp2,
                               const Xbyak::Xmm& tmp3,
-                              const std::size_t number_of_values_to_reduce = number_of_f32_in_zmm_);
+                              std::size_t number_of_values_to_reduce = number_of_f32_in_zmm_);
     static constexpr std::size_t number_of_f32_in_xmm_ = 4;
     static constexpr std::size_t number_of_f32_in_ymm_ = 8;
     static constexpr std::size_t number_of_f32_in_zmm_ = 16;

--- a/src/plugins/intel_cpu/src/nodes/llm_mlp.h
+++ b/src/plugins/intel_cpu/src/nodes/llm_mlp.h
@@ -15,9 +15,7 @@
 #include "openvino/core/node.hpp"
 #include "transformations/cpu_opset/x64/op/llm_mlp.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class LLMMLP : public Node {
 public:
@@ -51,6 +49,4 @@ private:
     LLMMLPNode::Config m_mlp_config;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.h
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class LogSoftmax : public Node {
 public:
@@ -24,7 +22,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -39,6 +37,4 @@ private:
     bool isLastDim = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/lora.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lora.cpp
@@ -141,7 +141,7 @@ void LoRA::createPrimitive() {
     m_graph.Activate();
 }
 
-void LoRA::execute(const dnnl::stream& /*strm*/) {
+void LoRA::execute([[maybe_unused]] const dnnl::stream& strm) {
     m_graph.Infer();
 }
 

--- a/src/plugins/intel_cpu/src/nodes/lora.h
+++ b/src/plugins/intel_cpu/src/nodes/lora.h
@@ -18,9 +18,7 @@
 #include "openvino/core/model.hpp"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class LoRA : public Node {
 public:
@@ -37,7 +35,7 @@ public:
     int registerToAllocationContext(int offset, AllocationContext& context) override;
     void createPrimitive() override;
     void prepareParams() override;
-    void execute(const dnnl::stream&) override;
+    void execute(const dnnl::stream& /*strm*/) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:
@@ -46,6 +44,4 @@ private:
     Graph m_graph;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/lora.h
+++ b/src/plugins/intel_cpu/src/nodes/lora.h
@@ -35,7 +35,7 @@ public:
     int registerToAllocationContext(int offset, AllocationContext& context) override;
     void createPrimitive() override;
     void prepareParams() override;
-    void execute(const dnnl::stream& /*strm*/) override;
+    void execute([[maybe_unused]] const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:

--- a/src/plugins/intel_cpu/src/nodes/lrn.h
+++ b/src/plugins/intel_cpu/src/nodes/lrn.h
@@ -29,7 +29,7 @@ public:
     void createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
                           const std::vector<MemoryDescPtr>& outputDesc) override;
     size_t descInputNumbers() override {
-        return static_cast<size_t>(getOriginalInputsNumber());
+        return getOriginalInputsNumber();
     }
     std::shared_ptr<MemoryDesc> getSrcMemDesc(const dnnl::primitive_desc& prim_desc, size_t idx) const override;
     bool created() const override;

--- a/src/plugins/intel_cpu/src/nodes/lrn.h
+++ b/src/plugins/intel_cpu/src/nodes/lrn.h
@@ -9,7 +9,6 @@
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "common/dnnl_executor.h"
 #include "graph_context.h"
@@ -17,9 +16,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Lrn : public Node {
 public:
@@ -31,9 +28,10 @@ public:
     size_t descInputNumbers() override {
         return getOriginalInputsNumber();
     }
-    std::shared_ptr<MemoryDesc> getSrcMemDesc(const dnnl::primitive_desc& prim_desc, size_t idx) const override;
-    bool created() const override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] std::shared_ptr<MemoryDesc> getSrcMemDesc(const dnnl::primitive_desc& prim_desc,
+                                                            size_t idx) const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
@@ -53,6 +51,4 @@ private:
     float beta = 1.0f;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/mathematics.h
+++ b/src/plugins/intel_cpu/src/nodes/mathematics.h
@@ -15,9 +15,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Math : public Node {
 public:
@@ -44,6 +42,4 @@ private:
     float gamma = 0.0f;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/matmul.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matmul.cpp
@@ -132,8 +132,7 @@ bool MatMul::isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std
 }
 
 MatMul::MatMul(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
-    : Node(op, context, MMShapeInferFactory(op)),
-      withBiases(false) {
+    : Node(op, context, MMShapeInferFactory(op)) {
     std::string errorMessage;
 
     if (!isSupportedOperation(op, errorMessage)) {

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -70,7 +70,7 @@ private:
                                                                const Shape& in1,
                                                                const Shape& out) const;
 
-    bool withBiases;
+    bool withBiases{false};
 
     void setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims, bool initWeights);
 

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -70,7 +70,7 @@ private:
                                                                const Shape& in1,
                                                                const Shape& out) const;
 
-    bool withBiases{false};
+    bool withBiases = false;
 
     void setPostOps(dnnl::primitive_attr& attr, const VectorDims& dims, bool initWeights);
 

--- a/src/plugins/intel_cpu/src/nodes/matmul.h
+++ b/src/plugins/intel_cpu/src/nodes/matmul.h
@@ -11,7 +11,6 @@
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "common/dnnl_executor.h"
 #include "cpu_types.h"
@@ -22,11 +21,10 @@
 #include "node.h"
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/node.hpp"
+#include "openvino/core/shape.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class MatMul : public Node {
 public:
@@ -36,16 +34,16 @@ public:
     void createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
                           const std::vector<MemoryDescPtr>& outputDesc) override;
     void initSupportedPrimitiveDescriptors() override;
-    MemoryDescPtr getSrcMemDesc(const dnnl::primitive_desc& prim_desc, size_t idx) const override;
-    bool canFuse(const NodePtr& node) const override;
-    bool created() const override;
+    [[nodiscard]] MemoryDescPtr getSrcMemDesc(const dnnl::primitive_desc& prim_desc, size_t idx) const override;
+    [[nodiscard]] bool canFuse(const NodePtr& node) const override;
+    [[nodiscard]] bool created() const override;
 
-    ov::element::Type getRuntimePrecision() const override;
+    [[nodiscard]] ov::element::Type getRuntimePrecision() const override;
     size_t descInputNumbers() override {
         return getOriginalInputsNumber();
     }
 
-    int getFusingAxis() const override {
+    [[nodiscard]] int getFusingAxis() const override {
         return getOutputShapeAtPort(0).getRank() - 1;
     }
 
@@ -55,10 +53,10 @@ public:
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
     const std::vector<impl_desc_type>& getDefaultImplPriority() override;
-    bool canBeExecutedInInt8() const override;
+    [[nodiscard]] bool canBeExecutedInInt8() const override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
 
 protected:
     AttrPtr initPrimitiveAttr() override;
@@ -68,7 +66,9 @@ private:
     using executorPtr = std::shared_ptr<DnnlExecutorLegacy>;
     executorPtr execPtr = nullptr;
     dnnl::memory::desc getBiasDescFrom(const DnnlMemoryDescCPtr& outMemDesc);
-    std::pair<Shape, Shape> makeDummyInputShapes(const Shape& in0, const Shape& in1, const Shape& out) const;
+    [[nodiscard]] std::pair<Shape, Shape> makeDummyInputShapes(const Shape& in0,
+                                                               const Shape& in1,
+                                                               const Shape& out) const;
 
     bool withBiases;
 
@@ -81,6 +81,4 @@ private:
     DnnlBlockedMemoryDescPtr outDataDesc;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.h
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.h
@@ -9,16 +9,13 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum class MatrixNmsSortResultType {
     CLASSID,  // sort selected boxes by class id (ascending) in each batch element
@@ -35,15 +32,15 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return false;
     }
     void prepareParams() override;
@@ -115,7 +112,7 @@ private:
     size_t m_realNumClasses = 0;
     size_t m_realNumBoxes = 0;
     float (*m_decay_fn)(float, float, float) = nullptr;
-    void checkPrecision(const ov::element::Type prec,
+    void checkPrecision(ov::element::Type prec,
                         const std::vector<ov::element::Type>& precList,
                         const std::string& name,
                         const std::string& type);
@@ -123,10 +120,8 @@ private:
     size_t nmsMatrix(const float* boxesData,
                      const float* scoresData,
                      BoxInfo* filterBoxes,
-                     const int64_t batchIdx,
-                     const int64_t classIdx);
+                     int64_t batchIdx,
+                     int64_t classIdx);
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.h
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.h
@@ -17,13 +17,13 @@
 
 namespace ov::intel_cpu::node {
 
-enum class MatrixNmsSortResultType {
+enum class MatrixNmsSortResultType : uint8_t {
     CLASSID,  // sort selected boxes by class id (ascending) in each batch element
     SCORE,    // sort selected boxes by score (descending) in each batch element
     NONE      // do not guarantee the order in each batch element
 };
 
-enum MatrixNmsDecayFunction { GAUSSIAN, LINEAR };
+enum MatrixNmsDecayFunction : uint8_t { GAUSSIAN, LINEAR };
 
 class MatrixNms : public Node {
 public:

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -40,7 +40,6 @@ public:
     using InputNodesMap = std::unordered_map<std::string, MemoryStateNode*>;
     using OutputNodesMap = std::unordered_map<std::string, MemoryNode*>;
 
-public:
     void registerOutput(MemoryOutputBase* node);
     void registerInput(MemoryInputBase* node);
     void remove(MemoryNode* node);
@@ -53,7 +52,6 @@ private:
     MemoryInputBase* getMemoryInputByName(const std::string& name);
     MemoryOutputBase* getMemoryOutputByName(const std::string& name);
 
-private:
     InputNodesMap memory_inputs;
     OutputNodesMap memory_outputs;
 };
@@ -145,7 +143,6 @@ class MemoryInputBase : public Input, public MemoryStateNode {
 public:
     enum class mode { read_value_assign, single_read_value };
 
-public:
     MemoryInputBase(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& ctx);
 
     ~MemoryInputBase() override;
@@ -185,7 +182,6 @@ protected:
                     const std::optional<std::vector<ov::element::Type>>& input_prc,
                     mode mode = mode::read_value_assign);
 
-protected:
     virtual void runStatic(dnnl::stream strm) = 0;
     virtual void runDynamic(dnnl::stream strm) = 0;
     virtual void assignStateHook() = 0;
@@ -196,11 +192,9 @@ protected:
 private:
     using executeHookPtr = void (MemoryInputBase::*)();
 
-private:
     void assignState();
     void bypassAssignState();
 
-private:
     /**
      * @brief keeps reference to output sibling node
      */
@@ -250,7 +244,6 @@ private:
         return body != nullptr;
     }
 
-private:
     std::shared_ptr<ov::Model> body = nullptr;
     std::unique_ptr<ov::intel_cpu::Graph> subGraph = nullptr;
     std::vector<MemoryPtr> subgraphMemoryPtrs;
@@ -303,7 +296,6 @@ private:
     void runStatic(dnnl::stream strm) override;
     void runDynamic(dnnl::stream strm) override;
 
-private:
     std::weak_ptr<ScaledDotProductAttention> m_sdpaNode;
     int m_child_port_idx = -1;
 };

--- a/src/plugins/intel_cpu/src/nodes/memory.hpp
+++ b/src/plugins/intel_cpu/src/nodes/memory.hpp
@@ -141,7 +141,7 @@ protected:
 
 class MemoryInputBase : public Input, public MemoryStateNode {
 public:
-    enum class mode { read_value_assign, single_read_value };
+    enum class mode : uint8_t { read_value_assign, single_read_value };
 
     MemoryInputBase(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& ctx);
 

--- a/src/plugins/intel_cpu/src/nodes/memory_state_base.h
+++ b/src/plugins/intel_cpu/src/nodes/memory_state_base.h
@@ -11,16 +11,14 @@
 #include "memory_state.h"
 #include "openvino/core/any.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class MemoryNode {
 public:
     explicit MemoryNode(std::string id) : m_id(std::move(id)) {}
     explicit MemoryNode(const std::shared_ptr<ov::Node>& op);
     virtual ~MemoryNode() = default;
-    const std::string& getId() const {
+    [[nodiscard]] const std::string& getId() const {
         return m_id;
     }
 
@@ -32,12 +30,10 @@ class MemoryStateNode : public MemoryNode {
 public:
     using MemoryNode::MemoryNode;
     virtual void assignState(MemStatePtr newState) = 0;
-    virtual MemStatePtr makeState() const = 0;
+    [[nodiscard]] virtual MemStatePtr makeState() const = 0;
 };
 
 using MmemoryStateNodePtr = std::shared_ptr<MemoryStateNode>;
 using MemoryStateNodeCPtr = std::shared_ptr<const MemoryStateNode>;
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"
@@ -101,12 +100,12 @@ private:
 
     std::vector<filteredBoxes> m_filtBoxes;  // rois after nms for each class in each image
 
-    void checkPrecision(const ov::element::Type prec,
+    void checkPrecision(ov::element::Type prec,
                         const std::vector<ov::element::Type>& precList,
                         const std::string& name,
                         const std::string& type);
 
-    static float intersectionOverUnion(const float* boxesI, const float* boxesJ, const bool normalized);
+    static float intersectionOverUnion(const float* boxesI, const float* boxesJ, bool normalized);
 
     void nmsWithEta(const float* boxes,
                     const float* scores,
@@ -114,7 +113,7 @@ private:
                     const VectorDims& boxesStrides,
                     const VectorDims& scoresStrides,
                     const VectorDims& roisnumStrides,
-                    const bool shared);
+                    bool shared);
 
     void nmsWithoutEta(const float* boxes,
                        const float* scores,
@@ -122,16 +121,16 @@ private:
                        const VectorDims& boxesStrides,
                        const VectorDims& scoresStrides,
                        const VectorDims& roisnumStrides,
-                       const bool shared);
+                       bool shared);
 
-    static const float* slice_class(const int batch_idx,
-                                    const int class_idx,
+    static const float* slice_class(int batch_idx,
+                                    int class_idx,
                                     const float* dataPtr,
                                     const VectorDims& dataStrides,
-                                    const bool is_boxes,
+                                    bool is_boxes,
                                     const int* roisnum,
                                     const VectorDims& roisnumStrides,
-                                    const bool shared);
+                                    bool shared);
 };
 
 }  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.hpp
@@ -18,7 +18,7 @@
 
 namespace ov::intel_cpu::node {
 
-enum class MulticlassNmsSortResultType {
+enum class MulticlassNmsSortResultType : uint8_t {
     CLASSID,  // sort selected boxes by class id (ascending) in each batch element
     SCORE,    // sort selected boxes by score (descending) in each batch element
     NONE      // do not guarantee the order in each batch element

--- a/src/plugins/intel_cpu/src/nodes/multinomial.hpp
+++ b/src/plugins/intel_cpu/src/nodes/multinomial.hpp
@@ -58,7 +58,7 @@ private:
     static constexpr size_t OUTPUT_PORT = 0lu;
     bool m_const_inputs[2] = {false, false};
     bool m_const_batch = false;
-    VectorDims m_output_shape = {};
+    VectorDims m_output_shape;
 
     /// General algorithm variables
     ov::element::Type m_probs_precision;

--- a/src/plugins/intel_cpu/src/nodes/mvn.h
+++ b/src/plugins/intel_cpu/src/nodes/mvn.h
@@ -48,7 +48,7 @@ struct jit_mvn_call_args {
 };
 
 struct jit_uni_mvn_mean_variance_kernel {
-    void (*ker_)(const jit_mvn_call_args*){nullptr};
+    void (*ker_)(const jit_mvn_call_args*) = nullptr;
 
     void operator()(const jit_mvn_call_args* args) const {
         assert(ker_);
@@ -64,7 +64,7 @@ struct jit_uni_mvn_mean_variance_kernel {
 };
 
 struct jit_uni_mvn_kernel {
-    void (*ker_)(const jit_mvn_call_args*){nullptr};
+    void (*ker_)(const jit_mvn_call_args*) = nullptr;
 
     void operator()(const jit_mvn_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/mvn.h
+++ b/src/plugins/intel_cpu/src/nodes/mvn.h
@@ -14,7 +14,6 @@
 #include <oneapi/dnnl/dnnl.hpp>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"
@@ -22,9 +21,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_mvn_config_params {
     MVNLayoutType layout;
@@ -51,15 +48,15 @@ struct jit_mvn_call_args {
 };
 
 struct jit_uni_mvn_mean_variance_kernel {
-    void (*ker_)(const jit_mvn_call_args*);
+    void (*ker_)(const jit_mvn_call_args*){nullptr};
 
-    void operator()(const jit_mvn_call_args* args) {
+    void operator()(const jit_mvn_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_mvn_mean_variance_kernel(jit_mvn_config_params jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_mvn_mean_variance_kernel() {}
+    explicit jit_uni_mvn_mean_variance_kernel(jit_mvn_config_params jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_mvn_mean_variance_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -67,18 +64,15 @@ struct jit_uni_mvn_mean_variance_kernel {
 };
 
 struct jit_uni_mvn_kernel {
-    void (*ker_)(const jit_mvn_call_args*);
+    void (*ker_)(const jit_mvn_call_args*){nullptr};
 
-    void operator()(const jit_mvn_call_args* args) {
+    void operator()(const jit_mvn_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_mvn_kernel(jit_mvn_config_params jcp, const dnnl_primitive_attr& attr)
-        : ker_(nullptr),
-          jcp_(jcp),
-          attr_(attr) {}
-    virtual ~jit_uni_mvn_kernel() {}
+    explicit jit_uni_mvn_kernel(jit_mvn_config_params jcp, const dnnl_primitive_attr& attr) : jcp_(jcp), attr_(attr) {}
+    virtual ~jit_uni_mvn_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -101,11 +95,11 @@ public:
         return false;
     }
 
-    inline bool getAcrossChannels() const {
+    bool getAcrossChannels() const {
         return mvnAttrs.initAcrossChannels_;
     }
 
-    inline bool getNormalizeVariance() const {
+    bool getNormalizeVariance() const {
         return mvnAttrs.normalizeVariance_;
     }
 
@@ -178,6 +172,4 @@ private:
     };
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/ngram.h
+++ b/src/plugins/intel_cpu/src/nodes/ngram.h
@@ -16,9 +16,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Ngram : public Node {
 public:
@@ -56,6 +54,4 @@ private:
     ov::element::Type idcesPrecision;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -5,15 +5,12 @@
 #pragma once
 
 #include <memory>
-#include <utility>
-#include <vector>
 
 #include "memory_desc/blocked_memory_desc.h"
 #include "memory_desc/cpu_memory_desc.h"
 #include "openvino/core/except.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class PortDescBase {
 public:
@@ -26,13 +23,13 @@ public:
      *
      * @return True if the port desc may be accepted false otherwise
      */
-    bool isCompatible(const PortDescBase& rhs) const {
+    [[nodiscard]] bool isCompatible(const PortDescBase& rhs) const {
         return typeid(*this) == typeid(rhs) && this->compareImpl(rhs);
     }
-    virtual MemoryDescPtr getMemDesc() const = 0;
+    [[nodiscard]] virtual MemoryDescPtr getMemDesc() const = 0;
 
 protected:
-    virtual bool compareImpl(const PortDescBase& rhs) const = 0;
+    [[nodiscard]] virtual bool compareImpl(const PortDescBase& rhs) const = 0;
 };
 
 using PortDescBasePtr = std::shared_ptr<PortDescBase>;
@@ -42,7 +39,7 @@ template <class T>
 class PortDescBase_ : public PortDescBase {
 protected:
     PortDescBase_() = default;
-    bool compareImpl(const PortDescBase& rhs) const override /*final*/ {
+    [[nodiscard]] bool compareImpl(const PortDescBase& rhs) const override /*final*/ {
         return static_cast<const T&>(*this).isCompatible(static_cast<const T&>(rhs));
     }
 };
@@ -54,10 +51,10 @@ public:
             OPENVINO_THROW("ParameterMismatch: PortDescGeneric constructor got nullptr");
         }
     }
-    bool isCompatible(const PortDescGeneric& rhs) const {
+    [[nodiscard]] bool isCompatible(const PortDescGeneric& rhs) const {
         return _memDesc->isCompatible(*rhs._memDesc);
     }
-    MemoryDescPtr getMemDesc() const override {
+    [[nodiscard]] MemoryDescPtr getMemDesc() const override {
         return _memDesc;
     }
 
@@ -69,16 +66,15 @@ class PortDescBlocked : public PortDescBase_<PortDescBlocked> {
 public:
     using CmpMask = BlockedMemoryDesc::CmpMask;
 
-public:
     PortDescBlocked(BlockedMemoryDescPtr memDesc, CmpMask cmpMask) : _memDesc(std::move(memDesc)), _cmpMask(cmpMask) {
         if (nullptr == _memDesc) {
             OPENVINO_THROW("ParameterMismatch: PortDescBlocked constructor got nullptr");
         }
     }
-    bool isCompatible(const PortDescBlocked& rhs) const {
+    [[nodiscard]] bool isCompatible(const PortDescBlocked& rhs) const {
         return _memDesc->isCompatible(*rhs._memDesc, _cmpMask) && (((~_cmpMask) | rhs._cmpMask).all());
     }
-    MemoryDescPtr getMemDesc() const override {
+    [[nodiscard]] MemoryDescPtr getMemDesc() const override {
         return _memDesc;
     }
 
@@ -109,7 +105,7 @@ public:
     PortConfig(PortConfig&& rhs) = default;
     PortConfig& operator=(PortConfig&& rhs) = default;
 
-    int inPlace() const {
+    [[nodiscard]] int inPlace() const {
         return _inPlacePort;
     }
 
@@ -117,7 +113,7 @@ public:
         _inPlacePort = port;
     }
 
-    bool constant() const {
+    [[nodiscard]] bool constant() const {
         return _constant;
     }
 
@@ -125,11 +121,11 @@ public:
         _constant = constant;
     }
 
-    MemoryDescPtr getMemDesc() const {
+    [[nodiscard]] MemoryDescPtr getMemDesc() const {
         return _desc->getMemDesc();
     }
 
-    PortDescBasePtr getPortDesc() const {
+    [[nodiscard]] PortDescBasePtr getPortDesc() const {
         return _desc;
     }
 
@@ -141,20 +137,21 @@ public:
         _desc = createPortDesc(desc, cmpMask);
     }
 
-    bool hasZeroDims() const {
+    [[nodiscard]] bool hasZeroDims() const {
         const auto desc = getMemDesc();
         return desc->getShape().hasZeroDims() && !desc->empty();
     }
 
 private:
-    PortDescBasePtr createPortDesc(const MemoryDescPtr& desc, BlockedMemoryDesc::CmpMask cmpMask) {
-        if (desc->getType() & Blocked)
+    static PortDescBasePtr createPortDesc(const MemoryDescPtr& desc, BlockedMemoryDesc::CmpMask cmpMask) {
+        if (desc->getType() & Blocked) {
             return createPortDesc(std::dynamic_pointer_cast<BlockedMemoryDesc>(desc), cmpMask);
+        }
 
         return std::make_shared<PortDescGeneric>(desc);
     }
 
-    PortDescBasePtr createPortDesc(const BlockedMemoryDescPtr& desc, BlockedMemoryDesc::CmpMask cmpMask) {
+    static PortDescBasePtr createPortDesc(const BlockedMemoryDescPtr& desc, BlockedMemoryDesc::CmpMask cmpMask) {
         return std::make_shared<PortDescBlocked>(desc, cmpMask);
     }
 
@@ -174,5 +171,4 @@ struct NodeConfig {
     std::vector<PortConfig> outConfs;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
@@ -21,7 +21,7 @@
 
 namespace ov::intel_cpu::node {
 
-enum NMSCandidateStatus { SUPPRESSED = 0, SELECTED = 1, UPDATED = 2 };
+enum NMSCandidateStatus : uint8_t { SUPPRESSED = 0, SELECTED = 1, UPDATED = 2 };
 
 class NonMaxSuppression : public Node {
 public:
@@ -71,7 +71,7 @@ public:
         float x, y;
         Point2D(const float px = 0.f, const float py = 0.f) : x(px), y(py) {}
         Point2D operator+(const Point2D& p) const {
-            return Point2D(x + p.x, y + p.y);
+            return {x + p.x, y + p.y};
         }
         Point2D& operator+=(const Point2D& p) {
             x += p.x;
@@ -79,16 +79,16 @@ public:
             return *this;
         }
         Point2D operator-(const Point2D& p) const {
-            return Point2D(x - p.x, y - p.y);
+            return {x - p.x, y - p.y};
         }
         Point2D operator*(const float coeff) const {
-            return Point2D(x * coeff, y * coeff);
+            return {x * coeff, y * coeff};
         }
     };
 
 private:
     // input
-    enum {
+    enum : uint8_t {
         NMS_BOXES,
         NMS_SCORES,
         NMS_MAX_OUTPUT_BOXES_PER_CLASS,
@@ -98,7 +98,7 @@ private:
     };
 
     // output
-    enum { NMS_SELECTED_INDICES, NMS_SELECTED_SCORES, NMS_VALID_OUTPUTS };
+    enum : uint8_t { NMS_SELECTED_INDICES, NMS_SELECTED_SCORES, NMS_VALID_OUTPUTS };
 
     float intersectionOverUnion(const float* boxesI, const float* boxesJ);
 

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
@@ -8,19 +8,18 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_shape.h"
 #include "cpu_types.h"
 #include "graph_context.h"
+#include "kernels/x64/jit_kernel_base.hpp"
 #include "kernels/x64/non_max_suppression.hpp"
 #include "node.h"
 #include "nodes/kernels/x64/jit_kernel_base.hpp"
 #include "openvino/core/node.hpp"
+#include "openvino/core/shape.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum NMSCandidateStatus { SUPPRESSED = 0, SELECTED = 1, UPDATED = 2 };
 
@@ -36,7 +35,7 @@ public:
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -59,10 +58,10 @@ public:
         int suppress_begin_index;
     };
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
 
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return false;
     }
 
@@ -103,7 +102,7 @@ private:
 
     float intersectionOverUnion(const float* boxesI, const float* boxesJ);
 
-    float rotatedIntersectionOverUnion(const Point2D (&vertices_0)[4], const float area_0, const float* box_1) const;
+    float rotatedIntersectionOverUnion(const Point2D (&vertices_0)[4], float area_0, const float* box_1) const;
 
     void nmsWithSoftSigma(const float* boxes,
                           const float* scores,
@@ -123,9 +122,9 @@ private:
                     const VectorDims& scores_strides,
                     std::vector<FilteredBox>& filtered_boxes);
 
-    void check1DInput(const Shape& shape, const std::string& name, const size_t port);
+    void check1DInput(const Shape& shape, const std::string& name, size_t port);
 
-    void checkOutput(const Shape& shape, const std::string& name, const size_t port);
+    void checkOutput(const Shape& shape, const std::string& name, size_t port);
 
     void createJitKernel();
 
@@ -159,6 +158,4 @@ private:
     std::shared_ptr<kernel::JitKernelBase> m_jit_kernel;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/non_zero.h
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.h
@@ -6,19 +6,16 @@
 
 #include <node.h>
 
-#include <cstddef>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "dnnl_extension_utils.h"
 #include "graph_context.h"
 #include "openvino/core/node.hpp"
+#include "openvino/core/shape.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class NonZero : public Node {
 public:
@@ -54,6 +51,4 @@ private:
     std::vector<size_t> getNonZeroElementsCount(const T* src, const Shape& inShape);
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -52,7 +52,7 @@ struct jit_normalize_call_args {
 };
 
 struct jit_uni_normalize_modulo_kernel {
-    void (*ker_)(const jit_normalize_call_args*){nullptr};
+    void (*ker_)(const jit_normalize_call_args*) = nullptr;
 
     void operator()(const jit_normalize_call_args* args) const {
         assert(ker_);
@@ -68,7 +68,7 @@ struct jit_uni_normalize_modulo_kernel {
 };
 
 struct jit_uni_normalize_kernel {
-    void (*ker_)(const jit_normalize_call_args*){nullptr};
+    void (*ker_)(const jit_normalize_call_args*) = nullptr;
 
     void operator()(const jit_normalize_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -107,7 +107,7 @@ public:
     bool neverExecute() const override;
     bool isExecutable() const override;
 
-    enum class NormEpsMode { ADD, MAX };
+    enum class NormEpsMode : uint8_t { ADD, MAX };
 
     struct NormalizeL2Attrs {
         LayoutType layout = LayoutType::ncsp;

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -24,9 +24,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 #if defined(OPENVINO_ARCH_X86_64)
 struct jit_normalize_config_params {
     bool is_nchw;
@@ -54,15 +52,15 @@ struct jit_normalize_call_args {
 };
 
 struct jit_uni_normalize_modulo_kernel {
-    void (*ker_)(const jit_normalize_call_args*);
+    void (*ker_)(const jit_normalize_call_args*){nullptr};
 
-    void operator()(const jit_normalize_call_args* args) {
+    void operator()(const jit_normalize_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    jit_uni_normalize_modulo_kernel(jit_normalize_config_params jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_normalize_modulo_kernel() {}
+    jit_uni_normalize_modulo_kernel(jit_normalize_config_params jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_normalize_modulo_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -70,18 +68,17 @@ struct jit_uni_normalize_modulo_kernel {
 };
 
 struct jit_uni_normalize_kernel {
-    void (*ker_)(const jit_normalize_call_args*);
+    void (*ker_)(const jit_normalize_call_args*){nullptr};
 
-    void operator()(const jit_normalize_call_args* args) {
+    void operator()(const jit_normalize_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
     explicit jit_uni_normalize_kernel(jit_normalize_config_params jcp, const dnnl_primitive_attr& attr)
-        : ker_(nullptr),
-          jcp_(jcp),
+        : jcp_(jcp),
           attr_(attr) {}
-    virtual ~jit_uni_normalize_kernel() {}
+    virtual ~jit_uni_normalize_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -139,7 +136,7 @@ private:
                                                                            const VectorDims& dims);
 
     protected:
-        inline float epsApply(const float& modulo, const NormEpsMode mode, const float eps) const {
+        [[nodiscard]] static float epsApply(const float& modulo, const NormEpsMode mode, const float eps) {
             return mode == NormEpsMode::ADD ? modulo + eps : std::max(modulo, eps);
         }
 
@@ -187,6 +184,4 @@ private:
     executorPtr execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/one_hot.h
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.h
@@ -18,9 +18,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/core/type/element_type_traits.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class OneHot : public Node {
 public:
@@ -30,10 +28,10 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override{};
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needShapeInfer() const override;
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needShapeInfer() const override;
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     };
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -41,7 +39,7 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 private:
-    typedef element_type_traits<ov::element::i32>::value_type in_type;
+    using in_type = element_type_traits<ov::element::i32>::value_type;
 
     struct OneHotContext {
         OneHot* nodePtr;
@@ -70,6 +68,4 @@ private:
     void one_hot(size_t prefix_size, size_t suffix_size);
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -42,7 +42,7 @@ protected:
 private:
     using VectorIdxs = std::vector<int32_t>;
 
-    enum PadMode { CONSTANT = 0, EDGE = 1, REFLECT = 2, SYMMETRIC = 3 };
+    enum PadMode : uint8_t { CONSTANT = 0, EDGE = 1, REFLECT = 2, SYMMETRIC = 3 };
 
     struct PadAttrs {
         PadMode padMode = CONSTANT;

--- a/src/plugins/intel_cpu/src/nodes/pad.h
+++ b/src/plugins/intel_cpu/src/nodes/pad.h
@@ -7,11 +7,9 @@
 #include <node.h>
 
 #include <cstddef>
-#include <cstdint>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_memory.h"
 #include "cpu_types.h"
@@ -19,9 +17,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Pad : public Node {
 public:
@@ -72,9 +68,7 @@ private:
         void padConstantCommon(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
         void padConstantZero(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
         void padEdge(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr);
-        void padReflectOrSymmetric(const MemoryPtr& srcMemPtr,
-                                   const MemoryPtr& dstMemPtr,
-                                   const bool isSymmetric = false);
+        void padReflectOrSymmetric(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, bool isSymmetric = false);
         void paramsInitialization(const PadAttrs& attrs,
                                   const std::vector<MemoryCPtr>& srcMemory,
                                   const std::vector<MemoryCPtr>& dstMemory);
@@ -135,6 +129,4 @@ private:
     bool shapeHasDataDependency = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/paged_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/paged_attn.h
@@ -16,9 +16,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class PagedAttention : public Node {
 public:
@@ -52,9 +50,7 @@ public:
     void createPrimitive() override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    static bool isQuantByChannel(const Config::CacheQuantMode mode,
-                                 const ov::element::Type precision,
-                                 const bool isKey);
+    static bool isQuantByChannel(Config::CacheQuantMode mode, ov::element::Type precision, bool isKey);
 
 private:
     ov::element::Type getRuntimePrecision() const override;
@@ -67,6 +63,4 @@ private:
     bool m_hasScore = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/pooling.h
@@ -18,9 +18,7 @@
 #include "oneapi/dnnl/dnnl.hpp"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Pooling : public Node {
 public:
@@ -60,7 +58,7 @@ private:
     dnnl::algorithm getPoolingAlgorithm() const;
     dnnl::pooling_forward::primitive_desc createDescriptorInternal(const dnnl::memory::desc& in_candidate,
                                                                    const dnnl::memory::desc& out_candidate,
-                                                                   const dnnl::algorithm alg);
+                                                                   dnnl::algorithm alg);
 
     AttrPtr pAttr;
 
@@ -70,6 +68,4 @@ private:
     bool useACL = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/priorbox.h
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class PriorBox : public Node {
 public:
@@ -55,6 +53,4 @@ private:
     int number_of_priors;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.h
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class PriorBoxClustered : public Node {
 public:
@@ -49,6 +47,4 @@ private:
     int number_of_priors;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/proposal.h
+++ b/src/plugins/intel_cpu/src/nodes/proposal.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
@@ -17,9 +16,7 @@
 
 using proposal_conf = ov::Extensions::Cpu::proposal_conf;
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Proposal : public Node {
 public:
@@ -28,9 +25,9 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     };
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -50,6 +47,4 @@ private:
     bool store_prob;  // store blob with proposal probabilities
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.h
@@ -15,9 +15,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class PSROIPooling : public Node {
 public:
@@ -27,7 +25,7 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override{};
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
@@ -71,8 +69,8 @@ private:
     void executeAverage(const inputType* srcData,
                         outputType* dstData,
                         const float* bottomRois,
-                        const int n,
-                        const int roiBatchInd,
+                        int n,
+                        int roiBatchInd,
                         const BlockedMemoryDesc& srcDesc,
                         const BlockedMemoryDesc& dstDesc);
 
@@ -80,8 +78,8 @@ private:
     void executeBilinear(const inputType* srcData,
                          outputType* dstData,
                          const float* bottomRois,
-                         const int currentRoi,
-                         const int roiBatchInd,
+                         int currentRoi,
+                         int roiBatchInd,
                          const BlockedMemoryDesc& srcDesc,
                          const BlockedMemoryDesc& dstDesc);
 
@@ -90,10 +88,10 @@ private:
                                    outputType* dstData,
                                    const float* bottomRois,
                                    const float* bottomTrans,
-                                   const int numClasses,
-                                   const int channelsEachClass,
-                                   const int currentRoi,
-                                   const int roiBatchInd);
+                                   int numClasses,
+                                   int channelsEachClass,
+                                   int currentRoi,
+                                   int roiBatchInd);
 
     template <typename inputType, typename outputType>
     void executeSpecified();
@@ -102,6 +100,4 @@ private:
     struct PSROIPoolingExecute;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.h
@@ -37,7 +37,7 @@ private:
     size_t pooledWidth = 0;
     size_t spatialBinsX = 0;
     size_t spatialBinsY = 0;
-    std::string mode = "";
+    std::string mode;
 
     int channels = 0;
     int height = 0;

--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.h
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.h
@@ -18,9 +18,7 @@
 #if defined(OPENVINO_ARCH_X86_64)
 #endif
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class QKVProjection : public Node {
 public:
@@ -56,6 +54,4 @@ private:
     QKVProjectionNode::Config m_config;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
@@ -13,7 +13,6 @@
 #include <random>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.hpp
@@ -76,8 +76,8 @@ private:
 
     void prepareGeneratorKernel();
 
-    enum PortIndex { SHAPE = 0, MIN_VAL, MAX_VAL };
-    enum AlgorithmType { STL = 0, PHILOX, MERSENNE_TWISTER };
+    enum PortIndex : uint8_t { SHAPE = 0, MIN_VAL, MAX_VAL };
+    enum AlgorithmType : uint8_t { STL = 0, PHILOX, MERSENNE_TWISTER };
 
     bool m_const_inputs[3] = {false, false, false};
 
@@ -86,7 +86,7 @@ private:
     uint64_t m_op_seed = 0lu;
     std::pair<uint64_t, uint64_t> m_state{0lu, 0lu};
 
-    VectorDims m_out_shape = {};
+    VectorDims m_out_shape;
     uint64_t m_output_elements_count = 1lu;
     OutputType m_min_val;
     OutputType m_max_val;

--- a/src/plugins/intel_cpu/src/nodes/range.h
+++ b/src/plugins/intel_cpu/src/nodes/range.h
@@ -13,9 +13,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Range : public Node {
 public:
@@ -24,11 +22,11 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     };
-    bool needShapeInfer() const override {
+    [[nodiscard]] bool needShapeInfer() const override {
         return false;
     };
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -50,6 +48,4 @@ private:
     static const size_t RANGE_DELTA = 2;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/range.h
+++ b/src/plugins/intel_cpu/src/nodes/range.h
@@ -32,7 +32,7 @@ public:
     void executeDynamicImpl(const dnnl::stream& strm) override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    enum StatusCode : int {
+    enum StatusCode : int8_t {
         OK = 0,
         PARAMETER_MISMATCH = -1,
     };

--- a/src/plugins/intel_cpu/src/nodes/rdft.h
+++ b/src/plugins/intel_cpu/src/nodes/rdft.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"
@@ -17,9 +16,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct RDFTExecutor {
 public:
@@ -139,7 +136,7 @@ private:
 struct RDFTKey {
     bool isInverse;
 
-    size_t hash() const {
+    [[nodiscard]] size_t hash() const {
         size_t seed = 0;
         seed = dnnl::impl::hash_combine(seed, isInverse);
         return seed;
@@ -150,6 +147,4 @@ struct RDFTKey {
     }
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -69,7 +69,7 @@ struct jit_reduce_post_call_args {
 };
 
 struct jit_uni_reduce_kernel {
-    void (*ker_)(const jit_reduce_call_args*){nullptr};
+    void (*ker_)(const jit_reduce_call_args*) = nullptr;
 
     void operator()(const jit_reduce_call_args* args) const {
         assert(ker_);
@@ -85,7 +85,7 @@ struct jit_uni_reduce_kernel {
 };
 
 struct jit_uni_reduce_post_kernel {
-    void (*ker_)(const jit_reduce_post_call_args*){nullptr};
+    void (*ker_)(const jit_reduce_post_call_args*) = nullptr;
 
     void operator()(const jit_reduce_post_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -27,9 +27,7 @@
 #    include "nodes/executors/reduce.hpp"
 #endif
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum ReduceLayoutType { reduce_ncsp, reduce_nspc, reduce_blocked };
 
@@ -71,15 +69,15 @@ struct jit_reduce_post_call_args {
 };
 
 struct jit_uni_reduce_kernel {
-    void (*ker_)(const jit_reduce_call_args*);
+    void (*ker_)(const jit_reduce_call_args*){nullptr};
 
-    void operator()(const jit_reduce_call_args* args) {
+    void operator()(const jit_reduce_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_reduce_kernel(jit_reduce_config_params jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_reduce_kernel() {}
+    explicit jit_uni_reduce_kernel(jit_reduce_config_params jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_reduce_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -87,18 +85,17 @@ struct jit_uni_reduce_kernel {
 };
 
 struct jit_uni_reduce_post_kernel {
-    void (*ker_)(const jit_reduce_post_call_args*);
+    void (*ker_)(const jit_reduce_post_call_args*){nullptr};
 
-    void operator()(const jit_reduce_post_call_args* args) {
+    void operator()(const jit_reduce_post_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
     explicit jit_uni_reduce_post_kernel(jit_reduce_config_params jcp, const dnnl_primitive_attr& attr)
-        : ker_(nullptr),
-          jcp_(jcp),
+        : jcp_(jcp),
           attr_(attr) {}
-    virtual ~jit_uni_reduce_post_kernel() {}
+    virtual ~jit_uni_reduce_post_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -137,7 +134,7 @@ private:
                                       size_t work_amount,
                                       size_t reduce_w = 2,
                                       size_t work_batch = 1,
-                                      const int* tab_idx = NULL);
+                                      const int* tab_idx = nullptr);
     inline void reduce_kernel_post_process(uint8_t* out_ptr);
     inline void reduce_kernel_reassign();
     inline void reduce_kernel_restore();
@@ -225,6 +222,4 @@ private:
 #endif
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/reduce.h
+++ b/src/plugins/intel_cpu/src/nodes/reduce.h
@@ -29,7 +29,7 @@
 
 namespace ov::intel_cpu::node {
 
-enum ReduceLayoutType { reduce_ncsp, reduce_nspc, reduce_blocked };
+enum ReduceLayoutType : uint8_t { reduce_ncsp, reduce_nspc, reduce_blocked };
 
 struct jit_reduce_config_params {
     ReduceLayoutType layout;

--- a/src/plugins/intel_cpu/src/nodes/reference.h
+++ b/src/plugins/intel_cpu/src/nodes/reference.h
@@ -14,9 +14,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/runtime/tensor.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Reference : public Node {
 public:
@@ -44,12 +42,9 @@ private:
     ov::TensorVector prepareInputs() const;
     ov::TensorVector prepareOutputs() const;
 
-private:
     const std::shared_ptr<ov::Node> ovCoreNode;
     const std::string additionalErrorMessage;
     bool hasOutputShapeDataDependency = false;  // flag to cache the output shape data dependency check result
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.h
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.h
@@ -33,7 +33,7 @@ struct jit_logistic_config_params {
 };
 
 struct jit_uni_logistic_kernel {
-    void (*ker_)(const jit_args_logistic*){nullptr};
+    void (*ker_)(const jit_args_logistic*) = nullptr;
 
     void operator()(const jit_args_logistic* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.h
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
@@ -18,9 +17,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_args_logistic {
     const void* src;
@@ -36,17 +33,17 @@ struct jit_logistic_config_params {
 };
 
 struct jit_uni_logistic_kernel {
-    void (*ker_)(const jit_args_logistic*);
+    void (*ker_)(const jit_args_logistic*){nullptr};
 
-    void operator()(const jit_args_logistic* args) {
+    void operator()(const jit_args_logistic* args) const {
         assert(ker_);
         ker_(args);
     }
 
     virtual void create_ker() = 0;
 
-    jit_uni_logistic_kernel() : ker_(nullptr) {}
-    virtual ~jit_uni_logistic_kernel() {}
+    jit_uni_logistic_kernel() {}
+    virtual ~jit_uni_logistic_kernel() = default;
 };
 
 class RegionYolo : public Node {
@@ -57,12 +54,12 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
 protected:
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override {
         execute(strm);
     }
@@ -88,6 +85,4 @@ private:
     inline void calculate_logistic(size_t start_index, int count, uint8_t* dst_data);
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.h
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.h
@@ -42,7 +42,7 @@ struct jit_uni_logistic_kernel {
 
     virtual void create_ker() = 0;
 
-    jit_uni_logistic_kernel() {}
+    jit_uni_logistic_kernel() = default;
     virtual ~jit_uni_logistic_kernel() = default;
 };
 

--- a/src/plugins/intel_cpu/src/nodes/reorder.h
+++ b/src/plugins/intel_cpu/src/nodes/reorder.h
@@ -21,9 +21,7 @@
 #include "onednn/iml_type_mapper.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Reorder : public Node {
 public:
@@ -97,6 +95,4 @@ private:
     TransposeExecutorPtr transposeExecutor;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/reorg_yolo.h
+++ b/src/plugins/intel_cpu/src/nodes/reorg_yolo.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ReorgYolo : public Node {
 public:
@@ -23,8 +21,8 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     }
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -35,6 +33,4 @@ private:
     int stride;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/reshape.h
+++ b/src/plugins/intel_cpu/src/nodes/reshape.h
@@ -7,15 +7,12 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Reshape : public Node {
 public:
@@ -23,12 +20,12 @@ public:
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    bool created() const override;
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
 
-    bool needShapeInfer() const override;
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needShapeInfer() const override;
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     }
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -40,6 +37,4 @@ private:
     mutable std::vector<int> lastSecondInputValues;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/reverse_sequence.h
+++ b/src/plugins/intel_cpu/src/nodes/reverse_sequence.h
@@ -16,9 +16,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ReverseSequence : public Node {
 public:
@@ -27,7 +25,7 @@ public:
     void getSupportedDescriptors() override{};
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -65,6 +63,4 @@ private:
     ov::element::Type lengthsPrecision;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/rms_norm.h
+++ b/src/plugins/intel_cpu/src/nodes/rms_norm.h
@@ -7,7 +7,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_memory.h"
 #include "cpu_types.h"
@@ -15,19 +14,17 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class RMSNorm : public Node {
 public:
     RMSNorm(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context);
 
     void getSupportedDescriptors() override {}
-    bool created() const override {
+    [[nodiscard]] bool created() const override {
         return getType() == Type::RMS;
     }
-    bool needPrepareParams() const override {
+    [[nodiscard]] bool needPrepareParams() const override {
         return false;
     }
     void executeDynamicImpl(const dnnl::stream& strm) override {
@@ -40,7 +37,7 @@ public:
 
 private:
     struct Executor {
-        virtual void execute(const std::vector<MemoryPtr>& inputs, const MemoryPtr output) = 0;
+        virtual void execute(const std::vector<MemoryPtr>& inputs, MemoryPtr output) = 0;
         virtual ~Executor() = default;
     };
 
@@ -51,6 +48,4 @@ private:
     float m_eps = 0.0f;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/rnn.h
+++ b/src/plugins/intel_cpu/src/nodes/rnn.h
@@ -50,7 +50,7 @@ public:
 
     void cleanup() override;
 
-    enum InOutKind { Layer = 0, HiddenState = 1, CellState = 2, Attention = 2 };
+    enum InOutKind : uint8_t { Layer = 0, HiddenState = 1, CellState = 2, Attention = 2 };
 
 protected:
     void prepareParams() override;
@@ -115,7 +115,7 @@ private:
 
         Interval(Dim min, Dim max) : minVal(min), maxVal(max) {}
 
-        bool isStatic() const {
+        [[nodiscard]] bool isStatic() const {
             return minVal == maxVal;
         }
 

--- a/src/plugins/intel_cpu/src/nodes/rnn.h
+++ b/src/plugins/intel_cpu/src/nodes/rnn.h
@@ -25,9 +25,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class RNN : public Node {
 public:
@@ -46,7 +44,7 @@ public:
 
     void execute(const dnnl::stream& strm) override;
 
-    inline bool hasNativeOrder() const {
+    bool hasNativeOrder() const {
         return nativeOrder;
     }
 
@@ -117,7 +115,7 @@ private:
 
         Interval(Dim min, Dim max) : minVal(min), maxVal(max) {}
 
-        bool isStatic() {
+        bool isStatic() const {
             return minVal == maxVal;
         }
 
@@ -173,6 +171,4 @@ private:
     std::unordered_set<MemoryPtr> m_weights_pull;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/roi_align.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.h
@@ -45,7 +45,7 @@ struct jit_roi_align_call_args {
 };
 
 struct jit_uni_roi_align_kernel {
-    void (*ker_)(const jit_roi_align_call_args*){nullptr};
+    void (*ker_)(const jit_roi_align_call_args*) = nullptr;
 
     void operator()(const jit_roi_align_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/roi_align.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.h
@@ -16,9 +16,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum ROIAlignLayoutType { ncsp, blk, nspc };
 
@@ -47,15 +45,15 @@ struct jit_roi_align_call_args {
 };
 
 struct jit_uni_roi_align_kernel {
-    void (*ker_)(const jit_roi_align_call_args*);
+    void (*ker_)(const jit_roi_align_call_args*){nullptr};
 
-    void operator()(const jit_roi_align_call_args* args) {
+    void operator()(const jit_roi_align_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_roi_align_kernel(jit_roi_align_params jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_roi_align_kernel() {}
+    explicit jit_uni_roi_align_kernel(jit_roi_align_params jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_roi_align_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -70,9 +68,9 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
@@ -92,6 +90,4 @@ private:
     std::shared_ptr<jit_uni_roi_align_kernel> roi_align_kernel = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/roi_align.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.h
@@ -18,9 +18,9 @@
 
 namespace ov::intel_cpu::node {
 
-enum ROIAlignLayoutType { ncsp, blk, nspc };
+enum ROIAlignLayoutType : uint8_t { ncsp, blk, nspc };
 
-enum ROIAlignedMode { ra_asymmetric, ra_half_pixel_for_nn, ra_half_pixel };
+enum ROIAlignedMode : uint8_t { ra_asymmetric, ra_half_pixel_for_nn, ra_half_pixel };
 
 struct jit_roi_align_params {
     Algorithm alg;

--- a/src/plugins/intel_cpu/src/nodes/roi_align_rotated.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align_rotated.cpp
@@ -98,7 +98,7 @@ void ROIAlignRotated::executeImpl() {
         clockwiseMode);
 }
 
-void ROIAlignRotated::execute(const dnnl::stream& /*strm*/) {
+void ROIAlignRotated::execute([[maybe_unused]] const dnnl::stream& strm) {
     const ov::element::Type type = getOriginalInputPrecisionAtPort(0);
     executeImpl<ov::element::f32>();
 

--- a/src/plugins/intel_cpu/src/nodes/roi_align_rotated.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_align_rotated.h
@@ -12,9 +12,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ROIAlignRotated : public Node {
 public:
@@ -23,8 +21,8 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:
@@ -38,6 +36,4 @@ private:
     bool clockwiseMode;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.h
@@ -57,7 +57,7 @@ struct jit_roi_pooling_call_args {
 };
 
 struct jit_uni_roi_pooling_kernel {
-    void (*ker_)(const jit_roi_pooling_call_args*){nullptr};
+    void (*ker_)(const jit_roi_pooling_call_args*) = nullptr;
 
     void operator()(const jit_roi_pooling_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.h
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.h
@@ -19,9 +19,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct jit_roi_pooling_params {
     int mb, c;
@@ -59,15 +57,15 @@ struct jit_roi_pooling_call_args {
 };
 
 struct jit_uni_roi_pooling_kernel {
-    void (*ker_)(const jit_roi_pooling_call_args*);
+    void (*ker_)(const jit_roi_pooling_call_args*){nullptr};
 
-    void operator()(const jit_roi_pooling_call_args* args) {
+    void operator()(const jit_roi_pooling_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_roi_pooling_kernel(jit_roi_pooling_params jpp) : ker_(nullptr), jpp_(jpp) {}
-    virtual ~jit_uni_roi_pooling_kernel() {}
+    explicit jit_uni_roi_pooling_kernel(jit_roi_pooling_params jpp) : jpp_(jpp) {}
+    virtual ~jit_uni_roi_pooling_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -82,7 +80,7 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void executeDynamicImpl(const dnnl::stream& strm) override;
     void prepareParams() override;
@@ -108,26 +106,26 @@ private:
         static std::shared_ptr<ROIPoolingExecutor> createROIPoolingNewExecutor(const jit_roi_pooling_params& jpp);
 
     protected:
-        static std::tuple<int, int, int, int> getBordersForMaxMode(const int roi_start_h,
-                                                                   const int roi_end_h,
-                                                                   const int roi_start_w,
-                                                                   const int roi_end_w,
-                                                                   const int ih,
-                                                                   const int oh,
-                                                                   const int iw,
-                                                                   const int ow,
-                                                                   const int pooled_h,
-                                                                   const int pooled_w);
-        static std::pair<float, float> getXYForBilinearMode(const float roi_start_h,
-                                                            const float roi_end_h,
-                                                            const float roi_start_w,
-                                                            const float roi_end_w,
-                                                            const int ih,
-                                                            const int oh,
-                                                            const int iw,
-                                                            const int ow,
-                                                            const int pooled_h,
-                                                            const int pooled_w);
+        static std::tuple<int, int, int, int> getBordersForMaxMode(int roi_start_h,
+                                                                   int roi_end_h,
+                                                                   int roi_start_w,
+                                                                   int roi_end_w,
+                                                                   int ih,
+                                                                   int oh,
+                                                                   int iw,
+                                                                   int ow,
+                                                                   int pooled_h,
+                                                                   int pooled_w);
+        static std::pair<float, float> getXYForBilinearMode(float roi_start_h,
+                                                            float roi_end_h,
+                                                            float roi_start_w,
+                                                            float roi_end_w,
+                                                            int ih,
+                                                            int oh,
+                                                            int iw,
+                                                            int ow,
+                                                            int pooled_h,
+                                                            int pooled_w);
 
     private:
         template <typename T>
@@ -155,6 +153,4 @@ private:
     executorPtr execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/roll.h
+++ b/src/plugins/intel_cpu/src/nodes/roll.h
@@ -16,9 +16,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Roll : public Node {
 public:
@@ -27,7 +25,7 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
@@ -64,6 +62,4 @@ private:
     static constexpr size_t AXES_INDEX = 2ul;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/rope.h
+++ b/src/plugins/intel_cpu/src/nodes/rope.h
@@ -16,9 +16,7 @@
 #include "openvino/core/node.hpp"
 #include "ov_ops/rotary_positional_embeddings.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class RoPE : public Node {
 public:
@@ -57,6 +55,4 @@ private:
     std::shared_ptr<Executor> m_executor;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.h
@@ -51,7 +51,7 @@ public:
     void createPrimitive() override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
-    enum KernelTypes { KT_REF, KT_ONEDNN, KT_MLAS, KT_ACL };
+    enum KernelTypes : uint8_t { KT_REF, KT_ONEDNN, KT_MLAS, KT_ACL };
 
     void assignState(const std::shared_ptr<VariableStateKVcache>& state, int idx);
 

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.h
@@ -20,9 +20,7 @@
 #include "transformations/cpu_opset/common/op/sdpa.hpp"
 #include "utils/plain_tensor.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ScaledDotProductAttention : public Node {
 public:
@@ -60,8 +58,9 @@ public:
     const std::vector<size_t> getKVCacheOrder() const {
         const auto& permute_axes = m_config.config.permute_axes;
         std::vector<size_t> real_order = m_kvstate_layout;
-        if (!permute_axes.empty())
+        if (!permute_axes.empty()) {
             real_order = {permute_axes[2], permute_axes[0], permute_axes[1], permute_axes[3]};
+        }
         return real_order;
     }
     struct SDPAQuantParam {
@@ -88,10 +87,10 @@ private:
         virtual void execute(const dnnl::stream& strm,
                              const Config& config,
                              const std::vector<MemoryPtr>& inputs,
-                             const MemoryPtr output,
-                             const MemoryPtr presentk_input,
-                             const MemoryPtr presentv_input,
-                             const MemoryPtr beam_input,
+                             MemoryPtr output,
+                             MemoryPtr presentk_input,
+                             MemoryPtr presentv_input,
+                             MemoryPtr beam_input,
                              const PlainTensor& k_scale_zp,
                              const PlainTensor& v_scale_zp) = 0;
         virtual ~Executor() = default;
@@ -113,6 +112,4 @@ private:
     SDPAQuantParam m_value_quant_param;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -101,9 +101,7 @@ bool ScatterUpdate::isExecutable() const {
 
 ScatterUpdate::ScatterUpdate(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
     : Node(op, context, NgraphShapeInferFactory(op)),
-      dataSize(0LU),
-      indicesSize(0LU),
-      axisSize(0LU),
+
       dataPrec(ov::element::dynamic),
       indicesPrec(ov::element::dynamic),
       axisPrec(ov::element::dynamic) {

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.h
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.h
@@ -18,10 +18,10 @@
 
 namespace ov::intel_cpu::node {
 
-enum class ScatterUpdateMode { ScatterUpdate, ScatterNDUpdate, ScatterElementsUpdate };
+enum class ScatterUpdateMode : uint8_t { ScatterUpdate, ScatterNDUpdate, ScatterElementsUpdate };
 
 namespace scatter_reductions {
-enum class CommonReduction { NONE, SUM, SUB, PROD, MIN, MAX, MEAN };
+enum class CommonReduction : uint8_t { NONE, SUM, SUB, PROD, MIN, MAX, MEAN };
 class ReduceMultiply {
 public:
     template <typename DT>
@@ -131,14 +131,14 @@ private:
     inline int64_t getIndicesValue(uint8_t* indices, size_t offset) const;
 
     ScatterUpdateMode scatterUpdateMode = ScatterUpdateMode::ScatterUpdate;
-    enum { DATA_ID, INDICES_ID, UPDATE_ID, AXIS_ID };
+    enum : uint8_t { DATA_ID, INDICES_ID, UPDATE_ID, AXIS_ID };
 
     Reduction reduction_type;
     bool use_init_val = true;
 
     // if axis can be set other than default 0.
     bool axisRelaxed = false;
-    size_t dataSize, indicesSize, axisSize;
+    size_t dataSize{0LU}, indicesSize{0LU}, axisSize{0LU};
     ov::element::Type dataPrec, indicesPrec, axisPrec;
     // In ov::PartialShape with rank 0 (scalars) is converted to ov::intel_cpu::Shape with rank 1.
     // Add flag set in constructor for workaround for ScatterNDUpdates

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.h
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.h
@@ -16,9 +16,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum class ScatterUpdateMode { ScatterUpdate, ScatterNDUpdate, ScatterElementsUpdate };
 
@@ -87,17 +85,17 @@ public:
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     void execute(const dnnl::stream& strm) override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 
     using Reduction = scatter_reductions::CommonReduction;
@@ -147,6 +145,4 @@ private:
     bool isUpdateScalar = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/search_sorted.h
+++ b/src/plugins/intel_cpu/src/nodes/search_sorted.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class SearchSorted : public Node {
 public:
@@ -24,8 +22,8 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:
@@ -38,6 +36,4 @@ private:
     bool right_mode = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/segment_max.h
+++ b/src/plugins/intel_cpu/src/nodes/segment_max.h
@@ -4,20 +4,16 @@
 
 #pragma once
 
-#include <cstdint>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "node.h"
 #include "openvino/core/node.hpp"
 #include "openvino/op/util/attr_types.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class SegmentMax : public Node {
 public:
@@ -27,10 +23,10 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
 
 private:
     template <class OV_DATA_TYPE>
@@ -44,6 +40,4 @@ private:
     std::vector<int32_t> lastNumSegments;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/shapeof.h
+++ b/src/plugins/intel_cpu/src/nodes/shapeof.h
@@ -13,9 +13,7 @@
 #include "graph_context.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ShapeOf : public Node {
 public:
@@ -44,6 +42,4 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -297,7 +297,7 @@ ShuffleChannels::ShuffleChannelsExecutor::ShuffleChannelsExecutor(const ShuffleC
     permuteKernel = std::make_unique<PermuteKernel>(params);
 }
 
-void ShuffleChannels::ShuffleChannelsExecutor::exec(const uint8_t* srcData, uint8_t* dstData, const int MB) {
+void ShuffleChannels::ShuffleChannelsExecutor::exec(const uint8_t* srcData, uint8_t* dstData, int MB) {
     if (!permuteKernel) {
         OPENVINO_THROW("Could not execute. Kernel for Transpose node was not compiled.");
     }

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.h
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.h
@@ -17,9 +17,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class ShuffleChannels : public Node {
 public:
@@ -31,7 +29,7 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
     struct ShuffleChannelsAttributes {
@@ -43,7 +41,7 @@ public:
         size_t dataSize = 1lu;
         VectorDims srcDims;
         VectorDims srcBlockedDims;
-        size_t hash() const;
+        [[nodiscard]] size_t hash() const;
         bool operator==(const ShuffleChannelsAttributes& rhs) const;
     };
 
@@ -55,7 +53,7 @@ private:
 
     struct ShuffleChannelsExecutor final {
         ShuffleChannelsExecutor(const ShuffleChannelsAttributes& attrs);
-        void exec(const uint8_t* srcData, uint8_t* dstData, const int MB);
+        void exec(const uint8_t* srcData, uint8_t* dstData, int MB);
         ~ShuffleChannelsExecutor() = default;
 
     private:
@@ -65,6 +63,4 @@ private:
     executorPtr execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/softmax.h
+++ b/src/plugins/intel_cpu/src/nodes/softmax.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "common/dnnl_executor.h"
 #include "graph_context.h"
@@ -16,9 +15,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class SoftMax : public Node {
 public:
@@ -28,7 +25,7 @@ public:
     void createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
                           const std::vector<MemoryDescPtr>& outputDesc) override;
     void getSupportedDescriptors() override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     AttrPtr initPrimitiveAttr() override;
     void prepareParams() override;
     void execute(const dnnl::stream& strm) override;
@@ -42,6 +39,4 @@ private:
     size_t axis = 0;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/space_to_batch.h
+++ b/src/plugins/intel_cpu/src/nodes/space_to_batch.h
@@ -6,18 +6,14 @@
 
 #include <node.h>
 
-#include <cstddef>
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "graph_context.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class SpaceToBatch : public Node {
 public:
@@ -46,6 +42,4 @@ private:
     void SpaceToBatchKernel();
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.h
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.h
@@ -17,9 +17,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class SpaceToDepth : public Node {
 public:
@@ -30,7 +28,7 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void prepareParams() override;
 
@@ -45,7 +43,7 @@ public:
         size_t nSpatialDims = 0lu;
         VectorDims srcBlockedDims;
         VectorDims destBlockedDims;
-        size_t hash() const;
+        [[nodiscard]] size_t hash() const;
         bool operator==(const SpaceToDepthAttrs& rhs) const;
     };
 
@@ -57,7 +55,7 @@ private:
 
     struct SpaceToDepthExecutor final {
         SpaceToDepthExecutor(const SpaceToDepthAttrs& attrs);
-        void exec(const uint8_t* srcData, uint8_t* dstData, const int MB);
+        void exec(const uint8_t* srcData, uint8_t* dstData, int MB);
         ~SpaceToDepthExecutor() = default;
 
     private:
@@ -67,6 +65,4 @@ private:
     executorPtr execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.h
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.h
@@ -32,7 +32,7 @@ public:
 
     void prepareParams() override;
 
-    enum Mode { BLOCKS_FIRST = 0, DEPTH_FIRST = 1 };
+    enum Mode : uint8_t { BLOCKS_FIRST = 0, DEPTH_FIRST = 1 };
 
     struct SpaceToDepthAttrs {
         LayoutType layoutType;

--- a/src/plugins/intel_cpu/src/nodes/split.h
+++ b/src/plugins/intel_cpu/src/nodes/split.h
@@ -9,8 +9,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "cpu_memory.h"
 #include "edge.h"
@@ -19,9 +17,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Split : public Node {
 public:
@@ -32,15 +28,15 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void selectOptimalPrimitiveDescriptor() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
 
     void initOptimalPrimitiveDescriptor() override;
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
 
-    bool needPrepareParams() const override;
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
     void prepareParams() override;
     void createPrimitive() override;
     void executeDynamicImpl(const dnnl::stream& strm) override {
@@ -59,7 +55,7 @@ private:
     public:
         SplitOptimizedExecutor(const BlockedMemoryDescCPtr& inDesc,
                                const std::vector<BlockedMemoryDescCPtr>& outDescs,
-                               const size_t axis);
+                               size_t axis);
         void exec(const uint8_t* srcData, const std::vector<uint8_t*>& dstRawMemPtrs) override;
 
     private:
@@ -70,7 +66,7 @@ private:
     };
 
     void optimizedNspc2Ncsp(size_t MB);
-    std::vector<uint8_t*> getRawDstMemPtrs() const;
+    [[nodiscard]] std::vector<uint8_t*> getRawDstMemPtrs() const;
 
     bool canUseOptimizedNspc2Ncsp = false;
 
@@ -82,6 +78,4 @@ private:
     std::vector<int> splitLengths;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/stft.h
+++ b/src/plugins/intel_cpu/src/nodes/stft.h
@@ -14,9 +14,7 @@
 #include "openvino/core/node.hpp"
 #include "rdft.h"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class STFT : public Node {
 public:
@@ -24,19 +22,19 @@ public:
 
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    bool created() const override;
+    [[nodiscard]] bool created() const override;
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void createPrimitive() override;
 
     void execute(const dnnl::stream& strm) override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
 protected:
-    bool needShapeInfer() const override;
+    [[nodiscard]] bool needShapeInfer() const override;
 
 private:
     /// STFT params
@@ -54,6 +52,4 @@ private:
     static constexpr size_t FRAME_STEP_IDX = 3lu;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/strided_slice.h
+++ b/src/plugins/intel_cpu/src/nodes/strided_slice.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_memory.h"
 #include "cpu_types.h"
@@ -18,9 +17,7 @@
 #include "memory_desc/blocked_memory_desc.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class StridedSlice : public Node {
 public:
@@ -140,6 +137,4 @@ private:
     std::vector<MemoryCPtr> dstMemory;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_pack.h
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_pack.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class StringTensorPack : public Node {
 public:
@@ -23,10 +21,10 @@ public:
     static bool isSupportedOperation(const std::shared_ptr<const ov::Node>& op, std::string& errorMessage) noexcept;
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
-    bool isExecutable() const override;
+    [[nodiscard]] bool isExecutable() const override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 
 private:
@@ -37,6 +35,4 @@ private:
     struct StringTensorPackExecute;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/string_tensor_unpack.h
+++ b/src/plugins/intel_cpu/src/nodes/string_tensor_unpack.h
@@ -12,9 +12,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class StringTensorUnpack : public Node {
 public:
@@ -24,11 +22,9 @@ public:
     void getSupportedDescriptors() override;
     void initSupportedPrimitiveDescriptors() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void executeDynamicImpl(const dnnl::stream& strm) override;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/subgraph.h
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.h
@@ -32,9 +32,7 @@
 #    include "cpu/x64/cpu_isa_traits.hpp"
 #endif
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Subgraph : public Node {
 public:
@@ -92,21 +90,21 @@ private:
     std::shared_ptr<SubgraphAttrs> subgraph_attrs;
 
     // Index of Paramater -> Index of broadcastable dimension from end
-    std::map<size_t, size_t> broadcastable_inputs = {};
+    std::map<size_t, size_t> broadcastable_inputs;
 
     size_t input_num = 0;
     size_t output_num = 0;
 
-    std::vector<MemoryPtr> srcMemPtrs = {};
-    std::vector<MemoryPtr> dstMemPtrs = {};
+    std::vector<MemoryPtr> srcMemPtrs;
+    std::vector<MemoryPtr> dstMemPtrs;
 
-    std::vector<ptrdiff_t> start_offset_in = {};
-    std::vector<ptrdiff_t> start_offset_out = {};
+    std::vector<ptrdiff_t> start_offset_in;
+    std::vector<ptrdiff_t> start_offset_out;
 
-    RepackedInputConfig repacked_constant_input_config = {};
+    RepackedInputConfig repacked_constant_input_config;
     // Ptr indices which are not processed by the snippets kernel
     // and used directly in the specific emitters (e.g. jit_brgemm_emitter)
-    std::set<size_t> external_ptrs_idces = {};
+    std::set<size_t> external_ptrs_idces;
 
     bool is_dynamic = false;
     // Input shapes that are used in PrepareParams and ShapeInfer to avoid frequent memory allocation
@@ -115,6 +113,4 @@ private:
     std::shared_ptr<SubgraphBaseExecutor> execPtr = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.h
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.h
@@ -23,9 +23,7 @@
 #include "graph_context.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 struct PortMap {
     // Data map rule
@@ -78,7 +76,7 @@ class DynamicBuffer {
 public:
     DynamicBuffer(MemoryPtr from_, std::vector<MemoryPtr> to_, const PortMap& map_rule_);
 
-    void execute(const dnnl::engine& eng, const int iter);
+    void execute(const dnnl::engine& eng, int iter);
     void transfer(const Node* node);
 
     void reset(int max_iter_count_);  // reset local
@@ -87,17 +85,12 @@ private:
     void init(const dnnl::engine& eng);
 
     /* methods for resize and refill buffer */
-    bool check_buffer() const;
+    [[nodiscard]] bool check_buffer() const;
     MemoryPtr create_buffer(const dnnl::engine& eng);
     void move_buffer(const MemoryPtr& new_buffer);
     void move_data();
 
-    static void copy(const uint8_t* src,
-                     uint8_t* dst,
-                     const size_t src_stride,
-                     const size_t dst_stride,
-                     const size_t count,
-                     const size_t len);
+    static void copy(const uint8_t* src, uint8_t* dst, size_t src_stride, size_t dst_stride, size_t count, size_t len);
 
     /* variable states */
     size_t len = 1lu;
@@ -136,7 +129,7 @@ public:
         return true;
     }
     // @todo limit to particular in / out ports
-    bool usesInOutMemoryMultipleTimes() {
+    static bool usesInOutMemoryMultipleTimes() {
         return true;
     }
 
@@ -159,15 +152,15 @@ private:
     void prepareDynamicBuffers();
     void prepareLoopBodyCurrentIteration();
     void prepareContinueCond();
-    void prepareInitialCond(const bool compileStage);
-    void prepareTripCount(const bool compileStage);
+    void prepareInitialCond(bool compileStage);
+    void prepareTripCount(bool compileStage);
 
     /* Dynamic support */
     void reshapeSubgraphInput();
     void reshapeAndFillOutput(const dnnl::stream& strm);
     bool checkForInputAndBodyShapesInequality() const;
     int getNumIteration(const std::vector<PortMap>& inputPortMap, const std::vector<PortMap>& outputPortMap) const;
-    void prepareParamsImpl(const bool compileStage);
+    void prepareParamsImpl(bool compileStage);
 
     /* run dynamic subgraph inside a static node */
     bool runAsDynamic() const;
@@ -214,6 +207,4 @@ private:
     const std::shared_ptr<ov::Node> ngraphOp;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/tile.h
+++ b/src/plugins/intel_cpu/src/nodes/tile.h
@@ -15,9 +15,7 @@
 #include "node.h"
 #include "openvino/core/node.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Tile : public Node, public TileBroadcastCommon {
 public:
@@ -48,6 +46,4 @@ private:
     VectorDims originRepeats;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/topk.h
+++ b/src/plugins/intel_cpu/src/nodes/topk.h
@@ -64,7 +64,7 @@ struct jit_topk_call_args {
 };
 
 struct jit_uni_topk_kernel {
-    void (*ker_)(const jit_topk_call_args*){nullptr};
+    void (*ker_)(const jit_topk_call_args*) = nullptr;
 
     void operator()(const jit_topk_call_args* args) const {
         assert(ker_);

--- a/src/plugins/intel_cpu/src/nodes/topk.h
+++ b/src/plugins/intel_cpu/src/nodes/topk.h
@@ -13,16 +13,13 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 enum TopKLayoutType { topk_ncsp, topk_nspc, topk_blocked };
 
@@ -67,15 +64,15 @@ struct jit_topk_call_args {
 };
 
 struct jit_uni_topk_kernel {
-    void (*ker_)(const jit_topk_call_args*);
+    void (*ker_)(const jit_topk_call_args*){nullptr};
 
-    void operator()(const jit_topk_call_args* args) {
+    void operator()(const jit_topk_call_args* args) const {
         assert(ker_);
         ker_(args);
     }
 
-    explicit jit_uni_topk_kernel(jit_topk_config_params jcp) : ker_(nullptr), jcp_(jcp) {}
-    virtual ~jit_uni_topk_kernel() {}
+    explicit jit_uni_topk_kernel(jit_topk_config_params jcp) : jcp_(jcp) {}
+    virtual ~jit_uni_topk_kernel() = default;
 
     virtual void create_ker() = 0;
 
@@ -158,6 +155,4 @@ private:
     std::shared_ptr<jit_uni_topk_kernel> topk_kernel = nullptr;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/topk.h
+++ b/src/plugins/intel_cpu/src/nodes/topk.h
@@ -21,9 +21,9 @@
 
 namespace ov::intel_cpu::node {
 
-enum TopKLayoutType { topk_ncsp, topk_nspc, topk_blocked };
+enum TopKLayoutType : uint8_t { topk_ncsp, topk_nspc, topk_blocked };
 
-enum TopKAlgorithm { topk_bubble_sort, topk_bitonic_sort, topk_heap_sort };
+enum TopKAlgorithm : uint8_t { topk_bubble_sort, topk_bitonic_sort, topk_heap_sort };
 
 struct jit_topk_config_params {
     bool mode_max;          // which of the two elements to select. ture: max; false: min

--- a/src/plugins/intel_cpu/src/nodes/transpose.h
+++ b/src/plugins/intel_cpu/src/nodes/transpose.h
@@ -18,9 +18,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
-namespace node {
+namespace ov::intel_cpu::node {
 
 class Transpose : public Node {
 public:
@@ -31,18 +29,18 @@ public:
     void initSupportedPrimitiveDescriptors() override;
     void createPrimitive() override;
     void execute(const dnnl::stream& strm) override;
-    bool created() const override;
-    bool canBeInPlace() const override {
+    [[nodiscard]] bool created() const override;
+    [[nodiscard]] bool canBeInPlace() const override {
         return false;
     }
 
-    const VectorDims& getOrder() const {
+    [[nodiscard]] const VectorDims& getOrder() const {
         return order;
     }
 
-    bool neverExecute() const override;
-    bool isExecutable() const override;
-    bool needPrepareParams() const override;
+    [[nodiscard]] bool neverExecute() const override;
+    [[nodiscard]] bool isExecutable() const override;
+    [[nodiscard]] bool needPrepareParams() const override;
     void prepareParams() override;
 
     void setOptimized(bool isOptimized) {
@@ -70,6 +68,4 @@ private:
     bool isOptimized = false;
 };
 
-}  // namespace node
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu::node

--- a/src/plugins/intel_cpu/src/nodes/unique.hpp
+++ b/src/plugins/intel_cpu/src/nodes/unique.hpp
@@ -11,7 +11,6 @@
 #include <memory>
 #include <oneapi/dnnl/dnnl_common.hpp>
 #include <string>
-#include <vector>
 
 #include "cpu_types.h"
 #include "graph_context.h"

--- a/src/plugins/intel_cpu/src/onednn/iml_type_mapper.h
+++ b/src/plugins/intel_cpu/src/onednn/iml_type_mapper.h
@@ -8,8 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 enum impl_desc_type : int64_t {
     unknown = 0x00000000,
@@ -136,7 +135,6 @@ enum impl_desc_type : int64_t {
 std::vector<std::string> extractTypeAndImplName(const std::string& priority);
 const char* impl_type_to_string(impl_desc_type type);
 impl_desc_type parse_impl_name(std::string impl_desc_name);
-bool contains(const std::vector<impl_desc_type>& priorities, const impl_desc_type impl_type_str);
+bool contains(const std::vector<impl_desc_type>& priorities, impl_desc_type impl_type_str);
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/partitioned_mem_blk.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_blk.h
@@ -10,8 +10,7 @@
 #include "cpu_memory.h"
 #include "openvino/core/except.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * This is a memory block that represents a view on a subblock inside another continuous dynamic memory block
@@ -30,10 +29,10 @@ public:
         OPENVINO_ASSERT(m_pBlock, "Memory block is uninitialized");
     }
 
-    void* getRawPtr() const noexcept override;
+    [[nodiscard]] void* getRawPtr() const noexcept override;
     void setExtBuff(void* ptr, size_t size) override;
     bool resize(size_t size) override;
-    bool hasExtBuffer() const noexcept override;
+    [[nodiscard]] bool hasExtBuffer() const noexcept override;
     void registerMemory(Memory* memPtr) override;
     void unregisterMemory(Memory* memPtr) override;
 
@@ -45,5 +44,4 @@ private:
     size_t m_size = 0;              // size of the viewed partition in bytes
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/perf_count.h
+++ b/src/plugins/intel_cpu/src/perf_count.h
@@ -11,8 +11,8 @@
 namespace ov::intel_cpu {
 
 class PerfCount {
-    uint64_t total_duration{0};
-    uint32_t num{0};
+    uint64_t total_duration = 0;
+    uint32_t num = 0;
 
     std::chrono::high_resolution_clock::time_point _start;
     std::chrono::high_resolution_clock::time_point _finish;

--- a/src/plugins/intel_cpu/src/perf_count.h
+++ b/src/plugins/intel_cpu/src/perf_count.h
@@ -8,38 +8,37 @@
 #include <cstdint>
 #include <ratio>
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class PerfCount {
-    uint64_t total_duration;
-    uint32_t num;
+    uint64_t total_duration{0};
+    uint32_t num{0};
 
-    std::chrono::high_resolution_clock::time_point __start = {};
-    std::chrono::high_resolution_clock::time_point __finish = {};
+    std::chrono::high_resolution_clock::time_point _start;
+    std::chrono::high_resolution_clock::time_point _finish;
 
 public:
-    PerfCount() : total_duration(0), num(0) {}
+    PerfCount() = default;
 
-    std::chrono::duration<double, std::milli> duration() const {
-        return __finish - __start;
+    [[nodiscard]] std::chrono::duration<double, std::milli> duration() const {
+        return _finish - _start;
     }
 
-    uint64_t avg() const {
+    [[nodiscard]] uint64_t avg() const {
         return (num == 0) ? 0 : total_duration / num;
     }
-    uint32_t count() const {
+    [[nodiscard]] uint32_t count() const {
         return num;
     }
 
 private:
     void start_itr() {
-        __start = std::chrono::high_resolution_clock::now();
+        _start = std::chrono::high_resolution_clock::now();
     }
 
     void finish_itr() {
-        __finish = std::chrono::high_resolution_clock::now();
-        total_duration += std::chrono::duration_cast<std::chrono::microseconds>(__finish - __start).count();
+        _finish = std::chrono::high_resolution_clock::now();
+        total_duration += std::chrono::duration_cast<std::chrono::microseconds>(_finish - _start).count();
         num++;
     }
 
@@ -59,8 +58,7 @@ public:
     }
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu
 
-#define GET_PERF(_node)    std::unique_ptr<PerfHelper>(new PerfHelper(_node->PerfCounter()))
-#define PERF(_node, _need) auto pc = _need ? GET_PERF(_node) : nullptr;
+#define GET_PERF(_node)    std::unique_ptr<PerfHelper>(new PerfHelper((_node)->PerfCounter()))
+#define PERF(_node, _need) auto pc = (_need) ? GET_PERF(_node) : nullptr;

--- a/src/plugins/intel_cpu/src/plugin.h
+++ b/src/plugins/intel_cpu/src/plugin.h
@@ -19,37 +19,38 @@
 #include "openvino/runtime/so_ptr.hpp"
 #include "openvino/runtime/threading/cpu_message.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Plugin : public ov::IPlugin {
 public:
     Plugin();
-    ~Plugin();
+    ~Plugin() override;
 
     std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>& model,
                                                       const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>& model,
-                                                      const ov::AnyMap& properties,
-                                                      const ov::SoPtr<ov::IRemoteContext>& context) const override {
+    std::shared_ptr<ov::ICompiledModel> compile_model(
+        [[maybe_unused]] const std::shared_ptr<const ov::Model>& model,
+        [[maybe_unused]] const ov::AnyMap& properties,
+        [[maybe_unused]] const ov::SoPtr<ov::IRemoteContext>& context) const override {
         OPENVINO_THROW_NOT_IMPLEMENTED("compile_model with RemoteContext is not supported by CPU plugin!");
     };
 
     void set_property(const ov::AnyMap& properties) override;
     ov::Any get_property(const std::string& name, const ov::AnyMap& arguments) const override;
     std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model, const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model,
-                                                     const ov::SoPtr<ov::IRemoteContext>& context,
-                                                     const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model([[maybe_unused]] std::istream& model,
+                                                     [[maybe_unused]] const ov::SoPtr<ov::IRemoteContext>& context,
+                                                     [[maybe_unused]] const ov::AnyMap& properties) const override {
         OPENVINO_THROW_NOT_IMPLEMENTED("import_model with RemoteContext is not supported by CPU plugin!");
     };
 
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model,
                                     const ov::AnyMap& properties) const override;
-    ov::SoPtr<ov::IRemoteContext> create_context(const ov::AnyMap& remote_properties) const override {
+    ov::SoPtr<ov::IRemoteContext> create_context([[maybe_unused]] const ov::AnyMap& remote_properties) const override {
         OPENVINO_THROW_NOT_IMPLEMENTED("create_context is not supported by CPU plugin!");
     };
-    ov::SoPtr<ov::IRemoteContext> get_default_context(const ov::AnyMap& remote_properties) const override {
+    ov::SoPtr<ov::IRemoteContext> get_default_context(
+        [[maybe_unused]] const ov::AnyMap& remote_properties) const override {
         OPENVINO_THROW_NOT_IMPLEMENTED("get_default_context is not supported by CPU plugin!");
     };
 
@@ -70,5 +71,4 @@ private:
     std::shared_ptr<void> specialSetup;
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/post_ops.hpp
+++ b/src/plugins/intel_cpu/src/post_ops.hpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <utility>
 #include <vector>
 
@@ -171,15 +170,15 @@ struct FakeQuantizePostOp {
         return m_levels;
     }
 
-    Type type() const {
+    [[nodiscard]] Type type() const {
         return m_type;
     }
 
-    bool isInputLowBroadcast() const {
+    [[nodiscard]] bool isInputLowBroadcast() const {
         return m_isInputLowBroadcasted;
     }
 
-    bool isOutputHighBroadcast() const {
+    [[nodiscard]] bool isOutputHighBroadcast() const {
         return m_isOutputHighBroadcasted;
     }
 
@@ -204,19 +203,19 @@ struct DepthwiseConvolutionPostOp {
           m_kernel(std::move(kernel)),
           m_strides(std::move(strides)) {}
 
-    size_t ih() const {
+    [[nodiscard]] size_t ih() const {
         return m_ih;
     }
 
-    size_t iw() const {
+    [[nodiscard]] size_t iw() const {
         return m_iw;
     }
 
-    const std::vector<size_t>& kernel() const {
+    [[nodiscard]] const std::vector<size_t>& kernel() const {
         return m_kernel;
     }
 
-    const std::vector<size_t>& strides() const {
+    [[nodiscard]] const std::vector<size_t>& strides() const {
         return m_strides;
     }
 
@@ -233,15 +232,15 @@ struct SumPostOp {
           m_zero_point(zero_point),
           m_dataType(dataType) {}
 
-    float scale() const {
+    [[nodiscard]] float scale() const {
         return m_scale;
     }
 
-    int32_t zeroPoint() const {
+    [[nodiscard]] int32_t zeroPoint() const {
         return m_zero_point;
     }
 
-    ov::element::Type_t dataType() const {
+    [[nodiscard]] ov::element::Type_t dataType() const {
         return m_dataType;
     }
 
@@ -257,15 +256,15 @@ enum class EltwiseKind : uint8_t {
     // @todo Binary?
 };
 
-EltwiseKind getEltwiseKind(const Algorithm alg);
+EltwiseKind getEltwiseKind(Algorithm alg);
 
-ScaleShiftPostOp::Type convertToScaleShiftOpt(const Algorithm alg);
+ScaleShiftPostOp::Type convertToScaleShiftOpt(Algorithm alg);
 
-ActivationPostOp::Type convertToActivationPostOpt(const Algorithm alg);
+ActivationPostOp::Type convertToActivationPostOpt(Algorithm alg);
 
-Algorithm convertToEltwiseAlgorithm(const ActivationPostOp::Type m_type);
+Algorithm convertToEltwiseAlgorithm(ActivationPostOp::Type m_type);
 
-FakeQuantizePostOp::Type convertToFqPostOp(const Algorithm alg);
+FakeQuantizePostOp::Type convertToFqPostOp(Algorithm alg);
 
 PostOps getPostOps(const std::vector<NodePtr>& fused, ov::element::Type_t sumDataType = ov::element::dynamic);
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/proxy_mem_blk.h
+++ b/src/plugins/intel_cpu/src/proxy_mem_blk.h
@@ -11,8 +11,7 @@
 #include "cpu_memory.h"
 #include "openvino/core/except.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * @brief A proxy object that additionally implements observer pattern
@@ -54,5 +53,4 @@ private:
 using ProxyMemoryBlockPtr = std::shared_ptr<ProxyMemoryBlock>;
 using ProxyMemoryBlockCPtr = std::shared_ptr<const ProxyMemoryBlock>;
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/shape_inference/custom/shapeof.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/shapeof.hpp
@@ -28,7 +28,7 @@ class ShapeOfShapeInfer : public ShapeInferEmptyPads {
 public:
     ShapeOfShapeInfer() = default;
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
-                 const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+                 [[maybe_unused]] const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         OPENVINO_ASSERT(!input_shapes.empty());
         return {{VectorDims{input_shapes.front().get().size()}}, ShapeInferStatus::success};
     }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/subgraph.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/subgraph.hpp
@@ -32,7 +32,7 @@ public:
         m_status_map[snippets::ShapeInferStatus::skip] = ov::intel_cpu::ShapeInferStatus::skip;
     }
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
-                 const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+                 [[maybe_unused]] const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         const auto& snippets_result = m_subgraph->shape_infer(input_shapes);
         OPENVINO_ASSERT(m_status_map.count(snippets_result.status) != 0,
                         "Failed to map snippets shapeInfer status to the plugin one");

--- a/src/plugins/intel_cpu/src/shape_inference/memory_accessor.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/memory_accessor.hpp
@@ -23,7 +23,7 @@ class MemoryAccessor : public ov::ITensorAccessor {
 public:
     MemoryAccessor(const container_type& ptrs, const std::vector<int64_t>& ranks) : m_ptrs{ptrs}, m_ranks(ranks) {}
 
-    ~MemoryAccessor() = default;
+    virtual ~MemoryAccessor() = default;
 
     ov::Tensor operator()(size_t port) const override {
         const auto t_iter = m_ptrs.find(port);

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -351,7 +351,7 @@ public:
     using ShapeInferBase::ShapeInferBase;
 
     std::optional<std::vector<StaticShape>> infer(const std::vector<StaticShapeRef>& input_shapes,
-                                                  const ov::ITensorAccessor& /*unused*/) override {
+                                                  [[maybe_unused]] const ov::ITensorAccessor& acc) override {
         return {op::copy_shape_infer(m_node.get(), input_shapes)};
     }
 };
@@ -364,7 +364,7 @@ public:
     using ShapeInferBase::ShapeInferBase;
 
     std::optional<std::vector<StaticShape>> infer(const std::vector<StaticShapeRef>& input_shapes,
-                                                  const ov::ITensorAccessor& /*unused*/) override {
+                                                  [[maybe_unused]] const ov::ITensorAccessor& acc) override {
         return {op::eltwise_shape_infer(m_node.get(), input_shapes)};
     }
 };
@@ -443,7 +443,7 @@ public:
     using ShapeInferBase::ShapeInferBase;
 
     std::optional<std::vector<StaticShape>> infer(const std::vector<StaticShapeRef>& input_shapes,
-                                                  const ov::ITensorAccessor& /*unused*/) override {
+                                                  [[maybe_unused]] const ov::ITensorAccessor& acc) override {
         return {shape_infer(static_cast<TOp*>(m_node.get()), input_shapes)};
     }
 };
@@ -498,7 +498,7 @@ public:
     using ShapeInferPaddingBase::ShapeInferPaddingBase;
 
     std::optional<std::vector<StaticShape>> infer(const std::vector<StaticShapeRef>& input_shapes,
-                                                  const ov::ITensorAccessor& /*unused*/) override {
+                                                  [[maybe_unused]] const ov::ITensorAccessor& acc) override {
         return {shape_infer(static_cast<TOp*>(m_node.get()), input_shapes, m_pads_begin, m_pads_end)};
     }
 };

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
@@ -32,7 +32,6 @@ public:
         ShapeInferStatus status;
     };
 
-public:
     virtual ~IShapeInfer() = default;
 
     /**

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_internal_dyn.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_internal_dyn.hpp
@@ -25,8 +25,8 @@ namespace ov::intel_cpu {
 class InternalDynShapeInfer final : public ShapeInferEmptyPads {
 public:
     InternalDynShapeInfer() = default;
-    Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
-                 const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+    Result infer([[maybe_unused]] const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
+                 [[maybe_unused]] const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         return {{}, ShapeInferStatus::skip};
     }
 

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_pass_through.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_pass_through.hpp
@@ -27,7 +27,7 @@ class ShapeInferPassThrough final : public ShapeInferEmptyPads {
 public:
     ShapeInferPassThrough() = default;
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
-                 const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
+                 [[maybe_unused]] const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {
         OPENVINO_ASSERT(!input_shapes.empty());
         return {{input_shapes.front()}, ShapeInferStatus::success};
     }

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_status.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_status.hpp
@@ -6,7 +6,7 @@
 
 namespace ov::intel_cpu {
 
-enum class ShapeInferStatus {
+enum class ShapeInferStatus : uint8_t {
     success,  ///< shapes were successfully calculated
     skip      ///< shape inference was skipped.
     ///< This status is used when the implementation was expectedly not able to compute defined output shape

--- a/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
@@ -33,7 +33,7 @@ public:
     /// \brief Construct a zero dimension
     StaticDimension() = default;
 
-    StaticDimension(const Dimension&) {
+    StaticDimension(const Dimension& /*unused*/) {
         OPENVINO_THROW("[shape infer] Shoudn't convert from Dimension to StaticDimension.");
     }
 
@@ -55,7 +55,7 @@ public:
     [[nodiscard]] value_type get_min_length() const;
     [[nodiscard]] value_type get_max_length() const;
 
-    [[nodiscard]] Interval& get_interval() const {
+    [[nodiscard]] static Interval& get_interval() {
         static Interval dummy{};
         OPENVINO_THROW("[shape infer] Shoudn't call get_interval() in StaticDimension.");
         return dummy;
@@ -73,8 +73,8 @@ public:
     StaticDimension& operator+=(const StaticDimension& dim);
     StaticDimension& operator*=(const StaticDimension& dim);
     StaticDimension& operator&=(const StaticDimension& dim);
-    StaticDimension operator/(const value_type divisor) const;
-    StaticDimension& operator/=(const value_type divisor);
+    StaticDimension operator/(value_type divisor) const;
+    StaticDimension& operator/=(value_type divisor);
 
     /// \brief Swap of dimensions
     friend void swap(StaticDimension& a, StaticDimension& b) noexcept {

--- a/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
@@ -33,7 +33,7 @@ public:
     /// \brief Construct a zero dimension
     StaticDimension() = default;
 
-    StaticDimension(const Dimension& /*unused*/) {
+    StaticDimension(const Dimension& /*dim*/) {
         OPENVINO_THROW("[shape infer] Shoudn't convert from Dimension to StaticDimension.");
     }
 

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.cpp
@@ -46,7 +46,7 @@ StaticShape::StaticShapeAdapter() = default;
 StaticShape::StaticShapeAdapter(const TDims& dims) : m_dims{dims} {}
 StaticShape::StaticShapeAdapter(TDims&& dims) noexcept : m_dims{std::move(dims)} {}
 StaticShape::StaticShapeAdapter(const StaticShape& other) : StaticShapeAdapter(*other) {}
-StaticShape::StaticShapeAdapter(const ov::PartialShape& /*unused*/) {
+StaticShape::StaticShapeAdapter([[maybe_unused]] const ov::PartialShape& shape) {
     partial_shape_convert_throw();
 }
 
@@ -143,7 +143,7 @@ bool StaticShape::broadcast_merge_into(StaticShape& dst,
 
 //-- Shape as reference
 StaticShapeRef::StaticShapeAdapter(const StaticShape& shape) : m_dims{&(*shape)} {}
-StaticShapeRef::StaticShapeAdapter(const ov::PartialShape& /*unused*/) {
+StaticShapeRef::StaticShapeAdapter([[maybe_unused]] const ov::PartialShape& shape) {
     partial_shape_convert_throw();
 }
 

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
@@ -72,7 +72,7 @@ public:
     StaticShapeAdapter(std::vector<value_type> dims) noexcept : m_dims(dims.begin(), dims.end()) {}
 
     StaticShapeAdapter(const StaticShape& other);
-    StaticShapeAdapter(const ov::PartialShape&);
+    StaticShapeAdapter(const ov::PartialShape& /*unused*/);
 
     const TDims& operator*() const& noexcept {
         return m_dims;
@@ -116,7 +116,7 @@ public:
     }
 
     [[nodiscard]] ov::Rank rank() const;
-    bool merge_rank(const ov::Rank& r) const;
+    [[nodiscard]] bool merge_rank(const ov::Rank& r) const;
     [[nodiscard]] ov::Shape to_shape() const;
     [[nodiscard]] ov::Shape get_max_shape() const;
     [[nodiscard]] ov::Shape get_min_shape() const;
@@ -228,7 +228,7 @@ public:
     constexpr StaticShapeAdapter(const StaticShapeAdapter<const TDims>& other) = default;
 
     StaticShapeAdapter(const StaticShape& shape);
-    StaticShapeAdapter(const ov::PartialShape&);
+    StaticShapeAdapter(const ov::PartialShape& /*unused*/);
 
     operator StaticShape() const {
         return m_dims ? StaticShape(*m_dims) : StaticShape();
@@ -252,7 +252,8 @@ public:
     }
 
     template <class T>
-    constexpr std::enable_if_t<is_static_shape_adapter<T>(), bool> compatible(const T& other) const {
+    [[nodiscard]] [[nodiscard]] constexpr std::enable_if_t<is_static_shape_adapter<T>(), bool> compatible(
+        const T& other) const {
         // for static shape compatible == both shape equals
         return *this == other;
     }
@@ -264,7 +265,7 @@ public:
     }
 
     [[nodiscard]] ov::Rank rank() const;
-    bool merge_rank(const ov::Rank& r) const;
+    [[nodiscard]] bool merge_rank(const ov::Rank& r) const;
     [[nodiscard]] ov::Shape to_shape() const;
     [[nodiscard]] ov::Shape get_max_shape() const;
     [[nodiscard]] ov::Shape get_min_shape() const;

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
@@ -72,7 +72,7 @@ public:
     StaticShapeAdapter(std::vector<value_type> dims) noexcept : m_dims(dims.begin(), dims.end()) {}
 
     StaticShapeAdapter(const StaticShape& other);
-    StaticShapeAdapter(const ov::PartialShape& /*unused*/);
+    StaticShapeAdapter(const ov::PartialShape& shape);
 
     const TDims& operator*() const& noexcept {
         return m_dims;
@@ -228,7 +228,7 @@ public:
     constexpr StaticShapeAdapter(const StaticShapeAdapter<const TDims>& other) = default;
 
     StaticShapeAdapter(const StaticShape& shape);
-    StaticShapeAdapter(const ov::PartialShape& /*unused*/);
+    StaticShapeAdapter(const ov::PartialShape& shape);
 
     operator StaticShape() const {
         return m_dims ? StaticShape(*m_dims) : StaticShape();

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/arm/pass/convert_group_conv.cpp
@@ -24,7 +24,7 @@ ov::intel_cpu::ConvertGroupConvolution::ConvertGroupConvolution() {
     auto gconv = ov::pass::pattern::wrap_type<ov::op::v1::GroupConvolution>();
 
     ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
-        enum Inputs { Data, Weights };
+        enum Inputs : uint8_t { Data, Weights };
         auto gconv = ov::as_type_ptr<ov::op::v1::GroupConvolution>(m.get_match_root());
         if (!gconv) {
             return false;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/leaky_relu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/leaky_relu.hpp
@@ -21,7 +21,7 @@ public:
 
     LeakyReluNode() = default;
 
-    LeakyReluNode(const ov::Output<ov::Node>& data, const float& negative_slope, const ov::element::Type output_type);
+    LeakyReluNode(const ov::Output<ov::Node>& data, const float& negative_slope, ov::element::Type output_type);
 
     void validate_and_infer_types() override;
 
@@ -29,7 +29,7 @@ public:
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
 
-    float get_slope() {
+    float get_slope() const {
         return m_negative_slope;
     }
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/ngram.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/ngram.hpp
@@ -30,7 +30,7 @@ public:
     OPENVINO_OP("Ngram", "cpu_plugin_opset");
 
     NgramNode() = default;
-    NgramNode(const ov::Output<Node>& embeddings, const ov::Output<Node>& batch_idces, const size_t k);
+    NgramNode(const ov::Output<Node>& embeddings, const ov::Output<Node>& batch_idces, size_t k);
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;
     bool visit_attributes(ov::AttributeVisitor& visitor) override;
     void validate_and_infer_types() override;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/power_static.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/power_static.hpp
@@ -25,7 +25,7 @@ public:
                     const float& power,
                     const float& scale,
                     const float& shift,
-                    const ov::element::Type output_type = ov::element::dynamic);
+                    ov::element::Type output_type = ov::element::dynamic);
 
     void validate_and_infer_types() override;
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/llm_mlp.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/llm_mlp.hpp
@@ -23,7 +23,7 @@ public:
 
     LLMMLPNode() = default;
 
-    enum class ACT_FN { SILU = 0, GELU = 1 };
+    enum class ACT_FN : uint8_t { SILU = 0, GELU = 1 };
 
     struct Config {
         ACT_FN act;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
@@ -85,7 +85,7 @@ private:
     void custom_constructor_validate_and_infer_types(const std::vector<size_t>& layout_input = {});
     static void validate_element_type(const ov::element::Type& element_type);
 
-    const BrgemmConfig m_config;
+    BrgemmConfig m_config;
     element::Type m_src_type = ov::element::dynamic;  // src element type of the corresponding BRGEMM
 };
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_copy_b.hpp
@@ -33,14 +33,14 @@ public:
     OPENVINO_OP("BrgemmCopyB", "SnippetsOpset");
 
     BrgemmCopyB(const Output<Node>& x,
-                const element::Type src_type,
+                element::Type src_type,
                 BrgemmConfig config,
-                const size_t offset_in = 0lu,
-                const size_t offset_out0 = 0lu,
-                const size_t offset_out1 = 0lu,
+                size_t offset_in = 0lu,
+                size_t offset_out0 = 0lu,
+                size_t offset_out1 = 0lu,
                 const std::vector<size_t>& layout_input = {});
     BrgemmCopyB(const Output<Node>& x,
-                const element::Type src_type,
+                element::Type src_type,
                 BrgemmConfig config,
                 const PortDescriptor& desc_in0,
                 const PortDescriptor& desc_out0,
@@ -71,7 +71,7 @@ public:
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;
 
     class ShapeInfer : public snippets::IShapeInferSnippets {
-        std::vector<size_t> m_layout{};
+        std::vector<size_t> m_layout;
         size_t m_num_outs = 1;
 
     public:
@@ -85,7 +85,7 @@ private:
     void custom_constructor_validate_and_infer_types(const std::vector<size_t>& layout_input = {});
     static void validate_element_type(const ov::element::Type& element_type);
 
-    const BrgemmConfig m_config{};
+    const BrgemmConfig m_config;
     element::Type m_src_type = ov::element::dynamic;  // src element type of the corresponding BRGEMM
 };
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
@@ -35,7 +35,7 @@ public:
     OPENVINO_OP("BrgemmCPU", "SnippetsOpset", snippets::op::Brgemm);
 
     struct PostopsConfig {
-        dnnl_post_ops post_ops = {};
+        dnnl_post_ops post_ops;
         std::optional<size_t> binary_postops_offset = std::nullopt;
         std::optional<ov::element::Type> forced_output_type = std::nullopt;
 
@@ -95,7 +95,7 @@ public:
     void add_binary_eltwise_postop(dnnl::impl::alg_kind_t alg_kind,
                                    const dnnl::memory::desc& desc,
                                    const ov::Output<Node>& postop_input,
-                                   const size_t binary_postop_offset);
+                                   size_t binary_postop_offset);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
 
@@ -119,9 +119,9 @@ private:
      */
     void add_postop_input(const ov::Output<Node>& postop_input);
 
-    const BrgemmConfig m_config = {};
+    const BrgemmConfig m_config;
 
-    PostopsConfig m_post_ops_config = {};
+    PostopsConfig m_post_ops_config;
 
     /**
      * @brief m_gemm_inputs_count represents the number of GeMM inputs of the BrgemmCPU,

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_cpu.hpp
@@ -119,7 +119,7 @@ private:
      */
     void add_postop_input(const ov::Output<Node>& postop_input);
 
-    const BrgemmConfig m_config;
+    BrgemmConfig m_config;
 
     PostopsConfig m_post_ops_config;
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
@@ -33,30 +33,30 @@ public:
                  bool are_wei_constant,
                  bool transposed_b);
 
-    dnnl::impl::cpu::x64::cpu_isa_t isa() const {
+    [[nodiscard]] dnnl::impl::cpu::x64::cpu_isa_t isa() const {
         return m_isa;
     }
-    bool is_amx() const;
-    bool with_wei_repacking() const {
+    [[nodiscard]] bool is_amx() const;
+    [[nodiscard]] bool with_wei_repacking() const {
         return m_with_wei_repacking;
     }
-    bool with_compensations() const {
+    [[nodiscard]] bool with_compensations() const {
         return m_with_compensations;
     }
-    bool with_scratchpad() const {
+    [[nodiscard]] bool with_scratchpad() const {
         return is_amx() || with_compensations();
     }
-    bool are_wei_blocked() const {
+    [[nodiscard]] bool are_wei_blocked() const {
         return m_are_wei_blocked;
     }
-    bool are_wei_constant() const {
+    [[nodiscard]] bool are_wei_constant() const {
         return m_are_wei_constant;
     }
 
-    size_t wei_n_blk() const {
+    [[nodiscard]] size_t wei_n_blk() const {
         return m_wei_n_blk;
     }
-    size_t wei_k_blk() const {
+    [[nodiscard]] size_t wei_k_blk() const {
         return m_wei_k_blk;
     }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/load_convert.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/load_convert.hpp
@@ -29,8 +29,8 @@ public:
 
     LoadConvertSaturation(const Output<Node>& x,
                           const ov::element::Type& destination_type,
-                          const size_t count = 1lu,
-                          const size_t offset = 0lu);
+                          size_t count = 1lu,
+                          size_t offset = 0lu);
     LoadConvertSaturation() = default;
 
     ov::element::Type get_destination_type() const {
@@ -63,8 +63,8 @@ public:
 
     LoadConvertTruncation(const Output<Node>& x,
                           const ov::element::Type& destination_type,
-                          const size_t count = 1lu,
-                          const size_t offset = 0lu);
+                          size_t count = 1lu,
+                          size_t offset = 0lu);
     LoadConvertTruncation() = default;
 
     ov::element::Type get_destination_type() const {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -18,9 +18,9 @@
 #    include "openvino/op/op.hpp"
 #    include "snippets/op/perf_count.hpp"
 
-using namespace ov::snippets::op;
-
 namespace ov::intel_cpu {
+
+using namespace ov::snippets::op;
 
 /**
  * @interface PerfCountRdtscBegin

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/store_convert.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/store_convert.hpp
@@ -29,8 +29,8 @@ public:
 
     StoreConvertSaturation(const Output<Node>& x,
                            const ov::element::Type& destination_type,
-                           const size_t count = 1lu,
-                           const size_t offset = 0lu);
+                           size_t count = 1lu,
+                           size_t offset = 0lu);
     StoreConvertSaturation() = default;
 
     ov::element::Type get_destination_type() const {
@@ -63,8 +63,8 @@ public:
 
     StoreConvertTruncation(const Output<Node>& x,
                            const ov::element::Type& destination_type,
-                           const size_t count = 1lu,
-                           const size_t offset = 0lu);
+                           size_t count = 1lu,
+                           size_t offset = 0lu);
     StoreConvertTruncation() = default;
 
     ov::element::Type get_destination_type() const {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/enforce_precision.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/enforce_precision.hpp
@@ -20,8 +20,8 @@ class EnforcePrecision : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("EnforcePrecision");
 
-    EnforcePrecision(const element::Type source,
-                     const element::Type target,
+    EnforcePrecision(element::Type source,
+                     element::Type target,
                      const std::function<std::set<std::vector<element::Type>>(const std::shared_ptr<ov::Node>& op)>&
                          get_supported_precisions = nullptr);
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/fuse_brgemm_cpu_postops.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/fuse_brgemm_cpu_postops.hpp
@@ -29,7 +29,7 @@ private:
     std::set<size_t>& m_brgemm_external_params_idces;
     // Note: this set is needed to collect external params.
     // This set will be converted to m_external_params_indices at run_on_model stage
-    std::set<std::shared_ptr<ov::op::v0::Parameter>> m_external_params = {};
+    std::set<std::shared_ptr<ov::op::v0::Parameter>> m_external_params;
 };
 
 /**

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.hpp
@@ -21,7 +21,7 @@ class SnippetsMarkSkipped : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("SnippetsMarkSkipped");
     SnippetsMarkSkipped(bool enableBF16 = false) : ModelPass(), enableBF16(enableBF16) {}
-    bool run_on_model(const std::shared_ptr<ov::Model>& /*m*/) override;
+    bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
 private:
     bool enableBF16 = false;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.hpp
@@ -21,7 +21,7 @@ class SnippetsMarkSkipped : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("SnippetsMarkSkipped");
     SnippetsMarkSkipped(bool enableBF16 = false) : ModelPass(), enableBF16(enableBF16) {}
-    bool run_on_model(const std::shared_ptr<ov::Model>&) override;
+    bool run_on_model(const std::shared_ptr<ov::Model>& /*m*/) override;
 
 private:
     bool enableBF16 = false;
@@ -41,7 +41,7 @@ chain. Order of SnippetsNodeType is important!:
 //  (in other words after tokenization). To handle this behavior, eltwise chains that start at input are marked as
 //  IgnoredAfterInputs. Tis is not a real plugin-side fusing, but rather a workaround to guarantee that snippets always
 //  executed in FP32.
-enum class NodeFusingType : int64_t {
+enum class NodeFusingType : int64_t {  // NOLINT(performance-enum-size)
     NotSet,
     FusedTerminator,
     FusedWithConvolution,

--- a/src/plugins/intel_cpu/src/transformations/tpp/x64/op/descriptor.hpp
+++ b/src/plugins/intel_cpu/src/transformations/tpp/x64/op/descriptor.hpp
@@ -13,7 +13,7 @@ namespace ov::intel_cpu::tpp::op {
 class OpDescTPP {
 public:
     // Note: zero arity represent equation arguments
-    enum class ARITY { UNDEFINED, UNARY, BINARY, ZERO };
+    enum class ARITY : uint8_t { UNDEFINED, UNARY, BINARY, ZERO };
     OpDescTPP() = default;
     // Note: for zero arity op_type is interpreted as the argument index (op inputs and args have different order)
     OpDescTPP(ARITY arity, int arg_idx) : m_arity(arity), m_value{arg_idx}, m_flags{0} {

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.h
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.h
@@ -14,8 +14,7 @@
 #include "openvino/core/type/element_type.hpp"
 #include "transformations/convert_precision.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Transformations {
 public:
@@ -26,7 +25,7 @@ public:
     void UpToLpt();
     void CpuSpecificOpSet();
     void PostLpt();
-    void Snippets(void);
+    void Snippets();
 
 private:
     std::shared_ptr<ov::Model> model;
@@ -37,9 +36,9 @@ private:
     void Lpt(const std::vector<ov::element::Type>& defaultPrecisions);
     void runLptPasses(const std::vector<ov::element::Type>& defaultPrecisions);
 
-    void MainSnippets(void);
+    void MainSnippets();
 
-    void PostSnippets(void);
+    void PostSnippets();
 
     static bool is_decompression_multiply(const std::shared_ptr<const ov::Node>& node);
 
@@ -48,5 +47,4 @@ private:
     static bool fuse_type_to_pa(const std::shared_ptr<ov::Node>& node, const precisions_map& precisions);
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/bfloat16.hpp
+++ b/src/plugins/intel_cpu/src/utils/bfloat16.hpp
@@ -57,7 +57,7 @@ public:
     }
 
 private:
-    constexpr bfloat16_t(uint16_t x, bool /*unused*/) : m_value{x} {}
+    constexpr bfloat16_t(uint16_t x, [[maybe_unused]] bool flag) : m_value{x} {}
     union alignas(16) F32 {
         F32(float val) : vfloat{val} {}
 

--- a/src/plugins/intel_cpu/src/utils/bfloat16.hpp
+++ b/src/plugins/intel_cpu/src/utils/bfloat16.hpp
@@ -44,20 +44,20 @@ public:
         return m_value;
     }
 
-    static inline uint16_t round_to_nearest_even(float x) {
+    static uint16_t round_to_nearest_even(float x) {
         return static_cast<uint16_t>((F32(x).vint + ((F32(x).vint & 0x00010000) >> 1)) >> 16);
     }
 
-    static inline uint16_t round_to_nearest(float x) {
+    static uint16_t round_to_nearest(float x) {
         return static_cast<uint16_t>((F32(x).vint + 0x8000) >> 16);
     }
 
-    static inline uint16_t truncate(float x) {
+    static uint16_t truncate(float x) {
         return static_cast<uint16_t>((F32(x).vint) >> 16);
     }
 
 private:
-    constexpr bfloat16_t(uint16_t x, bool) : m_value{x} {}
+    constexpr bfloat16_t(uint16_t x, bool /*unused*/) : m_value{x} {}
     union alignas(16) F32 {
         F32(float val) : vfloat{val} {}
 

--- a/src/plugins/intel_cpu/src/utils/blob_dump.h
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.h
@@ -17,8 +17,7 @@
 
 #include "memory_desc/dnnl_blocked_memory_desc.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 /**
  * Utility class to dump blob contant in plain format.
@@ -53,10 +52,9 @@ public:
     void dumpAsTxt(const std::string& dump_path) const;
     void dumpAsTxt(std::ostream& stream) const;
 
-    void* getDataPtr() const {
+    [[nodiscard]] void* getDataPtr() const {
         return memory->getData();
     }
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/codec_xor.hpp
+++ b/src/plugins/intel_cpu/src/utils/codec_xor.hpp
@@ -29,7 +29,7 @@ union CacheDecrypt {
 
     ~CacheDecrypt() {}
 
-    operator bool() {
+    operator bool() const {
         return m_decrypt_char || m_decrypt_str;
     }
 };

--- a/src/plugins/intel_cpu/src/utils/cpu_utils.hpp
+++ b/src/plugins/intel_cpu/src/utils/cpu_utils.hpp
@@ -86,8 +86,8 @@ inline bool isPerTensorOrPerChannelBroadcastable(const VectorDims& firstInputDim
             }
         }
     } else {
-        for (size_t i = 0; i < normalizedSecondInputDims.size(); i++) {
-            if (normalizedSecondInputDims[i] != 1) {
+        for (uint64_t normalizedSecondInputDim : normalizedSecondInputDims) {
+            if (normalizedSecondInputDim != 1) {
                 return false;
             }
         }

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -259,7 +259,7 @@ struct EnforceInferPrcDebug {
         }
     }
 
-    bool enabled(const std::string& type, const std::string& /*name*/, const std::string& org_names) {
+    bool enabled(const std::string& type, [[maybe_unused]] const std::string& name, const std::string& org_names) {
         std::string tag = type + "@" + org_names;
         std::smatch match;
         bool matched = true;

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -28,8 +28,7 @@
 #    include "openvino/core/model.hpp"
 #    include "utils/general_utils.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 // OV_CPU_DEBUG_LOG controls DEBUG_LOGs to output
 //
@@ -47,7 +46,7 @@ class DebugLogEnabled {
 public:
     DebugLogEnabled(const char* file, const char* func, int line, const char* name = nullptr);
 
-    const std::string& get_tag() const {
+    [[nodiscard]] const std::string& get_tag() const {
         return tag;
     }
     operator bool() const {
@@ -110,8 +109,9 @@ public:
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T> vec) {
-    for (const auto& element : vec)
+    for (const auto& element : vec) {
         os << element << "x";
+    }
     return os;
 }
 std::ostream& operator<<(std::ostream& os, const PortConfig& config);
@@ -124,34 +124,36 @@ std::ostream& operator<<(std::ostream& os, const MemoryDesc& desc);
 std::ostream& operator<<(std::ostream& os, const IMemory& mem);
 std::ostream& operator<<(std::ostream& os, const PrintableModel& model);
 std::ostream& operator<<(std::ostream& os, const PrintableDelta& d);
-std::ostream& operator<<(std::ostream& os, const Edge::ReorderStatus reorderStatus);
+std::ostream& operator<<(std::ostream& os, Edge::ReorderStatus reorderStatus);
 std::ostream& operator<<(std::ostream& os, const MemoryStatisticsRecord& record);
 
 std::ostream& operator<<(std::ostream& os, const dnnl::primitive_desc& desc);
 std::ostream& operator<<(std::ostream& os, const dnnl::memory::desc& desc);
-std::ostream& operator<<(std::ostream& os, const impl_desc_type impl_type);
-std::ostream& operator<<(std::ostream& os, const dnnl::memory::data_type dtype);
-std::ostream& operator<<(std::ostream& os, const dnnl::memory::format_tag format_tag);
+std::ostream& operator<<(std::ostream& os, impl_desc_type impl_type);
+std::ostream& operator<<(std::ostream& os, dnnl::memory::data_type dtype);
+std::ostream& operator<<(std::ostream& os, dnnl::memory::format_tag format_tag);
 std::ostream& operator<<(std::ostream& os, const dnnl::primitive_attr& attr);
 std::ostream& operator<<(std::ostream& os, const dnnl::algorithm& alg);
 
-void print_dnnl_memory(const dnnl::memory& memory, const size_t size, const int id, const char* message = "");
+void print_dnnl_memory(const dnnl::memory& memory, size_t size, int id, const char* message = "");
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const PrintableVector<T>& vec) {
     std::stringstream ss;
     auto N = vec.values.size();
     for (size_t i = 0; i < N; i++) {
-        if (i > 0)
+        if (i > 0) {
             ss << ",";
+        }
         if (ss.tellp() > vec.maxsize) {
             ss << "..." << N << "in total";
             break;
         }
-        if (std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value)
+        if (std::is_same_v<T, int8_t> || std::is_same_v<T, uint8_t>) {
             ss << static_cast<int>(vec.values[i]);
-        else
+        } else {
             ss << vec.values[i];
+        }
     }
     os << ss.str();
     return os;
@@ -165,8 +167,7 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
     return ov::intel_cpu::_write_all_to_stream(os << arg, std::forward<TS>(args)...);
 }
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu
 
 #    define DEBUG_ENABLE_NAME debug_enable_##__LINE__
 
@@ -199,11 +200,12 @@ static inline std::ostream& _write_all_to_stream(std::ostream& os, const T& arg,
  * from the log we can spot the node having issue when enabled bf16/f16
  */
 struct EnforceInferPrcDebug {
-    std::string safe_getenv(const char* name, const char* default_value = "") {
+    static std::string safe_getenv(const char* name, const char* default_value = "") {
         std::string value = default_value;
         const char* p = std::getenv(name);
-        if (p)
+        if (p) {
             value = p;
+        }
         return value;
     }
 
@@ -224,18 +226,22 @@ struct EnforceInferPrcDebug {
         } else {
             pattern_verbose = false;
         }
-        if (str_pos_pattern)
+        if (str_pos_pattern) {
             pos_pattern = std::regex(str_pos_pattern);
-        if (str_neg_pattern)
+        }
+        if (str_neg_pattern) {
             neg_pattern = std::regex(str_neg_pattern);
+        }
     }
 
     ~EnforceInferPrcDebug() {
         if (pattern_verbose) {
-            if (str_pos_pattern)
+            if (str_pos_pattern) {
                 std::cout << "OV_CPU_INFER_PRC_POS_PATTERN=\"" << str_pos_pattern << "\"" << '\n';
-            if (str_neg_pattern)
+            }
+            if (str_neg_pattern) {
                 std::cout << "OV_CPU_INFER_PRC_NEG_PATTERN=\"" << str_neg_pattern << "\"" << '\n';
+            }
             std::cout << "infer precision enforced Types: ";
             size_t total_cnt = 0;
             for (auto& ent : all_enabled_nodes) {
@@ -253,7 +259,7 @@ struct EnforceInferPrcDebug {
         }
     }
 
-    bool enabled(const std::string& type, const std::string& name, const std::string& org_names) {
+    bool enabled(const std::string& type, const std::string& /*name*/, const std::string& org_names) {
         std::string tag = type + "@" + org_names;
         std::smatch match;
         bool matched = true;

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.h
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.h
@@ -19,8 +19,7 @@
 #    include "openvino/util/common_util.hpp"
 #    include "utils/enum_class_hash.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class DebugCapsConfig {
 private:
@@ -32,14 +31,14 @@ public:
         readProperties();
     }
 
-    enum class FILTER {
+    enum class FILTER : uint8_t {
         BY_PORTS,
         BY_EXEC_ID,
         BY_TYPE,
         BY_NAME,
     };
 
-    enum class FORMAT {
+    enum class FORMAT : uint8_t {
         BIN,
         TEXT,
     };
@@ -89,6 +88,7 @@ public:
 
     struct PropertyGroup {
         virtual std::vector<PropertySetterPtr> getPropertySetters() = 0;
+        virtual ~PropertyGroup() = default;
 
         void parseAndSet(const std::string& str) {
             const auto& options = ov::util::split(str, ' ');
@@ -96,9 +96,10 @@ public:
             bool failed = false;
             auto getHelp = [propertySetters]() {
                 std::string help;
-                for (const auto& property : propertySetters)
+                for (const auto& property : propertySetters) {
                     help.append('\t' + property->getPropertyName() + "=<" + property->getPropertyValueDescription() +
                                 ">\n");
+                }
                 return help;
             };
 
@@ -124,7 +125,7 @@ public:
                 }
             }
 
-            if (failed)
+            if (failed) {
                 OPENVINO_THROW(
                     "Wrong syntax: ",
                     str,
@@ -132,6 +133,7 @@ public:
                     "The following space separated options are supported (option names are case insensitive):",
                     "\n",
                     getHelp());
+            }
         }
     };
 
@@ -158,13 +160,13 @@ public:
 private:
     struct PropertySetter {
         virtual bool parseAndSet(const std::string& str) = 0;
-        virtual std::string getPropertyValueDescription() const = 0;
+        [[nodiscard]] virtual std::string getPropertyValueDescription() const = 0;
 
         PropertySetter(std::string name) : propertyName(std::move(name)) {}
 
         virtual ~PropertySetter() = default;
 
-        const std::string& getPropertyName() const {
+        [[nodiscard]] const std::string& getPropertyName() const {
             return propertyName;
         }
 
@@ -184,7 +186,7 @@ private:
             property = str;
             return true;
         }
-        std::string getPropertyValueDescription() const override {
+        [[nodiscard]] std::string getPropertyValueDescription() const override {
             return propertyValueDescription;
         }
 
@@ -220,8 +222,9 @@ private:
                     std::find_if(propertyTokens.begin(), propertyTokens.end(), [tokenName](const Token& token) {
                         return token.name == tokenName;
                     });
-                if (foundToken == propertyTokens.end())
+                if (foundToken == propertyTokens.end()) {
                     return false;
+                }
 
                 for (const auto& bit : foundToken->bits) {
                     property.set(bit, tokenVal);
@@ -229,11 +232,12 @@ private:
             }
             return true;
         }
-        std::string getPropertyValueDescription() const override {
+        [[nodiscard]] std::string getPropertyValueDescription() const override {
             std::string supportedTokens = "comma separated filter tokens: ";
             for (size_t i = 0; i < propertyTokens.size(); i++) {
-                if (i)
+                if (i) {
                     supportedTokens.push_back(',');
+                }
                 supportedTokens.append(propertyTokens[i].name);
             }
             supportedTokens.append(
@@ -249,7 +253,6 @@ private:
     void readProperties();
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu
 
 #endif  // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/utils/general_utils.h
+++ b/src/plugins/intel_cpu/src/utils/general_utils.h
@@ -15,8 +15,7 @@
 #include "cpu_shape.h"
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 #if defined(__clang__) || defined(__GNUC__)
 #    define OV_CPU_FUNCTION_NAME __PRETTY_FUNCTION__
@@ -58,7 +57,7 @@ constexpr bool everyone_is(T val, P item, Args... item_others) {
     return val == item && everyone_is(val, item_others...);
 }
 
-constexpr inline bool implication(bool cause, bool cond) {
+constexpr bool implication(bool cause, bool cond) {
     return !cause || !!cond;
 }
 
@@ -80,7 +79,7 @@ std::string vec2str(const std::vector<T>& vec) {
         result << vec.back() << ")";
         return result.str();
     }
-    return std::string("()");
+    return "()";
 }
 
 /**
@@ -106,12 +105,14 @@ inline bool dimsEqualStrong(size_t lhs, size_t rhs) {
 inline bool dimsEqualStrong(const std::vector<size_t>& lhs,
                             const std::vector<size_t>& rhs,
                             size_t skipAxis = Shape::UNDEFINED_DIM) {
-    if (lhs.size() != rhs.size())
+    if (lhs.size() != rhs.size()) {
         return false;
+    }
 
     for (size_t i = 0; i < lhs.size(); i++) {
-        if (i != skipAxis && !dimsEqualStrong(lhs[i], rhs[i]))
+        if (i != skipAxis && !dimsEqualStrong(lhs[i], rhs[i])) {
             return false;
+        }
     }
 
     return true;
@@ -142,12 +143,14 @@ inline bool dimsEqualWeak(size_t lhs, size_t rhs) {
 inline bool dimsEqualWeak(const std::vector<size_t>& lhs,
                           const std::vector<size_t>& rhs,
                           size_t skipAxis = Shape::UNDEFINED_DIM) {
-    if (lhs.size() != rhs.size())
+    if (lhs.size() != rhs.size()) {
         return false;
+    }
 
     for (size_t i = 0; i < lhs.size(); i++) {
-        if (i != skipAxis && !dimsEqualWeak(lhs[i], rhs[i]))
+        if (i != skipAxis && !dimsEqualWeak(lhs[i], rhs[i])) {
             return false;
+        }
     }
 
     return true;
@@ -177,8 +180,9 @@ inline std::vector<std::string> split(const std::string& str, char delim) {
 
 template <class Container>
 inline std::string join(const Container& strs, char delim) {
-    if (strs.empty())
-        return std::string();
+    if (strs.empty()) {
+        return {};
+    }
 
     std::stringstream result;
     auto it = strs.begin();
@@ -201,5 +205,4 @@ inline bool all_of_values(const Container& container, const T& value) {
     });
 }
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/ngraph_transformation.hpp
+++ b/src/plugins/intel_cpu/src/utils/ngraph_transformation.hpp
@@ -21,8 +21,7 @@
 #    include "openvino/util/file_util.hpp"
 #    include "utils/platform.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class TransformationDumper {
 public:
@@ -34,12 +33,15 @@ public:
           type(type) {
         for (auto prev = infoMap.at(type).prev; prev != TransformationType::NumOfTypes; prev = infoMap.at(prev).prev) {
             // no need to serialize input graph if there was no transformations from previous dump
-            if (config.disable.transformations.filter[prev])
+            if (config.disable.transformations.filter[prev]) {
                 continue;
-            if (!config.dumpIR.transformations.filter[prev])
+            }
+            if (!config.dumpIR.transformations.filter[prev]) {
                 break;
-            if (wasDumped()[prev])
+            }
+            if (wasDumped()[prev]) {
                 return;
+            }
         }
         dump("_in");
     }
@@ -61,13 +63,13 @@ private:
     // std::hash<std::underlying_type<FILTER>::type> is necessary for Ubuntu-16.04 (gcc-5.4 and defect in C++11
     // standart)
     const std::
-        unordered_map<TransformationType, TransformationInfo, std::hash<std::underlying_type<TransformationType>::type>>
+        unordered_map<TransformationType, TransformationInfo, std::hash<std::underlying_type_t<TransformationType>>>
             infoMap = {{TransformationType::PreLpt, {"preLpt", TransformationType::NumOfTypes}},
                        {TransformationType::Lpt, {"lpt", TransformationType::PreLpt}},
                        {TransformationType::PostLpt, {"postLpt", TransformationType::Lpt}},
                        {TransformationType::Snippets, {"snippets", TransformationType::PostLpt}},
                        {TransformationType::Specific, {"cpuSpecific", TransformationType::Snippets}}};
-    std::bitset<TransformationType::NumOfTypes>& wasDumped(void) {
+    static std::bitset<TransformationType::NumOfTypes>& wasDumped() {
         static std::bitset<TransformationType::NumOfTypes> wasDumped;
         return wasDumped;
     }
@@ -103,8 +105,7 @@ private:
     }
 };
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu
 
 // 'EXPAND' wrapper is necessary to ensure __VA_ARGS__ behaves the same on all the platforms
 #    define CPU_DEBUG_CAP_EXPAND(x) x
@@ -112,18 +113,18 @@ private:
         _config.disable.transformations.filter[DebugCapsConfig::TransformationFilter::Type::_type]
 #    define CPU_DEBUG_CAP_IS_TRANSFORMATION_ENABLED(...) \
         CPU_DEBUG_CAP_EXPAND(!CPU_DEBUG_CAP_IS_TRANSFORMATION_DISABLED(__VA_ARGS__))
-#    define CPU_DEBUG_CAP_TRANSFORMATION_DUMP(_this, _type)                                                           \
-        OPENVINO_ASSERT(CPU_DEBUG_CAP_IS_TRANSFORMATION_ENABLED(_this->config.debugCaps, _type));                     \
-        auto dumperPtr =                                                                                              \
-            _this->config.debugCaps.dumpIR.transformations.filter[DebugCapsConfig::TransformationFilter::Type::_type] \
-                ? std::unique_ptr<TransformationDumper>(                                                              \
-                      new TransformationDumper(_this->config.debugCaps,                                               \
-                                               DebugCapsConfig::TransformationFilter::Type::_type,                    \
-                                               _this->model))                                                         \
-                : nullptr
-#    define CPU_DEBUG_CAP_TRANSFORMATION_SCOPE(_this, _type)                          \
-        if (CPU_DEBUG_CAP_IS_TRANSFORMATION_DISABLED(_this->config.debugCaps, _type)) \
-            return;                                                                   \
+#    define CPU_DEBUG_CAP_TRANSFORMATION_DUMP(_this, _type)                                                     \
+        OPENVINO_ASSERT(CPU_DEBUG_CAP_IS_TRANSFORMATION_ENABLED((_this)->config.debugCaps, _type));             \
+        auto dumperPtr = (_this)->config.debugCaps.dumpIR.transformations                                       \
+                                 .filter[DebugCapsConfig::TransformationFilter::Type::_type]                    \
+                             ? std::unique_ptr<TransformationDumper>(                                           \
+                                   new TransformationDumper((_this)->config.debugCaps,                          \
+                                                            DebugCapsConfig::TransformationFilter::Type::_type, \
+                                                            (_this)->model))                                    \
+                             : nullptr
+#    define CPU_DEBUG_CAP_TRANSFORMATION_SCOPE(_this, _type)                            \
+        if (CPU_DEBUG_CAP_IS_TRANSFORMATION_DISABLED((_this)->config.debugCaps, _type)) \
+            return;                                                                     \
         CPU_DEBUG_CAP_TRANSFORMATION_DUMP(_this, _type)
 #else
 #    define CPU_DEBUG_CAP_IS_TRANSFORMATION_DISABLED(_config, _type) false

--- a/src/plugins/intel_cpu/src/utils/node_dumper.h
+++ b/src/plugins/intel_cpu/src/utils/node_dumper.h
@@ -9,8 +9,7 @@
 #    include "openvino/util/file_util.hpp"
 #    include "utils/debug_caps_config.h"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 void dumpInputBlobs(const NodePtr& node, const DebugCapsConfig& config, int count = -1);
 void dumpOutputBlobs(const NodePtr& node, const DebugCapsConfig& config, int count = -1);
@@ -35,8 +34,8 @@ public:
 };
 
 #    define DUMP(...) DumpHelper __helper##__node(__VA_ARGS__);
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu
+
 #else  // CPU_DEBUG_CAPS
 #    define DUMP(...)
 #endif  // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -410,11 +410,13 @@ struct PlainTensor {
         return m_offset;
     }
     template <int dim, typename I>
-    int64_t offset(I i) const {
+    [[nodiscard]] [[nodiscard]] int64_t offset(I i) const {
         return m_offset + i * m_strides[dim];
     }
     template <int dim, typename I, typename... Is>
-    int64_t offset(I i, Is... indices) const {
+    [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] int64_t offset(
+        I i,
+        Is... indices) const {
         return i * m_strides[dim] + offset<dim + 1>(indices...);
     }
     template <typename DT, typename... Is>
@@ -439,13 +441,13 @@ struct PlainTensor {
     }
 
     template <typename... Is>
-    void* ptr_v(Is... indices) const {
+    [[nodiscard]] void* ptr_v(Is... indices) const {
         return reinterpret_cast<void*>(m_ptr.get() + offset<0>(indices...) * m_element_size / m_sub_byte_multiplier);
     }
 
     // when allow_broadcast is true, index to size-1 dim will always access 0.
     template <typename DT>
-    DT& at(const std::initializer_list<size_t>& index, bool allow_broadcast = false) const {
+    [[nodiscard]] [[nodiscard]] DT& at(const std::initializer_list<size_t>& index, bool allow_broadcast = false) const {
         size_t off = 0;
         const auto* it = index.begin();
         for (size_t i = 0; i < m_rank; i++) {

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -146,7 +146,10 @@ struct PlainTensor {
 
     PlainTensor() = default;
 
-    PlainTensor operator=(const PlainTensor& other) {
+    PlainTensor& operator=(const PlainTensor& other) {
+        if (this == &other) {
+            return *this;
+        }
         memcpy(&m_strides, &other.m_strides, sizeof(m_strides));
         memcpy(&m_dims, &other.m_dims, sizeof(m_dims));
         m_rank = other.m_rank;
@@ -188,7 +191,7 @@ struct PlainTensor {
         int count;
         // select all
         tensor_index() : start(0), end(INT_MAX), step(1) {}
-        bool slice_with_squeeze() {
+        [[nodiscard]] bool slice_with_squeeze() const {
             return end == INT_MIN;
         }
         // tensor_index(start)            : select 1 element (with squeeze)
@@ -364,7 +367,7 @@ struct PlainTensor {
         if (!data) {
             auto capacity_new = m_strides[0] * m_dims[0] * m_element_size;
             if (capacity_new > m_capacity) {
-                void* ptr;
+                void* ptr = nullptr;
 #ifdef _WIN32
                 ptr = _aligned_malloc(capacity_new, 64);
 #else
@@ -377,7 +380,7 @@ struct PlainTensor {
 #ifdef _WIN32
                     _aligned_free(ptr);
 #else
-                        ::free(ptr);
+                        ::free(ptr);  // NOLINT(cppcoreguidelines-no-malloc)
 #endif
                 });
                 m_capacity = capacity_new;
@@ -395,9 +398,10 @@ struct PlainTensor {
         resize(new_dims, sizeof(DT), precision_of<DT>::value, data, strides);
     }
 
-    size_t sub_byte_data_type_multiplier() const {
-        if (one_of(m_dt, ov::element::i4, ov::element::u4))
+    [[nodiscard]] size_t sub_byte_data_type_multiplier() const {
+        if (one_of(m_dt, ov::element::i4, ov::element::u4)) {
             return 2;
+        }
         return 1;
     }
 
@@ -443,7 +447,7 @@ struct PlainTensor {
     template <typename DT>
     DT& at(const std::initializer_list<size_t>& index, bool allow_broadcast = false) const {
         size_t off = 0;
-        auto it = index.begin();
+        const auto* it = index.begin();
         for (size_t i = 0; i < m_rank; i++) {
             size_t coordinate = (it != index.end()) ? (*it++) : 0;
             if (allow_broadcast && m_dims[i] == 1) {
@@ -491,7 +495,7 @@ struct PlainTensor {
         bool match = false;
         if (m_rank == expect_dims.size()) {
             match = true;
-            auto it = expect_dims.begin();
+            const auto* it = expect_dims.begin();
             for (size_t i = 0; i < m_rank; ++i, ++it) {
                 if (*it == 0 && special_zero) {
                     continue;
@@ -510,7 +514,7 @@ struct PlainTensor {
                 ss << m_dims[i] << ",";
             }
             ss << "] expect_dims=[";
-            for (auto& i : expect_dims) {
+            for (const auto& i : expect_dims) {
                 ss << i << ",";
             }
             ss << "]";
@@ -549,7 +553,7 @@ struct PlainTensor {
         int cur_row_lines_left = lines_per_row;
         size_t cur_line_elecnt = 0;
         size_t cur_row_elecnt = 0;
-        size_t i;
+        size_t i = 0;
         for (i = 0; i < sz && max_total_lines > 0; i++) {
             if ((i % last_dim_size) == 0 && m_rank > 1) {
                 ss << row_id << ":\t\t";

--- a/src/plugins/intel_cpu/src/utils/precision_support.h
+++ b/src/plugins/intel_cpu/src/utils/precision_support.h
@@ -6,12 +6,10 @@
 
 #include "openvino/core/type/element_type.hpp"
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 bool hasHardwareSupport(const ov::element::Type& precision);
 ov::element::Type defaultFloatPrecision();
 bool hasIntDotProductSupport();
 
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
+++ b/src/plugins/intel_cpu/src/utils/rt_info/memory_formats_attribute.hpp
@@ -40,7 +40,7 @@ public:
     [[nodiscard]] ov::Any merge(const ov::NodeVector& nodes) const override {
         std::set<std::string> unique_mem_format;
 
-        for (auto& node : nodes) {
+        for (const auto& node : nodes) {
             auto it_info = node->get_rt_info().find(MemoryFormat::get_type_info_static());
             if (it_info != node->get_rt_info().end()) {
                 std::string mem_format = it_info->second.template as<MemoryFormat>().to_string();

--- a/src/plugins/intel_cpu/src/utils/verbose.h
+++ b/src/plugins/intel_cpu/src/utils/verbose.h
@@ -11,8 +11,7 @@
 #    include <sstream>
 #    include <string>
 
-namespace ov {
-namespace intel_cpu {
+namespace ov::intel_cpu {
 
 class Verbose {
 public:
@@ -20,15 +19,17 @@ public:
         : node(_node),
           lvl(atoi(_lvl.c_str()) % 10),
           /* 1,  2,  3,  etc -> no color. 11, 22, 33, etc -> colorize */
-          colorUp(atoi(_lvl.c_str()) / 10) {
-        if (!shouldBePrinted())
+          colorUp((atoi(_lvl.c_str()) / 10) != 0) {
+        if (!shouldBePrinted()) {
             return;
+        }
         printInfo();
     }
 
     ~Verbose() {
-        if (!shouldBePrinted())
+        if (!shouldBePrinted()) {
             return;
+        }
 
         printDuration();
         flush();
@@ -48,8 +49,8 @@ private:
 
 // use heap allocation instead of stack to align with PERF macro (to have proper destruction order)
 #    define VERBOSE(...) const auto verbose = std::unique_ptr<Verbose>(new Verbose(__VA_ARGS__));
-}  // namespace intel_cpu
-}  // namespace ov
+}  // namespace ov::intel_cpu
+
 #else
 #    define VERBOSE(...)
 #endif  // CPU_DEBUG_CAPS

--- a/src/plugins/intel_cpu/src/weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/weights_cache.hpp
@@ -95,7 +95,7 @@ public:
     const WeightsSharing::Ptr& operator[](int socket_id) const;
 
 #ifdef CPU_DEBUG_CAPS
-    std::vector<std::pair<int, WeightsSharing::Statistics>> dumpStatistics() const;
+    [[nodiscard]] std::vector<std::pair<int, WeightsSharing::Statistics>> dumpStatistics() const;
 #endif  // CPU_DEBUG_CAPS
 
 private:

--- a/src/plugins/intel_cpu/tests/functional/custom/behavior/ov_executable_network/concurent_release_memory.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/behavior/ov_executable_network/concurent_release_memory.cpp
@@ -17,7 +17,7 @@ namespace ov {
 namespace test {
 // Openvino extension operation that sleeps for X us in its evaluate method
 namespace {
-enum class TestSteps { INIT, ENTER_EVALUATE, RUN_EVALUATE };
+enum class TestSteps : uint8_t { INIT, ENTER_EVALUATE, RUN_EVALUATE };
 }  // namespace
 
 class SleepCustomOp : public ov::op::Op {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/conversion.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/conversion.hpp
@@ -13,7 +13,7 @@ using namespace CPUTestUtils;
 
 namespace ov {
 namespace test {
-enum SpecialValue { none, nan, inf, overflow };
+enum SpecialValue : uint8_t { none, nan, inf, overflow };
 
 using convertLayerTestParamsSet = std::tuple<InputShape,         // input shapes
                                              ov::element::Type,  // input precision

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.hpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.hpp
@@ -12,7 +12,7 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 
-enum class MatMulNodeType {
+enum class MatMulNodeType : uint8_t {
     MatMul,
     FullyConnected
 };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/deformable_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/deformable_convolution.cpp
@@ -10,7 +10,7 @@
 using namespace CPUTestUtils;
 namespace ov {
 namespace test {
-enum OffsetType { ZERO, NATURAL, REAL_POSITIVE, REAL_NEGATIVE, REAL_MISC };
+enum OffsetType : uint8_t { ZERO, NATURAL, REAL_POSITIVE, REAL_NEGATIVE, REAL_MISC };
 
 typedef std::tuple<bool,       // with_bilinear_interpolation_pad
                    bool,       // with_modulation

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roi_pooling.cpp
@@ -16,7 +16,7 @@ using namespace CPUTestUtils;
 
 namespace ov {
 namespace test {
-enum ProposalGenerationMode { RANDOM, ULTIMATE_RIGHT_BORDER };
+enum ProposalGenerationMode : uint8_t { RANDOM, ULTIMATE_RIGHT_BORDER };
 
 using roiPoolingShapes = std::vector<InputShape>;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shape_ops.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shape_ops.cpp
@@ -18,7 +18,7 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 
-enum class shapeNodeType { Reshape, Squeeze, Unsqueeze, ReshapeWithNonZero };
+enum class shapeNodeType : uint8_t { Reshape, Squeeze, Unsqueeze, ReshapeWithNonZero };
 
 inline std::ostream& operator<<(std::ostream& os, shapeNodeType type) {
     switch (type) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/lora_pattern.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/lora_pattern.cpp
@@ -25,7 +25,7 @@ constexpr auto t5_name = "lora/MatMul.alpha";
 constexpr auto t6_name = "lora/MatMul.A";
 constexpr auto netType = ov::element::f32;
 
-enum class StatesPolicy {
+enum class StatesPolicy : uint8_t {
     EMPTY_TENSORS,
     RANDOM_TENSORS,
     UNDEFINED

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/quantized_matmuls_with_shared_weights.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/quantized_matmuls_with_shared_weights.cpp
@@ -16,7 +16,7 @@
 namespace ov {
 namespace test {
 
-enum class FQInterval { U8, I8 };
+enum class FQInterval : uint8_t { U8, I8 };
 inline std::ostream& operator<<(std::ostream& os, FQInterval interval) {
     switch (interval) {
     case FQInterval::U8:

--- a/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.hpp
@@ -88,7 +88,7 @@ using CPUSpecificParams = std::tuple<std::vector<cpu_memory_format_t>,  // input
                                      std::string                        // selected primitive type
                                      >;
 
-enum class nodeType { convolution, convolutionBackpropData, groupConvolution, groupConvolutionBackpropData };
+enum class nodeType : uint8_t { convolution, convolutionBackpropData, groupConvolution, groupConvolutionBackpropData };
 
 inline std::string nodeType2PluginType(nodeType nt) {
     if (nt == nodeType::convolution)

--- a/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/jit_kernel_test.cpp
@@ -175,8 +175,8 @@ private:
             load(a, a_ptr);
             load(b, b_ptr);
 
-            a.blend(b, 0xAAAA);
-            a.permute(order);
+            std::ignore = a.blend(b, 0xAAAA);
+            std::ignore = a.permute(order);
 
             store(result, a);
 

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
@@ -24,7 +24,7 @@
 using namespace testing;
 using namespace ov::intel_cpu;
 
-enum class ZeroPointType { NO_ZP, ZP_WEIGHTS_PRC, ZP_DECOMPRESSION_PRC };
+enum class ZeroPointType : uint8_t { NO_ZP, ZP_WEIGHTS_PRC, ZP_DECOMPRESSION_PRC };
 inline std::ostream& operator<<(std::ostream& os, ZeroPointType type) {
     switch (type) {
         case ZeroPointType::NO_ZP:
@@ -42,7 +42,7 @@ inline std::ostream& operator<<(std::ostream& os, ZeroPointType type) {
     return os;
 }
 
-enum class ZeroPointShape { SCALAR, PER_CHANNEL };
+enum class ZeroPointShape : uint8_t { SCALAR, PER_CHANNEL };
 inline std::ostream& operator<<(std::ostream& os, ZeroPointShape type) {
     switch (type) {
         case ZeroPointShape::SCALAR:

--- a/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/state_concat_sdpa.cpp
@@ -33,7 +33,7 @@ using namespace ov::intel_cpu;
 using namespace ov::gen_pattern;
 
 namespace {
-    enum InsertPoint {
+    enum InsertPoint : uint8_t {
         At_None,
         At_Convert,
         At_Gather,

--- a/src/plugins/intel_cpu/tests/unit/vectorized/paged_attn_cache_rotation.cpp
+++ b/src/plugins/intel_cpu/tests/unit/vectorized/paged_attn_cache_rotation.cpp
@@ -254,7 +254,7 @@ TYPED_TEST_P(CacheRotationKernelInputTypeParameterizedTest, RefBlockRotationGive
     compare_with_tolerance(test_values_after_rotation, this->ref_values_after_rotation, get_tolerance<TypeParam>());
 }
 
-enum class TargetInstructionSet { AVX2, AVX512 };
+enum class TargetInstructionSet : uint8_t { AVX2, AVX512 };
 
 #if defined(__GNUC__)
 #pragma GCC diagnostic push


### PR DESCRIPTION
### Details:
 - Enable clang-tidy checks on header files located in CPU plugin

### Tickets:
 - N/A
