### PR TITLE
[Snippets][CPU] Apply 'google-explicit-constructor' clang-tidy remarks

### DIFF
--- a/src/common/snippets/include/snippets/generator.hpp
+++ b/src/common/snippets/include/snippets/generator.hpp
@@ -51,7 +51,7 @@ public:
      * @brief Create schedule out of specific parameters
      * @param lr lowering result produced during code generation
      */
-    Schedule(LoweringResult&& lr) : lowering_result(lr) {}
+    explicit Schedule(LoweringResult&& lr) : lowering_result(lr) {}
     /**
      * @brief Returns callable instanse of code pointer
      */
@@ -73,7 +73,7 @@ public:
     /**
      * @brief Default constructor
      */
-    Generator(const std::shared_ptr<TargetMachine>& t) : target(t) {}
+    explicit Generator(const std::shared_ptr<TargetMachine>& t) : target(t) {}
     /**
      * @brief Default destructor
      */

--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -135,9 +135,9 @@ public:
 protected:
     // Note: The constructor initialization is private since an expression can be created only by Linear IR.
     //       The method must be used only by Linear IR builder of expressions!
-    Expression(const std::shared_ptr<Node>& n,
-               const std::shared_ptr<IShapeInferSnippetsFactory>& factory,
-               bool need_shape_infer = true);
+    explicit Expression(const std::shared_ptr<Node>& n,
+                        const std::shared_ptr<IShapeInferSnippetsFactory>& factory,
+                        bool need_shape_infer = true);
 
     // Virtual clone method which is called in clone_with_new_inputs with common logic
     virtual ExpressionPtr clone() const;

--- a/src/common/snippets/include/snippets/lowered/expression_factory.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression_factory.hpp
@@ -23,7 +23,7 @@ namespace ov::snippets::lowered {
 
 class ExpressionFactory {
 public:
-    ExpressionFactory(std::shared_ptr<IShapeInferSnippetsFactory> shape_infer_factory)
+    explicit ExpressionFactory(std::shared_ptr<IShapeInferSnippetsFactory> shape_infer_factory)
         : m_shape_infer_factory(std::move(shape_infer_factory)) {}
 
     template <typename T = Expression,

--- a/src/common/snippets/include/snippets/lowered/linear_ir.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir.hpp
@@ -74,7 +74,7 @@ public:
     using exprReverseIt = container::reverse_iterator;
     using constExprReverseIt = container::const_reverse_iterator;
 
-    LinearIR(Config config = {}, const std::shared_ptr<IShapeInferSnippetsFactory>& factory = {});
+    explicit LinearIR(Config config = {}, const std::shared_ptr<IShapeInferSnippetsFactory>& factory = {});
     LinearIR(const std::shared_ptr<ov::Model>& m,
              const std::shared_ptr<IShapeInferSnippetsFactory>& factory,
              Config config = {});

--- a/src/common/snippets/include/snippets/lowered/linear_ir_builder.hpp
+++ b/src/common/snippets/include/snippets/lowered/linear_ir_builder.hpp
@@ -17,14 +17,14 @@ namespace ov::snippets::lowered {
 class LinearIRBuilder {
 public:
     struct Config {
-        Config(bool deep_copy_of_shapes_ = true) : deep_copy_of_shapes(deep_copy_of_shapes_) {}
+        explicit Config(bool deep_copy_of_shapes_ = true) : deep_copy_of_shapes(deep_copy_of_shapes_) {}
 
         // If True, copy of stored pointer in `PortDescriptor::m_tensor_shape`.
         // If False, copy shapes as shared pointers.
         const bool deep_copy_of_shapes = true;
     };
 
-    LinearIRBuilder(Config config = {}) : m_config(config) {}
+    explicit LinearIRBuilder(Config config = Config{}) : m_config(config) {}
 
     /**
      * @brief Make a full copy of LinearIR by rules described in `m_config`

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -226,7 +226,7 @@ public:
     // The structure describes data pointer shift parameters:
     // pointer increment, finalization offset, element size of the port
     struct LoopPortDesc {
-        LoopPortDesc(int64_t inc = 0, int64_t fo = 0, int64_t ds = 0)
+        explicit LoopPortDesc(int64_t inc = 0, int64_t fo = 0, int64_t ds = 0)
             : ptr_increment(inc),
               finalization_offset(fo),
               data_size(ds) {}

--- a/src/common/snippets/include/snippets/lowered/pass/allocate_buffers.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/allocate_buffers.hpp
@@ -26,7 +26,7 @@ namespace ov::snippets::lowered::pass {
 class AllocateBuffers : public RangedPass {
 public:
     OPENVINO_RTTI("AllocateBuffers", "", RangedPass)
-    AllocateBuffers(bool is_optimized = true);
+    explicit AllocateBuffers(bool is_optimized = true);
 
     /**
      * @brief Apply the pass to the Linear IR`

--- a/src/common/snippets/include/snippets/lowered/pass/init_buffers_default.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/init_buffers_default.hpp
@@ -23,7 +23,7 @@ class InitBuffersDefault : public RangedPass {
 public:
     OPENVINO_RTTI("InitBuffersDefault", "", RangedPass);
 
-    InitBuffersDefault(size_t& buffer_scratchpad_size) : m_buffer_scratchpad_size(buffer_scratchpad_size) {
+    explicit InitBuffersDefault(size_t& buffer_scratchpad_size) : m_buffer_scratchpad_size(buffer_scratchpad_size) {
         m_buffer_scratchpad_size = 0;
     }
     /**

--- a/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_perf_count.hpp
@@ -24,7 +24,7 @@ namespace ov::snippets::lowered::pass {
 class InsertPerfCount : public RangedPass {
 public:
     OPENVINO_RTTI("InsertPerfCount", "", RangedPass);
-    InsertPerfCount(std::map<std::string, std::string> boundary_op_names);
+    explicit InsertPerfCount(std::map<std::string, std::string> boundary_op_names);
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 
 private:

--- a/src/common/snippets/include/snippets/lowered/pass/insert_perf_count_verbose.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/insert_perf_count_verbose.hpp
@@ -25,7 +25,7 @@ namespace ov::snippets::lowered::pass {
  */
 class InsertPerfCountVerbose : public snippets::lowered::pass::RangedPass {
 public:
-    InsertPerfCountVerbose(std::string subgraph_name) : m_subgraph_name(std::move(subgraph_name)) {}
+    explicit InsertPerfCountVerbose(std::string subgraph_name) : m_subgraph_name(std::move(subgraph_name)) {}
     OPENVINO_RTTI("InsertPerfCountVerbose", "", RangedPass);
 
     bool run(snippets::lowered::LinearIR& linear_ir,

--- a/src/common/snippets/include/snippets/lowered/pass/iter_handler.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/iter_handler.hpp
@@ -22,7 +22,7 @@ namespace ov::snippets::lowered::pass {
  */
 class UpdateMemoryAccessCounts : public pass::RangedPass {
 public:
-    UpdateMemoryAccessCounts(size_t count);
+    explicit UpdateMemoryAccessCounts(size_t count);
     OPENVINO_RTTI("UpdateMemoryAccessCounts", "", RangedPass);
     bool run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end) override;
     std::shared_ptr<pass::PassBase> merge(const std::shared_ptr<pass::PassBase>& other) override;
@@ -39,7 +39,7 @@ private:
  */
 class SetFillOffset : public pass::RangedPass {
 public:
-    SetFillOffset(size_t offset);
+    explicit SetFillOffset(size_t offset);
     OPENVINO_RTTI("SetFillOffset", "", RangedPass);
     bool run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end) override;
     std::shared_ptr<pass::PassBase> merge(const std::shared_ptr<pass::PassBase>& other) override;

--- a/src/common/snippets/include/snippets/lowered/pass/mark_loops.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/mark_loops.hpp
@@ -23,7 +23,7 @@ namespace ov::snippets::lowered::pass {
 class MarkLoops : public RangedPass {
 public:
     OPENVINO_RTTI("MarkLoops", "", RangedPass);
-    MarkLoops(size_t vector_size);
+    explicit MarkLoops(size_t vector_size);
     bool run(LinearIR& linear_ir, lowered::LinearIR::constExprIt begin, lowered::LinearIR::constExprIt end) override;
 
 private:

--- a/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/normalize_loop_ids.hpp
@@ -32,7 +32,7 @@ namespace ov::snippets::lowered::pass {
 class NormalizeLoopIDs : public Pass {
 public:
     OPENVINO_RTTI("NormalizeLoopIDs", "", Pass);
-    NormalizeLoopIDs(bool has_specific_loops = true) : m_has_specific_loops(has_specific_loops) {}
+    explicit NormalizeLoopIDs(bool has_specific_loops = true) : m_has_specific_loops(has_specific_loops) {}
     bool run(lowered::LinearIR& linear_ir) override;
 
 private:

--- a/src/common/snippets/include/snippets/lowered/pass/pass.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/pass.hpp
@@ -111,7 +111,7 @@ public:
     using PositionedPassLowered = snippets::pass::PositionedPass<lowered::pass::PassBase>;
 
     PassPipeline();
-    PassPipeline(const std::shared_ptr<PassConfig>& pass_config);
+    explicit PassPipeline(const std::shared_ptr<PassConfig>& pass_config);
 
     [[nodiscard]] const std::vector<std::shared_ptr<PassBase>>& get_passes() const {
         return m_passes;

--- a/src/common/snippets/include/snippets/lowered/pass/propagate_subtensors.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/propagate_subtensors.hpp
@@ -22,7 +22,7 @@ namespace ov::snippets::lowered::pass {
  */
 class UpdateSubtensors : public pass::RangedPass {
 public:
-    UpdateSubtensors(size_t tail_size);
+    explicit UpdateSubtensors(size_t tail_size);
     OPENVINO_RTTI("UpdateSubtensors", "", RangedPass);
     bool run(LinearIR& linear_ir, LinearIR::constExprIt begin, LinearIR::constExprIt end) override;
     std::shared_ptr<pass::PassBase> merge(const std::shared_ptr<pass::PassBase>& other) override;

--- a/src/common/snippets/include/snippets/lowered/pass/runtime_optimizer.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/runtime_optimizer.hpp
@@ -21,7 +21,7 @@ class RuntimeOptimizer : public ConstPass {
 public:
     OPENVINO_RTTI("RuntimeOptimizer", "0", ConstPass)
     RuntimeOptimizer() = default;
-    RuntimeOptimizer(const RuntimeConfigurator* configurator) : m_configurator(configurator) {
+    explicit RuntimeOptimizer(const RuntimeConfigurator* configurator) : m_configurator(configurator) {
         OPENVINO_ASSERT(configurator, "RuntimeConfigurator musn't be nullptr");
     }
     /**

--- a/src/common/snippets/include/snippets/lowered/pass/serialize_base.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/serialize_base.hpp
@@ -16,7 +16,7 @@ namespace ov::snippets::lowered::pass {
 class SerializeBase : public ConstPass {
 public:
     OPENVINO_RTTI("SerializeBase", "", ConstPass)
-    SerializeBase(std::string xml_path);
+    explicit SerializeBase(std::string xml_path);
 
 protected:
     static std::string get_bin_path();

--- a/src/common/snippets/include/snippets/lowered/pass/serialize_control_flow.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/serialize_control_flow.hpp
@@ -20,7 +20,7 @@ namespace ov::snippets::lowered::pass {
 class SerializeControlFlow : public SerializeBase {
 public:
     OPENVINO_RTTI("SerializeControlFlow", "", SerializeBase)
-    SerializeControlFlow(const std::string& xml_path, bool update_dynamic_ops = false)
+    explicit SerializeControlFlow(const std::string& xml_path, bool update_dynamic_ops = false)
         : SerializeBase(xml_path),
           m_update_dynamic_ops{update_dynamic_ops} {}
     bool run(const LinearIR& linear_ir) override;

--- a/src/common/snippets/include/snippets/lowered/pass/serialize_data_flow.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/serialize_data_flow.hpp
@@ -22,7 +22,7 @@ namespace ov::snippets::lowered::pass {
 class SerializeDataFlow : public SerializeBase {
 public:
     OPENVINO_RTTI("SerializeDataFlow", "", SerializeBase)
-    SerializeDataFlow(const std::string& xml_path) : SerializeBase(xml_path) {}
+    explicit SerializeDataFlow(const std::string& xml_path) : SerializeBase(xml_path) {}
     bool run(const LinearIR& linear_ir) override;
 };
 

--- a/src/common/snippets/include/snippets/lowered/pass/solve_buffer_memory.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/solve_buffer_memory.hpp
@@ -29,7 +29,7 @@ class SolveBufferMemory : public Pass {
 public:
     OPENVINO_RTTI("SolveBufferMemory", "", Pass);
 
-    SolveBufferMemory(size_t& static_buffer_scratchpad_size)
+    explicit SolveBufferMemory(size_t& static_buffer_scratchpad_size)
         : m_static_buffer_scratchpad_size(static_buffer_scratchpad_size) {}
     /**
      * @brief Apply the pass to the Linear IR

--- a/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
+++ b/src/common/snippets/include/snippets/lowered/port_descriptor.hpp
@@ -38,8 +38,14 @@ public:
     explicit PortDescriptor(const ov::Output<const ov::Node>& out,
                             VectorDims subtensor_shape = {},
                             std::vector<size_t> layout = {});
-    PortDescriptor(VectorDims shape, VectorDims subtensor_shape, std::vector<size_t> layout = {}, Reg reg = {});
-    PortDescriptor(VectorDimsPtr shape, VectorDims subtensor_shape, std::vector<size_t> layout = {}, Reg reg = {});
+    explicit PortDescriptor(VectorDims shape,
+                            VectorDims subtensor_shape,
+                            std::vector<size_t> layout = {},
+                            Reg reg = {});
+    explicit PortDescriptor(VectorDimsPtr shape,
+                            VectorDims subtensor_shape,
+                            std::vector<size_t> layout = {},
+                            Reg reg = {});
     PortDescriptor();
 
     [[nodiscard]] const VectorDims& get_shape() const;

--- a/src/common/snippets/include/snippets/lowered/reg_manager.hpp
+++ b/src/common/snippets/include/snippets/lowered/reg_manager.hpp
@@ -35,7 +35,7 @@ using LiveInterval = std::pair<decltype(Expression().get_exec_num()), decltype(E
 class RegManager {
 public:
     RegManager() = delete;
-    RegManager(const std::shared_ptr<const Generator>& generator) : m_generator(generator) {}
+    explicit RegManager(const std::shared_ptr<const Generator>& generator) : m_generator(generator) {}
     [[nodiscard]] RegType get_reg_type(const ov::Output<Node>& out) const {
         return m_generator->get_op_out_reg_type(out);
     }

--- a/src/common/snippets/include/snippets/op/brgemm.hpp
+++ b/src/common/snippets/include/snippets/op/brgemm.hpp
@@ -18,22 +18,22 @@ namespace ov::snippets::op {
 class Brgemm : virtual public modifier::MemoryAccess, public ov::op::Op {
 public:
     OPENVINO_OP("Brgemm", "SnippetsOpset");
-    Brgemm(const Output<Node>& A,
-           const Output<Node>& B,
-           size_t offset_a = 0LU,
-           size_t offset_b = 0LU,
-           size_t offset_c = 0LU,
-           const std::vector<size_t>& layout_a = {},
-           const std::vector<size_t>& layout_b = {},
-           const std::vector<size_t>& layout_c = {});
-    Brgemm(const Output<Node>& A,
-           const Output<Node>& B,
-           const PortDescriptor& desc_a,
-           const PortDescriptor& desc_b,
-           const PortDescriptor& desc_c,
-           const std::vector<size_t>& layout_a = {},
-           const std::vector<size_t>& layout_b = {},
-           const std::vector<size_t>& layout_c = {});
+    explicit Brgemm(const Output<Node>& A,
+                    const Output<Node>& B,
+                    size_t offset_a = 0LU,
+                    size_t offset_b = 0LU,
+                    size_t offset_c = 0LU,
+                    const std::vector<size_t>& layout_a = {},
+                    const std::vector<size_t>& layout_b = {},
+                    const std::vector<size_t>& layout_c = {});
+    explicit Brgemm(const Output<Node>& A,
+                    const Output<Node>& B,
+                    const PortDescriptor& desc_a,
+                    const PortDescriptor& desc_b,
+                    const PortDescriptor& desc_c,
+                    const std::vector<size_t>& layout_a = {},
+                    const std::vector<size_t>& layout_b = {},
+                    const std::vector<size_t>& layout_c = {});
     Brgemm() = default;
 
     size_t get_offset_a() const {

--- a/src/common/snippets/include/snippets/op/broadcastload.hpp
+++ b/src/common/snippets/include/snippets/op/broadcastload.hpp
@@ -29,7 +29,7 @@ class BroadcastLoad : public modifier::MemoryAccess, public ov::op::Op {
 public:
     OPENVINO_OP("BroadcastLoad", "SnippetsOpset");
 
-    BroadcastLoad(const Output<Node>& x, ov::Dimension bcast_dimension, size_t offset = 0LU);
+    explicit BroadcastLoad(const Output<Node>& x, ov::Dimension bcast_dimension, size_t offset = 0LU);
     BroadcastLoad() = default;
 
     size_t get_offset() const {

--- a/src/common/snippets/include/snippets/op/broadcastmove.hpp
+++ b/src/common/snippets/include/snippets/op/broadcastmove.hpp
@@ -26,7 +26,7 @@ class BroadcastMove : public ov::op::Op {
 public:
     OPENVINO_OP("BroadcastMove", "SnippetsOpset");
 
-    BroadcastMove(const Output<Node>& x, ov::Dimension bcast_dimension);
+    explicit BroadcastMove(const Output<Node>& x, ov::Dimension bcast_dimension);
     BroadcastMove() = default;
 
     bool visit_attributes(AttributeVisitor& visitor) override;

--- a/src/common/snippets/include/snippets/op/buffer.hpp
+++ b/src/common/snippets/include/snippets/op/buffer.hpp
@@ -36,9 +36,9 @@ class Buffer : public ov::op::Op {
 public:
     OPENVINO_OP("Buffer", "SnippetsOpset");
     Buffer() = default;
-    Buffer(const ov::Output<ov::Node>& arg);
-    Buffer(const OutputVector& arguments);
-    Buffer(const ov::Shape& shape, ov::element::Type element_type = ov::element::u8);
+    explicit Buffer(const ov::Output<ov::Node>& arg);
+    explicit Buffer(const OutputVector& arguments);
+    explicit Buffer(const ov::Shape& shape, ov::element::Type element_type = ov::element::u8);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
 
@@ -100,7 +100,7 @@ private:
     // The buffers with this implementation mustn't have source (parents)
     class NewMemoryImpl : public BaseImpl {
     public:
-        NewMemoryImpl(const ov::Shape& shape, ov::element::Type element_type);
+        explicit NewMemoryImpl(const ov::Shape& shape, ov::element::Type element_type);
 
         [[nodiscard]] size_t get_allocation_size() const override;
         [[nodiscard]] std::shared_ptr<BaseImpl> clone() const override;

--- a/src/common/snippets/include/snippets/op/fill.hpp
+++ b/src/common/snippets/include/snippets/op/fill.hpp
@@ -30,7 +30,7 @@ class Fill : public ov::op::Op {
 public:
     OPENVINO_OP("Fill", "SnippetsOpset");
 
-    Fill(const Output<Node>& x, size_t offset, uint32_t fill_value = 0x0);
+    explicit Fill(const Output<Node>& x, size_t offset, uint32_t fill_value = 0x0);
     Fill() = default;
 
     size_t get_offset() const {

--- a/src/common/snippets/include/snippets/op/horizon_max.hpp
+++ b/src/common/snippets/include/snippets/op/horizon_max.hpp
@@ -23,7 +23,7 @@ class HorizonMax : public ov::op::Op {
 public:
     OPENVINO_OP("HorizonMax", "SnippetsOpset");
 
-    HorizonMax(const Output<Node>& x);
+    explicit HorizonMax(const Output<Node>& x);
     HorizonMax() = default;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/src/common/snippets/include/snippets/op/horizon_sum.hpp
+++ b/src/common/snippets/include/snippets/op/horizon_sum.hpp
@@ -23,7 +23,7 @@ class HorizonSum : public ov::op::Op {
 public:
     OPENVINO_OP("HorizonSum", "SnippetsOpset");
 
-    HorizonSum(const Output<Node>& x);
+    explicit HorizonSum(const Output<Node>& x);
     HorizonSum() = default;
 
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/src/common/snippets/include/snippets/op/kernel.hpp
+++ b/src/common/snippets/include/snippets/op/kernel.hpp
@@ -23,7 +23,7 @@ class Kernel : public ov::op::Op {
 public:
     OPENVINO_OP("Kernel", "SnippetsOpset");
     Kernel() = default;
-    Kernel(lowered::LinearIR region);
+    explicit Kernel(lowered::LinearIR region);
 
     template <typename... ArgTypes>
     static std::shared_ptr<Kernel> make_kernel(bool is_dynamic, ArgTypes&&... args);
@@ -37,7 +37,7 @@ class KernelStatic : public Kernel {
 public:
     OPENVINO_OP("KernelStatic", "SnippetsOpset", Kernel);
     KernelStatic() = default;
-    KernelStatic(lowered::LinearIR region);
+    explicit KernelStatic(lowered::LinearIR region);
     size_t get_num_call_args() const override {
         return 2;
     }
@@ -48,7 +48,7 @@ class KernelDynamic : public Kernel {
 public:
     OPENVINO_OP("KernelDynamic", "SnippetsOpset", Kernel);
     KernelDynamic() = default;
-    KernelDynamic(lowered::LinearIR region);
+    explicit KernelDynamic(lowered::LinearIR region);
     size_t get_num_call_args() const override {
         return 1;
     }

--- a/src/common/snippets/include/snippets/op/load.hpp
+++ b/src/common/snippets/include/snippets/op/load.hpp
@@ -31,7 +31,7 @@ class Load : public modifier::MemoryAccess, public ov::op::Op {
 public:
     OPENVINO_OP("Load", "SnippetsOpset");
 
-    Load(const Output<Node>& x, size_t count = 1LU, size_t offset = 0LU);
+    explicit Load(const Output<Node>& x, size_t count = 1LU, size_t offset = 0LU);
     Load() = default;
 
     size_t get_offset() const {
@@ -66,7 +66,10 @@ protected:
 class LoadReorder : public Load {
 public:
     OPENVINO_OP("LoadReorder", "SnippetsOpset", Load);
-    LoadReorder(const Output<Node>& x, size_t count = 1LU, size_t offset = 0LU, std::vector<size_t> order = {});
+    explicit LoadReorder(const Output<Node>& x,
+                         size_t count = 1LU,
+                         size_t offset = 0LU,
+                         std::vector<size_t> order = {});
     LoadReorder() = default;
 
     void set_offset(size_t offset) {

--- a/src/common/snippets/include/snippets/op/loop.hpp
+++ b/src/common/snippets/include/snippets/op/loop.hpp
@@ -25,7 +25,7 @@ namespace ov::snippets::op {
 class LoopBase : public ov::op::Op {
 public:
     OPENVINO_OP("LoopBase", "SnippetsOpset");
-    LoopBase(const std::vector<Output<Node>>& args);
+    explicit LoopBase(const std::vector<Output<Node>>& args);
     LoopBase() = default;
 
 protected:

--- a/src/common/snippets/include/snippets/op/perf_count.hpp
+++ b/src/common/snippets/include/snippets/op/perf_count.hpp
@@ -70,7 +70,7 @@ private:
  */
 class CSVDumper : public Dumper {
 public:
-    CSVDumper(std::string csv_path);
+    explicit CSVDumper(std::string csv_path);
     ~CSVDumper() override;
 
     void update(const op::PerfCountEnd* node) override;
@@ -91,7 +91,7 @@ namespace op {
 class PerfCountBeginBase : public ov::op::Op {
 public:
     OPENVINO_OP("PerfCountBeginBase", "SnippetsOpset");
-    PerfCountBeginBase(const std::vector<Output<Node>>& args);
+    explicit PerfCountBeginBase(const std::vector<Output<Node>>& args);
     PerfCountBeginBase() = default;
 
     void validate_and_infer_types() override;
@@ -108,7 +108,7 @@ protected:
 class PerfCountEndBase : public ov::op::Op {
 public:
     OPENVINO_OP("PerfCountEndBase", "SnippetsOpset");
-    PerfCountEndBase(const std::vector<Output<Node>>& args);
+    explicit PerfCountEndBase(const std::vector<Output<Node>>& args);
     PerfCountEndBase() = default;
 
     void validate_and_infer_types() override;
@@ -141,9 +141,9 @@ private:
 class PerfCountEnd : public PerfCountEndBase {
 public:
     OPENVINO_OP("PerfCountEnd", "SnippetsOpset", PerfCountEndBase);
-    PerfCountEnd(const Output<Node>& pc_begin,
-                 std::vector<std::shared_ptr<utils::Dumper>> dumpers = {},
-                 const std::string& params = "");
+    explicit PerfCountEnd(const Output<Node>& pc_begin,
+                          std::vector<std::shared_ptr<utils::Dumper>> dumpers = {},
+                          const std::string& params = "");
     PerfCountEnd() = default;
     ~PerfCountEnd() override;
 

--- a/src/common/snippets/include/snippets/op/reg_spill.hpp
+++ b/src/common/snippets/include/snippets/op/reg_spill.hpp
@@ -30,7 +30,7 @@ namespace ov::snippets::op {
 class RegSpillBase : public ov::op::Op {
 public:
     OPENVINO_OP("RegSpillBaseBase", "SnippetsOpset");
-    RegSpillBase(const std::vector<Output<Node>>& args);
+    explicit RegSpillBase(const std::vector<Output<Node>>& args);
     RegSpillBase() = default;
     virtual const std::set<Reg>& get_regs_to_spill() const = 0;
     bool visit_attributes(AttributeVisitor& visitor) override;
@@ -44,7 +44,7 @@ class RegSpillEnd;
 class RegSpillBegin : public RegSpillBase {
 public:
     OPENVINO_OP("RegSpillBegin", "SnippetsOpset", RegSpillBase);
-    RegSpillBegin(std::set<Reg> regs_to_spill);
+    explicit RegSpillBegin(std::set<Reg> regs_to_spill);
 
     void validate_and_infer_types() override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& inputs) const override;
@@ -74,7 +74,7 @@ class RegSpillEnd : public RegSpillBase {
 public:
     OPENVINO_OP("RegSpillEnd", "SnippetsOpset", RegSpillBase);
     RegSpillEnd() = default;
-    RegSpillEnd(const Output<Node>& reg_spill_begin);
+    explicit RegSpillEnd(const Output<Node>& reg_spill_begin);
 
     void validate_and_infer_types() override;
 

--- a/src/common/snippets/include/snippets/op/shape_infer_op.hpp
+++ b/src/common/snippets/include/snippets/op/shape_infer_op.hpp
@@ -18,7 +18,7 @@ class ShapeInferOp : public ov::op::Op {
 public:
     OPENVINO_OP("ShapeInferOp", "SnippetsOpset");
     ShapeInferOp() = default;
-    ShapeInferOp(const OutputVector& args) : ov::op::Op(args) {}
+    explicit ShapeInferOp(const OutputVector& args) : ov::op::Op(args) {}
 };
 
 }  // namespace ov::snippets::op

--- a/src/common/snippets/include/snippets/op/store.hpp
+++ b/src/common/snippets/include/snippets/op/store.hpp
@@ -28,7 +28,7 @@ class Store : public modifier::MemoryAccess, public ov::op::Op {
 public:
     OPENVINO_OP("Store", "SnippetsOpset");
 
-    Store(const Output<Node>& x, size_t count = 1LU, size_t offset = 0LU);
+    explicit Store(const Output<Node>& x, size_t count = 1LU, size_t offset = 0LU);
     Store() = default;
 
     size_t get_offset() const {

--- a/src/common/snippets/include/snippets/op/subgraph.hpp
+++ b/src/common/snippets/include/snippets/op/subgraph.hpp
@@ -90,9 +90,9 @@ public:
 
     Subgraph() = default;
 
-    Subgraph(const OutputVector& args, const std::shared_ptr<ov::Model>& body);
+    explicit Subgraph(const OutputVector& args, const std::shared_ptr<ov::Model>& body);
 
-    Subgraph(const NodeVector& args, const std::shared_ptr<ov::Model>& body);
+    explicit Subgraph(const NodeVector& args, const std::shared_ptr<ov::Model>& body);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
 

--- a/src/common/snippets/include/snippets/op/vector_buffer.hpp
+++ b/src/common/snippets/include/snippets/op/vector_buffer.hpp
@@ -23,7 +23,7 @@ class VectorBuffer : public ov::op::Op {
 public:
     OPENVINO_OP("VectorBuffer", "SnippetsOpset");
 
-    VectorBuffer(ov::element::Type element_type = ov::element::f32);
+    explicit VectorBuffer(ov::element::Type element_type = ov::element::f32);
 
     bool visit_attributes(AttributeVisitor& visitor) override;
     std::shared_ptr<Node> clone_with_new_inputs(const OutputVector& new_args) const override;

--- a/src/common/snippets/include/snippets/pass/analyze_broadcastable_inputs.hpp
+++ b/src/common/snippets/include/snippets/pass/analyze_broadcastable_inputs.hpp
@@ -26,7 +26,7 @@ public:
     OPENVINO_MODEL_PASS_RTTI("snippets::pass::AnalyzeBroadcastableInputs");
     // [Index of Parameter -> Index of broadcastable dimension from end]
     using BroadcastableInputsMap = std::map<size_t, size_t>;
-    AnalyzeBroadcastableInputs(BroadcastableInputsMap& map);
+    explicit AnalyzeBroadcastableInputs(BroadcastableInputsMap& map);
 
     bool run_on_model(const std::shared_ptr<ov::Model>& body) override;
 

--- a/src/common/snippets/include/snippets/pass/common_optimizations.hpp
+++ b/src/common/snippets/include/snippets/pass/common_optimizations.hpp
@@ -18,7 +18,7 @@ class CommonOptimizations : public ov::pass::MatcherPass {
 
 public:
     OPENVINO_MATCHER_PASS_RTTI("snippets::pass::CommonOptimizations");
-    CommonOptimizations(const SnippetsTokenization::Config& config);
+    explicit CommonOptimizations(const SnippetsTokenization::Config& config);
 };
 
 }  // namespace ov::snippets::pass

--- a/src/common/snippets/include/snippets/pass/fc_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/fc_tokenization.hpp
@@ -17,7 +17,7 @@ namespace ov::snippets::pass {
 class TokenizeFCSnippets : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeFCSnippets");
-    TokenizeFCSnippets(const SnippetsTokenization::Config& config);
+    explicit TokenizeFCSnippets(const SnippetsTokenization::Config& config);
 };
 
 }  // namespace ov::snippets::pass

--- a/src/common/snippets/include/snippets/pass/gated_mlp_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/gated_mlp_tokenization.hpp
@@ -27,7 +27,7 @@ namespace ov::snippets::pass {
 class TokenizeGatedMLPSnippets : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeGatedMLPSnippets");
-    TokenizeGatedMLPSnippets(const SnippetsTokenization::Config& config);
+    explicit TokenizeGatedMLPSnippets(const SnippetsTokenization::Config& config);
 };
 
 }  // namespace ov::snippets::pass

--- a/src/common/snippets/include/snippets/pass/hash.hpp
+++ b/src/common/snippets/include/snippets/pass/hash.hpp
@@ -28,7 +28,7 @@ public:
      * @param output_hash_value Reference to output value. By applying hash pass on function, resulting hash value
      * will be set to this variable
      */
-    Hash(uint64_t& output_hash_value);
+    explicit Hash(uint64_t& output_hash_value);
 
 private:
     uint64_t& m_hash;

--- a/src/common/snippets/include/snippets/pass/manager.hpp
+++ b/src/common/snippets/include/snippets/pass/manager.hpp
@@ -23,8 +23,8 @@ namespace ov::snippets::pass {
  */
 class Manager : public ov::pass::Manager {
 public:
-    Manager(std::shared_ptr<ov::pass::PassConfig> pass_config = std::make_shared<ov::pass::PassConfig>(),
-            std::string name = "UnnamedSnippetsManager");
+    explicit Manager(std::shared_ptr<ov::pass::PassConfig> pass_config = std::make_shared<ov::pass::PassConfig>(),
+                     std::string name = "UnnamedSnippetsManager");
     ~Manager() override = default;
     using PassBase = ov::pass::PassBase;
     using Validate = ov::pass::Validate;

--- a/src/common/snippets/include/snippets/pass/mha_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/mha_tokenization.hpp
@@ -45,7 +45,7 @@ namespace ov::snippets::pass {
 class TokenizeMHASnippets : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeMHASnippets");
-    TokenizeMHASnippets(const SnippetsTokenization::Config& config);
+    explicit TokenizeMHASnippets(const SnippetsTokenization::Config& config);
 
     static std::vector<int32_t> get_fusion_transpose_order(size_t rank);
     static std::vector<int32_t> get_decomposed_transpose_order(size_t rank);

--- a/src/common/snippets/include/snippets/pass/mlp_seq_tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/mlp_seq_tokenization.hpp
@@ -32,7 +32,7 @@ namespace ov::snippets::pass {
 class TokenizeMLPSeqSnippets : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("snippets::pass::TokenizeMLPSeqSnippets");
-    TokenizeMLPSeqSnippets(const SnippetsTokenization::Config& config);
+    explicit TokenizeMLPSeqSnippets(const SnippetsTokenization::Config& config);
 
 private:
     static bool is_matmul_supported(const std::shared_ptr<ov::Node>& node);

--- a/src/common/snippets/include/snippets/pass/propagate_precision.hpp
+++ b/src/common/snippets/include/snippets/pass/propagate_precision.hpp
@@ -24,7 +24,7 @@ namespace ov::snippets::pass {
 class PropagatePrecision : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("snippets::pass::PropagatePrecision");
-    PropagatePrecision(const std::shared_ptr<const TargetMachine>& target_machine);
+    explicit PropagatePrecision(const std::shared_ptr<const TargetMachine>& target_machine);
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
     static std::vector<element::Type> get_precisions(const std::vector<element::Type>& input_precisions,

--- a/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
+++ b/src/common/snippets/include/snippets/pass/split_dimension_m.hpp
@@ -32,7 +32,7 @@ namespace ov::snippets::pass {
 class SplitDimensionM : public CommonOptimizations::SubgraphPass {
 public:
     OPENVINO_RTTI("SplitDimensionM", "0");
-    SplitDimensionM(size_t concurrency) : m_concurrency(concurrency) {}
+    explicit SplitDimensionM(size_t concurrency) : m_concurrency(concurrency) {}
 
     bool run_on_subgraph(const std::shared_ptr<op::Subgraph>& subgraph) override;
 

--- a/src/common/snippets/include/snippets/pass/tokenization.hpp
+++ b/src/common/snippets/include/snippets/pass/tokenization.hpp
@@ -153,7 +153,7 @@ public:
         CanBeFusedAsPostOpPred m_can_be_fused_as_postop = nullptr;
     };
 
-    SnippetsTokenization(Config config) : m_config(std::move(config)) {}
+    explicit SnippetsTokenization(Config config) : m_config(std::move(config)) {}
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
 private:

--- a/src/common/snippets/include/snippets/pass/validate.hpp
+++ b/src/common/snippets/include/snippets/pass/validate.hpp
@@ -21,7 +21,7 @@ namespace ov::snippets::pass {
 class Validate : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("snippets::pass::Validate");
-    Validate(const std::shared_ptr<ov::pass::PassConfig>& pass_config) : m_pass_config(pass_config) {}
+    explicit Validate(const std::shared_ptr<ov::pass::PassConfig>& pass_config) : m_pass_config(pass_config) {}
 
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 

--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -74,7 +74,7 @@ public:
  */
 class RuntimeConfigurator {
 public:
-    RuntimeConfigurator(std::shared_ptr<RuntimeConfig> c);
+    explicit RuntimeConfigurator(std::shared_ptr<RuntimeConfig> c);
     virtual ~RuntimeConfigurator() = default;
 
     /**

--- a/src/common/snippets/include/snippets/target_machine.hpp
+++ b/src/common/snippets/include/snippets/target_machine.hpp
@@ -46,7 +46,7 @@ class RuntimeConfigurator;
  */
 class TargetMachine {
 public:
-    TargetMachine(const std::shared_ptr<RuntimeConfigurator>& c) : configurator(c) {}
+    explicit TargetMachine(const std::shared_ptr<RuntimeConfigurator>& c) : configurator(c) {}
 
     virtual ~TargetMachine() = default;
 

--- a/src/common/snippets/include/snippets/utils/debug_caps_config.hpp
+++ b/src/common/snippets/include/snippets/utils/debug_caps_config.hpp
@@ -88,7 +88,7 @@ public:
 
 private:
     struct PropertySetter {
-        PropertySetter(std::string name) : propertyName(std::move(name)) {}
+        explicit PropertySetter(std::string name) : propertyName(std::move(name)) {}
         virtual ~PropertySetter() = default;
         virtual bool parseAndSet(const std::string& str) = 0;
         [[nodiscard]] virtual std::string getPropertyValueDescription() const = 0;

--- a/src/common/snippets/src/generator.cpp
+++ b/src/common/snippets/src/generator.cpp
@@ -65,7 +65,7 @@ LoweringResult Generator::generate(const lowered::LinearIRPtr& linear_ir, const 
     OV_ITT_TASK_NEXT(GENERATE, "::EmitCode")
     const auto kernel_op = op::Kernel::make_kernel(linear_ir->is_dynamic(), *linear_ir);
     kernel_op->compile_params = compile_params;
-    const lowered::RegManager& reg_manager(shared_from_this());
+    const lowered::RegManager reg_manager(shared_from_this());
     const auto kernel_expr = linear_ir->get_expr_factory()->build(kernel_op, std::vector<lowered::PortConnectorPtr>{});
     const auto kernel = target->get(kernel_expr->get_node()->get_type_info())(kernel_expr);
 

--- a/src/common/snippets/src/op/subgraph.cpp
+++ b/src/common/snippets/src/op/subgraph.cpp
@@ -623,7 +623,7 @@ snippets::Schedule Subgraph::generate(const void* compile_params) const {
     }
 
     auto lowering_result = m_generator->generate(linear_ir, compile_params);
-    return {std::move(lowering_result)};
+    return Schedule{std::move(lowering_result)};
 }
 
 const std::shared_ptr<RuntimeConfigurator>& Subgraph::get_runtime_configurator() const {

--- a/src/common/snippets/src/pass/hash.cpp
+++ b/src/common/snippets/src/pass/hash.cpp
@@ -127,7 +127,7 @@ class RTInfoHasher : public ov::AttributeVisitor {
     uint64_t& m_rt_hash;
 
 public:
-    RTInfoHasher(uint64_t& rt_hash) : m_rt_hash(rt_hash) {}
+    explicit RTInfoHasher(uint64_t& rt_hash) : m_rt_hash(rt_hash) {}
 
     void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override {
         if (auto* a = ov::as_type<ov::AttributeAdapter<std::set<std::string>>>(&adapter)) {

--- a/src/core/shape_inference/include/fft_base_shape_inference.hpp
+++ b/src/core/shape_inference/include/fft_base_shape_inference.hpp
@@ -83,7 +83,7 @@ std::vector<TRShape> shape_infer(const util::FFTBase* op,
     if (input_shapes.size() == 3 && input_shape.rank().is_static()) {
         if (axes) {
             ov::op::fft::apply_dims_from_sizes(op, output_shape, *axes, ta);
-        } else {
+        } else if (input_shape.size() > 0) {
             for (size_t i = 0; i < input_shape.size() - 1; ++i) {
                 output_shape[i] = ov::Dimension::dynamic();
             }

--- a/src/plugins/intel_cpu/src/compiled_model.cpp
+++ b/src/plugins/intel_cpu/src/compiled_model.cpp
@@ -225,7 +225,8 @@ CompiledModel::GraphGuard::Lock CompiledModel::get_graph() const {
 }
 
 std::shared_ptr<ov::ISyncInferRequest> CompiledModel::create_sync_infer_request() const {
-    return std::make_shared<SyncInferRequest>(std::static_pointer_cast<const CompiledModel>(shared_from_this()));
+    return std::make_shared<SyncInferRequest>(
+        CompiledModelHolder(std::static_pointer_cast<const CompiledModel>(shared_from_this())));
 }
 
 std::shared_ptr<ov::IAsyncInferRequest> CompiledModel::create_infer_request() const {

--- a/src/plugins/intel_cpu/src/compiled_model.h
+++ b/src/plugins/intel_cpu/src/compiled_model.h
@@ -108,7 +108,7 @@ private:
 // the CompiledModel internal structures
 class CompiledModelHolder {
 public:
-    CompiledModelHolder(std::shared_ptr<const CompiledModel> compiled_model)
+    explicit CompiledModelHolder(std::shared_ptr<const CompiledModel> compiled_model)
         : m_compiled_model(std::move(compiled_model)) {
         OPENVINO_ASSERT(!m_compiled_model->m_graphs.empty(),
                         "No graph was found in the compiled model: ",

--- a/src/plugins/intel_cpu/src/cpu_memory.h
+++ b/src/plugins/intel_cpu/src/cpu_memory.h
@@ -78,7 +78,7 @@ public:
  */
 class MemoryBlockWithReuse : public IMemoryBlock {
 public:
-    MemoryBlockWithReuse(int numa_node = -1) : m_data(nullptr, release), numa_node(numa_node) {}
+    explicit MemoryBlockWithReuse(int numa_node = -1) : m_data(nullptr, release), numa_node(numa_node) {}
     [[nodiscard]] void* getRawPtr() const noexcept override;
     void setExtBuff(void* ptr, size_t size) override;
     bool resize(size_t size) override;

--- a/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
+++ b/src/plugins/intel_cpu/src/dnnl_scratch_pad.h
@@ -21,7 +21,7 @@ class DnnlScratchPad {
     dnnl::engine eng;
 
 public:
-    DnnlScratchPad(dnnl::engine eng, int numa_node = -1) : eng(std::move(eng)) {
+    explicit DnnlScratchPad(dnnl::engine eng, int numa_node = -1) : eng(std::move(eng)) {
         auto baseMemoryBlock = make_unique<MemoryBlockWithReuse>(numa_node);
         baseBlockPtr = baseMemoryBlock.get();
         blockPtr = std::make_shared<DnnlMemoryBlock>(std::move(baseMemoryBlock));

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -356,7 +356,7 @@ void Edge::externalAllocate(const WeightsSharing::Ptr& weightsCache) {
         };
 
         auto ptr = weightsCache->findOrCreate(hash(), alloc, false);
-        memoryPtr = *ptr;
+        memoryPtr = static_cast<MemoryPtr>(*ptr);
         DEBUG_LOG(*this, " memoryPtr=", memoryPtr);
         useExternalMemory = true;
         status = Status::Allocated;

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/utils.hpp
@@ -35,7 +35,7 @@ size_t get_callee_saved_aux_gpr(std::vector<size_t>& available_gprs,
 // The class emit register spills for the possible call of external binary code
 class EmitABIRegSpills {
 public:
-    EmitABIRegSpills(dnnl::impl::cpu::x64::jit_generator_t* h);
+    explicit EmitABIRegSpills(dnnl::impl::cpu::x64::jit_generator_t* h);
     ~EmitABIRegSpills();
     [[nodiscard]] size_t get_num_spilled_regs() const {
         return m_regs_to_spill.size();

--- a/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/cpu_runtime_configurator.hpp
@@ -40,7 +40,7 @@ public:
 
 class CPURuntimeConfigurator : public ov::snippets::RuntimeConfigurator {
 public:
-    CPURuntimeConfigurator(ov::intel_cpu::MultiCacheWeakPtr cache);
+    explicit CPURuntimeConfigurator(ov::intel_cpu::MultiCacheWeakPtr cache);
 
     /**
      * @brief Calculate Loop parameters of Loop emitters and update these values in CPURuntimeConfig

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/cpu_generator.hpp
@@ -60,7 +60,7 @@ private:
 class CPUGenerator : public snippets::Generator {
 public:
     CPUGenerator(dnnl::impl::cpu::x64::cpu_isa_t isa, ov::intel_cpu::MultiCacheWeakPtr cache);
-    CPUGenerator(const std::shared_ptr<CPUTargetMachine>& target);
+    explicit CPUGenerator(const std::shared_ptr<CPUTargetMachine>& target);
     std::shared_ptr<Generator> clone() const override;
 
 protected:

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm.hpp
@@ -110,7 +110,7 @@ protected:
 };
 
 struct brgemm_ref_kernel : public dnnl::impl::cpu::x64::brgemm_kernel_t {
-    brgemm_ref_kernel(BrgemmKernelConfig c);
+    explicit brgemm_ref_kernel(BrgemmKernelConfig c);
     void operator()(dnnl::impl::cpu::x64::brgemm_kernel_params_t* args) const override;
     dnnl_status_t create_kernel() override {
         return dnnl_status_t::dnnl_success;

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.hpp
@@ -32,7 +32,7 @@ namespace ov::intel_cpu {
 struct BrgemmCopyBKernelConfig : public snippets::KernelExecutorBase::GenericConfig {
 public:
     BrgemmCopyBKernelConfig() = default;
-    BrgemmCopyBKernelConfig(const brgemm_utils::BrgemmConfig& brgemm_config);
+    explicit BrgemmCopyBKernelConfig(const brgemm_utils::BrgemmConfig& brgemm_config);
 
     bool operator==(const BrgemmCopyBKernelConfig& rhs) const;
     bool operator!=(const BrgemmCopyBKernelConfig& rhs) const {
@@ -175,7 +175,7 @@ struct BrgemmCopyBKernel : public InputRepackerKernel, public dnnl::impl::cpu::x
     };
 
     BrgemmCopyBKernel();
-    BrgemmCopyBKernel(const BrgemmCopyBKernelConfig& conf);
+    explicit BrgemmCopyBKernel(const BrgemmCopyBKernelConfig& conf);
 
     dnnl::impl::status_t create_kernel() override;
 

--- a/src/plugins/intel_cpu/src/infer_request.h
+++ b/src/plugins/intel_cpu/src/infer_request.h
@@ -33,7 +33,7 @@ class AsyncInferRequest;
 
 class SyncInferRequest : public ov::ISyncInferRequest {
 public:
-    SyncInferRequest(CompiledModelHolder compiled_model);
+    explicit SyncInferRequest(CompiledModelHolder compiled_model);
 
     void infer() override;
 

--- a/src/plugins/intel_cpu/src/memory_control.cpp
+++ b/src/plugins/intel_cpu/src/memory_control.cpp
@@ -103,7 +103,8 @@ private:
 #ifdef CPU_DEBUG_CAPS
 class IndividualMemoryBlockWithRelease : public IMemoryBlockObserver {
 public:
-    IndividualMemoryBlockWithRelease(std::shared_ptr<MemoryBlockWithRelease> pBlock) : m_pBlock(std::move(pBlock)) {}
+    explicit IndividualMemoryBlockWithRelease(std::shared_ptr<MemoryBlockWithRelease> pBlock)
+        : m_pBlock(std::move(pBlock)) {}
 
     [[nodiscard]] void* getRawPtr() const noexcept override {
         return m_pBlock->getRawPtr();

--- a/src/plugins/intel_cpu/src/node.cpp
+++ b/src/plugins/intel_cpu/src/node.cpp
@@ -1127,7 +1127,7 @@ void Node::prepareMemory(const DnnlMemoryDescPtr& intDesc, size_t indx) {
     if (weightCache != nullptr && memory::format_kind::blocked == intDesc->getDnnlDesc().get_format_kind()) {
         const auto string_hash = name + "_" + std::to_string(indx) + "_" +
                                  DnnlExtensionUtils::computeWeightsStringHash(internalBlob, intDesc);
-        ptr = *weightCache->findOrCreate(string_hash, create);
+        ptr = static_cast<MemoryPtr>(*weightCache->findOrCreate(string_hash, create));
     } else {
         ptr = create();
     }
@@ -1193,7 +1193,7 @@ MemoryPtr Node::prepareWeightMemory(DnnlMemoryDescPtr dstWeightDesc, DnnlMemoryD
     auto weightCache = context->getWeightsCache();
     if (weightCache != nullptr) {
         const auto string_hash = DnnlExtensionUtils::computeWeightsStringHash(edgeMem, dstWeightDesc);
-        ptr = *weightCache->findOrCreate(string_hash, create);
+        ptr = static_cast<MemoryPtr>(*weightCache->findOrCreate(string_hash, create));
     } else {
         ptr = create();
     }

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -68,7 +68,7 @@ public:
           inPlace(inPlace) {}
 
     PortConfigurator(ov::intel_cpu::LayoutType blockedDescType,
-                     ov::element::Type prc = ov::element::dynamic,
+                     ov::element::Type prc,
                      bool constant = false,
                      int inPlace = -1)
         : blockedDescCreator(getBlockedDescCreator(blockedDescType)),
@@ -187,7 +187,7 @@ public:
     struct Tag {};
 
     struct PerfCounters {
-        PerfCounters(const std::string& name)
+        explicit PerfCounters(const std::string& name)
             : execute(openvino::itt::handle(name)),
               getSupportedDescriptors(openvino::itt::handle<Tag<Node, 0>>("Node::getSupportedDescriptors")),
               initSupportedPrimitiveDescriptors(

--- a/src/plugins/intel_cpu/src/nodes/color_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/color_convert.cpp
@@ -70,7 +70,7 @@ class Converter : public ColorConvert::Converter {
     using Base = ColorConvert::Converter;
 
 public:
-    Converter(Node* node);
+    explicit Converter(Node* node);
 
     [[nodiscard]] bool singlePlane() const;
 
@@ -325,7 +325,7 @@ class TwoPlaneConvert;
 
 class RefConverter : public Converter {
 public:
-    RefConverter(Node* node);
+    explicit RefConverter(Node* node);
 
 protected:
     template <typename T>
@@ -560,7 +560,7 @@ const jit_uni_converter& jit_converter_get() {
 template <typename T>
 class SinglePlaneConvert<T, impl_desc_type::jit_uni> : public Converter {
 public:
-    SinglePlaneConvert(Node* node) : Converter(node) {
+    explicit SinglePlaneConvert(Node* node) : Converter(node) {
         jit_converter_create<T>();
     }
 
@@ -596,7 +596,7 @@ public:
 template <typename T>
 class TwoPlaneConvert<T, impl_desc_type::jit_uni> : public Converter {
 public:
-    TwoPlaneConvert(Node* node) : Converter(node) {
+    explicit TwoPlaneConvert(Node* node) : Converter(node) {
         jit_converter_create<T>();
     }
 
@@ -657,7 +657,7 @@ class ThreePlaneConvert;
 
 class RefConverter : public Converter {
 public:
-    RefConverter(Node* node);
+    explicit RefConverter(Node* node);
 
 protected:
     template <typename T>
@@ -896,7 +896,7 @@ const jit_uni_converter& jit_converter_get() {
 template <typename T>
 class SinglePlaneConvert<T, impl_desc_type::jit_uni> : public Converter {
 public:
-    SinglePlaneConvert(Node* node) : Converter(node) {
+    explicit SinglePlaneConvert(Node* node) : Converter(node) {
         jit_converter_create<T>();
     }
 
@@ -933,7 +933,7 @@ public:
 template <typename T>
 class ThreePlaneConvert<T, impl_desc_type::jit_uni> : public Converter {
 public:
-    ThreePlaneConvert(Node* node) : Converter(node) {
+    explicit ThreePlaneConvert(Node* node) : Converter(node) {
         jit_converter_create<T>();
     }
 

--- a/src/plugins/intel_cpu/src/nodes/common/arbitrary_order_desc_creator.h
+++ b/src/plugins/intel_cpu/src/nodes/common/arbitrary_order_desc_creator.h
@@ -16,7 +16,7 @@ namespace ov::intel_cpu {
 
 class ArbitraryOrderDescCreator : public BlockedDescCreator {
 public:
-    ArbitraryOrderDescCreator(VectorDims order);
+    explicit ArbitraryOrderDescCreator(VectorDims order);
 
     [[nodiscard]] CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
                                                   const Shape& srcShape) const override;

--- a/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/blocked_desc_creator.cpp
@@ -61,7 +61,7 @@ public:
 
 class ChannelBlockedCreator : public BlockedDescCreator {
 public:
-    ChannelBlockedCreator(size_t blockSize) : _blockSize(blockSize) {}
+    explicit ChannelBlockedCreator(size_t blockSize) : _blockSize(blockSize) {}
     [[nodiscard]] CpuBlockedMemoryDesc createDesc(const ov::element::Type& precision,
                                                   const Shape& srcShape) const override {
         OPENVINO_ASSERT(srcShape.getRank() >= 2, "Can't create blocked tensor descriptor!");

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -158,7 +158,7 @@ public:
 
     using convert_vec_t = void (*)(jit_generator_t&, const RegExp&, const RegExp&);
 
-    jit_convert_array(convert_vec_t convert_vec)
+    explicit jit_convert_array(convert_vec_t convert_vec)
         : jit_kernel(jit_name()),
           _convert_vec(convert_vec),
           _src_size(sizeof(src_t)),

--- a/src/plugins/intel_cpu/src/nodes/common/permute_kernel.h
+++ b/src/plugins/intel_cpu/src/nodes/common/permute_kernel.h
@@ -60,7 +60,7 @@ struct jit_uni_permute_kernel {
 
 class PermuteKernel {
 public:
-    PermuteKernel(const PermuteParams& params);
+    explicit PermuteKernel(const PermuteParams& params);
 
     void execute(const uint8_t* src_data, uint8_t* dst_data);
     void execute(const uint8_t* src_data, uint8_t* dst_data, int mb);

--- a/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/softmax.cpp
@@ -68,7 +68,7 @@ template <cpu_isa_t isa>
 struct jit_uni_softmax_kernel_f32 : public jit_uni_softmax_kernel, public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_softmax_kernel_f32)
 
-    jit_uni_softmax_kernel_f32(jit_softmax_config_params jcp)
+    explicit jit_uni_softmax_kernel_f32(jit_softmax_config_params jcp)
         : jit_uni_softmax_kernel(),
           jit_generator_t(jit_name()),
           jcp_(jcp) {}

--- a/src/plugins/intel_cpu/src/nodes/conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/conv.cpp
@@ -511,12 +511,12 @@ void Convolution::initSupportedPrimitiveDescriptors() {
         for (const auto& desc : nodeDescriptors) {
             if (auto it = m_atoi.find(desc.first); it != m_atoi.end()) {
                 const auto& inputDesc = desc.second;
-                nodeConfig.inConfs[it->second] = {inputDesc, getBlockedMask(inputDesc, m_attrs.isGrouped)};
+                nodeConfig.inConfs[it->second] = PortConfig(inputDesc, getBlockedMask(inputDesc, m_attrs.isGrouped));
             }
         }
 
         for (size_t i = 3; i < srcDescs.size(); i++) {
-            nodeConfig.inConfs[i] = srcDescs[i];
+            nodeConfig.inConfs[i] = PortConfig(srcDescs[i]);
         }
 
         const int inPlaceOutPort = withSum ? static_cast<int>(getParentEdges().size()) - 1 : -1;

--- a/src/plugins/intel_cpu/src/nodes/deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/deconv.cpp
@@ -158,7 +158,7 @@ bool DeconvKey::operator==(const DeconvKey& rhs) const {
  */
 class DeconvolutionShapeInferFactory : public ShapeInferFactory {
 public:
-    DeconvolutionShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit DeconvolutionShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
 
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<DeconvolutionShapeInfer>(m_op);
@@ -167,7 +167,7 @@ public:
 private:
     class DeconvolutionShapeInfer : public IShapeInfer {
     public:
-        DeconvolutionShapeInfer(const std::shared_ptr<ov::Node>& op)
+        explicit DeconvolutionShapeInfer(const std::shared_ptr<ov::Node>& op)
             : m_shape_infer(make_shape_inference(op)),
               m_port_mask((op->get_input_size() > 2) ? PortMask(2) : EMPTY_PORT_MASK) {}
 

--- a/src/plugins/intel_cpu/src/nodes/depth_to_space.h
+++ b/src/plugins/intel_cpu/src/nodes/depth_to_space.h
@@ -51,7 +51,7 @@ protected:
 private:
     DepthToSpaceAttrs attrs;
     struct DepthToSpaceExecutor {
-        DepthToSpaceExecutor(const DepthToSpaceAttrs& attrs);
+        explicit DepthToSpaceExecutor(const DepthToSpaceAttrs& attrs);
         void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& dstMemPtr, int MB);
         ~DepthToSpaceExecutor() = default;
 

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -667,7 +667,7 @@ void Eltwise::initSupportedPrimitiveDescriptors() {
                 const bool acceptAnyBatchStride = !isDynamicNode() && srcShape.getDims()[0] == 1;
                 const BlockedMemoryDesc::CmpMask inputMask =
                     acceptAnyBatchStride ? BlockedMemoryDesc::EMPTY_MASK : BlockedMemoryDesc::SKIP_OFFSET_MASK;
-                nodeConfig.inConfs[i] = {desc, inputMask, isInPlace};
+                nodeConfig.inConfs[i] = PortConfig(desc, inputMask, isInPlace);
             }
         }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_deconv.cpp
@@ -202,7 +202,7 @@ static MemoryPtr prepareWeightMemory(const std::vector<MemoryCPtr>& src, const E
         const std::string string_hash = format + "_" + std::to_string(src[1]->getSize()) + "_" +
                                         std::to_string(reinterpret_cast<uint64_t>(src[1]->getData()));
         DEBUG_LOG("ACLDeconvExecutor: findOrCreate, string_hash: ", string_hash);
-        return *weightCache->findOrCreate(string_hash, create);
+        return static_cast<MemoryPtr>(*weightCache->findOrCreate(string_hash, create));
     }
 
     DEBUG_LOG("ACLDeconvExecutor: Weights cache is not available");

--- a/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/acl/acl_fullyconnected_utils.cpp
@@ -230,7 +230,7 @@ MemoryPtr acl_fc_executor::reorderWeights(const MemoryArgs& memory,
         const std::string string_hash = format + "_" + std::to_string(memory.at(ARG_WEI)->getSize()) + "_" +
                                         std::to_string(reinterpret_cast<uint64_t>(memory.at(ARG_WEI)->getData()));
         DEBUG_LOG("ACLFullyConnectedExecutor: findOrCreate, string_hash: ", string_hash);
-        return *weightCache->findOrCreate(string_hash, create);
+        return static_cast<MemoryPtr>(*weightCache->findOrCreate(string_hash, create));
     }
 
     DEBUG_LOG("ACLFullyConnectedExecutor: Weights cache is not available");

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_shape_agnostic_data.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_shape_agnostic_data.hpp
@@ -13,7 +13,7 @@
 namespace ov::intel_cpu {
 
 struct DnnlShapeAgnosticData {
-    DnnlShapeAgnosticData(DnnlPrimitiveAttrs primAttrs, impl_desc_type implType = impl_desc_type::undef)
+    explicit DnnlShapeAgnosticData(DnnlPrimitiveAttrs primAttrs, impl_desc_type implType = impl_desc_type::undef)
         : m_primAttrs(std::move(primAttrs)),
           m_implType(implType) {}
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_utils.cpp
@@ -102,8 +102,9 @@ MemoryPtr prepareWeightsMemory(const DnnlMemoryDescPtr& srcWeightDesc,
 
     MemoryPtr ptr;
     if (globalWeightCache && dnnl::memory::format_kind::blocked == dstWeightDesc->getDnnlDesc().get_format_kind()) {
-        ptr = *globalWeightCache->findOrCreate(DnnlExtensionUtils::computeWeightsStringHash(weightsMem, dstWeightDesc),
-                                               create);
+        ptr = MemoryPtr(
+            *globalWeightCache->findOrCreate(DnnlExtensionUtils::computeWeightsStringHash(weightsMem, dstWeightDesc),
+                                             create));
     } else {
         ptr = create();
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -108,7 +108,7 @@ private:
 
 class ExecutorFactoryLegacy {
 public:
-    ExecutorFactoryLegacy(ExecutorContext::CPtr context) : context(std::move(context)) {}
+    explicit ExecutorFactoryLegacy(ExecutorContext::CPtr context) : context(std::move(context)) {}
     virtual ~ExecutorFactoryLegacy() = default;
 
     const ExecutorContext::CPtr context;

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.hpp
@@ -130,7 +130,7 @@ public:
     static constexpr size_t SCALES_ID = 2;
     static constexpr size_t AXES_ID = 3;
     static constexpr int CUBIC_GRID_LEN = 4;
-    InterpolateExecutor(ExecutorContext::CPtr context) : _context(std::move(context)) {}
+    explicit InterpolateExecutor(ExecutorContext::CPtr context) : _context(std::move(context)) {}
 
     virtual bool init(const InterpolateAttrs& interpolateAttrs,
                       const std::vector<MemoryDescPtr>& srcDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/matmul.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/matmul.hpp
@@ -21,7 +21,7 @@ public:
 
 class DnnlMatmulExecutor : public IMatmulExecutor {
 public:
-    DnnlMatmulExecutor(const dnnl::primitive_desc& pd) : m_executor(pd) {}
+    explicit DnnlMatmulExecutor(const dnnl::primitive_desc& pd) : m_executor(pd) {}
     void exec(const std::unordered_map<int, dnnl::memory>& primArgs, const dnnl::stream& strm) override {
         m_executor.exec(primArgs, strm);
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mlas/mlas_gemm.cpp
@@ -64,7 +64,7 @@ static MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory,
         const std::string string_hash = format + "_" + std::to_string(weightsMemory->getSize()) + "_" +
                                         std::to_string(reinterpret_cast<uint64_t>(weightsMemory->getData()));
         DEBUG_LOG("MlasGemmExecutor: findOrCreate, string_hash: ", string_hash);
-        return *weightCache->findOrCreate(string_hash, create);
+        return MemoryPtr(*weightCache->findOrCreate(string_hash, create));
     }
 
     DEBUG_LOG("MlasGemmExecutor: Weights cache is not available");

--- a/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/mvn.hpp
@@ -35,7 +35,7 @@ struct MVNAttrs {
 
 class MVNExecutor {
 public:
-    MVNExecutor(ExecutorContext::CPtr context);
+    explicit MVNExecutor(ExecutorContext::CPtr context);
     virtual bool init(const MVNAttrs& mvnAttrs,
                       const std::vector<MemoryDescPtr>& srcDescs,
                       const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/pooling.hpp
@@ -48,7 +48,7 @@ struct PoolingAttrs {
 
 class PoolingExecutor {
 public:
-    PoolingExecutor(ExecutorContext::CPtr context);
+    explicit PoolingExecutor(ExecutorContext::CPtr context);
     virtual bool init(const PoolingAttrs& poolingAttrs,
                       const std::vector<MemoryDescPtr>& srcDescs,
                       const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/precision_translation.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/precision_translation.hpp
@@ -52,7 +52,7 @@ using policy = std::function<ov::element::Type(const std::vector<ov::element::Ty
 
 struct PortsTranslation {
     template <typename... Policies>
-    PortsTranslation(Policies... policies) : m_policies{policies...} {}
+    explicit PortsTranslation(Policies... policies) : m_policies{policies...} {}
 
     std::vector<ov::element::Type> operator()(const std::vector<ov::element::Type>& types) const {
         assert(types.size() == m_policies.size());

--- a/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/reduce.hpp
@@ -24,7 +24,7 @@ struct ReduceAttrs {
 
 class ReduceExecutor {
 public:
-    ReduceExecutor(ExecutorContext::CPtr context);
+    explicit ReduceExecutor(ExecutorContext::CPtr context);
     virtual bool init(const ReduceAttrs& reduceAttrs,
                       const std::vector<MemoryDescPtr>& srcDescs,
                       const std::vector<MemoryDescPtr>& dstDescs,

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl.hpp
@@ -94,7 +94,7 @@ struct ShlTensor : public ShlStructure<csinn_tensor*> {
         reset(tensor);
     }
 
-    ShlTensor(const ShlSession& session) {
+    explicit ShlTensor(const ShlSession& session) {
         csinn_tensor* tensor = csinn_alloc_tensor(session.get());
         OPENVINO_ASSERT(tensor, "Failed to create csinn_tensor");
         reset(tensor);
@@ -189,7 +189,7 @@ struct ShlParams : public ShlStructure<T>, public IShlParams {
         this->reset(params);
     }
 
-    ShlParams(const ShlSession& session) {
+    explicit ShlParams(const ShlSession& session) {
         T params = static_cast<T>(csinn_alloc_params(sizeof(std::remove_pointer_t<T>), session.get()));
         OPENVINO_ASSERT(params, "Failed to create csinn_params");
         this->reset(params);
@@ -249,7 +249,7 @@ struct ShlStructureTraits<csinn_relu_params*> {
 struct ShlReluParams : public ShlParams<csinn_relu_params*> {
     using ShlParams<csinn_relu_params*>::ShlParams;
 
-    ShlReluParams(float alpha) {
+    explicit ShlReluParams(float alpha) {
         auto* params = static_cast<csinn_relu_params*>(this->get());
         params->n = alpha;
     }

--- a/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/shl/shl_fullyconnected.cpp
@@ -56,7 +56,7 @@ MemoryPtr prepareWeightMemory(const MemoryPtr weightsMemory, const ExecutorConte
         const std::string string_hash = format + "_" + std::to_string(weightsMemory->getSize()) + "_" +
                                         std::to_string(reinterpret_cast<uint64_t>(weightsMemory->getData()));
         DEBUG_LOG("ShlFCExecutor: findOrCreate, string_hash: ", string_hash);
-        return *weightCache->findOrCreate(string_hash, create);
+        return static_cast<MemoryPtr>(*weightCache->findOrCreate(string_hash, create));
     }
 
     DEBUG_LOG("ShlFCExecutor: Weights cache is not available");

--- a/src/plugins/intel_cpu/src/nodes/executors/type_mask.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/type_mask.hpp
@@ -37,12 +37,13 @@ struct TypeMask {
         _f8e8m0 = 1 << 22,
     };
 
-    TypeMask(const ov::element::Type precision) : value(generateMask(precision)), precision(precision) {}
+    explicit TypeMask(const ov::element::Type precision) : value(generateMask(precision)), precision(precision) {}
 
-    TypeMask(const uint64_t value) : value(value) {}
+    // TypeMask is designed to be implicitly convertible from uint64_t
+    TypeMask(const uint64_t value) : value(value) {}  // NOLINT(google-explicit-constructor)
 
     // can be treated as uint64_t mask
-    operator uint64_t() const {
+    operator uint64_t() const {  // NOLINT(google-explicit-constructor)
         return value;
     }
     // match

--- a/src/plugins/intel_cpu/src/nodes/executors/x64/matmul_small.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/x64/matmul_small.hpp
@@ -20,7 +20,7 @@ struct MatMulSmallAttrs {
 
 class MatMulSmallExecutor : public IMatmulExecutor {
 public:
-    MatMulSmallExecutor(MatMulSmallAttrs attrs);
+    explicit MatMulSmallExecutor(MatMulSmallAttrs attrs);
     void exec(const std::unordered_map<int, dnnl::memory>& primArgs, const dnnl::stream& strm) override;
     [[nodiscard]] DnnlMemoryDescPtr getScratchPadDesc() const override;
 

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -236,7 +236,7 @@ private:
     using executorPtr = std::shared_ptr<FakeQuantizeExecutor>;
     executorPtr execPtr = nullptr;
     struct FakeQuantizeJitExecutor : public FakeQuantizeExecutor {
-        FakeQuantizeJitExecutor(const jit_quantize_params& _jqp);
+        explicit FakeQuantizeJitExecutor(const jit_quantize_params& _jqp);
         void exec(const FakeQuantize& node) override;
         std::unique_ptr<jit_uni_quantize_kernel> pKernel;
     };

--- a/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fullyconnected.cpp
@@ -611,7 +611,7 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     nodeConfig.inConfs.resize(srcDescs.size());
     for (const auto& desc : nodeDescriptors) {
         if (auto it = m_atoi.find(desc.first); it != m_atoi.end()) {
-            nodeConfig.inConfs[it->second] = desc.second;
+            nodeConfig.inConfs[it->second] = PortConfig(desc.second);
         }
     }
 
@@ -619,7 +619,7 @@ void FullyConnected::initSupportedPrimitiveDescriptors() {
     // @todo pass all the input descriptors to getProperMemoryDescriptors and allow
     // to ignore extra input descriptors if necessery
     for (size_t i = 3; i < srcDescs.size(); i++) {
-        nodeConfig.inConfs[i] = srcDescs[i];
+        nodeConfig.inConfs[i] = PortConfig(srcDescs[i]);
     }
 
     const int inPlace = canBeInPlace() ? 0 : -1;

--- a/src/plugins/intel_cpu/src/nodes/gather_nd.h
+++ b/src/plugins/intel_cpu/src/nodes/gather_nd.h
@@ -44,7 +44,7 @@ private:
     } attrs;
 
     struct GatherNDExecutor {
-        GatherNDExecutor(const GatherNDAttributes& attrs);
+        explicit GatherNDExecutor(const GatherNDAttributes& attrs);
         ~GatherNDExecutor() = default;
         void exec(const MemoryPtr& srcMemPtr, const MemoryPtr& idxMemPtr, const MemoryPtr& dstMemPtr);
 

--- a/src/plugins/intel_cpu/src/nodes/input.cpp
+++ b/src/plugins/intel_cpu/src/nodes/input.cpp
@@ -583,9 +583,10 @@ void Input::cloneBlobIfRequired() {
         // original weights are stored.
         (!weightCache || context->getNumNumaNodes() == 1 || context->getCPUStreamExecutor()->get_streams_num() == 1);
 
-    memoryPtr = clone_is_not_needed ? std::make_shared<Memory>(getEngine(), memDesc, m_constOp->get_data_ptr())
-                                    : std::const_pointer_cast<const IMemory>(
-                                          weightCache ? *weightCache->findOrCreate(blobKey(), cloneBlob) : cloneBlob());
+    memoryPtr = clone_is_not_needed
+                    ? std::make_shared<Memory>(getEngine(), memDesc, m_constOp->get_data_ptr())
+                    : std::const_pointer_cast<const IMemory>(
+                          weightCache ? MemoryPtr(*weightCache->findOrCreate(blobKey(), cloneBlob)) : cloneBlob());
 }
 
 static std::vector<Shape> createInputShapes(const Shape& shape, const Type type) {

--- a/src/plugins/intel_cpu/src/nodes/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/interpolate.cpp
@@ -1902,7 +1902,7 @@ namespace {
  */
 class InterpolateShapeInferFactory : public ShapeInferFactory {
 public:
-    InterpolateShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit InterpolateShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         if (auto interp4 = ov::as_type_ptr<ov::op::v4::Interpolate>(m_op)) {
             const auto& attr = interp4->get_attrs();

--- a/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_generator.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/riscv64/jit_generator.hpp
@@ -47,9 +47,9 @@ namespace ov::intel_cpu::riscv64 {
 
 class jit_generator_t : public Xbyak_riscv::CodeGenerator {
 public:
-    jit_generator_t(size_t maxSize = Xbyak_riscv::DEFAULT_MAX_CODE_SIZE,
-                    void* userPtr = Xbyak_riscv::DontSetProtectRWE,
-                    Xbyak_riscv::Allocator* allocator = nullptr)
+    explicit jit_generator_t(size_t maxSize = Xbyak_riscv::DEFAULT_MAX_CODE_SIZE,
+                             void* userPtr = Xbyak_riscv::DontSetProtectRWE,
+                             Xbyak_riscv::Allocator* allocator = nullptr)
         : Xbyak_riscv::CodeGenerator(maxSize, userPtr, allocator) {}
     ~jit_generator_t() override = default;
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/executor_pa.cpp
@@ -2054,7 +2054,7 @@ struct AttentionExecutor : public PagedAttentionExecutor {
                      scale,
                      B_token,
                      max_context_len,
-                     alibi_slopes,
+                     static_cast<bool>(alibi_slopes),
                      init_rotation_coefficient_scratch);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/scaled_attn/mha_single_token.cpp
@@ -1429,7 +1429,7 @@ static void mha_single_token_kernel(const ov::intel_cpu::PlainTensor& query,
     }
     auto nthr = parallel_get_max_threads();
     auto kv_len = present_key.size(2);
-    bool pastkv_is_int8 = past_k_scale_zp;
+    bool pastkv_is_int8 = static_cast<bool>(past_k_scale_zp);
 #if defined(HAVE_AVX2) && !defined(HAVE_AVX512F)
     // avx2 will pre-compute the zero point and try to save the sub instruction in the dot_product,
     //  but it seems not necessary for avx512. Possible reason may be that for avx2 the cost of dot_product

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/jit_kernel.hpp
@@ -185,7 +185,7 @@ private:
 template <typename T>
 class then_expression {
 public:
-    then_expression(if_expression<T>& expr);
+    explicit then_expression(if_expression<T>& expr);
 
     template <typename F>
     void _else(F&& fn);
@@ -197,7 +197,7 @@ private:
 template <typename T>
 class if_expression {
 public:
-    if_expression(const boolean_expression<T>& expr) : _expr(expr) {}
+    explicit if_expression(const boolean_expression<T>& expr) : _expr(expr) {}
 
     ~if_expression() {
         if (!_is_exit_valid) {
@@ -250,11 +250,12 @@ public:
         return _reg;
     }
 
-    operator reg_type&() const {
+    // XByak relies on implicit conversions
+    operator reg_type&() const {  // NOLINT(google-explicit-constructor)
         return reg();
     }
 
-    operator Xbyak::RegExp() const {
+    operator Xbyak::RegExp() const {  // NOLINT(google-explicit-constructor)
         return reg();
     }
 
@@ -298,7 +299,7 @@ public:
     using arithmetic_type = std::conditional_t<std::is_pointer_v<T>, size_t, T>;
 
     variable(variable&&) noexcept = default;
-    variable(jit_kernel& krnl);
+    explicit variable(jit_kernel& krnl);
     variable(jit_kernel& krnl, const shared_reg<reg_type>& reg);
 
     std::conditional_t<std::is_pointer_v<T> && !std::is_pointer_v<std::remove_pointer_t<T>>,
@@ -517,7 +518,7 @@ public:
     constexpr static size_t length = N;
 
     variable(variable&&) noexcept = default;
-    variable(jit_kernel& krnl);
+    explicit variable(jit_kernel& krnl);
     variable(jit_kernel& krnl, const shared_reg<reg_type>& reg);
 
     const variable& operator=(reg_type& rhs) const {
@@ -641,7 +642,7 @@ struct jit_kernel : public dnnl::impl::cpu::x64::jit_generator_t {
         return {*this, internal::make_shared(res, *this)};
     }
 
-    jit_kernel(const char* name);
+    explicit jit_kernel(const char* name);
 
     template <typename RegType>
     const RegType& reserve();

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.hpp
@@ -210,7 +210,7 @@ struct Work {
     int blk_K_size = 0;
     int output_id = 0;
     void* p_raw_weights = nullptr;
-    operator bool() const {
+    explicit operator bool() const {
         return BN > 0;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/registers_pool.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/registers_pool.hpp
@@ -52,7 +52,7 @@ public:
 
     public:
         Reg() = default;
-        Reg(const RegistersPool::Ptr& regPool) {
+        explicit Reg(const RegistersPool::Ptr& regPool) {
             initialize(regPool);
         }
         Reg(const RegistersPool::Ptr& regPool, int requestedIdx) {
@@ -68,15 +68,16 @@ public:
             return *this;
         }
         Reg(Reg&& other) noexcept : reg(other.reg), regPool(std::move(other.regPool)) {}
-        operator TReg&() {
+        // XByak relies on implicit conversions
+        operator TReg&() {  // NOLINT(google-explicit-constructor)
             ensureValid();
             return reg;
         }
-        operator const TReg&() const {
+        operator const TReg&() const {  // NOLINT(google-explicit-constructor)
             ensureValid();
             return reg;
         }
-        operator Xbyak::RegExp() const {
+        operator Xbyak::RegExp() const {  // NOLINT(google-explicit-constructor)
             ensureValid();
             return reg;
         }
@@ -161,7 +162,7 @@ public:
 protected:
     class PhysicalSet {
     public:
-        PhysicalSet(int size) : isFreeIndexVector(size, true) {}
+        explicit PhysicalSet(int size) : isFreeIndexVector(size, true) {}
 
         void setAsUsed(size_t regIdx) {
             OPENVINO_ASSERT(regIdx < isFreeIndexVector.size(),
@@ -227,7 +228,7 @@ protected:
         OPENVINO_THROW("countUnusedOpmask: The Opmask is not supported in current instruction set");
     }
 
-    RegistersPool(int simdRegistersNumber) : simdSet(simdRegistersNumber) {
+    explicit RegistersPool(int simdRegistersNumber) : simdSet(simdRegistersNumber) {
         checkUniqueAndUpdate();
         generalSet.exclude(Xbyak::Reg64(Xbyak::Operand::RSP));
         generalSet.exclude(Xbyak::Reg64(Xbyak::Operand::RAX));

--- a/src/plugins/intel_cpu/src/nodes/mvn.h
+++ b/src/plugins/intel_cpu/src/nodes/mvn.h
@@ -119,7 +119,7 @@ private:
 
     class MVNExecutorBase {
     public:
-        MVNExecutorBase(const MVNAttrs& mvnAttrs);
+        explicit MVNExecutorBase(const MVNAttrs& mvnAttrs);
         virtual void exec(const uint8_t* in_ptr_,
                           uint8_t* dst_data,
                           const void* post_ops_data_,
@@ -160,7 +160,7 @@ private:
 
     class MVNRefExecutor : public MVNExecutorBase {
     public:
-        MVNRefExecutor(const MVNAttrs& mvnAttrs);
+        explicit MVNRefExecutor(const MVNAttrs& mvnAttrs);
 
         void exec(const uint8_t* src_data,
                   uint8_t* dst_data,

--- a/src/plugins/intel_cpu/src/nodes/node_config.h
+++ b/src/plugins/intel_cpu/src/nodes/node_config.h
@@ -83,10 +83,10 @@ class PortConfig {
 public:
     PortConfig() = default;
 
-    PortConfig(const MemoryDescPtr& desc,
-               BlockedMemoryDesc::CmpMask cmpMask = BlockedMemoryDesc::FULL_MASK,
-               int inPlacePort = -1,
-               bool isConstant = false)
+    explicit PortConfig(const MemoryDescPtr& desc,
+                        BlockedMemoryDesc::CmpMask cmpMask = BlockedMemoryDesc::FULL_MASK,
+                        int inPlacePort = -1,
+                        bool isConstant = false)
         : _desc(createPortDesc(desc, cmpMask)),
           _inPlacePort(inPlacePort),
           _constant(isConstant) {}

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.h
@@ -69,9 +69,9 @@ public:
 
     struct Point2D {
         float x, y;
-        Point2D(const float px = 0.F, const float py = 0.F) : x(px), y(py) {}
+        explicit Point2D(const float px = 0.F, const float py = 0.F) : x(px), y(py) {}
         Point2D operator+(const Point2D& p) const {
-            return {x + p.x, y + p.y};
+            return Point2D(x + p.x, y + p.y);
         }
         Point2D& operator+=(const Point2D& p) {
             x += p.x;
@@ -79,10 +79,10 @@ public:
             return *this;
         }
         Point2D operator-(const Point2D& p) const {
-            return {x - p.x, y - p.y};
+            return Point2D(x - p.x, y - p.y);
         }
         Point2D operator*(const float coeff) const {
-            return {x * coeff, y * coeff};
+            return Point2D(x * coeff, y * coeff);
         }
     };
 

--- a/src/plugins/intel_cpu/src/nodes/non_zero.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_zero.cpp
@@ -84,7 +84,9 @@ void NonZero::initSupportedPrimitiveDescriptors() {
                     inPrc.get_type_name(),
                     " precision on 0 port");
 
-    addSupportedPrimDesc({{LayoutType::ncsp}}, {{LayoutType::ncsp, ov::element::i32}}, impl_desc_type::ref);
+    addSupportedPrimDesc({{LayoutType::ncsp, ov::element::dynamic}},
+                         {{LayoutType::ncsp, ov::element::i32}},
+                         impl_desc_type::ref);
 }
 
 template <typename T>

--- a/src/plugins/intel_cpu/src/nodes/normalize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/normalize.cpp
@@ -127,7 +127,7 @@ template <cpu_isa_t isa>
 struct jit_uni_normalize_modulo_kernel_f32 : public jit_uni_normalize_modulo_kernel, public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_normalize_modulo_kernel_f32)
 
-    jit_uni_normalize_modulo_kernel_f32(jit_normalize_config_params jcp)
+    explicit jit_uni_normalize_modulo_kernel_f32(jit_normalize_config_params jcp)
         : jit_uni_normalize_modulo_kernel(jcp),
           jit_generator_t(jit_name()) {}
 
@@ -1037,7 +1037,7 @@ void NormalizeL2::execute([[maybe_unused]] const dnnl::stream& strm) {
 template <typename in_data_t, typename out_data_t>
 class NormalizeL2::NormalizeL2CornerCaseExecutor : public NormalizeL2::NormalizeL2Executor {
 public:
-    NormalizeL2CornerCaseExecutor(const VectorDims& dims)
+    explicit NormalizeL2CornerCaseExecutor(const VectorDims& dims)
         : workAmount(std::accumulate(dims.begin(), dims.end(), 1, std::multiplies<>())) {}
 
     void exec(const uint8_t* src_ptr, uint8_t* dst_ptr, [[maybe_unused]] const void** post_ops_data) override {

--- a/src/plugins/intel_cpu/src/nodes/normalize.h
+++ b/src/plugins/intel_cpu/src/nodes/normalize.h
@@ -59,7 +59,7 @@ struct jit_uni_normalize_modulo_kernel {
         ker_(args);
     }
 
-    jit_uni_normalize_modulo_kernel(jit_normalize_config_params jcp) : jcp_(jcp) {}
+    explicit jit_uni_normalize_modulo_kernel(jit_normalize_config_params jcp) : jcp_(jcp) {}
     virtual ~jit_uni_normalize_modulo_kernel() = default;
 
     virtual void create_ker() = 0;

--- a/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
+++ b/src/plugins/intel_cpu/src/nodes/qkv_proj.cpp
@@ -331,7 +331,7 @@ struct QKVProjection::Executor : public QKVProjection::ExecutorBase {
 template <typename T>
 struct QKVProjection::Executor : public QKVProjection::ExecutorBase {
     QKVProjection* m_pnode;
-    Executor(QKVProjection* pnode) : m_pnode(pnode) {}
+    explicit Executor(QKVProjection* pnode) : m_pnode(pnode) {}
     void execute() override {}
 };
 #endif

--- a/src/plugins/intel_cpu/src/nodes/range.cpp
+++ b/src/plugins/intel_cpu/src/nodes/range.cpp
@@ -91,10 +91,10 @@ void Range::initSupportedPrimitiveDescriptors() {
     } else {
         inDataConf.reserve(inputShapes.size());
         for (size_t i = 0; i < inputShapes.size(); ++i) {
-            inDataConf.emplace_back(LayoutType::ncsp);
+            inDataConf.emplace_back(LayoutType::ncsp, ov::element::dynamic);
         }
         outDataConf.reserve(1);
-        outDataConf.emplace_back(LayoutType::ncsp);
+        outDataConf.emplace_back(LayoutType::ncsp, ov::element::dynamic);
         addSupportedPrimDesc(inDataConf, outDataConf, impl_desc_type::ref_any);
     }
 }

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -957,7 +957,7 @@ struct RDFTJitExecutor : public RDFTExecutor {
 #endif
 
 struct RDFTRefExecutor : public RDFTExecutor {
-    RDFTRefExecutor(bool inverse) : RDFTExecutor(inverse) {}
+    explicit RDFTRefExecutor(bool inverse) : RDFTExecutor(inverse) {}
 
 private:
     std::vector<float> generateTwiddlesDFT(size_t inputSize,

--- a/src/plugins/intel_cpu/src/nodes/rdft.h
+++ b/src/plugins/intel_cpu/src/nodes/rdft.h
@@ -20,7 +20,7 @@ namespace ov::intel_cpu::node {
 
 struct RDFTExecutor {
 public:
-    RDFTExecutor(bool inverse) : isInverse(inverse) {}
+    explicit RDFTExecutor(bool inverse) : isInverse(inverse) {}
     virtual ~RDFTExecutor() = default;
     void execute(float* inputPtr,
                  float* outputPtr,

--- a/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
+++ b/src/plugins/intel_cpu/src/nodes/region_yolo.cpp
@@ -60,7 +60,7 @@ template <cpu_isa_t isa>
 struct jit_uni_logistic_kernel_f32 : public jit_uni_logistic_kernel, public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_logistic_kernel_f32)
 
-    jit_uni_logistic_kernel_f32(jit_logistic_config_params jcp)
+    explicit jit_uni_logistic_kernel_f32(jit_logistic_config_params jcp)
         : jit_uni_logistic_kernel(),
           jit_generator_t(jit_name()),
           jcp_(jcp) {}

--- a/src/plugins/intel_cpu/src/nodes/rnn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rnn.cpp
@@ -426,7 +426,7 @@ namespace {
  */
 class RnnShapeInfer : public IShapeInfer {
 public:
-    RnnShapeInfer(std::shared_ptr<ov::Node> op)
+    explicit RnnShapeInfer(std::shared_ptr<ov::Node> op)
         : is_sequence(!(RNN::isCell(op))),
           native_order(RNN::testNativeOrder(op)),
           m_shape_infer(make_shape_inference(std::move(op))) {}
@@ -466,7 +466,7 @@ private:
 
 class RnnShapeInferFactory final : public ShapeInferFactory {
 public:
-    RnnShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit RnnShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<RnnShapeInfer>(m_op);
     }
@@ -1009,15 +1009,15 @@ void RNN::fillWeights() {
         const std::string hash_w =
             getName() + "_0_" +
             std::to_string(dnnl::impl::primitive_hashing::get_md_hash(*w_data_desc->getDnnlDesc().get()));
-        m_initial_weights[0] = *weight_cache->findOrCreate(hash_w, create_w);
+        m_initial_weights[0] = MemoryPtr(*weight_cache->findOrCreate(hash_w, create_w));
 
         const std::string hash_r =
             getName() + "_1_" +
             std::to_string(dnnl::impl::primitive_hashing::get_md_hash(*w_state_desc->getDnnlDesc().get()));
-        m_initial_weights[1] = *weight_cache->findOrCreate(hash_r, create_r);
+        m_initial_weights[1] = MemoryPtr(*weight_cache->findOrCreate(hash_r, create_r));
     } else {
-        m_initial_weights[0] = create_w();
-        m_initial_weights[1] = create_r();
+        m_initial_weights[0] = MemoryPtr(create_w());
+        m_initial_weights[1] = MemoryPtr(create_r());
     }
 }
 
@@ -1075,9 +1075,9 @@ void RNN::fillBiases() {
         const std::string hash_str =
             getName() + "_2_" +
             std::to_string(dnnl::impl::primitive_hashing::get_md_hash(*w_bias_data_desc->getDnnlDesc().get()));
-        m_initial_weights[2] = *weight_cache->findOrCreate(hash_str, create);
+        m_initial_weights[2] = MemoryPtr(*weight_cache->findOrCreate(hash_str, create));
     } else {
-        m_initial_weights[2] = create();
+        m_initial_weights[2] = MemoryPtr(create());
     }
 }
 
@@ -1096,10 +1096,10 @@ void RNN::prepareMemory(const DnnlMemoryDescPtr& new_desc, size_t idx) {
         const std::string hash_str =
             getName() + "_" + std::to_string(idx) + "_" +
             std::to_string(dnnl::impl::primitive_hashing::get_md_hash(*new_desc->getDnnlDesc().get()));
-        res_ptr = *weight_cache->findOrCreate(hash_str, create);
+        res_ptr = MemoryPtr(*weight_cache->findOrCreate(hash_str, create));
         m_weights_pull.insert(res_ptr);
     } else {
-        res_ptr = create();
+        res_ptr = MemoryPtr(create());
     }
 
     internalBlobMemory[idx] = std::move(res_ptr);

--- a/src/plugins/intel_cpu/src/nodes/rnn.h
+++ b/src/plugins/intel_cpu/src/nodes/rnn.h
@@ -75,7 +75,7 @@ private:
     void prepareMemory(const DnnlMemoryDescPtr& new_desc, size_t idx) override;
     class RnnDnnlExecutor : public DnnlExecutorLegacy {
     public:
-        RnnDnnlExecutor(const dnnl::primitive_desc& pd);
+        explicit RnnDnnlExecutor(const dnnl::primitive_desc& pd);
 
         DnnlMemoryDescPtr getWeightIterDesc() const {
             return wghts_iter_md;

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -566,7 +566,7 @@ void ROIPooling::prepareParams() {
 template <typename T>
 class ROIPooling::ROIPoolingJitExecutor : public ROIPooling::ROIPoolingExecutor {
 public:
-    ROIPoolingJitExecutor(const jit_roi_pooling_params& jpp) {
+    explicit ROIPoolingJitExecutor(const jit_roi_pooling_params& jpp) {
 #if defined(OPENVINO_ARCH_X86_64)
         if (mayiuse(cpu::x64::avx512_core)) {
             roi_pooling_kernel = std::make_shared<jit_uni_roi_pooling_kernel_f32<cpu::x64::avx512_core>>(jpp);
@@ -720,7 +720,7 @@ private:
 template <typename T>
 class ROIPooling::ROIPoolingRefExecutor : public ROIPooling::ROIPoolingExecutor {
 public:
-    ROIPoolingRefExecutor(const jit_roi_pooling_params& _jpp) : jpp(_jpp) {}
+    explicit ROIPoolingRefExecutor(const jit_roi_pooling_params& _jpp) : jpp(_jpp) {}
     void exec(const IMemory& srcData, const IMemory& srcRoi, const IMemory& dst) override {
         auto src_strides = srcData.getDescWithType<BlockedMemoryDesc>()->getStrides();
         auto src_roi_step = srcRoi.getDescWithType<BlockedMemoryDesc>()->getStrides()[0];

--- a/src/plugins/intel_cpu/src/nodes/rope.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rope.cpp
@@ -105,7 +105,7 @@ struct RoPE::RoPEExecutorRotateHalf : public RoPE::Executor {
     const op::internal::RoPE::Config& m_config;
     std::shared_ptr<kernel::JitKernelBase> m_rotaryKernel;
 
-    RoPEExecutorRotateHalf(const op::internal::RoPE::Config& config) : m_config(config) {
+    explicit RoPEExecutorRotateHalf(const op::internal::RoPE::Config& config) : m_config(config) {
         jit_rotary_compile_params jcp;
         jcp.src_prc = precision_of<T>::value;
         jcp.dst_prc = precision_of<T>::value;
@@ -187,7 +187,7 @@ struct RoPE::RoPEExecutorInterleaved : public RoPE::Executor {
     const op::internal::RoPE::Config& m_config;
     std::shared_ptr<kernel::JitKernelBase> m_rotaryKernel;
 
-    RoPEExecutorInterleaved(const op::internal::RoPE::Config& config) : m_config(config) {
+    explicit RoPEExecutorInterleaved(const op::internal::RoPE::Config& config) : m_config(config) {
         jit_rotary_compile_params jcp;
         jcp.src_prc = precision_of<T>::value;
         jcp.dst_prc = precision_of<T>::value;
@@ -237,7 +237,7 @@ struct RoPE::RoPEExecutorChatGLM : public RoPE::Executor {
     const op::internal::RoPE::Config& m_config;
     std::shared_ptr<kernel::JitKernelBase> m_rotaryKernel;
 
-    RoPEExecutorChatGLM(const op::internal::RoPE::Config& config) : m_config(config) {
+    explicit RoPEExecutorChatGLM(const op::internal::RoPE::Config& config) : m_config(config) {
         jit_rotary_compile_params jcp;
         jcp.src_prc = precision_of<T>::value;
         jcp.dst_prc = precision_of<T>::value;
@@ -327,7 +327,7 @@ struct RoPE::RoPEExecutorQwen : public RoPE::Executor {
     const op::internal::RoPE::Config& m_config;
     std::shared_ptr<kernel::JitKernelBase> m_rotaryKernel;
 
-    RoPEExecutorQwen(const op::internal::RoPE::Config& config) : m_config(config) {
+    explicit RoPEExecutorQwen(const op::internal::RoPE::Config& config) : m_config(config) {
         jit_rotary_compile_params jcp;
         jcp.src_prc = precision_of<T>::value;
         jcp.dst_prc = precision_of<T>::value;

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.h
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.h
@@ -52,7 +52,7 @@ private:
     ShuffleChannelsAttributes attrs;
 
     struct ShuffleChannelsExecutor final {
-        ShuffleChannelsExecutor(const ShuffleChannelsAttributes& attrs);
+        explicit ShuffleChannelsExecutor(const ShuffleChannelsAttributes& attrs);
         void exec(const uint8_t* srcData, uint8_t* dstData, int MB);
         ~ShuffleChannelsExecutor() = default;
 

--- a/src/plugins/intel_cpu/src/nodes/space_to_depth.h
+++ b/src/plugins/intel_cpu/src/nodes/space_to_depth.h
@@ -54,7 +54,7 @@ private:
     SpaceToDepthAttrs attrs;
 
     struct SpaceToDepthExecutor final {
-        SpaceToDepthExecutor(const SpaceToDepthAttrs& attrs);
+        explicit SpaceToDepthExecutor(const SpaceToDepthAttrs& attrs);
         void exec(const uint8_t* srcData, uint8_t* dstData, int MB);
         ~SpaceToDepthExecutor() = default;
 

--- a/src/plugins/intel_cpu/src/nodes/subgraph.cpp
+++ b/src/plugins/intel_cpu/src/nodes/subgraph.cpp
@@ -179,7 +179,7 @@ struct SubgraphShapeInferResultKey {
 };
 
 struct SubgraphShapeInferResult {
-    SubgraphShapeInferResult(IShapeInfer::Result res) : result(std::move(res)) {}
+    explicit SubgraphShapeInferResult(IShapeInfer::Result res) : result(std::move(res)) {}
 
     IShapeInfer::Result result;
 };

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -205,7 +205,7 @@ public:
 
 class asBoolCheck : public PortChecker {
 public:
-    asBoolCheck(const MemoryPtr& mem) {
+    explicit asBoolCheck(const MemoryPtr& mem) {
         OPENVINO_ASSERT(mem->getDataType() == memory::data_type::u8);
         OPENVINO_ASSERT(mem->getShape() == Shape(VectorDims{1}));
         mem_holder = mem->getPrimitive();
@@ -220,7 +220,7 @@ public:
 
 class asIntCheck : public PortChecker {
 public:
-    asIntCheck(const MemoryPtr& mem) {
+    explicit asIntCheck(const MemoryPtr& mem) {
         OPENVINO_ASSERT(mem->getDataType() == memory::data_type::s32);
         OPENVINO_ASSERT(mem->getShape() == Shape(VectorDims{1}));
         mem_holder = mem->getPrimitive();
@@ -235,7 +235,7 @@ public:
 
 class staticValueCheck : public PortChecker {
 public:
-    staticValueCheck(const int& value) : value(value) {}
+    explicit staticValueCheck(const int& value) : value(value) {}
 
     int getStatus() override {
         return value;

--- a/src/plugins/intel_cpu/src/partitioned_mem_blk.h
+++ b/src/plugins/intel_cpu/src/partitioned_mem_blk.h
@@ -18,10 +18,10 @@ namespace ov::intel_cpu {
  */
 class PartitionedMemoryBlock : public IMemoryBlockObserver {
 public:
-    PartitionedMemoryBlock(MemoryBlockPtr pBlock,
-                           size_t total_chunks = 1,
-                           ptrdiff_t offset_chunks = 0,
-                           size_t size_chunks = 1)
+    explicit PartitionedMemoryBlock(MemoryBlockPtr pBlock,
+                                    size_t total_chunks = 1,
+                                    ptrdiff_t offset_chunks = 0,
+                                    size_t size_chunks = 1)
         : m_pBlock(std::move(pBlock)),
           m_total_chunks(total_chunks),
           m_offset_chunks(offset_chunks),

--- a/src/plugins/intel_cpu/src/shape_inference/custom/adaptive_pooling.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/adaptive_pooling.hpp
@@ -42,7 +42,7 @@ private:
 
 class AdaptivePoolingShapeInferFactory : public ShapeInferFactory {
 public:
-    AdaptivePoolingShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit AdaptivePoolingShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/color_convert.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/color_convert.hpp
@@ -26,7 +26,7 @@ using Result = IShapeInfer::Result;
  */
 class ColorConvertShapeInfer : public ShapeInferEmptyPads {
 public:
-    ColorConvertShapeInfer(bool singlePlain) : m_singlePlain(singlePlain) {}
+    explicit ColorConvertShapeInfer(bool singlePlain) : m_singlePlain(singlePlain) {}
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
     [[nodiscard]] port_mask_t get_port_mask() const override {
@@ -39,7 +39,7 @@ private:
 
 class ColorConvertShapeInferFactory : public ShapeInferFactory {
 public:
-    ColorConvertShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit ColorConvertShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/convolution.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/convolution.hpp
@@ -60,7 +60,7 @@ private:
 
 class ConvolutionShapeInferFactory : public ShapeInferFactory {
 public:
-    ConvolutionShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit ConvolutionShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/fullyconnected.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/fullyconnected.hpp
@@ -20,7 +20,7 @@ using Result = IShapeInfer::Result;
 
 class FCShapeInfer : public ShapeInferEmptyPads {
 public:
-    FCShapeInfer(size_t outPut_rank) : out_rank(outPut_rank) {}
+    explicit FCShapeInfer(size_t outPut_rank) : out_rank(outPut_rank) {}
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
@@ -34,7 +34,7 @@ private:
 
 class FCShapeInferFactory : public ShapeInferFactory {
 public:
-    FCShapeInferFactory(const std::shared_ptr<ov::Node>& op) : m_op(op) {}
+    explicit FCShapeInferFactory(const std::shared_ptr<ov::Node>& op) : m_op(op) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override {
         return std::make_shared<FCShapeInfer>(m_op->get_output_partial_shape(0).rank().get_length());
     }

--- a/src/plugins/intel_cpu/src/shape_inference/custom/gather.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/gather.hpp
@@ -44,7 +44,7 @@ private:
 
 class GatherShapeInferFactory : public ShapeInferFactory {
 public:
-    GatherShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit GatherShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/matmul.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/matmul.hpp
@@ -41,7 +41,7 @@ private:
 
 class MMShapeInferFactory : public ShapeInferFactory {
 public:
-    MMShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit MMShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/ngram.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/ngram.hpp
@@ -20,7 +20,7 @@ namespace ov::intel_cpu::node {
 using Result = IShapeInfer::Result;
 class NgramShapeInfer : public ShapeInferEmptyPads {
 public:
-    NgramShapeInfer(const size_t k) : m_k(k) {}
+    explicit NgramShapeInfer(const size_t k) : m_k(k) {}
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
 
@@ -34,7 +34,7 @@ private:
 
 class NgramShapeInferFactory : public ShapeInferFactory {
 public:
-    NgramShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit NgramShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/one_hot.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/one_hot.hpp
@@ -42,7 +42,7 @@ private:
 
 class OneHotShapeInferFactory : public ShapeInferFactory {
 public:
-    OneHotShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit OneHotShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/reshape.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/reshape.hpp
@@ -22,7 +22,7 @@ namespace ov::intel_cpu::node {
 using Result = IShapeInfer::Result;
 class ReshapeShapeInfer : public ShapeInferEmptyPads {
 public:
-    ReshapeShapeInfer(bool specialZero) : m_specialZero(specialZero) {}
+    explicit ReshapeShapeInfer(bool specialZero) : m_specialZero(specialZero) {}
     Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                  const std::unordered_map<size_t, MemoryPtr>& data_dependency) override;
     [[nodiscard]] port_mask_t get_port_mask() const override {
@@ -55,7 +55,7 @@ public:
 
 class ReshapeShapeInferFactory : public ShapeInferFactory {
 public:
-    ReshapeShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit ReshapeShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/rms_norm.hpp
@@ -14,7 +14,7 @@ namespace ov::intel_cpu::node {
 
 class RMSNormShapeInferFactory : public ShapeInferFactory {
 public:
-    RMSNormShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit RMSNormShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.cpp
@@ -25,7 +25,7 @@ namespace ov::intel_cpu::node {
 
 class SDPAShapeInfer : public ShapeInferEmptyPads {
 public:
-    SDPAShapeInfer(ScaledDotProductAttentionWithKVCache::Config config) : m_config(std::move(config)) {}
+    explicit SDPAShapeInfer(ScaledDotProductAttentionWithKVCache::Config config) : m_config(std::move(config)) {}
 
     IShapeInfer::Result infer(const std::vector<std::reference_wrapper<const VectorDims>>& input_shapes,
                               [[maybe_unused]] const std::unordered_map<size_t, MemoryPtr>& data_dependency) override {

--- a/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/scaled_attn.hpp
@@ -14,7 +14,7 @@ namespace ov::intel_cpu::node {
 
 class SDPAShapeInferFactory : public ShapeInferFactory {
 public:
-    SDPAShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit SDPAShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/strided_slice.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/strided_slice.hpp
@@ -50,7 +50,7 @@ private:
 
 class StridedSliceShapeInferFactory : public ShapeInferFactory {
 public:
-    StridedSliceShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit StridedSliceShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/custom/transpose.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/custom/transpose.hpp
@@ -54,7 +54,7 @@ private:
 
 class TransposeShapeInferFactory : public ShapeInferFactory {
 public:
-    TransposeShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
+    explicit TransposeShapeInferFactory(std::shared_ptr<ov::Node> op) : m_op(std::move(op)) {}
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 
 private:

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference.cpp
@@ -281,7 +281,7 @@ class ShapeInferBase : public IStaticShapeInfer {
 public:
     using iface_type = IStaticShapeInfer;
 
-    ShapeInferBase(std::shared_ptr<ov::Node> node) : m_node{std::move(node)} {
+    explicit ShapeInferBase(std::shared_ptr<ov::Node> node) : m_node{std::move(node)} {
         static_assert(std::is_same_v<int64_t, Dimension::value_type>, "Rank type not match to input_ranks type.");
         for (size_t i = 0; i < m_node->get_input_size(); ++i) {
             const auto& shape = m_node->get_input_partial_shape(i);
@@ -451,7 +451,7 @@ public:
 /** @brief Base shape inference object implementing the IStaticShapeInfer with padding support. */
 class ShapeInferPaddingBase : public ShapeInferBase {
 public:
-    ShapeInferPaddingBase(std::shared_ptr<ov::Node> node) : ShapeInferBase(std::move(node)) {}
+    explicit ShapeInferPaddingBase(std::shared_ptr<ov::Node> node) : ShapeInferBase(std::move(node)) {}
 
     const ov::CoordinateDiff& get_pads_begin() override {
         return m_pads_begin;

--- a/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/shape_inference_cpu.hpp
@@ -106,7 +106,7 @@ public:
      *
      * @param op ngraph operation
      */
-    NgraphShapeInferFactory(std::shared_ptr<ov::Node> op);
+    explicit NgraphShapeInferFactory(std::shared_ptr<ov::Node> op);
 
     [[nodiscard]] ShapeInferPtr makeShapeInfer() const override;
 

--- a/src/plugins/intel_cpu/src/shape_inference/static_dimension.cpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_dimension.cpp
@@ -6,6 +6,7 @@
 
 #include <ostream>
 
+#include "openvino/core/dimension.hpp"
 #include "openvino/core/except.hpp"
 
 namespace ov::intel_cpu {
@@ -25,12 +26,29 @@ StaticDimension::StaticDimension(value_type ldimension, value_type udimension) :
                     "]");
 }
 
+StaticDimension::StaticDimension(const ov::Dimension& dim) {
+    if (dim.is_static()) {
+        m_dimension = dim.get_length();
+    } else {
+        // For dynamic dimensions, set to 0
+        m_dimension = 0;
+    }
+}
+
 bool StaticDimension::operator==(const StaticDimension& dim) const {
     return m_dimension == dim.m_dimension;
 }
 
 bool StaticDimension::operator!=(const StaticDimension& dim) const {
     return m_dimension != dim.m_dimension;
+}
+
+bool StaticDimension::operator!=(value_type val) const {
+    return m_dimension != val;
+}
+
+bool StaticDimension::operator!=(int val) const {
+    return m_dimension != static_cast<value_type>(val);
 }
 
 StaticDimension StaticDimension::operator+(const StaticDimension& dim) const {
@@ -47,6 +65,18 @@ StaticDimension StaticDimension::operator-(const StaticDimension& dim) const {
 
 StaticDimension StaticDimension::operator*(const StaticDimension& dim) const {
     return {m_dimension * dim.m_dimension};
+}
+
+StaticDimension StaticDimension::operator+(value_type val) const {
+    return {m_dimension + val};
+}
+
+StaticDimension StaticDimension::operator-(value_type val) const {
+    return {m_dimension - val};
+}
+
+StaticDimension StaticDimension::operator*(value_type val) const {
+    return {m_dimension * val};
 }
 
 StaticDimension& StaticDimension::operator*=(const StaticDimension& dim) {
@@ -67,7 +97,7 @@ StaticDimension& StaticDimension::operator/=(const value_type divisor) {
 }
 
 StaticDimension StaticDimension::operator&(const StaticDimension& dim) const {
-    return (*this == dim) ? dim : 0;
+    return (*this == dim) ? dim : StaticDimension(0);
 }
 
 StaticDimension& StaticDimension::operator&=(const StaticDimension& dim) {
@@ -79,6 +109,10 @@ StaticDimension& StaticDimension::operator&=(const StaticDimension& dim) {
 
 bool StaticDimension::compatible(const StaticDimension& dim) const {
     return m_dimension == dim.m_dimension;
+}
+
+bool StaticDimension::compatible(value_type d) const {
+    return m_dimension == d;
 }
 
 bool StaticDimension::same_scheme(const StaticDimension& dim) const {
@@ -94,15 +128,62 @@ bool StaticDimension::merge(StaticDimension& dst, const StaticDimension& d1, con
 }
 
 bool StaticDimension::broadcast_merge(StaticDimension& dst, const StaticDimension& d1, const StaticDimension& d2) {
-    if (d1 == 1) {
+    if (d1.get_length() == 1) {
         dst = d2;
         return true;
     }
-    if (d2 == 1) {
+    if (d2.get_length() == 1) {
         dst = d1;
         return true;
     }
     return merge(dst, d1, d2);
+}
+
+StaticDimension& StaticDimension::operator=(const ov::Dimension& dim) {
+    if (dim.is_static()) {
+        m_dimension = dim.get_length();
+    } else {
+        // For dynamic dimensions, set to 0 (or could throw)
+        m_dimension = 0;
+    }
+    return *this;
+}
+
+StaticDimension& StaticDimension::operator=(value_type val) {
+    m_dimension = val;
+    return *this;
+}
+
+StaticDimension StaticDimension::operator*(const ov::Dimension& dim) const {
+    if (dim.is_static()) {
+        return {static_cast<value_type>(m_dimension * dim.get_length())};
+    }
+    // For dynamic dimensions, return 0 (or could throw)
+    return {0};
+}
+
+bool StaticDimension::operator!=(const ov::Dimension& dim) const {
+    if (dim.is_static()) {
+        return m_dimension != static_cast<value_type>(dim.get_length());
+    }
+    // Static dimension is never equal to dynamic dimension
+    return true;
+}
+
+bool StaticDimension::operator==(value_type val) const {
+    return m_dimension == val;
+}
+
+bool StaticDimension::operator==(int val) const {
+    return m_dimension == static_cast<value_type>(val);
+}
+
+bool StaticDimension::operator==(const ov::Dimension& dim) const {
+    if (dim.is_static()) {
+        return m_dimension == static_cast<value_type>(dim.get_length());
+    }
+    // Static dimension is never equal to dynamic dimension
+    return false;
 }
 
 StaticDimension::value_type StaticDimension::get_length() const {

--- a/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_dimension.hpp
@@ -23,7 +23,14 @@ public:
 
     /// \brief Construct a static dimension.
     /// \param dimension Value of the dimension.
-    StaticDimension(value_type dimension);
+    ///
+    /// \brief Construct a static dimension.
+    /// \param dimension Value of the dimension.
+    ///
+    /// \note Implicit conversion is intentionally allowed (explicit constructor disabled)
+    ///       because StaticDimension is used quite intensively throughout the codebase
+    ///       and requiring explicit conversions would make the code more verbose.
+    StaticDimension(value_type dimension);  // NOLINT(google-explicit-constructor)
 
     /// \brief Construct a static dimension.
     /// \param ldimension Value of the dimension (must be equal to udimension)
@@ -33,12 +40,12 @@ public:
     /// \brief Construct a zero dimension
     StaticDimension() = default;
 
-    StaticDimension(const Dimension& /*dim*/) {
-        OPENVINO_THROW("[shape infer] Shoudn't convert from Dimension to StaticDimension.");
-    }
+    StaticDimension(const Dimension& dim);  // NOLINT(google-explicit-constructor)
 
     bool operator==(const StaticDimension& dimension) const;
     bool operator!=(const StaticDimension& dimension) const;
+    bool operator!=(value_type val) const;
+    bool operator!=(int val) const;
 
     explicit operator size_t() const {
         return m_dimension;
@@ -63,6 +70,7 @@ public:
 
     [[nodiscard]] bool same_scheme(const StaticDimension& dim) const;
     [[nodiscard]] bool compatible(const StaticDimension& d) const;
+    [[nodiscard]] bool compatible(value_type d) const;
     static bool merge(StaticDimension& dst, const StaticDimension& d1, const StaticDimension& d2);
     static bool broadcast_merge(StaticDimension& dst, const StaticDimension& d1, const StaticDimension& d2);
 
@@ -70,9 +78,19 @@ public:
     StaticDimension operator-(const StaticDimension& dim) const;
     StaticDimension operator*(const StaticDimension& dim) const;
     StaticDimension operator&(const StaticDimension& dim) const;
+    StaticDimension operator+(value_type val) const;
+    StaticDimension operator-(value_type val) const;
+    StaticDimension operator*(value_type val) const;
+    StaticDimension operator*(const ov::Dimension& dim) const;
+    bool operator!=(const ov::Dimension& dim) const;
+    bool operator==(value_type val) const;
+    bool operator==(int val) const;
+    bool operator==(const ov::Dimension& dim) const;
     StaticDimension& operator+=(const StaticDimension& dim);
     StaticDimension& operator*=(const StaticDimension& dim);
     StaticDimension& operator&=(const StaticDimension& dim);
+    StaticDimension& operator=(const ov::Dimension& dim);
+    StaticDimension& operator=(value_type val);
     StaticDimension operator/(value_type divisor) const;
     StaticDimension& operator/=(value_type divisor);
 

--- a/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
+++ b/src/plugins/intel_cpu/src/shape_inference/static_shape.hpp
@@ -41,6 +41,12 @@ constexpr bool is_static_shape_adapter() {
     return std::is_same_v<U, StaticShapeRef> || std::is_same_v<U, StaticShape>;
 }
 
+// NOLINTBEGIN(google-explicit-constructor)
+
+// Implicit conversion is intentionally allowed (explicit constructor disabled)
+// because StaticDimension is used quite intensively throughout the codebase
+// and requiring explicit conversions would make the code more verbose.
+
 /**
  * @brief The static shape adapter by copy value to VectorDims.
  *
@@ -299,6 +305,8 @@ public:
 private:
     const TDims* m_dims = nullptr;
 };
+
+// NOLINTEND(google-explicit-constructor)
 
 template <class T>
 std::enable_if_t<is_static_shape_adapter<T>(), std::ostream&> operator<<(std::ostream& out, const T& shape) {

--- a/src/plugins/intel_cpu/src/sub_memory_manager.hpp
+++ b/src/plugins/intel_cpu/src/sub_memory_manager.hpp
@@ -17,7 +17,7 @@ public:
         bool last_used = false;
     };
 
-    SubMemoryManager(int num_sub_streams) {
+    explicit SubMemoryManager(int num_sub_streams) {
         assert(num_sub_streams);
         _num_sub_streams = num_sub_streams;
         MemoryInfo memory_info;

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/submodel.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/op/submodel.hpp
@@ -25,7 +25,7 @@ public:
 
     SubModel() = default;
 
-    SubModel(const std::shared_ptr<ov::Model>& body);
+    explicit SubModel(const std::shared_ptr<ov::Model>& body);
 
     SubModel(const OutputVector& args, const std::shared_ptr<ov::Model>& body);
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/insert_convert_after_extension.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/insert_convert_after_extension.hpp
@@ -14,7 +14,7 @@ namespace ov::pass {
 class InsertConvertAfterExtension : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("InsertConvertAfterExtension");
-    InsertConvertAfterExtension(bool convert_output_precision = true);
+    explicit InsertConvertAfterExtension(bool convert_output_precision = true);
 };
 
 }  // namespace ov::pass

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/interaction.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/interaction.hpp
@@ -21,9 +21,9 @@ public:
 
     InteractionNode() = default;
 
-    InteractionNode(const OutputVector& args);
+    explicit InteractionNode(const OutputVector& args);
 
-    InteractionNode(const NodeVector& args);
+    explicit InteractionNode(const NodeVector& args);
 
     bool visit_attributes(ov::AttributeVisitor& visitor) override;
 

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/llm_mlp.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/x64/op/llm_mlp.hpp
@@ -63,7 +63,7 @@ template <>
 class AttributeAdapter<ov::intel_cpu::LLMMLPNode::ACT_FN>
     : public EnumAttributeAdapterBase<ov::intel_cpu::LLMMLPNode::ACT_FN> {
 public:
-    AttributeAdapter(ov::intel_cpu::LLMMLPNode::ACT_FN& value)
+    explicit AttributeAdapter(ov::intel_cpu::LLMMLPNode::ACT_FN& value)
         : EnumAttributeAdapterBase<ov::intel_cpu::LLMMLPNode::ACT_FN>(value) {}
 
     OPENVINO_RTTI("AttributeAdapter<ov::intel_cpu::LLMMLPNode::ACT_FN>");

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.hpp
@@ -196,7 +196,7 @@ snippets::lowered::ExpressionPtr get_copy_b_expr(const snippets::lowered::Expres
 template <>
 class AttributeAdapter<intel_cpu::brgemm_utils::BrgemmConfig> : public VisitorAdapter {
 public:
-    AttributeAdapter(intel_cpu::brgemm_utils::BrgemmConfig& ref) : m_ref(ref) {}
+    explicit AttributeAdapter(intel_cpu::brgemm_utils::BrgemmConfig& ref) : m_ref(ref) {}
     bool visit_attributes(AttributeVisitor& visitor) override;
 
     OPENVINO_RTTI("AttributeAdapter<intel_cpu::brgemm_utils::BrgemmConfig>");

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/op/perf_count_rdtsc.hpp
@@ -44,7 +44,7 @@ public:
 class PerfCountRdtscEnd : public PerfCountEndBase {
 public:
     OPENVINO_OP("PerfCountRdtscEnd", "SnippetsOpset", PerfCountEndBase);
-    PerfCountRdtscEnd(const Output<Node>& pc_begin);
+    explicit PerfCountRdtscEnd(const Output<Node>& pc_begin);
     PerfCountRdtscEnd() = default;
     ~PerfCountRdtscEnd() override {
         double avg = 0;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/brgemm_to_brgemm_cpu.hpp
@@ -33,7 +33,7 @@ namespace ov::intel_cpu::pass {
 class BrgemmToBrgemmCPU : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("BrgemmToBrgemmCPU");
-    BrgemmToBrgemmCPU(std::set<size_t> constant_inputs_idxs)
+    explicit BrgemmToBrgemmCPU(std::set<size_t> constant_inputs_idxs)
         : m_constant_inputs_idxs(std::move(constant_inputs_idxs)) {}
 
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/eliminate_brgemm_copy_b.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/eliminate_brgemm_copy_b.hpp
@@ -26,7 +26,8 @@ namespace ov::intel_cpu::pass {
 class EliminateBrgemmCopyB : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("EliminateBrgemmCopyB");
-    EliminateBrgemmCopyB(ov::intel_cpu::InputRepackerMap& input_repackers) : m_input_repackers(input_repackers) {}
+    explicit EliminateBrgemmCopyB(ov::intel_cpu::InputRepackerMap& input_repackers)
+        : m_input_repackers(input_repackers) {}
 
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/fuse_brgemm_cpu_postops.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/fuse_brgemm_cpu_postops.hpp
@@ -19,7 +19,7 @@ namespace ov::intel_cpu::pass {
 class FuseBrgemmCPUPostops : public ov::pass::GraphRewrite {
 public:
     OPENVINO_GRAPH_REWRITE_RTTI("FuseBrgemmCPUPostops");
-    FuseBrgemmCPUPostops(std::set<size_t>& brgemm_external_params_idces);
+    explicit FuseBrgemmCPUPostops(std::set<size_t>& brgemm_external_params_idces);
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
     static bool can_be_fused_as_postop(const std::shared_ptr<const ov::Node>& node);
@@ -82,7 +82,7 @@ public:
 class FuseBinaryEltwise : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("FuseBinaryEltwise");
-    FuseBinaryEltwise(std::set<std::shared_ptr<ov::op::v0::Parameter>>& external_params);
+    explicit FuseBinaryEltwise(std::set<std::shared_ptr<ov::op::v0::Parameter>>& external_params);
 
     static bool can_be_fused(const std::shared_ptr<const ov::Node>& node);
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.hpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/snippets_mark_skipped.hpp
@@ -20,7 +20,7 @@ namespace ov::intel_cpu {
 class SnippetsMarkSkipped : public ov::pass::ModelPass {
 public:
     OPENVINO_MODEL_PASS_RTTI("SnippetsMarkSkipped");
-    SnippetsMarkSkipped(bool enableBF16 = false) : ModelPass(), enableBF16(enableBF16) {}
+    explicit SnippetsMarkSkipped(bool enableBF16 = false) : ModelPass(), enableBF16(enableBF16) {}
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 
 private:

--- a/src/plugins/intel_cpu/src/utils/bfloat16.hpp
+++ b/src/plugins/intel_cpu/src/utils/bfloat16.hpp
@@ -22,7 +22,9 @@ namespace ov::intel_cpu {
 class bfloat16_t {
 public:
     bfloat16_t() = default;
-    bfloat16_t(float value) noexcept
+    // Implicit conversion from float to bfloat16_t is intentionally allowed
+    // to avoid verbosity in the codebase
+    bfloat16_t(float value) noexcept  // NOLINT(google-explicit-constructor)
         : m_value{
 #if defined BFLOAT16_ROUND_MODE_TO_NEAREST
               round_to_nearest(value)
@@ -37,7 +39,7 @@ public:
           } {
     }
 
-    operator float() const {
+    operator float() const {  // NOLINT(google-explicit-constructor)
         auto bits = static_cast<uint32_t>(m_value) << 16;
         return ov::intel_cpu::bit_cast<float>(bits);
     }

--- a/src/plugins/intel_cpu/src/utils/blob_dump.h
+++ b/src/plugins/intel_cpu/src/utils/blob_dump.h
@@ -34,7 +34,7 @@ class BlobDumper {
 
 public:
     BlobDumper() = default;
-    BlobDumper(const DnnlBlockedMemoryDesc& desc) {
+    explicit BlobDumper(const DnnlBlockedMemoryDesc& desc) {
         dnnl::engine eng(dnnl::engine::kind::cpu, 0);
         memory = std::make_shared<Memory>(eng, desc);
     }

--- a/src/plugins/intel_cpu/src/utils/codec_xor.hpp
+++ b/src/plugins/intel_cpu/src/utils/codec_xor.hpp
@@ -23,13 +23,13 @@ union CacheDecrypt {
 
     CacheDecrypt() {}
 
-    CacheDecrypt(CacheDecryptStr fn) : m_decrypt_str(std::move(fn)) {}
+    explicit CacheDecrypt(CacheDecryptStr fn) : m_decrypt_str(std::move(fn)) {}
 
-    CacheDecrypt(CacheDecryptChar fn) : m_decrypt_char(std::move(fn)) {}
+    explicit CacheDecrypt(CacheDecryptChar fn) : m_decrypt_char(std::move(fn)) {}
 
     ~CacheDecrypt() {}
 
-    operator bool() const {
+    explicit operator bool() const {
         return m_decrypt_char || m_decrypt_str;
     }
 };

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
@@ -436,7 +436,7 @@ class OstreamAttributeVisitor : public ov::AttributeVisitor {
     std::ostream& os;
 
 public:
-    OstreamAttributeVisitor(std::ostream& os) : os(os) {}
+    explicit OstreamAttributeVisitor(std::ostream& os) : os(os) {}
 
     void on_adapter(const std::string& name, ov::ValueAccessor<void>& adapter) override {
         if (auto* a = ov::as_type<ov::AttributeAdapter<std::set<std::string>>>(&adapter)) {

--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.h
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.h
@@ -49,7 +49,7 @@ public:
     [[nodiscard]] const std::string& get_tag() const {
         return tag;
     }
-    operator bool() const {
+    explicit operator bool() const {
         return enabled;
     }
     static void break_at(const std::string& log);
@@ -64,7 +64,7 @@ class IMemory;
 
 class PrintableModel {
 public:
-    PrintableModel(const ov::Model& model, std::string tag = "", std::string prefix = "")
+    explicit PrintableModel(const ov::Model& model, std::string tag = "", std::string prefix = "")
         : model(model),
           tag(std::move(tag)),
           prefix(std::move(prefix)) {}
@@ -76,7 +76,7 @@ public:
 template <typename T>
 class PrintableVector {
 public:
-    PrintableVector(const std::vector<T>& values, int maxsize = 80) : values(values), maxsize(maxsize) {}
+    explicit PrintableVector(const std::vector<T>& values, int maxsize = 80) : values(values), maxsize(maxsize) {}
     const std::vector<T>& values;
     int maxsize;
 };

--- a/src/plugins/intel_cpu/src/utils/debug_caps_config.h
+++ b/src/plugins/intel_cpu/src/utils/debug_caps_config.h
@@ -160,7 +160,7 @@ private:
         virtual bool parseAndSet(const std::string& str) = 0;
         [[nodiscard]] virtual std::string getPropertyValueDescription() const = 0;
 
-        PropertySetter(std::string name) : propertyName(std::move(name)) {}
+        explicit PropertySetter(std::string name) : propertyName(std::move(name)) {}
 
         virtual ~PropertySetter() = default;
 

--- a/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
+++ b/src/plugins/intel_cpu/src/utils/plain_tensor.hpp
@@ -112,7 +112,7 @@ struct PlainTensor {
     ov::element::Type_t m_dt = ov::element::Type_t::dynamic;
     MemoryPtr m_mem;  // hold memory ptr reference
 
-    operator bool() const {
+    explicit operator bool() const {
         return m_ptr != nullptr;
     }
 
@@ -145,7 +145,7 @@ struct PlainTensor {
         return strides;
     }
 
-    PlainTensor(const MemoryPtr& mem) {
+    explicit PlainTensor(const MemoryPtr& mem) {
         reset(mem);
     }
 
@@ -201,7 +201,7 @@ struct PlainTensor {
         }
         // tensor_index(start)            : select 1 element (with squeeze)
         // tensor_index(start, end, step) : select a range w/o squeeze
-        tensor_index(int start, int end = INT_MIN, int step = 1) : start(start), end(end), step(step) {}
+        explicit tensor_index(int start, int end = INT_MIN, int step = 1) : start(start), end(end), step(step) {}
 
         void regularize(int size) {
             if (start < 0) {

--- a/src/plugins/intel_cpu/src/utils/serialize.hpp
+++ b/src/plugins/intel_cpu/src/utils/serialize.hpp
@@ -22,7 +22,7 @@ class ModelSerializer : private ov::pass::StreamSerialize {
 public:
     using CacheEncrypt = std::function<std::string(const std::string&)>;
 
-    ModelSerializer(std::ostream& ostream, const CacheEncrypt& encrypt_fn = {});
+    explicit ModelSerializer(std::ostream& ostream, const CacheEncrypt& encrypt_fn = {});
 
     void operator<<(const std::shared_ptr<ov::Model>& model);
 

--- a/src/plugins/intel_cpu/src/weights_cache.hpp
+++ b/src/plugins/intel_cpu/src/weights_cache.hpp
@@ -57,7 +57,7 @@ public:
 
         SharedMemory(std::unique_lock<std::mutex>&& lock, MemoryInfo::Ptr memory, MemoryPtr newPtr = nullptr);
 
-        operator MemoryPtr() const;
+        explicit operator MemoryPtr() const;
         [[nodiscard]] bool isValid() const;
         void valid(bool b);
 


### PR DESCRIPTION
### Details:
 - Fix "google-explicit-constructor" remarks reported by clang-tidy
 - Enable "google-explicit-constructor" clang-tidy checks on CI by default

### Tickets:
 - N/A
