### PR TITLE
[GPU] Add plain format support in reduce onednn impl manager

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
@@ -67,6 +67,7 @@ struct ReduceImplementationManager : public ImplementationManager {
         static const std::vector<format::type> supported_formats = {
             format::any,
             format::bfyx,
+            format::byxf,
             format::bfzyx,
             format::bfwzyx,
             format::b_fs_yx_fsv16,
@@ -110,10 +111,6 @@ struct ReduceImplementationManager : public ImplementationManager {
         if (out_layout == in_layout) {
             return false;
         }
-
-        // oneDNN reduction selects ref kernel for simple formats(bfyx..) which has perf regression with a decent tensor size.
-        if (format::is_simple_data_format(in_layout.format))
-            return false;
 
         // Onednn reduction does NOT support reordering of unreduced-axes.
         // Currently, an Onednn reduce layer which contains reduction of blocked axes(b-f) is expected to select planar format.

--- a/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
@@ -164,8 +164,8 @@ TEST_P(reduce_eltwise_activation_quantize, basic) {
     create_topologies(
         input_layout("input", get_input_layout(p, true)),
         reorder("input_reorder", input_info("input"), p.input_format, p.data_type),
-        data("in_lo", get_mem(get_per_channel_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
+        data("in_lo", get_mem(get_single_element_layout(p), min_random, 0)),
+        data("in_hi", get_mem(get_single_element_layout(p), 1, max_random)),
         data("out_lo", get_mem(get_single_element_layout(p), -128)),
         data("out_hi", get_mem(get_single_element_layout(p), 127)),
         data("eltwise_data", get_mem(get_output_layout(p))),

--- a/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
@@ -151,10 +151,10 @@ TEST_P(reduce_eltwise_activation_quantize, basic) {
     create_topologies(
         input_layout("input", get_input_layout(p, true)),
         reorder("input_reorder", input_info("input"), p.input_format, p.data_type),
-        data("in_lo", get_mem(get_single_element_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_single_element_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -128)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(p.out_shape.size() == 5 ? get_per_channel_layout_5d(p) : get_per_channel_layout(p), min_random, 0)),
+        data("in_hi", get_mem(p.out_shape.size() == 5 ? get_per_channel_layout_5d(p) : get_per_channel_layout(p), 1, max_random)),
+        data("out_lo", get_mem(p.out_shape.size() == 5 ? get_single_element_layout_5d(p) : get_single_element_layout(p), -128)),
+        data("out_hi", get_mem(p.out_shape.size() == 5 ? get_single_element_layout_5d(p) : get_single_element_layout(p), 127)),
         data("eltwise_data", get_mem(get_output_layout(p))),
         reduce("reduce", input_info("input_reorder"), p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("eltwise", { input_info("reduce"), input_info("eltwise_data") }, eltwise_mode::sum, p.default_type),
@@ -277,7 +277,7 @@ TEST_P(reduce_scale_activation, basic) {
     auto p = GetParam();
     create_topologies(
         input_layout("input", get_input_layout(p)),
-        data("scale_data", get_mem(get_single_element_layout(p), -0.125f)),
+        data("scale_data", get_mem(p.out_shape.size() == 5 ? get_single_element_layout_5d(p) : get_single_element_layout(p), -0.125f)),
         reduce("reduce", input_info("input"), p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("scale", { input_info("reduce"), input_info("scale_data") }, eltwise_mode::prod),
         activation("activation", input_info("scale"), activation_func::cos),
@@ -295,7 +295,7 @@ TEST_P(reduce_scale_activation, per_channel) {
     auto p = GetParam();
     create_topologies(
         input_layout("input", get_input_layout(p)),
-        data("scale_data", get_mem(get_per_channel_layout(p), -0.125f)),
+        data("scale_data", get_mem(p.out_shape.size() == 5 ? get_per_channel_layout_5d(p) : get_per_channel_layout(p), -0.125f)),
         reduce("reduce", input_info("input"), p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("scale", { input_info("reduce"), input_info("scale_data") }, eltwise_mode::prod),
         activation("activation", input_info("scale"), activation_func::cos),
@@ -313,7 +313,7 @@ TEST_P(reduce_scale_activation, dynamic) {
     auto p = GetParam();
     create_topologies(
         input_layout("input", get_dynamic_input_layout(p)),
-        data("scale_data", get_mem(get_per_channel_layout(p), -0.125f)),
+        data("scale_data", get_mem(p.out_shape.size() == 5 ? get_per_channel_layout_5d(p) : get_per_channel_layout(p), -0.125f)),
         reduce("reduce", input_info("input"), p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("scale", { input_info("reduce"), input_info("scale_data") }, eltwise_mode::prod),
         activation("activation", input_info("scale"), activation_func::cos),

--- a/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
@@ -102,9 +102,11 @@ public:
         if (p.out_shape.size() == 5) {
             // 5D case
             return layout{ {1, p.in_shape[1], 1, 1, 1}, p.default_type, (p.default_format.dimension() == 5) ? p.default_format : cldnn::format(format::bfzyx)};
-        } else {
+        } else if (p.out_shape.size() == 4){
             // 4D or other cases
             return layout{ {1, p.in_shape[1], 1, 1}, p.default_type, p.default_format };
+        } else {
+            OPENVINO_ASSERT(false, "NOT_IMPLEMENTED");
         }
     }
 
@@ -112,9 +114,11 @@ public:
         if (p.out_shape.size() == 5) {
             // 5D case
             return layout{ p.default_type, (p.default_format.dimension() == 5) ? p.default_format : cldnn::format(format::bfzyx) , tensor{1, 1, 1, 1, 1} };
-        } else {
+        } else if (p.out_shape.size() == 4) {
             // 4D or other cases
             return layout{ p.default_type, p.default_format, tensor{1, 1, 1, 1} };
+        } else {
+            OPENVINO_ASSERT(false, "NOT_IMPLEMENTED");
         }
     }
 };

--- a/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
@@ -101,6 +101,13 @@ public:
         return layout{ {1, p.in_shape[1], 1, 1}, p.default_type, p.default_format };
     }
 
+    layout get_per_channel_layout_5d(reduce_test_params& p) {
+        return layout{ {1, p.in_shape[1], 1, 1, 1}, p.default_type, format::bfzyx };
+    }
+
+    layout get_single_element_layout_5d(reduce_test_params& p) {
+        return layout{ p.default_type, format::bfzyx, tensor{1, 1, 1, 1, 1} };
+    }
 };
 }  // namespace
 
@@ -168,10 +175,10 @@ TEST_P(reduce_eltwise_activation_quantize, per_channel) {
     create_topologies(
         input_layout("input", get_input_layout(p, true)),
         reorder("input_reorder", input_info("input"), p.input_format, p.data_type),
-        data("in_lo", get_mem(get_per_channel_layout(p), min_random, 0)),
-        data("in_hi", get_mem(get_per_channel_layout(p), 1, max_random)),
-        data("out_lo", get_mem(get_single_element_layout(p), -128)),
-        data("out_hi", get_mem(get_single_element_layout(p), 127)),
+        data("in_lo", get_mem(p.out_shape.size() == 5 ? get_per_channel_layout_5d(p) : get_per_channel_layout(p), min_random, 0)),
+        data("in_hi", get_mem(p.out_shape.size() == 5 ? get_per_channel_layout_5d(p) : get_per_channel_layout(p), 1, max_random)),
+        data("out_lo", get_mem(p.out_shape.size() == 5 ? get_single_element_layout_5d(p) : get_single_element_layout(p), -128)),
+        data("out_hi", get_mem(p.out_shape.size() == 5 ? get_single_element_layout_5d(p) : get_single_element_layout(p), 127)),
         data("eltwise_data", get_mem(get_output_layout(p))),
         reduce("reduce", input_info("input_reorder"), p.reduce_mode, p.reduce_axes, p.keep_dims),
         eltwise("eltwise", { input_info("reduce"), input_info("eltwise_data") }, eltwise_mode::sum, p.default_type),

--- a/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/reduce_fusion_test.cpp
@@ -102,7 +102,7 @@ public:
         if (p.out_shape.size() == 5) {
             // 5D case
             return layout{ {1, p.in_shape[1], 1, 1, 1}, p.default_type, (p.default_format.dimension() == 5) ? p.default_format : cldnn::format(format::bfzyx)};
-        } else if (p.out_shape.size() == 4){
+        } else if (p.out_shape.size() <= 4){
             // 4D or other cases
             return layout{ {1, p.in_shape[1], 1, 1}, p.default_type, p.default_format };
         } else {
@@ -114,7 +114,7 @@ public:
         if (p.out_shape.size() == 5) {
             // 5D case
             return layout{ p.default_type, (p.default_format.dimension() == 5) ? p.default_format : cldnn::format(format::bfzyx) , tensor{1, 1, 1, 1, 1} };
-        } else if (p.out_shape.size() == 4) {
+        } else if (p.out_shape.size() <= 4) {
             // 4D or other cases
             return layout{ p.default_type, p.default_format, tensor{1, 1, 1, 1} };
         } else {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reduce_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reduce_gpu_test.cpp
@@ -2207,6 +2207,20 @@ INSTANTIATE_TEST_SUITE_P(onednn_reduce_gpu_b_fs_yx_fsv16_f16_f16,
                             TestParamType_general_reduce_gpu(17, 34, 1, 1, 16, 15, format::b_fs_yx_fsv16, reduce_mode::l1, {1, 0}, "reduce_gpu_b_fs_yx_fsv16", true, data_types::f16, false, data_types::f16),
                             TestParamType_general_reduce_gpu(17, 3, 1, 1, 14, 11, format::b_fs_yx_fsv16, reduce_mode::mean, {1}, "reduce_gpu_b_fs_yx_fsv16", true, data_types::f16, false, data_types::f16)
                         ), general_reduce_gpu::PrintToStringParamName);
+
+INSTANTIATE_TEST_SUITE_P(onednn_reduce_gpu_byxf_i8_f32,
+                        onednn_reduce_gpu_i8_f32,
+                        ::testing::Values(
+                            TestParamType_general_reduce_gpu(7, 3, 1, 1, 13, 11, format::byxf, reduce_mode::mean, {3, 2, 1, 0}, "reduce_gpu_byxf", true, data_types::i8, false, data_types::f32),
+                            TestParamType_general_reduce_gpu(17, 3, 1, 1, 14, 11, format::byxf, reduce_mode::mean, {1}, "reduce_gpu_byxf", true, data_types::i8, false, data_types::f32)
+                        ), general_reduce_gpu::PrintToStringParamName);
+
+INSTANTIATE_TEST_SUITE_P(onednn_reduce_gpu_byxf_f16_f16,
+                        onednn_reduce_gpu_f16_f16,
+                        ::testing::Values(
+                            TestParamType_general_reduce_gpu(17, 34, 1, 1, 16, 15, format::byxf, reduce_mode::l1, {1, 0}, "reduce_gpu_byxf", true, data_types::f16, false, data_types::f16),
+                            TestParamType_general_reduce_gpu(17, 3, 1, 1, 14, 11, format::byxf, reduce_mode::mean, {1}, "reduce_gpu_byxf", true, data_types::f16, false, data_types::f16)
+                        ), general_reduce_gpu::PrintToStringParamName);
 #endif  // ENABLE_ONEDNN_FOR_GPU
 
 #ifdef RUN_ALL_MODEL_CACHING_TESTS


### PR DESCRIPTION
### Details:
 - Add plain format support in reduce onednn impl manager
 - Because current onednn uses non-ref kernel for plain format input.
 - After this change, reduce layer is selected to ocl:combine_u8 from ocl_impl ref kernel and performance improved 8 times in the model of 169226.

### Tickets:
 - 169226
