### PR TITLE
[Snippets][CPU] Fix wa_increment type and enable dynamic matmuls on ARM

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_loop_emitters.hpp
@@ -47,7 +47,7 @@ protected:
     std::shared_ptr<Xbyak_aarch64::Label> loop_begin_label;
     std::shared_ptr<Xbyak_aarch64::Label> loop_end_label;
     size_t work_amount = 0;
-    int64_t wa_increment = 0;
+    size_t wa_increment = 0;
     bool evaluate_once = false;
     size_t loop_id = 0;
     bool is_work_amount_dynamic = false;
@@ -83,7 +83,7 @@ protected:
     size_t num_inputs = 0;
     size_t num_outputs = 0;
     size_t work_amount = 0;
-    int64_t wa_increment = 0;
+    size_t wa_increment = 0;
     std::vector<bool> is_incremented = {};
     std::vector<int64_t> ptr_increments = {};
     std::vector<int64_t> finalization_offsets = {};

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -502,7 +502,6 @@ std::vector<std::string> disabledTestPatterns() {
 #endif
     // smoke_Snippets test cases are not supported on arm64 platforms, except for listed below
     retVector.emplace_back(R"(smoke_Snippets(?!_Eltwise|_Convert|_FQDecomposition_|_MatMul/|_Reduce|_Softmax|_AddSoftmax).*)");
-    retVector.emplace_back(R"(smoke_Snippets_MatMul.*\[.*\?.*\].*)");
 #endif
 #if defined(_WIN32)
     retVector.emplace_back(R"(.*smoke_QuantizedConvolutionBatchNormTransposeOnWeights/QuantizedConvolutionBatchNorm.CompareWithRefs/conv_type=convolution_quantize_type=fake_quantize_intervals_type=per_(tensor|channel)_transpose_on_weights=true_device=CPU.*)");


### PR DESCRIPTION
### Details:
 - Use `size_t` for `wa_increment` instead of `int64_t` to correctly detect dynamic values
 - Enable dynamic matmul tests on ARM64 snippets

### Tickets:
 - N/A

### Dependencies:
 - https://github.com/openvinotoolkit/openvino/pull/31112