### PR TITLE
[RISCV64]: Implement CPU plugin just-in-time emitter for LessEqual operation 

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.cpp
@@ -613,6 +613,61 @@ size_t jit_maximum_emitter::get_inputs_num() const {
     return 2;
 }
 
+/// LESS EQUAL ///
+jit_less_equal_emitter::jit_less_equal_emitter(ov::intel_cpu::riscv64::jit_generator* host,
+                                               ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                               const ov::element::Type exec_prc)
+    : jit_emitter(host, host_isa, exec_prc) {
+    prepare_table();
+}
+
+jit_less_equal_emitter::jit_less_equal_emitter(ov::intel_cpu::riscv64::jit_generator* host,
+                                               ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                                               const std::shared_ptr<ov::Node>& node)
+    : jit_emitter(host, host_isa, get_arithmetic_binary_exec_precision(node)) {
+    prepare_table();
+}
+
+size_t jit_less_equal_emitter::get_inputs_num() const {
+    return 2;
+}
+
+size_t jit_less_equal_emitter::aux_fp_gprs_count() const {
+    return 1;
+}
+
+template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+void jit_less_equal_emitter::emit_isa(const std::vector<size_t>& in_vec_idxs,
+                                      const std::vector<size_t>& out_vec_idxs) const {
+    VReg src0 = VReg(in_vec_idxs[0]);
+    VReg src1 = VReg(in_vec_idxs[1]);
+    VReg dst = VReg(out_vec_idxs[0]);
+    FReg one = FReg(aux_fp_gpr_idxs[0]);
+    load_table_val("one", one);
+
+    h->vmv_v_x(dst, zero);                   // set dst to 0
+    h->vmfle_vv(mask_vreg(), src0, src1);    // compare "less than or equal", result in mask
+    h->vfadd_vf(dst, dst, one, VM::masked);  // set 1.0 where mask is true
+}
+
+void jit_less_equal_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
+                                       const std::vector<size_t>& out_vec_idxs) const {
+    if (host_isa_ == ov::intel_cpu::riscv64::cpu_isa_t::gv) {
+        emit_isa<ov::intel_cpu::riscv64::cpu_isa_t::gv>(in_vec_idxs, out_vec_idxs);
+    } else {
+        OPENVINO_THROW("Can't create jit eltwise kernel");
+    }
+}
+
+std::set<std::vector<element::Type>> jit_less_equal_emitter::get_supported_precisions(
+    const std::shared_ptr<ov::Node>& node) {
+    return {{element::f32, element::f32}};
+}
+
+void jit_less_equal_emitter::register_table_entries() {
+    push_arg_entry_of("one", CONST_1_F);
+}
+
 void jit_maximum_emitter::emit_impl(const std::vector<size_t>& in_vec_idxs,
                                     const std::vector<size_t>& out_vec_idxs) const {
     if (host_isa_ == ov::intel_cpu::riscv64::cpu_isa_t::gv) {

--- a/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/riscv64/jit_eltwise_emitters.hpp
@@ -181,6 +181,28 @@ private:
     void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
     void register_table_entries() override;
 };
+
+class jit_less_equal_emitter : public jit_emitter {
+public:
+    jit_less_equal_emitter(ov::intel_cpu::riscv64::jit_generator* host,
+                           ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                           const ov::element::Type exec_prc = ov::element::f32);
+    jit_less_equal_emitter(ov::intel_cpu::riscv64::jit_generator* host,
+                           ov::intel_cpu::riscv64::cpu_isa_t host_isa,
+                           const std::shared_ptr<ov::Node>& node);
+    size_t get_inputs_num() const override;
+    size_t aux_fp_gprs_count() const override;
+
+    static std::set<std::vector<element::Type>> get_supported_precisions(
+        const std::shared_ptr<ov::Node>& node = nullptr);
+
+private:
+    void emit_impl(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const override;
+    template <ov::intel_cpu::riscv64::cpu_isa_t isa>
+    void emit_isa(const std::vector<size_t>& in_vec_idxs, const std::vector<size_t>& out_vec_idxs) const;
+    void register_table_entries() override;
+};
+
 class jit_maximum_emitter : public jit_emitter {
 public:
     jit_maximum_emitter(jit_generator* host, cpu_isa_t host_isa, const element::Type exec_prc = element::f32);

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -886,6 +886,7 @@ public:
                     Algorithm::EltwiseExp,
                     Algorithm::EltwiseFloor,
                     Algorithm::EltwiseGreaterEqual,
+                    Algorithm::EltwiseLessEqual,
                     Algorithm::EltwiseLogicalAnd,
                     Algorithm::EltwiseLogicalNot,
                     Algorithm::EltwiseLogicalXor,

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -585,6 +585,7 @@ std::set<std::vector<element::Type>> eltwise_precision_helper::get_supported_pre
               OV_CASE(Algorithm::EltwiseEqual, jit_equal_emitter),
               OV_CASE(Algorithm::EltwiseFloor, jit_floor_emitter),
               OV_CASE(Algorithm::EltwiseGreaterEqual, jit_greater_equal_emitter),
+              OV_CASE(Algorithm::EltwiseLessEqual, jit_less_equal_emitter),
               OV_CASE(Algorithm::EltwiseLogicalAnd, jit_logical_and_emitter),
               OV_CASE(Algorithm::EltwiseLogicalNot, jit_logical_not_emitter),
               OV_CASE(Algorithm::EltwiseLogicalXor, jit_logical_xor_emitter),

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_uni_eltwise_generic.cpp
@@ -442,6 +442,7 @@ std::shared_ptr<jit_emitter> jit_uni_eltwise_generic<isa>::create_eltwise_emitte
               OV_CASE(Algorithm::EltwiseExp, jit_exp_emitter),
               OV_CASE(Algorithm::EltwiseFloor, jit_floor_emitter),
               OV_CASE(Algorithm::EltwiseGreaterEqual, jit_greater_equal_emitter),
+              OV_CASE(Algorithm::EltwiseLessEqual, jit_less_equal_emitter),
               OV_CASE(Algorithm::EltwiseLogicalAnd, jit_logical_and_emitter),
               OV_CASE(Algorithm::EltwiseLogicalNot, jit_logical_not_emitter),
               OV_CASE(Algorithm::EltwiseLogicalXor, jit_logical_xor_emitter),


### PR DESCRIPTION
### Details:
 - *Implement Jit Emitter for LessEqual*

### Tickets:
 - #30252
 -  Test Result
![image](https://github.com/user-attachments/assets/f7750355-b10b-4cca-934e-3a2520e3a778)