### PR TITLE
Fix pytest dependency conflict in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,8 +26,8 @@ pydata-sphinx-theme==0.14.4
 Pygments==2.15.1
 pyparsing==3.0.9
 pytest==8.4.0
-pytest-html==3.1.1
-pytest-metadata==1.11.0
+pytest-html==4.1.1
+pytest-metadata==3.1.1
 py>=1.11.0
 pytz==2022.7
 pyyaml==6.0.1


### PR DESCRIPTION
### Details:
 -  https://github.com/openvinotoolkit/openvino/pull/30823 had a conflict while it tried to update pytest-html. Resolved it in this PR

### Tickets:
 - *ticket-id*
