### PR TITLE
[PyOV] Enable free-threaded python build

### DIFF
--- a/cmake/developer_package/cross_compile/python_helpers.cmake
+++ b/cmake/developer_package/cross_compile/python_helpers.cmake
@@ -78,6 +78,16 @@ macro(ov_find_python3 find_package_mode)
 
     find_package(Python3 ${find_package_mode} COMPONENTS Interpreter ${python3_development_component})
 
+    if(ENABLE_NO_GIL_PYTHON_API)
+        if(Python3_VERSION VERSION_LESS "3.13")
+            message(FATAL_ERROR "ENABLE_NO_GIL_PYTHON_API requires Python >= 3.13, but found Python ${Python3_VERSION}")
+        else()
+            # the fourth value is gil_disabled, which is OFF by default
+            set(Python3_FIND_ABI "ANY" "ANY" "ANY" "ON")
+        endif()
+    endif()
+
+
     if(CMAKE_CROSSCOMPILING AND LINUX)
         ov_cross_compile_define_debian_arch_reset()
         set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${_old_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})

--- a/src/bindings/python/src/pyopenvino/CMakeLists.txt
+++ b/src/bindings/python/src/pyopenvino/CMakeLists.txt
@@ -60,6 +60,11 @@ list(FILTER SOURCES EXCLUDE REGEX ".*(frontend/(onnx|tensorflow|paddle|pytorch|j
 
 pybind11_add_module(${PROJECT_NAME} MODULE NO_EXTRAS ${SOURCES})
 
+if(ENABLE_NO_GIL_PYTHON_API)
+    # disable GIL for free-threaded python build
+    target_compile_definitions(${PROJECT_NAME} PRIVATE Py_GIL_DISABLED=1)
+endif()
+
 target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
 target_link_libraries(${PROJECT_NAME} PRIVATE openvino::core::dev openvino::runtime openvino::offline_transformations)

--- a/src/bindings/python/src/pyopenvino/frontend/frontend_module.cmake
+++ b/src/bindings/python/src/pyopenvino/frontend/frontend_module.cmake
@@ -22,6 +22,11 @@ function(frontend_module TARGET FRAMEWORK INSTALL_COMPONENT)
     add_dependencies(${TARGET_NAME} pyopenvino)
     add_dependencies(py_ov_frontends ${TARGET_NAME})
 
+    if(ENABLE_NO_GIL_PYTHON_API)
+        # disable GIL for free-threaded python build
+        target_compile_definitions(${TARGET_NAME} PRIVATE Py_GIL_DISABLED=1)
+    endif()
+
     target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
                                                       "${OpenVINOPython_SOURCE_DIR}/src/pyopenvino/utils/")
     target_link_libraries(${TARGET_NAME} PRIVATE openvino::runtime openvino::core::dev openvino::frontend::${FRAMEWORK})

--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -80,7 +80,11 @@ inline std::string get_version() {
     return version.buildNumber;
 }
 
+#ifdef Py_GIL_DISABLED
+PYBIND11_MODULE(_pyopenvino, m, py::mod_gil_not_used()) {
+#else
 PYBIND11_MODULE(_pyopenvino, m) {
+#endif
     m.doc() = "Package openvino._pyopenvino which wraps openvino C++ APIs";
     std::string pyopenvino_version = CI_BUILD_NUMBER;
     std::string runtime_version = get_version();


### PR DESCRIPTION
### Details:
 - Introduce a new cmake option `ENABLE_NO_GIL_PYTHON_API`, which allows to build free-threaded OV Python API.
 - Requires python3.13t+

### Tickets:
 - CVS-164541
