### PR TITLE
[GPU] Reuse the memory found in the first place

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_helpers.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_helpers.cpp
@@ -160,21 +160,19 @@ add_fusing_type onednn_add_fusing_helpers::get_add_fusing_type(
 }
 
 int32_t onednn_add_fusing_helpers::get_reused_eltwmem_idx(const program_node& node) {
-    int32_t reused_mem_idx = -1;   // if -1, no reused input memory
     if (node.get_preferred_impl_type() == impl_types::onednn) {
-        size_t eltw_dep = 0;
         for (auto& fused_op : node.get_fused_primitives()) {
             if (fused_op.is_type<eltwise>() && fused_op.deps.size() == 1) {
                 // If it is first sum, reuse the buffer
                 auto fusing_type = get_add_fusing_type(node, fused_op);
-                if (fusing_type != add_fusing_type::sum || eltw_dep != 0)
+                if (fusing_type != add_fusing_type::sum)
                     continue;
                 if (!fused_op.has_outer_dep())
                     continue;
-                reused_mem_idx = fused_op.outer_dep_start_idx;
+                return fused_op.outer_dep_start_idx;
             }
         }
     }
-    return reused_mem_idx;
+    return -1;   // if -1, no reused input memory
 }
 }  // namespace cldnn


### PR DESCRIPTION
### Details:
It is a fix for the regression introduced in #30957. The regression is caused by the reused memory is overwritten by other node shared in memory pool which leads to incorrect result. For the example below in red flow, `/1/MatMul_3106` reuses `/1/Multiply_3113` which shared memory with `/2/Tanh_3103` in memory pool. When `/1/Multiply_3113` goes as input source of `1/Select_107`, the memory is overwritten by `/2/Tanh_3103`.  The flow goes to green one after the change.

<img width="636" height="801" alt="image" src="https://github.com/user-attachments/assets/f7adcf76-8bfa-4d3e-9993-f461b9a7703c" />

### Tickets:
 - [CVS-169229](https://jira.devtools.intel.com/browse/CVS-169229)
