### PR TITLE
Fix TransposeMatmulTranspose fusion for cases where Matmul is connected to more than one node.

### DIFF
--- a/src/core/src/pass/manager.cpp
+++ b/src/core/src/pass/manager.cpp
@@ -251,7 +251,7 @@ public:
                 const auto& file_name = gen_file_name(model->get_name(), pass_name, viz_index++);
                 ov::pass::VisualizeTree vt(file_name + ".svg");
                 vt.run_on_model(model);
-                };
+            };
 
             if (m_visualize.is_bool()) {
                 _visualize();

--- a/src/core/src/pass/manager.cpp
+++ b/src/core/src/pass/manager.cpp
@@ -246,25 +246,12 @@ public:
 
     void visualize(const std::shared_ptr<ov::Model>& model, const std::string& pass_name) const {
         static size_t viz_index = 0;
-        std::string pass_name_short = " ";
-        int  pos = 0,nchars = 0;
-        std::string sub = "::";
         if (m_visualize.is_enabled()) {
             const auto& _visualize = [&]() {
-                while ((nchars = pass_name.find(sub, pos)) != std::string::npos) {      /* find sub */
-                    pos = nchars + sub.length();
-                    pass_name_short = pass_name.substr(nchars + 2);
-                }
-                if (pass_name_short == " ") {
-                    const auto& file_name = gen_file_name(model->get_name(), pass_name, viz_index++);
-                    ov::pass::VisualizeTree vt(file_name + ".svg");
-                    vt.run_on_model(model);
-                } else {
-                    const auto& file_name = gen_file_name(model->get_name(), pass_name_short, viz_index++);
-                    ov::pass::VisualizeTree vt(file_name + ".svg");
-                    vt.run_on_model(model);
-                }
-            };
+                const auto& file_name = gen_file_name(model->get_name(), pass_name, viz_index++);
+                ov::pass::VisualizeTree vt(file_name + ".svg");
+                vt.run_on_model(model);
+                };
 
             if (m_visualize.is_bool()) {
                 _visualize();

--- a/src/core/src/pass/manager.cpp
+++ b/src/core/src/pass/manager.cpp
@@ -246,11 +246,24 @@ public:
 
     void visualize(const std::shared_ptr<ov::Model>& model, const std::string& pass_name) const {
         static size_t viz_index = 0;
+        std::string pass_name_short = " ";
+        int  pos = 0,nchars = 0;
+        std::string sub = "::";
         if (m_visualize.is_enabled()) {
             const auto& _visualize = [&]() {
-                const auto& file_name = gen_file_name(model->get_name(), pass_name, viz_index++);
-                ov::pass::VisualizeTree vt(file_name + ".svg");
-                vt.run_on_model(model);
+                while ((nchars = pass_name.find(sub, pos)) != std::string::npos) {      /* find sub */
+                    pos = nchars + sub.length();
+                    pass_name_short = pass_name.substr(nchars + 2);
+                }
+                if (pass_name_short == " ") {
+                    const auto& file_name = gen_file_name(model->get_name(), pass_name, viz_index++);
+                    ov::pass::VisualizeTree vt(file_name + ".svg");
+                    vt.run_on_model(model);
+                } else {
+                    const auto& file_name = gen_file_name(model->get_name(), pass_name_short, viz_index++);
+                    ov::pass::VisualizeTree vt(file_name + ".svg");
+                    vt.run_on_model(model);
+                }
             };
 
             if (m_visualize.is_bool()) {

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -301,7 +301,7 @@ TransposeMatMulTransposeMatcher::TransposeMatMulTransposeMatcher(bool supports_i
     auto matmul_in_a = std::make_shared<Or>(OutputVector{input_a_m, transpose_a_m});
     auto matmul_in_b = std::make_shared<Or>(OutputVector{input_b_m, transpose_b_m});
 
-    auto matmul_m = wrap_type<ov::op::v0::MatMul>({ matmul_in_a, matmul_in_b });
+    auto matmul_m = wrap_type<ov::op::v0::MatMul>({ matmul_in_a, matmul_in_b }, consumers_count(1));
     auto transpose_c_order_m = wrap_type<ov::op::v0::Constant>(consumers_count(1));
     auto transpose_c_m = wrap_type<ov::op::v1::Transpose>({matmul_m, transpose_c_order_m}, output_transpose_predicate);
 
@@ -313,10 +313,6 @@ TransposeMatMulTransposeMatcher::TransposeMatMulTransposeMatcher(bool supports_i
             return false;
         }
 
-        auto users = matmul->get_output_target_inputs(0);
-        if (users.size() > 1 && ov::as_type<ov::op::v1::Transpose>(users.begin()->get_node()) != nullptr) {
-            return false;
-        }
         auto tranpose_c_order = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(transpose_c_order_m).get_node_shared_ptr());
         auto order_a = op::Gemm::default_order(matmul->get_input_partial_shape(0).size());
         auto order_b = op::Gemm::default_order(matmul->get_input_partial_shape(1).size());

--- a/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/transpose_fusion.cpp
@@ -313,6 +313,10 @@ TransposeMatMulTransposeMatcher::TransposeMatMulTransposeMatcher(bool supports_i
             return false;
         }
 
+        auto users = matmul->get_output_target_inputs(0);
+        if (users.size() > 1 && ov::as_type<ov::op::v1::Transpose>(users.begin()->get_node()) != nullptr) {
+            return false;
+        }
         auto tranpose_c_order = ov::as_type_ptr<ov::op::v0::Constant>(pattern_map.at(transpose_c_order_m).get_node_shared_ptr());
         auto order_a = op::Gemm::default_order(matmul->get_input_partial_shape(0).size());
         auto order_b = op::Gemm::default_order(matmul->get_input_partial_shape(1).size());

--- a/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/transformations/transpose_matmul_fusion_test.cpp
@@ -25,7 +25,7 @@ namespace ov {
 namespace test {
 namespace intel_gpu {
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion1) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion1) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
@@ -52,7 +52,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion1) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion2) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion2) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
@@ -81,7 +81,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion2) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion3) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion3) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
@@ -112,7 +112,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion3) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion4) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion4) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
@@ -145,7 +145,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion4) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion5) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion5) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
@@ -176,7 +176,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion5) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion6) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion6) {
     auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(2));
     auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(2));
     auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
@@ -192,7 +192,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion6) {
     comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion7) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion7) {
     auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{2, 4});
     auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{4, 2});
     auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
@@ -208,7 +208,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion7) {
     comparator.enable(FunctionsComparator::ATTRIBUTES);
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion8) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion8) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
@@ -227,7 +227,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion8) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion9) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion9) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{10, 20, 30, 40});
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{10, 40, 30, 20});
@@ -247,7 +247,7 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion9) {
     }
 }
 
-TEST_F(TransformationTestsF, TranposeMatmulFusion_Illegal_1) {
+TEST_F(TransformationTestsF, TransposeMatmulFusion_Illegal_1) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{10, 20});
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{20, 30});
@@ -258,24 +258,26 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion_Illegal_1) {
     }
 }
 
-//test cases are written for the case where we have two outputs (Transpose and another OP) are connected to Mtamul. In this case, MatmulTranpose Fusion cannot happen
-TEST_F(TransformationTestsF, TranposeMatmulFusion10) {
+//Test case is written for the case where we have two outputs (Transpose and another OP) are connected to MatMul. In this case, TransposeMatmulTranspose Fusion cannot happen
+TEST_F(TransformationTestsF, TransposeMatmulFusion10) {
     {
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 0, 2, 1, 3 });
         auto tranpose_a = std::make_shared<ov::op::v1::Transpose>(input_a, tranpose_a_const);
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, input_b);
+        auto tranpose_b_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 0, 2, 1, 3 });
+        auto tranpose_b = std::make_shared<ov::op::v1::Transpose>(input_b, tranpose_b_const);
+        auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, tranpose_b);
         auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 0, 2, 1, 3 });
         auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
         auto Shape_Of = std::make_shared<ov::op::v3::ShapeOf>(matmul);
 
-        model = std::make_shared<ov::Model>(ov::OutputVector{ tranpose_c, Shape_Of }, ov::ParameterVector{ input_a, input_b });
+        model = std::make_shared<ov::Model>(ov::OutputVector{ tranpose_c->output(0), Shape_Of }, ov::ParameterVector{ input_a, input_b });
         manager.register_pass<TransposeFusion>();
     }
     {
         std::vector<int64_t> order_a = { 0, 2, 1, 3 };
-        std::vector<int64_t> order_b = { 0, 1, 2, 3 };
+        std::vector<int64_t> order_b = { 0, 2, 1, 3 };
         std::vector<int64_t> order_c = { 0, 1, 2, 3 };
         auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
         auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
@@ -291,81 +293,6 @@ TEST_F(TransformationTestsF, TranposeMatmulFusion10) {
         auto Shape_Of = std::make_shared<ov::op::v3::ShapeOf>(gemm);
 
         model_ref = std::make_shared<ov::Model>(ov::OutputVector{ tranpose_d, Shape_Of }, ov::ParameterVector{ input_a, input_b });
-        comparator.enable(FunctionsComparator::ATTRIBUTES);
-    }
-}
-
-//test cases are written for the case where we have two outputs (Transpose and another OP) are connected to Mtamul. In this case, MatmulTranpose Fusion cannot happend 
-TEST_F(TransformationTestsF, TranposeMatmulFusion11) {
-    {
-        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto tranpose_a_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
-        auto tranpose_a = std::make_shared<ov::op::v1::Transpose>(input_a, tranpose_a_const);
-        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto tranpose_b_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
-        auto tranpose_b = std::make_shared<ov::op::v1::Transpose>(input_b, tranpose_b_const);
-        auto matmul = std::make_shared<ov::op::v0::MatMul>(tranpose_a, tranpose_b);
-        auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{4}, {0, 2, 1, 3});
-        auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
-        auto Shape_Of = std::make_shared<ov::op::v3::ShapeOf>(matmul);
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{tranpose_c->output(0), Shape_Of}, ov::ParameterVector{input_a, input_b});
-        manager.register_pass<TransposeFusion>();
-    }
-    {
-        std::vector<int64_t> order_a = {0, 2, 1, 3};
-        std::vector<int64_t> order_b = {0, 2, 1, 3};
-        std::vector<int64_t> order_c = {0, 1, 2, 3};
-        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(4));
-        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a,
-                                                              input_b,
-                                                              order_a,
-                                                              order_b,
-                                                              order_c,
-                                                              ov::element::dynamic);
-
-        auto tranpose_d_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{ 4 }, { 0, 2, 1, 3 });
-        auto tranpose_d = std::make_shared<ov::op::v1::Transpose>(gemm, tranpose_d_const);
-        auto Shape_Of = std::make_shared<ov::op::v3::ShapeOf>(gemm);
-
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{ tranpose_d, Shape_Of }, ov::ParameterVector{ input_a, input_b });
-        comparator.enable(FunctionsComparator::ATTRIBUTES);
-    }
-}
-
-TEST_F(TransformationTestsF, TranposeMatmulFusion12) {
-    {
-        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
-        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
-        auto matmul = std::make_shared<ov::op::v0::MatMul>(input_a, input_b);
-        auto tranpose_c_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{3}, {0, 2, 1});
-        auto tranpose_c = std::make_shared<ov::op::v1::Transpose>(matmul, tranpose_c_const);
-        auto Shape_Of = std::make_shared<ov::op::v3::ShapeOf>(matmul, ov::element::i32);
-
-
-        model = std::make_shared<ov::Model>(ov::OutputVector{tranpose_c, Shape_Of}, ov::ParameterVector{input_a, input_b});
-
-        const auto supports_immad = false;
-        manager.register_pass<TransposeFusion>(supports_immad);
-    }
-    {
-        std::vector<int64_t> order_a = {0, 1, 2};
-        std::vector<int64_t> order_b = {0, 1, 2};
-        std::vector<int64_t> order_c = {0, 1, 2};
-        auto input_a = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
-        auto input_b = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape::dynamic(3));
-        auto gemm = std::make_shared<ov::intel_gpu::op::Gemm>(input_a,
-                                                              input_b,
-                                                              order_a,
-                                                              order_b,
-                                                              order_c,
-                                                              ov::element::dynamic);
-
-        auto tranpose_d_const = ov::op::v0::Constant::create(ov::element::i64, ov::Shape{ 3 }, { 0, 2, 1});
-        auto tranpose_d = std::make_shared<ov::op::v1::Transpose>(gemm, tranpose_d_const);
-        auto Shape_Of = std::make_shared<ov::op::v3::ShapeOf>(gemm, ov::element::i32);
-        model_ref = std::make_shared<ov::Model>(ov::OutputVector{ tranpose_d, Shape_Of }, ov::ParameterVector{input_a, input_b});
         comparator.enable(FunctionsComparator::ATTRIBUTES);
     }
 }


### PR DESCRIPTION
### Details:
 -  Add one condition in TransposeMatmulTranspose function to avoid fusion if Matmul is connected to more than one nodes.
 - If we have Tranpose + Matmul + Tranpose pattern, the fusion happens and the ops are replaced with one gemm op with reorder inputs and reorder outputs. However, we have one case where the pattern is Transpose + Matmul + Transpose and ShapeOf. The pattern cannot be fused and the function needs to return false. 
 - The subgraph consist of "ShapeOf" cannot be simplified because of dynamic shapes.

### Description of the issue
The command below with dynamic shape cause the error intoroduced in the attached jira ticket. 
`benchmark_app.exe -d GPU -niter 1 --data_shape input_points[1,3,2,2],input_labels[1,3,2],image_embeddings[1,256,64,64],image_positional_embeddings[1,256,64,64] -m openvino_prompt_encoder_mask_decoder.xml `

The subgraph (2) in red line are not simplified and the matmul node is connected to two nodes, Transpose and ShapeOf. 
<img width="1223" height="668" alt="subgraph" src="https://github.com/user-attachments/assets/4f84947d-8d94-4ae3-8631-fa60f1c3e529" />

### Tickets:
 - [CVS-170392](https://jira.devtools.intel.com/browse/CVS-170392)
