### PR TITLE
[Py OV] [DOCS] Remove use of openvino-nightly PyPI module

### DIFF
--- a/docs/documentation_build_instructions.md
+++ b/docs/documentation_build_instructions.md
@@ -44,5 +44,6 @@ $ source env/bin/activate
 Depending on the needs, following variables can be added to first cmake call:
 - building C/C++ API:  `-DENABLE_CPP_API=ON`
 - building Python API: `-DENABLE_PYTHON_API=ON`
+- building GenAI API:  `-DENABLE_GENAI_API=ON`
 - building Notebooks:  `-DENABLE_NOTEBOOKS=ON`
 - building OVMS:       `-DENABLE_OVMS=ON -DOVMS_DOCS_DIR=<path_to_OVMS_repo>`

--- a/docs/documentation_build_instructions.md
+++ b/docs/documentation_build_instructions.md
@@ -47,3 +47,6 @@ Depending on the needs, following variables can be added to first cmake call:
 - building GenAI API:  `-DENABLE_GENAI_API=ON`
 - building Notebooks:  `-DENABLE_NOTEBOOKS=ON`
 - building OVMS:       `-DENABLE_OVMS=ON -DOVMS_DOCS_DIR=<path_to_OVMS_repo>`
+
+> > **Note:** When building the Python API documentation, the OpenVINO package version specified in [conf.py](./sphinx_setup/conf.py) is automatically downloaded using the [installation script](./scripts/install_appropriate_openvino_version.py).  
+> If you need a specific version or want to use an already installed OpenVINO package, modify these files accordingly.

--- a/docs/scripts/install_appropriate_openvino_version.py
+++ b/docs/scripts/install_appropriate_openvino_version.py
@@ -75,4 +75,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    

--- a/docs/scripts/install_appropriate_openvino_version.py
+++ b/docs/scripts/install_appropriate_openvino_version.py
@@ -31,6 +31,13 @@ def install_package(python_executable, package):
     subprocess.check_call([f'{python_executable}', '-m', 'pip', 'install', '-U', package, '--no-cache-dir'])
 
 
+def install_package_from_simple(python_executable, package):
+    subprocess.check_call([
+        f'{python_executable}', '-m', 'pip', 'install', '--pre', package,
+        '--extra-index-url', 'https://storage.openvinotoolkit.org/simple/wheels/nightly'
+    ])
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--ov_dir', type=Path, help='OpenVINO docs directory')
@@ -41,8 +48,12 @@ def main():
     version_name = determine_openvino_version(args.ov_dir.joinpath("conf.py"))
 
     if version_name == "nightly":
-        install_package(args.python, "openvino-nightly")
-        print("OpenVINO nightly version installed. OpenVINO GenAI nightly version is not available.")
+        install_package_from_simple(args.python, "openvino")
+        if args.enable_genai == 'ON':
+            install_package_from_simple(args.python, "openvino-genai")
+            print("OpenVINO nightly version installed. GenAI API nightly version installed.")
+        else:
+            print("OpenVINO nightly version installed. GenAI API disabled.")
     elif version_name is None or version_name == "latest":
         install_package(args.python, "openvino")
         if args.enable_genai == 'ON':
@@ -64,3 +75,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    


### PR DESCRIPTION
### Details:
 - Script for building Python API documentation was using the deprecated [openvino-nightly](https://pypi.org/project/openvino-nightly/) PyPI module.
 - Replace old command with `pip install --pre openvino --extra-index-url
https://storage.openvinotoolkit.org/simple/wheels/nightly`
- Download Python GenAI nightly from Simple PyPI if `-DENABLE_GENAI_API=ON`

### Tickets:
 - [CVS-165961](https://jira.devtools.intel.com/browse/CVS-165961)
