### PR TITLE
[GPU] Fix runtime error when mvn requires alignment

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -284,7 +284,9 @@ void add_required_reorders::run(program& p) {
                 }
             }
 
-            usr->recalc_output_layout(false);
+            if (!usr->is_all_valid_output_layouts()) {
+                usr->recalc_output_layout(false);
+            }
         }
 
         eliminate_pad_for_onednn_impl(p, *usr);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -283,6 +283,8 @@ void add_required_reorders::run(program& p) {
                     new_reorder_node.recalc_output_layout(true);
                 }
             }
+
+            usr->recalc_output_layout(false);
         }
 
         eliminate_pad_for_onednn_impl(p, *usr);

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/add_required_reorders.cpp
@@ -281,11 +281,8 @@ void add_required_reorders::run(program& p) {
                     p.add_intermediate(new_reorder_node, *usr, dep);
                     // Need to invalidate users because the output format of mvn follows input format.
                     new_reorder_node.recalc_output_layout(true);
+                    usr->recalc_output_layout(false);
                 }
-            }
-
-            if (!usr->is_all_valid_output_layouts()) {
-                usr->recalc_output_layout(false);
             }
         }
 


### PR DESCRIPTION
### Details:
 - It needs to call `recalc_output_layout(false)` after `invalidate()` by `recalc_output_layout(true)` from a new reorder node so that it prevents `valid_output_layouts` of the next node to be false.

### Tickets:
 - 168629
