### PR TITLE
add evaluate method for einsum

### DIFF
--- a/src/core/include/openvino/op/einsum.hpp
+++ b/src/core/include/openvino/op/einsum.hpp
@@ -68,6 +68,9 @@ public:
     /// of appearence
     ///
     static std::vector<std::string> extract_labels(const std::string& subscript);
+    
+    bool evaluate(TensorVector& outputs, const TensorVector& inputs) const override;
+    bool has_evaluate() const override;
 
 private:
     std::string m_equation;

--- a/src/core/src/op/einsum.cpp
+++ b/src/core/src/op/einsum.cpp
@@ -10,6 +10,8 @@
 #include <unordered_map>
 
 #include "einsum_shape_inference.hpp"
+#include "openvino/reference/einsum.hpp"
+
 #include "itt.hpp"
 
 namespace ov {
@@ -207,5 +209,16 @@ std::shared_ptr<Node> op::v7::Einsum::clone_with_new_inputs(const OutputVector& 
 void op::v7::Einsum::set_equation(std::string equation) {
     remove_whitespaces(equation);
     m_equation = std::move(equation);
+}
+
+bool op::v7::Einsum::evaluate(TensorVector& outputs, const TensorVector& inputs) const {
+    OV_OP_SCOPE(v7_Einsum_evaluate);
+    ov::reference::einsum(outputs, inputs, m_equation);
+    return true;
+}
+
+bool op::v7::Einsum::has_evaluate() const {
+    OV_OP_SCOPE(v7_Einsum_has_evaluate);
+    return true;
 }
 }  // namespace ov


### PR DESCRIPTION
### Details:
- Identified that the einsum operation was not functioning properly due to the absence of an overridden evaluate method.

- Implemented the evaluate method for einsum to ensure correct execution within loop constructs.

- Tested the fix.

### Tickets:
GSoC2025 –  pipeline enablement on Keras with OpenVINO backend
@rkazants 