### PR TITLE
[Snippets] Simplify subgraph tests body

### DIFF
--- a/src/common/snippets/tests/src/pass/collapse_subgraph.cpp
+++ b/src/common/snippets/tests/src/pass/collapse_subgraph.cpp
@@ -29,75 +29,55 @@ void CollapseSubgraphTests::run() {
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_Eltwise) {
     const auto& f = EltwiseFunction(std::vector<PartialShape> {{2, 3}, {1, 3}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_MatMulWithEltwise) {
     const auto& f = MatMulEltwiseBranchesFunction(std::vector<PartialShape> {{1, 3, 4, 4}, {1, 3, 4, 4}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_AvoidLoopEltwise) {
     const auto& f = EltwiseLogLoopFunction(std::vector<PartialShape> {{2, 5}, {2, 1}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_OneConvert) {
     const auto& f = ConvertFunction(std::vector<PartialShape>{{2, 5}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_ConvertInput) {
     const auto& f = ConvertInputFunction(std::vector<PartialShape>{{2, 5}, {1, 5}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_ConvertOutput) {
     const auto& f = ConvertOutputFunction(std::vector<PartialShape>{{2, 5}, {1, 5}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_ConvertStub) {
     const auto& f = ConvertStubFunction(std::vector<PartialShape>{{2, 5, 2}, {1, 5, 1}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_ConvertPartialInputsAndResults) {
     const auto& f = ConvertPartialInputsAndResultsFunction(std::vector<PartialShape>{{2, 5, 1}, {1, 5, 1}, {2, 1, 10}},
                                                            std::vector<ov::element::Type>{ov::element::i8, ov::element::bf16, ov::element::f32},
                                                            std::vector<ov::element::Type>{ov::element::f32, ov::element::i8});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_EltwiseTwoResultsFunction) {
     const auto& f = EltwiseTwoResultsFunction(std::vector<PartialShape>{{2, 5}, {2, 1}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
     comparator.enable(FunctionsComparator::CmpValues::NAMES);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(CollapseSubgraphTests, smoke_Snippets_ThreeFQFunction) {
     const auto& f = ThreeFQFunction(std::vector<PartialShape>{});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 }  // namespace snippets

--- a/src/common/snippets/tests/src/pass/mha_tokenization.cpp
+++ b/src/common/snippets/tests/src/pass/mha_tokenization.cpp
@@ -26,49 +26,37 @@ void TokenizeMHASnippetsTests::run() {
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_2D_Static) {
     const auto &f = MHA2DFunction(std::vector<PartialShape>{{12, 64}, {64, 12}, {12, 12}, {12, 64}},
                                   std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_2D_Dynamic) {
     const auto &f = MHA2DFunction(std::vector<PartialShape>{{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}},
                                   std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_2D_Partially_Dynamic) {
     const auto &f = MHA2DFunction(std::vector<PartialShape>{{12, 64}, {64, 12}, {-1, 12}, {12, 64}},
                                   std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Dynamic) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Partially_Dynamic) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 1, -1, 1}, {1, 128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Partially_Dynamic_Disabled_Dynamic) {
@@ -82,103 +70,77 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Partially_Dynamic_Disable
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Dynamic_M) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, -1, 12, 64}, {1, 128, 12, 64}, {1, 12, -1, 128}, {1, 128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_Dynamic_K) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 12, -1}, {1, 128, 12, -1}, {1, 12, 128, 128}, {1, 128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_3D) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{128, 12, 64}, {128, 12, 64}, {12, 128, 128}, {128, 12, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_3D_Dynamic) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{-1, -1, -1}, {-1, -1, -1}, {-1, -1, -1}, {-1, -1, -1}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), true, false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_with_MatMul0_Transpose) {
     const auto &f = MHAMatMul0TransposeFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}},
                                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}));
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_with_MatMul0_Transpose_Dynamic) {
     const auto &f = MHAMatMul0TransposeFunction(std::vector<PartialShape>{{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}},
                                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
                                                 false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_with_int_Matmuls) {
     const auto &f = MHAINT8MatMulTypeRelaxedFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 12, 128, 128}, {1, 128, 12, 64}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Transpose_extraction) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 128, 12, 64}, {1, 128, 12, 64}}, true);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Dynamic_Transpose_extraction) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}, true);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Transpose_extraction_and_unsupported_existing_transpose) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 12, 64, 128}, {1, 128, 12, 64}}, true,
                                                std::vector<int64_t>{0, 3, 1, 2});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Dynamic_Transpose_extraction_and_unsupported_existing_transpose) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}, true,
                                                std::vector<int64_t>{0, 3, 1, 2});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Transpose_fusion) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{1, 128, 12, 64}, {1, 64, 128, 12}, {1, 128, 12, 64}}, false,
                                                std::vector<int64_t>{0, 2, 1, 3});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Dynamic_Transpose_fusion) {
     const auto& f = MHATransposedInputFunction(std::vector<PartialShape>{{-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}}, false,
                                                std::vector<int64_t>{0, 2, 1, 3});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA3D_SplitM) {
@@ -186,10 +148,8 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA3D_SplitM) {
                                       std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
                                       std::vector<Shape>{{2, 64, 12, 64}, {12, 1, 64, 128}, {12, 2, 64, 128}, {1, 128, 12, 64}, {128, 12, 64}},
                                       false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(24);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA3D_SplitM_withMul) {
@@ -197,10 +157,8 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA3D_SplitM_withMul) {
                                       std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
                                       std::vector<Shape>{{4, 32, 12, 64}, {12, 1, 64, 128}, {12, 4, 32, 128}, {1, 128, 12, 64}, {128, 12, 64}},
                                       true);
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(16);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA4D_SplitM) {
@@ -208,10 +166,8 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA4D_SplitM) {
                                       std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
                                       std::vector<Shape>{{1, 12, 32, 16, 64}, {1, 16, 1, 64, 384}, {1, 1, 1, 1, 384}, {1, 1, 384, 16, 64}, {1, 384, 16, 64}},
                                       false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(60);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA4D_SplitM_withMul) {
@@ -219,59 +175,47 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA4D_SplitM_withMul) {
                                       std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}),
                                       std::vector<Shape>{{1, 12, 32, 16, 64}, {1, 16, 1, 64, 384}, {1, 1, 1, 1, 384}, {1, 1, 384, 16, 64}, {1, 384, 16, 64}},
                                       true);
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(60);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHAWOTranspose_SplitM) {
     const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{10, 9216, 128}, {10, 128, 9216}, {10, 9216, 128}},
                                                  std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
                                                  std::vector<Shape>{{10, 18, 512, 128}, {10, 1, 128, 9216}, {10, 1, 9216, 128}, {10, 9216, 128}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(18);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_SplitM_AlmostAllThreads) {
     const auto& f = MHAWOTransposeSplitMFunction(std::vector<PartialShape>{{5, 30, 32}, {5, 32, 30}, {5, 30, 32}},
                                                  std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32}),
                                                  std::vector<Shape>{{5, 10, 3, 32}, {5, 1, 32, 30}, {5, 1, 30, 32}, {5, 30, 32}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(32);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_4D_SplitM_DynamicParameter) {
     const auto &f = MHAFunction(std::vector<PartialShape>{{1, 128, 16, 64}, {1, 128, 16, 64}, {1, 16, 128, -1}, {1, 128, 16, 64}},
                                 std::vector<ov::element::Type>({ov::element::f32, ov::element::f32, ov::element::f32, ov::element::f32}), false, false);
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(32);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHASelect_SplitM) {
     const auto& f = MHASelectSplitMFunction(std::vector<PartialShape>{{8, 512, 18}, {8, 18, 64}, {1, 512, 64}, {1, 1, 64}, {8, 64, 512}},
                                             std::vector<Shape>{{8, 2, 256, 18}, {8, 1, 18, 64}, {1, 2, 256, 64}, {1, 1, 1, 64},
                                                                {8, 1, 64, 512}, {8, 512, 512}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(16);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHASelect_SplitM_ScalarParams) {
     const auto& f = MHASelectSplitMFunction(std::vector<PartialShape>{{8, 512, 18}, {8, 18, 64}, {1}, {64}, {8, 64, 512}},
                                             std::vector<Shape>{{8, 2, 256, 18}, {8, 1, 18, 64}, {}, {},
                                                                {8, 1, 64, 512}, {8, 512, 512}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
     config.set_concurrency(16);
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Reshape_extraction) {
@@ -280,9 +224,7 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Reshape_extraction) {
                                                                               {400, 14, 14, 14},
                                                                               {400, 14, 14, 1, 14},
                                                                               {400, 196, 80}}, true);
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Rank_Change_Reshape_extraction) {
@@ -291,9 +233,7 @@ TEST_F(TokenizeMHASnippetsTests, smoke_Snippets_MHA_Rank_Change_Reshape_extracti
                                                                                 {1, 16, 100, 100},
                                                                                 {1, 100, 1, 100, 100},
                                                                                 {100, 16, 100, 32}});
-    model = f.getOriginal();
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 }  // namespace snippets

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/aarch64/snipptes_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/aarch64/snipptes_mark_skipped.cpp
@@ -36,10 +36,8 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvMulRelu) {
                                                    std::make_shared<ov::op::v0::Relu>()};
     std::vector<PartialShape> inputShapes {{1, 2, 16, 16}, {1, 2, 1, 16}};
     const auto &f = ConvMulActivationFunction(inputShapes, eltwiseOps);
-    model = f.getOriginal();
     // Fully tokenizable, since Mul isn't fused into Convolution
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvSumRelu) {
@@ -48,10 +46,8 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvSumRelu) {
                                                    std::make_shared<ov::op::v0::Relu>()};
     std::vector<PartialShape> inputShapes {{1, 2, 16, 16}, {1, 2, 1, 16}};
     const auto &f = ConvMulActivationFunction(inputShapes, eltwiseOps);
-    model = f.getOriginal();
     // Fully tokenizable, since Add isn't fused into Convolution
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvBiasRelu) {
@@ -71,10 +67,8 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvBiasTwoRelu) {
                                                    std::make_shared<ov::op::v0::Relu>()};
     std::vector<PartialShape> inputShapes {{1, 2, 16, 16}};
     const auto &f = ConvBiasTwoActivationFunction(inputShapes, eltwiseOps);
-    model = f.getOriginal();
     // Partially tokenizable, since Bias and first Relu can be fused into Convolution
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipMatMulFused_MatMulBiasTwoRelu) {
@@ -95,10 +89,8 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipMatMulFused_MatMulBiasReluDi
                                                    std::make_shared<ov::op::v1::Divide>()};
     std::vector<PartialShape> inputShapes {{1, 2, 2, 16}, {16, 4}, {1, 2, 2, 4}};
     const auto &f = MatMulBiasActivationBinaryFunction(inputShapes, eltwiseOps);
-    model = f.getOriginal();
     // There will one Subgraph with Divide since Bias and Relu can be fused into MatMul
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 }  // namespace snippets

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/snipptes_mark_skipped.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/snipptes_mark_skipped.cpp
@@ -32,10 +32,8 @@ public:
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipAfterInputsMatMulEltwise) {
     const auto &f = MatMulEltwiseBranchesFunction(std::vector<PartialShape> {{1, 3, 4, 4}, {1, 3, 4, 4}});
-    model = f.getOriginal();
     // Fully tokenizable, since inputs are followed by MatMul
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvMulActivation) {
@@ -44,10 +42,8 @@ TEST_F(SnippetsMarkSkippedTests, smoke_Snippets_SkipConvFused_ConvMulActivation)
                                                    std::make_shared<ov::op::v0::Sqrt>()};
     std::vector<PartialShape> inputShapes {{1, 2, 16, 16}, {1, 2, 1, 16}};
     const auto &f = ConvMulActivationFunction(inputShapes, eltwiseOps);
-    model = f.getOriginal();
     // Fully tokenizable, since Mul with 2 inputs isn't fused into Convolution
-    model_ref = f.getReference();
-    run();
+    execute_and_validate_function(*this, f);
 }
 
 TEST_F(SnippetsMarkSkippedTests, smoke_SkipConvFused_ConvSumActivation) {

--- a/src/tests/ov_helpers/ov_snippets_models/include/snippets_helpers.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/snippets_helpers.hpp
@@ -78,6 +78,13 @@ protected:
     std::vector<size_t> custom_ops_num_inputs;
     void ResetCustomOpsInputs();
 };
+
+template <typename TestType>
+inline void execute_and_validate_function(TestType& test, const SnippetsFunctionBase& f) {
+    test.model = f.getOriginal();
+    test.model_ref = f.getReference();
+    test.run();
+}
 }  // namespace snippets
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Add `execute_and_validate_function` function to apply common subgraph operations across the tests
 - Get rid of model setting code duplications in snippets tests

### Tickets:
 - N/A
