### PR TITLE
Fix missing default partition_id in openvino_execute

### DIFF
--- a/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py
+++ b/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py
@@ -71,7 +71,13 @@ def execute_cached(compiled_model, *args):
     return result
 
 
-def openvino_execute(gm: GraphModule, *args, executor_parameters=None, partition_id, options):
+def openvino_execute(
+    gm: GraphModule,
+    *args,
+    executor_parameters=None,
+    partition_id: int = 0,
+    options=None,
+):
 
     executor_parameters = executor_parameters or DEFAULT_OPENVINO_PYTHON_CONFIG
 


### PR DESCRIPTION
## What & why
[execute(executor="strictly_openvino")](cci:1://file:///d:/Github/openvino/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py:46:0-59:25) crashed with  
`TypeError: openvino_execute() missing 1 required positional argument: 'partition_id'`.

The internal helper [openvino_execute()](cci:1://file:///d:/Github/openvino/src/bindings/python/src/openvino/frontend/pytorch/torchdynamo/execute.py:73:0-116:19) expected `partition_id` but its sole external caller (strictly-openvino path) didn’t supply one. This made the “strictly_openvino” mode unusable.

## How
Added a default value (`partition_id: int = 0`) to the function signature:

```python
def openvino_execute(
    gm: GraphModule,
    *args,
    executor_parameters=None,
    partition_id: int = 0,   # new default
    options=None,
):
```
No logic changes; existing callers still work, and the user-facing strictly-openvino execution path now runs without error.

