### PR TITLE
[core] Remove namespaces from pass names

### DIFF
--- a/src/core/src/pass/pass.cpp
+++ b/src/core/src/pass/pass.cpp
@@ -41,9 +41,13 @@ std::string ov::pass::PassBase::get_name() const {
             std::free);
         pass_name = demangled_name.get();
 #endif
+        if (pass_name.find_last_of(":") != string::npos) {
+            pass_name = pass_name.substr(pass_name.find_last_of(":") + 1);
+        }
         return pass_name;
     } else {
-        return m_name;
+        return m_name.find_last_of(":") != string::npos
+            ? m_name.substr(m_name.find_last_of(":") + 1) : m_name;
     }
 }
 


### PR DESCRIPTION
The presence of colons in pass names causes crashes when using pass serialization with the OV_ENABLE_SERIALIZE_TRACING option. This patch ensures that only the portion after the last colon is returned from the get_name() method.
