### PR TITLE
[Snippets][CPU] Fix uninitialized value jump reported by valgrind

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
@@ -244,7 +244,7 @@ void BrgemmCopyBKernel::operator()(const void* args) const {
 void BrgemmCopyBKernel::init_brgemm_copy_b_kernel(
     std::unique_ptr<dnnl::impl::cpu::x64::matmul::jit_brgemm_matmul_copy_b_t>& kernel,
     const BrgemmCopyBKernelConfig& conf) {
-    matmul::brgemm_matmul_conf_t brgCopyKernelConf;
+    matmul::brgemm_matmul_conf_t brgCopyKernelConf{};
     brgCopyKernelConf.src_dt = conf.get_src_dt();
     brgCopyKernelConf.wei_dt = conf.get_wei_dt();
     brgCopyKernelConf.orig_wei_dt = conf.get_original_wei_dt();


### PR DESCRIPTION
### Details:
Fix "Conditional jump or move depends on uninitialised value(s)" error

```
==2061018== Thread 4:
==2061018== Conditional jump or move depends on uninitialised value(s)
==2061018==    at 0x8D46DC3: dnnl::impl::cpu::x64::matmul::jit_brgemm_matmul_copy_b_transposed_t<Xbyak::Ymm>::generate()::{lambda(bool, bool)#1}::operator()(bool, bool) const (brgemm_matmul_copy_utils.cpp:4312)
==2061018==    by 0x8D474BE: dnnl::impl::cpu::x64::matmul::jit_brgemm_matmul_copy_b_transposed_t<Xbyak::Ymm>::generate() (brgemm_matmul_copy_utils.cpp:4367)
==2061018==    by 0x8D0AD86: dnnl::impl::cpu::x64::jit_generator::create_kernel() [clone .part.0] (jit_generator.hpp:2835)
```

### Tickets:
 - 169031
