### PR TITLE
[TRANSFORMATIONS][GPU] Add a condition sdpa fusion to avoid sdpa decomposition

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/sdpa_fusion.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/sdpa_fusion.cpp
@@ -155,8 +155,8 @@ SDPAFusion::SDPAFusion() {
         if (v_node_ps[-2] != S)
             return false;
 
-        // make sure that embedding dimension of key is the same as for query
-        if (k_node_ps[-1] != E)
+        // make sure that embedding dimension of key and value is the same as for query
+        if (k_node_ps[-1] != E || v_node_ps[-1] != E)
             return false;
 
         if (!valid_qk_shapes(ov::as_type_ptr<ov::op::v0::MatMul>(pattern_map.at(qk).get_node_shared_ptr()))) {


### PR DESCRIPTION
### Details:
 - *Why: The embedding dimension of key and value should be equal to be SDPA.  But current code doesn't check this condition and as the result SDPA fused node is decomposed at ScaledDotProductAttentionDecomposition*
 - *How: Add a condition to check the equal of embedding dimension of key and value for SDPA fusion*

### Tickets:
 - *166822*
