### PR TITLE
[CPU][DEBUG CAPS] Fix Windows build w/ debug caps

### DIFF
--- a/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
+++ b/src/plugins/intel_cpu/src/utils/debug_capabilities.cpp
@@ -218,7 +218,7 @@ std::ostream& operator<<(std::ostream& os, const Node& c_node) {
             std::stringstream ss;
             ss << ptr->getData();
             ret = ss.str();
-        } catch (const std::exception& e) {
+        } catch (const std::exception&) {
             ret = "?";
         }
         return ret;


### PR DESCRIPTION
### Details:
 - Fix unused exception variable warning during the build with debug caps on Windows platform 

### Tickets:
 - N/A
