### PR TITLE
[GPU] add check for RandomUniform to allgin precision of input.

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -285,6 +285,8 @@ public:
             for (const auto& output : node->outputs()) {
                 for (const auto& out_input : output.get_target_inputs()) {
                     auto target_node = out_input.get_node()->shared_from_this();
+                    if (target_node == node)
+                        continue;
                     if (!fp16_compression_is_disabled(target_node)) {
                         all_inputs_disabled = false;
                         break;


### PR DESCRIPTION
### Details:
 - *fix issue when the property disable_fp16_decomposation when the output of RandomUniform has more than one inputs and the inputs are in fp16*
 - *the model speecht5_tts/openvino_decoder_model is infected. *

### Tickets:
 - *CVS-168643*
