### PR TITLE
[CI] Disable faster build on clang-tidy job (#30699)

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -126,7 +126,7 @@ jobs:
             -DENABLE_TESTS=OFF \
             -DENABLE_NCC_STYLE=OFF \
             -DENABLE_CPPLINT=OFF \
-            -DENABLE_FASTER_BUILD=ON \
+            -DENABLE_FASTER_BUILD=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CMAKE_C_COMPILER_LAUNCHER }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CMAKE_CXX_COMPILER_LAUNCHER }} \
             -S ${OPENVINO_REPO} \


### PR DESCRIPTION
### Details:
Port of https://github.com/openvinotoolkit/openvino/pull/30699 from master.

Unblock clang-tidy build pipeline after changes in
`openvino/core/version.hpp`