### PR TITLE
[TRANSFORMATIONS] Rewrite RoPEFusionCosSinPreprocess using new Symbolic approach

### DIFF
--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -350,10 +350,8 @@ ov::pass::RoPEFusionGPTNEOX::RoPEFusionGPTNEOX() {
 ov::pass::RoPEFusionCosSinPreprocess::RoPEFusionCosSinPreprocess() {
     MATCHER_SCOPE(RoPEFusionCosSinPreprocess);
 
-    auto cos_const =
-        pattern::wrap_type<v0::Constant>(pattern::type_matches(element::f32));
-    auto sin_const =
-        pattern::wrap_type<v0::Constant>(pattern::type_matches(element::f32));
+    auto cos_const = pattern::wrap_type<v0::Constant>(pattern::type_matches(element::f32));
+    auto sin_const = pattern::wrap_type<v0::Constant>(pattern::type_matches(element::f32));
 
     auto node_batch_size = pattern::any_input(pattern::type_matches(element::i32) && pattern::shape_matches("[1]"));
     auto tile_batch = pattern::any_input(pattern::type_matches(element::i32) && pattern::shape_matches("[1]"));
@@ -384,7 +382,7 @@ ov::pass::RoPEFusionCosSinPreprocess::RoPEFusionCosSinPreprocess() {
                                            {{"batch_dims", 0}});
 
         auto unsqueeze = pattern::wrap_type<v1::Reshape>({index_Gather | index_Gather2, pattern::any_input()},
-                                                        pattern::shape_matches("[1, 1, ?, head_dims]"));
+                                                         pattern::shape_matches("[1, 1, ?, head_dims]"));
         auto unsqueeze2 = pattern::wrap_type<v0::Unsqueeze>({index_Gather2, 1});
 
         return unsqueeze2 | unsqueeze;


### PR DESCRIPTION
Details:
Rewrite the RoPEFusionCosSinPreprocess transformation using new Symbolic approach allowing for greater flexibility and more convenient pattern design.

Tickets:

[CVS-170019](https://jira.devtools.intel.com/browse/CVS-170019)

Signed-off-by: Andrii Staikov [andrii.staikov@intel.com](mailto:andrii.staikov@intel.com)