### PR TITLE
[GPU] Update preferred format selection for dynamic onednn convolution for VLMs

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -954,16 +954,18 @@ void layout_optimizer::set_onednn_dyn_conv_preferred_format(convolution_node& no
             node.set_preferred_output_fmt(0, cldnn::format::byxf);
         }
     } else if (is_fp16_input) {
-        if (input_layout.get_partial_shape().size() <= 4)
+        if (output_layout.get_partial_shape().size() <= 4)
             node.set_preferred_output_fmt(0, format::b_fs_yx_fsv16);
-        else if (input_layout.get_partial_shape().size() == 5)
+        else if (output_layout.get_partial_shape().size() == 5)
             node.set_preferred_output_fmt(0, format::b_fs_zyx_fsv16);
         else
             OPENVINO_ASSERT(false, "Unsupported input layout partial shape size ", input_layout.get_partial_shape().size());
-        // Use planar format for dynamic convolution with small input channel(IC <= 3)
-        if (input_layout.get_partial_shape()[1].is_static() &&
-            (input_layout.get_partial_shape()[1].get_length() <= 4 || output_layout.get_partial_shape()[1].get_length() <= 4)) {
-            node.set_preferred_output_fmt(0, format::get_default_format(input_layout.get_partial_shape().size()));
+        // Use planar format for dynamic convolution with small input/output channel(IC <= 4)
+        if (input_layout.get_partial_shape()[1].is_static() && input_layout.get_partial_shape()[1].get_length() <= 4) {
+            node.set_preferred_input_fmt(0, format::get_default_format(input_layout.get_partial_shape().size()));
+        }
+        if (output_layout.get_partial_shape()[1].is_static() && output_layout.get_partial_shape()[1].get_length() <= 4) {
+            node.set_preferred_output_fmt(0, format::get_default_format(output_layout.get_partial_shape().size()));
         }
     }
 }


### PR DESCRIPTION
### Details:
 - After this PR(https://github.com/openvinotoolkit/openvino/pull/30993), the preferred format of convolution is selected to `b_fs_yx_fsv16` and the input tag of onednn conv is selected as blocked format w/ b16 even if the input channel is small (e.g. IC<=4), which causes unnecessary computation cost.
 - Update preferred format selection logic to select planar format for input and output respectively
#### Before:
<img width="1062" height="487" alt="image" src="https://github.com/user-attachments/assets/071bc2eb-15d0-404e-8dbc-d00732eee20e" />

```
benchdnn.exe --verbose=5 --mode=p --cold-cache=wei --memory-kind=usm_device --conv --reset --allow-enum-tags-only=0 --engine=gpu --dir=FWD_I --alg=direct --dt=f16:f16:f16 --bia-dt=f16 --stag=aBcd16b --wtag=any --dtag=abcd --attr-scales= --attr-zero-points= --attr-scratchpad=user mb1_ic3oc1152_ih896oh64kh14sh14dh0ph0_iw896ow64kw14sw14dw0pw0
```
<img width="687" height="50" alt="image" src="https://github.com/user-attachments/assets/773149d8-49cc-48bf-823a-13465644d47a" />

#### After:
```
benchdnn.exe --verbose=5 --mode=p --cold-cache=wei --memory-kind=usm_device --conv --reset --allow-enum-tags-only=0 --engine=gpu --dir=FWD_I --alg=direct --dt=f16:f16:f16 --bia-dt=f16 --stag=abcd --wtag=any --dtag=aBcd16b --attr-scales= --attr-zero-points= --attr-scratchpad=user mb1_ic3oc1152_ih896oh64kh14sh14dh0ph0_iw896ow64kw14sw14dw0pw0
```
<img width="675" height="49" alt="image" src="https://github.com/user-attachments/assets/5d32848e-c8e5-4daf-8c63-9405b1775165" />


### Tickets:
 - 170672
