### PR TITLE
[OV JS] Support openvino-node types in TypeScript

### DIFF
--- a/src/bindings/js/.eslintrc-global.js
+++ b/src/bindings/js/.eslintrc-global.js
@@ -25,5 +25,6 @@ module.exports = {
     'keyword-spacing': ['error', { overrides: { catch: { after: false } } }],
     'prefer-destructuring': ["error", { "object": true, "array": false }],
     '@typescript-eslint/no-var-requires': 0,
+    "@typescript-eslint/no-misused-new": "off",
   }
 };


### PR DESCRIPTION
### Details:
 - Fix for `error TS2339: Property 'CompiledModel' does not exist on type 'NodeAddon'.` and others
 - Enable the following scenario in typescript:
```ts
function create_request(model: typeof ov.CompiledModel) {
  const val = model instanceof ov.CompiledModel;
  const result = model.createInferRequest();
}
```

### Tickets:
 - [CVS-168512](https://jira.devtools.intel.com/browse/CVS-168512)
