### PR TITLE
[GHA] Switch cleanup_caches to medium runners & Ubuntu 24 base image

### DIFF
--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   Cleanup_PIP:
     name: Cleanup PIP cache
-    runs-on: aks-linux-small
+    runs-on: aks-linux-medium
     if: ${{ github.repository_owner == 'openvinotoolkit' }}
     container:
       image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
@@ -64,7 +64,7 @@ jobs:
 
   Cleanup_ccache_lin:
     name: Cleanup Linux ccache
-    runs-on: aks-linux-small
+    runs-on: aks-linux-medium
     if: ${{ github.repository_owner == 'openvinotoolkit' }}
     container:
       image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04

--- a/.github/workflows/cleanup_caches.yml
+++ b/.github/workflows/cleanup_caches.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: aks-linux-medium
     if: ${{ github.repository_owner == 'openvinotoolkit' }}
     container:
-      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
+      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:24.04
       volumes:
         - /mount:/mount
     env:
@@ -40,7 +40,7 @@ jobs:
     runs-on: aks-linux-4-cores-16gb
     if: ${{ github.repository_owner == 'openvinotoolkit' }}
     container:
-      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
+      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:24.04
       volumes:
         - /mount:/mount
     env:
@@ -67,7 +67,7 @@ jobs:
     runs-on: aks-linux-medium
     if: ${{ github.repository_owner == 'openvinotoolkit' }}
     container:
-      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:20.04
+      image: openvinogithubactions.azurecr.io/dockerhub/ubuntu:24.04
       volumes:
         - /mount:/mount
     env:


### PR DESCRIPTION
Small runner doesn't have docker installed; while cleanup workflows use it.