### PR TITLE
[GPU] Add shape changed flag for subgraph input changed case

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -378,7 +378,9 @@ void primitive_inst::update_shape() {
                 break;
             }
         }
-        if (!subgraph_input_changed) {
+        if (subgraph_input_changed) {
+            set_flag(ExecutionFlags::SHAPE_CHANGED);
+        } else {
             GPU_DEBUG_TRACE_DETAIL << id() << ": skip shape_update, because it is in shape_of_subgraph and input shape is not changed\n";
             unset_flag(ExecutionFlags::SHAPE_CHANGED);
             return;


### PR DESCRIPTION
### Description of the issue
 - symptom: ScatterNDUpdate ocl_v2 in some models returns wrong output results.
 - root-cause: cldnn::ExecutionFlags::SHAPE_CHANGED is not set. As the result, the work group size is not set and uses default global{1,1,1}, local{1,1,1}.
 - how resolved: In case scatterNDUpdate node has is_in_shape_of_subgraph true, SHAPE_CHANGED flag is needed for subgraph input changed

#### The code and line that caused this issue
 - openvino/src/plugins/intel_gpu/src/graph/impls/ocl_v2/primitive_ocl_base.hpp
 - The functions, update_stages_flags() and execute_stage(), decides whether it executes update_dispatch_data_func which set work group sizes.

#### Reproduction step and snapshot
 - $ ./benchmark_app -d GPU -m "/nfs/inn/proj/vdp/vdp_tests/models/internal/tf/1.15.2/faster_rcnn_resnet50_lowproposals_coco/faster_rcnn_resnet50_lowproposals_coco.pb" -i "/path/to/input_bin_data_file/created/from/e2e" -shape "[2,-1,-1,3]" -data_shape "[2,600,600,3]" -layout "[NCHW]"

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? : reviewed unittests with "*scatter_nd_update_gpu*", but failed to find similar case.

### Tickets:
 - *169447*