### PR TITLE
[Snippets][TESTS] Refactor movebroadcast and codegen_gelu tests

### DIFF
--- a/src/common/snippets/tests/include/pass/movebroadcast.hpp
+++ b/src/common/snippets/tests/include/pass/movebroadcast.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Intel Corporation
+// Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/src/common/snippets/tests/include/pass/movebroadcast.hpp
+++ b/src/common/snippets/tests/include/pass/movebroadcast.hpp
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <common_test_utils/ov_test_utils.hpp>
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+class MoveBroadcastTests : public TransformationTestsF {
+protected:
+    void SetUp() override;
+};
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/common/snippets/tests/src/pass/movebroadcast.cpp
+++ b/src/common/snippets/tests/src/pass/movebroadcast.cpp
@@ -21,7 +21,6 @@ namespace snippets {
 void MoveBroadcastTests::SetUp() {
     TransformationTestsF::SetUp();
     manager.register_pass<::snippets::pass::InsertMoveBroadcast>();
-    disable_rt_info_check();
 }
 
 TEST_F(MoveBroadcastTests, InsertBroadcastMove) {

--- a/src/common/snippets/tests/src/pass/movebroadcast.cpp
+++ b/src/common/snippets/tests/src/pass/movebroadcast.cpp
@@ -5,32 +5,32 @@
 #include <gtest/gtest.h>
 
 #include "openvino/op/add.hpp"
-#include "snippets/pass/insert_movebroadcast.hpp"
 #include "snippets/op/broadcastmove.hpp"
+#include "snippets/pass/insert_movebroadcast.hpp"
+#include "subgraph_movebroadcast.hpp"
 
-#include "transformations/init_node_info.hpp"
-
-#include "common_test_utils/ov_test_utils.hpp"
+#include "pass/movebroadcast.hpp"
 
 using namespace testing;
 using namespace ov;
 
-//  todo: Rewrite this test using Snippets test infrastructure. See ./include/canonicalization.hpp for example
+namespace ov {
+namespace test {
+namespace snippets {
 
-TEST_F(TransformationTestsF, InsertBroadcastMove) {
-    {
-        auto data0 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 3});
-        auto data1 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 1});
-        auto add = std::make_shared<ov::op::v1::Add>(data0, data1);
-        model = std::make_shared<Model>(OutputVector{add}, ParameterVector{data0, data1});
-
-        manager.register_pass<snippets::pass::InsertMoveBroadcast>();
-    }
-    {
-        auto data0 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 3});
-        auto data1 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 1});
-        auto move1 = std::make_shared<snippets::op::BroadcastMove>(data1, ov::Dimension{3});
-        auto add = std::make_shared<ov::op::v1::Add>(data0, move1);
-        model_ref = std::make_shared<Model>(OutputVector{add}, ParameterVector{data0, data1});
-    }
+void MoveBroadcastTests::SetUp() {
+    TransformationTestsF::SetUp();
+    manager.register_pass<::snippets::pass::InsertMoveBroadcast>();
+    disable_rt_info_check();
 }
+
+TEST_F(MoveBroadcastTests, InsertBroadcastMove) {
+    std::vector<PartialShape> input_shapes = {Shape{2, 3}, Shape{1, 2, 1}};
+    MoveBroadcastFunction function(input_shapes);
+    model = function.getOriginal();
+    model_ref = function.getReference();
+}
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/codegen_gelu.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/codegen_gelu.cpp
@@ -1,4 +1,3 @@
-
 // Copyright (C) 2018-2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -7,7 +6,6 @@
 
 #include "snippets/codegen_gelu.hpp"
 #include "common_test_utils/test_constants.hpp"
-//  todo: Rewrite this test using Snippets test infrastructure. See add_convert or conv_eltwise for example
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/plugin/shared/include/snippets/codegen_gelu.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/codegen_gelu.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "shared_test_classes/base/snippets_test_utils.hpp"
+#include "subgraph_gelu.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/plugin/shared/include/snippets/codegen_gelu.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/codegen_gelu.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "shared_test_classes/base/snippets_test_utils.hpp"
-#include "subgraph_gelu.hpp"
 
 namespace ov {
 namespace test {

--- a/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
@@ -3,14 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "common_test_utils/common_utils.hpp"
-#include "openvino/op/gelu.hpp"
-#include "openvino/op/parameter.hpp"
-#include "openvino/pass/constant_folding.hpp"
 #include "snippets/codegen_gelu.hpp"
-#include "subgraph_simple.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "openvino/pass/constant_folding.hpp"
 #include "functional_test_utils/skip_tests_config.hpp"
-#include "openvino/op/add.hpp"
+#include "subgraph_gelu.hpp"
 
 namespace ov {
 namespace test {
@@ -42,24 +40,17 @@ namespace snippets {
 
     // Gelu from bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001
     void CodegenGelu::SetUp() {
-        InputShape inputShape0, inputShapes1;
+        InputShape inputShape0, inputShape1;
         ov::element::Type_t netPrecision;
         bool useSubgraph;
-        std::tie(netPrecision, inputShape0, inputShapes1, useSubgraph, targetDevice) = this->GetParam();
+        std::tie(netPrecision, inputShape0, inputShape1, useSubgraph, targetDevice) = this->GetParam();
 
-        init_input_shapes({inputShape0, inputShapes1});
+        init_input_shapes({inputShape0, inputShape1});
 
-        auto input0 = std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[0]);
-        auto input1 = std::make_shared<ov::op::v0::Parameter>(netPrecision, inputDynamicShapes[1]);
-        auto add = std::make_shared<ov::op::v1::Add>(input0, input1);
+        auto f = ov::test::snippets::CodegenGeluFunction(inputDynamicShapes, netPrecision, useSubgraph);
+        function = f.getOriginal();
 
-        auto gelu = std::make_shared<ov::op::v0::Gelu>(add);
-        auto result = std::make_shared<ov::op::v0::Result>(gelu);
-
-        function = std::make_shared<ov::Model>(
-            ov::ResultVector{result},
-            ov::ParameterVector{input0, input1},
-            "CodegenGelu");
+        setInferenceType(netPrecision);
 
         if (useSubgraph) {
             ov::pass::InitNodeInfo().run_on_model(function);

--- a/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
@@ -40,14 +40,12 @@ namespace snippets {
 
     // Gelu from bert-large-uncased-whole-word-masking-squad-fp32-onnx-0001
     void CodegenGelu::SetUp() {
-        InputShape inputShape0, inputShape1;
-        ov::element::Type_t netPrecision;
-        bool useSubgraph;
-        std::tie(netPrecision, inputShape0, inputShape1, useSubgraph, targetDevice) = this->GetParam();
+        auto [netPrecision, inputShape0, inputShape1, useSubgraph, targetDeviceValue] = this->GetParam();
+        targetDevice = targetDeviceValue;
 
         init_input_shapes({inputShape0, inputShape1});
 
-        auto f = ov::test::snippets::CodegenGeluFunction(inputDynamicShapes, netPrecision, useSubgraph);
+        auto f = ov::test::snippets::CodegenGeluFunction(inputDynamicShapes, netPrecision);
         function = f.getOriginal();
 
         setInferenceType(netPrecision);

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_gelu.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_gelu.hpp
@@ -12,8 +12,7 @@ namespace snippets {
 class CodegenGeluFunction : public SnippetsFunctionBase {
 public:
     CodegenGeluFunction(const std::vector<ov::PartialShape>& inputShapes,
-                        ov::element::Type_t precision = ov::element::f32,
-                        bool useSubgraph = false);
+                        ov::element::Type_t precision = ov::element::f32);
 
 protected:
     std::shared_ptr<ov::Model> initOriginal() const override;

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_gelu.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_gelu.hpp
@@ -16,9 +16,6 @@ public:
 
 protected:
     std::shared_ptr<ov::Model> initOriginal() const override;
-
-private:
-    bool m_use_subgraph;
 };
 
 }  // namespace snippets

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_gelu.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_gelu.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "snippets_helpers.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+class CodegenGeluFunction : public SnippetsFunctionBase {
+public:
+    CodegenGeluFunction(const std::vector<ov::PartialShape>& inputShapes,
+                        ov::element::Type_t precision = ov::element::f32,
+                        bool useSubgraph = false);
+
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+
+private:
+    bool m_use_subgraph;
+};
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov
+

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_movebroadcast.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_movebroadcast.hpp
@@ -12,8 +12,7 @@ namespace snippets {
 class MoveBroadcastFunction : public SnippetsFunctionBase {
 public:
     MoveBroadcastFunction(const std::vector<ov::PartialShape>& inputShapes,
-                         ov::element::Type_t precision = ov::element::f32,
-                         bool useSubgraph = false);
+                         ov::element::Type_t precision = ov::element::f32);
 
 protected:
     std::shared_ptr<ov::Model> initOriginal() const override;

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_movebroadcast.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_movebroadcast.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include "snippets_helpers.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+class MoveBroadcastFunction : public SnippetsFunctionBase {
+public:
+    MoveBroadcastFunction(const std::vector<ov::PartialShape>& inputShapes,
+                         ov::element::Type_t precision = ov::element::f32,
+                         bool useSubgraph = false);
+
+protected:
+    std::shared_ptr<ov::Model> initOriginal() const override;
+    std::shared_ptr<ov::Model> initReference() const override;
+
+private:
+    bool m_use_subgraph;
+};
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov

--- a/src/tests/ov_helpers/ov_snippets_models/include/subgraph_movebroadcast.hpp
+++ b/src/tests/ov_helpers/ov_snippets_models/include/subgraph_movebroadcast.hpp
@@ -17,9 +17,6 @@ public:
 protected:
     std::shared_ptr<ov::Model> initOriginal() const override;
     std::shared_ptr<ov::Model> initReference() const override;
-
-private:
-    bool m_use_subgraph;
 };
 
 }  // namespace snippets

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_gelu.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_gelu.cpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "subgraph_gelu.hpp"
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/gelu.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/pass/constant_folding.hpp"
+#include "transformations/init_node_info.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+CodegenGeluFunction::CodegenGeluFunction(const std::vector<ov::PartialShape>& inputShapes,
+                                         ov::element::Type_t precision,
+                                         bool useSubgraph)
+    : SnippetsFunctionBase(inputShapes, precision), m_use_subgraph(useSubgraph) {
+    OPENVINO_ASSERT(input_shapes.size() == 2, "Got invalid number of input shapes");
+}
+
+std::shared_ptr<ov::Model> CodegenGeluFunction::initOriginal() const {
+    auto input0 = std::make_shared<ov::op::v0::Parameter>(precision, input_shapes[0]);
+    auto input1 = std::make_shared<ov::op::v0::Parameter>(precision, input_shapes[1]);
+    auto add = std::make_shared<ov::op::v1::Add>(input0, input1);
+    auto gelu = std::make_shared<ov::op::v0::Gelu>(add);
+    auto result = std::make_shared<ov::op::v0::Result>(gelu);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input0, input1});
+
+    if (m_use_subgraph) {
+        ov::pass::InitNodeInfo().run_on_model(model);
+        ov::pass::ConstantFolding().run_on_model(model);
+    }
+    return model;
+}
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov
+

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_gelu.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_gelu.cpp
@@ -15,9 +15,8 @@ namespace test {
 namespace snippets {
 
 CodegenGeluFunction::CodegenGeluFunction(const std::vector<ov::PartialShape>& inputShapes,
-                                         ov::element::Type_t precision,
-                                         bool useSubgraph)
-    : SnippetsFunctionBase(inputShapes, precision), m_use_subgraph(useSubgraph) {
+                                         ov::element::Type_t precision)
+    : SnippetsFunctionBase(inputShapes, precision) {
     OPENVINO_ASSERT(input_shapes.size() == 2, "Got invalid number of input shapes");
 }
 
@@ -29,10 +28,6 @@ std::shared_ptr<ov::Model> CodegenGeluFunction::initOriginal() const {
     auto result = std::make_shared<ov::op::v0::Result>(gelu);
     auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input0, input1});
 
-    if (m_use_subgraph) {
-        ov::pass::InitNodeInfo().run_on_model(model);
-        ov::pass::ConstantFolding().run_on_model(model);
-    }
     return model;
 }
 

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_movebroadcast.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_movebroadcast.cpp
@@ -15,9 +15,8 @@ namespace test {
 namespace snippets {
 
 MoveBroadcastFunction::MoveBroadcastFunction(const std::vector<ov::PartialShape>& inputShapes,
-                                           ov::element::Type_t precision,
-                                           bool useSubgraph)
-    : SnippetsFunctionBase(inputShapes, precision), m_use_subgraph(useSubgraph) {
+                                           ov::element::Type_t precision)
+    : SnippetsFunctionBase(inputShapes, precision) {
     OPENVINO_ASSERT(input_shapes.size() == 2, "Got invalid number of input shapes");
 }
 
@@ -28,10 +27,6 @@ std::shared_ptr<ov::Model> MoveBroadcastFunction::initOriginal() const {
     auto result = std::make_shared<ov::op::v0::Result>(add);
     auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input0, input1});
 
-    if (m_use_subgraph) {
-        ov::pass::InitNodeInfo().run_on_model(model);
-        ov::pass::ConstantFolding().run_on_model(model);
-    }
     return model;
 }
 

--- a/src/tests/ov_helpers/ov_snippets_models/src/subgraph_movebroadcast.cpp
+++ b/src/tests/ov_helpers/ov_snippets_models/src/subgraph_movebroadcast.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include "subgraph_movebroadcast.hpp"
+
+#include "openvino/op/add.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/pass/constant_folding.hpp"
+#include "snippets/op/broadcastmove.hpp"
+#include "transformations/init_node_info.hpp"
+
+namespace ov {
+namespace test {
+namespace snippets {
+
+MoveBroadcastFunction::MoveBroadcastFunction(const std::vector<ov::PartialShape>& inputShapes,
+                                           ov::element::Type_t precision,
+                                           bool useSubgraph)
+    : SnippetsFunctionBase(inputShapes, precision), m_use_subgraph(useSubgraph) {
+    OPENVINO_ASSERT(input_shapes.size() == 2, "Got invalid number of input shapes");
+}
+
+std::shared_ptr<ov::Model> MoveBroadcastFunction::initOriginal() const {
+    auto input0 = std::make_shared<ov::op::v0::Parameter>(precision, input_shapes[0]);
+    auto input1 = std::make_shared<ov::op::v0::Parameter>(precision, input_shapes[1]);
+    auto add = std::make_shared<ov::op::v1::Add>(input0, input1);
+    auto result = std::make_shared<ov::op::v0::Result>(add);
+    auto model = std::make_shared<ov::Model>(ov::ResultVector{result}, ov::ParameterVector{input0, input1});
+
+    if (m_use_subgraph) {
+        ov::pass::InitNodeInfo().run_on_model(model);
+        ov::pass::ConstantFolding().run_on_model(model);
+    }
+    return model;
+}
+
+std::shared_ptr<ov::Model> MoveBroadcastFunction::initReference() const {
+    auto ref_data0 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{2, 3});
+    auto ref_data1 = std::make_shared<ov::op::v0::Parameter>(element::f32, Shape{1, 2, 1});
+    auto move1 = std::make_shared<ov::snippets::op::BroadcastMove>(ref_data1, ov::Dimension{3});
+    auto add_ref = std::make_shared<ov::op::v1::Add>(ref_data0, move1);
+    auto model = std::make_shared<Model>(OutputVector{add_ref}, ParameterVector{ref_data0, ref_data1});
+
+    return model;
+}
+
+}  // namespace snippets
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - Extract `movebroadcast` and `codegen_gelu` test subgraphs to the common snippets subgraphs location
 - Unify these tests with snippets tests infra to resolve corresponding "todo" remarks

### Tickets:
 - N/A
