### PR TITLE
[Snippets][CPU] Avoid pushing to the stack to avoid stack corruption in Gemm and GemmCopyB emitters

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
@@ -72,13 +72,13 @@ void jit_gemm_copy_b_emitter::emit_impl(const std::vector<size_t>& in, const std
     std::unordered_set<size_t> exclude = {};
     store_context(exclude);
 
-    h->mov(Xbyak_aarch64::XReg(10), Xbyak_aarch64::XReg(in[0]));
-    h->mov(Xbyak_aarch64::XReg(11), Xbyak_aarch64::XReg(out[0]));
-    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(10));
-    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(11));
+    h->mov(Xbyak_aarch64::XReg(20), Xbyak_aarch64::XReg(in[0]));
+    h->mov(Xbyak_aarch64::XReg(21), Xbyak_aarch64::XReg(out[0]));
+    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(20));
+    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(21));
     h->mov(Xbyak_aarch64::XReg(0), get_compiled_kernel_ptr());
-    h->mov(Xbyak_aarch64::XReg(9), get_execute_function_ptr());
-    h->blr(Xbyak_aarch64::XReg(9));
+    h->mov(Xbyak_aarch64::XReg(19), get_execute_function_ptr());
+    h->blr(Xbyak_aarch64::XReg(19));
 
     restore_context(exclude);
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_copy_b_emitter.cpp
@@ -72,19 +72,13 @@ void jit_gemm_copy_b_emitter::emit_impl(const std::vector<size_t>& in, const std
     std::unordered_set<size_t> exclude = {};
     store_context(exclude);
 
-    Xbyak_aarch64::XReg x0(0);
-    Xbyak_aarch64::XReg x1(1);
-    Xbyak_aarch64::XReg x2(2);
-    h->str(Xbyak_aarch64::XReg(in[0]), pre_ptr(h->sp, -get_vec_length()));
-    h->str(Xbyak_aarch64::XReg(out[0]), pre_ptr(h->sp, -get_vec_length()));
-    h->ldr(x2, post_ptr(h->sp, get_vec_length()));
-    h->ldr(x1, post_ptr(h->sp, get_vec_length()));
-    const auto& compiled_kernel = get_compiled_kernel_ptr();
-    h->mov(x0, compiled_kernel);
-
-    Xbyak_aarch64::XReg func_reg(9);
-    h->mov(func_reg, get_execute_function_ptr());
-    h->blr(func_reg);
+    h->mov(Xbyak_aarch64::XReg(10), Xbyak_aarch64::XReg(in[0]));
+    h->mov(Xbyak_aarch64::XReg(11), Xbyak_aarch64::XReg(out[0]));
+    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(10));
+    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(11));
+    h->mov(Xbyak_aarch64::XReg(0), get_compiled_kernel_ptr());
+    h->mov(Xbyak_aarch64::XReg(9), get_execute_function_ptr());
+    h->blr(Xbyak_aarch64::XReg(9));
 
     restore_context(exclude);
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
@@ -58,12 +58,36 @@ void jit_gemm_emitter::emit_impl(const std::vector<size_t>& in, const std::vecto
     std::unordered_set<size_t> exclude = {};
     store_context(exclude);
 
-    h->mov(Xbyak_aarch64::XReg(20), Xbyak_aarch64::XReg(in[0]));
-    h->mov(Xbyak_aarch64::XReg(21), Xbyak_aarch64::XReg(in[1]));
-    h->mov(Xbyak_aarch64::XReg(22), Xbyak_aarch64::XReg(out[0]));
-    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(20));
-    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(21));
-    h->mov(Xbyak_aarch64::XReg(3), Xbyak_aarch64::XReg(22));
+    auto get_free_scratch_reg = [&](const std::vector<size_t>& in_use) -> size_t {
+        for (size_t reg = 19; reg <= 28; ++reg) {
+            bool is_free = true;
+            for (size_t used_reg : in_use) {
+                if (reg == used_reg) {
+                    is_free = false;
+                    break;
+                }
+            }
+            if (is_free) {
+                return reg;
+            }
+        }
+        OV_CPU_JIT_EMITTER_THROW("No free scratch register available");
+    };
+
+    std::vector<size_t> used_regs = {in[0], in[1], out[0]};
+    auto temp_a = get_free_scratch_reg(used_regs);
+    used_regs.push_back(temp_a);
+    auto temp_b = get_free_scratch_reg(used_regs);
+    used_regs.push_back(temp_b);
+    auto temp_dst = get_free_scratch_reg(used_regs);
+
+    h->mov(Xbyak_aarch64::XReg(temp_a), Xbyak_aarch64::XReg(in[0]));
+    h->mov(Xbyak_aarch64::XReg(temp_b), Xbyak_aarch64::XReg(in[1]));
+    h->mov(Xbyak_aarch64::XReg(temp_dst), Xbyak_aarch64::XReg(out[0]));
+
+    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(temp_a));
+    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(temp_b));
+    h->mov(Xbyak_aarch64::XReg(3), Xbyak_aarch64::XReg(temp_dst));
     h->mov(Xbyak_aarch64::XReg(0), get_compiled_kernel_ptr());
     h->mov(Xbyak_aarch64::XReg(18), get_execute_function_ptr());
     h->blr(Xbyak_aarch64::XReg(18));

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
@@ -58,22 +58,15 @@ void jit_gemm_emitter::emit_impl(const std::vector<size_t>& in, const std::vecto
     std::unordered_set<size_t> exclude = {};
     store_context(exclude);
 
-    Xbyak_aarch64::XReg x0(0);
-    Xbyak_aarch64::XReg x1(1);
-    Xbyak_aarch64::XReg x2(2);
-    Xbyak_aarch64::XReg x3(3);
-    h->str(Xbyak_aarch64::XReg(in[0]), pre_ptr(h->sp, -get_vec_length()));
-    h->str(Xbyak_aarch64::XReg(in[1]), pre_ptr(h->sp, -get_vec_length()));
-    h->str(Xbyak_aarch64::XReg(out[0]), pre_ptr(h->sp, -get_vec_length()));
-    h->ldr(x3, post_ptr(h->sp, get_vec_length()));
-    h->ldr(x2, post_ptr(h->sp, get_vec_length()));
-    h->ldr(x1, post_ptr(h->sp, get_vec_length()));
-    const auto& compiled_kernel = get_compiled_kernel_ptr();
-    h->mov(x0, compiled_kernel);
-
-    Xbyak_aarch64::XReg func_reg(9);
-    h->mov(func_reg, get_execute_function_ptr());
-    h->blr(func_reg);
+    h->mov(Xbyak_aarch64::XReg(10), Xbyak_aarch64::XReg(in[0]));
+    h->mov(Xbyak_aarch64::XReg(11), Xbyak_aarch64::XReg(in[1]));
+    h->mov(Xbyak_aarch64::XReg(12), Xbyak_aarch64::XReg(out[0]));
+    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(10));
+    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(11));
+    h->mov(Xbyak_aarch64::XReg(3), Xbyak_aarch64::XReg(12));
+    h->mov(Xbyak_aarch64::XReg(0), get_compiled_kernel_ptr());
+    h->mov(Xbyak_aarch64::XReg(9), get_execute_function_ptr());
+    h->blr(Xbyak_aarch64::XReg(9));
 
     restore_context(exclude);
 }

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
@@ -58,15 +58,15 @@ void jit_gemm_emitter::emit_impl(const std::vector<size_t>& in, const std::vecto
     std::unordered_set<size_t> exclude = {};
     store_context(exclude);
 
-    h->mov(Xbyak_aarch64::XReg(10), Xbyak_aarch64::XReg(in[0]));
-    h->mov(Xbyak_aarch64::XReg(11), Xbyak_aarch64::XReg(in[1]));
-    h->mov(Xbyak_aarch64::XReg(12), Xbyak_aarch64::XReg(out[0]));
-    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(10));
-    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(11));
-    h->mov(Xbyak_aarch64::XReg(3), Xbyak_aarch64::XReg(12));
+    h->mov(Xbyak_aarch64::XReg(20), Xbyak_aarch64::XReg(in[0]));
+    h->mov(Xbyak_aarch64::XReg(21), Xbyak_aarch64::XReg(in[1]));
+    h->mov(Xbyak_aarch64::XReg(22), Xbyak_aarch64::XReg(out[0]));
+    h->mov(Xbyak_aarch64::XReg(1), Xbyak_aarch64::XReg(20));
+    h->mov(Xbyak_aarch64::XReg(2), Xbyak_aarch64::XReg(21));
+    h->mov(Xbyak_aarch64::XReg(3), Xbyak_aarch64::XReg(22));
     h->mov(Xbyak_aarch64::XReg(0), get_compiled_kernel_ptr());
-    h->mov(Xbyak_aarch64::XReg(9), get_execute_function_ptr());
-    h->blr(Xbyak_aarch64::XReg(9));
+    h->mov(Xbyak_aarch64::XReg(18), get_execute_function_ptr());
+    h->blr(Xbyak_aarch64::XReg(18));
 
     restore_context(exclude);
 }


### PR DESCRIPTION
### Details:
Use temporary scratch registers (callee saved) instead of stack to ensure this operation is safe

### Tickets:
 - N/A
