### PR TITLE
[GPU] Fix output buffer reset synchronization issue

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory.hpp
@@ -48,8 +48,8 @@ struct memory {
     virtual ~memory() = default;
     virtual void* lock(const stream& stream, mem_lock_type type = mem_lock_type::read_write) = 0;
     virtual void unlock(const stream& stream) = 0;
-    virtual event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) = 0;
-    virtual event::ptr fill(stream& stream, bool blocking = true) = 0;
+    virtual event::ptr fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) = 0;
+    virtual event::ptr fill(stream& stream, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) = 0;
     // only supports gpu_usm
     virtual void* buffer_ptr() const { return nullptr; }
 
@@ -147,8 +147,8 @@ struct simple_attached_memory : memory {
 
     void* lock(const stream& /* stream */, mem_lock_type /* type */) override { return _pointer; }
     void unlock(const stream& /* stream */) override {}
-    event::ptr fill(stream& /* stream */, unsigned char, bool) override { return nullptr; }
-    event::ptr fill(stream& /* stream */, bool) override { return nullptr; }
+    event::ptr fill(stream& /* stream */, unsigned char, const std::vector<event::ptr>&, bool) override { return nullptr; }
+    event::ptr fill(stream& /* stream */, const std::vector<event::ptr>&, bool) override { return nullptr; }
     shared_mem_params get_internal_params() const override { return { shared_mem_type::shared_mem_empty, nullptr, nullptr, nullptr,
 #ifdef _WIN32
         nullptr,

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -315,6 +315,7 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
         const std::string layer_name = m_inst.id();
         auto files = get_filenames_for_matched_layer_loading_binaries(config, layer_name);
         if (!files.empty()) {
+            m_stream.finish(); // Wait for stream completion before buffer assignment
             if (m_inst.is_input()) {
                 // Loading binary dumps for output tensors of input-layers : only one output exists or index(dstN) exists
                 auto dump_file = get_matched_from_filelist(files, "_dst0__");
@@ -383,6 +384,7 @@ NodeDebugHelper::NodeDebugHelper(const primitive_inst& inst)
 
         if (is_target_iteration(m_iter, config.get_dump_iterations()) &&
             config.get_dump_tensors() != ov::intel_gpu::DumpTensors::out && is_layer_for_dumping(config, layer_name)) {
+            m_stream.finish(); // Wait for stream completion before dumping input buffers
             std::string debug_str_for_bin_load = " Command for loading : OV_LOAD_DUMP_RAW_BINARY=\"" + layer_name + ":";
             for (size_t i = 0; i < m_inst.dependencies().size(); i++) {
                 std::string name = get_file_prefix() + "_src" + std::to_string(i);
@@ -427,12 +429,12 @@ NodeDebugHelper::~NodeDebugHelper() {
     const auto& config = m_network.get_config();
     // Dump output buffers of 'inst'
     if (config.get_dump_tensors_path().length() > 0) {
-        m_stream.finish();
         const std::string layer_name = m_inst.id();
 
         if (is_target_iteration(m_iter, config.get_dump_iterations()) &&
             config.get_dump_tensors() != ov::intel_gpu::DumpTensors::in &&
             is_layer_for_dumping(config, layer_name)) {
+            m_stream.finish(); // Wait for stream completion before dumping output buffers
             std::string debug_str_for_bin_load = " Command for loading : OV_LOAD_DUMP_RAW_BINARY=\""
                                                     + layer_name + ":";
             for (size_t i = 0; i < m_inst.outputs_memory_count(); i++) {

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -986,7 +986,8 @@ void primitive_inst::realloc_if_needed(bool prev_execution_skipped) {
             // TODO: check need_reset_output_memory per output
             if (need_reset_output_memory() && !can_be_optimized()) {
                 GPU_DEBUG_TRACE_DETAIL << id() << " : Need reset output memory considering user" << std::endl;
-                add_dep_event(_outputs[i]->fill(get_network().get_stream()));
+                auto dep_event = get_network().get_stream().enqueue_marker(_impl_params->dep_events);
+                add_dep_event(_outputs[i]->fill(get_network().get_stream(), {dep_event}));
             }
             GPU_DEBUG_PROFILED_STAGE_MEMALLOC_INFO("reuse_buffer");
         } else {
@@ -1017,7 +1018,8 @@ void primitive_inst::realloc_if_needed(bool prev_execution_skipped) {
             if (need_reset_output_memory() && !can_be_optimized() &&
                 _outputs[i]->from_memory_pool && _outputs[i]->get_layout().data_padding) {
                 GPU_DEBUG_TRACE_DETAIL << id() << " : Need reset output memory considering user" << std::endl;
-                add_dep_event(_outputs[i]->fill(get_network().get_stream()));
+                auto dep_event = get_network().get_stream().enqueue_marker(_impl_params->dep_events);
+                add_dep_event(_outputs[i]->fill(get_network().get_stream(), {dep_event}));
             }
         }
     }

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.cpp
@@ -33,6 +33,21 @@ instrumentation::profiling_interval get_profiling_interval(instrumentation::prof
 
 }  // namespace
 
+namespace cldnn::ocl::utils {
+std::vector<cl::Event> get_cl_events(const std::vector<event::ptr>& events) {
+    std::vector<cl::Event> cl_events;
+    for (const auto& ev : events) {
+        if (auto ocl_base_ev = downcast<ocl_base_event>(ev.get())) {
+            if (ocl_base_ev->get().get() != nullptr) {
+                cl_events.push_back(ocl_base_ev->get());
+            }
+        }
+    }
+
+    return cl_events;
+}
+}  // namespace cldnn::ocl::utils
+
 void CL_CALLBACK ocl_event::ocl_event_completion_callback(cl_event, cl_int, void* me) {
     reinterpret_cast<ocl_event*>(me)->_set = true;
     reinterpret_cast<ocl_event*>(me)->call_handlers();

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_event.hpp
@@ -14,6 +14,10 @@
 namespace cldnn {
 namespace ocl {
 
+namespace utils {
+std::vector<cl::Event> get_cl_events(const std::vector<event::ptr>& events);
+}  // namespace utils
+
 struct ocl_event : public ocl_base_event {
 public:
     ocl_event(cl::Event const& ev, uint64_t queue_stamp = 0)

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.cpp
@@ -115,20 +115,26 @@ void gpu_buffer::unlock(const stream& stream) {
     }
 }
 
-event::ptr gpu_buffer::fill(stream& stream, bool blocking) {
-    return fill(stream, 0, blocking);
+event::ptr gpu_buffer::fill(stream& stream, const std::vector<event::ptr>& dep_events, bool blocking) {
+    return fill(stream, 0, dep_events, blocking);
 }
 
-event::ptr gpu_buffer::fill(stream& stream, unsigned char pattern, bool blocking) {
+event::ptr gpu_buffer::fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return nullptr;
     }
     auto& cl_stream = downcast<ocl_stream>(stream);
     auto ev = stream.create_base_event();
-    cl::Event& ev_ocl = downcast<ocl_event>(ev.get())->get();
+    auto& ev_ocl = downcast<ocl_event>(ev.get())->get();
+    auto dep_ev_ocl = utils::get_cl_events(dep_events);
     try {
-        cl_stream.get_cl_queue().enqueueFillBuffer<unsigned char>(_buffer, pattern, 0, size(), nullptr, &ev_ocl);
+        cl_stream.get_cl_queue().enqueueFillBuffer<unsigned char>(_buffer,
+                                                                  pattern,
+                                                                  0,
+                                                                  size(),
+                                                                  dep_ev_ocl.empty() ? nullptr : &dep_ev_ocl,
+                                                                  &ev_ocl);
         if (blocking) {
             ev_ocl.wait();
         }
@@ -301,21 +307,27 @@ gpu_image2d::gpu_image2d(ocl_engine* engine,
     _slice_pitch = _buffer.getImageInfo<CL_IMAGE_SLICE_PITCH>();
 }
 
-event::ptr gpu_image2d::fill(stream& stream, bool blocking) {
-    return fill(stream, 0, blocking);
+event::ptr gpu_image2d::fill(stream& stream, const std::vector<event::ptr>& dep_events, bool blocking) {
+    return fill(stream, 0, dep_events, blocking);
 }
 
-event::ptr gpu_image2d::fill(stream& stream, unsigned char pattern, bool blocking) {
+event::ptr gpu_image2d::fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip EnqueueMemcpy for 0 size tensor" << std::endl;
         return nullptr;
     }
     auto& cl_stream = downcast<ocl_stream>(stream);
     auto ev = stream.create_base_event();
-    cl::Event& ev_ocl = downcast<ocl_event>(ev.get())->get();
+    auto& ev_ocl = downcast<ocl_event>(ev.get())->get();
+    auto dep_ev_ocl = utils::get_cl_events(dep_events);
     cl_uint4 pattern_uint4 = {{pattern, pattern, pattern, pattern}};
     try {
-        cl_stream.get_cl_queue().enqueueFillImage(_buffer, pattern_uint4, {0, 0, 0}, {_width, _height, 1}, 0, &ev_ocl);
+        cl_stream.get_cl_queue().enqueueFillImage(_buffer,
+                                                  pattern_uint4,
+                                                  {0, 0, 0},
+                                                  {_width, _height, 1},
+                                                  dep_ev_ocl.empty() ? nullptr : &dep_ev_ocl,
+                                                  &ev_ocl);
         if (blocking) {
             ev_ocl.wait();
         }
@@ -540,17 +552,23 @@ void gpu_usm::unlock(const stream& /* stream */) {
     }
 }
 
-event::ptr gpu_usm::fill(stream& stream, unsigned char pattern, bool blocking) {
+event::ptr gpu_usm::fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events, bool blocking) {
     if (_bytes_count == 0) {
         GPU_DEBUG_TRACE_DETAIL << "Skip gpu_usm::fill for 0 size tensor" << std::endl;
         return nullptr;
     }
     auto& cl_stream = downcast<ocl_stream>(stream);
     auto ev = stream.create_base_event();
-    cl::Event& ev_ocl = downcast<ocl_event>(ev.get())->get();
+    auto& ev_ocl = downcast<ocl_event>(ev.get())->get();
+    auto dep_ev_ocl = utils::get_cl_events(dep_events);
     try {
-        cl_stream.get_usm_helper().enqueue_fill_mem(
-                cl_stream.get_cl_queue(), _buffer.get(), static_cast<const void*>(&pattern), sizeof(unsigned char), _bytes_count, nullptr, &ev_ocl);
+        cl_stream.get_usm_helper().enqueue_fill_mem(cl_stream.get_cl_queue(),
+                                                    _buffer.get(),
+                                                    static_cast<const void*>(&pattern),
+                                                    sizeof(unsigned char),
+                                                    _bytes_count,
+                                                    dep_ev_ocl.empty() ? nullptr : &dep_ev_ocl,
+                                                    &ev_ocl);
         if (blocking) {
             ev_ocl.wait();
         }
@@ -561,8 +579,8 @@ event::ptr gpu_usm::fill(stream& stream, unsigned char pattern, bool blocking) {
     return ev;
 }
 
-event::ptr gpu_usm::fill(stream& stream, bool blocking) {
-    return fill(stream, 0, blocking);
+event::ptr gpu_usm::fill(stream& stream, const std::vector<event::ptr>& dep_events, bool blocking) {
+    return fill(stream, 0, dep_events, blocking);
 }
 
 event::ptr gpu_usm::copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) {

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_memory.hpp
@@ -32,8 +32,8 @@ struct gpu_buffer : public lockable_gpu_mem, public memory {
 
     void* lock(const stream& stream, mem_lock_type type = mem_lock_type::read_write) override;
     void unlock(const stream& stream) override;
-    event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) override;
-    event::ptr fill(stream& stream, bool blocking = true) override;
+    event::ptr fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) override;
+    event::ptr fill(stream& stream, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) override;
     shared_mem_params get_internal_params() const override;
     const cl::Buffer& get_buffer() const {
         assert(0 == _lock_count);
@@ -61,8 +61,8 @@ struct gpu_image2d : public lockable_gpu_mem, public memory {
 
     void* lock(const stream& stream, mem_lock_type type = mem_lock_type::read_write) override;
     void unlock(const stream& stream) override;
-    event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) override;
-    event::ptr fill(stream& stream, bool blocking = true) override;
+    event::ptr fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) override;
+    event::ptr fill(stream& stream, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) override;
     shared_mem_params get_internal_params() const override;
     const cl::Image2D& get_buffer() const {
         assert(0 == _lock_count);
@@ -115,8 +115,8 @@ struct gpu_usm : public lockable_gpu_mem, public memory {
     cl::UsmMemory& get_buffer() { return _buffer; }
     void* buffer_ptr() const override { return _buffer.get(); }
 
-    event::ptr fill(stream& stream, unsigned char pattern, bool blocking = true) override;
-    event::ptr fill(stream& stream, bool blocking = true) override;
+    event::ptr fill(stream& stream, unsigned char pattern, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) override;
+    event::ptr fill(stream& stream, const std::vector<event::ptr>& dep_events = {}, bool blocking = true) override;
     shared_mem_params get_internal_params() const override;
 
     event::ptr copy_from(stream& stream, const void* data_ptr, size_t src_offset, size_t dst_offset, size_t size, bool blocking) override;

--- a/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/ocl/ocl_stream.cpp
@@ -271,12 +271,7 @@ event::ptr ocl_stream::enqueue_kernel(kernel& kernel,
     std::vector<cl::Event> dep_events;
     std::vector<cl::Event>* dep_events_ptr = nullptr;
     if (m_sync_method == SyncMethods::events) {
-        for (auto& dep : deps) {
-            if (auto ocl_base_ev = std::dynamic_pointer_cast<ocl_base_event>(dep)) {
-                if (ocl_base_ev->get().get() != nullptr)
-                    dep_events.push_back(ocl_base_ev->get());
-            }
-        }
+        dep_events = utils::get_cl_events(deps);
         dep_events_ptr = &dep_events;
     } else if (m_sync_method == SyncMethods::barriers) {
         sync_events(deps, is_output);
@@ -318,13 +313,7 @@ event::ptr ocl_stream::enqueue_marker(std::vector<event::ptr> const& deps, bool 
 
     if (m_sync_method == SyncMethods::events) {
         cl::Event ret_ev;
-        std::vector<cl::Event> dep_events;
-        for (auto& dep : deps) {
-            if (auto ocl_base_ev = dynamic_cast<ocl_base_event*>(dep.get()))
-                if (ocl_base_ev->get().get() != nullptr)
-                    dep_events.push_back(ocl_base_ev->get());
-        }
-
+        std::vector<cl::Event> dep_events = utils::get_cl_events(deps);
         try {
             if (dep_events.empty()) {
                 return create_user_event(true);


### PR DESCRIPTION
### Details:
 - In some cases during dynamic model execution, user primitive might request reset memory (for example, when a convolution requires buffer paddings to be filled with zeroes). Previously, fill() call was performed without considering dependency events, which could cause data to be overwritten while the assigned buffer was still in use by earlier operations. So this change extends fill() interface with dependencies events support to ensure proper synchronization.
 - Updated layers dump logic: previously, finish() call was implicitly called after each primitive in case of enabled dumping, regardless whether primitive was selected or not, making it impossible to debug synchronization issues. This change applies finish() only when the primitive is selected for dumping.

### Tickets:
 - *[CVS-169845](https://jira.devtools.intel.com/browse/CVS-169845)*
