### PR TITLE
Fix ENABLE_SYSTEM_TBB=OFF scenario for homebrew installed TBB on macOS

### DIFF
--- a/src/cmake/ov_parallel.cmake
+++ b/src/cmake/ov_parallel.cmake
@@ -105,7 +105,7 @@ macro(ov_find_package_tbb)
             if(APPLE)
                 find_program(BREW_EXECUTABLE brew)
                 if(BREW_EXECUTABLE)
-                    execute_process(COMMAND ${BREW_EXECUTABLE} --prefix
+                    execute_process(COMMAND "${BREW_EXECUTABLE}" --prefix
                                     OUTPUT_VARIABLE BREW_PREFIX
                                     OUTPUT_STRIP_TRAILING_WHITESPACE
                                     RESULT_VARIABLE BREW_RESULT)


### PR DESCRIPTION
### Details:
Before this patch `ENABLE_SYSTEM_TBB=OFF` policy was ignored if TBB is installed in `brew --prefix` location

### Tickets:
 - N/A
