### PR TITLE
[GPU] Use 3D shape for onednn 1D convolution

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -81,7 +81,7 @@ static std::shared_ptr<dnnl::convolution_forward::primitive_desc> get_convolutio
     }
 
     if (prim->bias.is_valid()) {
-        auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, true);
+        auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, onednn::mem_flags::flatten);
         return std::make_shared<dnnl::convolution_forward::primitive_desc>(
             engine.get_onednn_engine(),
             dnnl::prop_kind::forward_inference,
@@ -152,7 +152,7 @@ protected:
                 a_zp = a_zp_node.get_attached_memory_ptr();
             }
 
-            dnnl::memory::desc desc = onednn::layout_to_memory_desc(a_zp->get_layout(), dnnl::memory::format_tag::a, true);
+            dnnl::memory::desc desc = onednn::layout_to_memory_desc(a_zp->get_layout(), dnnl::memory::format_tag::a, onednn::mem_flags::flatten);
             args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, a_zp->get_onednn_memory(desc)});
 
             GPU_DEBUG_TRACE_DETAIL << instance.id() << " activations_zero_points: "
@@ -161,7 +161,7 @@ protected:
 
         if (instance.weights_zero_points_term()) {
             auto w_zp = instance.weights_zero_points_memory();
-            dnnl::memory::desc desc = onednn::layout_to_memory_desc(w_zp->get_layout(), dnnl::memory::format_tag::a, true);
+            dnnl::memory::desc desc = onednn::layout_to_memory_desc(w_zp->get_layout(), dnnl::memory::format_tag::a, onednn::mem_flags::flatten);
             args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, w_zp->get_onednn_memory(desc)});
 
             GPU_DEBUG_TRACE_DETAIL << instance.id() << " weights_zero_points: "
@@ -326,7 +326,7 @@ public:
                                     *_attrs.get());
             _pd = *prim_desc;
         } else {
-            auto bias_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(2), dnnl::memory::format_tag::any, true);
+            auto bias_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(2), dnnl::memory::format_tag::any, onednn::mem_flags::flatten);
             auto prim_desc = std::make_shared<dnnl::convolution_forward::primitive_desc>(
                                     ib.get_engine().get_onednn_engine(),
                                     dnnl::prop_kind::forward_inference, dnnl::algorithm::convolution_direct,

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -58,9 +58,7 @@ static std::shared_ptr<dnnl::convolution_forward::primitive_desc> get_convolutio
         weights_layout.format = format::get_default_format(weights_layout.get_rank() + 1, true, true);
     }
 
-    auto input_md   = onednn::layout_to_memory_desc(input_layout, tag_in_out);
-    auto weights_md = onednn::layout_to_memory_desc(weights_layout, dnnl::memory::format_tag::any);
-    auto output_md  = onednn::layout_to_memory_desc(output_layout, tag_in_out);
+    auto [input_md, weights_md, output_md] = onednn::get_conv_memory_descs(input_layout, weights_layout, output_layout, tag_in_out);
 
     // adjust_conv_dilation_pad(dilation, stride, pad_l, pad_r, input_md, output_md, weights_md, grouped_weights);
     for (size_t i = 0; i < dilation.size(); i++) {
@@ -295,9 +293,10 @@ public:
 
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ib.getKernelImplParams());
 
-        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0), dnnl::memory::format_tag::undef);
-        auto weights_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(1), dnnl::memory::format_tag::any);
-        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout(), dnnl::memory::format_tag::undef);
+        auto [input_md, weights_md, output_md] = onednn::get_conv_memory_descs(impl_params->get_input_layout(0),
+                                                                                impl_params->get_input_layout(1),
+                                                                                impl_params->get_output_layout(),
+                                                                                dnnl::memory::format_tag::undef);
 
         dnnl::memory::dims strides;
         dnnl::memory::dims dilates;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp
@@ -58,9 +58,9 @@ static std::shared_ptr<dnnl::convolution_forward::primitive_desc> get_convolutio
         weights_layout.format = format::get_default_format(weights_layout.get_rank() + 1, true, true);
     }
 
-    auto input_md = onednn::layout_to_memory_desc(input_layout, tag_in_out);
+    auto input_md   = onednn::layout_to_memory_desc(input_layout, tag_in_out);
     auto weights_md = onednn::layout_to_memory_desc(weights_layout, dnnl::memory::format_tag::any);
-    auto output_md = onednn::layout_to_memory_desc(output_layout, tag_in_out);
+    auto output_md  = onednn::layout_to_memory_desc(output_layout, tag_in_out);
 
     // adjust_conv_dilation_pad(dilation, stride, pad_l, pad_r, input_md, output_md, weights_md, grouped_weights);
     for (size_t i = 0; i < dilation.size(); i++) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -53,7 +53,7 @@ static std::shared_ptr<dnnl::deconvolution_forward::primitive_desc> get_deconvol
     }
 
     if (prim->bias.is_valid()) {
-        auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, true);
+        auto bias_md = onednn::layout_to_memory_desc(impl_params.get_input_layout(2), dnnl::memory::format_tag::any, onednn::mem_flags::flatten);
         return std::make_shared<dnnl::deconvolution_forward::primitive_desc>(
             engine.get_onednn_engine(),
             dnnl::prop_kind::forward_inference,
@@ -192,7 +192,7 @@ public:
                                     *_attrs.get());
             _pd = *prim_desc;
         } else {
-            auto bias_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(2), dnnl::memory::format_tag::any, true);
+            auto bias_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(2), dnnl::memory::format_tag::any, onednn::mem_flags::flatten);
             auto prim_desc = std::make_shared<dnnl::deconvolution_forward::primitive_desc>(
                                     ib.get_engine().get_onednn_engine(),
                                     dnnl::prop_kind::forward_inference, dnnl::algorithm::deconvolution_direct,

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/deconvolution_onednn.cpp
@@ -30,9 +30,7 @@ static std::shared_ptr<dnnl::deconvolution_forward::primitive_desc> get_deconvol
     dnnl::memory::dims pad_l(prim->pad.begin(), prim->pad.end());
     dnnl::memory::dims pad_r(prim->pad.begin(), prim->pad.end());
 
-    auto input_md = onednn::layout_to_memory_desc(input_layout, tag_in_out);
-    auto weights_md = onednn::layout_to_memory_desc(weights_layout, dnnl::memory::format_tag::any);
-    auto output_md = onednn::layout_to_memory_desc(output_layout, tag_in_out);
+    auto [input_md, weights_md, output_md] = onednn::get_conv_memory_descs(input_layout, weights_layout, output_layout, tag_in_out);
     auto grouped_weights = format::is_grouped(weights_layout.format) || prim->grouped_weights_shape;
 
     for (size_t i = 0; i < dilation.size(); i++) {
@@ -168,9 +166,10 @@ public:
 
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ib.getKernelImplParams());
 
-        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0), dnnl::memory::format_tag::undef);
-        auto weights_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(1), dnnl::memory::format_tag::any);
-        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout(), dnnl::memory::format_tag::undef);
+        auto [input_md, weights_md, output_md] = onednn::get_conv_memory_descs(impl_params->get_input_layout(0),
+                                                                            impl_params->get_input_layout(1),
+                                                                            impl_params->get_output_layout(),
+                                                                            dnnl::memory::format_tag::undef);
 
         dnnl::memory::dims strides;
         dnnl::memory::dims dilates;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -270,7 +270,8 @@ struct typed_primitive_onednn_impl : public typed_primitive_impl<PType> {
                         } else {
                             dnnl::memory::desc md = onednn::layout_to_memory_desc(
                                                             impl_params->get_input_layout(fused_desc.at(idx).mem_dep),
-                                                            fused_desc.at(idx).tag, fused_desc.at(idx).flatten);
+                                                            fused_desc.at(idx).tag,
+                                                            (fused_desc.at(idx).flatten ? onednn::mem_flags::flatten : onednn::mem_flags::None));
 
                             _post_ops.append_binary(aalgorithm, md);
                         }

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -54,8 +54,8 @@ protected:
         auto input_layout = impl_params.get_input_layout(0);
         auto output_layout = impl_params.get_output_layout();
 
-        auto input_md = onednn::layout_to_memory_desc(input_layout, dnnl::memory::format_tag::undef, false, false, true);
-        auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::undef, false, false, true);
+        auto input_md = onednn::layout_to_memory_desc(input_layout, dnnl::memory::format_tag::undef, onednn::mem_flags::need_blocked);
+        auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::undef, onednn::mem_flags::need_blocked);
 
         OPENVINO_ASSERT(input_md.get_format_kind() != dnnl::memory::format_kind::any,
                         "[GPU] The format kind of the input memory descriptor of onednn reorder cannot be 'any'.");
@@ -87,8 +87,8 @@ public:
 
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ib.getKernelImplParams());
 
-        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0), dnnl::memory::format_tag::undef, false, false, true);
-        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout(), dnnl::memory::format_tag::undef, false, false, true);
+        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0), dnnl::memory::format_tag::undef, onednn::mem_flags::need_blocked);
+        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout(), dnnl::memory::format_tag::undef, onednn::mem_flags::need_blocked);
 
         auto prim_desc = std::make_shared<dnnl::reorder::primitive_desc>(
             ib.get_engine().get_onednn_engine(),

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
@@ -46,13 +46,6 @@ protected:
         return args;
     }
 
-    static dnnl::memory::desc layout_to_memory_desc(cldnn::layout l) {
-        auto rank = cldnn::format::dimension(l.format);
-        dnnl::memory::dims dims = convert_tensor(l.get_tensor(), rank, cldnn::format::is_grouped(l.format));
-        dnnl::memory::desc res(dims, convert_data_type(l.data_type), convert_data_format(l.format));
-        return res;
-    }
-
     static std::shared_ptr<dnnl::reorder::primitive_desc> get_reorder_primitive_descriptor(const kernel_impl_params& impl_params,
                                                                                            const dnnl::primitive_attr& attr) {
         auto& engine = impl_params.prog->get_engine();
@@ -61,8 +54,8 @@ protected:
         auto input_layout = impl_params.get_input_layout(0);
         auto output_layout = impl_params.get_output_layout();
 
-        auto input_md = layout_to_memory_desc(input_layout);
-        auto output_md = layout_to_memory_desc(output_layout);
+        auto input_md = onednn::layout_to_memory_desc(input_layout, dnnl::memory::format_tag::undef, false, false, true);
+        auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::undef, false, false, true);
 
         OPENVINO_ASSERT(input_md.get_format_kind() != dnnl::memory::format_kind::any,
                         "[GPU] The format kind of the input memory descriptor of onednn reorder cannot be 'any'.");
@@ -94,8 +87,8 @@ public:
 
         const kernel_impl_params* impl_params = reinterpret_cast<kernel_impl_params*>(ib.getKernelImplParams());
 
-        auto input_md = layout_to_memory_desc(impl_params->get_input_layout(0));
-        auto output_md = layout_to_memory_desc(impl_params->get_output_layout());
+        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0), dnnl::memory::format_tag::undef, false, false, true);
+        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout(), dnnl::memory::format_tag::undef, false, false, true);
 
         auto prim_desc = std::make_shared<dnnl::reorder::primitive_desc>(
             ib.get_engine().get_onednn_engine(),

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -35,9 +35,16 @@ dnnl::memory::format_tag convert_data_format(cldnn::format fmt);
 cldnn::format convert_data_format(dnnl::memory::format_tag fmt);
 dnnl::memory::format_tag get_default_data_format(const cldnn::layout& l);
 dnnl::memory::format_tag convert_gemm_data_format(dnnl::memory::dims dims, format target);
+
+enum class mem_flags : uint32_t {
+    None         = 0,
+    flatten      = 1 << 0,
+    use_strides  = 1 << 1,
+    need_blocked = 1 << 2,
+};
+
 dnnl::memory::desc layout_to_memory_desc(cldnn::layout l,
-                        dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::undef,
-                        bool flatten = false, bool use_strides = false, bool need_blocked = false);
+                        dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::undef, mem_flags flags = mem_flags::None);
 std::tuple<dnnl::memory::desc, dnnl::memory::desc, dnnl::memory::desc> get_conv_memory_descs(cldnn::layout input_layout,
                                                                  cldnn::layout weights_layout,
                                                                  cldnn::layout output_layout,

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -37,7 +37,11 @@ dnnl::memory::format_tag get_default_data_format(const cldnn::layout& l);
 dnnl::memory::format_tag convert_gemm_data_format(dnnl::memory::dims dims, format target);
 dnnl::memory::desc layout_to_memory_desc(cldnn::layout l,
                         dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::undef,
-                        bool flatten = false, bool use_strides = false);
+                        bool flatten = false, bool use_strides = false, bool need_blocked = false);
+std::tuple<dnnl::memory::desc, dnnl::memory::desc, dnnl::memory::desc> get_conv_memory_descs(cldnn::layout input_layout,
+                                                                 cldnn::layout weights_layout,
+                                                                 cldnn::layout output_layout,
+                                                                 dnnl::memory::format_tag target_fmt = dnnl::memory::format_tag::undef);
 dnnl::algorithm convert_activation_func(cldnn::activation_func func);
 std::vector<std::vector<size_t>> get_candidate_orders(dnnl::memory::desc desc);
 cldnn::format find_format(dnnl::memory::desc desc, bool is_grouped = false);

--- a/src/plugins/intel_gpu/src/runtime/layout.cpp
+++ b/src/plugins/intel_gpu/src/runtime/layout.cpp
@@ -479,6 +479,11 @@ bool layout::compatible(const layout& other) const {
         (!blocks1.empty() && l1.format.dims_order() != l2.format.dims_order()))
         return false;
 
+    // Since it is not possible to properly check compatibility for custom formats, return false
+    if (l1.format == cldnn::format::custom || l2.format == cldnn::format::custom) {
+        return false;
+    }
+
     if (check_format(format::b_fs_yx_fsv2) ||
         check_format(format::b_fs_yx_fsv4) ||
         check_format(format::fs_b_yx_fsv32) ||

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -9909,7 +9909,7 @@ TEST(convolution_gpu_onednn, spatial_1d) {
     topology t(input, weights, conv, output_reorder);
 
     ExecutionConfig config_test = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc conv_impl_test = { format::b_fs_yx_fsv16, "", impl_types::onednn };
+    ov::intel_gpu::ImplementationDesc conv_impl_test = { format::bfyx, "", impl_types::onednn };
     config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl_test } }));
     config_test.set_property(ov::intel_gpu::optimize_data(true));
     config_test.set_property(ov::intel_gpu::allow_new_shape_infer(true));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -9908,11 +9908,11 @@ TEST(convolution_gpu_onednn, spatial_1d) {
 
     topology t(input, weights, conv, output_reorder);
 
-    ExecutionConfig config_test = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc conv_impl_test = { format::b_fs_yx_fsv16, "", impl_types::onednn };
-    config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl_test } }));
-    config_test.set_property(ov::intel_gpu::optimize_data(true));
-    config_test.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ExecutionConfig config_test_blocked = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc conv_impl_test_blocked = { format::b_fs_yx_fsv16, "", impl_types::onednn };
+    config_test_blocked.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "conv", conv_impl_test_blocked } }));
+    config_test_blocked.set_property(ov::intel_gpu::optimize_data(true));
+    config_test_blocked.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     ExecutionConfig config_test_planar = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc conv_impl_test_planar = { format::bfyx, "", impl_types::onednn };
@@ -9926,28 +9926,28 @@ TEST(convolution_gpu_onednn, spatial_1d) {
     config_ref.set_property(ov::intel_gpu::optimize_data(true));
     config_ref.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
-    network network_test(engine, t, config_test);
+    network network_test_blocked(engine, t, config_test_blocked);
     network network_test_planar(engine, t, config_test_planar);
     network network_ref(engine, t, config_ref);
 
-    network_test.set_input_data("input", input_mem);
+    network_test_blocked.set_input_data("input", input_mem);
     network_test_planar.set_input_data("input", input_mem);
     network_ref.set_input_data("input", input_mem);
 
-    auto outputs_test = network_test.execute();
+    auto outputs_test_blocked = network_test_blocked.execute();
     auto outputs_test_planar = network_test_planar.execute();
     auto outputs_ref = network_ref.execute();
 
-    ASSERT_EQ(outputs_test.size(), size_t(1));
-    ASSERT_EQ(outputs_test.begin()->first, "reorder");
+    ASSERT_EQ(outputs_test_blocked.size(), size_t(1));
+    ASSERT_EQ(outputs_test_blocked.begin()->first, "reorder");
     ASSERT_EQ(outputs_test_planar.size(), size_t(1));
     ASSERT_EQ(outputs_test_planar.begin()->first, "reorder");
     ASSERT_EQ(outputs_ref.size(), size_t(1));
     ASSERT_EQ(outputs_ref.begin()->first, "reorder");
 
-    auto output_memory_test = outputs_test.at("reorder").get_memory();
-    auto output_layout_test = output_memory_test->get_layout();
-    cldnn::mem_lock<float> output_ptr_test(output_memory_test, get_test_stream());
+    auto output_memory_test_blocked = outputs_test_blocked.at("reorder").get_memory();
+    auto output_layout_test_blocked = output_memory_test_blocked->get_layout();
+    cldnn::mem_lock<float> output_ptr_test_blocked(output_memory_test_blocked, get_test_stream());
 
     auto output_memory_test_planar = outputs_test_planar.at("reorder").get_memory();
     auto output_layout_test_planar = output_memory_test_planar->get_layout();
@@ -9958,12 +9958,12 @@ TEST(convolution_gpu_onednn, spatial_1d) {
     cldnn::mem_lock<float> output_ptr_ref(output_memory_ref, get_test_stream());
 
     ov::PartialShape expected_shape = {1, 16, 4};
-    ASSERT_EQ(output_layout_test.get_partial_shape(), expected_shape);
+    ASSERT_EQ(output_layout_test_blocked.get_partial_shape(), expected_shape);
     ASSERT_EQ(output_layout_test_planar.get_partial_shape(), expected_shape);
     ASSERT_EQ(output_layout_ref.get_partial_shape(), expected_shape);
 
     for (size_t i = 0; i < output_memory_ref->count(); i++) {
-        ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test.data()[i]);
+        ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test_blocked.data()[i]);
         ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test_planar.data()[i]);
     }
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -3095,7 +3095,7 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     auto topology_ref = create_topology();
 
     ExecutionConfig config_test = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc deconv_impl_test = { format::b_fs_yx_fsv16, "", impl_types::onednn };
+    ov::intel_gpu::ImplementationDesc deconv_impl_test = { format::bfyx, "", impl_types::onednn };
     config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "deconv", deconv_impl_test } }));
     config_test.set_property(ov::intel_gpu::optimize_data(true));
     config_test.set_property(ov::intel_gpu::allow_new_shape_infer(true));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -3092,13 +3092,20 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     };
 
     auto topology_test = create_topology();
+    auto topology_test_planar = create_topology();
     auto topology_ref = create_topology();
 
     ExecutionConfig config_test = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc deconv_impl_test = { format::bfyx, "", impl_types::onednn };
+    ov::intel_gpu::ImplementationDesc deconv_impl_test = { format::b_fs_yx_fsv16, "", impl_types::onednn };
     config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "deconv", deconv_impl_test } }));
     config_test.set_property(ov::intel_gpu::optimize_data(true));
     config_test.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    ExecutionConfig config_test_planar = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc deconv_impl_test_planar = { format::bfyx, "", impl_types::onednn };
+    config_test_planar.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "deconv", deconv_impl_test_planar } }));
+    config_test_planar.set_property(ov::intel_gpu::optimize_data(true));
+    config_test_planar.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     ExecutionConfig config_ref = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc deconv_impl_ref = { format::bfyx, "", impl_types::ocl };
@@ -3107,6 +3114,7 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     config_ref.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     network network_test(engine, topology_test, config_test);
+    network network_test_planar(engine, topology_test_planar, config_test_planar);
     network network_ref(engine, topology_ref, config_ref);
 
     auto input_data = rg.generate_random_1d<ov::float16>(input_pshape.size(), -1, 1);
@@ -3114,13 +3122,17 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     set_values(input_mem, input_data);
 
     network_test.set_input_data("input", input_mem);
+    network_test_planar.set_input_data("input", input_mem);
     network_ref.set_input_data("input", input_mem);
 
     auto outputs_test = network_test.execute();
+    auto outputs_test_planar = network_test_planar.execute();
     auto outputs_ref = network_ref.execute();
 
     ASSERT_EQ(outputs_test.size(), size_t(1));
     ASSERT_EQ(outputs_test.begin()->first, "reorder");
+    ASSERT_EQ(outputs_test_planar.size(), size_t(1));
+    ASSERT_EQ(outputs_test_planar.begin()->first, "reorder");
     ASSERT_EQ(outputs_ref.size(), size_t(1));
     ASSERT_EQ(outputs_ref.begin()->first, "reorder");
 
@@ -3128,16 +3140,22 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     auto output_layout_test = output_memory_test->get_layout();
     cldnn::mem_lock<float> output_ptr_test(output_memory_test, get_test_stream());
 
+    auto output_memory_test_planar = outputs_test_planar.at("reorder").get_memory();
+    auto output_layout_test_planar = output_memory_test_planar->get_layout();
+    cldnn::mem_lock<float> output_ptr_test_planar(output_memory_test_planar, get_test_stream());
+
     auto output_memory_ref = outputs_ref.at("reorder").get_memory();
     auto output_layout_ref = output_memory_ref->get_layout();
     cldnn::mem_lock<float> output_ptr_ref(output_memory_ref, get_test_stream());
 
     ov::PartialShape expected_shape = {1, 16, 8};
     ASSERT_EQ(output_layout_test.get_partial_shape(), expected_shape);
+    ASSERT_EQ(output_layout_test_planar.get_partial_shape(), expected_shape);
     ASSERT_EQ(output_layout_ref.get_partial_shape(), expected_shape);
 
     for (size_t i = 0; i < output_memory_ref->count(); i++) {
         ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test.data()[i]);
+        ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test_planar.data()[i]);
     }
 }
 #endif

--- a/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/deconvolution_gpu_test.cpp
@@ -3091,15 +3091,15 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
         return topology;
     };
 
-    auto topology_test = create_topology();
+    auto topology_test_blocked = create_topology();
     auto topology_test_planar = create_topology();
     auto topology_ref = create_topology();
 
-    ExecutionConfig config_test = get_test_default_config(engine);
-    ov::intel_gpu::ImplementationDesc deconv_impl_test = { format::b_fs_yx_fsv16, "", impl_types::onednn };
-    config_test.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "deconv", deconv_impl_test } }));
-    config_test.set_property(ov::intel_gpu::optimize_data(true));
-    config_test.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+    ExecutionConfig config_test_blocked = get_test_default_config(engine);
+    ov::intel_gpu::ImplementationDesc deconv_impl_test_blocked = { format::b_fs_yx_fsv16, "", impl_types::onednn };
+    config_test_blocked.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ { "deconv", deconv_impl_test_blocked } }));
+    config_test_blocked.set_property(ov::intel_gpu::optimize_data(true));
+    config_test_blocked.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
     ExecutionConfig config_test_planar = get_test_default_config(engine);
     ov::intel_gpu::ImplementationDesc deconv_impl_test_planar = { format::bfyx, "", impl_types::onednn };
@@ -3113,7 +3113,7 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     config_ref.set_property(ov::intel_gpu::optimize_data(true));
     config_ref.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
-    network network_test(engine, topology_test, config_test);
+    network network_test_blocked(engine, topology_test_blocked, config_test_blocked);
     network network_test_planar(engine, topology_test_planar, config_test_planar);
     network network_ref(engine, topology_ref, config_ref);
 
@@ -3121,24 +3121,24 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     auto input_mem = engine.allocate_memory({ input_pshape, data_types::f16, format::bfyx });
     set_values(input_mem, input_data);
 
-    network_test.set_input_data("input", input_mem);
+    network_test_blocked.set_input_data("input", input_mem);
     network_test_planar.set_input_data("input", input_mem);
     network_ref.set_input_data("input", input_mem);
 
-    auto outputs_test = network_test.execute();
+    auto outputs_test_blocked = network_test_blocked.execute();
     auto outputs_test_planar = network_test_planar.execute();
     auto outputs_ref = network_ref.execute();
 
-    ASSERT_EQ(outputs_test.size(), size_t(1));
-    ASSERT_EQ(outputs_test.begin()->first, "reorder");
+    ASSERT_EQ(outputs_test_blocked.size(), size_t(1));
+    ASSERT_EQ(outputs_test_blocked.begin()->first, "reorder");
     ASSERT_EQ(outputs_test_planar.size(), size_t(1));
     ASSERT_EQ(outputs_test_planar.begin()->first, "reorder");
     ASSERT_EQ(outputs_ref.size(), size_t(1));
     ASSERT_EQ(outputs_ref.begin()->first, "reorder");
 
-    auto output_memory_test = outputs_test.at("reorder").get_memory();
-    auto output_layout_test = output_memory_test->get_layout();
-    cldnn::mem_lock<float> output_ptr_test(output_memory_test, get_test_stream());
+    auto output_memory_test_blocked = outputs_test_blocked.at("reorder").get_memory();
+    auto output_layout_test_blocked = output_memory_test_blocked->get_layout();
+    cldnn::mem_lock<float> output_ptr_test_blocked(output_memory_test_blocked, get_test_stream());
 
     auto output_memory_test_planar = outputs_test_planar.at("reorder").get_memory();
     auto output_layout_test_planar = output_memory_test_planar->get_layout();
@@ -3149,12 +3149,12 @@ TEST(deconvolution_gpu_onednn, spatial_1d) {
     cldnn::mem_lock<float> output_ptr_ref(output_memory_ref, get_test_stream());
 
     ov::PartialShape expected_shape = {1, 16, 8};
-    ASSERT_EQ(output_layout_test.get_partial_shape(), expected_shape);
+    ASSERT_EQ(output_layout_test_blocked.get_partial_shape(), expected_shape);
     ASSERT_EQ(output_layout_test_planar.get_partial_shape(), expected_shape);
     ASSERT_EQ(output_layout_ref.get_partial_shape(), expected_shape);
 
     for (size_t i = 0; i < output_memory_ref->count(); i++) {
-        ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test.data()[i]);
+        ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test_blocked.data()[i]);
         ASSERT_EQ(output_ptr_ref.data()[i], output_ptr_test_planar.data()[i]);
     }
 }


### PR DESCRIPTION
### Descriptions
 - Previously, 3D tensors for oneDNN 1D convolution were forcefully expanded to 4D.
 - This caused shape mismatches between node and impl, breaking model cache.
 - Modified to keep 3D tensors as-is when both input and output are 3D.
 - Excluding cases where input/output is already blocked.
#### The code and line that caused this issue
 - src/plugins/intel_gpu/src/graph/impls/onednn/convolution_onednn.cpp:
 - src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
#### Problematic graph
![image](https://github.com/user-attachments/assets/ad73ab4b-12a5-495b-bd2f-4e9d756ab28d)
#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
        convolution_gpu_onednn.spatial_1d
        deconvolution_gpu_onednn.spatial_1d
### Tickets:
 - *168091*
