### PR TITLE
Transformation for marking a new type format (#30671)

### DIFF
--- a/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
+++ b/src/common/low_precision_transformations/tests/mark_dequantization_subgraph_transformation.cpp
@@ -22,6 +22,7 @@
 #include "openvino/op/relu.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/subtract.hpp"
+#include "openvino/op/gather.hpp"
 
 using namespace ov;
 
@@ -942,4 +943,92 @@ TEST_F(TransformationTests, KeepDequantizationPrecisionTransformationFoldingWith
     auto func_comparator = FunctionsComparator::with_default();
     auto result = func_comparator(model_ref, model);
     ASSERT_TRUE(result.valid) << result.message;
+}
+
+inline std::shared_ptr<Model> make_gather_model(element::Type data_type,
+                                                element::Type indices_type,
+                                                bool use_data_convert,
+                                                bool use_indices_convert,
+                                                bool indices_as_param,
+                                                bool reference_model = false) {
+    using op::v0::Constant;
+    using op::v0::Convert;
+    using op::v0::Parameter;
+    using op::v8::Gather;
+
+    ParameterVector params;
+
+    std::shared_ptr<Node> data = std::make_shared<Constant>(data_type, Shape{4}, 2);
+    if (reference_model)
+        enable_keep_const_precision(data);
+    if (use_data_convert) {
+        data = std::make_shared<Convert>(data, element::f32);
+        if (reference_model)
+            disable_constant_folding(data);
+    }
+
+    std::shared_ptr<Node> indices;
+    if (indices_as_param) {
+        params.push_back(std::make_shared<Parameter>(indices_type, Shape{3}));
+        indices = params.back();
+    } else {
+        indices = std::make_shared<Constant>(indices_type, Shape{3}, 1);
+    }
+    if (reference_model)
+        enable_keep_const_precision(indices);
+
+    if (use_indices_convert) {
+        indices = std::make_shared<Convert>(indices, element::i32);
+        if (reference_model)
+            disable_constant_folding(indices);
+    }
+
+    auto axis = std::make_shared<Constant>(element::i64, Shape{1}, 0);
+    auto gather = std::make_shared<Gather>(data, indices, axis);
+    if (reference_model)
+        disable_constant_folding(gather);
+
+    return std::make_shared<Model>(OutputVector{gather}, params);
+}
+
+TEST_F(TransformationTestsF, MarkGatherSubgraph) {
+    auto data_type = element::f8e4m3;
+    auto indices_type = element::u4;
+
+    model = make_gather_model(data_type, indices_type, true, true, false);
+    model_ref = make_gather_model(data_type, indices_type, true, true, false, true);
+
+    manager.register_pass<pass::MarkGatherSubgraph>(
+        element::TypeVector{element::f8e4m3, element::f16},
+        element::TypeVector{element::u4, element::u8}
+    );
+
+    manager.register_pass<pass::ConstantFolding>();
+    precisions_map map = {
+        {data_type, element::f32},
+        {indices_type, element::i32},
+    };
+    manager.register_pass<pass::ConvertPrecision>(map);
+    comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
+}
+
+TEST_F(TransformationTestsF, MarkGatherSubgraph_IndicesAsParam) {
+    auto data_type = element::f8e4m3;
+    auto indices_type = element::u4;
+
+    model = make_gather_model(data_type, indices_type, true, true, true);
+    model_ref = make_gather_model(data_type, indices_type, true, true, true, true);
+
+    manager.register_pass<pass::MarkGatherSubgraph>(
+        element::TypeVector{element::f8e4m3, element::f16},
+        element::TypeVector{element::u4, element::u8}
+    );
+
+    manager.register_pass<pass::ConstantFolding>();
+    precisions_map map = {
+        {data_type, element::f32},
+        {indices_type, element::i32},
+    };
+    manager.register_pass<pass::ConvertPrecision>(map);
+    comparator.enable(FunctionsComparator::CmpValues::RUNTIME_KEYS);
 }

--- a/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
+++ b/src/common/transformations/include/transformations/low_precision/mark_dequantization_subgraph.hpp
@@ -110,5 +110,28 @@ public:
                                          bool add_precision_sensitive_convert = false);
 };
 
+/**
+ * Marks subgraphs where Gather receives:
+ *   - data: Constant in table_values_precisions → (optional Convert)
+ *   - indices: Constant/Parameter in indices_precisions → (optional Convert)
+ * Disables constant folding for Converts, enables keep-precision for Constants.
+ *
+ * Pattern:
+ *
+ *        [Constant]    [Constant/Parameter]   [Axis]
+ *            |                  |                |
+ *      (optional Convert) (optional Convert)     |
+ *            |                  |                |
+ *            +--------+---------+--------+-------+
+ *                     |         |        |
+ *              Gather (data, indices, axis)
+ */
+class TRANSFORMATIONS_API MarkGatherSubgraph : public ov::pass::MatcherPass {
+public:
+    OPENVINO_MATCHER_PASS_RTTI("MarkGatherSubgraph")
+    MarkGatherSubgraph(const element::TypeVector& table_values_precisions,
+                       const element::TypeVector& indices_precisions);
+};
+
 }  // namespace pass
 }  // namespace ov

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -131,6 +131,9 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     using namespace ov::pass;
     REGISTER_PASS(manager, InitNodeInfo)
     if (m_low_precision_enabled) {
+        // Transformation call example, to check with the real model
+        manager.register_pass<MarkGatherSubgraph>(element::TypeVector{element::f8e4m3},
+                                                  element::TypeVector{element::u4});
         manager.register_pass<ov::pass::MarkDequantization>(element::TypeVector{ov::element::i32,
                                                                                 ov::element::u32,
                                                                                 ov::element::i16,

--- a/src/common/transformations/src/transformations/convert_precision.cpp
+++ b/src/common/transformations/src/transformations/convert_precision.cpp
@@ -612,6 +612,10 @@ bool fuse_type_to_eye_v9(const std::shared_ptr<ov::Node>& node, const precisions
 bool fuse_type_to_parameter(const std::shared_ptr<ov::Node>& node,
                             const precisions_map& precisions,
                             bool convert_input_precision) {
+    // Parameter marked with is_keep_const_precision should be kept in their own precision until they reach the plugin
+    if (is_keep_const_precision(node))
+        return false;
+
     auto it = precisions.find(node->get_output_element_type(0));
     if (it == precisions.end())
         return false;

--- a/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
+++ b/src/common/transformations/src/transformations/low_precision/mark_dequantization_subgraph.cpp
@@ -5,6 +5,7 @@
 #include "transformations/low_precision/mark_dequantization_subgraph.hpp"
 
 #include "itt.hpp"
+#include "openvino/op/gather.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/subtract.hpp"
@@ -370,5 +371,45 @@ ov::pass::KeepDequantizationPrecision::KeepDequantizationPrecision(const element
     };
 
     auto m = std::make_shared<Matcher>(multiply_pattern, "KeepDequantizationPrecision");
+    this->register_matcher(m, callback);
+}
+
+ov::pass::MarkGatherSubgraph::MarkGatherSubgraph(const element::TypeVector& table_values_precisions,
+                                                 const element::TypeVector& indices_precisions) {
+    MATCHER_SCOPE(MarkGatherSubgraph);
+
+    // 1. Data input → (optional Convert) → (input to Gather[0])
+    auto data_input = wrap_type<op::v0::Constant>(check_precision(table_values_precisions));
+    auto data_convert = pattern::optional<op::v0::Convert>({data_input});
+
+    // 2. Indices input → (optional Convert) → (input to Gather[1])
+    auto indices_input = wrap_type<op::v0::Constant, op::v0::Parameter>(check_precision(indices_precisions));
+    auto indices_convert = pattern::optional<op::v0::Convert>({indices_input});
+
+    // Gather (fp, integral, any)
+    auto axis = any_input(value_matches("0"));
+    auto gather = wrap_type<op::v8::Gather>({data_convert, indices_convert, axis});
+
+    matcher_pass_callback callback = [=](Matcher& m) {
+        const auto& pm = m.get_pattern_map();
+        auto gather_node = pm.at(gather);
+        if (transformation_callback(gather_node)) {
+            return false;
+        }
+
+        for (const auto& node : {gather, data_convert, indices_convert}) {
+            if (pm.count(node))
+                ov::disable_constant_folding(pm.at(node));
+        }
+
+        for (const auto& node : {data_input, indices_input}) {
+            if (pm.count(node))
+                ov::enable_keep_const_precision(pm.at(node));
+        }
+
+        return false;
+    };
+
+    auto m = std::make_shared<Matcher>(gather, "MarkGatherSubgraph");
     this->register_matcher(m, callback);
 }

--- a/src/core/src/preprocess/pre_post_process.cpp
+++ b/src/core/src/preprocess/pre_post_process.cpp
@@ -81,6 +81,8 @@ void transformation_pipeline(std::shared_ptr<ov::Model>& model) {
     REGISTER_PASS(manager, SharedOpOptimization)
 
     // 1. Set "disable_const_folding" attribute
+    // we have to add a call into the PrePostProcessing, it runs before compile_model call
+    REGISTER_PASS(manager, MarkGatherSubgraph, element::TypeVector{element::f8e4m3}, element::TypeVector{element::u4});
     REGISTER_PASS(manager,
                   MarkDequantization,
                   TypeVector{i32, u32, i16, u16, i8, u8, i4, u4, nf4, f4e2m1, f8e4m3, f8e5m2, f8e8m0});


### PR DESCRIPTION
### Details:
 Marks subgraphs where Gather receives:
   - data: FP Constant → (optional Convert)
   - indices: INT/UINT Constant → (optional Convert) Disables constant folding for Converts, enables keep-precision for Constants.

Pattern matched by MarkGatherSubgraph

```text
[FP Constant]      [INT/UINT Constant]      [Axis]
 (keep_const_prec)  (keep_const_prec)         |
      |                   |                   |
(optional Convert)  (optional Convert)        |
  (disable_cf)        (disable_cf)            |
      |                   |                   |
      +---------+---------+---------+---------+
                |         |         |
                    Gather
           (data, indices, axis)
```

### Tickets:
 - *CVS-167084*

PR to master: #30671

