### PR TITLE
docs(typo, py3-bindings): minor typo in comment

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -162,7 +162,7 @@ else()
 endif()
 
 if(NOT SETUP_PY_REQUIREMENTS_FOUND)
-    # setup.py requirements are importnant to build wheel
+    # setup.py requirements are important to build wheel
     set(ENABLE_WHEEL_DEFAULT OFF)
 endif()
 


### PR DESCRIPTION
I was reading through the codebase and found this typo :P