### PR TITLE
[TRANSFORMATIONS] Extended PositionIDsReplacerQwen pattern to optionally match Convert and Reshape nodes

### DIFF
--- a/src/common/transformations/src/transformations/sdpa_to_paged_attention/position_ids_replacer.cpp
+++ b/src/common/transformations/src/transformations/sdpa_to_paged_attention/position_ids_replacer.cpp
@@ -72,7 +72,9 @@ ov::pass::PositionIDsReplacerQwen::PositionIDsReplacerQwen(const Output<Node>& p
     auto p_current_len = wrap_type<v8::Gather>({p_shape_of, _const(), _const()});
 
     auto p_neg_const = wrap_type<v0::Constant>();
-    auto p_neg_mul = wrap_type<v1::Multiply>({p_current_len, p_neg_const});
+    auto p_neg_const_convert = optional<v0::Convert>(p_neg_const);
+    auto p_neg_const_reshape = optional<v1::Reshape>({p_neg_const_convert, any_input()});
+    auto p_neg_mul = wrap_type<v1::Multiply>({p_current_len, p_neg_const_reshape});
 
     // For now, it has always been a constant, but this may change in the future.
     // In case of model being in FP16, there will be a decompressing subgraph:

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -666,7 +666,8 @@ TEST_F(SDPAToPATest, SDPAToPA_Qwen7bChat_PositionIDsReplacerQwenPattern) {
     {
         auto max_context_len = std::make_shared<v0::Parameter>(element::i32, PartialShape{});
         auto max_context_len_i64 = std::make_shared<v0::Convert>(max_context_len, element::i64);
-        auto max_context_len_reshaped = std::make_shared<v1::Reshape>(max_context_len_i64, v0::Constant::create(element::i64, Shape{1}, {1}), true);
+        auto max_context_len_reshaped =
+            std::make_shared<v1::Reshape>(max_context_len_i64, v0::Constant::create(element::i64, Shape{1}, {1}), true);
         max_context_len->set_friendly_name("max_context_len");
 
         auto rotary_emb_sincos = std::make_shared<v0::Parameter>(element::f32, PartialShape{1, DYN, 1, 128});
@@ -674,11 +675,15 @@ TEST_F(SDPAToPATest, SDPAToPA_Qwen7bChat_PositionIDsReplacerQwenPattern) {
 
         auto fake_input = std::make_shared<v0::Parameter>(element::i64, PartialShape{DYN, DYN});
         auto shape = std::make_shared<v3::ShapeOf>(fake_input, element::i64);
-        auto gather = std::make_shared<v8::Gather>(shape, v0::Constant::create(element::i64, Shape{1}, {1}), v0::Constant::create(element::i64, Shape{}, {0}));
+        auto gather = std::make_shared<v8::Gather>(shape,
+                                                   v0::Constant::create(element::i64, Shape{1}, {1}),
+                                                   v0::Constant::create(element::i64, Shape{1}, {0}));
 
         auto minus_one = v0::Constant::create(element::i32, Shape{1}, {-1});
         auto minus_one_converted = std::make_shared<v0::Convert>(minus_one, element::i64);
-        auto minus_one_reshaped = std::make_shared<v1::Reshape>(minus_one_converted, v0::Constant::create(element::i64, Shape{1}, {-1}), true);
+        auto minus_one_reshaped = std::make_shared<v1::Reshape>(minus_one_converted,
+                                                                v0::Constant::create(element::i64, Shape{1}, {-1}),
+                                                                true);
         auto past_offset = std::make_shared<v1::Multiply>(gather, minus_one_reshaped);
 
         auto start_const = v0::Constant::create(element::i64, Shape{1}, {0});
@@ -686,11 +691,16 @@ TEST_F(SDPAToPATest, SDPAToPA_Qwen7bChat_PositionIDsReplacerQwenPattern) {
         auto step_const = v0::Constant::create(element::i64, Shape{1}, {1});
         auto axis_const = v0::Constant::create(element::i64, Shape{1}, {1});
 
-        auto slice_1 = std::make_shared<v8::Slice>(rotary_emb_sincos, start_const, max_context_len_reshaped, step_const, axis_const);
+        auto slice_1 = std::make_shared<v8::Slice>(rotary_emb_sincos,
+                                                   start_const,
+                                                   max_context_len_reshaped,
+                                                   step_const,
+                                                   axis_const);
         auto slice_2 = std::make_shared<v8::Slice>(slice_1, past_offset, stop_const, step_const, axis_const);
         auto result = std::make_shared<v0::Result>(slice_2);
 
-        model = std::make_shared<Model>(ResultVector{result}, ParameterVector{max_context_len, rotary_emb_sincos, fake_input, position_ids});
+        model = std::make_shared<Model>(ResultVector{result},
+                                        ParameterVector{max_context_len, rotary_emb_sincos, fake_input, position_ids});
         manager.register_pass<pass::PositionIDsReplacerQwen>(position_ids);
     }
 
@@ -698,7 +708,9 @@ TEST_F(SDPAToPATest, SDPAToPA_Qwen7bChat_PositionIDsReplacerQwenPattern) {
         auto rotary_emb_sincos = std::make_shared<v0::Parameter>(element::f32, PartialShape{1, DYN, 1, 128});
         auto position_ids = std::make_shared<v0::Parameter>(element::i64, PartialShape{DYN});
 
-        auto gather_new = std::make_shared<v8::Gather>(rotary_emb_sincos, position_ids, v0::Constant::create(element::i64, Shape{}, {1}));
+        auto gather_new = std::make_shared<v8::Gather>(rotary_emb_sincos,
+                                                       position_ids,
+                                                       v0::Constant::create(element::i64, Shape{}, {1}));
         auto new_shape = v0::Constant::create(element::i64, Shape{4}, {-1, 1, 1, 128});
         auto reshaped = std::make_shared<v1::Reshape>(gather_new, new_shape, true);
 

--- a/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
+++ b/src/common/transformations/tests/op_conversions/sdpa_to_paged_attention_test.cpp
@@ -40,6 +40,7 @@
 #include "openvino/op/transpose.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/op/variadic_split.hpp"
+#include "transformations/sdpa_to_paged_attention/position_ids_replacer.hpp"
 #include "transformations/sdpa_to_paged_attention/prev_sequence_length_pattern.hpp"
 #include "transformations/sdpa_to_paged_attention/state_management_pattern.hpp"
 #include "transformations/sdpa_to_paged_attention/total_sequence_length_pattern.hpp"
@@ -654,6 +655,56 @@ TEST_F(SDPAToPATest, SDPAToPA_Qwen7bChat_TotalSequenceLengthPattern) {
         auto result = std::make_shared<v0::Result>(max_context_len_aligned);
         model_ref = std::make_shared<ov::Model>(ResultVector{result}, params);
     }
+    // TODO: align precisions, check the copying of "fuse_names" attr in SDPAToPagedAttention
+    // checking the graph structure and names, other checks are temporarily disabled:
+    comparator.disable(FunctionsComparator::PRECISIONS);
+    disable_result_friendly_names_check();
+    disable_rt_info_check();
+}
+
+TEST_F(SDPAToPATest, SDPAToPA_Qwen7bChat_PositionIDsReplacerQwenPattern) {
+    {
+        auto max_context_len = std::make_shared<v0::Parameter>(element::i32, PartialShape{});
+        auto max_context_len_i64 = std::make_shared<v0::Convert>(max_context_len, element::i64);
+        auto max_context_len_reshaped = std::make_shared<v1::Reshape>(max_context_len_i64, v0::Constant::create(element::i64, Shape{1}, {1}), true);
+        max_context_len->set_friendly_name("max_context_len");
+
+        auto rotary_emb_sincos = std::make_shared<v0::Parameter>(element::f32, PartialShape{1, DYN, 1, 128});
+        auto position_ids = std::make_shared<v0::Parameter>(element::i64, PartialShape{DYN});
+
+        auto fake_input = std::make_shared<v0::Parameter>(element::i64, PartialShape{DYN, DYN});
+        auto shape = std::make_shared<v3::ShapeOf>(fake_input, element::i64);
+        auto gather = std::make_shared<v8::Gather>(shape, v0::Constant::create(element::i64, Shape{1}, {1}), v0::Constant::create(element::i64, Shape{}, {0}));
+
+        auto minus_one = v0::Constant::create(element::i32, Shape{1}, {-1});
+        auto minus_one_converted = std::make_shared<v0::Convert>(minus_one, element::i64);
+        auto minus_one_reshaped = std::make_shared<v1::Reshape>(minus_one_converted, v0::Constant::create(element::i64, Shape{1}, {-1}), true);
+        auto past_offset = std::make_shared<v1::Multiply>(gather, minus_one_reshaped);
+
+        auto start_const = v0::Constant::create(element::i64, Shape{1}, {0});
+        auto stop_const = v0::Constant::create(element::i64, Shape{1}, {std::numeric_limits<int64_t>().max()});
+        auto step_const = v0::Constant::create(element::i64, Shape{1}, {1});
+        auto axis_const = v0::Constant::create(element::i64, Shape{1}, {1});
+
+        auto slice_1 = std::make_shared<v8::Slice>(rotary_emb_sincos, start_const, max_context_len_reshaped, step_const, axis_const);
+        auto slice_2 = std::make_shared<v8::Slice>(slice_1, past_offset, stop_const, step_const, axis_const);
+        auto result = std::make_shared<v0::Result>(slice_2);
+
+        model = std::make_shared<Model>(ResultVector{result}, ParameterVector{max_context_len, rotary_emb_sincos, fake_input, position_ids});
+        manager.register_pass<pass::PositionIDsReplacerQwen>(position_ids);
+    }
+
+    {
+        auto rotary_emb_sincos = std::make_shared<v0::Parameter>(element::f32, PartialShape{1, DYN, 1, 128});
+        auto position_ids = std::make_shared<v0::Parameter>(element::i64, PartialShape{DYN});
+
+        auto gather_new = std::make_shared<v8::Gather>(rotary_emb_sincos, position_ids, v0::Constant::create(element::i64, Shape{}, {1}));
+        auto new_shape = v0::Constant::create(element::i64, Shape{4}, {-1, 1, 1, 128});
+        auto reshaped = std::make_shared<v1::Reshape>(gather_new, new_shape, true);
+
+        model_ref = std::make_shared<Model>(OutputVector{reshaped}, ParameterVector{rotary_emb_sincos, position_ids});
+    }
+
     // TODO: align precisions, check the copying of "fuse_names" attr in SDPAToPagedAttention
     // checking the graph structure and names, other checks are temporarily disabled:
     comparator.disable(FunctionsComparator::PRECISIONS);


### PR DESCRIPTION
### Details:
 - Extended `PositionIDsReplacerQwen` pattern to optionally match Convert and Reshape node that may appear between negation constant and Multiply operation. This handles cases where ConstantFolding has not removed these intermediate nodes.
 - Backport of https://github.com/openvinotoolkit/openvino/pull/31079 

### Tickets:
 - *[CVS-168361](https://jira.devtools.intel.com/browse/CVS-168361)*
