### PR TITLE
[CPU] fix int8 models crash issue during inference on the GNR platform with fp16 inference_precision

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -400,12 +400,6 @@ std::tuple<VecMemoryDescs, MemoryDescPtr> Convolution::initMemoryDescriptors(ov:
             srcDescs.push_back(MemoryDescUtils::makeEmptyDesc());
             continue;
         }
-        // int8 convolution with f16 bias is not supported in oneDNN
-        if (i == BIAS && m_attrs.withBias && canBeExecutedInInt8() && srcTypes[i] == ov::element::f16) {
-            auto srcDesc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(ov::element::f32, getInputShapeAtPort(i));
-            srcDescs.push_back(srcDesc);
-            continue;
-        }
         auto srcDesc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(srcTypes[i], getInputShapeAtPort(i));
         srcDescs.push_back(srcDesc);
     }

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -400,6 +400,12 @@ std::tuple<VecMemoryDescs, MemoryDescPtr> Convolution::initMemoryDescriptors(ov:
             srcDescs.push_back(MemoryDescUtils::makeEmptyDesc());
             continue;
         }
+        // int8 convolution with f16 bias is not supported in oneDNN
+        if (i == BIAS && m_attrs.withBias && canBeExecutedInInt8() && srcTypes[i] == ov::element::f16) {
+            auto srcDesc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(ov::element::f32, getInputShapeAtPort(i));
+            srcDescs.push_back(srcDesc);
+            continue;
+        }
         auto srcDesc = creatorsMap.at(LayoutType::ncsp)->createSharedDesc(srcTypes[i], getInputShapeAtPort(i));
         srcDescs.push_back(srcDesc);
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/convolution_implementations.cpp
@@ -49,7 +49,10 @@ static const TypeMapping dnnlConvTypeMapping {
     {{_bf16, _f16, _any, _any},                        pt(bypass(), bypass(), use<0>(), use<0>())},
     {{_f16, _bf16, _any, _any},                        pt(bypass(), bypass(), use<0>(), use<0>())},
     // quantization configuration
-    {{_u8 | _i8, _i8, _quant | _hw_float | _i32 | _dynamic, _quant | _hw_float | _i32 | _dynamic}, pt(bypass(), bypass(), bypass(),  bypass())},
+    // int8 conv does not support f16 output and bias
+    {{_u8 | _i8, _i8,  _quant |_bf16 | _f32 | _i32 | _dynamic,  _quant | _bf16 | _f32 | _i32 | _dynamic}, pt(bypass(), bypass(), bypass(),  bypass())},
+    {{_u8 | _i8, _i8, _f16, _u8 | _i8 | _i32 | _bf16 | _f32}, pt(bypass(), bypass(), just<f32>(), bypass())},
+    {{_u8 | _i8, _i8, _any, _any}, pt(bypass(), bypass(), just<f32>(), just<f32>())},
     // @todo should we fallback to FPXX instead of _f32?
     {{_any, _any, _any, _any},                                pt(just<f32>(), just<f32>(), just<f32>(), just<f32>())},
     // @todo explicitly cover configuration limitations for oneDNN on ARM


### PR DESCRIPTION


### Details:
 - *fix int8 models crash issue during inference on the GNR platform with fp16 inference_precision. int8 convolution with f16 bias is not supported in oneDNN. When bias type is f16, we need force it to f32 to ensure compatibility.*


### Tickets:
 - *CVS-169361*
