### PR TITLE
[CLANG-TIDY] Add cmake option to automatically apply clang-tidy remarks if possible

### DIFF
--- a/cmake/developer_package/features.cmake
+++ b/cmake/developer_package/features.cmake
@@ -81,6 +81,7 @@ ov_dependent_option (ENABLE_CPPLINT_REPORT "Build cpplint report instead of fail
 ov_option (ENABLE_CLANG_FORMAT "Enable clang-format checks during the build" ${STYLE_CHECKS_DEFAULT})
 
 ov_option (ENABLE_CLANG_TIDY "Enable clang-tidy checks during the build" OFF)
+ov_dependent_option (ENABLE_CLANG_TIDY_FIX "Enable clang-tidy automatic fixes during the build" OFF "ENABLE_CLANG_TIDY" OFF)
 
 ov_option (ENABLE_NCC_STYLE "Enable ncc style check" ${STYLE_CHECKS_DEFAULT})
 

--- a/cmake/developer_package/plugins/plugins.cmake
+++ b/cmake/developer_package/plugins/plugins.cmake
@@ -104,8 +104,12 @@ function(ov_add_plugin)
 
         if (OV_PLUGIN_ADD_CLANG_TIDY)
             if (ENABLE_CLANG_TIDY)
+                set(clang_tidy_options "--extra-arg=-Wno-unused-command-line-argument")
+                if(ENABLE_CLANG_TIDY_FIX)
+                    list(APPEND clang_tidy_options "--fix-errors")
+                endif()
                 set_target_properties(${OV_PLUGIN_NAME} PROPERTIES
-                    CXX_CLANG_TIDY "${CLANG_TIDY};--extra-arg=-Wno-unused-command-line-argument")
+                    CXX_CLANG_TIDY "${CLANG_TIDY};${clang_tidy_options}")
             endif()
         endif()
 


### PR DESCRIPTION
### Details:
Usage:
```bash
$ cmake -DENABLE_CLANG_TIDY=ON -DENABLE_CLANG_TIDY_FIX=ON ..
```

### Tickets:
 - N/A
