### PR TITLE
[TRANSFORMATIONS] Rewrite CausalMaskPreprocess using new Symbolic approach

### DIFF
--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -10,12 +10,14 @@
 #include <limits>
 #include <memory>
 #include <vector>
+#include <variant>
 
 #include "openvino/core/descriptor_tensor.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/op/constant.hpp"
 #include "openvino/op/convert.hpp"
 #include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pattern/op/op.hpp"
 #include "openvino/util/pp.hpp"
 #include "transformations/rt_info/attributes.hpp"
 #include "transformations_visibility.hpp"
@@ -298,6 +300,21 @@ ov::pass::pattern::op::Predicate constant_predicate(std::function<bool(const std
         return false;
     });
 }
+
+TRANSFORMATIONS_API std::shared_ptr<ov::Node> NewGenStridedSlice(const std::shared_ptr<ov::Node>& data,
+                                                                 const ov::pass::pattern::PatternOp& start,
+                                                                 const ov::pass::pattern::PatternOp& stop,
+                                                                 const ov::pass::pattern::PatternOp& step,
+                                                                 size_t axis);
+
+using symbol_variant = std::variant<float, int32_t, int64_t, std::string>;
+
+TRANSFORMATIONS_API std::shared_ptr<ov::Node> NewGenSlice(const std::shared_ptr<ov::Node>& data,
+                                                          symbol_variant start,
+                                                          symbol_variant stop,
+                                                          symbol_variant step,
+                                                          size_t axis);
+
 }  // namespace util
 }  // namespace op
 }  // namespace ov

--- a/src/common/transformations/include/transformations/utils/utils.hpp
+++ b/src/common/transformations/include/transformations/utils/utils.hpp
@@ -9,8 +9,8 @@
 #include <functional>
 #include <limits>
 #include <memory>
-#include <vector>
 #include <variant>
+#include <vector>
 
 #include "openvino/core/descriptor_tensor.hpp"
 #include "openvino/core/rt_info.hpp"

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -462,7 +462,8 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
     auto varsplit_view_Reshape = pattern::wrap_type<opset1::VariadicSplit>({view_Reshape, 3, {"ndims", "end"}});
     varsplit_view_Reshape->set_output_size(2);
     // x interleave (-x[:,:,:, 1::2], x[:,:,:, 0::2])
-    auto slice_Slice_1174 = ov::op::util::NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 1, INT_MAX, 2, 3);
+    auto slice_Slice_1174 =
+        ov::op::util::NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 1, INT_MAX, 2, 3);
 
     auto neg_Multiply_1177 =
         pattern::wrap_type<opset1::Multiply>({slice_Slice_1174, -1.0f}, {{"auto_broadcast", "numpy"}});
@@ -470,7 +471,8 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
     auto Unsqueeze_28998 = pattern::wrap_type<opset1::Reshape>({neg_Multiply_1177, {"-1", "1", "head_num", "32", "1"}},
                                                                {{"special_zero", false}});
 
-    auto slice_Slice_1168 = ov::op::util::NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 0, INT_MAX, 2, 3);
+    auto slice_Slice_1168 =
+        ov::op::util::NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 0, INT_MAX, 2, 3);
     auto Unsqueeze_65525 = pattern::wrap_type<opset1::Unsqueeze>({slice_Slice_1168, -1});
     auto Unsqueeze_28999 = pattern::wrap_type<opset1::Reshape>({slice_Slice_1168, {"-1", "1", "head_num", "32", "1"}},
                                                                {{"special_zero", false}});
@@ -637,7 +639,8 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
         auto slice1 = pattern::wrap_type<v8::Slice>({cos_sin_cache, {0}, seq_length, {1}, {1}});
         auto slice2 = pattern::wrap_type<v8::Slice>({cos_sin_cache, {0, 0}, scatter_update0, {1, 1}, {0}});
         auto ss_stop = pattern::wrap_type<v0::Constant>();
-        auto strided_slice0 = ov::op::util::NewGenStridedSlice(cos_sin_cache, {0, 0}, ss_stop | scatter_update0, {1, 1}, 1);
+        auto strided_slice0 =
+            ov::op::util::NewGenStridedSlice(cos_sin_cache, {0, 0}, ss_stop | scatter_update0, {1, 1}, 1);
 
         auto concat1 = pattern::wrap_type<v0::Concat>({{-1}, {1}, seq_length, {"ndims/2"}, {2}}, {{"axis", 0}});
         auto const_target_shape3 =
@@ -872,7 +875,8 @@ ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
                                                                           pattern::shape_matches("[?, 1, 1, 128]"),
                                                                           {{"special_zero", false}});
 
-    auto slice_StridedSlice_446 = ov::op::util::NewGenStridedSlice(rotary_emb_cos, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
+    auto slice_StridedSlice_446 =
+        ov::op::util::NewGenStridedSlice(rotary_emb_cos, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
     auto mul_Multiply_552 = pattern::wrap_type<v1::Multiply>(
         {slice_Slice_543, slice_StridedSlice_446 | slice_Slice_446 | reshape_cos_to_expected_layout},
         {{"auto_broadcast", "numpy"}});
@@ -919,7 +923,8 @@ ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
     auto cat_Concat_593 = pattern::wrap_type<v0::Concat>(
         {ListUnpack_586_Squeeze_0 | ListUnpack_Squeeze_0_1, ListUnpack_586_Squeeze | ListUnpack_Squeeze_1},
         {{"axis", -1}});
-    auto slice_StridedSlice_470 = ov::op::util::NewGenStridedSlice(rotary_emb_sin, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
+    auto slice_StridedSlice_470 =
+        ov::op::util::NewGenStridedSlice(rotary_emb_sin, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
     auto slice_Slice_470 = pattern::wrap_type<v8::Slice>({rotary_emb_sin, Gather_377635 | neg_Multiply, INT_MAX, 1, 1});
     auto gather_sin_by_pos_ids = pattern::wrap_type<v8::Gather>({rotary_emb_sin, position_ids, 1}, {{"batch_dims", 0}});
     auto reshape_sin_to_expected_layout = pattern::wrap_type<v1::Reshape>({gather_sin_by_pos_ids, pattern::any_input()},

--- a/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/fuse_rotary_positional_embeddings.cpp
@@ -167,7 +167,7 @@ ov::pass::RoPEFusionFlux::RoPEFusionFlux() {
 }
 
 ov::pass::RoPEFusionGPTNEOX::RoPEFusionGPTNEOX() {
-    using namespace ov::op;
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionGPTNEOX);
 
     // rope pattern matching triggers a little design flaw:
@@ -189,9 +189,9 @@ ov::pass::RoPEFusionGPTNEOX::RoPEFusionGPTNEOX() {
 
     auto int32_max = std::numeric_limits<std::int32_t>::max();
 
-    auto x2 = ov::op::util::NewGenSlice(x, "half_ndims", int32_max, 1, 3);
+    auto x2 = NewGenSlice(x, "half_ndims", int32_max, 1, 3);
     auto x2neg = pattern::wrap_type<v1::Multiply>({x2 | varsplit->output(1), -1.0f}, {{"auto_broadcast", "numpy"}});
-    auto x1 = ov::op::util::NewGenSlice(x, 0, "half_ndims", 1, 3);
+    auto x1 = NewGenSlice(x, 0, "half_ndims", 1, 3);
     auto x_rotate_half = pattern::wrap_type<v0::Concat>({x2neg, x1 | varsplit->output(0)}, {{"axis", -1}});
 
     auto mul_cos = pattern::wrap_type<v1::Multiply>({x_or_cos1, x_or_cos2}, {{"auto_broadcast", "numpy"}});
@@ -248,6 +248,7 @@ ov::pass::RoPEFusionGPTNEOX::RoPEFusionGPTNEOX() {
 }
 
 ov::pass::RoPEFusionCosSinPreprocess::RoPEFusionCosSinPreprocess() {
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionCosSinPreprocess);
 
     auto cos_const = pattern::wrap_type<v0::Constant>(pattern::type_matches(element::f32));
@@ -259,7 +260,7 @@ ov::pass::RoPEFusionCosSinPreprocess::RoPEFusionCosSinPreprocess() {
 
     auto prepare_cos_sin_gptneox = [&](std::shared_ptr<Node> const_tab) {
         auto slice = pattern::wrap_type<v8::Slice>({const_tab, {0}, node_batch_size, {1}, {0}});
-        auto strided_slice = ov::op::util::NewGenStridedSlice(const_tab, {0}, node_batch_size, {1}, 0);
+        auto strided_slice = NewGenStridedSlice(const_tab, {0}, node_batch_size, {1}, 0);
         return pattern::wrap_type<v6::GatherElements>({strided_slice | slice, gather_positions}, {{"axis", 2}});
     };
 
@@ -269,14 +270,14 @@ ov::pass::RoPEFusionCosSinPreprocess::RoPEFusionCosSinPreprocess() {
     auto prepare_cos_sin_llama = [&](std::shared_ptr<Node> const_tab) {
         auto ScatterUpdate = pattern::wrap_type<v3::ScatterUpdate>({{0, 0, 0}, 2, seq_len, 0});
         auto slice_Slice = pattern::wrap_type<v8::Slice>({const_tab, {0}, seq_len, {1}, {2}});
-        auto slice_StridedSlice = ov::op::util::NewGenStridedSlice(const_tab, {0, 0, 0}, ScatterUpdate, {1, 1, 1}, 2);
+        auto slice_StridedSlice = NewGenStridedSlice(const_tab, {0, 0, 0}, ScatterUpdate, {1, 1, 1}, 2);
         auto squeeze = pattern::wrap_type<v1::Reshape>({slice_StridedSlice | slice_Slice, pattern::any_input()},
                                                        pattern::shape_matches("[?, head_dims]"));
         auto index_Gather = pattern::wrap_type<v8::Gather>({squeeze, gather_positions_2d, 0}, {{"batch_dims", 0}});
 
         // another simplified pattern for gathering at position_ids
         auto slice_Slice2 = pattern::wrap_type<v8::Slice>({const_tab, {0}, seq_len, {1}, {0}});
-        auto slice_StridedSlice2 = ov::op::util::NewGenStridedSlice(const_tab, {0}, seq_len, {1}, 0);
+        auto slice_StridedSlice2 = NewGenStridedSlice(const_tab, {0}, seq_len, {1}, 0);
         auto index_Gather2 =
             pattern::wrap_type<v8::Gather>({slice_Slice2 | slice_StridedSlice2, gather_positions_2d, 0},
                                            {{"batch_dims", 0}});
@@ -329,14 +330,15 @@ ov::pass::RoPEFusionCosSinPreprocess::RoPEFusionCosSinPreprocess() {
 
 // only a fraction of head_size is rotary-embedded
 ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionIOSlicing);
     auto int32_max = std::numeric_limits<std::int32_t>::max();
     auto data = pattern::any_input(pattern::rank_equals(4));
     auto varsplit = pattern::wrap_type<op::v1::VariadicSplit>({data, 3, {"ndims", "?"}});
     varsplit->set_output_size(2);
 
-    auto x = ov::op::util::NewGenSlice(data, 0, "ndims", 1, 3);
-    auto y = ov::op::util::NewGenSlice(data, "ndims", int32_max, 1, 3);
+    auto x = NewGenSlice(data, 0, "ndims", 1, 3);
+    auto y = NewGenSlice(data, "ndims", int32_max, 1, 3);
     auto x_emb =
         pattern::wrap_type<op::internal::RoPE>({x | varsplit->output(0), pattern::any_input(), pattern::any_input()}) |
         pattern::wrap_type<op::internal::RoPE>(
@@ -376,6 +378,7 @@ ov::pass::RoPEFusionIOSlicing::RoPEFusionIOSlicing() {
 
 // gptneox-preprocess of input data
 ov::pass::RoPEFusionPreprocess::RoPEFusionPreprocess() {
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionPreprocess);
 
     // Pattern for input to be sliced (for models with combined QKV projection)
@@ -384,7 +387,7 @@ ov::pass::RoPEFusionPreprocess::RoPEFusionPreprocess() {
     auto input_to_trans = pattern::any_input(pattern::rank_equals(4));
 
     // Slice input if needed: [B, L, H, S] -> [B, L', H, S]
-    auto input_slice = ov::op::util::NewGenSlice(input_to_slice, {"slice_start"}, {"slice_stop"}, 1, 3);
+    auto input_slice = NewGenSlice(input_to_slice, {"slice_start"}, {"slice_stop"}, 1, 3);
 
     // Transpose input if needed: [B, L, H, S] -> [B, H, L, S]
     auto x = pattern::wrap_type<op::v1::Transpose>({input_slice | input_to_trans, {0, 2, 1, 3}});
@@ -448,6 +451,7 @@ static std::shared_ptr<ov::Node> repeat_interleave_pattern(const ov::Output<ov::
 }
 
 ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionGPTJ);
 
     auto gather_sin_cos = pattern::any_input(pattern::type_matches(ov::element::f32));
@@ -457,13 +461,12 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
     auto repeat_interleave_cos = repeat_interleave_pattern(varsplit->output(1));
 
     auto view_Reshape = pattern::any_input(pattern::rank_equals(4));
-    auto slice_Slice_965 = ov::op::util::NewGenSlice(view_Reshape, 0, "ndims", 1, 3);
+    auto slice_Slice_965 = NewGenSlice(view_Reshape, 0, "ndims", 1, 3);
     // view_Reshape : B,L,H,S
     auto varsplit_view_Reshape = pattern::wrap_type<opset1::VariadicSplit>({view_Reshape, 3, {"ndims", "end"}});
     varsplit_view_Reshape->set_output_size(2);
     // x interleave (-x[:,:,:, 1::2], x[:,:,:, 0::2])
-    auto slice_Slice_1174 =
-        ov::op::util::NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 1, INT_MAX, 2, 3);
+    auto slice_Slice_1174 = NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 1, INT_MAX, 2, 3);
 
     auto neg_Multiply_1177 =
         pattern::wrap_type<opset1::Multiply>({slice_Slice_1174, -1.0f}, {{"auto_broadcast", "numpy"}});
@@ -471,8 +474,7 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
     auto Unsqueeze_28998 = pattern::wrap_type<opset1::Reshape>({neg_Multiply_1177, {"-1", "1", "head_num", "32", "1"}},
                                                                {{"special_zero", false}});
 
-    auto slice_Slice_1168 =
-        ov::op::util::NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 0, INT_MAX, 2, 3);
+    auto slice_Slice_1168 = NewGenSlice(slice_Slice_965 | varsplit_view_Reshape->output(0), 0, INT_MAX, 2, 3);
     auto Unsqueeze_65525 = pattern::wrap_type<opset1::Unsqueeze>({slice_Slice_1168, -1});
     auto Unsqueeze_28999 = pattern::wrap_type<opset1::Reshape>({slice_Slice_1168, {"-1", "1", "head_num", "32", "1"}},
                                                                {{"special_zero", false}});
@@ -481,7 +483,7 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
                                            {{"axis", -1}});
 
     auto ShapeOf_169068 = pattern::wrap_type<opset1::ShapeOf>({stack_1182});
-    auto flatten_Slice_1194 = ov::op::util::NewGenSlice(ShapeOf_169068, 0, 3, 1, 0);
+    auto flatten_Slice_1194 = NewGenSlice(ShapeOf_169068, 0, 3, 1, 0);
     auto flatten_Concat_1197 = pattern::wrap_type<opset1::Concat>({flatten_Slice_1194, {-1}}, {{"axis", 0}});
     // If with special zero, no need to use shapeof to get full shape
     auto flatten_Reshape_1198 = pattern::wrap_type<opset1::Reshape>({stack_1182, flatten_Concat_1197});
@@ -499,7 +501,7 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
     // *cos + *sin
     auto rotary_emb = pattern::wrap_type<opset1::Add>({mul_cos, mul_sin}, {{"auto_broadcast", "numpy"}});
 
-    auto slice_Slice_971 = ov::op::util::NewGenSlice(view_Reshape, "ndims", INT_MAX, 1, 3);
+    auto slice_Slice_971 = NewGenSlice(view_Reshape, "ndims", INT_MAX, 1, 3);
     auto result = pattern::wrap_type<opset1::Concat>({rotary_emb, slice_Slice_971 | varsplit_view_Reshape->output(1)},
                                                      {{"axis", -1}});
 
@@ -570,6 +572,7 @@ ov::pass::RoPEFusionGPTJ::RoPEFusionGPTJ() {
 }
 
 ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool support_2d_rope) {
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionChatGLM);
 
     //  [seq_length, batch_size, input_size(will be cropped to match hidden state size)]
@@ -604,7 +607,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
         input_key = std::move(cur_key);
     }
 
-    auto slice0 = ov::op::util::NewGenSlice(input_key, 0, "ndims", 1, 3);
+    auto slice0 = NewGenSlice(input_key, 0, "ndims", 1, 3);
     auto var_split0 = pattern::wrap_type<v1::VariadicSplit>({input_key, 3, {"ndims", "end"}});
     var_split0->set_output_size(2);
 
@@ -639,8 +642,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
         auto slice1 = pattern::wrap_type<v8::Slice>({cos_sin_cache, {0}, seq_length, {1}, {1}});
         auto slice2 = pattern::wrap_type<v8::Slice>({cos_sin_cache, {0, 0}, scatter_update0, {1, 1}, {0}});
         auto ss_stop = pattern::wrap_type<v0::Constant>();
-        auto strided_slice0 =
-            ov::op::util::NewGenStridedSlice(cos_sin_cache, {0, 0}, ss_stop | scatter_update0, {1, 1}, 1);
+        auto strided_slice0 = NewGenStridedSlice(cos_sin_cache, {0, 0}, ss_stop | scatter_update0, {1, 1}, 1);
 
         auto concat1 = pattern::wrap_type<v0::Concat>({{-1}, {1}, seq_length, {"ndims/2"}, {2}}, {{"axis", 0}});
         auto const_target_shape3 =
@@ -656,7 +658,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
             pattern::wrap_type<v0::Constant>(pattern::value_matches("seq_len, batch, 1, ndims/2, 2"));
 
         auto slice3 = pattern::wrap_type<v8::Slice>({cos_sin_cache, {0}, seq_length, {1}, {0}});
-        auto strided_slice1 = ov::op::util::NewGenStridedSlice(cos_sin_cache, {0}, seq_length, {1}, 0);
+        auto strided_slice1 = NewGenStridedSlice(cos_sin_cache, {0}, seq_length, {1}, 0);
 
         // [seq_length, 1, batch, half_rotary_dims, 2]
         reshape1 = pattern::wrap_type<v1::Reshape>(
@@ -681,7 +683,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
     auto concat2 = pattern::wrap_type<v0::Concat>({y_even, y_odd}, {{"axis", -1}});
 
     auto shape_of0 = pattern::wrap_type<ov::op::util::ShapeOfBase>({concat2});
-    auto slice4 = ov::op::util::NewGenSlice(shape_of0, 0, 3, 1, 0);
+    auto slice4 = NewGenSlice(shape_of0, 0, 3, 1, 0);
     auto concat3 = pattern::wrap_type<v0::Concat>({slice4, {-1}}, {{"axis", 0}});
 
     std::shared_ptr<ov::Node> const_target_shape6 = nullptr;
@@ -700,7 +702,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
         reshape2 = pattern::wrap_type<v1::Reshape>({concat2, concat3 | const_target_shape6 | const_target_shape7},
                                                    {{"special_zero", true}});
     }
-    auto slice5 = ov::op::util::NewGenSlice(input_key, "ndims", INT_MAX, 1, 3);
+    auto slice5 = NewGenSlice(input_key, "ndims", INT_MAX, 1, 3);
 
     auto concat4 = pattern::wrap_type<v0::Concat>({reshape2, slice5 | var_split0->output(1)}, {{"axis", -1}});
     auto result = concat4 | reshape2;
@@ -764,7 +766,7 @@ ov::pass::RoPEFusionChatGLM::RoPEFusionChatGLM(int split_output_id, const bool s
 }
 
 ov::pass::RoPEFusionChatGLMHF::RoPEFusionChatGLMHF() {
-    using namespace ov::op;
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionChatGLMHF);
 
     auto qk_linear = pattern::any_input(pattern::shape_matches("[?, 1, ?]"));
@@ -774,7 +776,7 @@ ov::pass::RoPEFusionChatGLMHF::RoPEFusionChatGLMHF() {
     auto reshape = pattern::wrap_type<v1::Reshape>({qk_linear, pattern::any_input()},
                                                    pattern::shape_matches("[?, head_cnt, 1, head_size]"),
                                                    {{"special_zero", false}});
-    auto slice_1 = ov::op::util::NewGenSlice(reshape, 0, "ndims", 1, 3);
+    auto slice_1 = NewGenSlice(reshape, 0, "ndims", 1, 3);
 
     auto const_idx =
         pattern::wrap_type<ov::opset1::Constant>(pattern::type_matches(ov::element::i32) && const_idx_predicate);
@@ -782,12 +784,12 @@ ov::pass::RoPEFusionChatGLMHF::RoPEFusionChatGLMHF() {
     auto repeat_interleave_sin = pattern::wrap_type<v8::Gather>({sin, const_idx, -1}, {{"batch_dims", 0}});
 
     auto multiply = pattern::wrap_type<v1::Multiply>({slice_1, repeat_interleave_cos}, {{"auto_broadcast", "numpy"}});
-    auto slice_2 = ov::op::util::NewGenSlice(slice_1, 1, INT_MAX, 2, 3);
+    auto slice_2 = NewGenSlice(slice_1, 1, INT_MAX, 2, 3);
     auto neg = pattern::wrap_type<v1::Multiply>({slice_2, -1}, {{"auto_broadcast", "numpy"}});
     auto unsqueeze_1 = pattern::wrap_type<v1::Reshape>({neg, pattern::any_input()},
                                                        pattern::shape_matches("[?, head_cnt, 1, ndims/2, 1]"),
                                                        {{"special_zero", false}});
-    auto slice_3 = ov::op::util::NewGenSlice(slice_1, 0, INT_MAX, 2, 3);
+    auto slice_3 = NewGenSlice(slice_1, 0, INT_MAX, 2, 3);
     auto unsqueeze_2 = pattern::wrap_type<v1::Reshape>({slice_3, pattern::any_input()},
                                                        pattern::shape_matches("[?, head_cnt, 1, ndims/2, 1]"),
                                                        {{"special_zero", false}});
@@ -798,7 +800,7 @@ ov::pass::RoPEFusionChatGLMHF::RoPEFusionChatGLMHF() {
     auto multiply_1 = pattern::wrap_type<v1::Multiply>({flatten, repeat_interleave_sin}, {{"auto_broadcast", "numpy"}});
     auto add = pattern::wrap_type<v1::Add>({multiply, multiply_1}, {{"auto_broadcast", "numpy"}});
 
-    auto slice_5 = ov::op::util::NewGenSlice(reshape, "ndims", INT_MAX, 1, 3);
+    auto slice_5 = NewGenSlice(reshape, "ndims", INT_MAX, 1, 3);
     auto result = pattern::wrap_type<v0::Concat>({add, slice_5}, {{"axis", -1}});
 
     matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
@@ -840,7 +842,7 @@ ov::pass::RoPEFusionChatGLMHF::RoPEFusionChatGLMHF() {
 }
 
 ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
-    using namespace ov::op;
+    using namespace ov::op::util;
     MATCHER_SCOPE(RoPEFusionQwen);
 
     // rotary_emb_cos & rotary_emb_sin are sliced by present kv-length (past-kv-length + cur_len)
@@ -857,7 +859,7 @@ ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
         pattern::wrap_type<v1::Reshape>({ListUnpack_410_VariadicSplit->output(split_output_id), pattern::any_input()},
                                         pattern::shape_matches("[?, ?, head_cnt, head_size]"),
                                         {{"special_zero", true}});
-    auto slice_Slice_543 = ov::op::util::NewGenSlice(view_Reshape_424, 0, "head_size", 1, 3);
+    auto slice_Slice_543 = NewGenSlice(view_Reshape_424, 0, "head_size", 1, 3);
 
     auto ShapeOf_485735 = pattern::wrap_type<ov::op::util::ShapeOfBase>({pattern::any_input()}, {});
     auto Multiply_567524 = pattern::wrap_type<v1::Multiply>({ShapeOf_485735, -1}, {{"auto_broadcast", "numpy"}});
@@ -875,8 +877,7 @@ ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
                                                                           pattern::shape_matches("[?, 1, 1, 128]"),
                                                                           {{"special_zero", false}});
 
-    auto slice_StridedSlice_446 =
-        ov::op::util::NewGenStridedSlice(rotary_emb_cos, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
+    auto slice_StridedSlice_446 = NewGenStridedSlice(rotary_emb_cos, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
     auto mul_Multiply_552 = pattern::wrap_type<v1::Multiply>(
         {slice_Slice_543, slice_StridedSlice_446 | slice_Slice_446 | reshape_cos_to_expected_layout},
         {{"auto_broadcast", "numpy"}});
@@ -923,8 +924,7 @@ ov::pass::RoPEFusionQwen::RoPEFusionQwen(int split_output_id) {
     auto cat_Concat_593 = pattern::wrap_type<v0::Concat>(
         {ListUnpack_586_Squeeze_0 | ListUnpack_Squeeze_0_1, ListUnpack_586_Squeeze | ListUnpack_Squeeze_1},
         {{"axis", -1}});
-    auto slice_StridedSlice_470 =
-        ov::op::util::NewGenStridedSlice(rotary_emb_sin, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
+    auto slice_StridedSlice_470 = NewGenStridedSlice(rotary_emb_sin, ScatterUpdate_463814, {0, INT_MAX}, {1, 1}, 1);
     auto slice_Slice_470 = pattern::wrap_type<v8::Slice>({rotary_emb_sin, Gather_377635 | neg_Multiply, INT_MAX, 1, 1});
     auto gather_sin_by_pos_ids = pattern::wrap_type<v8::Gather>({rotary_emb_sin, position_ids, 1}, {{"batch_dims", 0}});
     auto reshape_sin_to_expected_layout = pattern::wrap_type<v1::Reshape>({gather_sin_by_pos_ids, pattern::any_input()},

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -7,8 +7,8 @@
 #include <assert.h>
 
 #include <functional>
-#include <vector>
 #include <memory>
+#include <vector>
 
 #include "openvino/core/validation_util.hpp"
 #include "openvino/op/add.hpp"
@@ -33,10 +33,10 @@
 #include "openvino/op/tanh.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/op/util/shape_of_base.hpp"
-#include "openvino/util/common_util.hpp"
 #include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "openvino/util/common_util.hpp"
 
 namespace ov {
 namespace op {
@@ -601,7 +601,8 @@ std::shared_ptr<ov::Node> NewGenSlice(const std::shared_ptr<ov::Node>& data,
     auto slice_step = ParseSymbolVariant({step});
     auto slice_axis = ParseSymbolVariant({static_cast<int64_t>(axis)});
 
-    auto opt1 = ov::pass::pattern::wrap_type<ov::op::v8::Slice>({data, slice_start, slice_stop, slice_step, slice_axis});
+    auto opt1 =
+        ov::pass::pattern::wrap_type<ov::op::v8::Slice>({data, slice_start, slice_stop, slice_step, slice_axis});
 
     std::vector<symbol_variant> vbegin(axis + 1, 0);
     std::vector<symbol_variant> vend(axis + 1, 0);
@@ -633,7 +634,6 @@ std::shared_ptr<ov::Node> NewGenSlice(const std::shared_ptr<ov::Node>& data,
 
     return opt1 | opt2;
 }
-
 
 }  // namespace util
 }  // namespace op

--- a/src/common/transformations/src/transformations/utils/utils.cpp
+++ b/src/common/transformations/src/transformations/utils/utils.cpp
@@ -7,6 +7,7 @@
 #include <assert.h>
 
 #include <functional>
+#include <vector>
 #include <memory>
 
 #include "openvino/core/validation_util.hpp"
@@ -26,10 +27,13 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/sigmoid.hpp"
+#include "openvino/op/slice.hpp"
+#include "openvino/op/strided_slice.hpp"
 #include "openvino/op/subtract.hpp"
 #include "openvino/op/tanh.hpp"
 #include "openvino/op/util/multi_subgraph_base.hpp"
 #include "openvino/op/util/shape_of_base.hpp"
+#include "openvino/util/common_util.hpp"
 #include "openvino/pass/pattern/op/optional.hpp"
 #include "openvino/pass/pattern/op/or.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
@@ -543,6 +547,93 @@ bool process_subgraph(ov::pass::ModelPass& model_pass, const std::shared_ptr<Nod
 
     return changed;
 }
+
+static std::string ParseSymbolVariant(std::vector<symbol_variant> values) {
+    std::vector<std::string> symbol_strings;
+    symbol_strings.reserve(values.size());
+    for (auto& value : values) {
+        if (std::holds_alternative<float>(value)) {
+            symbol_strings.push_back(std::to_string(std::get<float>(value)));
+        } else if (std::holds_alternative<int>(value)) {
+            symbol_strings.push_back(std::to_string(std::get<int>(value)));
+        } else if (std::holds_alternative<int32_t>(value)) {
+            symbol_strings.push_back(std::to_string(std::get<int32_t>(value)));
+        } else if (std::holds_alternative<int64_t>(value)) {
+            symbol_strings.push_back(std::to_string(std::get<int64_t>(value)));
+        } else {
+            symbol_strings.push_back(std::get<std::string>(value));
+        }
+    }
+
+    return ov::util::join(symbol_strings);
+}
+
+std::shared_ptr<ov::Node> NewGenStridedSlice(const std::shared_ptr<ov::Node>& data,
+                                             const ov::pass::pattern::PatternOp& start,
+                                             const ov::pass::pattern::PatternOp& stop,
+                                             const ov::pass::pattern::PatternOp& step,
+                                             size_t axis) {
+    std::vector<int64_t> begin_mask(axis + 1, 1);
+    std::vector<int64_t> end_mask(axis + 1, 1);
+    std::vector<int64_t> new_axis_mask;
+    std::vector<int64_t> shrink_axis_mask;
+    std::vector<int64_t> ellipsis_mask;
+
+    begin_mask[axis] = 0;
+    end_mask[axis] = 0;
+
+    return ov::pass::pattern::wrap_type<ov::op::v1::StridedSlice>({data, start, stop, step},
+                                                                  {{"begin_mask", begin_mask},
+                                                                   {"end_mask", end_mask},
+                                                                   {"new_axis_mask", new_axis_mask},
+                                                                   {"shrink_axis_mask", shrink_axis_mask},
+                                                                   {"ellipsis_mask", ellipsis_mask}});
+}
+
+std::shared_ptr<ov::Node> NewGenSlice(const std::shared_ptr<ov::Node>& data,
+                                      symbol_variant start,
+                                      symbol_variant stop,
+                                      symbol_variant step,
+                                      size_t axis) {
+    using namespace ov::pass;
+    auto slice_start = ParseSymbolVariant({start});
+    auto slice_stop = ParseSymbolVariant({stop});
+    auto slice_step = ParseSymbolVariant({step});
+    auto slice_axis = ParseSymbolVariant({static_cast<int64_t>(axis)});
+
+    auto opt1 = ov::pass::pattern::wrap_type<ov::op::v8::Slice>({data, slice_start, slice_stop, slice_step, slice_axis});
+
+    std::vector<symbol_variant> vbegin(axis + 1, 0);
+    std::vector<symbol_variant> vend(axis + 1, 0);
+    std::vector<symbol_variant> vstride(axis + 1, 1);
+
+    vbegin[axis] = start;
+    vend[axis] = stop;
+    vstride[axis] = step;
+
+    auto begin = ParseSymbolVariant(vbegin);
+    auto end = ParseSymbolVariant(vend);
+    auto stride = ParseSymbolVariant(vstride);
+
+    std::vector<int64_t> begin_mask(axis + 1, 1);
+    std::vector<int64_t> end_mask(axis + 1, 1);
+    std::vector<int64_t> new_axis_mask;
+    std::vector<int64_t> shrink_axis_mask;
+    std::vector<int64_t> ellipsis_mask;
+
+    begin_mask[axis] = 0;
+    end_mask[axis] = 0;
+
+    auto opt2 = pattern::wrap_type<ov::op::v1::StridedSlice>({data, begin, end, stride},
+                                                             {{"begin_mask", begin_mask},
+                                                              {"end_mask", end_mask},
+                                                              {"new_axis_mask", new_axis_mask},
+                                                              {"shrink_axis_mask", shrink_axis_mask},
+                                                              {"ellipsis_mask", ellipsis_mask}});
+
+    return opt1 | opt2;
+}
+
 
 }  // namespace util
 }  // namespace op

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.cpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.cpp
@@ -8,9 +8,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 
 #include "openvino/cc/pass/itt.hpp"
 #include "openvino/core/graph_util.hpp"
+#include "openvino/core/model.hpp"
 #include "openvino/core/node_vector.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
@@ -31,12 +33,13 @@
 #include "openvino/op/select.hpp"
 #include "openvino/op/shape_of.hpp"
 #include "openvino/op/slice.hpp"
-#include "openvino/op/strided_slice.hpp"
 #include "openvino/op/tile.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/pass/matcher_pass.hpp"
 #include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/label.hpp"
 #include "openvino/pass/pattern/op/op.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "openvino/util/pp.hpp"
 #include "transformations/cpu_opset/common/op/causal_mask_preprocess.hpp"

--- a/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.hpp
+++ b/src/plugins/intel_cpu/src/transformations/cpu_opset/common/pass/causal_mask_preprocess_fusion.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/matcher_pass.hpp"
+#include "openvino/pass/pass.hpp"
 
 namespace ov::intel_cpu {
 
-class CausalMaskPreprocessFusion : public ov::pass::GraphRewrite {
+class CausalMaskPreprocessFusion : public ov::pass::ModelPass {
 public:
-    OPENVINO_GRAPH_REWRITE_RTTI("CausalMaskPreprocessFusion");
-    CausalMaskPreprocessFusion();
+    OPENVINO_MODEL_PASS_RTTI("CausalMaskPreprocessFusion");
+    CausalMaskPreprocessFusion() = default;
+    bool run_on_model(const std::shared_ptr<ov::Model>& model) override;
 };
 
 }  // namespace ov::intel_cpu


### PR DESCRIPTION
Details:
Rewrite the CausalMaskPreprocess transformation using new Symbolic approach allowing for greater flexibility and more convenient pattern design.

Tickets:


[CVS-170029](https://jira.devtools.intel.com/browse/CVS-170029)

Signed-off-by: Andrii Staikov [andrii.staikov@intel.com](mailto:andrii.staikov@intel.com)