### PR TITLE
[GPU] Handle 3D tensors by expanding to 4D in onednn reduce

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.cpp
@@ -57,8 +57,8 @@ protected:
         // oneDNN reduction does not allow this. So this function reverts it.
         reorder_unreduced_axis_no_fusion(input_layout, output_layout, prim->axes);
 
-        auto input_md = onednn::layout_to_memory_desc(input_layout);
-        auto output_md = onednn::layout_to_memory_desc(output_layout);
+        auto input_md = onednn::layout_to_memory_desc(input_layout, dnnl::memory::format_tag::undef, mem_flags::need_blocked);
+        auto output_md = onednn::layout_to_memory_desc(output_layout, dnnl::memory::format_tag::undef, mem_flags::need_blocked);
 
         float p = 0.f;
         float eps = 0.f;
@@ -122,8 +122,8 @@ public:
         dnnl::algorithm alg;
         ib >> make_data(&alg, sizeof(dnnl::algorithm));
 
-        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0));
-        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout());
+        auto input_md = onednn::layout_to_memory_desc(impl_params->get_input_layout(0), dnnl::memory::format_tag::undef, mem_flags::need_blocked);
+        auto output_md = onednn::layout_to_memory_desc(impl_params->get_output_layout(), dnnl::memory::format_tag::undef, mem_flags::need_blocked);
 
         float p, eps;
         ib >> p >> eps;


### PR DESCRIPTION
### Descriptions
 - The purpose of PR #31050 was to allow oneDNN convolution to directly handle 3D input tensors without expanding them to 4D.
 - However, oneDNN reduce should be excluded from this change, as it is closely tied to cldnn implementation, which expects 3D tensors to be expanded to 4D.
 - This PR resolves the issue by rollback the behavior of oneDNN reduce to its previous state before PR #31050.

### The code and line that caused this issue
 - https://github.com/openvinotoolkit/openvino/blob/fe702efe5064fd9dd765d3eebca0cb4b3fd5d162/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.cpp#L60

### Problematic graph
<img width="826" height="656" alt="image" src="https://github.com/user-attachments/assets/f1780272-3c79-4b01-8099-0ee0cb4b53ca" />


### Checklist
- [x] Is it a proper fix? (not a workaround)
- [ ] Did you include a test case for this fix, if necessary?  
  → A test case is not required, as this change is a rollback to the original behavior.
- [ ] Did you review existing tests that can be extended to cover this scenario?  
  → It doesn't need.

### Tickets
- *170856*
