### PR TITLE
[TRANSFORMATIONS] Rewrite RoPEFusionIOSlicing using new Symbolic approach

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -439,9 +439,9 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
     auto x = NewGenSlice(data, 0, "ndims", 1, 3);
     auto y = NewGenSlice(data, "ndims", int32_max, 1, 3);
     auto x_emb = pattern::wrap_type<op::internal::RoPE>(
-        {x | varsplit->output(0), pattern::wrap_const(), pattern::wrap_const()}) |
-    pattern::wrap_type<op::internal::RoPE>(
-        {x | varsplit->output(0), pattern::wrap_const(), pattern::wrap_const(), pattern::wrap_const()});
+            {x | varsplit->output(0), pattern::any_input(), pattern::any_input()}) |
+        pattern::wrap_type<op::internal::RoPE>(
+            {x | varsplit->output(0), pattern::any_input(), pattern::any_input(), pattern::any_input()});
     auto result = pattern::wrap_type<opset1::Concat>({x_emb, y | varsplit->output(1)}, {{"axis", -1}});
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -438,8 +438,8 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
 
     auto x = NewGenSlice(data, 0, "ndims", 1, 3);
     auto y = NewGenSlice(data, "ndims", int32_max, 1, 3);
-    auto x_emb = pattern::wrap_type<op::internal::RoPE>(
-            {x | varsplit->output(0), pattern::any_input(), pattern::any_input()}) |
+    auto x_emb =
+        pattern::wrap_type<op::internal::RoPE>({x | varsplit->output(0), pattern::any_input(), pattern::any_input()}) |
         pattern::wrap_type<op::internal::RoPE>(
             {x | varsplit->output(0), pattern::any_input(), pattern::any_input(), pattern::any_input()});
     auto result = pattern::wrap_type<opset1::Concat>({x_emb, y | varsplit->output(1)}, {{"axis", -1}});

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -462,7 +462,6 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
             return false;
 
         // remove slice & concat
-        // rope_node->set_argument(0, pattern_map.at(data));
         rope_node->input(0).replace_source_output(pattern_map.at(data));
         rope_node->set_friendly_name(root->get_friendly_name());
         ov::copy_runtime_info({rope_node, pattern_map.at(result).get_node_shared_ptr()}, rope_node);

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -438,8 +438,10 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
 
     auto x = NewGenSlice(data, 0, "ndims", 1, 3);
     auto y = NewGenSlice(data, "ndims", int32_max, 1, 3);
-    auto x_emb = pattern::wrap_type<op::internal::RoPE>({x | varsplit->output(0), pattern::wrap_const(), pattern::wrap_const()}) |
-                 pattern::wrap_type<op::internal::RoPE>({x | varsplit->output(0), pattern::wrap_const(), pattern::wrap_const(), pattern::wrap_const()});
+    auto x_emb = pattern::wrap_type<op::internal::RoPE>(
+        {x | varsplit->output(0), pattern::wrap_const(), pattern::wrap_const()}) |
+    pattern::wrap_type<op::internal::RoPE>(
+        {x | varsplit->output(0), pattern::wrap_const(), pattern::wrap_const(), pattern::wrap_const()});
     auto result = pattern::wrap_type<opset1::Concat>({x_emb, y | varsplit->output(1)}, {{"axis", -1}});
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
@@ -452,7 +454,7 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
 
         auto symbols = m.get_symbols();
         auto ndims = symbols["ndims"];
-        if (!ndims.is_static() && !ndims.is_integer())
+        if (!ndims.is_static() || !ndims.is_integer())
             return false;
 
         const auto& config = rope_node->get_config();

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -433,7 +433,7 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
     MATCHER_SCOPE(RoPEFusionIOSlicing);
     auto int32_max = std::numeric_limits<std::int32_t>::max();
     auto data = pattern::any_input(pattern::rank_equals(4));
-    auto varsplit = pattern::wrap_type<opset1::VariadicSplit>({data, 3, {"ndims", "?"}});
+    auto varsplit = pattern::wrap_type<op::v1::VariadicSplit>({data, 3, {"ndims", "?"}});
     varsplit->set_output_size(2);
 
     auto x = NewGenSlice(data, 0, "ndims", 1, 3);

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -442,7 +442,7 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
         pattern::wrap_type<op::internal::RoPE>({x | varsplit->output(0), pattern::any_input(), pattern::any_input()}) |
         pattern::wrap_type<op::internal::RoPE>(
             {x | varsplit->output(0), pattern::any_input(), pattern::any_input(), pattern::any_input()});
-    auto result = pattern::wrap_type<opset1::Concat>({x_emb, y | varsplit->output(1)}, {{"axis", -1}});
+    auto result = pattern::wrap_type<op::v0::Concat>({x_emb, y | varsplit->output(1)}, {{"axis", -1}});
 
     matcher_pass_callback callback = [OV_CAPTURE_CPY_AND_THIS](ov::pass::pattern::Matcher& m) {
         const auto& pattern_map = m.get_pattern_value_map();


### PR DESCRIPTION
Details:
Rewrite the RoPEFusionIOSlicing transformation using new Symbolic approach allowing for greater flexibility and more convenient pattern design.

Tickets:

CVS-170021
Signed-off-by: Andrii Staikov [andrii.staikov@intel.com](mailto:andrii.staikov@intel.com)