### PR TITLE
[NPU] Dynamic batching via BatchMode::PLUGIN 

### DIFF
--- a/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_infer_request.hpp
@@ -89,6 +89,7 @@ private:
     std::unique_ptr<Pipeline> _pipeline;
 
     bool _pipelineIsCreated = false;
+    bool _pipelineNeedsReallocation = false;
 };
 
 }  //  namespace intel_npu

--- a/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
+++ b/src/plugins/intel_npu/src/backend/include/zero_pipeline.hpp
@@ -19,7 +19,8 @@ public:
              const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
              const std::shared_ptr<IGraph>& graph,
              const std::vector<std::vector<std::shared_ptr<ov::ITensor>>>& input_tensors,
-             const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors);
+             const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors,
+             size_t batch_size = 1);
 
     Pipeline(const Pipeline&) = delete;
     Pipeline& operator=(const Pipeline&) = delete;

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -150,11 +150,8 @@ void ZeroInferRequest::create_pipeline() {
                                   _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str(),
                                   batchSize.value());
 
-                    get_level_zero_input(inputIndex, i) = allocate_tensor(_metadata.inputs.at(inputIndex),
-                                                                          inputIndex,
-                                                                          true,
-                                                                          *_inputAllocator,
-                                                                          batchSize);
+                    get_level_zero_input(inputIndex, i) =
+                        allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator, batchSize);
                 }
             }
             continue;

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -101,8 +101,7 @@ ZeroInferRequest::ZeroInferRequest(const std::shared_ptr<ZeroInitStructsHolder>&
             continue;
         }
 
-        get_level_zero_input(ioIndex) =
-            allocate_tensor(inputDescriptor, ioIndex, INPUT, *_inputAllocator, batchSize);
+        get_level_zero_input(ioIndex) = allocate_tensor(inputDescriptor, ioIndex, INPUT, *_inputAllocator, batchSize);
 
         ++ioIndex;
     }
@@ -134,15 +133,15 @@ void ZeroInferRequest::create_pipeline() {
             //     _logger.debug("ZeroInferRequest::create_pipeline - tensors %s were already allocated",
             //                   _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
             // } else {
-                for (size_t i = 0; i < get_user_inputs(inputIndex).size(); i++) {
-                    get_level_zero_inputs(inputIndex).resize(get_user_inputs(inputIndex).size());
+            for (size_t i = 0; i < get_user_inputs(inputIndex).size(); i++) {
+                get_level_zero_inputs(inputIndex).resize(get_user_inputs(inputIndex).size());
 
-                    _logger.debug("ZeroInferRequest::create_pipeline - allocate new input tensor for batched input: %s",
-                                  _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
+                _logger.debug("ZeroInferRequest::create_pipeline - allocate new input tensor for batched input: %s",
+                              _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
 
-                    get_level_zero_input(inputIndex, i) =
-                        allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator, batch_size);
-                }
+                get_level_zero_input(inputIndex, i) =
+                    allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, true, *_inputAllocator, batch_size);
+            }
             // }
             continue;
         }
@@ -155,11 +154,8 @@ void ZeroInferRequest::create_pipeline() {
 
         _logger.debug("ZeroInferRequest::create_pipeline - allocate new input tensor %s",
                       _metadata.inputs.at(inputIndex).nodeFriendlyName.c_str());
-        get_level_zero_input(inputIndex) = allocate_tensor(_metadata.inputs.at(inputIndex),
-                                                           inputIndex,
-                                                           INPUT,
-                                                           *_inputAllocator,
-                                                           batch_size);
+        get_level_zero_input(inputIndex) =
+            allocate_tensor(_metadata.inputs.at(inputIndex), inputIndex, INPUT, *_inputAllocator, batch_size);
     }
 
     for (size_t outputIndex = 0; outputIndex < _metadata.outputs.size(); ++outputIndex) {
@@ -170,11 +166,8 @@ void ZeroInferRequest::create_pipeline() {
         }
         _logger.debug("ZeroInferRequest::create_pipeline - allocate new output tensor %s",
                       _metadata.outputs.at(outputIndex).nodeFriendlyName.c_str());
-        _levelZeroOutputTensors.at(outputIndex) = allocate_tensor(_metadata.outputs.at(outputIndex),
-                                                                  outputIndex,
-                                                                  OUTPUT,
-                                                                  *_outputAllocator,
-                                                                  batch_size);
+        _levelZeroOutputTensors.at(outputIndex) =
+            allocate_tensor(_metadata.outputs.at(outputIndex), outputIndex, OUTPUT, *_outputAllocator, batch_size);
     }
     _logger.debug("ZeroInferRequest::create_pipeline - init completed");
 
@@ -204,8 +197,12 @@ void ZeroInferRequest::create_pipeline() {
     _logger.debug("ZeroInferRequest::create_pipeline - constructing pipeline");
 
     // Construct pipeline
-    _pipeline =
-        std::make_unique<Pipeline>(_config, _initStructs, _graph, _levelZeroInputTensors, _levelZeroOutputTensors, batch_size.has_value() ? batch_size.value() : 1);
+    _pipeline = std::make_unique<Pipeline>(_config,
+                                           _initStructs,
+                                           _graph,
+                                           _levelZeroInputTensors,
+                                           _levelZeroOutputTensors,
+                                           batch_size.has_value() ? batch_size.value() : 1);
 
     _logger.debug("ZeroInferRequest::create_pipeline - SyncInferRequest completed");
 }
@@ -385,8 +382,11 @@ void ZeroInferRequest::set_tensors(const ov::Output<const ov::Node>& port,
                         _logger.debug("ZeroInferRequest::set_tensors - tensor wasn't created in the same L0 context, "
                                       "create a L0 tensor");
 
-                        get_level_zero_input(foundPort.idx, i) =
-                            allocate_tensor(_metadata.inputs.at(foundPort.idx), foundPort.idx, true, *_inputAllocator, batch_size);
+                        get_level_zero_input(foundPort.idx, i) = allocate_tensor(_metadata.inputs.at(foundPort.idx),
+                                                                                 foundPort.idx,
+                                                                                 true,
+                                                                                 *_inputAllocator,
+                                                                                 batch_size);
                     }
 
                     data = get_level_zero_input(foundPort.idx, i)->data();
@@ -445,11 +445,8 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
     std::vector<ov::SoPtr<ov::ITensor>> tensorVector = {userTensors};
     auto batch_size = _graph->get_batch_size(_metadata, tensorVector);
 
-    levelZeroTensors = allocate_tensor(metadata,
-                                       ioIndex,
-                                       isInput,
-                                       isInput ? *_inputAllocator : *_outputAllocator,
-                                       batch_size);
+    levelZeroTensors =
+        allocate_tensor(metadata, ioIndex, isInput, isInput ? *_inputAllocator : *_outputAllocator, batch_size);
 
     auto zeroTensor = std::dynamic_pointer_cast<ZeroTensor>(levelZeroTensors);
     if (zeroTensor != nullptr) {
@@ -566,9 +563,9 @@ void ZeroInferRequest::infer_async() {
 
         if (!_pipelineIsCreated || _pipelineNeedsReallocation) {
             OV_ITT_TASK_NEXT(ZERO_INFER, "create_pipeline");
-            create_pipeline(); // Reallocate pipeline if necessary
+            create_pipeline();  // Reallocate pipeline if necessary
             _pipelineIsCreated = true;
-            _pipelineNeedsReallocation = false; // Reset reallocation flag
+            _pipelineNeedsReallocation = false;  // Reset reallocation flag
         } else {
             if (_initStructs->getMutableCommandListExtVersion() >= ZE_MAKE_VERSION(1, 0)) {
                 update_pipeline_if_memory_changed();

--- a/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_infer_request.cpp
@@ -21,6 +21,8 @@ constexpr std::size_t SINGLE_TENSOR = 0;
 constexpr bool INPUT = true;
 constexpr bool OUTPUT = false;
 
+constexpr std::size_t DEFAULT_BATCH_SIZE = 1;
+
 /**
  * @brief Checks that the metadata of the provided descriptor corresponds to the values registered in the Level Zero
  * structure.
@@ -219,7 +221,7 @@ void ZeroInferRequest::create_pipeline() {
                                            _graph,
                                            _levelZeroInputTensors,
                                            _levelZeroOutputTensors,
-                                           batchSize.has_value() ? batchSize.value() : 1);
+                                           batchSize.has_value() ? batchSize.value() : DEFAULT_BATCH_SIZE);
 
     _logger.debug("ZeroInferRequest::create_pipeline - SyncInferRequest completed");
 }
@@ -344,7 +346,7 @@ void ZeroInferRequest::set_tensor(const ov::Output<const ov::Node>& port, const 
             get_user_inputs(foundPort.idx).resize(1);
             get_user_inputs(foundPort.idx).shrink_to_fit();
 
-            _graph->set_batch_size(batchSizeCandidate.has_value() ? batchSizeCandidate.value() : 1);
+            _graph->set_batch_size(batchSizeCandidate.has_value() ? batchSizeCandidate.value() : DEFAULT_BATCH_SIZE);
         }
 
         get_user_input(foundPort.idx) = tensor;
@@ -535,7 +537,7 @@ ov::SoPtr<ov::ITensor> ZeroInferRequest::get_tensor(const ov::Output<const ov::N
     if (!isInput && _pipelineNeedsReallocation) {
         _logger.debug(
             "ZeroInferRequest::get_tensor - set new output tensor as pipeline reallocated required, batch size: %zu",
-            batch_size.has_value() ? batch_size.value() : 0);
+            batch_size.has_value() ? batch_size.value() : DEFAULT_BATCH_SIZE);
         userTensors = levelZeroTensors;
     }
 

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -35,7 +35,7 @@ Pipeline::Pipeline(const Config& config,
         _graph->resize_last_submitted_event(_number_of_command_lists);
     }
 
-    _logger.debug("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
+    _logger.info("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||
                         _init_structs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -34,7 +34,7 @@ Pipeline::Pipeline(const Config& config,
         _config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
         _graph->resize_last_submitted_event(_number_of_command_lists);
     }
-    
+
     _logger.debug("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -88,7 +88,7 @@ Pipeline::Pipeline(const Config& config,
     }
 
     for (size_t i = 0; i < _number_of_command_lists; i++) {
-        _logger.debug("set args for command list number: %zu", i);
+        _logger.debug("Pipeline - set args for command list number: %zu", i);
         size_t io_index = 0;
         for (const auto& desc : graph->get_input_descriptors()) {
             if (isMainInputWeightsName(desc.info.name)) {
@@ -97,7 +97,7 @@ Pipeline::Pipeline(const Config& config,
             }
 
             if (io_index < input_tensors.size() && input_tensors.at(io_index).size() > 1) {
-                _logger.debug("set args for input index: %zu", io_index);
+                _logger.debug("Pipeline - set args for input index: %zu", io_index);
                 void* data = nullptr;
                 auto remote_tensor = std::dynamic_pointer_cast<ZeroRemoteTensor>(input_tensors.at(io_index).at(i));
                 if (remote_tensor == nullptr) {

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -16,20 +16,26 @@
 #include "intel_npu/utils/zero/zero_types.hpp"
 
 namespace intel_npu {
-
 Pipeline::Pipeline(const Config& config,
                    const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                    const std::shared_ptr<IGraph>& graph,
                    const std::vector<std::vector<std::shared_ptr<ov::ITensor>>>& input_tensors,
-                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors)
+                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors, size_t batch_size)
     : _init_structs(init_structs),
       _graph(graph),
       _config(config),
       _id(_graph->get_unique_id()),
-      _number_of_command_lists(_graph->get_batch_size().has_value() ? *_graph->get_batch_size() : 1),
+      _number_of_command_lists(_graph->get_batch_size().has_value() ? *_graph->get_batch_size() : batch_size),
       _logger("Pipeline", _config.get<LOG_LEVEL>()) {
     OV_ITT_SCOPED_TASK(itt::domains::LevelZeroBackend, "Zero_infer_request::Pipeline::Pipeline");
-    _logger.debug("Pipeline - initialize started");
+    auto batch = _graph->get_batch_size().has_value() ? *_graph->get_batch_size() : batch_size;
+
+    if (_init_structs->getCommandQueueDdiTable().version() < ZE_MAKE_VERSION(1, 1) &&
+        _config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
+        _graph->resize_last_submitted_event(_number_of_command_lists);
+    }
+    
+    _logger.debug("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||
                         _init_structs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),
@@ -86,7 +92,7 @@ Pipeline::Pipeline(const Config& config,
                 continue;
             }
 
-            if (input_tensors.at(io_index).size() > 1) {
+            if (io_index < input_tensors.size() && input_tensors.at(io_index).size() > 1) {
                 void* data = nullptr;
                 auto remote_tensor = std::dynamic_pointer_cast<ZeroRemoteTensor>(input_tensors.at(io_index).at(i));
                 if (remote_tensor == nullptr) {

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -20,7 +20,8 @@ Pipeline::Pipeline(const Config& config,
                    const std::shared_ptr<ZeroInitStructsHolder>& init_structs,
                    const std::shared_ptr<IGraph>& graph,
                    const std::vector<std::vector<std::shared_ptr<ov::ITensor>>>& input_tensors,
-                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors, size_t batch_size)
+                   const std::vector<std::shared_ptr<ov::ITensor>>& output_tensors,
+                   size_t batch_size)
     : _init_structs(init_structs),
       _graph(graph),
       _config(config),
@@ -35,7 +36,9 @@ Pipeline::Pipeline(const Config& config,
         _graph->resize_last_submitted_event(_number_of_command_lists);
     }
 
-    _logger.info("Pipeline - initialize started, batch %i, number_of_command_lists %i", batch, _number_of_command_lists);
+    _logger.info("Pipeline - initialize started, batch %i, number_of_command_lists %i",
+                 batch,
+                 _number_of_command_lists);
 
     OPENVINO_ASSERT(_sync_output_with_fences || !_config.get<RUN_INFERENCES_SEQUENTIALLY>() ||
                         _init_structs->getCommandQueueDdiTable().version() >= ZE_MAKE_VERSION(1, 1),

--- a/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
+++ b/src/plugins/intel_npu/src/backend/src/zero_pipeline.cpp
@@ -88,6 +88,7 @@ Pipeline::Pipeline(const Config& config,
     }
 
     for (size_t i = 0; i < _number_of_command_lists; i++) {
+        _logger.debug("set args for command list number: %zu", i);
         size_t io_index = 0;
         for (const auto& desc : graph->get_input_descriptors()) {
             if (isMainInputWeightsName(desc.info.name)) {
@@ -96,6 +97,7 @@ Pipeline::Pipeline(const Config& config,
             }
 
             if (io_index < input_tensors.size() && input_tensors.at(io_index).size() > 1) {
+                _logger.debug("set args for input index: %zu", io_index);
                 void* data = nullptr;
                 auto remote_tensor = std::dynamic_pointer_cast<ZeroRemoteTensor>(input_tensors.at(io_index).at(i));
                 if (remote_tensor == nullptr) {

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -18,6 +18,13 @@
 
 namespace intel_npu {
 
+struct IONodeMetadata {
+    IONodeMetadata() = default;
+    IONodeMetadata(const ArgumentDescriptor&d);
+    std::optional<ArgumentDescriptor> descriptor;
+    std::optional<size_t> extract_batch(const ov::Shape &shape) const;
+};
+
 class IGraph : public std::enable_shared_from_this<IGraph> {
 public:
     IGraph(ze_graph_handle_t handle, NetworkMetadata metadata, const Config& config, std::optional<ov::Tensor> blob);
@@ -59,15 +66,16 @@ public:
     const std::shared_ptr<Event>& get_last_submitted_event(size_t indexOfCommandList) const;
     void resize_last_submitted_event(size_t batch);
     void set_batch_size(std::size_t batch);
+    void reset_last_batch_size();
 
     uint32_t get_unique_id();
     void set_last_submitted_id(uint32_t id_index);
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
-    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors) const;
+    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors, const IONodeMetadata &input_output_info) const;
 
-    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors);
+    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors, const IONodeMetadata &input_output_info);
 
 protected:
     /**

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -22,7 +22,9 @@ struct IONodeMetadata {
     IONodeMetadata(const ArgumentDescriptor& d);
     std::optional<ArgumentDescriptor> descriptor;
     std::optional<size_t> extract_batch(const ov::Shape& shape) const;
-    std::optional<size_t> extract_batch(const ov::Shape& shape, std::optional<ov::PartialShape> partial_shape) const;
+    std::optional<size_t> extract_batch(const ov::Shape& shape,
+                                        std::optional<ov::PartialShape> partial_shape_ir,
+                                        std::optional<ov::PartialShape> partial_shape_compiler) const;
 };
 
 class IGraph : public std::enable_shared_from_this<IGraph> {

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -13,6 +13,9 @@
 #include "intel_npu/utils/zero/zero_wrappers.hpp"
 #include "openvino/runtime/profiling_info.hpp"
 
+#include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/so_ptr.hpp"
+
 namespace intel_npu {
 
 class IGraph : public std::enable_shared_from_this<IGraph> {
@@ -54,12 +57,16 @@ public:
 
     void set_last_submitted_event(const std::shared_ptr<Event>& event, size_t indexOfCommandList);
     const std::shared_ptr<Event>& get_last_submitted_event(size_t indexOfCommandList) const;
+    void resize_last_submitted_event(size_t batch);
 
     uint32_t get_unique_id();
     void set_last_submitted_id(uint32_t id_index);
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
+    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors) const;
+
+    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors);
 
 protected:
     /**
@@ -79,7 +86,6 @@ protected:
      * @returns The batch size deduced by the algorithm or the default value of 1 if batching cannot be performed inside
      * the plugin.
      */
-    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata);
 
     ze_graph_handle_t _handle = nullptr;
     NetworkMetadata _metadata;

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -22,9 +22,7 @@ struct IONodeMetadata {
     IONodeMetadata(const ArgumentDescriptor& d);
     std::optional<ArgumentDescriptor> descriptor;
     std::optional<size_t> extract_batch(const ov::Shape& shape) const;
-    std::optional<size_t> extract_batch(const ov::Shape& shape,
-                                        std::optional<ov::PartialShape> partial_shape_ir,
-                                        std::optional<ov::PartialShape> partial_shape_compiler) const;
+    std::optional<size_t> extract_batch(const ov::Shape& shape, std::optional<ov::PartialShape> partial_shape) const;
 };
 
 class IGraph : public std::enable_shared_from_this<IGraph> {

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -23,6 +23,9 @@ struct IONodeMetadata {
     std::optional<ArgumentDescriptor> descriptor;
     std::optional<size_t> extract_batch(const ov::Shape& shape) const;
     std::optional<size_t> extract_batch(const ov::Shape& shape, std::optional<ov::PartialShape> partial_shape) const;
+    std::optional<size_t> extract_batch_impl(const ov::Shape& shape,
+                                             std::optional<ov::PartialShape> partial_shape,
+                                             size_t index) const;
 };
 
 class IGraph : public std::enable_shared_from_this<IGraph> {

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -22,6 +22,7 @@ struct IONodeMetadata {
     IONodeMetadata(const ArgumentDescriptor& d);
     std::optional<ArgumentDescriptor> descriptor;
     std::optional<size_t> extract_batch(const ov::Shape& shape) const;
+    std::optional<size_t> extract_batch(const ov::Shape& shape, std::optional<ov::PartialShape> partial_shape) const;
 };
 
 class IGraph : public std::enable_shared_from_this<IGraph> {
@@ -72,7 +73,8 @@ public:
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
-    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors,
+    std::optional<size_t> determine_batch_size(const NetworkMetadata& metadata,
+                                               const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors,
                                                const IONodeMetadata& input_output_info) const;
 
     std::optional<size_t> get_batch_size(const NetworkMetadata& metadata,

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -58,6 +58,7 @@ public:
     void set_last_submitted_event(const std::shared_ptr<Event>& event, size_t indexOfCommandList);
     const std::shared_ptr<Event>& get_last_submitted_event(size_t indexOfCommandList) const;
     void resize_last_submitted_event(size_t batch);
+    void set_batch_size(std::size_t batch);
 
     uint32_t get_unique_id();
     void set_last_submitted_id(uint32_t id_index);

--- a/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
+++ b/src/plugins/intel_npu/src/common/include/intel_npu/common/igraph.hpp
@@ -11,18 +11,17 @@
 #include "intel_npu/network_metadata.hpp"
 #include "intel_npu/utils/zero/zero_utils.hpp"
 #include "intel_npu/utils/zero/zero_wrappers.hpp"
-#include "openvino/runtime/profiling_info.hpp"
-
 #include "openvino/runtime/itensor.hpp"
+#include "openvino/runtime/profiling_info.hpp"
 #include "openvino/runtime/so_ptr.hpp"
 
 namespace intel_npu {
 
 struct IONodeMetadata {
     IONodeMetadata() = default;
-    IONodeMetadata(const ArgumentDescriptor&d);
+    IONodeMetadata(const ArgumentDescriptor& d);
     std::optional<ArgumentDescriptor> descriptor;
-    std::optional<size_t> extract_batch(const ov::Shape &shape) const;
+    std::optional<size_t> extract_batch(const ov::Shape& shape) const;
 };
 
 class IGraph : public std::enable_shared_from_this<IGraph> {
@@ -73,9 +72,12 @@ public:
     uint32_t get_last_submitted_id() const;
 
     const std::optional<std::size_t> get_batch_size() const;
-    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors, const IONodeMetadata &input_output_info) const;
+    std::optional<size_t> determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& input_tensors,
+                                               const IONodeMetadata& input_output_info) const;
 
-    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors, const IONodeMetadata &input_output_info);
+    std::optional<size_t> get_batch_size(const NetworkMetadata& metadata,
+                                         const std::vector<ov::SoPtr<ov::ITensor>>& tensors,
+                                         const IONodeMetadata& input_output_info);
 
 protected:
     /**

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -15,9 +15,9 @@ namespace intel_npu {
 
 IONodeMetadata::IONodeMetadata(const ArgumentDescriptor& d) : descriptor(d) {}
 
-std::optional<size_t> extract_batch_impl(const ov::Shape& shape,
-                                         std::optional<ov::PartialShape> partial_shape,
-                                         size_t index) {
+std::optional<size_t> IONodeMetadata::extract_batch_impl(const ov::Shape& shape,
+                                                         std::optional<ov::PartialShape> partial_shape,
+                                                         size_t index) const {
     if (partial_shape.has_value()) {
         if (partial_shape.value()[index].is_dynamic()) {
             return shape[index];

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -16,12 +16,10 @@ namespace intel_npu {
 IONodeMetadata::IONodeMetadata(const ArgumentDescriptor& d) : descriptor(d) {}
 
 std::optional<size_t> extract_batch_impl(const ov::Shape& shape,
-                                         std::optional<ov::PartialShape> partial_shape_ir,
-                                         std::optional<ov::PartialShape> partial_shape_compiler,
+                                         std::optional<ov::PartialShape> partial_shape,
                                          size_t index) {
-    if (partial_shape_ir.has_value() && partial_shape_compiler.has_value()) {
-        if (partial_shape_ir.value()[index].is_dynamic() &&
-            partial_shape_ir.value()[index] != partial_shape_compiler.value()[index]) {
+    if (partial_shape.has_value()) {
+        if (partial_shape.value()[index].is_dynamic()) {
             return shape[index];
         }
         return std::nullopt;
@@ -30,17 +28,20 @@ std::optional<size_t> extract_batch_impl(const ov::Shape& shape,
 }
 
 std::optional<size_t> IONodeMetadata::extract_batch(const ov::Shape& shape) const {
-    return extract_batch(shape, std::nullopt, std::nullopt);
+    return extract_batch(shape, std::nullopt);
 }
 
 std::optional<size_t> IONodeMetadata::extract_batch(const ov::Shape& shape,
-                                                    std::optional<ov::PartialShape> partial_shape_ir,
-                                                    std::optional<ov::PartialShape> partial_shape_compiler) const {
+                                                    std::optional<ov::PartialShape> partial_shape) const {
     if (descriptor.has_value()) {
-        return extract_batch_impl(shape,
-                                  partial_shape_ir.has_value() ? partial_shape_ir : std::nullopt,
-                                  partial_shape_compiler.has_value() ? partial_shape_compiler : std::nullopt,
-                                  0);
+        auto nLayout = descriptor.value().info.networkLayout;
+        if (nLayout == ZE_GRAPH_ARGUMENT_LAYOUT_NCHW || nLayout == ZE_GRAPH_ARGUMENT_LAYOUT_NHWC ||
+            nLayout == ZE_GRAPH_ARGUMENT_LAYOUT_NCDHW || nLayout == ZE_GRAPH_ARGUMENT_LAYOUT_NDHWC ||
+            nLayout == ZE_GRAPH_ARGUMENT_LAYOUT_NC) {
+            return extract_batch_impl(shape, partial_shape.has_value() ? partial_shape : std::nullopt, 0);
+        } else if (nLayout == ZE_GRAPH_ARGUMENT_LAYOUT_CN) {
+            return extract_batch_impl(shape, partial_shape.has_value() ? partial_shape : std::nullopt, 1);
+        }
     }
     return std::nullopt;  // TODO get layout from shape
 }
@@ -159,10 +160,8 @@ std::optional<size_t> IGraph::determine_batch_size(const NetworkMetadata& metada
     // A first dimensionin shape  may be appeared 'C' as well.
     // We need to get batch Idx and determine a true batch value here.
     // Let's use input_output_info as a helper.
-    const ov::PartialShape& first_partial_shape_ir = *metadata.inputs.at(0).shapeFromIRModel;
-    const ov::PartialShape& first_partial_shape_compiler = metadata.inputs.at(0).shapeFromCompiler;
-    auto candidateBatchSizeIfExist =
-        input_output_info.extract_batch(first_shape, first_partial_shape_ir, first_partial_shape_compiler);
+    const ov::PartialShape& first_partial_shape = *metadata.inputs.at(0).shapeFromIRModel;
+    auto candidateBatchSizeIfExist = input_output_info.extract_batch(first_shape, first_partial_shape);
     if (!candidateBatchSizeIfExist.has_value()) {
         return std::nullopt;  // Return std::nullopt if there is no batch dimension
     }

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -157,6 +157,11 @@ std::optional<size_t> IGraph::determine_batch_size(const NetworkMetadata& metada
         return std::nullopt;  // Return std::nullopt if the shape is empty
     }
 
+    if (!metadata.inputs.at(0).shapeFromIRModel.has_value()) {
+        _logger.debug("Batching on the plugin is not used, batching is handled by the compiler");
+        return std::nullopt;
+    }
+
     // A first dimensionin shape  may be appeared 'C' as well.
     // We need to get batch Idx and determine a true batch value here.
     // Let's use input_output_info as a helper.

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -83,6 +83,10 @@ void IGraph::resize_last_submitted_event(size_t batch) {
     _last_submitted_event.resize(batch);
 }
 
+void IGraph::set_batch_size(std::size_t batch) {
+    _batch_size = batch;
+}
+
 uint32_t IGraph::get_unique_id() {
     return _unique_id++;
 }
@@ -96,6 +100,10 @@ uint32_t IGraph::get_last_submitted_id() const {
 }
 
 std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<ov::ITensor>>& tensors) const {
+    if (get_batch_size() > 1) {
+        return get_batch_size();
+    }
+
     if (tensors.empty()) {
         return std::nullopt; // Return std::nullopt if no input tensors are set
     }

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -105,30 +105,30 @@ std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<o
     }
 
     if (tensors.empty()) {
-        return std::nullopt; // Return std::nullopt if no input tensors are set
+        return std::nullopt;  // Return std::nullopt if no input tensors are set
     }
 
     const auto& first_tensor = tensors.at(0);
     if (!first_tensor) {
-        return std::nullopt; // Return std::nullopt if the first tensor is null
+        return std::nullopt;  // Return std::nullopt if the first tensor is null
     }
 
     const auto& first_shape = first_tensor->get_shape();
     if (first_shape.empty()) {
-        return std::nullopt; // Return std::nullopt if the shape is empty
+        return std::nullopt;  // Return std::nullopt if the shape is empty
     }
 
-    const size_t candidateBatchSize = first_shape.at(0); // Assume batch size is the first dimension
+    const size_t candidateBatchSize = first_shape.at(0);  // Assume batch size is the first dimension
 
     auto checkBatchSizeConsistency = [candidateBatchSize](const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
         for (const auto& tensor : tensors) {
             if (!tensor) {
-                return false; // Tensor is null
+                return false;  // Tensor is null
             }
 
             const auto& shape = tensor->get_shape();
             if (shape.empty() || shape.at(0) != candidateBatchSize) {
-                return false; // Inconsistent batch size
+                return false;  // Inconsistent batch size
             }
         }
         return true;
@@ -136,7 +136,7 @@ std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<o
 
     if (!checkBatchSizeConsistency(tensors)) {
         _logger.info("Inconsistent batch sizes in input tensors");
-        return std::nullopt; // Return std::nullopt if batch sizes are inconsistent
+        return std::nullopt;  // Return std::nullopt if batch sizes are inconsistent
     }
 
     _logger.debug("Dynamic Batching is handled by the plugin");
@@ -144,7 +144,8 @@ std::optional<size_t> IGraph::determine_batch_size(const std::vector<ov::SoPtr<o
     return candidateBatchSize;
 }
 
-std::optional<size_t> IGraph::get_batch_size(const NetworkMetadata& metadata, const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
+std::optional<size_t> IGraph::get_batch_size(const NetworkMetadata& metadata,
+                                             const std::vector<ov::SoPtr<ov::ITensor>>& tensors) {
     if (!metadata.outputs.at(0).shapeFromIRModel.has_value()) {
         _logger.debug("Batching on the plugin is not used, batching is handled by the compiler");
         return std::nullopt;

--- a/src/plugins/intel_npu/src/common/src/igraph.cpp
+++ b/src/plugins/intel_npu/src/common/src/igraph.cpp
@@ -165,8 +165,8 @@ std::optional<size_t> IGraph::determine_batch_size(const NetworkMetadata& metada
     // A first dimensionin shape  may be appeared 'C' as well.
     // We need to get batch Idx and determine a true batch value here.
     // Let's use input_output_info as a helper.
-    const ov::PartialShape& first_partial_shape = *metadata.inputs.at(0).shapeFromIRModel;
-    auto candidateBatchSizeIfExist = input_output_info.extract_batch(first_shape, first_partial_shape);
+    const ov::PartialShape& firstPartialShape = *metadata.inputs.at(0).shapeFromIRModel;
+    auto candidateBatchSizeIfExist = input_output_info.extract_batch(first_shape, firstPartialShape);
     if (!candidateBatchSizeIfExist.has_value()) {
         return std::nullopt;  // Return std::nullopt if there is no batch dimension
     }

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -122,7 +122,8 @@ void Graph::initialize(const Config& config) {
             _logger.debug("got pfnGetArgumentProperties3 for input: %s", _input_descriptors.back().to_string().c_str());
         } else {
             _output_descriptors.push_back(ArgumentDescriptor{arg3, index});
-            _logger.debug("got pfnGetArgumentProperties3 for output: %s", _output_descriptors.back().to_string().c_str());
+            _logger.debug("got pfnGetArgumentProperties3 for output: %s",
+                          _output_descriptors.back().to_string().c_str());
         }
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -168,12 +168,6 @@ void Graph::initialize(const Config& config) {
 
     _batch_size = get_batch_size(_metadata, {}, {});
 
-    const ov::PartialShape& firstOutputShape = *_metadata.outputs.at(0).shapeFromIRModel;
-    if (firstOutputShape[0].is_dynamic()) {
-        _logger.info("Dynamic batch, will initialize command_lists later");
-        return;
-    }
-
     if (_zeroInitStruct->getCommandQueueDdiTable().version() < ZE_MAKE_VERSION(1, 1) &&
         config.get<RUN_INFERENCES_SEQUENTIALLY>()) {
         auto number_of_command_lists = _batch_size.has_value() ? *_batch_size : 1;

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -165,7 +165,7 @@ void Graph::initialize(const Config& config) {
     //  releasing it here to avoid unnecessary memory usage.
     _blobIsReleased = release_blob(config);
 
-    _batch_size = get_batch_size(_metadata, {});
+    _batch_size = get_batch_size(_metadata, {}, {});
 
     const ov::PartialShape& firstOutputShape = *_metadata.outputs.at(0).shapeFromIRModel;
     if (firstOutputShape[0].is_dynamic()) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -162,7 +162,14 @@ void Graph::initialize(const Config& config) {
     //  _zeGraphExt->initializeGraph(). The driver will not access the original blob from this moment on, so we are
     //  releasing it here to avoid unnecessary memory usage.
     _blobIsReleased = release_blob(config);
-    _batch_size = get_batch_size(_metadata);
+
+    _batch_size = get_batch_size(_metadata, {});
+
+    const ov::PartialShape& firstOutputShape = *_metadata.outputs.at(0).shapeFromIRModel;
+    if (firstOutputShape[0].is_dynamic()) {
+        _logger.debug("Dynamic batch, will initialize command_lists later");
+        return;
+    }
 
     if (_zeroInitStruct->getCommandQueueDdiTable().version() < ZE_MAKE_VERSION(1, 1) &&
         config.get<RUN_INFERENCES_SEQUENTIALLY>()) {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/graph.cpp
@@ -119,8 +119,10 @@ void Graph::initialize(const Config& config) {
 
         if (arg3.type == ZE_GRAPH_ARGUMENT_TYPE_INPUT) {
             _input_descriptors.push_back(ArgumentDescriptor{arg3, index});
+            _logger.debug("got pfnGetArgumentProperties3 for input: %s", _input_descriptors.back().to_string().c_str());
         } else {
             _output_descriptors.push_back(ArgumentDescriptor{arg3, index});
+            _logger.debug("got pfnGetArgumentProperties3 for output: %s", _output_descriptors.back().to_string().c_str());
         }
     }
 
@@ -167,7 +169,7 @@ void Graph::initialize(const Config& config) {
 
     const ov::PartialShape& firstOutputShape = *_metadata.outputs.at(0).shapeFromIRModel;
     if (firstOutputShape[0].is_dynamic()) {
-        _logger.debug("Dynamic batch, will initialize command_lists later");
+        _logger.info("Dynamic batch, will initialize command_lists later");
         return;
     }
 

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -36,6 +36,11 @@
 
 #define UseCopyForNativeBinary(T) (T < ZE_GRAPH_EXT_VERSION_1_7)
 
+namespace {
+constexpr std::size_t BATCH_AXIS = 0;
+constexpr std::size_t DEFAULT_BATCH_SIZE = 1;
+}  // namespace
+
 namespace intel_npu {
 
 ZeGraphExtWrappers::ZeGraphExtWrappers(const std::shared_ptr<ZeroInitStructsHolder>& zeroInitStruct)
@@ -370,7 +375,7 @@ static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                 // lower bound is ignored, so we set it to 1 just to satisfy the Dimension constructor,
                 // upper bound is set to the value from shapeFromCompiler as it is filled with upper bounds
                 // in case of dynamic dimensions
-                if (id == 0 && shapeFromCompiler[id] == 1) {
+                if (id == BATCH_AXIS && shapeFromCompiler[id] == DEFAULT_BATCH_SIZE) {
                     logger.info("Ignore dynamic batch size upper limit, but keep the dimension dynamic as a metadata "
                                 "from compiler has been lost.");
                     // We need to kepp batch dimension dynamic

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -369,7 +369,12 @@ static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                 // lower bound is ignored, so we set it to 1 just to satisfy the Dimension constructor,
                 // upper bound is set to the value from shapeFromCompiler as it is filled with upper bounds
                 // in case of dynamic dimensions
-                shapeFromIRModel.push_back(ov::Dimension(1, shapeFromCompiler[id]));
+                if (id == 0) {
+                    // We need to kepp batch dimension dynamic
+                    shapeFromIRModel.push_back(ov::Dimension(1, dynamicDim));
+                } else {
+                    shapeFromIRModel.push_back(ov::Dimension(1, shapeFromCompiler[id]));
+                }
             }
         }
     }

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -348,6 +348,7 @@ ze_graph_handle_t ZeGraphExtWrappers::getGraphHandle(const uint8_t& blobData, si
  */
 static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                                     const std::optional<ze_graph_argument_metadata_t>& metadata) {
+    auto logger = Logger::global().clone("getIODescriptor");
     ov::element::Type_t precision = zeroUtils::toOVElementType(arg.devicePrecision);
     ov::Shape shapeFromCompiler;
     ov::PartialShape shapeFromIRModel;
@@ -369,7 +370,9 @@ static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                 // lower bound is ignored, so we set it to 1 just to satisfy the Dimension constructor,
                 // upper bound is set to the value from shapeFromCompiler as it is filled with upper bounds
                 // in case of dynamic dimensions
-                if (id == 0) {
+                if (id == 0 && shapeFromCompiler[id] == 1) {
+                    logger.info("Ignore dynamic batch size upper limit, but keep the dimension dynamic as a metadata "
+                                "from compiler has been lost.");
                     // We need to kepp batch dimension dynamic
                     shapeFromIRModel.push_back(ov::Dimension(1, dynamicDim));
                 } else {

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -370,7 +370,7 @@ static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                 // lower bound is ignored, so we set it to 1 just to satisfy the Dimension constructor,
                 // upper bound is set to the value from shapeFromCompiler as it is filled with upper bounds
                 // in case of dynamic dimensions
-                if (id == 0) {
+                if (id == 0 && shapeFromCompiler[id] == 1) {
                     logger.info("Ignore dynamic batch size upper limit, but keep the dimension dynamic as a metadata "
                                 "from compiler has been lost.");
                     // We need to kepp batch dimension dynamic

--- a/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
+++ b/src/plugins/intel_npu/src/compiler_adapter/src/ze_graph_ext_wrappers.cpp
@@ -370,7 +370,7 @@ static IODescriptor getIODescriptor(const ze_graph_argument_properties_3_t& arg,
                 // lower bound is ignored, so we set it to 1 just to satisfy the Dimension constructor,
                 // upper bound is set to the value from shapeFromCompiler as it is filled with upper bounds
                 // in case of dynamic dimensions
-                if (id == 0 && shapeFromCompiler[id] == 1) {
+                if (id == 0) {
                     logger.info("Ignore dynamic batch size upper limit, but keep the dimension dynamic as a metadata "
                                 "from compiler has been lost.");
                     // We need to kepp batch dimension dynamic

--- a/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
+++ b/src/plugins/intel_npu/src/utils/include/intel_npu/utils/zero/zero_utils.hpp
@@ -18,6 +18,17 @@ namespace intel_npu {
 struct ArgumentDescriptor {
     ze_graph_argument_properties_3_t info;
     uint32_t idx;
+    std::string to_string() const {
+        std::stringstream sstream;
+        sstream << "dims_count: " << info.dims_count << " - [";
+        for (uint32_t i = 0; i < std::min<uint32_t>(info.dims_count, ZE_MAX_GRAPH_ARGUMENT_DIMENSIONS_SIZE); i ++) {
+            sstream << info.dims[i] << ",";
+        }
+        sstream << "]"
+                << ", networkLayout: " << std::to_string(static_cast<size_t>(info.networkLayout))
+                << ", deviceLayout: " << std::to_string(static_cast<size_t>(info.deviceLayout));
+        return sstream.str();
+    }
 };
 
 namespace zeroUtils {

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -23,7 +23,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
 const std::vector<ov::AnyMap> DynamicBatchedConfigs = {
     {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}};
 
-INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_BehaviorTest,
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          DynamicBatchedTensorsRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(DynamicBatchedConfigs)),

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -10,9 +10,9 @@
 
 using namespace ov::test::behavior;
 
-const std::vector<ov::AnyMap> batchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN), ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)},
-                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER), ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)},
-                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::AUTO), ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)}};
+const std::vector<ov::AnyMap> batchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)},
+                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER)},
+                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::AUTO)}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          BatchedTensorsRunTests,
@@ -20,7 +20,9 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(batchedConfigs)),
                          BatchedTensorsRunTests::getTestCaseName);
 
-const std::vector<ov::AnyMap> DynamicBatchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}};
+const std::vector<ov::AnyMap> DynamicBatchedConfigs = {
+    {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
+     ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          DynamicBatchedTensorsRunTests,

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -19,3 +19,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(batchedConfigs)),
                          BatchedTensorsRunTests::getTestCaseName);
+
+const std::vector<ov::AnyMap> DynamicBatchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+                         DynamicBatchedTensorsRunTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(DynamicBatchedConfigs)),
+                         BatchedTensorsRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -10,9 +10,9 @@
 
 using namespace ov::test::behavior;
 
-const std::vector<ov::AnyMap> batchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)},
-                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER)},
-                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::AUTO)}};
+const std::vector<ov::AnyMap> batchedConfigs = {{ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN), ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)},
+                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::COMPILER), ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)},
+                                                {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::AUTO), ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)}};
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                          BatchedTensorsRunTests,

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -20,21 +20,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(batchedConfigs)),
                          BatchedTensorsRunTests::getTestCaseName);
 
-const std::vector<ov::AnyMap> DynamicBatchedConfigsMLIR = {
-    {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
-     ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)}};
-
-const std::vector<ov::AnyMap> DynamicBatchedConfigsCID = {
+const std::vector<ov::AnyMap> DynamicBatchedConfigs = {
     {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTestMLIR,
+INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_BehaviorTest,
                          DynamicBatchedTensorsRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(DynamicBatchedConfigsMLIR)),
-                         BatchedTensorsRunTests::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTestCID,
-                         DynamicBatchedTensorsRunTests,
-                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(DynamicBatchedConfigsCID)),
+                                            ::testing::ValuesIn(DynamicBatchedConfigs)),
                          BatchedTensorsRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.cpp
@@ -20,12 +20,21 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(batchedConfigs)),
                          BatchedTensorsRunTests::getTestCaseName);
 
-const std::vector<ov::AnyMap> DynamicBatchedConfigs = {
+const std::vector<ov::AnyMap> DynamicBatchedConfigsMLIR = {
     {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
      ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR)}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
+const std::vector<ov::AnyMap> DynamicBatchedConfigsCID = {
+    {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN)}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTestMLIR,
                          DynamicBatchedTensorsRunTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(DynamicBatchedConfigs)),
+                                            ::testing::ValuesIn(DynamicBatchedConfigsMLIR)),
+                         BatchedTensorsRunTests::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTestCID,
+                         DynamicBatchedTensorsRunTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(DynamicBatchedConfigsCID)),
                          BatchedTensorsRunTests::getTestCaseName);

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -8,7 +8,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 #include "common/npu_test_env_cfg.hpp"
 #include "common/utils.hpp"
 #include "functional_test_utils/ov_plugin_cache.hpp"
@@ -22,6 +21,7 @@
 #include "openvino/runtime/core.hpp"
 #include "openvino/runtime/intel_npu/level_zero/level_zero.hpp"
 #include "overload/overload_test_utils_npu.hpp"
+#include "shared_test_classes/base/ov_behavior_test_utils.hpp"
 
 using CompilationParams = std::tuple<std::string,  // Device name
                                      ov::AnyMap    // Config
@@ -127,6 +127,16 @@ public:
         return std::make_shared<Model>(res, params);
     }
 };
+
+// To avoid error: no previous declaration
+void executeMutlipleTensorsBatchInfer(ov::InferRequest req,
+                                      size_t batch_value,
+                                      const Shape& non_batched_shape,
+                                      ov::RemoteContext& context);
+void executeContiguousTensorBatchInfer(ov::InferRequest req,
+                                       size_t batch_value,
+                                       const Shape& non_batched_shape,
+                                       ov::RemoteContext& context);
 
 // Second test group inheriting from the first
 using DynamicBatchedTensorsRunTests = BatchedTensorsRunTests;

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -128,6 +128,10 @@ public:
     }
 };
 
+// Second test group inheriting from the first
+class DynamicBatchedTensorsRunTests : public BatchedTensorsRunTests {
+};
+
 TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
@@ -420,7 +424,7 @@ TEST_P(BatchedTensorsRunTests, SetInputDifferentRemoteTensorsMultipleInferMCL) {
     }
 }
 
-TEST_P(BatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer) {
+TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 
@@ -467,7 +471,7 @@ TEST_P(BatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer) {
     }
 }
 
-TEST_P(BatchedTensorsRunTests, DynamicSetInputDifferentTensorsMultipleInfer) {
+TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputDifferentTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
 

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -129,8 +129,7 @@ public:
 };
 
 // Second test group inheriting from the first
-class DynamicBatchedTensorsRunTests : public BatchedTensorsRunTests {
-};
+using DynamicBatchedTensorsRunTests = BatchedTensorsRunTests;
 
 TEST_P(BatchedTensorsRunTests, SetInputRemoteTensorsMultipleInfer) {
     // Skip test according to plugin specific disabledTestPatterns() (if any)
@@ -464,20 +463,21 @@ TEST_P(DynamicBatchedTensorsRunTests, DynamicSetInputRemoteTensorsMultipleInfer)
             }
         }
         req.infer();  // Adds '1' to each element
-        for (size_t i = 0; i < batch; i ++) {
+        for (size_t i = 0; i < batch; i++) {
             for (size_t j = 0; j < one_shape_size; ++j) {
-                auto expected =  testNum + 20 * (i + 1) + 1;
-                EXPECT_EQ(actual[i * one_shape_size + j], expected) << "Infer " << testNum << ": Expected=" << expected
-                                                << ", actual=" << actual[j] << " for index " << j << ", batch: " << i;
+                auto expected = testNum + 20 * (i + 1) + 1;
+                EXPECT_EQ(actual[i * one_shape_size + j], expected)
+                    << "Infer " << testNum << ": Expected=" << expected << ", actual=" << actual[j] << " for index "
+                    << j << ", batch: " << i;
             }
         }
     }
 }
 
-
-void executeMutlipleTensorsBatchInfer(ov::InferRequest req, size_t batch_value,
-                                       const Shape& non_batched_shape,
-                                       ov::RemoteContext &context) {
+void executeMutlipleTensorsBatchInfer(ov::InferRequest req,
+                                      size_t batch_value,
+                                      const Shape& non_batched_shape,
+                                      ov::RemoteContext& context) {
     auto non_batched_shape_size = ov::shape_size(non_batched_shape);
     std::vector<ov::Tensor> tensors;
     tensors.reserve(batch_value);
@@ -490,7 +490,8 @@ void executeMutlipleTensorsBatchInfer(ov::InferRequest req, size_t batch_value,
     req.set_tensors("tensor_input0", tensors);
 
     auto actual_tensor = req.get_tensor("tensor_output0");
-    ASSERT_EQ(actual_tensor.get_byte_size(), tensors.back().get_byte_size() * tensors.size() ) << "\"tensor_output0\" must have the same size as \"tensor_input0\" for batch_value value:" << batch_value;
+    ASSERT_EQ(actual_tensor.get_byte_size(), tensors.back().get_byte_size() * tensors.size())
+        << "\"tensor_output0\" must have the same size as \"tensor_input0\" for batch_value value:" << batch_value;
     auto* actual = actual_tensor.data<float>();
     for (auto testNum = 0; testNum < 1; testNum++) {
         for (size_t i = 0; i < batch_value; ++i) {
@@ -500,11 +501,12 @@ void executeMutlipleTensorsBatchInfer(ov::InferRequest req, size_t batch_value,
             }
         }
         req.infer();
-        for (size_t i = 0; i < batch_value; i ++) {
+        for (size_t i = 0; i < batch_value; i++) {
             for (size_t j = 0; j < non_batched_shape_size; ++j) {
-                auto expected =  testNum + 20 * (i + 1) + 1;
-                EXPECT_EQ(actual[i * non_batched_shape_size + j], expected) << "Infer " << testNum << ": Expected=" << expected
-                                                << ", actual=" << actual[j] << " for index " << j << ", batch: " << i;
+                auto expected = testNum + 20 * (i + 1) + 1;
+                EXPECT_EQ(actual[i * non_batched_shape_size + j], expected)
+                    << "Infer " << testNum << ": Expected=" << expected << ", actual=" << actual[j] << " for index "
+                    << j << ", batch: " << i;
             }
         }
     }
@@ -610,16 +612,18 @@ TEST_P(DynamicBatchedTensorsRunTests, SetInputRemoteSingleBatchedTensorSingleInf
         }
         req.infer();  // Adds '1' to each element
         for (size_t j = 0; j < tensor_shape_size; ++j) {
-            auto expected = testNum + 20 * ( j / one_shape_size + 1) + 1;
-            EXPECT_EQ(actual[j], expected) << "Infer " << testNum << ": Expected=" << expected
-                                            << ", actual=" << actual[j] << " for index " << j << ", batch: " << j / one_shape_size;
+            auto expected = testNum + 20 * (j / one_shape_size + 1) + 1;
+            EXPECT_EQ(actual[j], expected)
+                << "Infer " << testNum << ": Expected=" << expected << ", actual=" << actual[j] << " for index " << j
+                << ", batch: " << j / one_shape_size;
         }
     }
 }
 
-void executeContiguousTensorBatchInfer(ov::InferRequest req, size_t batch_value,
+void executeContiguousTensorBatchInfer(ov::InferRequest req,
+                                       size_t batch_value,
                                        const Shape& non_batched_shape,
-                                       ov::RemoteContext &context) {
+                                       ov::RemoteContext& context) {
     auto non_batched_shape_size = ov::shape_size(non_batched_shape);
     auto tensor_shape = non_batched_shape;
     tensor_shape[0] = batch_value;
@@ -631,7 +635,8 @@ void executeContiguousTensorBatchInfer(ov::InferRequest req, size_t batch_value,
 
     req.set_tensors("tensor_input0", tensors);
     auto actual_tensor = req.get_tensor("tensor_output0");
-    ASSERT_EQ(actual_tensor.get_byte_size(), tensors.back().get_byte_size()) << "\"tensor_output0\" must have the same size as \"tensor_input0\" for batch_value value:" << batch_value;
+    ASSERT_EQ(actual_tensor.get_byte_size(), tensors.back().get_byte_size())
+        << "\"tensor_output0\" must have the same size as \"tensor_input0\" for batch_value value:" << batch_value;
 
     auto* actual = actual_tensor.data<float>();
     auto* f = tensors.back().data<float>();
@@ -641,9 +646,10 @@ void executeContiguousTensorBatchInfer(ov::InferRequest req, size_t batch_value,
     req.infer();
     // check that we got valid inference results on each lines of N
     for (size_t j = 0; j < tensor_shape_size; ++j) {
-        auto expected = batch_value + 20 * ( j / non_batched_shape_size + 1) + 1;
+        auto expected = batch_value + 20 * (j / non_batched_shape_size + 1) + 1;
         EXPECT_EQ(actual[j], expected) << "Infer " << batch_value << ": Expected=" << expected
-                                       << ", actual=" << actual[j] << " for index " << j << ", batch: " << j / non_batched_shape_size;
+                                       << ", actual=" << actual[j] << " for index " << j
+                                       << ", batch: " << j / non_batched_shape_size;
     }
 }
 
@@ -672,7 +678,7 @@ TEST_P(DynamicBatchedTensorsRunTests, SetInputRemoteSingleBatchedTensorDynamicBa
     ov::InferRequest req;
     req = execNet.create_infer_request();
     std::vector<ov::Tensor> tensors;
-    for (size_t tensor_batch = model_batch_bottom_bound; tensor_batch <= model_batch_upper_bound; tensor_batch++ ) {
+    for (size_t tensor_batch = model_batch_bottom_bound; tensor_batch <= model_batch_upper_bound; tensor_batch++) {
         // dynamically change N of contiduous memory tensor in [model_batch_bottom_bound..model_batch_upper_bound]
         // and check that the output tensor kept modified accordingly
         executeContiguousTensorBatchInfer(req, tensor_batch, one_shape, context);
@@ -704,7 +710,7 @@ TEST_P(DynamicBatchedTensorsRunTests, SetInputRemoteSingleBatchedTensorDynamicBa
     ov::InferRequest req;
     req = execNet.create_infer_request();
     std::vector<ov::Tensor> tensors;
-    for (size_t tensor_batch = model_batch_upper_bound; tensor_batch >= model_batch_bottom_bound ; tensor_batch-- ) {
+    for (size_t tensor_batch = model_batch_upper_bound; tensor_batch >= model_batch_bottom_bound; tensor_batch--) {
         // dynamically change N of contiduous memory tensor in [model_batch_bottom_bound..model_batch_upper_bound]
         // and check that the output tensor kept modified accordingly
         executeContiguousTensorBatchInfer(req, tensor_batch, one_shape, context);

--- a/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/batched_tensors_tests/batched_run.hpp
@@ -631,7 +631,7 @@ void executeContiguousTensorBatchInfer(ov::InferRequest req, size_t batch_value,
 
     req.set_tensors("tensor_input0", tensors);
     auto actual_tensor = req.get_tensor("tensor_output0");
-    ASSERT_EQ(actual_tensor.get_byte_size(), tensor.get_byte_size()) << "\"tensor_output0\" must have the same size as \"tensor_input0\" for batch_value value:" << batch_value;
+    ASSERT_EQ(actual_tensor.get_byte_size(), tensors.back().get_byte_size()) << "\"tensor_output0\" must have the same size as \"tensor_input0\" for batch_value value:" << batch_value;
 
     auto* actual = actual_tensor.data<float>();
     auto* f = tensors.back().data<float>();

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -54,6 +54,26 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(batchingConfigs)),
                          InferRequestRunTests::getTestCaseName);
 
+const std::vector<ov::AnyMap> DynamicBatchedConfigsMLIR = {
+    {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
+     ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR),
+     ov::log::level(ov::log::Level::WARNING)}};
+
+const std::vector<ov::AnyMap> DynamicBatchedConfigsCID = {
+    {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN), ov::log::level(ov::log::Level::WARNING)}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchingSeqTests_MLIR,
+                         DynamicBatchingRunSeqTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(DynamicBatchedConfigsMLIR)),
+                         InferRequestRunTests::getTestCaseName);
+
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchingSeqTests_CID,
+                         DynamicBatchingRunSeqTests,
+                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
+                                            ::testing::ValuesIn(DynamicBatchedConfigsCID)),
+                         InferRequestRunTests::getTestCaseName);
+
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,
                          ROITensorInference,
                          ::testing::Combine(::testing::Values(tensor_roi::roi_nchw()),

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -54,24 +54,13 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
                                             ::testing::ValuesIn(batchingConfigs)),
                          InferRequestRunTests::getTestCaseName);
 
-const std::vector<ov::AnyMap> DynamicBatchedConfigsMLIR = {
-    {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN),
-     ov::intel_npu::compiler_type(ov::intel_npu::CompilerType::MLIR),
-     ov::log::level(ov::log::Level::WARNING)}};
-
-const std::vector<ov::AnyMap> DynamicBatchedConfigsCID = {
+const std::vector<ov::AnyMap> DynamicBatchedConfigs = {
     {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN), ov::log::level(ov::log::Level::WARNING)}};
 
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchingSeqTests_MLIR,
+INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_DynamicBatchingSeqTests,
                          DynamicBatchingRunSeqTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(DynamicBatchedConfigsMLIR)),
-                         InferRequestRunTests::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchingSeqTests_CID,
-                         DynamicBatchingRunSeqTests,
-                         ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
-                                            ::testing::ValuesIn(DynamicBatchedConfigsCID)),
+                                            ::testing::ValuesIn(DynamicBatchedConfigs)),
                          InferRequestRunTests::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(compatibility_smoke_BehaviorTest,

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.cpp
@@ -57,7 +57,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTest,
 const std::vector<ov::AnyMap> DynamicBatchedConfigs = {
     {ov::intel_npu::batch_mode(ov::intel_npu::BatchMode::PLUGIN), ov::log::level(ov::log::Level::WARNING)}};
 
-INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_DynamicBatchingSeqTests,
+INSTANTIATE_TEST_SUITE_P(smoke_DynamicBatchingSeqTests,
                          DynamicBatchingRunSeqTests,
                          ::testing::Combine(::testing::Values(ov::test::utils::DEVICE_NPU),
                                             ::testing::ValuesIn(DynamicBatchedConfigs)),

--- a/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/infer_request_run.hpp
@@ -1051,6 +1051,66 @@ TEST_P(BatchingRunSeqTests, CheckMultipleBatchingRunsSeq) {
     }
 }
 
+using DynamicBatchingRunSeqTests = InferRequestRunTests;
+
+TEST_P(DynamicBatchingRunSeqTests, DynamicCheckMultipleBatchingRunsSeq) {
+    auto modelShape = PartialShape{ov::Dimension(1, 10), 2, 64, 64};
+    auto shape = Shape{4, 2, 64, 64};
+    auto shape_size = ov::shape_size(shape);
+    auto model = createModel(element::f32, modelShape, "N...");
+
+    auto context = core->get_default_context(target_device);
+
+    configuration[ov::intel_npu::run_inferences_sequentially.name()] = true;
+    configuration[ov::intel_npu::tiles.name()] = 2;
+    compiled_model = core->compile_model(model, target_device, configuration);
+
+    const uint32_t inferences = 32;
+    std::array<ov::InferRequest, inferences> inference_request;
+    ov::Tensor input_tensor;
+    std::array<ov::Tensor, inferences> output_tensor;
+
+    input_tensor = context.create_host_tensor(ov::element::f32, shape);
+    for (uint32_t i = 0; i < inferences; i++) {
+        inference_request[i] = compiled_model.create_infer_request();
+        output_tensor[i] = context.create_host_tensor(ov::element::f32, shape);
+    }
+
+    inference_request[0].set_input_tensor(input_tensor);
+    inference_request[0].set_output_tensor(output_tensor[0]);
+
+    const uint32_t runs = 10;
+    for (uint32_t z = 0; z < runs; z++) {
+        auto* input_data = reinterpret_cast<float*>(input_tensor.data());
+        for (size_t i = 0; i < shape_size; ++i) {
+            input_data[i] = static_cast<float>(z);
+        }
+
+        inference_request[0].start_async();  // Adds '1' to each element
+
+        for (uint32_t i = 1; i < inferences; i++) {
+            inference_request[i].set_input_tensor(output_tensor[i - 1]);
+            inference_request[i].set_output_tensor(output_tensor[i]);
+
+            inference_request[i].start_async();  // Adds '1' to each element
+        }
+
+        inference_request[inferences - 1].wait();
+
+        float expected_result = static_cast<float>(z) + 1.f;
+
+        for (uint32_t i = 0; i < inferences; i++) {
+            auto* output_tensor_data = reinterpret_cast<float*>(output_tensor[i].data());
+            for (size_t j = 0; j < shape_size; ++j) {
+                EXPECT_NEAR(output_tensor_data[j], expected_result, 1e-5)
+                    << "Run=" << z << "Output=" << i << " Expected=" << expected_result
+                    << ", actual=" << output_tensor_data[j] << " for index " << j;
+            }
+            expected_result++;
+        }
+    }
+}
+
 using ROITensorInference = OVInferRequestInferenceTests;
 
 TEST_P(ROITensorInference, InferenceROITensor) {

--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -904,4 +904,13 @@ Example:
         </filters>
     </skip_config>
 
+    <!-- E#168772 -->
+    <skip_config>
+        <message>Tests currently skipped until dynamic batch is fully supported (need NPU compiler alignment/driver update)</message>
+        <filters>
+            <filter>.*DynamicBatchingRunSeqTests.*</filter>
+            <filter>.*DynamicBatchedTensorsRunTests.*</filter>
+        </filters>
+    </skip_config>
+
 </skip_configs>


### PR DESCRIPTION
The clone of https://github.com/openvinotoolkit/openvino/pull/30723
Ticket: 168772

### Details:
#### Dynamic batch case

Managed to infer this case:
`./benchmark_app.exe -m <resnet-v1-50.xml> -d NPU -load_config plugin_batch_dynamic.json -shape [1..3,3,244,244] -data_shape [2,3,244,244] `
Where _plugin_batch_dynamic.json_:
```
{
        "NPU": {"NPU_BATCH_MODE": "PLUGIN"}
} 
```
Compiled with batch resized to 1:
```
func.func @main(%arg0: tensor<1x3x244x244xui8>) -> tensor<1x1000xf32> {
```

Result:
```
[ INFO ] data  ([N,C,H,W], u8, [2,3,244,244], dyn:[1..3,3,244,244]):    random (image/numpy array is expected)

...

[WARNING] 12:13:57.69 [IGraph] Networks using dynamic batch are handled by the plugin
IGraph::determine_batch_size tensors candidateBatchSize 2
[DEBUG] 12:13:57.69 [IGraph] Batching is handled by the plugin

...

[Pipeline] Pipeline - initialize started, batch 2, _number_of_command_lists 2
[Step 4/11] Reading model files
[ INFO ] Loading model files
[ INFO ] Read model took 11.37 ms
[ INFO ] Original model I/O parameters:
[ INFO ] Network inputs:
[ INFO ]     data (node: data) : f32 / [...] / [?,3,224,224]
[ INFO ] Network outputs:
[ INFO ]     prob (node: prob) : f32 / [...] / [?,1000]
[Step 5/11] Resizing model to match image sizes and given batch
[ INFO ] Number of test configurations is calculated basing on -data_shape parameter
[ WARNING ] data: layout is not set explicitly, so it is defaulted to NCHW. It is STRONGLY recommended to set layout manually to avoid further issues.
[ INFO ] Reshaping model: 'data': [1..3,3,244,244]
[ INFO ] Reshape model took 1.84 ms
[Step 6/11] Configuring input of the model
[ INFO ] Model batch size: 2
[ INFO ] Network inputs:
[ INFO ]     data (node: data) : u8 / [N,C,H,W] / [1..3,3,244,244]
[ INFO ] Network outputs:
[ INFO ]     prob (node: prob) : f32 / [...] / [1..3,1000]

...

[Step 11/11] Dumping statistics report
[ INFO ] Execution Devices: [ NPU ]
[ INFO ] Count:               18352 iterations
[ INFO ] Duration:            60048.31 ms
[ INFO ] Latency:
[ INFO ]    Median:           26.00 ms
[ INFO ]    Average:          26.11 ms
[ INFO ]    Min:              13.24 ms
[ INFO ]    Max:              104.34 ms
[ INFO ] Throughput:          611.24 FPS
```

#### Static batch case

Performance results for comparison:
```
./benchmark_app.exe -m <resnet-v1-50.xml> -d NPU -load_config plugin_batch_dynamic.json -shape [2,3,244,244]  
```
Compiled with batch resized to 1:
```
func.func @main(%arg0: tensor<1x3x244x244xui8>) -> tensor<1x1000xf32> {
```

Result:
```
[ INFO ] data  ([N,C,H,W], u8, [2,3,244,244], static):  random (image/numpy array is expected)
[Step 11/11] Dumping statistics report
[ INFO ] Execution Devices: [ NPU ]
[ INFO ] Count:               18336 iterations
[ INFO ] Duration:            60044.19 ms
[ INFO ] Latency:
[ INFO ]    Median:           26.14 ms
[ INFO ]    Average:          26.16 ms
[ INFO ]    Min:              23.99 ms
[ INFO ]    Max:              135.00 ms
[ INFO ] Throughput:          610.75 FPS
```

### Tickets:
 - E#168772

