### PR TITLE
[NPU] Add U2 precision support in NPU plugin

### DIFF
--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -701,6 +701,8 @@ void ZeroInferRequest::check_network_precision(const ov::element::Type_t precisi
         break;
     case ov::element::Type_t::nf4:
         break;
+    case ov::element::Type_t::u2:
+        break;
     case ov::element::Type_t::u4:
         break;
     case ov::element::Type_t::i4:
@@ -726,9 +728,10 @@ void ZeroInferRequest::check_network_precision(const ov::element::Type_t precisi
     case ov::element::Type_t::boolean:
         break;
     default:
-        OPENVINO_THROW("Unsupported tensor precision: " + ov::element::Type(precision).get_type_name() +
-                       "! Supported precisions: FP32, FP16, BF16, FP8, NF4, U4, I4, U8, I8, U16, I16, U32, I32, U64, "
-                       "I64, FP64, BOOLEAN");
+        OPENVINO_THROW(
+            "Unsupported tensor precision: " + ov::element::Type(precision).get_type_name() +
+            "! Supported precisions: FP32, FP16, BF16, FP8, NF4, U2, U4, I4, U8, I8, U16, I16, U32, I32, U64, "
+            "I64, FP64, BOOLEAN");
     }
 }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/driver_compiler_adapter.cpp
@@ -105,6 +105,8 @@ std::string ovPrecisionToLegacyPrecisionString(const ov::element::Type& precisio
         return "U64";
     case ov::element::Type_t::u1:
         return "BIN";
+    case ov::element::Type_t::u2:
+        return "U2";
     case ov::element::Type_t::boolean:
         return "BOOL";
     case ov::element::Type_t::dynamic:

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -103,6 +103,8 @@ static inline ov::element::Type_t toOVElementType(const ze_graph_argument_precis
         return ov::element::Type_t::i32;
     case ZE_GRAPH_ARGUMENT_PRECISION_INT64:
         return ov::element::Type_t::i64;
+    case ZE_GRAPH_ARGUMENT_PRECISION_UINT2:
+        return ov::element::Type_t::u2;
     case ZE_GRAPH_ARGUMENT_PRECISION_BIN:
         return ov::element::Type_t::u1;
     case ZE_GRAPH_ARGUMENT_PRECISION_UINT4:

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -64,6 +64,7 @@ const std::vector<ov::element::Type> prcs = {
     ov::element::i32,
     ov::element::i64,
     ov::element::u1,
+    ov::element::u2,
     ov::element::u4,
     ov::element::u8,
     ov::element::u16,

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -915,4 +915,12 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#170977 -->
+    <skip_config>
+        <message>Tests currently skipped until u2 precision fully supported (need NPU compiler alignment/driver update)</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u2.*</filter>
+        </filters>
+    </skip_config>
+
 </skip_configs>

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/skip_tests.xml
@@ -914,4 +914,12 @@ Example:
             <filter>.*TestCompiledModelNPU.samePlatformProduceTheSameBlobCacheEnabled.*</filter>
         </filters>
     </skip_config>
+
+    <!-- E#170977 -->
+    <skip_config>
+        <message>Tests currently skipped until u2 precision fully supported (need NPU compiler alignment/driver update)</message>
+        <filters>
+            <filter>.*InferRequestCheckTensorPrecision.*type=u2.*</filter>
+        </filters>
+    </skip_config>
 </skip_configs>

--- a/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/io_tensor.hpp
+++ b/src/tests/functional/plugin/shared/include/behavior/ov_infer_request/io_tensor.hpp
@@ -68,6 +68,7 @@ struct OVInferRequestCheckTensorPrecision : public testing::WithParamInterface<O
         ov::element::i32,
         ov::element::i64,
         ov::element::u1,
+        ov::element::u2,
         ov::element::u4,
         ov::element::u8,
         ov::element::u16,


### PR DESCRIPTION
### Details:
 - *Add U2 precision support for NPU. Support for I2 not available yet in OV.*
 - *Update L0 extension which include I2/U2 graph arg precision.*
 - *Add tests - currently skipped until fully supported (need NPU compiler alignment - driver update).*
 
### Tickets:
 - *E-170977*
