### PR TITLE
[Snippets] Disable cpplint for snippets target

### DIFF
--- a/src/common/snippets/CMakeLists.txt
+++ b/src/common/snippets/CMakeLists.txt
@@ -43,7 +43,6 @@ target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime
 target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${PUBLIC_HEADERS_DIR}>
                                           PRIVATE $<BUILD_INTERFACE:${SHAPE_INFER_INCLUDE_DIR}>)
 
-add_cpplint_target(${TARGET_NAME}_cpplint FOR_TARGETS ${TARGET_NAME})
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME})
 
 ov_mark_target_as_cc(${TARGET_NAME})

--- a/src/common/snippets/include/snippets/kernel_executor_table.hpp
+++ b/src/common/snippets/include/snippets/kernel_executor_table.hpp
@@ -88,13 +88,13 @@ public:
 
     // Note: override when final is redundant, but needed to avoid warnings on some compilers
     void update_by_expression(const lowered::ExpressionPtr& expr,
-                              const lowered::LinearIRCPtr& linear_ir) override final {  // NOLINT
+                              const lowered::LinearIRCPtr& linear_ir) override final {
         update_config(expr, linear_ir, m_config);
         OPENVINO_ASSERT(m_config.is_completed(), "Failed to update kernel config in update_by_expression");
         update_kernel(m_config, m_kernel);
         OPENVINO_ASSERT(m_kernel, "Failed to compile kernel executor");
     }
-    void update_by_config(const GenericConfig& new_config) override final {  // NOLINT
+    void update_by_config(const GenericConfig& new_config) override final {
         if (m_config.hash() == new_config.hash()) {
             return;
         }

--- a/src/common/snippets/include/snippets/lowered/pass/brgemm_blocking.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/brgemm_blocking.hpp
@@ -107,7 +107,7 @@ public:
 
     bool run(snippets::lowered::LinearIR& linear_ir,
              snippets::lowered::LinearIR::constExprIt begin,
-             snippets::lowered::LinearIR::constExprIt end) override final {  // NOLINT
+             snippets::lowered::LinearIR::constExprIt end) override final {
         OV_ITT_SCOPED_TASK(ov::pass::itt::domains::SnippetsTransform, "Snippets::BrgemmBlocking")
         const auto& loop_manager = linear_ir.get_loop_manager();
         bool modified = false;


### PR DESCRIPTION
### Details:
Plugin targets that use `clang-format` stop using `cpplint`

### Tickets:
 - N/A
