### PR TITLE
[OV JS] Fix compileModel() return type

### DIFF
--- a/src/bindings/js/node/src/compiled_model.cpp
+++ b/src/bindings/js/node/src/compiled_model.cpp
@@ -28,7 +28,6 @@ Napi::Function CompiledModelWrap::get_class(Napi::Env env) {
 }
 
 Napi::Object CompiledModelWrap::wrap(Napi::Env env, ov::CompiledModel compiled_model) {
-    Napi::HandleScope scope(env);
     const auto& prototype = env.GetInstanceData<AddonData>()->compiled_model;
     if (!prototype) {
         OPENVINO_THROW("Invalid pointer to CompiledModel prototype.");

--- a/src/bindings/js/node/src/core_wrap.cpp
+++ b/src/bindings/js/node/src/core_wrap.cpp
@@ -196,12 +196,7 @@ void compileModelThreadModel(TsfnContextModel* context) {
     context->_compiled_model = core.compile_model(context->_model, context->_device, context->_config);
 
     auto callback = [](Napi::Env env, Napi::Function, TsfnContextModel* context) {
-        Napi::HandleScope scope(env);
-        auto obj = CompiledModelWrap::get_class(env).New({});
-        auto cm = Napi::ObjectWrap<CompiledModelWrap>::Unwrap(obj);
-        cm->set_compiled_model(context->_compiled_model);
-
-        context->deferred.Resolve(obj);
+        context->deferred.Resolve(CompiledModelWrap::wrap(env, context->_compiled_model));
     };
 
     context->tsfn.BlockingCall(context, callback);
@@ -213,12 +208,7 @@ void compileModelThreadPath(TsfnContextPath* context) {
     context->_compiled_model = core.compile_model(context->_model, context->_device, context->_config);
 
     auto callback = [](Napi::Env env, Napi::Function, TsfnContextPath* context) {
-        Napi::HandleScope scope(env);
-        auto obj = CompiledModelWrap::get_class(env).New({});
-        auto cm = Napi::ObjectWrap<CompiledModelWrap>::Unwrap(obj);
-        cm->set_compiled_model(context->_compiled_model);
-
-        context->deferred.Resolve(obj);
+        context->deferred.Resolve(CompiledModelWrap::wrap(env, context->_compiled_model));
     };
 
     context->tsfn.BlockingCall(context, callback);

--- a/src/bindings/js/node/tests/unit/basic.test.js
+++ b/src/bindings/js/node/tests/unit/basic.test.js
@@ -200,9 +200,15 @@ describe('ov basic tests.', () => {
       });
     });
 
-    it.skip('compileModel() returns a Promise of CompiledModel', async () => {
-      // CVS-167943
+    it('compileModel(model:Model) returns Promise<CompiledModel>', async () => {
       const promise = core.compileModel(model, 'CPU');
+      assert.ok(promise instanceof Promise);
+      const cm = await promise;
+      assert.ok(cm instanceof ov.CompiledModel);
+    });
+
+    it('compileModel(model_path) returns Promise<CompiledModel>', async () => {
+      const promise = core.compileModel(testModelFP32.xml, 'CPU');
       assert.ok(promise instanceof Promise);
       const cm = await promise;
       assert.ok(cm instanceof ov.CompiledModel);


### PR DESCRIPTION
### Details:
 - It was not possible to check the type of `CompiledModel` object returned by `core.compileModel()`, because it was incorrectly wrapped.
 - Unskip test `it.skip('compileModel() returns a Promise of CompiledModel', async () => {`

### Tickets:
 - [CVS-167943](https://jira.devtools.intel.com/browse/CVS-167943)
