### PR TITLE
[Protopipe] Add ModelHelper utilities for model preparation, tensor naming, and output clamping

### DIFF
--- a/src/plugins/intel_npu/tools/protopipe/main.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/main.cpp
@@ -17,6 +17,7 @@
 
 #include "utils/error.hpp"
 #include "utils/logger.hpp"
+#include "utils/model.hpp"
 #include "version.hpp"
 
 static constexpr char help_message[] = "Optional. Print the usage message.";
@@ -259,15 +260,19 @@ int main(int argc, char* argv[]) {
                 std::cout << "stream " << task.name() << ": " << task.result().str() << std::endl;
             }
             std::cout << "\n";
+
+            utils::cleanupTempFiles();
         }
         if (any_scenario_failed) {
             return EXIT_FAILURE;
         }
     } catch (const std::exception& e) {
         std::cout << e.what() << std::endl;
+        utils::cleanupTempFiles();
         throw;
     } catch (...) {
         std::cout << "Unknown error" << std::endl;
+        utils::cleanupTempFiles();
         throw;
     }
     return 0;

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -371,6 +371,10 @@ struct convert<OpenVINOParams> {
             params.config.emplace("MODEL_PRIORITY", toPriority(node["priority"].as<std::string>()));
         }
 
+        if (node["clamp_outputs"]) {
+            params.clamp_outputs = node["clamp_outputs"].as<bool>();
+        }
+
         if (node["nireq"]) {
             params.nireq = node["nireq"].as<size_t>();
         }

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
@@ -94,6 +94,7 @@ struct OpenVINOParams {
     LayerVariantAttr<std::vector<size_t>> reshape;
     std::map<std::string, std::string> config;
     size_t nireq = 1u;
+    bool clamp_outputs = false;
 };
 
 struct ONNXRTParams {

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/ov_layers_reader.cpp
@@ -9,6 +9,7 @@
 #include <openvino/openvino.hpp>
 
 #include "utils/error.hpp"
+#include "utils/model.hpp"
 
 #include <fstream>
 
@@ -137,19 +138,11 @@ static void cfgReshape(const std::shared_ptr<ov::Model>& model,
     model->reshape(partial_shapes);
 }
 
-static std::string make_default_tensor_name(const ov::Output<const ov::Node>& output) {
-    auto default_name = output.get_node()->get_friendly_name();
-    if (output.get_node()->get_output_size() > 1) {
-        default_name += ':' + std::to_string(output.get_index());
-    }
-    return default_name;
-}
-
 static std::vector<std::string> extractLayerNames(ov::OutputVector& outputs) {
     std::vector<std::string> names;
     std::transform(outputs.begin(), outputs.end(), std::back_inserter(names), [](auto& node) {
         if (node.get_names().empty()) {
-            node.set_names({make_default_tensor_name(node)});
+            node.set_names({utils::make_default_tensor_name(node)});
         }
         return node.get_any_name();
     });

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -16,8 +16,9 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
     using P = cv::gapi::ov::Params<cv::gapi::Generic>;
     std::unique_ptr<P> network;
     if (std::holds_alternative<OpenVINOParams::ModelPath>(params.path)) {
-        const auto& model_path = utils::ensureNamedModel(std::get<OpenVINOParams::ModelPath>(params.path));
-        network = std::make_unique<P>(tag, model_path.model, model_path.bin, params.device);
+        utils::ModelHelper modelHelper{params};
+        modelHelper.prepareModel();
+        network = std::make_unique<P>(tag, modelHelper.getXmlPath(), modelHelper.getBinPath(), params.device);
     } else {
         GAPI_Assert(std::holds_alternative<OpenVINOParams::BlobPath>(params.path));
         const auto& blob_path = std::get<OpenVINOParams::BlobPath>(params.path);

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -7,6 +7,7 @@
 
 #include "scenario/inference.hpp"
 #include "utils/error.hpp"
+#include "utils/model.hpp"
 
 #include <opencv2/gapi/infer/onnx.hpp>  // onnx::Params
 #include <opencv2/gapi/infer/ov.hpp>    // ov::Params
@@ -15,7 +16,7 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
     using P = cv::gapi::ov::Params<cv::gapi::Generic>;
     std::unique_ptr<P> network;
     if (std::holds_alternative<OpenVINOParams::ModelPath>(params.path)) {
-        const auto& model_path = std::get<OpenVINOParams::ModelPath>(params.path);
+        const auto& model_path = utils::ensureNamedModel(std::get<OpenVINOParams::ModelPath>(params.path));
         network = std::make_unique<P>(tag, model_path.model, model_path.bin, params.device);
     } else {
         GAPI_Assert(std::holds_alternative<OpenVINOParams::BlobPath>(params.path));

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.cpp
@@ -1,4 +1,5 @@
 #include "utils/model.hpp"
+#include "utils/error.hpp"
 
 #include <filesystem>
 #include <fstream>
@@ -6,46 +7,93 @@
 
 namespace utils {
 
-std::string make_default_tensor_name(const ov::Output<const ov::Node>& output) {
-    auto default_name = output.get_node()->get_friendly_name();
-    if (output.get_node()->get_output_size() > 1) {
-        default_name += ':' + std::to_string(output.get_index());
+std::vector<std::filesystem::path> ModelHelper::s_tempFiles;
+
+ModelHelper::ModelHelper(const OpenVINOParams& params) : m_params(params) {
+    ov::Core core;
+    if (std::holds_alternative<OpenVINOParams::ModelPath>(m_params.path)) {
+        const auto& model_path = std::get<OpenVINOParams::ModelPath>(m_params.path);
+        m_model = core.read_model(model_path.model, model_path.bin);
+        m_xmlPath = model_path.model;
+        m_binPath = model_path.bin;
+    } else {
+        THROW_ERROR("Unsupported path type for OpenVINO model.");
     }
-    return default_name;
 }
 
-OpenVINOParams::ModelPath ensureNamedModel(const OpenVINOParams::ModelPath& modelPath) {
-    ov::Core core;
-    auto model = core.read_model(modelPath.model, modelPath.bin);
+void ModelHelper::cleanupAllTempFiles() {
+    for (const auto& path : s_tempFiles) {
+        if (std::filesystem::exists(path)) {
+            std::filesystem::remove(path);
+        }
+    }
+    s_tempFiles.clear();
+}
+
+void ModelHelper::prepareModel() {
     bool need_save = false;
-    for (auto& input : model->inputs()) {
+    need_save = ensureNamedTensors() || need_save;
+
+    if (need_save) {
+        saveTempModel();
+    }
+}
+
+bool ModelHelper::ensureNamedTensors() {
+    bool need_save = false;
+    for (auto& input : m_model->inputs()) {
         if (input.get_names().empty()) {
             need_save = true;
             input.set_names({make_default_tensor_name(input)});
         }
     }
-    for (auto& output : model->outputs()) {
+    for (auto& output : m_model->outputs()) {
         if (output.get_names().empty()) {
             need_save = true;
             output.set_names({make_default_tensor_name(output)});
         }
     }
 
-    if (!need_save) {
-        return modelPath;
-    }
+    return need_save;
+}
 
-    std::filesystem::path tmp_xml = std::filesystem::temp_directory_path() / ("named_" + std::filesystem::path(modelPath.model).filename().string());
+bool ModelHelper::saveTempModel() {
+    std::filesystem::path tmp_xml = std::filesystem::temp_directory_path() / ("tmp_" + m_xmlPath.filename().string());
     std::filesystem::path tmp_bin = tmp_xml;
     tmp_bin.replace_extension(".bin");
 
-    ov::pass::Serialize(tmp_xml.string(), "").run_on_model(model);
+    ov::pass::Serialize(tmp_xml.string(), "").run_on_model(m_model);
 
     if (std::filesystem::exists(tmp_bin)) {
         std::filesystem::remove(tmp_bin);
     }
+    if (std::filesystem::exists(tmp_xml)) {
+        m_xmlPath = tmp_xml;
+        s_tempFiles.push_back(tmp_xml);
 
-    return OpenVINOParams::ModelPath{tmp_xml.string(), modelPath.bin};
+        return true;
+    }
+    return false;
+}
+
+const std::string ModelHelper::getXmlPath() const {
+    return m_xmlPath.string();
+}
+
+const std::string ModelHelper::getBinPath() const {
+    return m_binPath.string();
+}
+
+void cleanupTempFiles() {
+    ModelHelper::cleanupAllTempFiles();
+}
+
+std::string make_default_tensor_name(const ov::Output<const ov::Node>& output) {
+    auto default_name = output.get_node()->get_friendly_name();
+    if (output.get_node()->get_output_size() > 1) {
+        default_name += ':' + std::to_string(output.get_index());
+    }
+    return default_name;
 }
 
 } // namespace utils

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.cpp
@@ -1,0 +1,51 @@
+#include "utils/model.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace utils {
+
+std::string make_default_tensor_name(const ov::Output<const ov::Node>& output) {
+    auto default_name = output.get_node()->get_friendly_name();
+    if (output.get_node()->get_output_size() > 1) {
+        default_name += ':' + std::to_string(output.get_index());
+    }
+    return default_name;
+}
+
+OpenVINOParams::ModelPath ensureNamedModel(const OpenVINOParams::ModelPath& modelPath) {
+    ov::Core core;
+    auto model = core.read_model(modelPath.model, modelPath.bin);
+    bool need_save = false;
+    for (auto& input : model->inputs()) {
+        if (input.get_names().empty()) {
+            need_save = true;
+            input.set_names({make_default_tensor_name(input)});
+        }
+    }
+    for (auto& output : model->outputs()) {
+        if (output.get_names().empty()) {
+            need_save = true;
+            output.set_names({make_default_tensor_name(output)});
+        }
+    }
+
+    if (!need_save) {
+        return modelPath;
+    }
+
+    std::filesystem::path tmp_xml = std::filesystem::temp_directory_path() / ("named_" + std::filesystem::path(modelPath.model).filename().string());
+    std::filesystem::path tmp_bin = tmp_xml;
+    tmp_bin.replace_extension(".bin");
+
+    ov::pass::Serialize(tmp_xml.string(), "").run_on_model(model);
+
+    if (std::filesystem::exists(tmp_bin)) {
+        std::filesystem::remove(tmp_bin);
+    }
+
+    return OpenVINOParams::ModelPath{tmp_xml.string(), modelPath.bin};
+}
+
+} // namespace utils

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
@@ -1,3 +1,7 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #pragma once
 
 #include <vector>

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
@@ -1,15 +1,44 @@
 #pragma once
 
 #include <string>
-#include <openvino/openvino.hpp>
+#include <vector>
 
+#include <openvino/openvino.hpp>
 #include "scenario/inference.hpp"
 
 namespace utils {
 
-// Loads a model, ensures all IO tensors are named, and saves to a temp file if needed.
-OpenVINOParams::ModelPath ensureNamedModel(const OpenVINOParams::ModelPath& modelPath);
-
 std::string make_default_tensor_name(const ov::Output<const ov::Node>& output);
+
+void cleanupTempFiles();
+
+class ModelHelper {
+public:
+    ModelHelper(const OpenVINOParams& params);
+    ~ModelHelper() = default;
+
+    static void cleanupAllTempFiles();
+
+    void prepareModel();
+
+    const std::string getXmlPath() const;
+    const std::string getBinPath() const;
+
+private:
+    bool ensureNamedTensors();
+    bool saveTempModel();
+    bool deleteTempModel();
+
+private:
+    std::shared_ptr<ov::Model> m_model;
+    const OpenVINOParams& m_params;
+
+    std::filesystem::path m_xmlPath;
+    std::filesystem::path m_binPath;
+
+    static std::vector<std::filesystem::path> s_tempFiles;
+
+    bool m_tempModelSaved = false;
+};
 
 } // namespace utils

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <openvino/openvino.hpp>
+
+#include "scenario/inference.hpp"
+
+namespace utils {
+
+// Loads a model, ensures all IO tensors are named, and saves to a temp file if needed.
+OpenVINOParams::ModelPath ensureNamedModel(const OpenVINOParams::ModelPath& modelPath);
+
+std::string make_default_tensor_name(const ov::Output<const ov::Node>& output);
+
+} // namespace utils

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string>
 #include <vector>
+#include <string>
 
 #include <openvino/openvino.hpp>
 #include "scenario/inference.hpp"
@@ -26,8 +26,9 @@ public:
 
 private:
     bool ensureNamedTensors();
+    void clampOutputs();
+
     bool saveTempModel();
-    bool deleteTempModel();
 
 private:
     std::shared_ptr<ov::Model> m_model;

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
@@ -30,7 +30,7 @@ public:
 
 private:
     bool ensureNamedTensors();
-    void clampOutputs();
+    bool clampOutputs();
 
     bool saveTempModel();
 

--- a/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/utils/model.hpp
@@ -38,8 +38,6 @@ private:
     std::filesystem::path m_binPath;
 
     static std::vector<std::filesystem::path> s_tempFiles;
-
-    bool m_tempModelSaved = false;
 };
 
 } // namespace utils

--- a/src/plugins/intel_npu/tools/protopipe/version.hpp.in
+++ b/src/plugins/intel_npu/tools/protopipe/version.hpp.in
@@ -1,3 +1,3 @@
 #pragma once
 
-#define APP_VERSION   "v1.0.0-@GIT_SHA@"
+#define APP_VERSION   "v1.0.1-@GIT_SHA@"


### PR DESCRIPTION
### Details:
 - *Introduced ModelHelper class for managing OpenVINO model preparation steps before passing the model to G-API.*
 - *Added automatic naming for input and output tensors if names are missing.*
 - *Implemented output clamping based on configured output precision for all model outputs. Clamping can be enabled by setting `clamp_outputs: true` in the model parameters.*
 - *Provided utility functions for temporary model saving and cleanup. The temporary model needs to be saved because the paths to the XML and BIN files are passed to G-API. However, all temporary files created are deleted after Protopipe execution.*

### Tickets:
 - *EISW-170440*
 - *EISW-168451*
