### PR TITLE
[PyOV] Bump pytest to `8.4.1`

### DIFF
--- a/tests/e2e_tests/requirements.txt
+++ b/tests/e2e_tests/requirements.txt
@@ -20,7 +20,7 @@ scikit-image>=0.17.2
 tabulate==0.9.0
 
 pytest>=5.0,<=7.0.1; python_version < '3.10'
-pytest==8.4.0; python_version >= '3.10'
+pytest==8.4.1; python_version >= '3.10'
 pytest-cov==6.2.1
 # pytest-html==1.19.0
 pytest-html


### PR DESCRIPTION
### Details:
 - Instead of https://github.com/openvinotoolkit/openvino/pull/31025, which can't be rebased
 - https://github.com/openvinotoolkit/open_model_zoo/pull/4016 has been merged, which should fix the pip conflicts check

### Tickets:
 - N/A
