### PR TITLE
[CPU] serialize kv-cache precision information for ScaledDotProductAttention

### DIFF
--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -22,6 +22,7 @@
 
 #include "cpu_types.h"
 #include "node.h"
+#include "nodes/scaled_attn.h"
 #include "onednn/dnnl.h"
 #include "openvino/core/except.hpp"
 #include "openvino/core/model.hpp"
@@ -122,6 +123,13 @@ std::map<std::string, std::string> extract_node_metadata(const NodePtr& node) {
     serialization_info[ov::exec_model_info::EXECUTION_ORDER] = std::to_string(node->getExecIndex());
 
     serialization_info[ov::exec_model_info::RUNTIME_PRECISION] = node->getRuntimePrecision().get_type_name();
+    // record kv cache precision for ScaledDotProductAttention node
+    if (node->getType() == Type::ScaledDotProductAttention) {
+        auto* sdpa_node = dynamic_cast<ov::intel_cpu::node::ScaledDotProductAttention*>(node.get());
+        if (sdpa_node) {
+            serialization_info["kv_cache_precision"] = sdpa_node->getKVCachePrecision().get_type_name();
+        }
+    }
 
     return serialization_info;
 }


### PR DESCRIPTION
### Details:
 - *Currently, KV cache precision is only displayed in the execution graph for Paged Attention, and there is no way to verify precision for SDPA without inserting print statements into OpenVino. To address this, we have added serialization of KV cache precision information in the execution graph for SDPA, enabling better verification and debugging of SDPA precision.*


### Tickets:
 - *CVS-168845*
