### PR TITLE
[GPU] Add bzyxf input format for tensor transform in reorder calc output layout

### DIFF
--- a/src/plugins/intel_gpu/src/graph/reorder.cpp
+++ b/src/plugins/intel_gpu/src/graph/reorder.cpp
@@ -159,7 +159,8 @@ layout reorder_inst::calc_output_layout(reorder_node const& node, kernel_impl_pa
     }
 
     if ((ofmt == format::bs_fs_fsv8_bsv8 || ofmt == format::os_i_osv8__ai8 || ofmt == format::os_i_osv16__ai8 || ofmt == format::os_i_osv16 ||
-        ofmt == format::bfzyx || ifmt == format::bfzyx || ofmt == format::b_fs_zyx_fsv16 || ifmt == format::b_fs_zyx_fsv16 ||
+        ofmt == format::bfzyx || ifmt == format::bfzyx || ifmt == format::bzyxf ||
+        ofmt == format::b_fs_zyx_fsv16 || ifmt == format::b_fs_zyx_fsv16 ||
         ofmt == format::bs_fs_zyx_bsv16_fsv16 || ifmt == format::bs_fs_zyx_bsv16_fsv16 ||
         ofmt == format::bs_fs_zyx_bsv16_fsv32 || ifmt == format::bs_fs_zyx_bsv16_fsv32 ||
         ofmt == format::b_fs_zyx_fsv32 || ifmt == format::b_fs_zyx_fsv32 ||

--- a/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/reorder_inputs_test.cpp
@@ -163,6 +163,38 @@ TEST(reorder_inputs, mixed_ranks_gather) {
     ASSERT_EQ(gather2_node.get_output_layout().format, format::bfwzyx);
 }
 
+TEST(reorder_inputs, mixed_ranks_reshape) {
+    // Topology:
+    // transpose -> (5d) -> reshape -> (3d)
+    // Expected: (bfzyx:5d) -> reorder -> (bfyx:4d) -> reshape -> (bfyx:3d)
+
+    auto& engine = get_test_engine();
+    auto shape = engine.allocate_memory(layout{ { 3 }, data_types::i64, format::bfyx });
+    set_values<int64_t>(shape, { 0, -1, 2 });
+
+    topology topology;
+    topology.add(input_layout("input", layout{ { 1, 2, 32, 128, 128 }, data_types::f16, format::bzyxf }));
+    topology.add(input_layout("eltw_input", layout{ { 1, 524288, 2 }, data_types::f16, format::bfyx }));
+    topology.add(data("shape", shape));
+    topology.add(permute("permute", input_info("input"), { 0, 2, 3, 4, 1 }));
+    topology.add(reshape("reshape", input_info("permute"), input_info("shape"), true, ov::PartialShape{ 1, 524288, 2 }));
+    topology.add(eltwise("eltwise", input_info("reshape"), input_info("eltw_input"), eltwise_mode::sum));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+
+    program::ptr prog = nullptr;
+    OV_ASSERT_NO_THROW(prog = program::build_program(engine, topology, config));
+    ASSERT_NE(prog, nullptr);
+
+    auto prog_impl = prog.get();
+
+    auto& reshape_node = prog_impl->get_node("reshape");
+
+    ov::PartialShape expected_reorder_shape{ 1, 32, 16384, 2 };
+    ASSERT_EQ(reshape_node.get_input_layouts()[0].get_partial_shape(), expected_reorder_shape);
+}
+
 TEST(reorder_inputs, impl_forcing_basic_format) {
     auto& engine = get_test_engine();
     auto input = engine.allocate_memory({ data_types::f32, format::bfyx, { 1, 2, 4, 1 } });


### PR DESCRIPTION
### Details:
 - Add bzyxf input format for tensor transform in reorder calc output layout

### Tickets:
 - 168257
