### PR TITLE
[CPU] Disable smoke_Model_Distribution_MatMul_NoTranspose tests on ARM platforms

### DIFF
--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -501,6 +501,8 @@ std::vector<std::string> disabledTestPatterns() {
     retVector.emplace_back(R"(smoke_MatMulSharedCompressedWeights.*)");
     retVector.emplace_back(R"(smoke_Model_Distribution_MatMulSharedCompressedWeights.*)");
     retVector.emplace_back(R"(smoke_MatmulAndGatherSharedWeightsDecompression.*)");
+    // Issue: 170863
+    retVector.emplace_back(R"(smoke_Model_Distribution_MatMul_NoTranspose.*)");
     // smoke_Snippets test cases are not supported on arm32 platforms
 #if !defined(OPENVINO_ARCH_ARM64)
     retVector.emplace_back(R"(smoke_Snippets.*)");


### PR DESCRIPTION
### Details:
 - Disable `smoke_Model_Distribution_MatMul_NoTranspose` tests on ARM platforms where it sporadically fails with high % reproduction rate on CI

### Tickets:
 - 170863
