### PR TITLE
[CPU] Apply 'bugprone-narrowing-conversions' and 'cppcoreguidelines-narrowing-conversions' clang-tidy remarks

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -30,14 +30,12 @@
 # -readability-uppercase-literal-suffix. 
 #
 ### Checks that are turned off but better be enabled later:
-# -bugprone-narrowing-conversions
 # -bugprone-easily-swappable-parameters
 # -bugprone-exception-escape. There are a lot of legacy code which does not handle exceptions properly and just catches them all. Major refactoring is required to correct this.
 # -bugprone-implicit-widening-of-multiplication-result
 # -bugprone-incorrect-roundings. There are explicit ways to perform rounding (i.e. std::floor(), std::round(), etc). Requires careful updates case by case
 # -bugprone-signed-char-misuse. The source code contains valid logic when pointer to the data is interpreted as int8_t (i.e. weights tensor)
 # -cppcoreguidelines-avoid-const-or-ref-data-members
-# -cppcoreguidelines-narrowing-conversions
 # -google-default-arguments,
 # -google-explicit-constructor,
 # -google-readability-casting,
@@ -66,7 +64,6 @@ Checks: >
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-incorrect-roundings,
-  -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
@@ -75,7 +72,6 @@ Checks: >
   -cppcoreguidelines-explicit-virtual-functions,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-misleading-capture-default-by-value,
-  -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
@@ -113,6 +109,10 @@ WarningsAsErrors: '*'
 FormatStyle: file
 HeaderFilterRegex: 'src/plugins/intel_cpu/src/.*\.h(pp)?$'
 CheckOptions:
+  - key: bugprone-narrowing-conversions.IgnoreConversionFromTypes
+    value: "size_t;ptrdiff_t;size_type;difference_type;value_type;uint32_t;uint64_t;unsigned long;unsigned int;ov::intel_cpu::Dim"
+  - key: cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes
+    value: "size_t;ptrdiff_t;size_type;difference_type;value_type;uint32_t;uint64_t;unsigned long;unsigned int;ov::intel_cpu::Dim"
   - key: cppcoreguidelines-avoid-do-while.IgnoreMacros
     value: true
   # use = instead of {} for initialization

--- a/src/plugins/intel_cpu/src/dnnl_postops_composer_legacy.cpp
+++ b/src/plugins/intel_cpu/src/dnnl_postops_composer_legacy.cpp
@@ -128,7 +128,7 @@ bool DnnlPostOpsComposerLegacy::appendScale(const std::vector<float>& scale, boo
     bool fuseIntoWeiScale = false;
     // Use dest scale when last post-ops is per-tensor quantization.
     if ((isINT8 && isLastPostOp && scale.size() == 1)) {
-        dst_scale_val = 1.0 / scale[0];
+        dst_scale_val = 1.0F / scale[0];
         updateDestScales();
         return true;
     }

--- a/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_ext_emitters.hpp
+++ b/src/plugins/intel_cpu/src/emitters/plugin/x64/jit_dnnl_ext_emitters.hpp
@@ -77,7 +77,7 @@ public:
                     ov::element::Type exec_prc = ov::element::f32)
         : jit_dnnl_emitter(host, host_isa, n, exec_prc) {
         kind = dnnl_eltwise_elu;
-        alpha = ov::as_type_ptr<ov::op::v0::Elu>(n)->get_alpha();
+        alpha = static_cast<float>(ov::as_type_ptr<ov::op::v0::Elu>(n)->get_alpha());
         beta = 0.f;
 
         set_injector();
@@ -108,8 +108,8 @@ public:
         : jit_dnnl_emitter(host, host_isa, n, exec_prc) {
         kind = dnnl_eltwise_clip;
         auto op = ov::as_type_ptr<ov::op::v0::Clamp>(n);
-        alpha = op->get_min();
-        beta = op->get_max();
+        alpha = static_cast<float>(op->get_min());
+        beta = static_cast<float>(op->get_max());
 
         set_injector();
     }

--- a/src/plugins/intel_cpu/src/graph_dumper.cpp
+++ b/src/plugins/intel_cpu/src/graph_dumper.cpp
@@ -308,7 +308,7 @@ void summary_perf(const Graph& graph) {
     double total_avg = 0;
     uint64_t total = 0;
     for (const auto& node : graph.GetNodes()) {  // important: graph.graphNodes are in topological order
-        double avg = node->PerfCounter().avg();
+        auto avg = node->PerfCounter().avg();
         auto type = node->getTypeStr() + "_" + node->getPrimitiveDescriptorType();
 
         total += node->PerfCounter().count() * avg;
@@ -420,7 +420,7 @@ void average_counters(const Graph& graph) {
     uint64_t total = 0;
 
     auto toMs = [](uint64_t value) {
-        return std::chrono::microseconds(value).count() / 1000.0;
+        return static_cast<double>(std::chrono::microseconds(value).count()) / 1000.0;
     };
 
     auto printAverageCounter = [&toMs, &file](const NodePtr& node) {

--- a/src/plugins/intel_cpu/src/memory_control.cpp
+++ b/src/plugins/intel_cpu/src/memory_control.cpp
@@ -228,7 +228,7 @@ private:
         m_workspace = std::make_shared<MemoryBlockWithRelease>();
 
         for (const auto& box : boxes_to_process) {
-            int64_t offset = staticMemSolver.get_offset(box.id);
+            int64_t offset = staticMemSolver.get_offset(static_cast<int>(box.id));
             auto memoryBlock = std::make_shared<StaticPartitionMemoryBlock>(m_workspace, offset * alignment);
             m_blocks[box.id] = std::move(memoryBlock);
         }

--- a/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.cpp
+++ b/src/plugins/intel_cpu/src/memory_desc/blocked_memory_desc.cpp
@@ -64,9 +64,9 @@ std::string BlockedMemoryDesc::serializeFormat() const {
     }
 
     for (size_t i = 0; i < shape.getRank(); ++i) {
-        char nextLetter = startLetter + order[i];
+        auto nextLetter = static_cast<char>(startLetter + order[i]);
         if (blockedAxis.count(i)) {
-            nextLetter = toupper(nextLetter);
+            nextLetter = static_cast<char>(toupper(nextLetter));
         }
         result << nextLetter;
     }

--- a/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
+++ b/src/plugins/intel_cpu/src/nodes/bin_conv.cpp
@@ -1406,9 +1406,9 @@ void BinaryConvolution::executeReference(const uint8_t* src,
                 const int i_bottom_overflow = nstl::max(IH, (oh * KSH + (KH - 1) * (KDH + 1) - padT + 1)) - IH;
                 const int kh_padding = KH - div_up(i_top_overflow, (KDH + 1)) - div_up(i_bottom_overflow, (KDH + 1));
 
-                return IC * kh_padding * kw_padding;
+                return static_cast<float>(IC * kh_padding * kw_padding);
             }
-            return IC * KH * KW;
+            return static_cast<float>(IC * KH * KW);
         }();
 
         float a_fp = base_value - static_cast<float>(2 * a);

--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -875,7 +875,7 @@ struct ConvertFrom4BitContext {
 }
 
 [[maybe_unused]] static int8_t get_u4(const uint8_t& val, bool high) {
-    return high ? (val >> 4) : (val & 0xF);
+    return static_cast<int8_t>(high ? (val >> 4) : (val & 0xF));
 }
 
 template <typename T>

--- a/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_greedy_decoder.cpp
@@ -169,12 +169,12 @@ void CTCGreedyDecoder::execute([[maybe_unused]] const dnnl::stream& strm) {
     parallel_nt(0, threadBody);
 
     parallel_for(B, [&](size_t b) {
-        int prevClassIdx = -1;
+        float prevClassIdx = -1.0f;
         size_t outputIndex = b * T;
         const size_t sequenceLength = sequenceLengths[b];
         float* shiftedOut = outputSequences + b * T;
         for (size_t t = 0; t < sequenceLength; ++t) {
-            if (*shiftedOut < blankIndex && (!mergeRepeated || *shiftedOut != prevClassIdx)) {
+            if (*shiftedOut < static_cast<float>(blankIndex) && (!mergeRepeated || *shiftedOut != prevClassIdx)) {
                 outputSequences[outputIndex++] = *shiftedOut;
             }
             prevClassIdx = *shiftedOut;

--- a/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/src/nodes/ctc_loss.cpp
@@ -226,7 +226,7 @@ void CTCLoss::execute([[maybe_unused]] const dnnl::stream& strm) {
                     expSum += std::exp(logits[btcT + c]);
                 }
                 for (size_t s = 0LU; s < decodedTargetLen; s++) {
-                    logProbabilities[t][s] = logits[btcT + targetD[s]] - std::log(expSum);
+                    logProbabilities[t][s] = static_cast<float>(logits[btcT + targetD[s]] - std::log(expSum));
                 }
                 btcT += classesNum;
                 if (++workCounter >= end) {

--- a/src/plugins/intel_cpu/src/nodes/detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/detection_output.cpp
@@ -778,10 +778,10 @@ inline void DetectionOutput::decodeBBoxes(const float* priorData,
         float locYMax = locData[4 * p * locNumForClasses + 3];
 
         if (!normalized) {
-            priorXMin /= imgWidth;
-            priorYMin /= imgHeight;
-            priorXMax /= imgWidth;
-            priorYMax /= imgHeight;
+            priorXMin /= static_cast<float>(imgWidth);
+            priorYMin /= static_cast<float>(imgHeight);
+            priorXMax /= static_cast<float>(imgWidth);
+            priorYMax /= static_cast<float>(imgHeight);
         }
 
         if (codeType == CodeType::CORNER) {

--- a/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
+++ b/src/plugins/intel_cpu/src/nodes/executors/interpolate.cpp
@@ -116,15 +116,15 @@ float ov::intel_cpu::InterpolateExecutor::coordTransToInput(int outCoord,
                                                             int inShape,
                                                             int outShape) const {
     if (scale == 1.0F || (inShape == outShape)) {
-        return outCoord;
+        return static_cast<float>(outCoord);
     }
     switch (interpAttrs.coordTransMode) {
     case InterpolateCoordTransMode::half_pixel: {
-        return (outCoord + 0.5F) / scale - 0.5F;
+        return (static_cast<float>(outCoord) + 0.5F) / scale - 0.5F;
     }
     case InterpolateCoordTransMode::pytorch_half_pixel: {
         if (outShape > 1) {
-            return (outCoord + 0.5F) / scale - 0.5F;
+            return (static_cast<float>(outCoord) + 0.5F) / scale - 0.5F;
         }
         return 0;
     }
@@ -132,11 +132,11 @@ float ov::intel_cpu::InterpolateExecutor::coordTransToInput(int outCoord,
         return static_cast<float>(outCoord) / scale;
     }
     case InterpolateCoordTransMode::tf_half_pixel_for_nn: {
-        return (outCoord + 0.5F) / scale;
+        return (static_cast<float>(outCoord) + 0.5F) / scale;
     }
     case InterpolateCoordTransMode::align_corners: {
         if (outShape > 1) {
-            return outCoord * (static_cast<float>(inShape - 1) / static_cast<float>(outShape - 1));
+            return static_cast<float>(outCoord) * (static_cast<float>(inShape - 1) / static_cast<float>(outShape - 1));
         }
         return 0;
     }
@@ -152,7 +152,7 @@ int ov::intel_cpu::InterpolateExecutor::nearestRound(float originCoord,
                                                      InterpolateNearestMode nearestMode) {
     switch (nearestMode) {
     case InterpolateNearestMode::round_prefer_floor: {
-        if (originCoord == (static_cast<int>(originCoord) + 0.5F)) {
+        if (originCoord == (static_cast<float>(static_cast<int>(originCoord)) + 0.5F)) {
             return static_cast<int>(std::floor(originCoord));
         }
         return static_cast<int>(std::round(originCoord));
@@ -192,8 +192,8 @@ void ov::intel_cpu::InterpolateExecutor::linearOnnxCF(int outCoord,
     index0 = std::min(static_cast<int>(inCoord), inShape - 1);
     index1 = std::min(index0 + 1, inShape - 1);
 
-    weight1 = std::fabs(inCoord - index0);
-    weight0 = std::fabs(inCoord - index1);
+    weight1 = std::fabs(inCoord - static_cast<float>(index0));
+    weight0 = std::fabs(inCoord - static_cast<float>(index1));
     if (index0 == index1) {
         weight0 = 0.5F;
         weight1 = 0.5F;
@@ -383,7 +383,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                 if (r < 0 || r >= static_cast<int>(ID)) {
                     weightOD[oz * diaOD + i] = 0.F;
                 } else {
-                    float dz = iz - r;
+                    float dz = iz - static_cast<float>(r);
                     weightOD[oz * diaOD + i] = az * triangleCoeff(az * dz);
                 }
             }
@@ -396,7 +396,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                 if (r < 0 || r >= static_cast<int>(IH)) {
                     weightOH[oy * diaOH + i] = 0.F;
                 } else {
-                    float dy = iy - r;
+                    float dy = iy - static_cast<float>(r);
                     weightOH[oy * diaOH + i] = ay * triangleCoeff(ay * dy);
                 }
             }
@@ -409,7 +409,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblLinear(const VectorDims& srcDim
                 if (r < 0 || r >= static_cast<int>(IW)) {
                     weightOW[ox * diaOW + i] = 0.F;
                 } else {
-                    float dx = ix - r;
+                    float dx = ix - static_cast<float>(r);
                     weightOW[ox * diaOW + i] = ax * triangleCoeff(ax * dx);
                 }
             }
@@ -421,10 +421,10 @@ std::vector<float> ov::intel_cpu::InterpolateExecutor::getCubicCoeffs(float mant
     float m = std::fabs(mantissa);
     std::vector<float> coeffs(4, 0.F);
 
-    coeffs[0] = a * (m - 1.0) * (m - 1.0) * m;
-    coeffs[1] = ((a + 2.0) * m - (a + 3.0)) * m * m + 1.0;
-    coeffs[2] = (((-a - 2.0) * m + (2.0 * a + 3.0)) * m - a) * m;
-    coeffs[3] = -a * m * m * (m - 1.0);
+    coeffs[0] = a * (m - 1.0f) * (m - 1.0f) * m;
+    coeffs[1] = ((a + 2.0f) * m - (a + 3.0f)) * m * m + 1.0f;
+    coeffs[2] = (((-a - 2.0f) * m + (2.0f * a + 3.0f)) * m - a) * m;
+    coeffs[3] = -a * m * m * (m - 1.0f);
     return coeffs;
 }
 
@@ -462,7 +462,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
         float ix = coordTransToInput(ox, fx, IW, OW);
         auto ix_r = static_cast<int>(std::floor(ix));
         xOrigin[ox] = ix_r;
-        float m = ix - ix_r;
+        float m = ix - static_cast<float>(ix_r);
         std::vector<float> coffes = getCubicCoeffs(m, cubicCoeff);
         xFactor[CUBIC_GRID_LEN * ox] = coffes[0];
         xFactor[CUBIC_GRID_LEN * ox + 1] = coffes[1];
@@ -478,7 +478,7 @@ void ov::intel_cpu::InterpolateExecutor::buildTblCubic(const VectorDims& srcDimP
         float iy = coordTransToInput(oy, fy, IH, OH);
         auto iy_r = static_cast<int>(std::floor(iy));
         yOrigin[oy] = iy_r;
-        float m = iy - iy_r;
+        float m = iy - static_cast<float>(iy_r);
         std::vector<float> coffes = getCubicCoeffs(m, cubicCoeff);
         yFactor[CUBIC_GRID_LEN * oy] = coffes[0];
         yFactor[CUBIC_GRID_LEN * oy + 1] = coffes[1];

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.cpp
@@ -315,8 +315,8 @@ void ExperimentalDetectronDetectionOutput::execute([[maybe_unused]] const dnnl::
     std::vector<float> refined_boxes(classes_num_ * rois_num * 4, 0);
     std::vector<float> refined_scores(classes_num_ * rois_num, 0);
     std::vector<float> refined_boxes_areas(classes_num_ * rois_num, 0);
-    Indexer refined_box_idx({classes_num_, rois_num, 4});
-    Indexer refined_score_idx({classes_num_, rois_num});
+    Indexer refined_box_idx({static_cast<int>(classes_num_), rois_num, 4});
+    Indexer refined_score_idx({static_cast<int>(classes_num_), rois_num});
 
     refine_boxes(boxes,
                  deltas,
@@ -326,7 +326,7 @@ void ExperimentalDetectronDetectionOutput::execute([[maybe_unused]] const dnnl::
                  refined_boxes_areas.data(),
                  refined_scores.data(),
                  rois_num,
-                 classes_num_,
+                 static_cast<int>(classes_num_),
                  max_delta_log_wh_,
                  1.0F);
 
@@ -345,7 +345,7 @@ void ExperimentalDetectronDetectionOutput::execute([[maybe_unused]] const dnnl::
                detections_per_class[class_idx],
                rois_num,
                -1,
-               max_detections_per_class_,
+               static_cast<int>(max_detections_per_class_),
                score_threshold_,
                nms_threshold_);
         total_detections_num += detections_per_class[class_idx];

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_detection_output.h
@@ -42,8 +42,8 @@ private:
     float score_threshold_;
     float nms_threshold_;
     float max_delta_log_wh_;
-    int classes_num_;
-    int max_detections_per_class_;
+    int64_t classes_num_;
+    int64_t max_detections_per_class_;
     int max_detections_per_image_;
     bool class_agnostic_box_regression_;
     std::vector<float> deltas_weights_;

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_generate_proposals_single_image.cpp
@@ -116,7 +116,8 @@ void refine_anchors(const float* deltas,
             proposals[p_idx + 1] = y0;
             proposals[p_idx + 2] = x1;
             proposals[p_idx + 3] = y1;
-            proposals[p_idx + 4] = static_cast<int>(min_box_W <= box_w) * static_cast<int>(min_box_H <= box_h) * score;
+            proposals[p_idx + 4] =
+                static_cast<float>(min_box_W <= box_w) * static_cast<float>(min_box_H <= box_h) * score;
         }
     });
 }
@@ -325,8 +326,8 @@ ExperimentalDetectronGenerateProposalsSingleImage::ExperimentalDetectronGenerate
 
     min_size_ = proposalAttrs.min_size;
     nms_thresh_ = proposalAttrs.nms_threshold;
-    pre_nms_topn_ = proposalAttrs.pre_nms_count;
-    post_nms_topn_ = proposalAttrs.post_nms_count;
+    pre_nms_topn_ = static_cast<int>(proposalAttrs.pre_nms_count);
+    post_nms_topn_ = static_cast<int>(proposalAttrs.post_nms_count);
 
     coordinates_offset = 0.0F;
 

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.cpp
@@ -76,14 +76,14 @@ void ExperimentalDetectronPriorGridGenerator::execute([[maybe_unused]] const dnn
     // Execute
     const int layer_width = grid_w_ ? grid_w_ : getParentEdgeAt(INPUT_FEATUREMAP)->getMemory().getStaticDims()[3];
     const int layer_height = grid_h_ ? grid_h_ : getParentEdgeAt(INPUT_FEATUREMAP)->getMemory().getStaticDims()[2];
-    const float step_w =
-        (stride_w_ != 0.0F)
-            ? stride_w_
-            : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[3]) / layer_width;
-    const float step_h =
-        (stride_h_ != 0.0F)
-            ? stride_h_
-            : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[2]) / layer_height;
+    const float step_w = (stride_w_ != 0.0F)
+                             ? stride_w_
+                             : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[3]) /
+                                   static_cast<float>(layer_width);
+    const float step_h = (stride_h_ != 0.0F)
+                             ? stride_h_
+                             : static_cast<float>(getParentEdgeAt(INPUT_IMAGE)->getMemory().getStaticDims()[2]) /
+                                   static_cast<float>(layer_height);
 
     const auto* bottom_data_0 = getSrcDataAtPortAs<const float>(0);
     auto* top_data_0 = getDstDataAtPortAs<float>(OUTPUT_ROIS);
@@ -91,10 +91,10 @@ void ExperimentalDetectronPriorGridGenerator::execute([[maybe_unused]] const dnn
     for (int h = 0; h < layer_height; ++h) {
         for (int w = 0; w < layer_width; ++w) {
             for (int s = 0; s < num_priors_; ++s) {
-                top_data_0[0] = bottom_data_0[4 * s + 0] + step_w * (w + 0.5F);
-                top_data_0[1] = bottom_data_0[4 * s + 1] + step_h * (h + 0.5F);
-                top_data_0[2] = bottom_data_0[4 * s + 2] + step_w * (w + 0.5F);
-                top_data_0[3] = bottom_data_0[4 * s + 3] + step_h * (h + 0.5F);
+                top_data_0[0] = bottom_data_0[4 * s + 0] + step_w * (static_cast<float>(w) + 0.5F);
+                top_data_0[1] = bottom_data_0[4 * s + 1] + step_h * (static_cast<float>(h) + 0.5F);
+                top_data_0[2] = bottom_data_0[4 * s + 2] + step_w * (static_cast<float>(w) + 0.5F);
+                top_data_0[3] = bottom_data_0[4 * s + 3] + step_h * (static_cast<float>(h) + 0.5F);
                 top_data_0 += 4;
             }
         }

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.h
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_priorgridgenerator.h
@@ -43,8 +43,8 @@ private:
 
     const int OUTPUT_ROIS{0};
 
-    int grid_w_;
-    int grid_h_;
+    int64_t grid_w_;
+    int64_t grid_h_;
     float stride_w_;
     float stride_h_;
 };

--- a/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
+++ b/src/plugins/intel_cpu/src/nodes/experimental_detectron_roifeatureextractor.cpp
@@ -63,10 +63,12 @@ void pre_calc_for_bilinear_interpolate(const int height,
         for (int pw = 0; pw < pooled_width; pw++) {
             for (int iy = 0; iy < iy_upper; iy++) {
                 const T yy = roi_start_h + ph * bin_size_h +
-                             static_cast<T>(iy + .5f) * bin_size_h / static_cast<T>(roi_bin_grid_h);  // e.g., 0.5, 1.5
+                             static_cast<T>(static_cast<T>(iy) + static_cast<T>(.5f)) * bin_size_h /
+                                 static_cast<T>(roi_bin_grid_h);  // e.g., 0.5, 1.5
                 for (int ix = 0; ix < ix_upper; ix++) {
                     const T xx = roi_start_w + pw * bin_size_w +
-                                 static_cast<T>(ix + .5f) * bin_size_w / static_cast<T>(roi_bin_grid_w);
+                                 static_cast<T>(static_cast<T>(ix) + static_cast<T>(.5f)) * bin_size_w /
+                                     static_cast<T>(roi_bin_grid_w);
 
                     T x = xx;
                     T y = yy;
@@ -302,9 +304,9 @@ ExperimentalDetectronROIFeatureExtractor::ExperimentalDetectronROIFeatureExtract
 
     const auto roiFeatureExtractor = ov::as_type_ptr<const ov::op::v6::ExperimentalDetectronROIFeatureExtractor>(op);
     const auto& attr = roiFeatureExtractor->get_attrs();
-    output_dim_ = attr.output_size;
+    output_dim_ = static_cast<int>(attr.output_size);
     pyramid_scales_ = attr.pyramid_scales;
-    sampling_ratio_ = attr.sampling_ratio;
+    sampling_ratio_ = static_cast<int>(attr.sampling_ratio);
     aligned_ = attr.aligned;
     pooled_height_ = output_dim_;
     pooled_width_ = output_dim_;

--- a/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/src/nodes/extract_image_patches.cpp
@@ -518,14 +518,27 @@ void ExtractImagePatches::ExtractImagePatchesRefExecutor::executeReference(void*
     parallel_for4d(OB, jpp.KH, jpp.KW, IC, [&](const size_t ob, const size_t kh, const size_t kw, const size_t ic) {
         const int64_t iw_start = static_cast<int64_t>(kw * RW) - PL;
         const int64_t ih_start = static_cast<int64_t>(kh * RH) - PT;
-        const size_t ih_lpad = ih_start >= 0 ? 0 : std::ceil(-1.F * ih_start / jpp.SH);
-        const size_t iw_lpad = iw_start >= 0 ? 0 : std::ceil(-1.F * iw_start / jpp.SW);
+        const size_t ih_lpad =
+            ih_start >= 0
+                ? 0
+                : static_cast<size_t>(std::ceil(-1.F * static_cast<float>(ih_start) / static_cast<float>(jpp.SH)));
+        const size_t iw_lpad =
+            iw_start >= 0
+                ? 0
+                : static_cast<size_t>(std::ceil(-1.F * static_cast<float>(iw_start) / static_cast<float>(jpp.SW)));
 
         const size_t ih_hpad =
-            std::ceil((IH - 1.F * ih_start) / jpp.SH) > jpp.OH ? jpp.OH : std::ceil((IH + -1.F * ih_start) / jpp.SH);
-        const size_t iw_hpad = std::ceil((jpp.IW - 1.F * iw_start) / jpp.SW) > jpp.OW
-                                   ? jpp.OW
-                                   : std::ceil((jpp.IW - 1.F * iw_start) / jpp.SW);
+            static_cast<size_t>(std::ceil((static_cast<float>(IH) - 1.F * static_cast<float>(ih_start)) /
+                                          static_cast<float>(jpp.SH))) > jpp.OH
+                ? jpp.OH
+                : static_cast<size_t>(std::ceil((static_cast<float>(IH) + -1.F * static_cast<float>(ih_start)) /
+                                                static_cast<float>(jpp.SH)));
+        const size_t iw_hpad =
+            static_cast<size_t>(std::ceil((static_cast<float>(jpp.IW) - 1.F * static_cast<float>(iw_start)) /
+                                          static_cast<float>(jpp.SW))) > jpp.OW
+                ? jpp.OW
+                : static_cast<size_t>(std::ceil((static_cast<float>(jpp.IW) - 1.F * static_cast<float>(iw_start)) /
+                                                static_cast<float>(jpp.SW)));
 
         char* my_dst_ptr = dst_data + (ob * ostrides_partial[0] + kh * ostrides_partial[1] + kw * ostrides_partial[2] +
                                        ic * ostrides_partial[3]) *
@@ -578,13 +591,26 @@ void ExtractImagePatches::ExtractImagePatchesJitExecutor::executeOptimizedGeneri
     parallel_for4d(OB, jpp.KH, jpp.KW, IC, [&](const size_t ob, const size_t kh, const size_t kw, const size_t ic) {
         const int64_t ih_start = kh * RH - PT;
         const int64_t iw_start = kw * RW - PL;
-        const size_t ih_lpad = ih_start >= 0 ? 0 : std::ceil(-1.F * ih_start / jpp.SH);
-        const size_t iw_lpad = iw_start >= 0 ? 0 : std::ceil(-1.F * iw_start / jpp.SW);
+        const size_t ih_lpad =
+            ih_start >= 0
+                ? 0
+                : static_cast<size_t>(std::ceil(-1.F * static_cast<float>(ih_start) / static_cast<float>(jpp.SH)));
+        const size_t iw_lpad =
+            iw_start >= 0
+                ? 0
+                : static_cast<size_t>(std::ceil(-1.F * static_cast<float>(iw_start) / static_cast<float>(jpp.SW)));
         const size_t ih_hpad =
-            std::ceil((IH - 1.F * ih_start) / jpp.SH) > jpp.OH ? jpp.OH : std::ceil((IH - 1.F * ih_start) / jpp.SH);
-        const size_t iw_hpad = std::ceil((jpp.IW - 1.F * iw_start) / jpp.SW) > jpp.OW
-                                   ? jpp.OW
-                                   : std::ceil((jpp.IW - 1.F * iw_start) / jpp.SW);
+            static_cast<size_t>(std::ceil((static_cast<float>(IH) - 1.F * static_cast<float>(ih_start)) /
+                                          static_cast<float>(jpp.SH))) > jpp.OH
+                ? jpp.OH
+                : static_cast<size_t>(std::ceil((static_cast<float>(IH) - 1.F * static_cast<float>(ih_start)) /
+                                                static_cast<float>(jpp.SH)));
+        const size_t iw_hpad =
+            static_cast<size_t>(std::ceil((static_cast<float>(jpp.IW) - 1.F * static_cast<float>(iw_start)) /
+                                          static_cast<float>(jpp.SW))) > jpp.OW
+                ? jpp.OW
+                : static_cast<size_t>(std::ceil((static_cast<float>(jpp.IW) - 1.F * static_cast<float>(iw_start)) /
+                                                static_cast<float>(jpp.SW)));
 
         size_t dst_offset =
             ob * ostrides_partial[0] + kh * ostrides_partial[1] + kw * ostrides_partial[2] + ic * ostrides_partial[3];
@@ -637,8 +663,14 @@ jit_extract_image_patches_params ExtractImagePatches::ExtractImagePatchesExecuto
         const int64_t ihStep = kSizes[0] + (rates[0] - 1) * (kSizes[0] - 1);
         const int64_t iwStep = kSizes[1] + (rates[1] - 1) * (kSizes[1] - 1);
 
-        int64_t PW = (std::ceil(1.F * jpp.IW / strides[1]) - 1) * strides[1] + iwStep - jpp.IW;
-        int64_t PH = (std::ceil(1.F * IH / strides[0]) - 1) * strides[0] + ihStep - IH;
+        int64_t PW =
+            (static_cast<int64_t>(std::ceil(1.F * static_cast<float>(jpp.IW) / static_cast<float>(strides[1]))) - 1) *
+                strides[1] +
+            iwStep - jpp.IW;
+        int64_t PH =
+            (static_cast<int64_t>(std::ceil(1.F * static_cast<float>(IH) / static_cast<float>(strides[0]))) - 1) *
+                strides[0] +
+            ihStep - IH;
 
         int64_t increment_sign = 0;
         if (padType == ExtImgPatcherPadType::SAME_LOWER) {

--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1748,7 +1748,9 @@ void FakeQuantize::executeReference() {
 
         parallel_nd(N, CB, D, H, W, [&](dim_t n, dim_t cb, dim_t d, dim_t h, dim_t w) {
             uint8_t bin_val = 0x00;
-            for (int c = cb * nbits, shift = 0; c < std::min(static_cast<dim_t>(C), (cb + 1) * nbits); c++, shift++) {
+            for (int c = static_cast<int>(cb) * nbits, shift = 0;
+                 c < std::min(static_cast<int>(C), (static_cast<int>(cb) + 1) * nbits);
+                 c++, shift++) {
                 size_t src_off = n * s_str[0] + c * s_str[1];
                 if (srcDims.size() == 4) {
                     src_off += h * s_str[2] + w * s_str[3];
@@ -1791,7 +1793,7 @@ void FakeQuantize::executeReference() {
 
             float src_val = src[src_off];
 
-            int wei_idx = getAxis() == 0 ? n : c;
+            int wei_idx = getAxis() == 0 ? static_cast<int>(n) : static_cast<int>(c);
             float cl = broadcasted[static_cast<size_t>(FQ_add_input_type::CROP_LOW)] ? cropLow[0] : cropLow[wei_idx];
             float ch = broadcasted[static_cast<size_t>(FQ_add_input_type::CROP_HIGH)] ? cropHigh[0] : cropHigh[wei_idx];
             float isc =
@@ -1922,7 +1924,7 @@ void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_ke
         parallel_nd(N, CB, D, [&](dim_t n, dim_t cb, [[maybe_unused]] dim_t d) {
             auto arg = jit_quantize_call_args();
 
-            int c = cb * blk_size;
+            int c = static_cast<int>(cb) * blk_size;
 
             size_t data_off = n * s_str[0] + c * s_str[1];
 
@@ -1953,9 +1955,9 @@ void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_ke
         parallel_nd(N, CB, D, B, [&](dim_t n, dim_t cb, dim_t d, dim_t b) {
             auto arg = jit_quantize_call_args();
 
-            const int c = cb * blk_size;
-            const int h = b * batch_size / W;
-            const int w = b * batch_size % W;
+            const int c = static_cast<int>(cb) * blk_size;
+            const int h = static_cast<int>(b) * batch_size / W;
+            const int w = static_cast<int>(b) * batch_size % W;
 
             const size_t data_off = srcDims.size() == 3 || srcDims.size() == 4
                                         ? n * s_str[0] + c * s_str[1] + h * s_str[2] + w
@@ -1988,7 +1990,7 @@ void FakeQuantize::executeQuantization(const std::unique_ptr<jit_uni_quantize_ke
         parallel_nd_legacy(N, CB, D, H, [&](dim_t n, dim_t cb, dim_t d, dim_t h) {
             auto arg = jit_quantize_call_args();
 
-            int c = cb * blk_size;
+            int c = static_cast<int>(cb) * blk_size;
 
             size_t data_off = 0;
             if (srcDims.size() == 2) {

--- a/src/plugins/intel_cpu/src/nodes/gather.cpp
+++ b/src/plugins/intel_cpu/src/nodes/gather.cpp
@@ -862,9 +862,9 @@ int8_t Gather::get_i4(const uint8_t& val, bool high) {
 
 int8_t Gather::get_u4(const uint8_t& val, bool high) {
     if (high) {
-        return (val >> 4) & 0xF;
+        return static_cast<int8_t>((val >> 4) & 0xF);
     }
-    return val & 0xF;
+    return static_cast<int8_t>(val & 0xF);
 }
 
 struct ExecCompressedContext {

--- a/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
+++ b/src/plugins/intel_cpu/src/nodes/generate_proposals.cpp
@@ -117,7 +117,8 @@ void refine_anchors(const float* deltas,
             proposals[p_idx + 2] = x1;
             proposals[p_idx + 3] = y1;
             proposals[p_idx + 4] = score;
-            proposals[p_idx + 5] = static_cast<int>(min_box_W <= box_w) * static_cast<int>(min_box_H <= box_h) * 1.0;
+            proposals[p_idx + 5] =
+                static_cast<float>(static_cast<int>(min_box_W <= box_w) * static_cast<int>(min_box_H <= box_h)) * 1.0f;
         }
     });
 }
@@ -323,8 +324,8 @@ GenerateProposals::GenerateProposals(const std::shared_ptr<ov::Node>& op, const 
 
     min_size_ = proposalAttrs.min_size;
     nms_thresh_ = proposalAttrs.nms_threshold;
-    pre_nms_topn_ = proposalAttrs.pre_nms_count;
-    post_nms_topn_ = proposalAttrs.post_nms_count;
+    pre_nms_topn_ = static_cast<int>(proposalAttrs.pre_nms_count);
+    post_nms_topn_ = static_cast<int>(proposalAttrs.post_nms_count);
     coordinates_offset_ = proposalAttrs.normalized ? 0.F : 1.F;
 
     roi_indices_.resize(post_nms_topn_);

--- a/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/kernels/x64/mlp_kernel.cpp
@@ -366,10 +366,10 @@ static void repackB(int8_t* dst, int8_t* src, int N_stride, int N, int K) {
         auto* psrc = src + k;
         int n = 0;
         for (; n < 16 && n < N; n++, psrc += N_stride) {
-            *dst++ = is_k0_valid ? psrc[0] : 0;
-            *dst++ = is_k1_valid ? psrc[1] : 0;
-            *dst++ = is_k2_valid ? psrc[2] : 0;
-            *dst++ = is_k3_valid ? psrc[3] : 0;
+            *dst++ = is_k0_valid ? psrc[0] : int8_t(0);
+            *dst++ = is_k1_valid ? psrc[1] : int8_t(0);
+            *dst++ = is_k2_valid ? psrc[2] : int8_t(0);
+            *dst++ = is_k3_valid ? psrc[3] : int8_t(0);
         }
         for (; n < 16; n++) {
             *dst++ = 0;

--- a/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
+++ b/src/plugins/intel_cpu/src/nodes/log_softmax.cpp
@@ -56,7 +56,7 @@ LogSoftmax::LogSoftmax(const std::shared_ptr<ov::Node>& op, const GraphContext::
     if (dimsSize == 0) {
         dimsSize += 1;
     }
-    axis = logSoftMax->get_axis();
+    axis = static_cast<int>(logSoftMax->get_axis());
     if (axis < 0) {
         axis += dimsSize;
     }

--- a/src/plugins/intel_cpu/src/nodes/lrn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/lrn.cpp
@@ -137,7 +137,7 @@ Lrn::Lrn(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
         alg = isAcrossMaps ? dnnl::algorithm::lrn_across_channels : dnnl::algorithm::lrn_within_channel;
         alpha = static_cast<float>(lrn->get_alpha());
         beta = static_cast<float>(lrn->get_beta());
-        k = static_cast<float>(lrn->get_bias());
+        k = static_cast<int>(lrn->get_bias());
         size = lrn->get_nsize();
     } else {
         OPENVINO_THROW_NOT_IMPLEMENTED(errorMessage);
@@ -202,7 +202,7 @@ void Lrn::prepareParams() {
                                                            key.size,
                                                            key.alpha,
                                                            key.beta,
-                                                           key.k,
+                                                           static_cast<float>(key.k),
                                                            key.attr);
 
         const bool found = DnnlExtensionUtils::find_implementation(prim_desc, key.implType);
@@ -248,7 +248,7 @@ void Lrn::createDescriptor(const std::vector<MemoryDescPtr>& inputDesc,
                                                   size,
                                                   alpha,
                                                   beta,
-                                                  k);
+                                                  static_cast<float>(k));
 
     descs.push_back(desc);
 }

--- a/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/matrix_nms.cpp
@@ -106,7 +106,7 @@ MatrixNms::MatrixNms(const std::shared_ptr<ov::Node>& op, const GraphContext::CP
     m_normalized = attrs.normalized;
     if (m_decayFunction == MatrixNmsDecayFunction::LINEAR) {
         m_decay_fn = [](float iou, float max_iou, [[maybe_unused]] float sigma) -> float {
-            return (1. - iou) / (1. - max_iou + 1e-10F);
+            return (1.F - iou) / (1.F - max_iou + 1e-10F);
         };
     } else {
         m_decay_fn = [](float iou, float max_iou, float sigma) -> float {
@@ -448,7 +448,7 @@ void MatrixNms::execute([[maybe_unused]] const dnnl::stream& strm) {
             auto originalIndex = originalOffset + j;
             selectedIndices[j + outputOffset] = static_cast<int>(m_filteredBoxes[originalIndex].index);
             auto* selectedBase = selectedOutputs + (outputOffset + j) * 6;
-            selectedBase[0] = m_filteredBoxes[originalIndex].classIndex;
+            selectedBase[0] = static_cast<float>(m_filteredBoxes[originalIndex].classIndex);
             selectedBase[1] = m_filteredBoxes[originalIndex].score;
             selectedBase[2] = m_filteredBoxes[originalIndex].box.x1;
             selectedBase[3] = m_filteredBoxes[originalIndex].box.y1;

--- a/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
+++ b/src/plugins/intel_cpu/src/nodes/multiclass_nms.cpp
@@ -420,7 +420,7 @@ void MultiClassNms::execute([[maybe_unused]] const dnnl::stream& strm) {
             const auto& box_info = m_filtBoxes[original_index];
 
             auto* selected_base = selected_outputs + (output_offset + j) * 6;
-            selected_base[0] = box_info.class_index;
+            selected_base[0] = static_cast<float>(box_info.class_index);
             selected_base[1] = box_info.score;
 
             auto& selected_index = selected_indices[j + output_offset];
@@ -436,7 +436,8 @@ void MultiClassNms::execute([[maybe_unused]] const dnnl::stream& strm) {
                     offset += roisnum[i];
                 }
                 // selected index from (M, C, 4)
-                selected_index = _flattened_index((offset + box_info.box_index), box_info.class_index, m_numClasses);
+                selected_index =
+                    _flattened_index(static_cast<int>(offset + box_info.box_index), box_info.class_index, m_numClasses);
                 int idx = box_info.class_index * boxesStrides[0] + offset * boxesStrides[1];
                 const float* curboxes = boxes + idx;  // a slice of boxes of current class current image
                 selected_base[2] = curboxes[4 * box_info.box_index];

--- a/src/plugins/intel_cpu/src/nodes/mvn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/mvn.cpp
@@ -1973,7 +1973,7 @@ MVN::MVN(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& context)
         }
     } else if (auto mvnOp = ov::as_type_ptr<ov::op::v0::MVN>(op)) {
         mvnAttrs.normalizeVariance_ = mvnOp->get_normalize_variance();
-        mvnAttrs.epsValue_ = mvnOp->get_eps();
+        mvnAttrs.epsValue_ = static_cast<float>(mvnOp->get_eps());
         mvnAttrs.initAcrossChannels_ = mvnOp->get_across_channels();
     } else {
         OPENVINO_THROW_NOT_IMPLEMENTED("Node is not an instance of MVN from the operation set v0 or v6");

--- a/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
+++ b/src/plugins/intel_cpu/src/nodes/non_max_suppression.cpp
@@ -886,7 +886,10 @@ void NonMaxSuppression::nmsRotated(const float* boxes,
             auto* sorted_indices_ptr = sorted_indices.data();
             auto* filtered_boxes_ptr = filtered_boxes.data() + batch_idx * m_classes_num * m_output_boxes_per_class +
                                        class_idx * m_output_boxes_per_class;
-            *filtered_boxes_ptr = FilteredBox(sorted_indices[0].first, batch_idx, class_idx, sorted_indices[0].second);
+            *filtered_boxes_ptr = FilteredBox(sorted_indices[0].first,
+                                              static_cast<int>(batch_idx),
+                                              static_cast<int>(class_idx),
+                                              sorted_indices[0].second);
             io_selection_size++;
             if (sorted_boxes_size > 1LU) {
                 sorted_indices_ptr++;
@@ -919,8 +922,8 @@ void NonMaxSuppression::nmsRotated(const float* boxes,
 
                     if (candidate_status == NMSCandidateStatus::SELECTED) {
                         *(++filtered_boxes_ptr) = FilteredBox((*sorted_indices_ptr).first,
-                                                              batch_idx,
-                                                              class_idx,
+                                                              static_cast<int>(batch_idx),
+                                                              static_cast<int>(class_idx),
                                                               (*sorted_indices_ptr).second);
                         io_selection_size++;
                     }

--- a/src/plugins/intel_cpu/src/nodes/one_hot.cpp
+++ b/src/plugins/intel_cpu/src/nodes/one_hot.cpp
@@ -64,7 +64,7 @@ OneHot::OneHot(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr& co
     if (depthNode) {
         depth = depthNode->cast_vector<uint32_t>()[0];
     }
-    axis = oneHot->get_axis();
+    axis = static_cast<int32_t>(oneHot->get_axis());
 
     VectorDims srcDims = getInputShapeAtPort(INDICES_ID).getDims();
     if (ov::is_scalar(srcDims)) {

--- a/src/plugins/intel_cpu/src/nodes/priorbox.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox.cpp
@@ -97,7 +97,7 @@ PriorBox::PriorBox(const std::shared_ptr<ov::Node>& op, const GraphContext::CPtr
         }
     }
 
-    number_of_priors = ov::op::v0::PriorBox::number_of_priors(attrs);
+    number_of_priors = static_cast<int>(ov::op::v0::PriorBox::number_of_priors(attrs));
 
     if (attrs.variance.size() == 1 || attrs.variance.size() == 4) {
         for (float i : attrs.variance) {
@@ -169,12 +169,12 @@ void PriorBox::execute([[maybe_unused]] const dnnl::stream& strm) {
     if (!scale_all_sizes) {
         // mxnet-like PriorBox
         if (step_ == -1) {
-            step_ = 1.F * IH / H;
+            step_ = 1.F * static_cast<float>(IH) / static_cast<float>(H);
         } else {
-            step_ *= IH;
+            step_ *= static_cast<float>(IH);
         }
         for (auto& size : min_size_) {
-            size *= IH;
+            size *= static_cast<float>(IH);
         }
     }
 
@@ -189,8 +189,8 @@ void PriorBox::execute([[maybe_unused]] const dnnl::stream& strm) {
     float IHI = 1.0F / static_cast<float>(IH);
 
     if (step_ == 0) {
-        step_x = static_cast<float>(IW) / W;
-        step_y = static_cast<float>(IH) / H;
+        step_x = static_cast<float>(IW) / static_cast<float>(W);
+        step_y = static_cast<float>(IH) / static_cast<float>(H);
     } else {
         step_x = step_;
         step_y = step_;
@@ -215,11 +215,11 @@ void PriorBox::execute([[maybe_unused]] const dnnl::stream& strm) {
     for (int64_t h = 0; h < H; ++h) {
         for (int64_t w = 0; w < W; ++w) {
             if (step_ == 0) {
-                center_x = (w + 0.5F) * step_x;
-                center_y = (h + 0.5F) * step_y;
+                center_x = (static_cast<float>(w) + 0.5F) * step_x;
+                center_y = (static_cast<float>(h) + 0.5F) * step_y;
             } else {
-                center_x = (offset + w) * step_;
-                center_y = (offset + h) * step_;
+                center_x = (offset + static_cast<float>(w)) * step_;
+                center_y = (offset + static_cast<float>(h)) * step_;
             }
 
             for (size_t s = 0; s < fixed_size.size(); ++s) {
@@ -229,14 +229,18 @@ void PriorBox::execute([[maybe_unused]] const dnnl::stream& strm) {
                 if (!fixed_ratio.empty()) {
                     for (float ar : fixed_ratio) {
                         auto density_ = static_cast<int64_t>(density[s]);
-                        auto shift = static_cast<int64_t>(fixed_size[s] / density_);
+                        auto shift = static_cast<int64_t>(fixed_size[s] / static_cast<float>(density_));
                         ar = std::sqrt(ar);
                         float box_width_ratio = fixed_size[s] * 0.5F * ar;
                         float box_height_ratio = fixed_size[s] * 0.5F / ar;
                         for (int64_t r = 0; r < density_; ++r) {
                             for (int64_t c = 0; c < density_; ++c) {
-                                float center_x_temp = center_x - fixed_size_ / 2.F + shift / 2.F + c * shift;
-                                float center_y_temp = center_y - fixed_size_ / 2.F + shift / 2.F + r * shift;
+                                float center_x_temp = center_x - static_cast<float>(fixed_size_) / 2.F +
+                                                      static_cast<float>(shift) / 2.F +
+                                                      static_cast<float>(c) * static_cast<float>(shift);
+                                float center_y_temp = center_y - static_cast<float>(fixed_size_) / 2.F +
+                                                      static_cast<float>(shift) / 2.F +
+                                                      static_cast<float>(r) * static_cast<float>(shift);
                                 calculate_data(center_x_temp, center_y_temp, box_width_ratio, box_height_ratio, true);
                             }
                         }
@@ -244,11 +248,15 @@ void PriorBox::execute([[maybe_unused]] const dnnl::stream& strm) {
                 } else {
                     if (!density.empty()) {
                         auto density_ = static_cast<int64_t>(density[s]);
-                        auto shift = static_cast<int64_t>(fixed_size[s] / density_);
+                        auto shift = static_cast<int64_t>(fixed_size[s] / static_cast<float>(density_));
                         for (int64_t r = 0; r < density_; ++r) {
                             for (int64_t c = 0; c < density_; ++c) {
-                                float center_x_temp = center_x - fixed_size_ / 2.F + shift / 2.F + c * shift;
-                                float center_y_temp = center_y - fixed_size_ / 2.F + shift / 2.F + r * shift;
+                                float center_x_temp = center_x - static_cast<float>(fixed_size_) / 2.F +
+                                                      static_cast<float>(shift) / 2.F +
+                                                      static_cast<float>(c) * static_cast<float>(shift);
+                                float center_y_temp = center_y - static_cast<float>(fixed_size_) / 2.F +
+                                                      static_cast<float>(shift) / 2.F +
+                                                      static_cast<float>(r) * static_cast<float>(shift);
                                 calculate_data(center_x_temp, center_y_temp, box_width, box_height, true);
                             }
                         }
@@ -260,14 +268,18 @@ void PriorBox::execute([[maybe_unused]] const dnnl::stream& strm) {
                         }
 
                         auto density_ = static_cast<int64_t>(density[s]);
-                        auto shift = static_cast<int64_t>(fixed_size[s] / density_);
+                        auto shift = static_cast<int64_t>(fixed_size[s] / static_cast<float>(density_));
                         ar = std::sqrt(ar);
                         float box_width_ratio = fixed_size[s] * 0.5F * ar;
                         float box_height_ratio = fixed_size[s] * 0.5F / ar;
                         for (int64_t r = 0; r < density_; ++r) {
                             for (int64_t c = 0; c < density_; ++c) {
-                                float center_x_temp = center_x - fixed_size_ / 2.F + shift / 2.F + c * shift;
-                                float center_y_temp = center_y - fixed_size_ / 2.F + shift / 2.F + r * shift;
+                                float center_x_temp = center_x - static_cast<float>(fixed_size_) / 2.F +
+                                                      static_cast<float>(shift) / 2.F +
+                                                      static_cast<float>(c) * static_cast<float>(shift);
+                                float center_y_temp = center_y - static_cast<float>(fixed_size_) / 2.F +
+                                                      static_cast<float>(shift) / 2.F +
+                                                      static_cast<float>(r) * static_cast<float>(shift);
                                 calculate_data(center_x_temp, center_y_temp, box_width_ratio, box_height_ratio, true);
                             }
                         }

--- a/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
+++ b/src/plugins/intel_cpu/src/nodes/priorbox_clustered.cpp
@@ -117,8 +117,8 @@ void PriorBoxClustered::execute([[maybe_unused]] const dnnl::stream& strm) {
     float step_w = step_widths == 0 ? step : step_widths;
     float step_h = step_heights == 0 ? step : step_heights;
     if (step_w == 0 && step_h == 0) {
-        step_w = static_cast<float>(img_width) / layer_width;
-        step_h = static_cast<float>(img_height) / layer_height;
+        step_w = static_cast<float>(img_width) / static_cast<float>(layer_width);
+        step_h = static_cast<float>(img_height) / static_cast<float>(layer_height);
     }
 
     auto* dst_data = getDstDataAtPortAs<float>(0);
@@ -126,17 +126,17 @@ void PriorBoxClustered::execute([[maybe_unused]] const dnnl::stream& strm) {
 
     size_t var_size = variances.size();
     parallel_for2d(layer_height, layer_width, [&](int64_t h, int64_t w) {
-        float center_x = (w + offset) * step_w;
-        float center_y = (h + offset) * step_h;
+        float center_x = (static_cast<float>(w) + offset) * step_w;
+        float center_y = (static_cast<float>(h) + offset) * step_h;
 
         for (int s = 0; s < number_of_priors; ++s) {
             float box_width = widths[s];
             float box_height = heights[s];
 
-            float xmin = (center_x - box_width / 2.0F) / img_width;
-            float ymin = (center_y - box_height / 2.0F) / img_height;
-            float xmax = (center_x + box_width / 2.0F) / img_width;
-            float ymax = (center_y + box_height / 2.0F) / img_height;
+            float xmin = (center_x - box_width / 2.0F) / static_cast<float>(img_width);
+            float ymin = (center_y - box_height / 2.0F) / static_cast<float>(img_height);
+            float xmax = (center_x + box_width / 2.0F) / static_cast<float>(img_width);
+            float ymax = (center_y + box_height / 2.0F) / static_cast<float>(img_height);
 
             if (clip) {
                 xmin = (std::min)((std::max)(xmin, 0.0F), 1.0F);

--- a/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/psroi_pooling.cpp
@@ -193,8 +193,8 @@ inline float bilinearInterp(const inputType* data, const float x, const float y,
     auto x2 = static_cast<int>(std::ceil(x));
     auto y1 = static_cast<int>(std::floor(y));
     auto y2 = static_cast<int>(std::ceil(y));
-    float distX = x - x1;
-    float distY = y - y1;
+    float distX = x - static_cast<float>(x1);
+    float distY = y - static_cast<float>(y1);
 
     float value11 = data[y1 * width_ + x1];
     float value12 = data[y2 * width_ + x1];
@@ -325,7 +325,7 @@ void PSROIPooling::executeAverage(const inputType* srcData,
 
             size_t dstIndex = binOffOut + h * hOutputStride + w * wOutputStride + outBlkRes;
             dstData[dstIndex] = 0;
-            if (binArea) {
+            if (static_cast<bool>(binArea)) {
                 float outSum = 0.0F;
                 const int heightIndexBound = hEnd * hInputStride;
                 const int widthIndexBound = wEnd * wInputStride;
@@ -420,9 +420,11 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
         for (size_t binY = 0; binY < spatialBinsY; binY++) {
             const float boxYmin = roiStartH + (binY + 0) * (roiHeight / spatialBinsY);
             const float boxYmax = roiStartH + (binY + 1) * (roiHeight / spatialBinsY);
-            const float heightScale = nh > 1 ? (boxYmax - boxYmin) * (height - 1) / (pooledHeight - 1) : 0.0F;
-            const float inY =
-                nh > 1 ? (h * heightScale + boxYmin * (height - 1)) : 0.5F * (boxYmin + boxYmax) * (height - 1);
+            const float heightScale =
+                nh > 1 ? (boxYmax - boxYmin) * static_cast<float>(height - 1) / static_cast<float>(pooledHeight - 1)
+                       : 0.0F;
+            const float inY = nh > 1 ? (static_cast<float>(h) * heightScale + boxYmin * static_cast<float>(height - 1))
+                                     : 0.5F * (boxYmin + boxYmax) * static_cast<float>(height - 1);
             for (size_t binX = 0; binX < spatialBinsX; binX++) {
                 size_t gc = c + (binY * spatialBinsX + binX) * nc;
                 if (srcDesc.hasLayoutType(LayoutType::nspc)) {
@@ -441,11 +443,15 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
                 const float boxXmin = roiStartW + (binX + 0) * (roiWidth / spatialBinsX);
                 const float boxXmax = roiStartW + (binX + 1) * (roiWidth / spatialBinsX);
 
-                const float widthScale = nw > 1 ? (boxXmax - boxXmin) * (width - 1) / (pooledWidth - 1) : 0.0F;
-                const float inX =
-                    nw > 1 ? (w * widthScale + boxXmin * (width - 1)) : 0.5F * (boxXmin + boxXmax) * (width - 1);
+                const float widthScale =
+                    nw > 1 ? (boxXmax - boxXmin) * static_cast<float>(width - 1) / static_cast<float>(pooledWidth - 1)
+                           : 0.0F;
+                const float inX = nw > 1
+                                      ? (static_cast<float>(w) * widthScale + boxXmin * static_cast<float>(width - 1))
+                                      : 0.5F * (boxXmin + boxXmax) * static_cast<float>(width - 1);
 
-                if (inY >= 0 && inY <= height - 1 && inX >= 0 && inX <= width - 1) {
+                if (inY >= 0 && inY <= static_cast<float>(height - 1) && inX >= 0 &&
+                    inX <= static_cast<float>(width - 1)) {
                     const auto topYIndex = static_cast<int>(floorf(inY));
                     auto bottomYIndex = static_cast<int>(ceilf(inY));
                     const auto leftXIndex = static_cast<int>(floorf(inX));
@@ -468,10 +474,11 @@ void PSROIPooling::executeBilinear(const inputType* srcData,
                     const float bottomLeft = bottomData[bottomLeftIndex];
                     const float bottomRight = bottomData[bottomRightIndex];
 
-                    const float top = topLeft + (topRight - topLeft) * (inX - leftXIndex);
-                    const float bottom = bottomLeft + (bottomRight - bottomLeft) * (inX - leftXIndex);
+                    const float top = topLeft + (topRight - topLeft) * (inX - static_cast<float>(leftXIndex));
+                    const float bottom =
+                        bottomLeft + (bottomRight - bottomLeft) * (inX - static_cast<float>(leftXIndex));
 
-                    accum += top + (bottom - top) * (inY - topYIndex);
+                    accum += top + (bottom - top) * (inY - static_cast<float>(topYIndex));
                 }
             }
         }
@@ -546,8 +553,8 @@ void PSROIPooling::executeBilinearDeformable(const inputType* srcData,
                 : bottomTrans[(((currentRoi * numClasses + classId) * 2 + 1) * partSize + partH) * partSize + partW] *
                       transStd;
 
-        float wStart = w * binSizeW + roiStartW + transX * roiWidth;
-        float hStart = h * binSizeH + roiStartH + transY * roiHeight;
+        float wStart = static_cast<float>(w) * binSizeW + roiStartW + transX * roiWidth;
+        float hStart = static_cast<float>(h) * binSizeH + roiStartH + transY * roiHeight;
 
         float sum = 0;
         int count = 0;
@@ -574,7 +581,7 @@ void PSROIPooling::executeBilinearDeformable(const inputType* srcData,
                 count++;
             }
         }
-        dstData[dstIndex] = count == 0 ? 0 : sum / count;
+        dstData[dstIndex] = count == 0 ? 0 : sum / static_cast<float>(count);
     });
 }
 

--- a/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
+++ b/src/plugins/intel_cpu/src/nodes/random_uniform.cpp
@@ -398,8 +398,10 @@ void RandomUniform::prepareMersenneTwisterParams() {
         auto approx_start = thread_offset * static_cast<float>(ithr);
         auto approx_end = thread_offset * (static_cast<float>(ithr + 1));
 
-        auto state_start = static_cast<uint64_t>(std::floor(approx_start) * m_uint_storage_capacity_per_thread);
-        auto state_end = static_cast<uint64_t>(std::floor(approx_end) * m_uint_storage_capacity_per_thread);
+        auto state_start =
+            static_cast<uint64_t>(std::floor(approx_start) * static_cast<double>(m_uint_storage_capacity_per_thread));
+        auto state_end =
+            static_cast<uint64_t>(std::floor(approx_end) * static_cast<double>(m_uint_storage_capacity_per_thread));
 
         // Rounding failsafes
         if (ithr == 0) {
@@ -419,7 +421,7 @@ void RandomUniform::prepareMersenneTwisterParams() {
 
         params.src_start_idx = state_start;
         params.dst_start_idx = destination_start;
-        params.state_accesses_count = state_accesses;
+        params.state_accesses_count = static_cast<uint64_t>(state_accesses);
     });
 }
 

--- a/src/plugins/intel_cpu/src/nodes/rdft.cpp
+++ b/src/plugins/intel_cpu/src/nodes/rdft.cpp
@@ -807,8 +807,8 @@ std::vector<float> RDFTExecutor::generateTwiddlesFFT(size_t N) {
     for (size_t numBlocks = 1; numBlocks < N; numBlocks *= 2) {
         for (size_t block = 0; block < numBlocks; block++) {
             double angle = 2 * PI * block / (numBlocks * 2);
-            twiddles.push_back(std::cos(angle));
-            twiddles.push_back(-std::sin(angle));
+            twiddles.push_back(static_cast<float>(std::cos(angle)));
+            twiddles.push_back(static_cast<float>(-std::sin(angle)));
         }
     }
     return twiddles;
@@ -889,18 +889,18 @@ struct RDFTJitExecutor : public RDFTExecutor {
             if (type == real_to_complex) {
                 for (int k = 0; k < simdSize; k++) {
                     double angle = 2 * PI * (K * simdSize + k) * n / inputSize;
-                    twiddles[((K * inputSize + n) * simdSize + k) * 2] = std::cos(angle);
-                    twiddles[((K * inputSize + n) * simdSize + k) * 2 + 1] = -std::sin(angle);
+                    twiddles[((K * inputSize + n) * simdSize + k) * 2] = static_cast<float>(std::cos(angle));
+                    twiddles[((K * inputSize + n) * simdSize + k) * 2 + 1] = static_cast<float>(-std::sin(angle));
                 }
             } else if (type == complex_to_real || type == complex_to_complex) {
                 for (int k = 0; k < simdSize; k++) {
                     double angle = 2 * PI * (K * simdSize + k) * n / inputSize;
-                    twiddles[(K * inputSize + n) * 2 * simdSize + k] = std::cos(angle);
+                    twiddles[(K * inputSize + n) * 2 * simdSize + k] = static_cast<float>(std::cos(angle));
                 }
                 for (int k = 0; k < simdSize; k++) {
                     double angle = 2 * PI * (K * simdSize + k) * n / inputSize;
                     twiddles[((K * inputSize + n) * 2 + 1) * simdSize + k] =
-                        isInverse ? std::sin(angle) : -std::sin(angle);
+                        isInverse ? static_cast<float>(std::sin(angle)) : static_cast<float>(-std::sin(angle));
                 }
             }
         });
@@ -909,8 +909,9 @@ struct RDFTJitExecutor : public RDFTExecutor {
             parallel_for2d(outputSize - start, inputSize, [&](size_t k, size_t n) {
                 k += start;
                 double angle = 2 * PI * k * n / inputSize;
-                twiddles[2 * (k * inputSize + n)] = std::cos(angle);
-                twiddles[2 * (k * inputSize + n) + 1] = isInverse ? std::sin(angle) : -std::sin(angle);
+                twiddles[2 * (k * inputSize + n)] = static_cast<float>(std::cos(angle));
+                twiddles[2 * (k * inputSize + n) + 1] =
+                    isInverse ? static_cast<float>(std::sin(angle)) : static_cast<float>(-std::sin(angle));
             });
         }
         return twiddles;
@@ -967,8 +968,8 @@ private:
             if (!isInverse) {
                 angle = -angle;
             }
-            twiddles[(k * inputSize + n) * 2] = std::cos(angle);
-            twiddles[(k * inputSize + n) * 2 + 1] = std::sin(angle);
+            twiddles[(k * inputSize + n) * 2] = static_cast<float>(std::cos(angle));
+            twiddles[(k * inputSize + n) * 2 + 1] = static_cast<float>(std::sin(angle));
         });
         return twiddles;
     }

--- a/src/plugins/intel_cpu/src/nodes/roi_align.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_align.cpp
@@ -1013,8 +1013,8 @@ void ROIAlign::executeSpecified() {
             roiHeight = std::max(roiHeight, 1.0F);
             roiWidth = std::max(roiWidth, 1.0F);
         }
-        float binHeight = roiHeight / pooledH;
-        float binWidth = roiWidth / pooledW;
+        float binHeight = roiHeight / static_cast<float>(pooledH);
+        float binWidth = roiWidth / static_cast<float>(pooledW);
 
         auto samplingRatioX = samplingRatio == 0 ? static_cast<int>(ceil(binWidth)) : samplingRatio;
         auto samplingRatioY = samplingRatio == 0 ? static_cast<int>(ceil(binHeight)) : samplingRatio;
@@ -1022,8 +1022,8 @@ void ROIAlign::executeSpecified() {
         uint64_t numSamplesInBin = static_cast<uint64_t>(samplingRatioX) * samplingRatioY;
         numSamples[n] = numSamplesInBin;
 
-        float sampleDistanceX = binWidth / samplingRatioX;
-        float sampleDistanceY = binHeight / samplingRatioY;
+        float sampleDistanceX = binWidth / static_cast<float>(samplingRatioX);
+        float sampleDistanceY = binHeight / static_cast<float>(samplingRatioY);
         // prepare arrays for sampling points and weights
         size_t paramsSize = BLIParamsNum * numSamplesInBin * binCount;
         weightsTbl[n] = std::vector<float>(paramsSize, 0.F);
@@ -1046,10 +1046,13 @@ void ROIAlign::executeSpecified() {
             for (int xBinInd = 0; xBinInd < pooledW; ++xBinInd) {
                 // run into bin
                 for (int ySampleInd = 0; ySampleInd < samplingRatioY; ySampleInd++) {
-                    float sampleY = y1 + yBinInd * binHeight + sampleDistanceY * (0.5F + ySampleInd);
+                    float sampleY = y1 + static_cast<float>(yBinInd) * binHeight +
+                                    sampleDistanceY * (0.5F + static_cast<float>(ySampleInd));
                     for (int xSampleInd = 0; xSampleInd < samplingRatioX; xSampleInd++) {
-                        float sampleX = x1 + xBinInd * binWidth + sampleDistanceX * (0.5F + xSampleInd);
-                        if (sampleX < -1.0 || sampleX > W || sampleY < -1.0 || sampleY > H) {
+                        float sampleX = x1 + static_cast<float>(xBinInd) * binWidth +
+                                        sampleDistanceX * (0.5F + static_cast<float>(xSampleInd));
+                        if (sampleX < -1.0f || sampleX > static_cast<float>(W) || sampleY < -1.0f ||
+                            sampleY > static_cast<float>(H)) {
                             // For this sample we save 4 index of (0,0) and 4 weight of 0
                             if (!isPlainFmt) {
                                 auto startPoint = reinterpret_cast<size_t>(&srcData[batchSrcOffset]);
@@ -1144,7 +1147,7 @@ void ROIAlign::executeSpecified() {
                 arg.weights = static_cast<const float*>(&weightsTbl[n][binOffset]);
                 arg.work_amount = C;
                 arg.num_samples = numSamplesROI;
-                float numSamplesInBinInvert = 1.F / numSamplesROI;
+                float numSamplesInBinInvert = 1.0f / static_cast<float>(numSamplesROI);
                 arg.scale = static_cast<const float*>(&numSamplesInBinInvert);
                 auto* threadBuf = static_cast<float*>(
                     &workingBuf[static_cast<size_t>(parallel_get_thread_num()) * static_cast<size_t>(bufSize)]);
@@ -1175,7 +1178,7 @@ void ROIAlign::executeSpecified() {
                 // buffer with absolute index
                 arg.buffer = static_cast<void*>(&srcIndexTbl[n][paramOffset]);
                 arg.weights = static_cast<const float*>(&weightsTbl[n][paramOffset]);
-                float numSamplesInBinInvert = 1.F / numSamplesROI;
+                float numSamplesInBinInvert = 1.0f / static_cast<float>(numSamplesROI);
                 arg.scale = static_cast<const float*>(&numSamplesInBinInvert);
                 arg.num_samples = numSamplesROI;
                 (*roi_align_kernel)(&arg);
@@ -1190,7 +1193,7 @@ void ROIAlign::executeSpecified() {
             size_t binOffset = yBinInd * pooledW + xBinInd;
             size_t binDstOffset = n * batchOutputStride + cIdx * binCount + binOffset;
             int paramOffset = binOffset * BLIParamsNum * numSamplesROI;
-            float numSamplesInBinInvert = 1.F / numSamplesROI;
+            float numSamplesInBinInvert = 1.0f / static_cast<float>(numSamplesROI);
 
             float pooledValue = 0;
             for (auto binSampleInd = 0; binSampleInd < numSamplesROI; binSampleInd++) {

--- a/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/src/nodes/roi_pooling.cpp
@@ -695,8 +695,8 @@ private:
                         arg.dst =
                             &dst[n * dst_strides[0] + cb * dst_strides[1] + oh * dst_strides[2] + ow * dst_strides[3]];
 
-                        arg.xf = in_x - left_x_index;
-                        arg.yf = in_y - top_y_index;
+                        arg.xf = in_x - static_cast<float>(left_x_index);
+                        arg.yf = in_y - static_cast<float>(top_y_index);
 
                         arg.xoff = sizeof(T) * (right_x_index - left_x_index) * jpp.c_block;
                         arg.yoff = sizeof(T) * (bottom_y_index - top_y_index) * jpp.iw * jpp.c_block;
@@ -874,11 +874,14 @@ public:
                                     src_data[roi_batch_ind * src_strides[0] + ch_blk_cur * src_strides[1] +
                                              bottom_y_index * src_strides[2] + right_x_index * src_strides[3] + c];
 
-                                const float top = top_left + (top_right - top_left) * (in_x - left_x_index);
-                                const float bottom = bottom_left + (bottom_right - bottom_left) * (in_x - left_x_index);
+                                const float top =
+                                    top_left + (top_right - top_left) * (in_x - static_cast<float>(left_x_index));
+                                const float bottom = bottom_left + (bottom_right - bottom_left) *
+                                                                       (in_x - static_cast<float>(left_x_index));
 
                                 dst[n * dst_strides[0] + ch_blk_cur * dst_strides[1] + oh * dst_strides[2] +
-                                    ow * dst_strides[3] + c] = top + (bottom - top) * (in_y - top_y_index);
+                                    ow * dst_strides[3] + c] =
+                                    top + (bottom - top) * (in_y - static_cast<float>(top_y_index));
                             }
                         }
                     }
@@ -956,8 +959,12 @@ std::pair<float, float> ROIPooling::ROIPoolingExecutor::getXYForBilinearMode(con
                                                                              const int ow,
                                                                              const int pooled_h,
                                                                              const int pooled_w) {
-    float height_scale = (pooled_h > 1 ? ((roi_end_h - roi_start_h) * (ih - 1)) / (pooled_h - 1) : 0);
-    float width_scale = (pooled_w > 1 ? ((roi_end_w - roi_start_w) * (iw - 1)) / (pooled_w - 1) : 0);
+    float height_scale =
+        (pooled_h > 1 ? ((roi_end_h - roi_start_h) * static_cast<float>(ih - 1)) / static_cast<float>(pooled_h - 1)
+                      : 0.0f);
+    float width_scale =
+        (pooled_w > 1 ? ((roi_end_w - roi_start_w) * static_cast<float>(iw - 1)) / static_cast<float>(pooled_w - 1)
+                      : 0.0f);
 
     float in_y = NAN;
     float in_x = NAN;
@@ -966,14 +973,17 @@ std::pair<float, float> ROIPooling::ROIPoolingExecutor::getXYForBilinearMode(con
     // and as result excess of right limit for proposal value,
     // if the border case (current_h == pooled_h - 1) will not be handled explicitly
     if (pooled_h > 1) {
-        in_y = (oh == pooled_h - 1 ? roi_end_h * (ih - 1) : (oh * height_scale + roi_start_h * (ih - 1)));
+        in_y =
+            (oh == pooled_h - 1 ? roi_end_h * static_cast<float>(ih - 1)
+                                : (static_cast<float>(oh) * height_scale + roi_start_h * static_cast<float>(ih - 1)));
     } else {
-        in_y = 0.5 * (roi_start_h + roi_end_h) * (ih - 1);
+        in_y = 0.5f * (roi_start_h + roi_end_h) * static_cast<float>(ih - 1);
     }
     if (pooled_w > 1) {
-        in_x = (ow == pooled_w - 1 ? roi_end_w * (iw - 1) : (ow * width_scale + roi_start_w * (iw - 1)));
+        in_x = (ow == pooled_w - 1 ? roi_end_w * static_cast<float>(iw - 1)
+                                   : (static_cast<float>(ow) * width_scale + roi_start_w * static_cast<float>(iw - 1)));
     } else {
-        in_x = 0.5 * (roi_start_w + roi_end_w) * (iw - 1);
+        in_x = 0.5f * (roi_start_w + roi_end_w) * static_cast<float>(iw - 1);
     }
 
     return std::make_pair(in_x, in_y);

--- a/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scaled_attn.cpp
@@ -169,7 +169,7 @@ struct MHAKernel {
         auto Hk = present_key.size(1);
         size_t h_each_group_len = H / Hk;
         if (d_scale == 0.0F) {
-            d_scale = 1.0F / sqrt(head_size);
+            d_scale = 1.0F / static_cast<float>(sqrt(head_size));
         }
 
         auto k_stride_s = present_key.stride(3);
@@ -532,7 +532,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_ONEDNN, T> {
                     float d_scale = 0.0F) {
         auto head_size = query.size(3);
         if (d_scale == 0.0F) {
-            d_scale = 1.0F / sqrt(head_size);
+            d_scale = 1.0F / static_cast<float>(sqrt(head_size));
         }
 
         prepare_brgemm_prim(strm, query, present_key, present_value, has_out_transpose);
@@ -748,7 +748,7 @@ struct MHAKernel<ScaledDotProductAttention::KT_MLAS, float> {
         size_t h_each_group_len = H / h_group_num;
 
         if (d_scale == 0.0F) {
-            d_scale = 1.0F / sqrt(head_size);
+            d_scale = 1.0F / static_cast<float>(sqrt(head_size));
         }
         auto k_stride_s = present_key.stride(3);
 

--- a/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
+++ b/src/plugins/intel_cpu/src/nodes/scatter_update.cpp
@@ -769,7 +769,7 @@ void ScatterUpdate::scatterElementsUpdate(const MemoryPtr& mem_data,
                 for (const auto& counter : mean_reduction_counters) {
                     auto dst = &dataPtr[offsets[0] + counter.first * dataBlock_axisplus1];
                     const auto N = counter.second + static_cast<int32_t>(use_init_val);
-                    *dst = static_cast<DataType>(static_cast<double>(*dst) / N);
+                    *dst = static_cast<DataType>(static_cast<double>(*dst) / static_cast<double>(N));
                 }
 
                 // increment
@@ -896,7 +896,7 @@ void ScatterUpdate::execute([[maybe_unused]] const dnnl::stream& strm) {
             axis = *axisPtr32;
         } else {
             auto* axisPtr64 = reinterpret_cast<int64_t*>(axisPtr);
-            axis = *axisPtr64;
+            axis = static_cast<int>(*axisPtr64);
         }
 
         CPU_NODE_ASSERT(axis < static_cast<int>(srcRank) && axis >= (static_cast<int>(srcRank) * -1),

--- a/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/src/nodes/shuffle_channels.cpp
@@ -90,7 +90,7 @@ ShuffleChannels::ShuffleChannels(const std::shared_ptr<ov::Node>& op, const Grap
 
     auto shuffleChannels = ov::as_type_ptr<const ov::op::v0::ShuffleChannels>(op);
     attrs.group = shuffleChannels->get_group();
-    attrs.axis = shuffleChannels->get_axis();
+    attrs.axis = static_cast<int>(shuffleChannels->get_axis());
     attrs.dataRank = getInputShapeAtPort(0).getRank();
     if (attrs.axis < 0) {
         attrs.axis += attrs.dataRank;

--- a/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
+++ b/src/plugins/intel_cpu/src/nodes/tensoriterator.cpp
@@ -117,7 +117,7 @@ public:
         auto part_dims = part_blob->getShape().getStaticDims();
 
         auto abs_stride = std::abs(stride);
-        auto sign_of_stride = stride < 0.0F ? -1 : 1;
+        auto sign_of_stride = stride < 0 ? -1 : 1;
 
         iter_count = full_dims[axis] / abs_stride;
 
@@ -557,10 +557,10 @@ void TensorIterator::createPrimitive() {
         algorithm = Algorithm::TensorIteratorLoop;
         auto spec_port = loopOp->get_special_body_ports();
         if (spec_port.current_iteration_input_idx != -1) {
-            loopBodyCurrentIterationIdx.push_back(spec_port.current_iteration_input_idx);
+            loopBodyCurrentIterationIdx.push_back(static_cast<int>(spec_port.current_iteration_input_idx));
         }
         if (spec_port.body_condition_output_idx != -1) {
-            loopBodyConditionOutputIdx = spec_port.body_condition_output_idx;
+            loopBodyConditionOutputIdx = static_cast<int>(spec_port.body_condition_output_idx);
         }
         loopTripCountIdx = 0;
         loopExecutionConditionIdx = 1;

--- a/src/plugins/intel_cpu/src/utils/codec_xor.cpp
+++ b/src/plugins/intel_cpu/src/utils/codec_xor.cpp
@@ -17,11 +17,11 @@ void codec_xor(char* dst_str, const char* src_str, size_t len) {
 
     if (dst_str == src_str) {
         parallel_for(len, [&](size_t key_idx) {
-            dst_str[key_idx] ^= codec_key[key_idx % key_size];
+            dst_str[key_idx] = static_cast<char>(dst_str[key_idx] ^ codec_key[key_idx % key_size]);
         });
     } else {
         parallel_for(len, [&](size_t key_idx) {
-            dst_str[key_idx] = src_str[key_idx] ^ codec_key[key_idx % key_size];
+            dst_str[key_idx] = static_cast<char>(src_str[key_idx] ^ codec_key[key_idx % key_size]);
         });
     }
 }


### PR DESCRIPTION
### Details:
 - Fix "bugprone-narrowing-conversions" and "cppcoreguidelines-narrowing-conversions" remarks reported by clang-tidy
 - Enable "bugprone-narrowing-conversions" and "cppcoreguidelines-narrowing-conversions" clang-tidy checks on CI by default

### Tickets:
 - N/A
