### PR TITLE
[GPU] Add canonicalization for attention mask shape with rank less than 4

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -230,8 +230,7 @@ protected:
         auto extend_output = impl_params.output_layouts[0].get_partial_shape().size() < 4;
         auto extend_attn_mask = false;
 
-        // Check attention mask:
-        // According to SDPA specification, it must be either at least 2-dimensional or empty if it is to be ignored
+        // According to SDPA specification, attention mask should have 2-dimensions or more or empty
         const auto attn_mask_idx = 3;
         if (impl_params.input_layouts.size() > attn_mask_idx) {
             const auto& attn_mask_shape = impl_params.get_input_layout(attn_mask_idx).get_partial_shape();

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/scaled_dot_product_attention.cpp
@@ -226,6 +226,21 @@ protected:
         return is_generate;
     }
 
+    static bool requires_shape_canonicalization(const kernel_impl_params& impl_params) {
+        auto extend_output = impl_params.output_layouts[0].get_partial_shape().size() < 4;
+        auto extend_attn_mask = false;
+
+        // Check attention mask:
+        // According to SDPA specification, it must be either at least 2-dimensional or empty if it is to be ignored
+        const auto attn_mask_idx = 3;
+        if (impl_params.input_layouts.size() > attn_mask_idx) {
+            const auto& attn_mask_shape = impl_params.get_input_layout(attn_mask_idx).get_partial_shape();
+            extend_attn_mask = attn_mask_shape.size() != 0 && attn_mask_shape.size() < 4;
+        }
+
+        return extend_output || extend_attn_mask;
+    }
+
     event::ptr execute_impl(const std::vector<event::ptr>& events, scaled_dot_product_attention_inst& instance) override {
         if (need_indirect_load(instance)) {
             return execute_stage(events, instance, indirect_sdpa);
@@ -431,6 +446,12 @@ public:
             return pshape;
         };
 
+        const auto attn_mask_idx = 3;
+        if (updated_impl_params.input_layouts.size() > attn_mask_idx) {
+            const auto attn_mask_shape = updated_impl_params.input_layouts[attn_mask_idx].get_partial_shape();
+            updated_impl_params.input_layouts[attn_mask_idx].set_partial_shape(extend_shape_to_rank_from_begin(attn_mask_shape));
+        }
+
         // For scale of 1D tensor or attention_mask of empty shape, use extend_shape_to_rank_from_end as before
         for (auto& input_layout : updated_impl_params.input_layouts) {
             input_layout.set_partial_shape(input_layout.get_partial_shape().size() <= 1 ?
@@ -452,7 +473,7 @@ public:
         std::vector<kernel_selector::kernel_data> kernels_data;
         auto& kernel_selector = kernel_selector_t::Instance();
         const bool is_output_rank_4d = impl_param.output_layouts[0].get_partial_shape().size() == 4;
-        auto params = is_output_rank_4d ? impl_param : static_canonicalize_shapes(impl_param);
+        auto params = requires_shape_canonicalization(impl_param) ? static_canonicalize_shapes(impl_param) : impl_param;
 
         auto sdpa_kernel_params = get_kernel_params(params, params.is_dynamic());
         // Known limitation: In vision encoding model of qwen-vl, when the shape of sdpa is 3D and num_heads is 1,
@@ -495,7 +516,7 @@ public:
     }
 
     void update(primitive_inst& inst, const kernel_impl_params& impl_params) override {
-        auto new_impl_params = impl_params.output_layouts[0].get_partial_shape().size() == 4 ? impl_params : canonicalize_shapes(impl_params);
+        auto new_impl_params = requires_shape_canonicalization(impl_params) ? canonicalize_shapes(impl_params) : impl_params;
         update_dispatch_data(new_impl_params);
         inst.update_shape_info_tensor(new_impl_params);
     }

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp
@@ -503,6 +503,24 @@ const std::vector<std::vector<InputShape>> dynamic_shapes_4D {
         // attn shape: [B, 1, -1, L0+L1]
         {ov::test::InputShape{ov::PartialShape{-1, 1, -1, -1},
             {ov::Shape{1, 1, 1, 2}, ov::Shape{1, 1, 1, 10}, ov::Shape{2, 1, 1, 2}}}
+    },
+    // 4D inputs, 2D mask
+    {
+        // q shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 245, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // k shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 245, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // v shape
+        {ov::test::InputShape{ov::PartialShape{-1, 8, -1, 64},
+            {ov::Shape{1, 8, 245, 64}, ov::Shape{1, 8, 1, 64}, ov::Shape{2, 8, 10, 64}}}
+        },
+        // attn shape: [B, 1, -1, L0+L1]
+        {ov::test::InputShape{ov::PartialShape{-1, -1},
+            {ov::Shape{245, 245}, ov::Shape{1, 1}, ov::Shape{10, 10}}}
         },
     }
 };

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp
@@ -503,6 +503,7 @@ const std::vector<std::vector<InputShape>> dynamic_shapes_4D {
         // attn shape: [B, 1, -1, L0+L1]
         {ov::test::InputShape{ov::PartialShape{-1, 1, -1, -1},
             {ov::Shape{1, 1, 1, 2}, ov::Shape{1, 1, 1, 10}, ov::Shape{2, 1, 1, 2}}}
+        },
     },
     // 4D inputs, 2D mask
     {


### PR DESCRIPTION
### Details:
 - Add canonicalization check for attention mask shape. Previously, using an attention mask with rank less than 4 could lead to kernel compilation errors and incorrect indexing. However, according to SDPA specification, it can be either at least 2-dimensional or empty if it is to be ignored
 - Related transformation PRs that squeeze attention mask in some cases: https://github.com/openvinotoolkit/openvino/pull/31089 and https://github.com/openvinotoolkit/openvino/pull/30659 

### Tickets:
 - [CVS-165700](https://jira.devtools.intel.com/browse/CVS-165700)
 - [CVS-169359](https://jira.devtools.intel.com/browse/CVS-169359)
