### PR TITLE
[GPU] Add binary_div post-op for oneDNN

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/fused_primitive_desc.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/fused_primitive_desc.hpp
@@ -119,6 +119,7 @@ enum class onednn_post_op_type : uint32_t {
     binary_max,
     binary_min,
     binary_relu,
+    binary_div,
     scale,
     sum,
     optimized,
@@ -142,6 +143,7 @@ static inline std::ostream& operator<< (std::ostream& os, onednn_post_op_type& t
         case onednn_post_op_type::binary_max: os << "binary_max"; break;
         case onednn_post_op_type::binary_min: os << "binary_min"; break;
         case onednn_post_op_type::binary_relu: os << "binary_relu"; break;
+        case onednn_post_op_type::binary_div: os << "binary_div"; break;
         case onednn_post_op_type::scale: os << "scale"; break;
         case onednn_post_op_type::sum: os << "sum"; break;
         case onednn_post_op_type::optimized: os << "optimized"; break;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/primitive_onednn_base.h
@@ -406,6 +406,7 @@ protected:
                 case onednn_post_op_type::binary_mul:
                 case onednn_post_op_type::binary_max:
                 case onednn_post_op_type::binary_min:
+                case onednn_post_op_type::binary_div:
                 {
                     auto binary_op_mem = instance.fused_memory(memory_offset);
                     dnnl::algorithm alg;

--- a/src/plugins/intel_gpu/src/graph/include/to_string_utils.h
+++ b/src/plugins/intel_gpu/src/graph/include/to_string_utils.h
@@ -97,6 +97,7 @@ inline std::string onednn_post_op_type_to_str(onednn_post_op_type type) {
     case onednn_post_op_type::binary_max: return "binary_max";
     case onednn_post_op_type::binary_min: return "binary_min";
     case onednn_post_op_type::binary_relu: return "binary_relu";
+    case onednn_post_op_type::binary_div: return "binary_div";
     case onednn_post_op_type::scale: return "scale";
     case onednn_post_op_type::sum: return "sum";
     case onednn_post_op_type::optimized: return "optimized";

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1108,6 +1108,7 @@ dnnl::post_ops program_node::try_optimize_post_ops(std::vector<fused_primitive_d
             case onednn_post_op_type::binary_mul:
             case onednn_post_op_type::binary_max:
             case onednn_post_op_type::binary_min:
+            case onednn_post_op_type::binary_div:
             {
                 dnnl::algorithm alg;
                 dnnl::memory::desc desc;

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1538,6 +1538,7 @@ void program_node::create_onednn_primitive_attributes(
                                   type == onednn_post_op_type::binary_max ||
                                   type == onednn_post_op_type::binary_min ||
                                   type == onednn_post_op_type::binary_relu ||
+                                  type == onednn_post_op_type::binary_div ||
                                   type == onednn_post_op_type::scale ||
                                   type == onednn_post_op_type::sum;
 
@@ -1657,6 +1658,8 @@ void program_node::create_onednn_primitive_attributes(
                 set_binary_op(dnnl::algorithm::binary_sub, onednn_post_op_type::binary_sub);
             } else if (desc.typed_desc<eltwise>()->mode == eltwise_mode::prod) {
                 set_binary_op(dnnl::algorithm::binary_mul, onednn_post_op_type::binary_mul);
+            } else if (desc.typed_desc<eltwise>()->mode == eltwise_mode::div) {
+                set_binary_op(dnnl::algorithm::binary_div, onednn_post_op_type::binary_div);
             } else {
                 std::stringstream error_msg;
                 error_msg << "Unsupported eltwise mode: " << static_cast<int>(desc.typed_desc<eltwise>()->mode) << ". ";

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -4374,4 +4374,28 @@ INSTANTIATE_TEST_SUITE_P(eltwise_sum_fusings_gpu, onednn_replace_full_tensor_sum
     convolution_eltw_sum_test_params{ CASE_CONV_ELTW_SUM_TO_BINARY_ADD, 2, 2, 3 },
 }));
 
+class conv_elt_fp16_onednn : public WeightsPrimitiveFusingTestOneDNN {};
+TEST_P(conv_elt_fp16_onednn, basic_activation_eltwise_div) {
+    auto p = GetParam();
+
+    create_topologies(
+        input_layout("input", get_input_layout(p)),
+        data("weights", get_mem(get_weights_layout(p))),
+        data("bias", get_mem(get_per_channel_layout(p))),
+        data("slope_data", get_mem(get_prelu_slope_layout(p))),
+        data("eltwise_data", get_mem(get_output_layout(p), 1.0f)),
+        convolution("conv_prim", input_info("input"), "weights", "bias", p.groups, p.stride, p.dilation, p.pad, p.pad, format::is_grouped(get_weights_layout(p).format)),
+        activation("activation", input_info("conv_prim"), "slope_data", activation_func::relu_negative_slope),
+        eltwise("eltwise", input_info("activation"), input_info("eltwise_data"), eltwise_mode::div),
+        reorder("reorder_bfyx", input_info("eltwise"), p.default_format, data_types::f32)
+    );
+
+    tolerance = 0.002f;
+    execute(p);
+}
+
+INSTANTIATE_TEST_SUITE_P(fusings_gpu, conv_elt_fp16_onednn, ::testing::ValuesIn(std::vector<convolution_test_params>{
+    convolution_test_params{ CASE_CONV_FP16_1, 2, 2, 4 },
+}));
+
 #endif  // ENABLE_ONEDNN_FOR_GPU


### PR DESCRIPTION
### Details:
 - Add binary_div post-op for oneDNN because oneDNN v3.9.0 supports it.

### Issue:
> RuntimeError: Exception from src/inference/src/cpp/infer_request.cpp:223:
> Check 'false' failed at src/plugins/intel_gpu/src/graph/program_node.cpp:1640:
> Unsupported eltwise mode: 4. divide:__module.model.git.encoder.layer.0.attention.self/aten::div/Divide is fused node of gemm:__module.model.git.encoder.layer.0.attention.self/aten::matmul/MatMul
- Pytorch frontend has disabled divide conversion since [PTFE div translation](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/div.cpp#L49).
- This was not a problem on iGPU because GPU Plugin supported eltwise fusion for division.
- On the other hand, it was being handled as an exception for oneDNN in [program_node.cpp](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/graph/program_node.cpp#L1662).
- But oneDNN supports this as well.

### Related to:
- [PTFE div translation](https://github.com/openvinotoolkit/openvino/blob/master/src/frontends/pytorch/src/op/div.cpp#L49).
- [program_node.cpp](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/src/graph/program_node.cpp#L1662).

### Tickets:
 - 169280
