### PR TITLE
[GPU] Added missing variables for model caching in SDPA.

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/test_cases/sdpa_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/sdpa_gpu_test.cpp
@@ -35,6 +35,23 @@ struct sdpa_test_params {
     int sequence_length_q;
     int sequence_length_kv;
     int batch;
+    bool use_scalar_scale_val;
+    float scale_val;
+    bool use_scalar_attn_mask;
+    float attn_mask_val;
+
+    // Constructor for basic tests (backward compatibility)
+    sdpa_test_params(int h_size, int n_heads, int seq_q, int seq_kv, int b)
+        : head_size(h_size), num_heads(n_heads), sequence_length_q(seq_q),
+          sequence_length_kv(seq_kv), batch(b), use_scalar_scale_val(false),
+          scale_val(1.0f), use_scalar_attn_mask(false), attn_mask_val(0.0f) {}
+
+    // Constructor for advanced caching tests
+    sdpa_test_params(int h_size, int n_heads, int seq_q, int seq_kv, int b,
+                     bool use_scale, float scale, bool use_mask, float mask)
+        : head_size(h_size), num_heads(n_heads), sequence_length_q(seq_q),
+          sequence_length_kv(seq_kv), batch(b), use_scalar_scale_val(use_scale),
+          scale_val(scale), use_scalar_attn_mask(use_mask), attn_mask_val(mask) {}
 };
 
 struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
@@ -51,7 +68,7 @@ struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
         set_values(mem, input_data);
     }
 
-    cldnn::memory::ptr run_network(bool is_caching_test, bool use_micro_sdpa,
+    std::tuple<cldnn::memory::ptr, cldnn::network::ptr> run_network(bool is_caching_test, bool use_micro_sdpa,
             cldnn::layout input0_dyn_layout,
             cldnn::layout input1_dyn_layout,
             cldnn::layout input2_dyn_layout,
@@ -59,22 +76,39 @@ struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
             cldnn::memory::ptr input0,
             cldnn::memory::ptr input1,
             cldnn::memory::ptr input2,
-            cldnn::memory::ptr input3) {
+            cldnn::memory::ptr input3,
+            bool use_scalar_scale_val = false,
+            float scale_val = 1.0f,
+            bool use_scalar_attn_mask = false,
+            float attn_mask_val = 0.0f) {
         auto& engine = get_test_engine();
         topology topo;
         topo.add(input_layout("input0", input0_dyn_layout));
         topo.add(input_layout("input1", input1_dyn_layout));
         topo.add(input_layout("input2", input2_dyn_layout));
         topo.add(input_layout("input3", input3_dyn_layout));
-        topo.add(scaled_dot_product_attention("sdpa", {input_info("input0"), input_info("input1"), input_info("input2"), input_info("input3")},
-            false, -1, {0,2,1,3}, {0,2,1,3}, {0,2,1,3}, {0,1,2,3}, {}, false));
+
+        auto sdpa_prim = scaled_dot_product_attention("sdpa", {input_info("input0"), input_info("input1"), input_info("input2"), input_info("input3")},
+            false, -1, {0,2,1,3}, {0,2,1,3}, {0,2,1,3}, {0,1,2,3}, {}, false);
+
+        if (use_scalar_scale_val) {
+            sdpa_prim.scale_val = scale_val;
+        }
+
+        if (use_scalar_attn_mask) {
+            sdpa_prim.attn_mask_val = attn_mask_val;
+        }
+
+        topo.add(sdpa_prim);
         topo.add(reorder("result",input_info("sdpa"), format::bfyx, data_types::f16));
 
         ExecutionConfig config = get_test_default_config(engine);
         config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
 
         if (use_micro_sdpa) {
-            config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"sdpa", {format::type::bfyx, "sdpa_micro"}} }));
+            if (!is_caching_test) {
+                config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"sdpa", {format::type::bfyx, "sdpa_micro"}} }));
+            }
         } else {
             config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"sdpa", {format::type::bfyx, "sdpa_ref"}} }));
         }
@@ -88,7 +122,7 @@ struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
 
         auto outputs = net->execute();
         auto output = outputs.at("result").get_memory();
-        return output;
+        return {output, net};
     }
 
     void execute(sdpa_test_params& p, bool is_caching_test = false) {
@@ -97,6 +131,10 @@ struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
         const auto seq_length_q = p.sequence_length_q;
         const auto seq_length_kv = p.sequence_length_kv;
         const auto batch = p.batch;
+        const auto use_scalar_scale_val = p.use_scalar_scale_val;
+        const auto scale_val = p.scale_val;
+        const auto use_scalar_attn_mask = p.use_scalar_attn_mask;
+        const auto attn_mask_val = p.attn_mask_val;
 
         auto& engine = get_test_engine();
         cldnn::layout input0_dyn_layout({-1, -1, num_heads, head_size}, data_types::f16, format::bfyx);
@@ -119,12 +157,30 @@ struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
         load_input(input2, 2);
         load_input(input3, 3);
 
-        auto mem_ref_ptr = run_network(is_caching_test, false,
+        auto [mem_ref_ptr, net_ref_ptr] = run_network(is_caching_test, false,
                                         input0_dyn_layout, input1_dyn_layout, input2_dyn_layout, input3_dyn_layout,
-                                        input0, input1, input2, input3);
-        auto mem_opt_ptr = run_network(is_caching_test, true,
+                                        input0, input1, input2, input3,
+                                        use_scalar_scale_val, scale_val, use_scalar_attn_mask, attn_mask_val);
+        auto [mem_opt_ptr, net_opt_ptr] = run_network(is_caching_test, true,
                                         input0_dyn_layout, input1_dyn_layout, input2_dyn_layout, input3_dyn_layout,
-                                        input0, input1, input2, input3);
+                                        input0, input1, input2, input3,
+                                        use_scalar_scale_val, scale_val, use_scalar_attn_mask, attn_mask_val);
+
+        if (is_caching_test) {
+            auto inst = net_opt_ptr->get_primitive("sdpa");
+            auto& sdpa_node = inst->get_node().as<scaled_dot_product_attention>();
+
+            if (use_scalar_scale_val) {
+                ASSERT_TRUE(sdpa_node.get_primitive()->scale_val.has_value());
+                ASSERT_FLOAT_EQ(sdpa_node.get_primitive()->scale_val.value(), scale_val);
+            }
+
+            if (use_scalar_attn_mask) {
+                ASSERT_TRUE(sdpa_node.get_primitive()->attn_mask_val.has_value());
+                ASSERT_FLOAT_EQ(sdpa_node.get_primitive()->attn_mask_val.value(), attn_mask_val);
+            }
+        }
+
         cldnn::mem_lock<ov::float16, mem_lock_type::read> ref_data(mem_ref_ptr, get_test_stream());
         cldnn::mem_lock<ov::float16, mem_lock_type::read> opt_data(mem_opt_ptr, get_test_stream());
         {
@@ -155,11 +211,21 @@ struct sdpa_gpu_test : public ::testing::TestWithParam<sdpa_test_params> {
 
     static std::string
     PrintToStringParamName(const testing::TestParamInfo<sdpa_test_params>& info) {
-        return "sdpa_gpu_test_" + std::to_string(info.param.head_size) + "_" +
+        std::string result = "sdpa_gpu_test_" + std::to_string(info.param.head_size) + "_" +
                std::to_string(info.param.num_heads) + "_" +
                std::to_string(info.param.sequence_length_q) + "_" +
                std::to_string(info.param.sequence_length_kv) + "_" +
                std::to_string(info.param.batch);
+
+        if (info.param.use_scalar_scale_val) {
+            result += "_scale_" + std::to_string(static_cast<int>(info.param.scale_val * 1000));
+        }
+
+        if (info.param.use_scalar_attn_mask) {
+            result += "_mask_" + std::to_string(static_cast<int>(info.param.attn_mask_val * 1000));
+        }
+
+        return result;
     }
 };
 
@@ -167,7 +233,9 @@ INSTANTIATE_TEST_SUITE_P(
     smoke_sdpa_gpu_test,
     sdpa_gpu_test,
     ::testing::Values(
-        sdpa_test_params{64, 32, 990, 128, 2}
+        sdpa_test_params{64, 32, 990, 128, 2},
+        sdpa_test_params{64, 32, 128, 128, 2, true, 0.125f, false, 0.0f},  // scale_val only
+        sdpa_test_params{64, 32, 128, 128, 2, false, 1.0f, true, 0.5f}     // attn_mask only
     ),
     sdpa_gpu_test::PrintToStringParamName
 );
@@ -178,6 +246,11 @@ TEST_P(sdpa_gpu_test, basic) {
         return;
     auto p = GetParam();
     execute(p);
+}
+
+TEST_P(sdpa_gpu_test, basic_caching) {
+    auto p = GetParam();
+    execute(p, true);
 }
 #endif
 } // namespace


### PR DESCRIPTION
### Descriptions
 - An accuracy issue was caused by the scalar scale value in SDPA not being properly cached or retrieved from the model cache.
 - The scalar attention mask was also missing from the cache and has been fixed as part of this update.

#### The code and line that caused this issue
 - https://github.com/openvinotoolkit/openvino/blob/068396fde0e8fdc69359cf9946f2ceb7b0fd348e/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp#L119
 - https://github.com/openvinotoolkit/openvino/blob/068396fde0e8fdc69359cf9946f2ceb7b0fd348e/src/plugins/intel_gpu/include/intel_gpu/primitives/scaled_dot_product_attention.hpp#L139

#### Problematic graph 
<img width="2289" height="827" alt="image" src="https://github.com/user-attachments/assets/cc17f978-03ac-4b0f-9fba-df2395a773f9" />

#### Checklist
- [x] Is it a proper fix? (not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to cover this scenario? Which test did you review?       https://github.com/openvinotoolkit/openvino/blob/068396fde0e8fdc69359cf9946f2ceb7b0fd348e/src/plugins/intel_gpu/tests/unit/test_cases/sdpa_gpu_test.cpp#L40

### Tickets:
 - *168790*
