### PR TITLE
[CORE] Refactor function signatures to use std::filesystem::path

### DIFF
--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -69,7 +69,7 @@ Napi::Value CoreWrap::read_model_sync(const Napi::CallbackInfo& info) {
         std::shared_ptr<ov::Model> model;
 
         if (ov::js::validate<Napi::String, Napi::String>(info, allowed_signatures)) {
-            model = _core.read_model(info[0].ToString(), info[1].ToString());
+            model = _core.read_model(buffer_to_string(info[0]), buffer_to_string(info[1]));
         } else if (ov::js::validate<Napi::Buffer<uint8_t>, Napi::Buffer<uint8_t>>(info, allowed_signatures)) {
             std::string model_str = buffer_to_string(info[0]);
 
@@ -87,7 +87,7 @@ Napi::Value CoreWrap::read_model_sync(const Napi::CallbackInfo& info) {
 
             model = _core.read_model(model_str, weight_tensor);
         } else if (ov::js::validate<Napi::String>(info, allowed_signatures)) {
-            model = _core.read_model(info[0].ToString());
+            model = _core.read_model(buffer_to_string(info[0].ToString()));
         } else if (ov::js::validate<Napi::String, TensorWrap>(info, allowed_signatures)) {
             model = _core.read_model(info[0].ToString(), cast_to_tensor(info, 1));
         } else {

--- a/src/common/util/include/openvino/util/file_util.hpp
+++ b/src/common/util/include/openvino/util/file_util.hpp
@@ -176,42 +176,13 @@ inline int64_t file_size(const char* path) {
  * @param[in]  path  The file name
  * @return     file size
  */
-inline bool file_exists(const char* path) {
-#if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-    std::wstring widefilename = ov::util::string_to_wstring(path);
-    const wchar_t* file_name = widefilename.c_str();
-#elif defined(__ANDROID__) || defined(ANDROID)
-    std::string file_name = path;
-    std::string::size_type pos = file_name.find('!');
-    if (pos != std::string::npos) {
-        file_name = file_name.substr(0, pos);
+inline bool file_exists(const ov::util::Path& path) {
+    if (path.empty()) {
+        return false;
     }
-#else
-    const char* file_name = path;
-#endif
-    std::ifstream in(file_name, std::ios_base::binary | std::ios_base::ate);
-    return in.good();
-}
-
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-
-/**
- * @brief      Returns true if file exists
- * @param[in]  path  The file name
- * @return     true if file exists
- */
-inline bool file_exists(const std::wstring& path) {
-    return file_exists(wstring_to_string(path).c_str());
-}
-#endif  // OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-
-/**
- * @brief      Returns true if file exists
- * @param[in]  path  The file name
- * @return     true if file exists
- */
-inline bool file_exists(const std::string& path) {
-    return file_exists(path.c_str());
+    // Check if the file exists
+    std::error_code ec;
+    return std::filesystem::exists(path, ec) && !ec;
 }
 
 std::string get_file_ext(const std::string& path);

--- a/src/inference/dev_api/openvino/runtime/icore.hpp
+++ b/src/inference/dev_api/openvino/runtime/icore.hpp
@@ -63,8 +63,8 @@ public:
      * @param properties Optional map of pairs: (property name, property value) relevant only for this read operation.
      * @return shared pointer to ov::Model
      */
-    virtual std::shared_ptr<ov::Model> read_model(const std::string& model_path,
-                                                  const std::string& bin_path,
+    virtual std::shared_ptr<ov::Model> read_model(const std::filesystem::path& model_path,
+                                                  const std::filesystem::path& bin_path,
                                                   const AnyMap& properties) const = 0;
 
     virtual ov::AnyMap create_compile_config(const std::string& device_name, const ov::AnyMap& origConfig) const = 0;

--- a/src/inference/include/openvino/runtime/core.hpp
+++ b/src/inference/include/openvino/runtime/core.hpp
@@ -65,27 +65,6 @@ public:
      */
     std::map<std::string, Version> get_versions(const std::string& device_name) const;
 
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-    /**
-     * @brief Reads models from IR / ONNX / PDPD / TF / TFLite file formats.
-     * @param model_path Path to a model.
-     * @param bin_path Path to a data file.
-     * For IR format (*.bin):
-     *  * if `bin_path` is empty, will try to read a bin file with the same name as xml and
-     *  * if the bin file with the same name is not found, will load IR without weights.
-     * For the following file formats the `bin_path` parameter is not used:
-     *  * ONNX format (*.onnx)
-     *  * PDPD (*.pdmodel)
-     *  * TF (*.pb, *.meta, SavedModel directory)
-     *  * TFLite (*.tflite)
-     * @param properties Optional map of pairs: (property name, property value) relevant only for this read operation.
-     * @return A model.
-     */
-    std::shared_ptr<ov::Model> read_model(const std::wstring& model_path,
-                                          const std::wstring& bin_path = {},
-                                          const ov::AnyMap& properties = {}) const;
-#endif
-
     /**
      * @brief Reads models from IR / ONNX / PDPD / TF / TFLite file formats.
      * @param model_path Path to a model.
@@ -102,19 +81,10 @@ public:
      * @return A model.
      * @{
      */
-    std::shared_ptr<ov::Model> read_model(const std::string& model_path,
-                                          const std::string& bin_path = {},
+    std::shared_ptr<ov::Model> read_model(const std::filesystem::path& model_path,
+                                          const std::filesystem::path& bin_path = {},
                                           const ov::AnyMap& properties = {}) const;
 
-    template <class Path, std::enable_if_t<std::is_same_v<Path, std::filesystem::path>>* = nullptr>
-    auto read_model(const Path& model_path, const Path& bin_path = {}, const ov::AnyMap& properties = {}) const {
-        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>) {
-            return read_model(model_path.wstring(), bin_path.wstring(), properties);
-        } else {
-            // use string conversion as default
-            return read_model(model_path.string(), bin_path.string(), properties);
-        }
-    }
     /// @}
 
     /**
@@ -135,22 +105,10 @@ public:
      * @{
      */
     template <typename... Properties>
-    util::EnableIfAllStringAny<CompiledModel, Properties...> read_model(const std::string& model_path,
-                                                                        const std::string& bin_path,
+    util::EnableIfAllStringAny<CompiledModel, Properties...> read_model(const std::filesystem::path& model_path,
+                                                                        const std::filesystem::path& bin_path,
                                                                         Properties&&... properties) const {
         return read_model(model_path, bin_path, AnyMap{std::forward<Properties>(properties)...});
-    }
-
-    template <class Path,
-              class... Properties,
-              std::enable_if_t<std::is_same_v<Path, std::filesystem::path> && (sizeof...(Properties) > 0)>* = nullptr>
-    auto read_model(const Path& model_path, const Path& bin_path, Properties&&... properties) const {
-        if constexpr (std::is_same_v<typename Path::value_type, wchar_t>) {
-            return read_model(model_path.wstring(), bin_path.wstring(), std::forward<Properties>(properties)...);
-        } else {
-            // use string conversion as default
-            return read_model(model_path.string(), bin_path.string(), std::forward<Properties>(properties)...);
-        }
     }
     /// @}
 

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -79,18 +79,9 @@ Core::Core(const std::string& xml_config_file) {
 
 std::map<std::string, Version> Core::get_versions(const std::string& device_name) const {
     OV_CORE_CALL_STATEMENT({ return _impl->get_versions(device_name); })}
-#ifdef OPENVINO_ENABLE_UNICODE_PATH_SUPPORT
-std::shared_ptr<ov::Model> Core::read_model(const std::wstring& model_path,
-                                            const std::wstring& bin_path,
-                                            const ov::AnyMap& properties) const {
-    OV_CORE_CALL_STATEMENT(return _impl->read_model(ov::util::wstring_to_string(model_path),
-                                                    ov::util::wstring_to_string(bin_path),
-                                                    properties););
-}
-#endif
 
-std::shared_ptr<ov::Model> Core::read_model(const std::string& model_path,
-                                            const std::string& bin_path,
+std::shared_ptr<ov::Model> Core::read_model(const std::filesystem::path& model_path,
+                                            const std::filesystem::path& bin_path,
                                             const AnyMap& properties) const {
     OV_CORE_CALL_STATEMENT(return _impl->read_model(model_path, bin_path, properties););
 }

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1753,8 +1753,8 @@ void ov::CoreImpl::add_mutex(const std::string& dev_name) {
     dev_mutexes[dev_name];
 }
 
-std::shared_ptr<ov::Model> ov::CoreImpl::read_model(const std::string& modelPath,
-                                                    const std::string& binPath,
+std::shared_ptr<ov::Model> ov::CoreImpl::read_model(const std::filesystem::path& modelPath,
+                                                    const std::filesystem::path& binPath,
                                                     const AnyMap& properties) const {
     OV_ITT_SCOPE(FIRST_INFERENCE, ov::itt::domains::ReadTime, "CoreImpl::read_model from file");
     auto local_core_config = coreConfig;

--- a/src/inference/src/dev/core_impl.hpp
+++ b/src/inference/src/dev/core_impl.hpp
@@ -318,8 +318,8 @@ public:
     std::shared_ptr<ov::Model> read_model(const std::shared_ptr<AlignedBuffer>& model,
                                           const std::shared_ptr<AlignedBuffer>& weights) const override;
 
-    std::shared_ptr<ov::Model> read_model(const std::string& model_path,
-                                          const std::string& bin_path,
+    std::shared_ptr<ov::Model> read_model(const std::filesystem::path& model_path,
+                                          const std::filesystem::path& bin_path,
                                           const AnyMap& properties) const override;
 
     ov::SoPtr<ov::ICompiledModel> compile_model(const std::shared_ptr<const ov::Model>& model,

--- a/src/inference/src/model_reader.cpp
+++ b/src/inference/src/model_reader.cpp
@@ -108,15 +108,15 @@ void update_v10_model(std::shared_ptr<ov::Model>& model, bool frontendMode = fal
 namespace ov {
 namespace util {
 
-std::shared_ptr<ov::Model> read_model(const std::string& modelPath,
-                                      const std::string& binPath,
+std::shared_ptr<ov::Model> read_model(const std::filesystem::path& modelPath,
+                                      const std::filesystem::path& binPath,
                                       const std::vector<ov::Extension::Ptr>& extensions,
                                       bool enable_mmap) {
     // Fix unicode name
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-    std::wstring model_path = ov::util::string_to_wstring(modelPath.c_str());
+    std::wstring model_path = modelPath.wstring();
 #else
-    std::string model_path = modelPath;
+    std::string model_path = modelPath.string();
 #endif
 
     // Try to load with FrontEndManager
@@ -128,9 +128,9 @@ std::shared_ptr<ov::Model> read_model(const std::string& modelPath,
 
     if (!binPath.empty()) {
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-        const std::wstring& weights_path = ov::util::string_to_wstring(binPath.c_str());
+        const std::wstring& weights_path = binPath.wstring();
 #else
-        const std::string& weights_path = binPath;
+        const std::string& weights_path = binPath.string();
 #endif
         params.emplace_back(weights_path);
     }
@@ -148,12 +148,12 @@ std::shared_ptr<ov::Model> read_model(const std::string& modelPath,
         return model;
     }
 
-    const auto fileExt = modelPath.substr(modelPath.find_last_of(".") + 1);
+    const auto fileExt = model_path.substr(model_path.find_last_of(".") + 1);
     std::string FEs;
     for (const auto& fe_name : manager.get_available_front_ends())
         FEs += fe_name + " ";
     OPENVINO_THROW("Unable to read the model: ",
-                   modelPath,
+                   model_path,
                    " Please check that model format: ",
                    fileExt,
                    " is supported and the model is correct.",

--- a/src/inference/src/model_reader.cpp
+++ b/src/inference/src/model_reader.cpp
@@ -114,7 +114,7 @@ std::shared_ptr<ov::Model> read_model(const std::filesystem::path& modelPath,
                                       bool enable_mmap) {
     // Fix unicode name
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-    std::wstring model_path = modelPath.wstring();
+    std::string model_path = ov::util::wstring_to_string(modelPath.wstring());
 #else
     std::string model_path = modelPath.string();
 #endif
@@ -128,7 +128,7 @@ std::shared_ptr<ov::Model> read_model(const std::filesystem::path& modelPath,
 
     if (!binPath.empty()) {
 #if defined(OPENVINO_ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-        const std::wstring& weights_path = binPath.wstring();
+        const std::string& weights_path = ov::util::wstring_to_string(binPath.wstring());
 #else
         const std::string& weights_path = binPath.string();
 #endif

--- a/src/inference/src/model_reader.hpp
+++ b/src/inference/src/model_reader.hpp
@@ -24,8 +24,8 @@ namespace util {
  * @param enable_mmap boolean to enable/disable `mmap` use in Frontend
  * @return Shared pointer to ov::Model
  */
-std::shared_ptr<ov::Model> read_model(const std::string& modelPath,
-                                      const std::string& binPath,
+std::shared_ptr<ov::Model> read_model(const std::filesystem::path& modelPath,
+                                      const std::filesystem::path& binPath,
                                       const std::vector<ov::Extension::Ptr>& extensions,
                                       bool enable_mmap);
 

--- a/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_icore.hpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_icore.hpp
@@ -49,7 +49,7 @@ public:
     MOCK_METHOD(std::shared_ptr<ov::Model>, read_model, (const std::string&, const ov::Tensor&, bool), (const));
     MOCK_METHOD(std::shared_ptr<ov::Model>,
                 read_model,
-                (const std::string&, const std::string&, const ov::AnyMap&),
+                (const std::filesystem::path&, const std::filesystem::path&, const ov::AnyMap&),
                 (const));
     MOCK_METHOD(std::shared_ptr<ov::Model>,
                 read_model,


### PR DESCRIPTION

### Details:
 - `read_model()`
 - `file_exists()`

### Tickets:
 - *ticket-id*
