### PR TITLE
[CPU] `FakeQuantize` src and dst offset fix

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/src/nodes/fake_quantize.cpp
@@ -1802,11 +1802,11 @@ void FakeQuantize::executeReference() {
         parallel_nd(N, C, D, H, W, [&](dim_t n, dim_t c, dim_t d, dim_t h, dim_t w) {
             size_t src_off = n * s_str[0];
             if (srcDims.size() == 5) {
-                src_off += d * s_str[2] + h * s_str[3] + w * s_str[4];
+                src_off += c * s_str[1] + d * s_str[2] + h * s_str[3] + w * s_str[4];
             } else if (srcDims.size() == 4) {
-                src_off += h * s_str[2] + w * s_str[3];
+                src_off += c * s_str[1] + h * s_str[2] + w * s_str[3];
             } else if (srcDims.size() == 3) {
-                src_off += h * s_str[2];
+                src_off += c * s_str[1] + h * s_str[2];
             } else if (srcDims.size() == 2) {
                 src_off += c * s_str[1];
             }
@@ -1830,13 +1830,15 @@ void FakeQuantize::executeReference() {
             dst_val = roundf(dst_val);
             dst_val = dst_val * osc + osh;
 
-            size_t dst_off = n * d_str[0] + c * d_str[1];
+            size_t dst_off = n * d_str[0];
             if (dstDims.size() == 5) {
-                dst_off += d * d_str[2] + h * d_str[3] + w * d_str[4];
+                dst_off += c * d_str[1] + d * d_str[2] + h * d_str[3] + w * d_str[4];
             } else if (dstDims.size() == 4) {
-                dst_off += h * d_str[2] + w * d_str[3];
+                dst_off += c * d_str[1] + h * d_str[2] + w * d_str[3];
             } else if (dstDims.size() == 3) {
-                dst_off += h * d_str[2];
+                dst_off += c * d_str[1] + h * d_str[2];
+            } else if (dstDims.size() == 2) {
+                dst_off += c * d_str[1];
             }
 
             dst[dst_off] = dst_val;


### PR DESCRIPTION
### Details:
 - `src` and `dst` offsets were calculated incorrectly for reference implementation

### Tickets:
 - *ticket-id*
