### PR TITLE
Change plugin::import_model to get constant ov::Tensor

### DIFF
--- a/src/inference/dev_api/openvino/runtime/iplugin.hpp
+++ b/src/inference/dev_api/openvino/runtime/iplugin.hpp
@@ -192,7 +192,7 @@ public:
      * @param properties A ov::AnyMap of properties
      * @return An Compiled model
      */
-    virtual std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const;
+    virtual std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const;
 
     /**
      * @brief Creates an compiled model from an previously exported model using plugin implementation
@@ -203,7 +203,7 @@ public:
      * @param properties A ov::AnyMap of properties
      * @return An Compiled model
      */
-    virtual std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    virtual std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties) const;
 

--- a/src/inference/src/dev/iplugin.cpp
+++ b/src/inference/src/dev/iplugin.cpp
@@ -84,7 +84,8 @@ std::shared_ptr<ov::ICompiledModel> ov::IPlugin::compile_model(const std::string
 
 // Implementation for backward compatibility for Nvidia plugin
 // TODO: Update Nvidia plugin in contrib repo and make ov::IPlugin::import_model abstract again
-std::shared_ptr<ov::ICompiledModel> ov::IPlugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
+std::shared_ptr<ov::ICompiledModel> ov::IPlugin::import_model(const ov::Tensor& model,
+                                                              const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);

--- a/src/inference/src/dev/iplugin.cpp
+++ b/src/inference/src/dev/iplugin.cpp
@@ -84,13 +84,13 @@ std::shared_ptr<ov::ICompiledModel> ov::IPlugin::compile_model(const std::string
 
 // Implementation for backward compatibility for Nvidia plugin
 // TODO: Update Nvidia plugin in contrib repo and make ov::IPlugin::import_model abstract again
-std::shared_ptr<ov::ICompiledModel> ov::IPlugin::import_model(ov::Tensor& model, const ov::AnyMap& properties) const {
+std::shared_ptr<ov::ICompiledModel> ov::IPlugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 };
 
-std::shared_ptr<ov::ICompiledModel> ov::IPlugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> ov::IPlugin::import_model(const ov::Tensor& model,
                                                               const ov::SoPtr<ov::IRemoteContext>& context,
                                                               const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};

--- a/src/inference/src/dev/plugin.cpp
+++ b/src/inference/src/dev/plugin.cpp
@@ -79,11 +79,11 @@ ov::SoPtr<ov::ICompiledModel> ov::Plugin::import_model(std::istream& model,
     OV_PLUGIN_CALL_STATEMENT(return {m_ptr->import_model(model, context, config), m_so});
 }
 
-ov::SoPtr<ov::ICompiledModel> ov::Plugin::import_model(ov::Tensor& model, const ov::AnyMap& properties) const {
+ov::SoPtr<ov::ICompiledModel> ov::Plugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
     OV_PLUGIN_CALL_STATEMENT(return {m_ptr->import_model(model, properties), m_so});
 }
 
-ov::SoPtr<ov::ICompiledModel> ov::Plugin::import_model(ov::Tensor& model,
+ov::SoPtr<ov::ICompiledModel> ov::Plugin::import_model(const ov::Tensor& model,
                                                        const ov::SoPtr<ov::IRemoteContext>& context,
                                                        const ov::AnyMap& config) const {
     OV_PLUGIN_CALL_STATEMENT(return {m_ptr->import_model(model, context, config), m_so});

--- a/src/inference/src/dev/plugin.hpp
+++ b/src/inference/src/dev/plugin.hpp
@@ -53,9 +53,9 @@ public:
 
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model, const ov::AnyMap& properties) const;
 
-    SoPtr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const;
+    SoPtr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const;
 
-    SoPtr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    SoPtr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                            const ov::SoPtr<ov::IRemoteContext>& context,
                                            const ov::AnyMap& config) const;
 

--- a/src/inference/tests/functional/caching_test.cpp
+++ b/src/inference/tests/functional/caching_test.cpp
@@ -385,8 +385,8 @@ private:
                 return create_mock_compiled_model(m_models[name], mockPlugin);
             }));
 
-        ON_CALL(plugin, import_model(A<ov::Tensor&>(), _))
-            .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+        ON_CALL(plugin, import_model(A<const ov::Tensor&>(), _))
+            .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
                 if (m_checkConfigCb) {
                     m_checkConfigCb(config);
                 }
@@ -396,9 +396,9 @@ private:
                 return create_mock_compiled_model(m_models[name], mockPlugin);
             }));
 
-        ON_CALL(plugin, import_model(A<ov::Tensor&>(), _, _))
+        ON_CALL(plugin, import_model(A<const ov::Tensor&>(), _, _))
             .WillByDefault(
-                Invoke([&](ov::Tensor& itensor, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap& config) {
+                Invoke([&](const ov::Tensor& itensor, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap& config) {
                     if (m_checkConfigCb) {
                         m_checkConfigCb(config);
                     }
@@ -475,8 +475,8 @@ TEST_P(CachingTest, TestLoad) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -492,8 +492,8 @@ TEST_P(CachingTest, TestLoad) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& model : comp_models) {
             EXPECT_CALL(*model, export_model(_)).Times(0);  // No more 'export_model' for existing model
         }
@@ -520,8 +520,8 @@ TEST_P(CachingTest, TestLoad_by_device_name) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -537,8 +537,8 @@ TEST_P(CachingTest, TestLoad_by_device_name) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& model : comp_models) {
             EXPECT_CALL(*model, export_model(_)).Times(0);  // No more 'export_model' for existing models
         }
@@ -561,8 +561,8 @@ TEST_P(CachingTest, TestLoadCustomImportExport) {
     EXPECT_CALL(*mockPlugin, get_property(ov::internal::caching_properties.name(), _)).Times(AnyNumber());
     EXPECT_CALL(*mockPlugin, get_property(ov::device::capabilities.name(), _)).Times(AnyNumber());
 
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _))
-        .WillByDefault(Invoke([&](ov::Tensor& s, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _))
+        .WillByDefault(Invoke([&](const ov::Tensor& s, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&) {
             char a[sizeof(customData)];
             OPENVINO_ASSERT(customDataSize <= s.get_byte_size());
             std::memcpy(a, s.data(), customDataSize);
@@ -573,7 +573,7 @@ TEST_P(CachingTest, TestLoadCustomImportExport) {
             return create_mock_compiled_model(m_models[name], mockPlugin);
         }));
 
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).WillByDefault(Invoke([&](ov::Tensor& s, const ov::AnyMap&) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).WillByDefault(Invoke([&](const ov::Tensor& s, const ov::AnyMap&) {
         char a[sizeof(customData)];
         OPENVINO_ASSERT(customDataSize <= s.get_byte_size());
         std::memcpy(a, s.data(), customDataSize);
@@ -596,8 +596,8 @@ TEST_P(CachingTest, TestLoadCustomImportExport) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -612,8 +612,8 @@ TEST_P(CachingTest, TestLoadCustomImportExport) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& model : comp_models) {
             EXPECT_CALL(*model, export_model(_)).Times(0);  // No 'export_model' for existing models
         }
@@ -696,8 +696,8 @@ TEST_P(CachingTest, TestChangeLoadConfig_With_Cache_Dir_inline) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -711,8 +711,8 @@ TEST_P(CachingTest, TestChangeLoadConfig_With_Cache_Dir_inline) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& model : comp_models) {
             EXPECT_CALL(*model, export_model(_)).Times(0);  // No more 'export_model' for existing models
         }
@@ -1223,8 +1223,8 @@ TEST_P(CachingTest, TestClearCacheDir) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         for (auto& model : comp_models) {
             EXPECT_CALL(*model, export_model(_)).Times(0);
         }
@@ -1276,8 +1276,8 @@ TEST_P(CachingTest, TestChangeCacheDirFailure) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1293,8 +1293,8 @@ TEST_P(CachingTest, TestChangeCacheDirFailure) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1358,8 +1358,8 @@ TEST_P(CachingTest, TestDeviceArchitecture) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1375,8 +1375,8 @@ TEST_P(CachingTest, TestDeviceArchitecture) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1392,8 +1392,8 @@ TEST_P(CachingTest, TestDeviceArchitecture) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1409,8 +1409,8 @@ TEST_P(CachingTest, TestDeviceArchitecture) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1449,8 +1449,8 @@ TEST_P(CachingTest, TestNoDeviceArchitecture) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1466,8 +1466,8 @@ TEST_P(CachingTest, TestNoDeviceArchitecture) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1552,8 +1552,8 @@ TEST_P(CachingTest, TestThrowOnImport) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1570,11 +1570,11 @@ TEST_P(CachingTest, TestThrowOnImport) {
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
         if (m_remoteContext) {
-            EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(1).WillOnce(Throw(1));
-            EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+            EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(1).WillOnce(Throw(1));
+            EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         } else {
-            EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-            EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1).WillOnce(Throw(1));
+            EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+            EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1).WillOnce(Throw(1));
         }
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
@@ -1589,8 +1589,8 @@ TEST_P(CachingTest, TestThrowOnImport) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1614,8 +1614,8 @@ TEST_P(CachingTest, TestModelModified) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1641,8 +1641,8 @@ TEST_P(CachingTest, TestModelModified) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1657,8 +1657,8 @@ TEST_P(CachingTest, TestModelModified) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1683,8 +1683,8 @@ TEST_P(CachingTest, TestCacheFileCorrupted) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1707,8 +1707,8 @@ TEST_P(CachingTest, TestCacheFileCorrupted) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1722,8 +1722,8 @@ TEST_P(CachingTest, TestCacheFileCorrupted) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1748,8 +1748,8 @@ TEST_P(CachingTest, TestCacheFileOldVersion) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1787,8 +1787,8 @@ TEST_P(CachingTest, TestCacheFileOldVersion) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1803,8 +1803,8 @@ TEST_P(CachingTest, TestCacheFileOldVersion) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -1848,8 +1848,8 @@ TEST_P(CachingTest, TestCacheFileWithCompiledModelRuntimeProperties) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1886,8 +1886,8 @@ TEST_P(CachingTest, TestCacheFileWithCompiledModelRuntimeProperties) {
             .Times(!m_remoteContext ? 1 : 0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(0);
         m_post_mock_net_callbacks.emplace_back([&](MockICompiledModelImpl& net) {
             EXPECT_CALL(net, export_model(_)).Times(1);
         });
@@ -1902,8 +1902,8 @@ TEST_P(CachingTest, TestCacheFileWithCompiledModelRuntimeProperties) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(m_remoteContext ? 1 : 0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(!m_remoteContext ? 1 : 0);
         for (auto& net : comp_models) {
             EXPECT_CALL(*net, export_model(_)).Times(0);
         }
@@ -2197,7 +2197,7 @@ TEST_P(CachingTest, LoadAUTO_OneDevice) {
         deviceToLoad += ":mock.0";
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _))
             .Times(TEST_COUNT - index - 1);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(index);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(index);
         OV_ASSERT_NO_THROW(testLoad([&](ov::Core& core) {
             core.set_property(ov::cache_dir(cacheDir));
             m_testFunction(core);
@@ -2228,7 +2228,7 @@ TEST_P(CachingTest, LoadAUTOWithConfig) {
         deviceToLoad += ":mock.0";
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _))
             .Times(TEST_COUNT - index - 1);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(index);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(index);
         OV_ASSERT_NO_THROW(testLoad([&](ov::Core& core) {
             m_testFunctionWithCfg(core, {{ov::cache_dir.name(), cacheDir}});
         }));
@@ -2305,8 +2305,8 @@ TEST_P(CachingTest, LoadMulti_race) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(devCount - 1);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(devCount - 1);
         testLoad([&](ov::Core& core) {
             core.set_property(ov::cache_dir(cacheDir));
             OV_ASSERT_NO_THROW(m_testFunction(core));
@@ -2349,8 +2349,8 @@ TEST_P(CachingTest, LoadMultiWithConfig_race) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(devCount - 1);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(devCount - 1);
         testLoad([&](ov::Core& core) {
             OV_ASSERT_NO_THROW(m_testFunctionWithCfg(core, {{ov::cache_dir.name(), cacheDir}}));
         });
@@ -2394,10 +2394,10 @@ TEST_P(CachingTest, LoadMulti_Archs) {
 
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
             .Times(TEST_DEVICE_MAX_COUNT / 2)
-            .WillRepeatedly(Invoke([&](ov::Tensor& s, const ov::AnyMap&) {
+            .WillRepeatedly(Invoke([&](const ov::Tensor& s, const ov::AnyMap&) {
                 size_t pos = 0;
                 auto name = getline_from_buffer(s.data<const char>(), s.get_byte_size(), pos);
                 std::lock_guard<std::mutex> lock(mock_creation_mutex);
@@ -2499,7 +2499,7 @@ TEST_P(CachingTest, LoadBATCHWithConfig) {
         deviceToLoad += ":mock.0";
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _))
             .Times(TEST_COUNT - index - 1);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(index);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(index);
         testLoad([&](ov::Core& core) {
             m_testFunctionWithCfg(core, {{ov::cache_dir.name(), cacheDir}});
         });
@@ -2531,8 +2531,8 @@ TEST_P(CachingTest, Load_threads) {
         EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
         EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-        EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(THREADS_COUNT - 1);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+        EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(THREADS_COUNT - 1);
         testLoad([&](ov::Core& core) {
             core.set_property({{ov::cache_dir.name(), cacheDir}});
             std::vector<std::thread> threads;
@@ -2551,8 +2551,8 @@ TEST_P(CachingTest, Load_threads) {
 }
 
 TEST_P(CachingTest, Load_mmap) {
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2583,8 +2583,8 @@ TEST_P(CachingTest, Load_mmap) {
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         core.set_property({{ov::cache_dir.name(), m_cacheDir}});
         m_testFunction(core);
@@ -2594,8 +2594,8 @@ TEST_P(CachingTest, Load_mmap) {
 }
 
 TEST_P(CachingTest, Load_mmap_is_disabled) {
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2626,8 +2626,8 @@ TEST_P(CachingTest, Load_mmap_is_disabled) {
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         core.set_property({{ov::cache_dir.name(), m_cacheDir}});
         core.set_property({ov::enable_mmap(false)});
@@ -2638,8 +2638,8 @@ TEST_P(CachingTest, Load_mmap_is_disabled) {
 }
 
 TEST_P(CachingTest, Load_mmap_is_not_supported_by_plugin) {
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2665,8 +2665,8 @@ TEST_P(CachingTest, Load_mmap_is_not_supported_by_plugin) {
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         core.set_property({{ov::cache_dir.name(), m_cacheDir}});
         core.set_property({ov::enable_mmap(true)});
@@ -2677,8 +2677,8 @@ TEST_P(CachingTest, Load_mmap_is_not_supported_by_plugin) {
 }
 
 TEST_P(CachingTest, Load_mmap_is_disabled_local_cfg) {
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2709,8 +2709,8 @@ TEST_P(CachingTest, Load_mmap_is_disabled_local_cfg) {
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         const auto config = ov::AnyMap{{ov::cache_dir(m_cacheDir)}, {ov::enable_mmap(false)}};
         m_testFunctionWithCfg(core, config);
@@ -2720,8 +2720,8 @@ TEST_P(CachingTest, Load_mmap_is_disabled_local_cfg) {
 }
 
 TEST_P(CachingTest, Load_mmap_is_not_supported_by_plugin_local_cfg) {
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2747,8 +2747,8 @@ TEST_P(CachingTest, Load_mmap_is_not_supported_by_plugin_local_cfg) {
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         const auto config = ov::AnyMap{{ov::cache_dir(m_cacheDir)}, {ov::enable_mmap(false)}};
         m_testFunctionWithCfg(core, config);
@@ -2758,8 +2758,8 @@ TEST_P(CachingTest, Load_mmap_is_not_supported_by_plugin_local_cfg) {
 }
 
 TEST_P(CachingTest, import_from_cache_model_and_weights_path_properties_not_supported) {
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2787,8 +2787,8 @@ TEST_P(CachingTest, import_from_cache_model_and_weights_path_properties_not_supp
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         const auto config = ov::AnyMap{{ov::cache_dir(m_cacheDir)}};
         m_testFunctionWithCfg(core, config);
@@ -2808,8 +2808,8 @@ TEST_P(CachingTest, import_from_cache_model_and_weights_path_properties_are_supp
                 ov::weights_path.name(),
             };
         }));
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2837,8 +2837,8 @@ TEST_P(CachingTest, import_from_cache_model_and_weights_path_properties_are_supp
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
     testLoad([&](ov::Core& core) {
         const auto config = ov::AnyMap{{ov::cache_dir(m_cacheDir)}};
         m_testFunctionWithCfg(core, config);
@@ -2856,8 +2856,8 @@ TEST_P(CachingTest, import_from_compiled_blob_weights_path_property_is_supported
                                                  ov::weights_path.name(),
                                                  ov::hint::model.name()};
         }));
-    ON_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _))
-        .WillByDefault(Invoke([&](ov::Tensor& itensor, const ov::AnyMap& config) {
+    ON_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _))
+        .WillByDefault(Invoke([&](const ov::Tensor& itensor, const ov::AnyMap& config) {
             if (m_checkConfigCb) {
                 m_checkConfigCb(config);
             }
@@ -2878,8 +2878,8 @@ TEST_P(CachingTest, import_from_compiled_blob_weights_path_property_is_supported
     EXPECT_CALL(*mockPlugin, compile_model(_, _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _, _)).Times(0);
     EXPECT_CALL(*mockPlugin, import_model(A<std::istream&>(), _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _, _)).Times(0);
-    EXPECT_CALL(*mockPlugin, import_model(A<ov::Tensor&>(), _)).Times(1);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _, _)).Times(0);
+    EXPECT_CALL(*mockPlugin, import_model(A<const ov::Tensor&>(), _)).Times(1);
 
     EXPECT_CALL(*mockPlugin, compile_model(A<const std::shared_ptr<const ov::Model>&>(), _)).Times(1);
     if (m_type == TestLoadType::EModelName) {

--- a/src/plugins/auto/src/plugin.cpp
+++ b/src/plugins/auto/src/plugin.cpp
@@ -99,12 +99,12 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
     OPENVINO_NOT_IMPLEMENTED;
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::AnyMap& properties) const {
     OPENVINO_NOT_IMPLEMENTED;
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& properties) const {
     OPENVINO_NOT_IMPLEMENTED;

--- a/src/plugins/auto/src/plugin.hpp
+++ b/src/plugins/auto/src/plugin.hpp
@@ -70,10 +70,10 @@ public:
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                              const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties) const override;
 

--- a/src/plugins/auto/tests/functional/behavior/auto_func_test.cpp
+++ b/src/plugins/auto/tests/functional/behavior/auto_func_test.cpp
@@ -476,11 +476,11 @@ public:
         return compile_model(ov_model, properties, context);
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;

--- a/src/plugins/auto/tests/functional/behavior/auto_func_test.cpp
+++ b/src/plugins/auto/tests/functional/behavior/auto_func_test.cpp
@@ -476,7 +476,8 @@ public:
         return compile_model(ov_model, properties, context);
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 

--- a/src/plugins/auto_batch/src/plugin.cpp
+++ b/src/plugins/auto_batch/src/plugin.cpp
@@ -350,11 +350,11 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
     OPENVINO_NOT_IMPLEMENTED;
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model, const ov::AnyMap& properties) const {
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
     OPENVINO_NOT_IMPLEMENTED;
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& properties) const {
     OPENVINO_NOT_IMPLEMENTED;

--- a/src/plugins/auto_batch/src/plugin.hpp
+++ b/src/plugins/auto_batch/src/plugin.hpp
@@ -53,7 +53,8 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override;
 
     std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,

--- a/src/plugins/auto_batch/src/plugin.hpp
+++ b/src/plugins/auto_batch/src/plugin.hpp
@@ -53,9 +53,9 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 

--- a/src/plugins/auto_batch/tests/unit/mock_common.hpp
+++ b/src/plugins/auto_batch/tests/unit/mock_common.hpp
@@ -46,11 +46,11 @@ public:
                 (const, override));
     MOCK_METHOD(std::shared_ptr<ov::ICompiledModel>,
                 import_model,
-                (ov::Tensor&, const ov::AnyMap&),
+                (const ov::Tensor&, const ov::AnyMap&),
                 (const, override));
     MOCK_METHOD(std::shared_ptr<ov::ICompiledModel>,
                 import_model,
-                (ov::Tensor&, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&),
+                (const ov::Tensor&, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&),
                 (const, override));
     MOCK_METHOD(ov::SupportedOpsMap,
                 query_model,

--- a/src/plugins/hetero/src/plugin.cpp
+++ b/src/plugins/hetero/src/plugin.cpp
@@ -154,14 +154,14 @@ std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(std::istrea
     return compiled_model;
 }
 
-std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(const ov::Tensor& model,
                                                                      const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }
 
-std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> ov::hetero::Plugin::import_model(const ov::Tensor& model,
                                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                                      const ov::AnyMap& properties) const {
     OPENVINO_NOT_IMPLEMENTED;

--- a/src/plugins/hetero/src/plugin.hpp
+++ b/src/plugins/hetero/src/plugin.hpp
@@ -51,9 +51,9 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 

--- a/src/plugins/hetero/src/plugin.hpp
+++ b/src/plugins/hetero/src/plugin.hpp
@@ -51,7 +51,8 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override;
 
     std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,

--- a/src/plugins/hetero/tests/functional/hetero_tests.cpp
+++ b/src/plugins/hetero/tests/functional/hetero_tests.cpp
@@ -563,11 +563,11 @@ public:
         return compile_model(ov_model, properties, context);
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;

--- a/src/plugins/hetero/tests/functional/hetero_tests.cpp
+++ b/src/plugins/hetero/tests/functional/hetero_tests.cpp
@@ -563,7 +563,8 @@ public:
         return compile_model(ov_model, properties, context);
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -577,7 +577,8 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model_str
     return deserialize_model(deserializer, config);
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model_tensor, const ov::AnyMap& config) const {
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model_tensor,
+                                                         const ov::AnyMap& config) const {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "import_model");
 
     CacheDecrypt decrypt{codec_xor};

--- a/src/plugins/intel_cpu/src/plugin.cpp
+++ b/src/plugins/intel_cpu/src/plugin.cpp
@@ -577,7 +577,7 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model_str
     return deserialize_model(deserializer, config);
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model_tensor, const ov::AnyMap& config) const {
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model_tensor, const ov::AnyMap& config) const {
     OV_ITT_SCOPE(FIRST_INFERENCE, itt::domains::intel_cpu_LT, "import_model");
 
     CacheDecrypt decrypt{codec_xor};

--- a/src/plugins/intel_cpu/src/plugin.h
+++ b/src/plugins/intel_cpu/src/plugin.h
@@ -38,7 +38,8 @@ public:
 
     void set_property(const ov::AnyMap& properties) override;
     ov::Any get_property(const std::string& name, const ov::AnyMap& arguments) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override;
     std::shared_ptr<ov::ICompiledModel> import_model([[maybe_unused]] const ov::Tensor& model,
                                                      [[maybe_unused]] const ov::SoPtr<ov::IRemoteContext>& context,
                                                      [[maybe_unused]] const ov::AnyMap& properties) const override {

--- a/src/plugins/intel_cpu/src/plugin.h
+++ b/src/plugins/intel_cpu/src/plugin.h
@@ -38,8 +38,8 @@ public:
 
     void set_property(const ov::AnyMap& properties) override;
     ov::Any get_property(const std::string& name, const ov::AnyMap& arguments) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model([[maybe_unused]] ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model([[maybe_unused]] const ov::Tensor& model,
                                                      [[maybe_unused]] const ov::SoPtr<ov::IRemoteContext>& context,
                                                      [[maybe_unused]] const ov::AnyMap& properties) const override {
         OPENVINO_THROW_NOT_IMPLEMENTED("import_model with RemoteContext is not supported by CPU plugin!");

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
@@ -59,8 +59,8 @@ public:
     std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model,

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -367,14 +367,14 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
     return std::make_shared<CompiledModel>(ib, shared_from_this(), context_impl, config, loaded_from_cache);
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::AnyMap& config) const{
     std::string device_id = get_device_id(config);
     auto context = get_default_context(device_id);
     return import_model(model, { context, nullptr }, config);
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& config) const{
     SharedStreamBuffer buf{reinterpret_cast<char*>(model.data()), model.get_byte_size()};

--- a/src/plugins/intel_npu/src/plugin/include/plugin.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/plugin.hpp
@@ -52,7 +52,8 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& stream, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& stream,
+                                                     const ov::AnyMap& properties) const override;
 
     std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& stream,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,

--- a/src/plugins/intel_npu/src/plugin/include/plugin.hpp
+++ b/src/plugins/intel_npu/src/plugin/include/plugin.hpp
@@ -52,9 +52,9 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& stream, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& stream, const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& stream,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& stream,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 

--- a/src/plugins/intel_npu/src/plugin/src/plugin.cpp
+++ b/src/plugins/intel_npu/src/plugin/src/plugin.cpp
@@ -841,13 +841,13 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& stream,
     return import_model(stream, properties);
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model, const ov::AnyMap& properties) const {
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }
 
-std::shared_ptr<ov::ICompiledModel> Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> Plugin::import_model(const ov::Tensor& model,
                                                          const ov::SoPtr<ov::IRemoteContext>& context,
                                                          const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};

--- a/src/plugins/intel_npu/tests/functional/behavior/npuw/mocks/mock_plugins.hpp
+++ b/src/plugins/intel_npu/tests/functional/behavior/npuw/mocks/mock_plugins.hpp
@@ -127,10 +127,10 @@ public:
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties));
     MOCK_CONST_METHOD2_T(import_model,
-                         std::shared_ptr<ov::ICompiledModel>(ov::Tensor& model,
+                         std::shared_ptr<ov::ICompiledModel>(const ov::Tensor& model,
                                                              const ov::AnyMap& properties));
     MOCK_CONST_METHOD3_T(import_model,
-                         std::shared_ptr<ov::ICompiledModel>(ov::Tensor& model,
+                         std::shared_ptr<ov::ICompiledModel>(const ov::Tensor& model,
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties));
     MOCK_CONST_METHOD2_T(query_model,

--- a/src/plugins/proxy/src/plugin.cpp
+++ b/src/plugins/proxy/src/plugin.cpp
@@ -494,14 +494,14 @@ std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(std::istream
                                                       context);
 }
 
-std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(const ov::Tensor& model,
                                                                     const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
     std::istream stream{&buffer};
     return import_model(stream, properties);
 }
 
-std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> ov::proxy::Plugin::import_model(const ov::Tensor& model,
                                                                     const ov::SoPtr<ov::IRemoteContext>& context,
                                                                     const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};

--- a/src/plugins/proxy/src/plugin.hpp
+++ b/src/plugins/proxy/src/plugin.hpp
@@ -43,7 +43,8 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override;
 
     std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,

--- a/src/plugins/proxy/src/plugin.hpp
+++ b/src/plugins/proxy/src/plugin.hpp
@@ -43,9 +43,9 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 

--- a/src/plugins/proxy/tests/proxy_tests.cpp
+++ b/src/plugins/proxy/tests/proxy_tests.cpp
@@ -471,11 +471,11 @@ public:
         return compile_model(ov_model, properties, context);
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;

--- a/src/plugins/proxy/tests/proxy_tests.cpp
+++ b/src/plugins/proxy/tests/proxy_tests.cpp
@@ -471,7 +471,8 @@ public:
         return compile_model(ov_model, properties, context);
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 

--- a/src/plugins/template/src/plugin.cpp
+++ b/src/plugins/template/src/plugin.cpp
@@ -266,7 +266,7 @@ std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(
 }
 // ! [plugin:import_model_with_remote]
 
-std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(const ov::Tensor& model,
                                                                               const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};
     std::istream stream{&buffer};
@@ -274,7 +274,7 @@ std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(ov
 }
 
 std::shared_ptr<ov::ICompiledModel> ov::template_plugin::Plugin::import_model(
-    ov::Tensor& model,
+    const ov::Tensor& model,
     const ov::SoPtr<ov::IRemoteContext>& context,
     const ov::AnyMap& properties) const {
     ov::SharedStreamBuffer buffer{reinterpret_cast<char*>(model.data()), model.get_byte_size()};

--- a/src/plugins/template/src/plugin.hpp
+++ b/src/plugins/template/src/plugin.hpp
@@ -41,7 +41,8 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override;
 
     std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,

--- a/src/plugins/template/src/plugin.hpp
+++ b/src/plugins/template/src/plugin.hpp
@@ -41,9 +41,9 @@ public:
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
 

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
@@ -239,7 +239,8 @@ class MockPlugin : public ov::IPlugin {
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 

--- a/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
+++ b/src/tests/test_utils/common_test_utils/include/common_test_utils/file_utils.hpp
@@ -239,11 +239,11 @@ class MockPlugin : public ov::IPlugin {
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override {
         OPENVINO_NOT_IMPLEMENTED;

--- a/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.cpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.cpp
@@ -86,7 +86,8 @@ public:
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override {
         if (m_plugin)
             return m_plugin->import_model(model, properties);
         OPENVINO_NOT_IMPLEMENTED;
@@ -180,7 +181,8 @@ std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(std::istream& model
     return m_plugin->import_model(model, context, properties);
 }
 
-std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
+std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(const ov::Tensor& model,
+                                                             const ov::AnyMap& properties) const {
     set_parameters_if_need();
     return m_plugin->import_model(model, properties);
 }

--- a/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.cpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.cpp
@@ -86,13 +86,13 @@ public:
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override {
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override {
         if (m_plugin)
             return m_plugin->import_model(model, properties);
         OPENVINO_NOT_IMPLEMENTED;
     }
 
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override {
         if (m_plugin)
@@ -180,11 +180,11 @@ std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(std::istream& model
     return m_plugin->import_model(model, context, properties);
 }
 
-std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(ov::Tensor& model, const ov::AnyMap& properties) const {
+std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(const ov::Tensor& model, const ov::AnyMap& properties) const {
     set_parameters_if_need();
     return m_plugin->import_model(model, properties);
 }
-std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(ov::Tensor& model,
+std::shared_ptr<ov::ICompiledModel> MockPlugin::import_model(const ov::Tensor& model,
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties) const {
     set_parameters_if_need();

--- a/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.hpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.hpp
@@ -38,8 +38,8 @@ public:
     std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model, const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(ov::Tensor& model,
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
     ov::SupportedOpsMap query_model(const std::shared_ptr<const ov::Model>& model,

--- a/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.hpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/mock_engine/mock_plugin.hpp
@@ -38,7 +38,8 @@ public:
     std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;
-    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model, const ov::AnyMap& properties) const override;
+    std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                     const ov::AnyMap& properties) const override;
     std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                      const ov::SoPtr<ov::IRemoteContext>& context,
                                                      const ov::AnyMap& properties) const override;

--- a/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_iplugin.hpp
+++ b/src/tests/test_utils/unit_test_utils/mocks/openvino/runtime/mock_iplugin.hpp
@@ -40,10 +40,10 @@ public:
                 import_model,
                 (std::istream&, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&),
                 (const));
-    MOCK_METHOD(std::shared_ptr<ov::ICompiledModel>, import_model, (ov::Tensor&, const ov::AnyMap&), (const));
+    MOCK_METHOD(std::shared_ptr<ov::ICompiledModel>, import_model, (const ov::Tensor&, const ov::AnyMap&), (const));
     MOCK_METHOD(std::shared_ptr<ov::ICompiledModel>,
                 import_model,
-                (ov::Tensor&, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&),
+                (const ov::Tensor&, const ov::SoPtr<ov::IRemoteContext>&, const ov::AnyMap&),
                 (const));
     MOCK_METHOD(ov::SupportedOpsMap,
                 query_model,


### PR DESCRIPTION
### Details:
 - Change plugin::import_model to get constant ov::Tensor
 - Fix for https://github.com/openvinotoolkit/openvino/pull/31137

### Tickets:
 - [CVS-166953](https://jira.devtools.intel.com/browse/CVS-166953)
