### PR TITLE
fix(wheel, pybind311): use python3-packaging instead of python3-wheel for python tag checks

### DIFF
--- a/src/bindings/python/wheel/CMakeLists.txt
+++ b/src/bindings/python/wheel/CMakeLists.txt
@@ -6,10 +6,10 @@
 # Define proper package name
 #
 
-execute_process(COMMAND ${Python3_EXECUTABLE} -c "import wheel.vendored.packaging.tags as tags ; print(f'{tags.interpreter_name()}{tags.interpreter_version()}')"
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "import packaging.tags as tags ; print(f'{tags.interpreter_name()}{tags.interpreter_version()}')"
                 OUTPUT_VARIABLE PYTHON_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT PYTHON_TAG)
-    message(FATAL_ERROR "Failed to detect Python Tag via wheel.vendored.packaging.tags. Please, check 'wheel' dependency version update")
+    message(FATAL_ERROR "Failed to detect Python Tag via packaging.tags. Please, check 'packaging' dependency version update")
 endif()
 
 execute_process(COMMAND ${Python3_EXECUTABLE} -c "from setuptools.command.bdist_wheel import get_abi_tag; print(f'{get_abi_tag()}')"
@@ -18,10 +18,10 @@ if(NOT ABI_TAG)
     message(FATAL_ERROR "Failed to detect ABI Tag via setuptools.command.bdist_wheel. Please, check 'setuptools' dependency version update")
 endif()
 
-execute_process(COMMAND ${Python3_EXECUTABLE} -c "import wheel.vendored.packaging.tags as tags ; print(f'{next(tags.platform_tags())}')"
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "import packaging.tags as tags ; print(f'{next(tags.platform_tags())}')"
                 OUTPUT_VARIABLE PLATFORM_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT PLATFORM_TAG)
-    message(FATAL_ERROR "Failed to detect Platform Tag via wheel.vendored.packaging.tags. Please, check 'wheel' dependency version update")
+    message(FATAL_ERROR "Failed to detect Platform Tag via packaging.tags. Please, check 'packaging' dependency version update")
 endif()
 
 # defines wheel architecture part of `PLATFORM_TAG`


### PR DESCRIPTION
Seems that we've been using a vendored version of [`python3-packaging`](https://pypi.org/project/packaging/) for these checks, that has been removed on a [`python3-wheel` commit](https://github.com/pypa/wheel/pull/655/commits/0bf4cb6c8769a95e577bebd436278b7468f15ebf) and got published on `wheel==0.46.0`, which makes it unbuildable on those versions up


