### PR TITLE
[GPU] Disable crop buffer fusing for better perf

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -384,9 +384,9 @@ static bool is_optimizable_padding_for_crop(const crop_node& node,
         (input_layout.spatial(0) - offsets.spatial[0] - output_layout.get_tensor().spatial[0]) != 0 ||
         (input_layout.spatial(1) - offsets.spatial[1] - output_layout.get_tensor().spatial[1]) != 0));
 
-    for (auto user : node.get_users()) {
-        if (user->is_type<gemm>() && user->get_dependency_index(node) < 2) {
-            if (is_input_lower_pad || is_input_upper_pad) {
+    if (is_input_lower_pad || is_input_upper_pad) {
+        for (auto user : node.get_users()) {
+            if (user->is_type<gemm>() && user->get_dependency_index(node) < 2) {
                 return false;
             }
         }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -874,6 +874,10 @@ void prepare_buffer_fusing::run(program& p) {
                     }
                 }
             }
+            // For better performance, disable buffer fusing with data padding which causes selecting gemm_ref kernel instead of gemm_tiled_opt
+            if (node.get_users().front()->is_type<gemm>() && crop_layout.data_padding)
+                return;
+
             node.set_output_layout(crop_layout);
             node.can_be_optimized(true);
             propagate_padding_to_opt_out_users(node, node.get_output_layout().data_padding);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -498,6 +498,24 @@ bool crop_in_place_optimization::match(const program_node& node,
                 crop_params.input_offsets[0].spatial[1] != 0) {
                 return false;
             }
+            // Do not optimize out for possibly crop padding to select gemm_tiled_opt kernel
+            auto crop_layout = node.get_output_layout();
+            auto& crop_node = node.as<crop>();
+            std::pair<const program_node*, layout> user_info;
+            if (can_crop_be_optimized_simple_data_format(crop_layout, input_layout)) {
+                auto has_padding_expect_batch = [](const padding pad) {
+                    return std::any_of(std::next(pad._lower_size.begin()), pad._lower_size.end(), [](int32_t i){ return i > 0; }) ||
+                           std::any_of(std::next(pad._upper_size.begin()), pad._upper_size.end(), [](int32_t i){ return i > 0; });
+                };
+                update_in_place_crop_padding_simple_data_format(crop_layout,
+                                                                input_layout,
+                                                                user_info,
+                                                                crop_params.input_offsets[0],
+                                                                crop_node.get_primitive()->axis,
+                                                                is_runtime);
+                if (has_padding_expect_batch(crop_layout.data_padding))
+                    return false;
+            }
         }
         if (user->is_type<reshape>()) {
             // runtime buffer fusing is only handled when there is only one reshape user
@@ -874,10 +892,6 @@ void prepare_buffer_fusing::run(program& p) {
                     }
                 }
             }
-            // For better performance, disable buffer fusing with data padding which causes selecting gemm_ref kernel instead of gemm_tiled_opt
-            if (node.get_users().front()->is_type<gemm>() && crop_layout.data_padding)
-                return;
-
             node.set_output_layout(crop_layout);
             node.can_be_optimized(true);
             propagate_padding_to_opt_out_users(node, node.get_output_layout().data_padding);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -374,6 +374,24 @@ static bool is_optimizable_padding_for_crop(const crop_node& node,
         input_layout.data_padding._lower_size[3] != 0 || input_layout.data_padding._upper_size[3] != 0)
         return false;
 
+    // For static shape, gemm ref kernel is selected if there is padding on the feature, x, or y axes.
+    // In such cases, do not optimize out this crop to use the opt kernel.
+    // TODO: Modify gemm_tiled_opt kernel to support padding even in static shape.
+    auto output_layout = node.get_output_layout();
+    bool is_input_lower_pad = offsets.feature[0] != 0 || offsets.spatial[0] != 0 || offsets.spatial[1] != 0;
+    bool is_input_upper_pad = (output_layout.is_static() &&
+        ((input_layout.feature() - offsets.feature[0] - output_layout.get_tensor().feature[0]) != 0 ||
+        (input_layout.spatial(0) - offsets.spatial[0] - output_layout.get_tensor().spatial[0]) != 0 ||
+        (input_layout.spatial(1) - offsets.spatial[1] - output_layout.get_tensor().spatial[1]) != 0));
+
+    for (auto user : node.get_users()) {
+        if (user->is_type<gemm>() && user->get_dependency_index(node) < 2) {
+            if (is_input_lower_pad || is_input_upper_pad) {
+                return false;
+            }
+        }
+    }
+
     auto opt_lower_pad = offsets.feature[0];
     auto opt_upper_pad = input_layout.feature() - offsets.feature[0] - crop_layout.get_tensor().feature[0];
 
@@ -488,22 +506,6 @@ bool crop_in_place_optimization::match(const program_node& node,
         // TODO: Need to allow optimization for gemm user
         if (node.is_dynamic() && (user->is_type<convolution>() || user->is_type<gemm>()))
             return false;
-        // For static shape, gemm ref kernel is selected if there is padding on the feature, x, or y axes.
-        // In such cases, do not optimize out this crop to use the opt kernel.
-        // TODO: Modify gemm_tiled_opt kernel to support padding even in static shape.
-        if ((!node.is_dynamic() || is_runtime) && user->is_type<gemm>() &&
-            (user->get_dependency_index(node) == 0 || user->get_dependency_index(node) == 1)) {
-            auto output_layout = node.get_output_layout();
-            const auto offsets = crop_params.input_offsets[0];
-            const auto& crop_size = output_layout.get_tensor();
-            if ((offsets.feature[0] != 0 || offsets.spatial[0] != 0 || offsets.spatial[1] != 0) ||
-                (output_layout.is_static() &&
-                ((input_layout.feature() - offsets.feature[0] - crop_size.feature[0]) != 0 ||
-                (input_layout.spatial(0) - offsets.spatial[0] - crop_size.spatial[0]) != 0 ||
-                (input_layout.spatial(1) - offsets.spatial[1] - crop_size.spatial[1]) != 0))) {
-                return false;
-            }
-        }
         if (user->is_type<reshape>()) {
             // runtime buffer fusing is only handled when there is only one reshape user
             if (node.is_dynamic() && node.get_users().size() != 1)

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -709,7 +709,7 @@ TEST(prepare_buffer_fusing, in_place_crop_static) {
         ASSERT_EQ(output_ptr_2[i], out2[i]);
 }
 
-TEST(prepare_buffer_fusing, in_place_crop_static_padding_and_gemm) {
+TEST(prepare_buffer_fusing, disable_crop_buffer_fusing_with_shift_right_padding) {
     auto& engine = get_test_engine();
 
     auto gemm_input_mem = engine.allocate_memory({ {1, 4, 4, 2}, data_types::f32, format::bfyx });

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -747,7 +747,7 @@ TEST(prepare_buffer_fusing, in_place_crop_static_padding_and_gemm) {
         auto outputs = network.execute();
 
         auto crop_prim = network.get_primitive("crop");
-        ASSERT_EQ(crop_prim->can_be_optimized(), true);
+        ASSERT_EQ(crop_prim->can_be_optimized(), false);    // Not opt out because the user, gemm node, has paddings at spatial dimensions
 
         auto output = outputs.at("output").get_memory();
         cldnn::mem_lock<float> output_ptr(output, get_test_stream());


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - If crop is buffer-fused with data padding, the user, gemm node would select ref kernel instead of tiled_opt which is better for performance.
 - Hot to solve: Add a condition to check possibly crop padding at match step of crop buffer fusing

## The code and line that caused this issue (if it is not changed directly)
- openvino/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp program_helpers::do_for_types<crop>() could add paddings when crop buffer optimized out is done
- openvino/src/plugins/intel_gpu/src/kernel_selector/kernels/gemm/gemm_kernel_tiled_opt.cpp validate() func doesn't support paddings for f,x,y

## Problematic graph
 - onenote: "GPU-Dev3.one#timm_eca_halonext26ts"
![image](https://github.com/user-attachments/assets/07ba234c-7624-4917-802b-c9ba79c56818)


## Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *166822*