### PR TITLE
[GPU] Add func test for implicit padding in dynamic convolution

### DIFF
--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
@@ -176,32 +176,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_ExplicitPad1D, Convolutio
                 ::testing::Values(false)),
                 ConvolutionLayerGPUTestDynamic::getTestCaseName);
 
-const std::vector<std::vector<size_t>> kernels2DImplicit = { {3, 3} };
-const std::vector<std::vector<size_t>> strides2DImplicit = { {1, 1} };
-const std::vector<size_t> numOutChannelsImplicit = { 3 };
-const std::vector<InputShape> inputShapes2DImplicit = {
-    {
-        {1, 3, {224, 448}, {224, 448}},
-        {{1, 3, 224, 224}, {1, 3, 448, 448}}
-    }
-};
-
-INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_ImplicitPad2D, ConvolutionLayerGPUTestDynamic,
-        ::testing::Combine(
-                ::testing::Combine(
-                        ::testing::ValuesIn(kernels2DImplicit),
-                        ::testing::ValuesIn(strides2DImplicit),
-                        ::testing::Values(std::vector<ptrdiff_t>{0, 0}),
-                        ::testing::Values(std::vector<ptrdiff_t>{0, 0}),
-                        ::testing::Values(std::vector<size_t>{1, 1}),
-                        ::testing::ValuesIn(numOutChannelsImplicit),
-                        ::testing::Values(ov::op::PadType::SAME_UPPER)),
-                ::testing::Values(ov::element::f32),
-                ::testing::ValuesIn(inputShapes2DImplicit),
-                ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
-                ::testing::Values(false)),
-                ConvolutionLayerGPUTestDynamic::getTestCaseName);
-
 // ======== 2D convolutions
 const std::vector<ov::test::InputShape> dynInputShapes2D = {
     {

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
@@ -208,6 +208,10 @@ const std::vector<ov::test::InputShape> dynInputShapes2D = {
         {1, 10, ov::Dimension::dynamic(), ov::Dimension::dynamic()},
         {{1, 10, 20, 20}, {1, 10, 30, 30}, {1, 10, 40, 20}}
     },
+    {
+        {1, 3, {224, 448}, {224, 448}},
+        {{1, 3, 224, 224}, {1, 3, 448, 448}}
+    }
 };
 
 // Specific range causes output static shapeS
@@ -245,7 +249,7 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_dynamic2DSymAutoPad, Conv
                         ::testing::Values(std::vector<size_t>{1, 1}),
                         ::testing::Values(10),
                         ::testing::ValuesIn({ov::op::PadType::SAME_LOWER, ov::op::PadType::SAME_UPPER})),
-                ::testing::Values(ov::element::f16),
+                ::testing::ValuesIn({ov::element::f16, ov::element::f32}),
                 ::testing::ValuesIn(dynInputShapes2D),
                 ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
                 ::testing::Values(false)),

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/convolution.cpp
@@ -176,6 +176,32 @@ INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_ExplicitPad1D, Convolutio
                 ::testing::Values(false)),
                 ConvolutionLayerGPUTestDynamic::getTestCaseName);
 
+const std::vector<std::vector<size_t>> kernels2DImplicit = { {3, 3} };
+const std::vector<std::vector<size_t>> strides2DImplicit = { {1, 1} };
+const std::vector<size_t> numOutChannelsImplicit = { 3 };
+const std::vector<InputShape> inputShapes2DImplicit = {
+    {
+        {1, 3, {224, 448}, {224, 448}},
+        {{1, 3, 224, 224}, {1, 3, 448, 448}}
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(smoke_ConvolutionLayerGPUTest_ImplicitPad2D, ConvolutionLayerGPUTestDynamic,
+        ::testing::Combine(
+                ::testing::Combine(
+                        ::testing::ValuesIn(kernels2DImplicit),
+                        ::testing::ValuesIn(strides2DImplicit),
+                        ::testing::Values(std::vector<ptrdiff_t>{0, 0}),
+                        ::testing::Values(std::vector<ptrdiff_t>{0, 0}),
+                        ::testing::Values(std::vector<size_t>{1, 1}),
+                        ::testing::ValuesIn(numOutChannelsImplicit),
+                        ::testing::Values(ov::op::PadType::SAME_UPPER)),
+                ::testing::Values(ov::element::f32),
+                ::testing::ValuesIn(inputShapes2DImplicit),
+                ::testing::Values<std::string>(ov::test::utils::DEVICE_GPU),
+                ::testing::Values(false)),
+                ConvolutionLayerGPUTestDynamic::getTestCaseName);
+
 // ======== 2D convolutions
 const std::vector<ov::test::InputShape> dynInputShapes2D = {
     {


### PR DESCRIPTION
### Details:
- Add a functional test for implicit padding in dynamic convolutions.

### Issue: 
- The implicit padding is updated after calling `update_shape_info_tensor()` in primitive_inst.cpp.
- That means a shape agnostic kernel of convolution doesn't work well with implicit padding.
- For this reason, if a shape agnostic kernel is selected when there is implicit padding, the accuracy drop occurs. 
- So this test is to ensure that `dynamic_impls` is not chosen for implicit padding in convolution.

### Related to:
- [convolution_impls.cpp](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/graph/registry/convolution_impls.cpp#L28)
- [PR#31185](https://github.com/openvinotoolkit/openvino/pull/31185)

### Tickets:
 - 169416