### PR TITLE
[GPU] Fix GPU Plugin for Leaky Relu with 1D Slope Input Parameter

### DIFF
--- a/src/frontends/onnx/frontend/src/op/leaky_relu.cpp
+++ b/src/frontends/onnx/frontend/src/op/leaky_relu.cpp
@@ -18,7 +18,7 @@ ov::OutputVector leaky_relu(const ov::frontend::onnx::Node& node) {
     auto data = node.get_ov_inputs().at(0);
     double alpha = node.get_attribute_value<double>("alpha", 0.01);
 
-    std::shared_ptr<ov::Node> alpha_node = v0::Constant::create(data.get_element_type(), ov::Shape{1}, {alpha});
+    std::shared_ptr<ov::Node> alpha_node = v0::Constant::create(data.get_element_type(), ov::Shape{}, {alpha});
     return {std::make_shared<v0::PRelu>(data, alpha_node)};
 }
 

--- a/src/frontends/onnx/frontend/src/op/leaky_relu.cpp
+++ b/src/frontends/onnx/frontend/src/op/leaky_relu.cpp
@@ -18,7 +18,7 @@ ov::OutputVector leaky_relu(const ov::frontend::onnx::Node& node) {
     auto data = node.get_ov_inputs().at(0);
     double alpha = node.get_attribute_value<double>("alpha", 0.01);
 
-    std::shared_ptr<ov::Node> alpha_node = v0::Constant::create(data.get_element_type(), ov::Shape{}, {alpha});
+    std::shared_ptr<ov::Node> alpha_node = v0::Constant::create(data.get_element_type(), ov::Shape{1}, {alpha});
     return {std::make_shared<v0::PRelu>(data, alpha_node)};
 }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -213,7 +213,7 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
             //       [N, M, 1] --> [1, N, M, 1]
             auto input_shape = outOp->get_input_partial_shape(0);
             if ((constDims.size() != 1 && constDims.size() < input_shape.size()) ||
-                (constDims.size() == 1 && input_shape.is_static() && static_cast<int64_t>(constDims[0]) != input_shape[1].get_length())) {
+                (constDims.size() == 1 && input_shape.size() != 1 && input_shape.is_static() && static_cast<int64_t>(constDims[0]) != input_shape[1].get_length())) {
                 // Reshape 'constDims' according to the numpy broadcasting rule.
                 ov::Shape slope_shape(input_shape.size(), 1);
                 for (size_t j = 1; j <= constDims.size(); j++)

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -213,7 +213,7 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
             //       [N, M, 1] --> [1, N, M, 1]
             auto input_shape = outOp->get_input_partial_shape(0);
             if ((constDims.size() != 1 && constDims.size() < input_shape.size()) ||
-                (constDims.size() == 1 && input_shape.size() != 1 && input_shape.is_static() && static_cast<int64_t>(constDims[0]) != input_shape[1].get_length())) {
+                (constDims.size() == 1 && input_shape.is_static() && input_shape.size() > 1 && static_cast<int64_t>(constDims[0]) != input_shape[1].get_length())) {
                 // Reshape 'constDims' according to the numpy broadcasting rule.
                 ov::Shape slope_shape(input_shape.size(), 1);
                 for (size_t j = 1; j <= constDims.size(); j++)

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -213,7 +213,8 @@ static void CreateConstantOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v0
             //       [N, M, 1] --> [1, N, M, 1]
             auto input_shape = outOp->get_input_partial_shape(0);
             if ((constDims.size() != 1 && constDims.size() < input_shape.size()) ||
-                (constDims.size() == 1 && input_shape.is_static() && input_shape.size() > 1 && static_cast<int64_t>(constDims[0]) != input_shape[1].get_length())) {
+                (constDims.size() == 1 && input_shape.is_static() && input_shape.size() > 1 &&
+                static_cast<int64_t>(constDims[0]) != input_shape[1].get_length())) {
                 // Reshape 'constDims' according to the numpy broadcasting rule.
                 ov::Shape slope_shape(input_shape.size(), 1);
                 for (size_t j = 1; j <= constDims.size(); j++)

--- a/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
+++ b/src/plugins/intel_gpu/tests/functional/shared_tests_instances/single_layer_tests/activation.cpp
@@ -86,6 +86,7 @@ std::map<std::vector<ov::Shape>, std::vector<ov::Shape>> big_ranks = {
 std::map<std::vector<ov::Shape>, std::vector<ov::Shape>> preluBasic = {
         {{{1, 10, 20}}, {{10}, {20}, {10, 20}}},
         {{{1, 128}}, {{1}, {128}}},
+        {{{24}}, {{1}}},
 };
 
 auto static_shapes_param_transform = [](const std::vector<std::pair<std::vector<ov::Shape>, ov::Shape>>& original_shapes) {


### PR DESCRIPTION
PRelu Inputs from the SPEC: https://docs.openvino.ai/2025/documentation/openvino-ir-format/operation-sets/operation-specs/activation/prelu-1.html

1: data. A tensor of type T and arbitrary shape. Required.

2: slope. A tensor of type T and rank greater or equal to 1. Tensor with negative slope values. Required.

Note: Channels dimension corresponds to the second dimension of data input tensor. If slope input rank is 1 and its dimension is equal to the second dimension of data input, then per channel broadcast is applied. Otherwise slope input is broadcasted with numpy rules, description is available in Broadcast Rules For Elementwise Operations.

JIRA: [CVS-165844](https://jira.devtools.intel.com/browse/CVS-165844)