### PR TITLE
[CPU] Added rank check in CPU/DNNL BlockedMemoryDesc constructors

### DIFF
--- a/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/cpu_blocked_memory_desc.cpp
@@ -45,6 +45,10 @@ CpuBlockedMemoryDesc::CpuBlockedMemoryDesc(ov::element::Type prc,
         OPENVINO_THROW("CpuBlockedMemoryDesc do not support undefined order.");
     }
 
+    if (blockedDims.size() < shape.getRank()) {
+        OPENVINO_THROW("Can't create CpuBlockedMemoryDesc. Blocked dims has rank less than planar dims");
+    }
+
     if (std::any_of(blockedDims.begin() + shape.getRank(), blockedDims.end(), [](size_t val) {
             return val == Shape::UNDEFINED_DIM;
         })) {

--- a/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/dnnl_blocked_memory_desc.cpp
@@ -135,6 +135,10 @@ DnnlBlockedMemoryDesc::DnnlBlockedMemoryDesc(ov::element::Type prc,
         OPENVINO_THROW("DnnlBlockedMemoryDesc doesn't support undefined order.");
     }
 
+    if (blockedDims.size() < shape.getRank()) {
+        OPENVINO_THROW("Can't create DnnlBlockedMemoryDesc. Blocked dims has rank less than planar dims");
+    }
+
     if (std::any_of(blockedDims.begin() + shape.getRank(), blockedDims.end(), [](size_t val) {
             return val == Shape::UNDEFINED_DIM || val == 0;
         })) {


### PR DESCRIPTION
### Details:
 - *If `BlockedDims` have rank less than `Shape` in constructors in CPU/DNNL BlockedMemoryDesc, we will get out-of-bounds access in check for dynamic blocks. The PR adds the checks `blockedDims.size() < shape.getRank()` with exception throwing in the   CPU/DNNL BlockedMemoryDesc ctors*

### Tickets:
 - *N/A*
