### PR TITLE
[GPU] Update abs_threshold for ROIAlign functional tests

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
@@ -14,7 +14,6 @@ protected:
         ROIAlignLayerTest::SetUp();
         auto param = this->GetParam();
         ov::element::Type model_type = std::get<7>(param);
-        targetDevice = std::get<8>(param);
         if (model_type == ov::element::f32) {
             abs_threshold = 1e-5;   // ROIAlign may introduce small differences when output values are very small,
             rel_threshold = 5e-2;   // so the threshold should account for this behavior.
@@ -28,8 +27,6 @@ protected:
         ROIAlignV9LayerTest::SetUp();
         auto param = this->GetParam();
         ov::element::Type model_type = std::get<8>(param);
-        targetDevice = std::get<9>(param);
-
         if (model_type == ov::element::f32) {
             abs_threshold = 1e-5;   // ROIAlign may introduce small differences when output values are very small,
             rel_threshold = 5e-2;   // so the threshold should account for this behavior.

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
@@ -8,6 +8,35 @@ namespace {
 using ov::test::ROIAlignLayerTest;
 using ov::test::ROIAlignV9LayerTest;
 
+class ROIAlignLayerGPUTest : public ROIAlignLayerTest {
+protected:
+    void SetUp() override {
+        ROIAlignLayerTest::SetUp();
+        auto param = this->GetParam();
+        ov::element::Type model_type = std::get<7>(param);
+        targetDevice = std::get<8>(param);
+        if (targetDevice == "GPU" && model_type == ov::element::f32) {
+            abs_threshold = 1e-5;   // ROIAlign may introduce small differences when output values are very small,
+            rel_threshold = 5e-2;   // so the threshold should account for this behavior.
+        }
+    }
+};
+
+class ROIAlignV9LayerGPUTest : public ROIAlignV9LayerTest {
+protected:
+    void SetUp() override {
+        ROIAlignV9LayerTest::SetUp();
+        auto param = this->GetParam();
+        ov::element::Type model_type = std::get<8>(param);
+        targetDevice = std::get<9>(param);
+
+        if (targetDevice == "GPU" && model_type == ov::element::f32) {
+            abs_threshold = 1e-5;   // ROIAlign may introduce small differences when output values are very small,
+            rel_threshold = 5e-2;   // so the threshold should account for this behavior.
+        }
+    }
+};
+
 const std::vector<ov::element::Type> netPRCs = {
     ov::element::f32
     // There is no possibility to test ROIAlign in fp16 precision,
@@ -21,8 +50,16 @@ const std::vector<ov::element::Type> netPRCs = {
     // ov::element::f16
 };
 
+TEST_P(ROIAlignLayerGPUTest, Inference) {
+    run();
+}
+
+TEST_P(ROIAlignV9LayerGPUTest, Inference) {
+    run();
+}
+
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_average,
-                         ROIAlignLayerTest,
+                         ROIAlignLayerGPUTest,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{3, 8, 16, 16}},
                                                                                                 {{2, 1, 16, 16}},
@@ -35,10 +72,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_average,
                                             ::testing::Values("avg"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignLayerTest::getTestCaseName);
+                         ROIAlignLayerGPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max,
-                         ROIAlignLayerTest,
+                         ROIAlignLayerGPUTest,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 8, 20, 20}},
                                                                                                 {{2, 1, 20, 20}},
@@ -51,10 +88,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max,
                                             ::testing::Values("max"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignLayerTest::getTestCaseName);
+                         ROIAlignLayerGPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_asym,
-                         ROIAlignV9LayerTest,
+                         ROIAlignV9LayerGPUTest,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 1, 8, 8}},
                                                                                                 {{2, 8, 20, 20}},
@@ -69,10 +106,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_asym,
                                             ::testing::Values("asymmetric"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignV9LayerTest::getTestCaseName);
+                         ROIAlignV9LayerGPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_hpfn,
-                         ROIAlignV9LayerTest,
+                         ROIAlignV9LayerGPUTest,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 1, 8, 8}},
                                                                                                 {{2, 8, 20, 20}},
@@ -87,10 +124,10 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_avg_hpfn,
                                             ::testing::Values("half_pixel_for_nn"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignV9LayerTest::getTestCaseName);
+                         ROIAlignV9LayerGPUTest::getTestCaseName);
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max_hp,
-                         ROIAlignV9LayerTest,
+                         ROIAlignV9LayerGPUTest,
                          ::testing::Combine(::testing::ValuesIn(ov::test::static_shapes_to_test_representation(
                                                             std::vector<std::vector<ov::Shape>>{{{2, 1, 8, 8}},
                                                                                                 {{2, 8, 20, 20}},
@@ -105,5 +142,5 @@ INSTANTIATE_TEST_SUITE_P(smoke_TestsROIAlign_max_hp,
                                             ::testing::Values("half_pixel"),
                                             ::testing::ValuesIn(netPRCs),
                                             ::testing::Values(ov::test::utils::DEVICE_GPU)),
-                         ROIAlignV9LayerTest::getTestCaseName);
+                         ROIAlignV9LayerGPUTest::getTestCaseName);
 }  // namespace

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/roi_align.cpp
@@ -15,7 +15,7 @@ protected:
         auto param = this->GetParam();
         ov::element::Type model_type = std::get<7>(param);
         targetDevice = std::get<8>(param);
-        if (targetDevice == "GPU" && model_type == ov::element::f32) {
+        if (model_type == ov::element::f32) {
             abs_threshold = 1e-5;   // ROIAlign may introduce small differences when output values are very small,
             rel_threshold = 5e-2;   // so the threshold should account for this behavior.
         }
@@ -30,7 +30,7 @@ protected:
         ov::element::Type model_type = std::get<8>(param);
         targetDevice = std::get<9>(param);
 
-        if (targetDevice == "GPU" && model_type == ov::element::f32) {
+        if (model_type == ov::element::f32) {
             abs_threshold = 1e-5;   // ROIAlign may introduce small differences when output values are very small,
             rel_threshold = 5e-2;   // so the threshold should account for this behavior.
         }

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -176,8 +176,6 @@ std::vector<std::string> disabledTestPatterns() {
             R"(.*smoke_RDFT_5d_last_axis/RDFTLayerTest.Inference/IS=\(10.4.8.2.5\)_modelType=f32_Axes=\(0.1.2.3.4\)_SignalSize=\(\).*)",
             // Issue: 136862
             R"(.*smoke_ConditionGPUTest_static/StaticConditionLayerGPUTest.CompareWithRefs/IS=\(3.6\)_netPRC=i8_ifCond=PARAM_targetDevice=GPU_.*)",
-            // Issue: 142900
-            // R"(.*smoke_TestsROIAlign_.*ROIAlignV9LayerTest.*)",
             // Use weight from model not from path hint
             R"(.*compile_from_weightless_blob.*)",
 

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -177,7 +177,7 @@ std::vector<std::string> disabledTestPatterns() {
             // Issue: 136862
             R"(.*smoke_ConditionGPUTest_static/StaticConditionLayerGPUTest.CompareWithRefs/IS=\(3.6\)_netPRC=i8_ifCond=PARAM_targetDevice=GPU_.*)",
             // Issue: 142900
-            R"(.*smoke_TestsROIAlign_.*ROIAlignV9LayerTest.*)",
+            // R"(.*smoke_TestsROIAlign_.*ROIAlignV9LayerTest.*)",
             // Use weight from model not from path hint
             R"(.*compile_from_weightless_blob.*)",
 

--- a/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
@@ -119,10 +119,6 @@ void ROIAlignLayerTest::SetUp() {
                                                             spatial_scale,
                                                             pooling_mode);
     function = std::make_shared<ov::Model>(roi_align->outputs(), ov::ParameterVector{param}, "roi_align");
-
-    if (targetDevice == "GPU" && model_type == ov::element::f32) {
-        abs_threshold = 1e-4;   // ROIAlign may have very small differences in results
-    }
 }
 
 std::string ROIAlignV9LayerTest::getTestCaseName(const testing::TestParamInfo<roialignV9Params>& obj) {
@@ -203,10 +199,6 @@ void ROIAlignV9LayerTest::SetUp() {
                                                             ov::EnumNames<ov::op::v9::ROIAlign::PoolingMode>::as_enum(pooling_mode),
                                                             ov::EnumNames<ov::op::v9::ROIAlign::AlignedMode>::as_enum(roi_aligned_mode));
     function = std::make_shared<ov::Model>(roi_align->outputs(), ov::ParameterVector{param}, "roi_align");
-
-    if (targetDevice == "GPU" && model_type == ov::element::f32) {
-        abs_threshold = 1e-4;   // ROIAlign may have very small differences in results
-    }
 }
 }  // namespace test
 }  // namespace ov

--- a/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
@@ -120,7 +120,7 @@ void ROIAlignLayerTest::SetUp() {
                                                             pooling_mode);
     function = std::make_shared<ov::Model>(roi_align->outputs(), ov::ParameterVector{param}, "roi_align");
 
-    if (model_type == ov::element::f32) {
+    if (targetDevice == "GPU" && model_type == ov::element::f32) {
         abs_threshold = 1e-4;   // ROIAlign may have very small differences in results
     }
 }
@@ -204,7 +204,7 @@ void ROIAlignV9LayerTest::SetUp() {
                                                             ov::EnumNames<ov::op::v9::ROIAlign::AlignedMode>::as_enum(roi_aligned_mode));
     function = std::make_shared<ov::Model>(roi_align->outputs(), ov::ParameterVector{param}, "roi_align");
 
-    if (model_type == ov::element::f32) {
+    if (targetDevice == "GPU" && model_type == ov::element::f32) {
         abs_threshold = 1e-4;   // ROIAlign may have very small differences in results
     }
 }

--- a/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
@@ -119,6 +119,10 @@ void ROIAlignLayerTest::SetUp() {
                                                             spatial_scale,
                                                             pooling_mode);
     function = std::make_shared<ov::Model>(roi_align->outputs(), ov::ParameterVector{param}, "roi_align");
+
+    if (model_type == ov::element::f32) {
+        abs_threshold = 1e-4;   // ROIAlign may have very small differences in results
+    }
 }
 
 std::string ROIAlignV9LayerTest::getTestCaseName(const testing::TestParamInfo<roialignV9Params>& obj) {
@@ -199,6 +203,10 @@ void ROIAlignV9LayerTest::SetUp() {
                                                             ov::EnumNames<ov::op::v9::ROIAlign::PoolingMode>::as_enum(pooling_mode),
                                                             ov::EnumNames<ov::op::v9::ROIAlign::AlignedMode>::as_enum(roi_aligned_mode));
     function = std::make_shared<ov::Model>(roi_align->outputs(), ov::ParameterVector{param}, "roi_align");
+
+    if (model_type == ov::element::f32) {
+        abs_threshold = 1e-4;   // ROIAlign may have very small differences in results
+    }
 }
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - Some of ROIAlign functional test failed because the threshold was not properly updated.
 - The threshold was updated as: threshold = abs_threshold + rel_threshold * expected.
 - When an expected value was small, the threshold may be lower than difference to check even though the difference was not error.
 - So the abs_threshold and rel_threshold were increased to differentiate the errors.

#### The code and line that caused this issue (if it is not changed directly)
 - src/tests/functional/plugin/shared/src/single_op/roi_align.cpp (SetUp())

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - $ bin/intel64/Debug/ov_gpu_func_tests --gtest_filter="smoke_TestsROIAlign_*

### Tickets:
 - *142900*
