### PR TITLE
Disable sporadicaly failing test on Windows

### DIFF
--- a/src/inference/tests/functional/ov_core_threading.cpp
+++ b/src/inference/tests/functional/ov_core_threading.cpp
@@ -104,6 +104,10 @@ TEST_F(CoreThreadingTests, RegisterPlugin) {
 
 // tested function: RegisterPlugins
 TEST_F(CoreThreadingTests, RegisterPlugins) {
+#    ifdef _WIN32
+    // TODO: CVS-133087
+    GTEST_SKIP() << "This test sporadically crashes on Windows";
+#    endif
     ov::Core core;
     std::atomic<unsigned int> index{0};
     auto file_prefix = ov::test::utils::generateTestFilePrefix();


### PR DESCRIPTION
### Details:
 - Disable CoreThreadingTests.RegisterPlugins test, because it sporadically crashes on Windows. Obvious solution was not found. Disabled until is fixed

### Tickets:
 - CVS-133087
