### PR TITLE
[core] The OV core set mmap threshold to static default value (linux only)

### DIFF
--- a/src/common/util/include/openvino/util/os.hpp
+++ b/src/common/util/include/openvino/util/os.hpp
@@ -31,6 +31,9 @@ void set_mmap_threshold(int threshold);
 constexpr void set_mmap_threshold(int) {}
 #endif
 
+namespace linux {
+/// @brief Default mmap threshold value for memory allocation in bytes.
 inline constexpr int default_mmap_th = 128 * 1024;
+}  // namespace linux
 
 }  // namespace ov::util

--- a/src/common/util/include/openvino/util/os.hpp
+++ b/src/common/util/include/openvino/util/os.hpp
@@ -20,4 +20,17 @@ constexpr bool may_i_use_dynamic_code() {
 }
 #endif
 
+/**
+ * @brief Set the mmap threshold value for memory allocation
+ *
+ * @param threshold threshold value (bytes).
+ */
+#if defined(__linux)
+void set_mmap_threshold(int threshold);
+#else
+constexpr void set_mmap_threshold(int) {}
+#endif
+
+inline constexpr int default_mmap_th = 128 * 1024;
+
 }  // namespace ov::util

--- a/src/common/util/include/openvino/util/os.hpp
+++ b/src/common/util/include/openvino/util/os.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "openvino/util/pp.hpp"
+
 #if defined(_WIN32)
 #    include <windows.h>
 #endif
@@ -25,11 +27,19 @@ constexpr bool may_i_use_dynamic_code() {
  *
  * @param threshold threshold value (bytes).
  */
-#if defined(__linux)
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
 void set_mmap_threshold(int threshold);
 #else
 constexpr void set_mmap_threshold(int) {}
 #endif
+
+constexpr bool may_i_use_mallopt() {
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
+    return true;
+#else
+    return false;
+#endif
+};
 
 namespace linux {
 /// @brief Default mmap threshold value for memory allocation in bytes.

--- a/src/common/util/src/os/lin/os.cpp
+++ b/src/common/util/src/os/lin/os.cpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/util/os.hpp"
+
+#include <malloc.h>
+
+#include <iostream>  // remove
+#include <stdexcept>
+
+namespace ov::util {
+void set_mmap_threshold(int threshold) {
+    if (mallopt(M_MMAP_THRESHOLD, threshold) != 1) {
+        throw std::runtime_error("Set M_MMAP_THRESHOLD failed");
+    }
+}
+}  // namespace ov::util

--- a/src/common/util/src/os/lin/os.cpp
+++ b/src/common/util/src/os/lin/os.cpp
@@ -6,13 +6,14 @@
 
 #include <malloc.h>
 
-#include <iostream>  // remove
 #include <stdexcept>
 
 namespace ov::util {
 void set_mmap_threshold(int threshold) {
+#if defined(M_MMAP_THRESHOLD)
     if (mallopt(M_MMAP_THRESHOLD, threshold) != 1) {
         throw std::runtime_error("Set M_MMAP_THRESHOLD failed");
     }
+#endif
 }
 }  // namespace ov::util

--- a/src/common/util/src/os/lin/os.cpp
+++ b/src/common/util/src/os/lin/os.cpp
@@ -4,16 +4,18 @@
 
 #include "openvino/util/os.hpp"
 
-#include <malloc.h>
-
 #include <stdexcept>
 
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
+#    include <malloc.h>
+#endif
+
 namespace ov::util {
+#if defined(OPENVINO_GNU_LIBC) && !defined(__ANDROID__)
 void set_mmap_threshold(int threshold) {
-#if defined(M_MMAP_THRESHOLD)
     if (mallopt(M_MMAP_THRESHOLD, threshold) != 1) {
         throw std::runtime_error("Set M_MMAP_THRESHOLD failed");
     }
-#endif
 }
+#endif
 }  // namespace ov::util

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -24,7 +24,7 @@ const auto mmap_cfg = [] {
     constexpr int32_t not_set = -1;
     // Use default MMAP threshold value as static if not set by user using environment variable
     if (const auto env_mmap_th = util::getenv_int("ENV_MALLOC_MMAP_THRESHOLD_", not_set); env_mmap_th == not_set) {
-        util::set_mmap_threshold(util::default_mmap_th);
+        util::set_mmap_threshold(util::linux::default_mmap_th);
     }
     return nullptr;
 }();

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -18,17 +18,17 @@ namespace ov {
 
 namespace {
 
-#if defined(__linux)
 // Configure mmap when OV library used
-const auto mmap_cfg = [] {
-    constexpr int32_t not_set = -1;
-    // Use default MMAP threshold value as static if not set by user using environment variable
-    if (const auto env_mmap_th = util::getenv_int("ENV_MALLOC_MMAP_THRESHOLD_", not_set); env_mmap_th == not_set) {
-        util::set_mmap_threshold(util::linux::default_mmap_th);
+[[maybe_unused]] const auto mmap_cfg = [] {
+    if constexpr (util::may_i_use_mallopt()) {
+        constexpr int32_t not_set = -1;
+        // Use default MMAP threshold value as static if not set by user using environment variable
+        if (const auto env_mmap_th = util::getenv_int("ENV_MALLOC_MMAP_THRESHOLD_", not_set); env_mmap_th == not_set) {
+            util::set_mmap_threshold(util::linux::default_mmap_th);
+        }
     }
     return nullptr;
 }();
-#endif
 
 std::string find_plugins_xml(const std::string& xml_file) {
     std::string xml_file_name = xml_file;

--- a/src/inference/src/cpp/core.cpp
+++ b/src/inference/src/cpp/core.cpp
@@ -10,11 +10,25 @@
 #include "openvino/frontend/manager.hpp"
 #include "openvino/runtime/device_id_parser.hpp"
 #include "openvino/runtime/iremote_context.hpp"
+#include "openvino/util/env_util.hpp"
 #include "openvino/util/file_util.hpp"
+#include "openvino/util/os.hpp"
 
 namespace ov {
 
 namespace {
+
+#if defined(__linux)
+// Configure mmap when OV library used
+const auto mmap_cfg = [] {
+    constexpr int32_t not_set = -1;
+    // Use default MMAP threshold value as static if not set by user using environment variable
+    if (const auto env_mmap_th = util::getenv_int("ENV_MALLOC_MMAP_THRESHOLD_", not_set); env_mmap_th == not_set) {
+        util::set_mmap_threshold(util::default_mmap_th);
+    }
+    return nullptr;
+}();
+#endif
 
 std::string find_plugins_xml(const std::string& xml_file) {
     std::string xml_file_name = xml_file;


### PR DESCRIPTION
### Details:
 - For Linux builds the OV core library set the MMAP threshold for allocator value to default but it will be static instead of dynamic
 - The change allow better memory restore by system if released by process
 - TODO: Performance impact measurement is ongoing
 
### Tickets:
 - CVS-158568
