### PR TITLE
[PyOV] Automatic stub update - remove Setup Python step

### DIFF
--- a/.github/workflows/update_pyapi_stubs.yml
+++ b/.github/workflows/update_pyapi_stubs.yml
@@ -27,11 +27,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-
-      - name: Set up Python
-        uses: actions/setup-python@0ae58361cdfd39e2950bed97a1e26aa20c3d8955  # v4
-        with:
-          python-version: '3.10'
           
       - name: Get latest OpenVINO artifacts
         id: openvino_download


### PR DESCRIPTION
### Details:
 - This job has been just introduced and can't be tested on forks, I need to make master PRs
 - Setup Python task does not seem to work with Azure hosted Linux
 - It throws `Error: The version '3.10' with architecture 'x64' was not found for this operating system.`
 - Python 3.10 for Linux is clearly in the versions manifest: [raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)
 - Let's try relying on the `openvino_provider` container Python version

### Tickets:
 - N/A
