### PR TITLE
[`intel_npu`] [`ENV`] [`CONFIGS`] Support case sensitive `YES/NO`, 'TRUE/FALSE`, `0/1` boolean values for env vars of configs

### DIFF
--- a/src/plugins/intel_npu/src/al/src/config/config.cpp
+++ b/src/plugins/intel_npu/src/al/src/config/config.cpp
@@ -33,9 +33,13 @@ void splitAndApply(const std::string& str, char delim, std::function<void(std::s
 //
 
 bool OptionParser<bool>::parse(std::string_view val) {
-    if (val == "YES") {
+    std::string strVal(val);
+    std::transform(strVal.begin(), strVal.end(), strVal.begin(), [](char c) {
+        return std::toupper(c);
+    });
+    if (strVal == "YES" || strVal == "TRUE" || strVal == "1") {
         return true;
-    } else if (val == "NO") {
+    } else if (strVal == "NO" || strVal == "FALSE" || strVal == "0") {
         return false;
     }
 


### PR DESCRIPTION
…values for npu plugin config env vars

### Details:
 - *Currently, NPU plugin forces user to explicitly set `YES/NO` for boolean values of env vars from configs. By this PR, possible supported values will be more flexible and intuitive*

### Tickets:
 - *ticket-id*
