### PR TITLE
[GHA][CLANG-TIDY] Make workflow log less verbose in Ubuntu 22.04 scenarios

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -241,7 +241,7 @@ jobs:
           --parallel $(($(nproc) - 1)) \
           --config ${{ env.CMAKE_BUILD_TYPE }} \
           --target openvino_intel_cpu_plugin \
-          -- -k 0
+          -- -k
         # TODO: add --quiet after switch to Ubuntu 24.04+
 
       - name: Show sccache stats
@@ -311,7 +311,7 @@ jobs:
           --parallel $(($(nproc) - 1)) \
           --config ${{ env.CMAKE_BUILD_TYPE }} \
           --target openvino_intel_cpu_plugin \
-          -- -k 0
+          -- -k
         # TODO: add --quiet after switch to Ubuntu 24.04+
 
   Overall_Status:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -194,7 +194,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive # to prevent apt-get from waiting user input
       CMAKE_BUILD_TYPE: 'Release'
-      CMAKE_GENERATOR: 'Ninja Multi-Config'
+      CMAKE_GENERATOR: 'Unix Makefiles'
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_COMPILE_WARNING_AS_ERROR: 'ON'
@@ -228,6 +228,7 @@ jobs:
             -DENABLE_NCC_STYLE=OFF \
             -DENABLE_CPPLINT=OFF \
             -DENABLE_FASTER_BUILD=OFF \
+            -DCMAKE_RULE_MESSAGES=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CMAKE_C_COMPILER_LAUNCHER }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CMAKE_CXX_COMPILER_LAUNCHER }} \
             -S ${OPENVINO_REPO} \
@@ -262,7 +263,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive # to prevent apt-get from waiting user input
       CMAKE_BUILD_TYPE: 'Release'
-      CMAKE_GENERATOR: 'Ninja Multi-Config'
+      CMAKE_GENERATOR: 'Unix Makefiles'
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_COMPILE_WARNING_AS_ERROR: 'ON'
@@ -297,6 +298,7 @@ jobs:
             -DENABLE_NCC_STYLE=OFF \
             -DENABLE_CPPLINT=OFF \
             -DENABLE_FASTER_BUILD=OFF \
+            -DCMAKE_RULE_MESSAGES=OFF \
             -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CMAKE_C_COMPILER_LAUNCHER }} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CMAKE_CXX_COMPILER_LAUNCHER }} \
             -S ${OPENVINO_REPO} \


### PR DESCRIPTION
### Details:
"Build-aarch64" and "Build-riscv64" jobs are switched from "Ninja Multi-Config" to "Unix Makefiles" generator and add `-DCMAKE_RULE_MESSAGES=OFF` to suppress Make rule messages

These changes are temporary solution related to TODO comments about adding `--quiet` after switching to Ubuntu 24.04+ (with newer ninja version that have this flag) by providing an alternative solution for Ubuntu 22.04 environments. The `-DCMAKE_RULE_MESSAGES=OFF` flag reduces build log verbosity by suppressing the rule messages that Make normally prints during compilation. `-DCMAKE_RULE_MESSAGES=OFF` is not applicable for ninja

### Tickets:
 - N/A
