### PR TITLE
[CPU] Apply 'readability-const-return-type' clang-tidy remarks

### DIFF
--- a/src/common/snippets/.clang-tidy
+++ b/src/common/snippets/.clang-tidy
@@ -45,7 +45,6 @@
 # -misc-header-include-cycle,
 # -misc-non-private-member-variables-in-classes,
 # -misc-use-anonymous-namespace,
-# -readability-const-return-type
 # -readability-function-cognitive-complexity. Reasonable way to enforce splitting complex code into simple functions
 # -readability-isolate-declaration
 # -readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers
@@ -103,7 +102,6 @@ Checks: >
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-use-anonymous-namespace,
-  -readability-const-return-type,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-isolate-declaration,

--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -45,7 +45,6 @@
 # -misc-header-include-cycle,
 # -misc-non-private-member-variables-in-classes,
 # -misc-use-anonymous-namespace,
-# -readability-const-return-type
 # -readability-function-cognitive-complexity. Reasonable way to enforce splitting complex code into simple functions
 # -readability-isolate-declaration
 # -readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers
@@ -103,7 +102,6 @@ Checks: >
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-use-anonymous-namespace,
-  -readability-const-return-type,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-isolate-declaration,

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -736,7 +736,7 @@ public:
                                        NameFromType(getType()));
         return false;
     }
-    const bool keepOrigPrecision() const {
+    bool keepOrigPrecision() const {
         return keepOriginalPrecision;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/def_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/def_conv.cpp
@@ -153,10 +153,10 @@ private:
     Vmm get_vmm_acc(int idx) {
         return Vmm(idx + jcp_.ur_w + 1);
     }
-    Ymm get_ymm_acc(int idx) {
+    Xbyak::Ymm get_ymm_acc(int idx) {
         return Ymm(idx + jcp_.ur_w + 1);
     }
-    Xmm get_xmm_acc(int idx) {
+    Xbyak::Xmm get_xmm_acc(int idx) {
         return Xmm(idx + jcp_.ur_w + 1);
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_convolution_primitive.hpp
@@ -70,19 +70,19 @@ public:
 
     void execute(dnnl_primitive_args& primArgs);
 
-    [[nodiscard]] const DnnlMemoryDescPtr srcDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr srcDesc() const {
         return m_srcDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr dstDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr dstDesc() const {
         return m_dstDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr weightsDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr weightsDesc() const {
         return m_weiDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr scratchPadDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr scratchPadDesc() const {
         return m_scratchPadDesc;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_fullyconnected_primitive.hpp
@@ -41,19 +41,19 @@ public:
 
     void execute(const dnnl_primitive_args& primArgs) const;
 
-    [[nodiscard]] const DnnlMemoryDescPtr srcDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr srcDesc() const {
         return m_srcDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr dstDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr dstDesc() const {
         return m_dstDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr weightsDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr weightsDesc() const {
         return m_weiDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr scratchPadDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr scratchPadDesc() const {
         return m_scratchPadDesc;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/dnnl/dnnl_matmul_primitive.hpp
@@ -39,19 +39,19 @@ public:
 
     void execute(const dnnl_primitive_args& primArgs) const;
 
-    [[nodiscard]] const DnnlMemoryDescPtr srcDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr srcDesc() const {
         return m_srcDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr dstDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr dstDesc() const {
         return m_dstDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr weightsDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr weightsDesc() const {
         return m_weiDesc;
     }
 
-    [[nodiscard]] const DnnlMemoryDescPtr scratchPadDesc() const {
+    [[nodiscard]] DnnlMemoryDescPtr scratchPadDesc() const {
         return m_scratchPadDesc;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor.hpp
@@ -76,7 +76,7 @@ public:
         return implPriorities;
     }
 
-    [[nodiscard]] const WeightsSharing::Ptr getWeightsCache() const {
+    [[nodiscard]] WeightsSharing::Ptr getWeightsCache() const {
         return weightsCache;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/executor_implementation.hpp
@@ -110,11 +110,11 @@ public:
         return m_name;
     }
 
-    [[nodiscard]] const ExecutorType type() const {
+    [[nodiscard]] ExecutorType type() const {
         return m_type;
     }
 
-    [[nodiscard]] const OperationType operationType() const {
+    [[nodiscard]] OperationType operationType() const {
         return m_operationType;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/eye.h
+++ b/src/plugins/intel_cpu/src/nodes/eye.h
@@ -49,7 +49,7 @@ private:
     void executeSpecified();
     template <typename T>
     struct EyeExecute;
-    const size_t getRowNum() const {
+    size_t getRowNum() const {
         auto rowMem = getSrcMemoryAtPort(ROWS_NUM);
         if (rowMem == nullptr) {
             THROW_CPU_NODE_ERR("doesn't contain row_count data");
@@ -58,7 +58,7 @@ private:
 
         return rowPtr[0];
     }
-    const size_t getColNum() const {
+    size_t getColNum() const {
         auto colMem = getSrcMemoryAtPort(COLS_NUM);
         if (colMem == nullptr) {
             THROW_CPU_NODE_ERR("doesn't contain col_count data");
@@ -67,7 +67,7 @@ private:
 
         return colPtr[0];
     }
-    const int getDiagIndex() const {
+    int getDiagIndex() const {
         auto diagIndMem = getSrcMemoryAtPort(DIAGONAL_INDEX);
         if (diagIndMem == nullptr) {
             THROW_CPU_NODE_ERR("doesn't contain diag_index data");
@@ -76,7 +76,7 @@ private:
 
         return diagIndexPtr[0];
     }
-    const std::vector<int> getBatchShape() const {
+    std::vector<int> getBatchShape() const {
         if (withBatchShape) {
             const auto batchShapeSize =
                 static_cast<const int>(getSrcMemoryAtPort(BATCH_SHAPE)->getShape().getElementsCount());
@@ -88,7 +88,7 @@ private:
         return std::vector<int>{};
     }
 
-    static const size_t getBatchVolume(const std::vector<int>& batchShape) {
+    static size_t getBatchVolume(const std::vector<int>& batchShape) {
         return std::accumulate(begin(batchShape), end(batchShape), 1, std::multiplies<>());
     }
     bool withBatchShape = false;

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.h
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.h
@@ -136,7 +136,7 @@ public:
     const std::vector<float>& getOutputShift() const {
         return outputShift;
     }
-    const size_t getLevels() const {
+    size_t getLevels() const {
         return levels;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/brgemm_kernel.hpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/brgemm_kernel.hpp
@@ -40,13 +40,13 @@ public:
     [[nodiscard]] size_t get_scratch_a_size() const;
     // bytes needed to place scratch buffer b
     [[nodiscard]] size_t get_scratch_b_size() const;
-    [[nodiscard]] static const size_t get_mblk_size() {
+    [[nodiscard]] static size_t get_mblk_size() {
         return matmulOptimalM;
     }
-    [[nodiscard]] const size_t get_k_blk() const {
+    [[nodiscard]] size_t get_k_blk() const {
         return K_blk;
     }
-    [[nodiscard]] static const size_t get_wsp_size() {
+    [[nodiscard]] static size_t get_wsp_size() {
         return 4 * 1024;
     }
 

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.h
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.h
@@ -55,7 +55,7 @@ public:
 
     void assignState(const std::shared_ptr<VariableStateKVcache>& state, int idx);
 
-    const std::vector<size_t> getKVCacheOrder() const {
+    std::vector<size_t> getKVCacheOrder() const {
         const auto& permute_axes = m_config.config.permute_axes;
         std::vector<size_t> real_order = m_kvstate_layout;
         if (!permute_axes.empty()) {

--- a/src/plugins/intel_cpu/src/utils/ngraph_utils.hpp
+++ b/src/plugins/intel_cpu/src/utils/ngraph_utils.hpp
@@ -38,7 +38,7 @@ inline std::string getImplPriorityValue(const std::shared_ptr<ov::Node>& node) {
 }
 
 template <typename T>
-inline const std::shared_ptr<T> getNgraphOpAs(const std::shared_ptr<ov::Node>& op) {
+inline std::shared_ptr<T> getNgraphOpAs(const std::shared_ptr<ov::Node>& op) {
     auto typedOp = ov::as_type_ptr<T>(op);
     if (!typedOp) {
         OPENVINO_THROW("Can't get ngraph node ", op->get_type_name(), " with name ", op->get_friendly_name());


### PR DESCRIPTION
### Details:
 - Fix "readability-const-return-type" remarks reported by clang-tidy
 - Enable "readability-const-return-type" clang-tidy checks on CI by default

### Tickets:
 - N/A
