### PR TITLE
[ONNX] Aligned SplitOP's expected behavior between ONNX and OpenVINO

### DIFF
--- a/src/frontends/onnx/frontend/src/op/split.cpp
+++ b/src/frontends/onnx/frontend/src/op/split.cpp
@@ -4,6 +4,7 @@
 
 #include "utils/split.hpp"
 
+#include "core/null_node.hpp"
 #include "core/operator_set.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/variadic_split.hpp"
@@ -35,7 +36,7 @@ ov::OutputVector split(const ov::frontend::onnx::Node& node) {
     const auto inputs = node.get_ov_inputs();
     const auto axis = node.get_attribute_value<int64_t>("axis", 0);
 
-    if (inputs.size() < 2) {
+    if (inputs.size() < 2 || ov::op::util::is_null(inputs.at(1))) {
         const auto outputs_number = node.get_output_names().size();
         return ov::op::util::make_split(inputs.at(0), outputs_number, axis);
     } else {

--- a/src/frontends/onnx/frontend/src/utils/split.cpp
+++ b/src/frontends/onnx/frontend/src/utils/split.cpp
@@ -21,6 +21,19 @@ OutputVector make_split(const Output<ov::Node>& value, const std::vector<int64_t
 }
 
 OutputVector make_split(const Output<ov::Node>& value, int64_t num_splits, int64_t axis) {
+    auto axis_shape = value.get_partial_shape()[axis];
+    if (axis_shape.is_static()) {
+        auto axis_len = axis_shape.get_length();
+        // In ONNX definition, if the tensor is not evenly splittable the last chunk will be smaller.
+        // Handle the case when axis_len is not divisible by num_splits
+        if (axis_len % num_splits) {
+            auto avg_axis = axis_len / num_splits + 1;
+            auto last_output_value = axis_len % avg_axis;
+            std::vector<int64_t> split_lengths(num_splits, avg_axis);
+            split_lengths.back() = last_output_value;
+            return make_split(value, split_lengths, axis);
+        }
+    }
     const auto axis_node = ov::op::v0::Constant::create(ov::element::i64, Shape{}, {axis});
     const auto split = std::make_shared<ov::op::v1::Split>(value, axis_node, num_splits);
 

--- a/src/frontends/onnx/frontend/src/utils/split.cpp
+++ b/src/frontends/onnx/frontend/src/utils/split.cpp
@@ -22,7 +22,8 @@ OutputVector make_split(const Output<ov::Node>& value, const std::vector<int64_t
 
 OutputVector make_split(const Output<ov::Node>& value, int64_t num_splits, int64_t axis) {
     auto value_shape = value.get_partial_shape();
-    if (value_shape.rank().is_static() && value_shape.size() > axis && value_shape[axis].is_static()) {
+    if (value_shape.rank().is_static() && value_shape.size() > static_cast<size_t>(axis) &&
+        value_shape[axis].is_static()) {
         auto axis_len = value_shape[axis].get_length();
         // In ONNX definition, if the tensor is not evenly splittable the last chunk will be smaller.
         // Handle the case when axis_len is not divisible by num_splits

--- a/src/frontends/onnx/frontend/src/utils/split.cpp
+++ b/src/frontends/onnx/frontend/src/utils/split.cpp
@@ -29,15 +29,8 @@ OutputVector make_split(const Output<ov::Node>& value, int64_t num_splits, int64
         // In ONNX definition, if the tensor is not evenly splittable the last chunk will be smaller.
         // Handle the case when axis_len is not divisible by num_splits
         if (axis_len % num_splits) {
-            auto avg_axis = axis_len / num_splits + 1;
+            auto avg_axis = (axis_len + num_splits - 1) / num_splits;  // Round up division
             auto last_output_value = axis_len % avg_axis;
-            auto total_len = avg_axis * (num_splits - 1) + last_output_value;
-            FRONT_END_GENERAL_CHECK(total_len == axis_len && last_output_value > 0,
-                                    "The split parameters are not valid. The axis length ",
-                                    axis_len,
-                                    " split into",
-                                    num_splits,
-                                    ", can not promise the last chunk will be smaller than the others.");
             std::vector<int64_t> split_lengths(num_splits, avg_axis);
             split_lengths.back() = last_output_value;
             return make_split(value, split_lengths, axis);

--- a/src/frontends/onnx/frontend/src/utils/split.cpp
+++ b/src/frontends/onnx/frontend/src/utils/split.cpp
@@ -4,6 +4,7 @@
 
 #include "utils/split.hpp"
 
+#include "openvino/frontend/exception.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/split.hpp"
 #include "openvino/op/variadic_split.hpp"
@@ -30,6 +31,13 @@ OutputVector make_split(const Output<ov::Node>& value, int64_t num_splits, int64
         if (axis_len % num_splits) {
             auto avg_axis = axis_len / num_splits + 1;
             auto last_output_value = axis_len % avg_axis;
+            auto total_len = avg_axis * (num_splits - 1) + last_output_value;
+            FRONT_END_GENERAL_CHECK(total_len == axis_len,
+                                    "The split parameters are not valid. The axis length ",
+                                    axis_len,
+                                    " split into",
+                                    num_splits,
+                                    ", can not promise the last chunk will be smaller than the others.");
             std::vector<int64_t> split_lengths(num_splits, avg_axis);
             split_lengths.back() = last_output_value;
             return make_split(value, split_lengths, axis);

--- a/src/frontends/onnx/frontend/src/utils/split.cpp
+++ b/src/frontends/onnx/frontend/src/utils/split.cpp
@@ -32,7 +32,7 @@ OutputVector make_split(const Output<ov::Node>& value, int64_t num_splits, int64
             auto avg_axis = axis_len / num_splits + 1;
             auto last_output_value = axis_len % avg_axis;
             auto total_len = avg_axis * (num_splits - 1) + last_output_value;
-            FRONT_END_GENERAL_CHECK(total_len == axis_len,
+            FRONT_END_GENERAL_CHECK(total_len == axis_len && last_output_value > 0,
                                     "The split parameters are not valid. The axis length ",
                                     axis_len,
                                     " split into",

--- a/src/frontends/onnx/frontend/src/utils/split.cpp
+++ b/src/frontends/onnx/frontend/src/utils/split.cpp
@@ -21,9 +21,9 @@ OutputVector make_split(const Output<ov::Node>& value, const std::vector<int64_t
 }
 
 OutputVector make_split(const Output<ov::Node>& value, int64_t num_splits, int64_t axis) {
-    auto axis_shape = value.get_partial_shape()[axis];
-    if (axis_shape.is_static()) {
-        auto axis_len = axis_shape.get_length();
+    auto value_shape = value.get_partial_shape();
+    if (value_shape.rank().is_static() && value_shape.size() > axis && value_shape[axis].is_static()) {
+        auto axis_len = value_shape[axis].get_length();
         // In ONNX definition, if the tensor is not evenly splittable the last chunk will be smaller.
         // Handle the case when axis_len is not divisible by num_splits
         if (axis_len % num_splits) {

--- a/src/frontends/onnx/tests/__init__.py
+++ b/src/frontends/onnx/tests/__init__.py
@@ -68,8 +68,6 @@ xfail_issue_99969 = xfail_test(reason="Resize - Results mismatch / "
 xfail_issue_99970 = xfail_test(reason="Scatter and ScatterND - RuntimeError: Check '(reduction == none)' failed at "
                                       "src/frontends/onnx/frontend/src/op/scatter_elements.cpp OR at "
                                       "src/frontends/onnx/frontend/src/op/scatter_nd")
-xfail_issue_99973 = xfail_test(reason="Split -  RuntimeError: While validating ONNX node "
-                                      "'<Node(Split): output_1, output_2, output_3, output_4>'")
 xfail_issue_38710 = xfail_test(reason="RuntimeError: data has zero dimension which is not allowed")
 xfail_issue_38713 = xfail_test(reason="RuntimeError: OV does not support the following ONNX operations: "
                                       "ai.onnx.preview.training.Momentum")

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -49,7 +49,6 @@ from tests import (
     xfail_issue_99968,
     xfail_issue_99969,
     xfail_issue_99970,
-    xfail_issue_99973,
     xfail_issue_101965,
     xfail_issue_113506,
     skip_dynamic_model,

--- a/src/frontends/onnx/tests/tests_python/test_backend.py
+++ b/src/frontends/onnx/tests/tests_python/test_backend.py
@@ -454,11 +454,6 @@ tests_expected_to_fail = [
         "OnnxBackendNodeModelTest.test_scatternd_min_cpu",
     ),
     (
-        xfail_issue_99973,
-        "OnnxBackendNodeModelTest.test_split_1d_uneven_split_opset18_cpu",
-        "OnnxBackendNodeModelTest.test_split_2d_uneven_split_opset18_cpu",
-    ),
-    (
         xfail_issue_101965,
         "OnnxBackendNodeModelTest.test_dft_axis_cpu",
         "OnnxBackendNodeModelTest.test_dft_cpu",
@@ -569,9 +564,7 @@ tests_expected_to_fail = [
     (
         xfail_issue_125485,
         "OnnxBackendNodeModelTest.test_affine_grid_2d_align_corners_cpu",
-        "OnnxBackendNodeModelTest.test_affine_grid_2d_align_corners_expanded_cpu",
         "OnnxBackendNodeModelTest.test_affine_grid_2d_cpu",
-        "OnnxBackendNodeModelTest.test_affine_grid_2d_expanded_cpu",
         "OnnxBackendNodeModelTest.test_affine_grid_3d_align_corners_cpu",
         "OnnxBackendNodeModelTest.test_affine_grid_3d_align_corners_expanded_cpu",
         "OnnxBackendNodeModelTest.test_affine_grid_3d_cpu",


### PR DESCRIPTION
### Details:

- The ONNX SplitOP's split input is `optional`, and ONNX frontend didn't handle this case.
- The ONNX SplitOP allows the `(split dim % split number) != 0`. OV need to be 0.


### Tickets:
 - *CVS-169063*
