### PR TITLE
[PyOV][GHA] Change stubgen runner to Azure

### DIFF
--- a/.github/workflows/update_pyapi_stubs.yml
+++ b/.github/workflows/update_pyapi_stubs.yml
@@ -12,6 +12,18 @@ on:
 jobs:
   update-stubs:
     runs-on: aks-linux-medium
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    container:
+      image: 'openvinogithubactions.azurecr.io/openvino_provider:0.1.0'
+      volumes:
+        - /mount:/mount
+        - ${{ github.workspace }}:${{ github.workspace }}
+    outputs:
+      ov_wheel_source: ${{ steps.openvino_download.outputs.ov_wheel_source }}
+      ov_version: ${{ steps.openvino_download.outputs.ov_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/update_pyapi_stubs.yml
+++ b/.github/workflows/update_pyapi_stubs.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   update-stubs:
-    runs-on: ubuntu-latest
+    runs-on: aks-linux-medium
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2


### PR DESCRIPTION
### Details:
 - Testing the `openvino_provider` util in fork is not possible, PRs to master are needed
 - The current implementation fails with `FileNotFoundError: [Errno 2] No such file or directory: '/mount/.../master/commit/latest_public_linux_ubuntu_22_04_x86_64_release.txt'`
 - This PR closely matches the usage of `openvino_provider` to example given in https://github.com/openvinotoolkit/openvino/blob/master/docs/dev/ci/github_actions/openvino_provider.md

### Tickets:
 - N/A
