### PR TITLE
[Core][Unicode] Refactor model path handling for read_model

### DIFF
--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -145,7 +145,12 @@ public:
               class... Properties,
               std::enable_if_t<std::is_same_v<Path, std::filesystem::path> && (sizeof...(Properties) > 0)>* = nullptr>
     auto read_model(const Path& model_path, const Path& bin_path, Properties&&... properties) const {
-        return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>) {
+            return read_model(model_path.wstring(), bin_path.wstring(), std::forward<Properties>(properties)...);
+        } else {
+            // use string conversion as default
+            return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
+        }
     }
     /// @}
 
@@ -250,7 +255,7 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const AnyMap& properties = {}) const {
-        return compile_model(model_path.string(), properties);
+            return compile_model(model_path.string(), properties);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -281,7 +286,7 @@ public:
 
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, Properties&&... properties) {
-        return compile_model(model_path.string(), std::forward<Properties>(properties)...);
+            return compile_model(model_path.string(), std::forward<Properties>(properties)...);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -313,7 +318,7 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, const AnyMap& properties = {}) {
-        return compile_model(model_path.string(), device_name, properties);
+            return compile_model(model_path.string(), device_name, properties);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -347,7 +352,7 @@ public:
 
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, Properties&&... properties) {
-        return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
+            return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -84,12 +84,6 @@ public:
     std::shared_ptr<ov::Model> read_model(const std::wstring& model_path,
                                           const std::wstring& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
-    template <class Path,
-              std::enable_if_t<std::is_same_v<Path, std::filesystem::path> &&
-                               std::is_same_v<typename Path::value_type, wchar_t>>* = nullptr>
-    auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
-        return read_model(model_path.wstring(), bin_path.wstring(), properties);
-    }
 #endif
 
     /**
@@ -112,6 +106,15 @@ public:
                                           const std::string& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
 
+    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
+    auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>) {
+            return read_model(model_path.wstring(), bin_path.wstring(), properties);
+        } else {
+            // use string conversion as default
+            return read_model(model_path.string(), bin_path.string(), properties);
+        }
+    }
     /// @}
 
     /**
@@ -142,11 +145,7 @@ public:
               class... Properties,
               std::enable_if_t<std::is_same_v<Path, std::filesystem::path> && (sizeof...(Properties) > 0)>* = nullptr>
     auto read_model(const Path& model_path, const Path& bin_path, Properties&&... properties) const {
-        if constexpr (std::is_same_v<typename Path::value_type, char>) {
-            return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
-        } else if constexpr (std::is_same_v<typename Path::value_type, wchar_t>) {
-            return read_model(model_path.wstring(), bin_path.wstring(), std::forward<Properties>(properties)...);
-        }
+        return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
     }
     /// @}
 

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -112,12 +112,6 @@ public:
                                           const std::string& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
 
-    template <class Path,
-              std::enable_if_t<std::is_same_v<Path, std::filesystem::path> &&
-                               std::is_same_v<typename Path::value_type, char>>* = nullptr>
-    auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
-        return read_model(model_path.string(), bin_path.string(), properties);
-    }
     /// @}
 
     /**
@@ -148,7 +142,11 @@ public:
               class... Properties,
               std::enable_if_t<std::is_same_v<Path, std::filesystem::path> && (sizeof...(Properties) > 0)>* = nullptr>
     auto read_model(const Path& model_path, const Path& bin_path, Properties&&... properties) const {
-        return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
+        if constexpr (std::is_same_v<typename Path::value_type, char>) {
+            return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
+        } else if constexpr (std::is_same_v<typename Path::value_type, wchar_t>) {
+            return read_model(model_path.wstring(), bin_path.wstring(), std::forward<Properties>(properties)...);
+        }
     }
     /// @}
 

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -255,7 +255,10 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const AnyMap& properties = {}) const {
-        return compile_model(model_path.string(), properties);
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>)
+            return compile_model(model_path.wstring(), properties);
+        else
+            return compile_model(model_path.string(), properties);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -286,7 +289,10 @@ public:
 
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, Properties&&... properties) {
-        return compile_model(model_path.string(), std::forward<Properties>(properties)...);
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>)
+            return compile_model(model_path.wstring(), std::forward<Properties>(properties)...);
+        else
+            return compile_model(model_path.string(), std::forward<Properties>(properties)...);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -318,7 +324,10 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, const AnyMap& properties = {}) {
-        return compile_model(model_path.string(), device_name, properties);
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>)
+            return compile_model(model_path.wstring(), device_name, properties);
+        else
+            return compile_model(model_path.string(), device_name, properties);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -352,7 +361,10 @@ public:
 
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, Properties&&... properties) {
-        return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>)
+            return compile_model(model_path.wstring(), device_name, std::forward<Properties>(properties)...);
+        else
+            return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -453,7 +453,10 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     void add_extension(const Path& model_path) {
-        add_extension(model_path.string());
+        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>)
+            return add_extension(model_path.wstring());
+        else
+            return add_extension(model_path.string());
     }
     /// @}
 

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -255,7 +255,7 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const AnyMap& properties = {}) const {
-            return compile_model(model_path.string(), properties);
+        return compile_model(model_path.string(), properties);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -286,7 +286,7 @@ public:
 
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, Properties&&... properties) {
-            return compile_model(model_path.string(), std::forward<Properties>(properties)...);
+        return compile_model(model_path.string(), std::forward<Properties>(properties)...);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -318,7 +318,7 @@ public:
 
     template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, const AnyMap& properties = {}) {
-            return compile_model(model_path.string(), device_name, properties);
+        return compile_model(model_path.string(), device_name, properties);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
@@ -352,7 +352,7 @@ public:
 
     template <class Path, class... Properties, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
     auto compile_model(const Path& model_path, const std::string& device_name, Properties&&... properties) {
-            return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
+        return compile_model(model_path.string(), device_name, std::forward<Properties>(properties)...);
     }
 
 #ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -143,17 +143,8 @@ TEST_F(CoreBaseTest, read_model_with_std_fs_path_unicode) {
     generate_test_model_files("test-model");
     ov::Core core;
     for (std::size_t testIndex = 0; testIndex < ov::test::utils::test_unicode_postfix_vector.size(); testIndex++) {
-        std::wstring model_file_name_w = model_files_name_w[testIndex];
-        std::wstring weight_file_name_w = weight_files_name_w[testIndex];
-        std::filesystem::path model_path, weight_path;
-#    ifdef _WIN32
-        model_path = std::filesystem::path(model_file_name_w);
-        weight_path = std::filesystem::path(weight_file_name_w);
-#    else
-        model_path = std::filesystem::path(ov::util::wstring_to_string(model_file_name_w));
-        weight_path = std::filesystem::path(ov::util::wstring_to_string(weight_file_name_w));
-#    endif
-
+        std::filesystem::path model_path = model_files_name_w[testIndex];
+        std::filesystem::path weight_path = weight_files_name_w[testIndex];
         {
             const auto model = core.read_model(model_path);
             EXPECT_NE(model, nullptr);

--- a/src/inference/tests/functional/ov_core_test.cpp
+++ b/src/inference/tests/functional/ov_core_test.cpp
@@ -191,5 +191,20 @@ TEST_F(CoreBaseTest, compile_model_with_std_fs_path) {
         const auto model = core.compile_model(model_path, devices.at(0), ov::AnyMap{});
         EXPECT_TRUE(model);
     }
+#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+    for (std::size_t testIndex = 0; testIndex < ov::test::utils::test_unicode_postfix_vector.size(); testIndex++) {
+        std::filesystem::path model_path_w = model_files_name_w[testIndex];
+        {
+            const auto model = core.compile_model(model_path_w);
+            EXPECT_TRUE(model);
+        }
+        {
+            const auto devices = core.get_available_devices();
+
+            const auto model = core.compile_model(model_path_w, devices.at(0), ov::AnyMap{});
+            EXPECT_TRUE(model);
+        }
+    }
+#endif
 }
 }  // namespace ov::test

--- a/src/tests/test_utils/common_test_utils/src/file_utils.cpp
+++ b/src/tests/test_utils/common_test_utils/src/file_utils.cpp
@@ -103,7 +103,7 @@ std::string getOpenvinoLibDirectory() {
 #endif
 }
 
-std::string getExecutableDirectory() {
+std::string getExecutableDirectoryA() {
     std::string path;
 #ifdef _WIN32
     char buffer[MAX_PATH];
@@ -122,6 +122,30 @@ std::string getExecutableDirectory() {
     }
     path = std::string(buffer, len);
     return ov::util::get_directory(path).string();
+}
+
+#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+std::wstring getExecutableDirectoryW() {
+#    ifdef _WIN32
+    WCHAR ov_ext_path[MAX_PATH];
+    HMODULE hm = NULL;
+    GetModuleFileNameW(hm, (LPWSTR)ov_ext_path, sizeof(ov_ext_path) / sizeof(ov_ext_path[0]));
+    auto path = std::wstring(ov_ext_path);
+    return ov::util::get_directory(path).wstring();
+#    elif defined(__linux__) || defined(__APPLE__) || defined(__EMSCRIPTEN__)
+    return ov::util::string_to_wstring(getExecutableDirectoryA());
+#    else
+#        error "Unsupported OS"
+#    endif
+}
+#endif
+
+std::string getExecutableDirectory() {
+#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
+    return ov::util::wstring_to_string(getExecutableDirectoryW());
+#else
+    return getExecutableDirectoryA();
+#endif
 }
 
 std::string getCurrentWorkingDir() {

--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/test_model/test_model.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/test_model/test_model.hpp
@@ -14,7 +14,6 @@ namespace ov {
 namespace test {
 namespace utils {
 
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
 /**
  * @brief generates IR files (XML and BIN files) with the test model.
  *        Passed reference vector is filled with OpenVINO operations to validate after the network reading.
@@ -23,22 +22,8 @@ namespace utils {
  * @param input_type input element type of the generated model
  * @param input_shape dims on the input layer of the generated model
  */
-void generate_test_model(const std::wstring& model_path,
-                         const std::wstring& weights_path,
-                         const ov::element::Type& input_type = ov::element::f32,
-                         const ov::PartialShape& input_shape = {1, 3, 227, 227});
-#endif
-
-/**
- * @brief generates IR files (XML and BIN files) with the test model.
- *        Passed reference vector is filled with OpenVINO operations to validate after the network reading.
- * @param model_path used to serialize the generated network
- * @param weights_path used to serialize the generated weights
- * @param input_type input element type of the generated model
- * @param input_shape dims on the input layer of the generated model
- */
-void generate_test_model(const std::string& model_path,
-                         const std::string& weights_path,
+void generate_test_model(const std::filesystem::path& model_path,
+                         const std::filesystem::path& weights_path,
                          const ov::element::Type& input_type = ov::element::f32,
                          const ov::PartialShape& input_shape = {1, 3, 227, 227});
 

--- a/src/tests/test_utils/functional_test_utils/include/functional_test_utils/test_model/test_model.hpp
+++ b/src/tests/test_utils/functional_test_utils/include/functional_test_utils/test_model/test_model.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <string>
 #include <vector>
 

--- a/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
@@ -1,7 +1,6 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <filesystem>
 #include "functional_test_utils/test_model/test_model.hpp"
 
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"

--- a/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
+++ b/src/tests/test_utils/functional_test_utils/src/test_model/test_model.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-
+#include <filesystem>
 #include "functional_test_utils/test_model/test_model.hpp"
 
 #include "common_test_utils/subgraph_builders/conv_pool_relu.hpp"
@@ -13,23 +13,8 @@
 namespace ov {
 namespace test {
 namespace utils {
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-void generate_test_model(const std::wstring& model_path,
-                         const std::wstring& weights_path,
-                         const ov::element::Type& input_type,
-                         const ov::PartialShape& input_shape) {
-    ov::pass::Manager manager;
-#    ifdef _WIN32
-    manager.register_pass<ov::pass::Serialize>(model_path, weights_path);
-#    else
-    manager.register_pass<ov::pass::Serialize>(ov::util::wstring_to_string(model_path),
-                                               ov::util::wstring_to_string(weights_path));
-#    endif
-    manager.run_passes(ov::test::utils::make_conv_pool_relu(input_shape.to_shape(), input_type));
-}
-#endif
-void generate_test_model(const std::string& model_path,
-                         const std::string& weights_path,
+void generate_test_model(const std::filesystem::path& model_path,
+                         const std::filesystem::path& weights_path,
                          const ov::element::Type& input_type,
                          const ov::PartialShape& input_shape) {
     ov::pass::Manager manager;


### PR DESCRIPTION
### Details:
 - Using `if constexpr`  instead additional template function for `read_model ` API

### Tickets:
 - CVS-168219
