### PR TITLE
[CPU] Fix the select OP parameter convert wrong value issue

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_eltwise_emitters.cpp
@@ -2564,7 +2564,7 @@ size_t jit_select_emitter::get_inputs_num() const {
 
 std::set<std::vector<element::Type>> jit_select_emitter::get_supported_precisions(
     [[maybe_unused]] const std::shared_ptr<ov::Node>& node) {
-    return {{element::f32, element::f32, element::f32}};
+    return {{element::f32, element::f32, element::f32}, {element::i32, element::i32, element::i32}};
 }
 
 size_t jit_select_emitter::aux_vecs_count() const {

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
@@ -71,8 +71,7 @@ ov::element::Type eltwise_precision_helper::get_precision(const size_t inputs_nu
 
     // To select the most suitable precision from inputs are mixed-precision
     // Preference is given to higher bitwidth, and for equal bitwidth, to real (floating point) types.
-    auto select_precision_from_inputs = [](const ov::element::Type(&src_prc)[MAX_ELTWISE_INPUTS],
-                                           const size_t inputs_number) {
+    const auto input_precision = [&] {
         auto selected_type = src_prc[0];  // Start with the first input's precision
         for (size_t i = 1; i < inputs_number; i++) {
             if (selected_type.bitwidth() > src_prc[i].bitwidth()) {
@@ -86,9 +85,7 @@ ov::element::Type eltwise_precision_helper::get_precision(const size_t inputs_nu
             selected_type = src_prc[i];
         }
         return selected_type;
-    };
-
-    const auto input_precision = select_precision_from_inputs(src_prc, inputs_number);
+    } ();
 
     for (const auto prc : exec_precisions_priority) {
         if (input_precision != prc) {

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
@@ -11,7 +11,6 @@
 #include <set>
 #include <vector>
 
-#include "cpu_types.h"
 #include "nodes/executors/eltwise.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
@@ -70,29 +70,46 @@ ov::element::Type eltwise_precision_helper::get_precision(const size_t inputs_nu
         supported_precision_intersection = prcs_intersect;
     }
 
+    // To select the most suitable precision from inputs are mixed-precision
+    // Preference is given to higher bitwidth, and for equal bitwidth, to real (floating point) types.
+    auto select_precision_from_inputs = [](const ov::element::Type(&src_prc)[MAX_ELTWISE_INPUTS],
+                                           const size_t inputs_number) {
+        auto selected_type = src_prc[0];  // Start with the first input's precision
+        for (size_t i = 1; i < inputs_number; i++) {
+            if (selected_type.bitwidth() > src_prc[i].bitwidth()) {
+                continue;
+            }
+            // If bitwidths are equal and selected_type is real (floating point), keep it
+            if (selected_type.bitwidth() == src_prc[i].bitwidth() && selected_type.is_real()) {
+                continue;
+            }
+            // Otherwise, update selected_type to the current input's precision
+            selected_type = src_prc[i];
+        }
+        return selected_type;
+    };
+
+    const auto input_precision = select_precision_from_inputs(src_prc, inputs_number);
+
     for (const auto prc : exec_precisions_priority) {
+        if (input_precision != prc) {
+            continue;
+        }
         if (std::any_of(supported_precision_intersection.begin(),
                         supported_precision_intersection.end(),
-                        [&prc, &src_prc](const std::vector<element::Type>& precisions) {
-                            return (std::find(precisions.begin(), precisions.end(), prc) != precisions.end()) &&
-                                   (std::find(src_prc, src_prc + sizeof(src_prc), prc) != src_prc + sizeof(src_prc));
+                        [&prc](const std::vector<element::Type>& precisions) {
+                            // L56 has the check that all precisions are equal
+                            // So only check the first one
+                            return (precisions[0] == prc);
                         })) {
             exec_prc = prc;
             break;
         }
     }
 
-    if (Algorithm::EltwiseSelect != eltwise_data.front().algo || exec_prc == ov::element::dynamic) {
-        for (size_t i = 0; i < inputs_number; i++) {
-            if (src_prc[i] != exec_prc) {
-                exec_prc = ov::element::f32;
-                break;
-            }
-        }
-    }
-
     if (exec_prc == ov::element::dynamic) {
-        OPENVINO_THROW("Eltwise jitter failed to specify execution precision for Eltwise node");
+        // Fallback to fp32 if no other precision is found
+        exec_prc = ov::element::f32;
     }
 
     return exec_prc;

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
@@ -85,7 +85,7 @@ ov::element::Type eltwise_precision_helper::get_precision(const size_t inputs_nu
             selected_type = src_prc[i];
         }
         return selected_type;
-    } ();
+    }();
 
     for (const auto prc : exec_precisions_priority) {
         if (input_precision != prc) {

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
@@ -74,17 +74,19 @@ ov::element::Type eltwise_precision_helper::get_precision(const size_t inputs_nu
                         supported_precision_intersection.end(),
                         [&prc, &src_prc](const std::vector<element::Type>& precisions) {
                             return (std::find(precisions.begin(), precisions.end(), prc) != precisions.end()) &&
-                                   (src_prc[0] == prc);
+                                   (std::find(src_prc, src_prc + sizeof(src_prc), prc) != src_prc + sizeof(src_prc));
                         })) {
             exec_prc = prc;
             break;
         }
     }
 
-    for (size_t i = 0; i < inputs_number; i++) {
-        if (src_prc[i] != exec_prc) {
-            exec_prc = ov::element::f32;
-            break;
+    if (Algorithm::EltwiseSelect != eltwise_data.front().algo || exec_prc == ov::element::dynamic) {
+        for (size_t i = 0; i < inputs_number; i++) {
+            if (src_prc[i] != exec_prc) {
+                exec_prc = ov::element::f32;
+                break;
+            }
         }
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/jit_eltwise_common.cpp
@@ -11,6 +11,7 @@
 #include <set>
 #include <vector>
 
+#include "cpu_types.h"
 #include "nodes/executors/eltwise.hpp"
 #include "openvino/core/except.hpp"
 #include "openvino/core/type/element_type.hpp"


### PR DESCRIPTION
### Details:
 - The current `selectOP` needs to do type conversions: int32 -> fp32 -> int32.
 - Those convertion are not necessary
 - INT_MAX will be INT_MIN after this conversion. This will cause accuracy issue.

### Tickets:
 - *CVS-169898*
