### PR TITLE
Revert "[GPU] enable dynamic shape conv on compile graph pass (#30944)"

### DIFF
--- a/src/plugins/intel_gpu/src/graph/registry/convolution_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/registry/convolution_impls.cpp
@@ -23,7 +23,9 @@ const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<convo
         OV_GPU_CREATE_INSTANCE_OCL(ocl::ConvolutionImplementationManager, shape_types::static_shape)
         OV_GPU_CREATE_INSTANCE_OCL(ocl::ConvolutionImplementationManager, shape_types::dynamic_shape,
             [](const cldnn::program_node& node){
-                return !node.can_use(impl_types::onednn);
+                if (node.can_use(impl_types::onednn))
+                    return false;
+                return node.as<convolution>().use_explicit_padding();
         })
     };
 


### PR DESCRIPTION
This reverts commit 8e4cc9eb2e55f4f2504f755f46d7a67eb936f710.

### Details:
 - Currently implicit padding is not updated in shape agnostic kernel.
 - For convolution, shape agnostic kernel is available only for explicit padding.

### Tickets:
 - 169416
