### PR TITLE
Update optimum-intel for validation

### DIFF
--- a/tests/requirements_pytorch
+++ b/tests/requirements_pytorch
@@ -44,7 +44,7 @@ huggingface-hub==0.25.2
 
 # For now, we decided to pin a specific working version of optimum-intel.
 # It will be discussed in the future how to manage versioning of the components properly.
-git+https://github.com/huggingface/optimum-intel.git@dba7dced0145b539bb0563e5d5741d00daeb8025; python_version < "3.12"
+git+https://github.com/huggingface/optimum-intel.git@8ba536cd0a2bf93e9e88408b0048a7695db5be0b; python_version < "3.12"
 # set 'export HF_HUB_ENABLE_HF_TRANSFER=1' to benefits from hf_transfer
 hf_transfer==0.1.8
 


### PR DESCRIPTION
**Details:** optimum interface has been changed and no longer compatible with the current optimum-intel version. Need to update optimum-intel.

**Ticket:** 169173
