### PR TITLE
[GPU] Handle runtime scale value with scalar attention mask and scale input for SDPA

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
@@ -131,6 +131,14 @@ inline uint FUNC(get_bt_index_value)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uin
 #if TARGET_SEQ_LEN_BLOCK_SIZE == 1
 /* This version is used for 2nd token */
 
+#if HAS_SCALE_INPUT
+#if HAS_ATTN_MASK_INPUT
+#define SCALE_TYPE INPUT4_TYPE
+#else
+#define SCALE_TYPE INPUT3_TYPE
+#endif
+#endif
+
 REQD_SUB_GROUP_SIZE(SUBGROUP_SIZE)
 __attribute__((reqd_work_group_size(1, 1, V_HEAD_SIZE * SG_SCALE_FACTOR)))
 KERNEL(sdpa_opt)(
@@ -142,7 +150,7 @@ KERNEL(sdpa_opt)(
     const __global INPUT3_TYPE* attn_mask,
 #endif
 #if HAS_SCALE_INPUT
-    const __global INPUT4_TYPE* scale,
+    const __global SCALE_TYPE* scale,
 #endif
     __global OUTPUT_TYPE* output,
 #if IS_KV_COMPRESSED
@@ -725,7 +733,11 @@ KERNEL(sdpa_opt)(
 
 #if HAS_SCALE_INPUT
     #define ATTN_SCALE_BUFFER , scale
+#if HAS_ATTN_MASK_INPUT
     #define ATTN_SCALE_BUFFER_ARG , const __global INPUT4_TYPE* scale
+#else
+    #define ATTN_SCALE_BUFFER_ARG , const __global INPUT3_TYPE* scale
+#endif
 #else
     #define ATTN_SCALE_BUFFER
     #define ATTN_SCALE_BUFFER_ARG
@@ -821,10 +833,17 @@ inline MASK_VECTOR_TYPE FUNC(load_attn_mask)(OPTIONAL_SHAPE_INFO_ARG
 }
 
 #if IS_PAGED_ATTENTION && HAS_ALIBI
-#if HAS_SCALE_INPUT
+#if HAS_SCALE_INPUT && HAS_ATTN_MASK_INPUT
 #define ALIBI_TYPE INPUT5_TYPE
 #else
 #define ALIBI_TYPE INPUT4_TYPE
+#endif
+#endif
+#if HAS_SCALE_INPUT
+#if HAS_ATTN_MASK_INPUT
+#define SCALE_TYPE INPUT4_TYPE
+#else
+#define SCALE_TYPE INPUT3_TYPE
 #endif
 #endif
 
@@ -841,7 +860,7 @@ KERNEL(sdpa_opt)(
     const __global INPUT3_TYPE* attn_mask,
 #endif
 #if HAS_SCALE_INPUT
-    const __global INPUT4_TYPE* scale,
+    const __global SCALE_TYPE* scale,
 #endif
 #if IS_PAGED_ATTENTION && HAS_ALIBI
     const __global ALIBI_TYPE* alibi_slopes,

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl
@@ -128,9 +128,6 @@ inline uint FUNC(get_bt_index_value)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uin
 
 #ifdef SDPA_STAGE_0
 
-#if TARGET_SEQ_LEN_BLOCK_SIZE == 1
-/* This version is used for 2nd token */
-
 #if HAS_SCALE_INPUT
 #if HAS_ATTN_MASK_INPUT
 #define SCALE_TYPE INPUT4_TYPE
@@ -138,6 +135,9 @@ inline uint FUNC(get_bt_index_value)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uin
 #define SCALE_TYPE INPUT3_TYPE
 #endif
 #endif
+
+#if TARGET_SEQ_LEN_BLOCK_SIZE == 1
+/* This version is used for 2nd token */
 
 REQD_SUB_GROUP_SIZE(SUBGROUP_SIZE)
 __attribute__((reqd_work_group_size(1, 1, V_HEAD_SIZE * SG_SCALE_FACTOR)))
@@ -733,11 +733,7 @@ KERNEL(sdpa_opt)(
 
 #if HAS_SCALE_INPUT
     #define ATTN_SCALE_BUFFER , scale
-#if HAS_ATTN_MASK_INPUT
-    #define ATTN_SCALE_BUFFER_ARG , const __global INPUT4_TYPE* scale
-#else
-    #define ATTN_SCALE_BUFFER_ARG , const __global INPUT3_TYPE* scale
-#endif
+    #define ATTN_SCALE_BUFFER_ARG , const __global SCALE_TYPE* scale
 #else
     #define ATTN_SCALE_BUFFER
     #define ATTN_SCALE_BUFFER_ARG
@@ -837,13 +833,6 @@ inline MASK_VECTOR_TYPE FUNC(load_attn_mask)(OPTIONAL_SHAPE_INFO_ARG
 #define ALIBI_TYPE INPUT5_TYPE
 #else
 #define ALIBI_TYPE INPUT4_TYPE
-#endif
-#endif
-#if HAS_SCALE_INPUT
-#if HAS_ATTN_MASK_INPUT
-#define SCALE_TYPE INPUT4_TYPE
-#else
-#define SCALE_TYPE INPUT3_TYPE
 #endif
 #endif
 

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_ref.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_ref.cl
@@ -121,6 +121,13 @@ inline uint FUNC(get_bt_index_value)(OPTIONAL_SHAPE_INFO_ARG uint b, uint f, uin
     #define GET_COMPRESSION_INDEX(INPUT, b, f, y, x) GET_DATA_INDEX(INPUT, (b), (0), (y), (0));
 #endif
 #endif
+#if HAS_SCALE_INPUT
+#if HAS_ATTN_MASK_INPUT
+#define SCALE_TYPE INPUT4_TYPE
+#else
+#define SCALE_TYPE INPUT3_TYPE
+#endif
+#endif
 
 KERNEL(sdpa_ref)(
     OPTIONAL_SHAPE_INFO_ARG
@@ -131,7 +138,7 @@ KERNEL(sdpa_ref)(
     const __global INPUT3_TYPE* attn_mask,
 #endif
 #if HAS_SCALE_INPUT
-    const __global INPUT4_TYPE* scale,
+    const __global SCALE_TYPE* scale,
 #endif
     __global OUTPUT_TYPE* output,
 #if IS_KV_COMPRESSED

--- a/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp
+++ b/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp
@@ -24,6 +24,7 @@ typedef std::tuple<ov::element::Type,                // netPrecision
                    std::vector<InputShape>,          // shape
                    bool,                             // is_causal
                    bool,                             // has_attn
+                   bool,                             // is_attn_const
                    bool,                             // has_scale
                    bool,                             // is_scale_const
                    std::vector<std::vector<int64_t>> // input_transpose
@@ -40,6 +41,7 @@ protected:
     void transpose_prepare(std::vector<InputShape>& shapes, const std::vector<std::vector<int64_t>>& input_transpose);
     bool is_causal;
     bool has_attn;
+    bool is_attn_const;
     bool has_scale;
     bool is_scale_const;
 };
@@ -50,10 +52,11 @@ std::string ScaledAttnLayerGPUTest::getTestCaseName(const testing::TestParamInfo
     std::vector<std::vector<int64_t>> input_transpose;
     bool is_causal;
     bool has_attn;
+    bool is_attn_const;
     bool has_scale;
     bool is_scale_const;
     bool transpose_enable;
-    std::tie(inType, inputShapes, is_causal, has_attn, has_scale, is_scale_const, input_transpose) = obj.param;
+    std::tie(inType, inputShapes, is_causal, has_attn, is_attn_const, has_scale, is_scale_const, input_transpose) = obj.param;
 
     transpose_enable = (input_transpose.size() != 0);
     std::ostringstream result;
@@ -71,6 +74,7 @@ std::string ScaledAttnLayerGPUTest::getTestCaseName(const testing::TestParamInfo
     }
     result << "is_causal=" << is_causal << "_";
     result << "has_attn=" << has_attn << "_";
+    result << "is_attn_const=" << is_attn_const << "_";
     result << "has_scale=" << has_scale << "_";
     result << "is_scale_const=" << is_scale_const << "_";
     result << "with_transpose" << transpose_enable << "_";
@@ -85,7 +89,7 @@ void ScaledAttnLayerGPUTest::SetUp() {
 
     targetDevice = ov::test::utils::DEVICE_GPU;
 
-    std::tie(inType, inputShapes, is_causal, has_attn, has_scale, is_scale_const, input_transpose) = this->GetParam();
+    std::tie(inType, inputShapes, is_causal, has_attn, is_attn_const, has_scale, is_scale_const, input_transpose) = this->GetParam();
 
     transpose_prepare(inputShapes, input_transpose);
     init_input_shapes(inputShapes);
@@ -98,25 +102,45 @@ void ScaledAttnLayerGPUTest::SetUp() {
     inputParams[0]->set_friendly_name("q");
     inputParams[1]->set_friendly_name("k");
     inputParams[2]->set_friendly_name("v");
-    if (has_attn || has_scale) {
-        inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(
-            inType, has_attn ? inputDynamicShapes[3] : ov::PartialShape{}));
+    if (!has_attn && has_scale) {
+        inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, ov::PartialShape{}));
         inputParams.back()->set_friendly_name("attention_mask");
-    }
-    if (has_scale && !is_scale_const) {
-        inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, ov::PartialShape{1}));
-        inputParams.back()->set_friendly_name("scale");
+        if (!is_scale_const) {
+            inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, ov::PartialShape{1}));
+            inputParams.back()->set_friendly_name("scale");
+        }
+    } else {
+        if (has_attn && !is_attn_const) {
+            inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[3]));
+            inputParams.back()->set_friendly_name("attention_mask");
+            if (has_scale && !is_scale_const) {
+                inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(inType, ov::PartialShape{1}));
+                inputParams.back()->set_friendly_name("scale");
+            }
+        }
     }
 
     ov::OutputVector inputParams_transpose;
     for (size_t i = 0; i < inputParams.size(); i++) {
         inputParams_transpose.push_back(inputParams[i]);
     }
+    if (has_attn && is_attn_const) {
+        auto attn_const = std::make_shared<ov::op::v0::Constant>(inType, ov::Shape{}, 0.0f);
+        attn_const->set_friendly_name("attention_mask");
+        inputParams_transpose.push_back(attn_const);
+        if (has_scale && !is_scale_const) {
+            auto scale_param = std::make_shared<ov::op::v0::Parameter>(inType, ov::PartialShape{1});
+            scale_param->set_friendly_name("scale");
+            inputParams.push_back(scale_param);
+            inputParams_transpose.push_back(scale_param);
+        }
+    }
     if (has_scale && is_scale_const) {
         auto scale_const = std::make_shared<ov::op::v0::Constant>(inType, ov::Shape({1}), 0.35f);
         scale_const->set_friendly_name("scale");
         inputParams_transpose.push_back(scale_const);
     }
+
     if (input_transpose.size() != 0) {
         auto rank = input_transpose[0].size();
         // deal with transpose.
@@ -238,7 +262,7 @@ void ScaledAttnLayerGPUTest::generate_inputs(const std::vector<ov::Shape>& targe
         }
     } else {
         int idx = 3;
-        if (has_attn) {
+        if (has_attn && !is_attn_const) {
             shapes.push_back(targetInputStaticShapes[3]);
             ov::Tensor attn_tensor = ov::test::utils::create_and_fill_tensor(ov::element::f16, shapes[idx], attn_data);
             inputs.insert({model_inputs[idx++].get_node_shared_ptr(), attn_tensor});
@@ -257,9 +281,10 @@ TEST_P(ScaledAttnLayerGPUTest, CompareWithRefs) {
     std::vector<std::vector<int64_t>> input_transpose;
     bool is_causal;
     bool has_attn;
+    bool is_attn_const;
     bool has_scale;
     bool is_scale_const;
-    std::tie(inType, inputShapes, is_causal, has_attn, has_scale, is_scale_const, input_transpose) = this->GetParam();
+    std::tie(inType, inputShapes, is_causal, has_attn, is_attn_const, has_scale, is_scale_const, input_transpose) = this->GetParam();
     run();
 }
 
@@ -290,6 +315,7 @@ const auto dynamic_shape_params_3D = testing::Combine(testing::Values(ov::elemen
                                                       testing::ValuesIn(dynamic_shapes_3D),
                                                       testing::Values(false),
                                                       testing::Values(true, false),
+                                                      testing::Values(false),
                                                       testing::Values(true, false),
                                                       testing::Values(false),
                                                       testing::ValuesIn({disable_transpose, transpose_all_3D}));
@@ -535,6 +561,7 @@ const auto dynamic_shape_params_4D = testing::Combine(testing::Values(ov::elemen
                                                    testing::Values(true, false),
                                                    testing::Values(true, false),
                                                    testing::Values(true, false),
+                                                   testing::Values(true, false),
                                                    testing::ValuesIn({disable_transpose, transpose_value}));
 
 INSTANTIATE_TEST_SUITE_P(smoke_ScaledAttnDynamic4D_GPU,
@@ -622,6 +649,7 @@ const auto static_shape_params = testing::Combine(testing::Values(ov::element::f
                                                   testing::ValuesIn(static_shapes),
                                                   testing::Values(true, false),
                                                   testing::Values(true, false),
+                                                  testing::Values(false),
                                                   testing::Values(true, false),
                                                   testing::Values(false),
                                                   testing::ValuesIn({disable_transpose, transpose_all_4D}));


### PR DESCRIPTION
### Details:
 - After this PR(https://github.com/openvinotoolkit/openvino/pull/31159) is applied, SDPA block of cross attention for Whisper decoder is fused. Accordingly, attention mask input is added as scalar value, but there is an issue that SDPA kernel does not properly handle the input argument index when the scale has input
 - Fix to handle runtime scale value with scalar attention mask and scale input for SDPA
 
#### The code and line that caused this issue (if it is not changed directly)
 - [sdpa_opt.cl#L145](https://github.com/openvinotoolkit/openvino/blob/81b12888af9ca39b18e1a13dca49428f9437acfd/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl#L145)
 - [sdpa_opt.cl#L728](https://github.com/openvinotoolkit/openvino/blob/81b12888af9ca39b18e1a13dca49428f9437acfd/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl#L728)
 - [sdpa_opt.cl#L844](https://github.com/openvinotoolkit/openvino/blob/81b12888af9ca39b18e1a13dca49428f9437acfd/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/sdpa_opt.cl#L844)
 ```
[GPU] ProgramBuilder build failed!
Program build failed(0_part_0):
1:3265:17: error: unknown type name 'INPUT4_TYPE'
 const __global INPUT4_TYPE* scale,
                ^
1:3402:10: warning: 'KEY_BLOCK_SIZE' macro redefined
....
1:7199:2: error: unknown type name 'INPUT4_TYPE'
 ATTN_SCALE_BUFFER_ARG
 ^
1:7184:49: note: expanded from macro 'ATTN_SCALE_BUFFER_ARG'
....
1:7287:17: error: unknown type name 'INPUT4_TYPE'
 const __global INPUT4_TYPE* scale,
                ^
1:7613:10: warning: 'KEY_BLOCK_READ' macro redefined
....
```

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - pytest test_ovc_mo.py --modules pipelines/production/onnx/pytorch_converted/heavy -k ONNX_WhisperDecoder --dynamism_type=None
 - ./benchmark_app -m /home/andrew/work/openvino/frameworks.ai.openvino.tests/e2e_oss/out_dir/ONNX_WhisperDecoder_api_2_True_batch_1_device_GPU_precision_FP16/model.xml -d GPU -hint none -niter 1 -nireq 1 -data_shape tokens[5,1],in_v_5a[5,51,512],in_v_4a[5,51,512],in_v_3a[5,51,512],in_v_2a[5,51,512],in_v_1a[5,51,512],in_v_0a[5,51,512],in_k_5a[5,51,512],in_k_4a[5,51,512],in_k_3a[5,51,512],in_k_2a[5,51,512],in_k_1a[5,51,512],in_k_0a[5,51,512],audio_features[5,1500,512]

#### Problematic graph
 - ![image](https://github.com/user-attachments/assets/7291f963-40d9-45fe-a171-2dca95fbf230)

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?
[smoke_ScaledAttnDynamic4D_GPU](https://github.com/openvinotoolkit/openvino/blob/master/src/plugins/intel_gpu/tests/functional/single_layer_tests/dynamic/scaled_dot_product_attention.cpp)

### Tickets:
 - 170070
