### PR TITLE
Disable precompiled headers on Windows

### DIFF
--- a/.github/workflows/windows_conditional_compilation.yml
+++ b/.github/workflows/windows_conditional_compilation.yml
@@ -179,7 +179,6 @@ jobs:
             -DENABLE_NCC_STYLE=OFF `
             -DENABLE_PROFILING_ITT=ON `
             -DSELECTIVE_BUILD=COLLECT `
-            -DENABLE_FASTER_BUILD=ON `
             -DENABLE_UNITY_BUILD=ON `
             -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON `
             -S ${{ env.OPENVINO_REPO }} `

--- a/.github/workflows/windows_vs2022_debug.yml
+++ b/.github/workflows/windows_vs2022_debug.yml
@@ -71,7 +71,6 @@ jobs:
         -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
         -DENABLE_STRICT_DEPENDENCIES=OFF
         -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON
-        -DENABLE_FASTER_BUILD=ON
 
   CXX_Unit_Tests:
     name: C++ unit tests

--- a/.github/workflows/windows_vs2022_release.yml
+++ b/.github/workflows/windows_vs2022_release.yml
@@ -75,7 +75,6 @@ jobs:
             -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
             -DENABLE_STRICT_DEPENDENCIES=OFF
             -DCMAKE_DISABLE_FIND_PACKAGE_PkgConfig=ON
-            -DENABLE_FASTER_BUILD=ON
 
   Samples:
     needs: [ Build, Smart_CI ]


### PR DESCRIPTION
### Details:
 - Disable precompiled headers on Windows because ccache doesn't work with msvc and pch


### Tickets:
 - *ticket-id*
