### PR TITLE
[Core] Refactor f32 to f4e2m1 conversion logic and rounding tests

### DIFF
--- a/src/core/src/type/float4_e2m1.cpp
+++ b/src/core/src/type/float4_e2m1.cpp
@@ -30,76 +30,104 @@ static constexpr std::array<float, 16> f4e2m1_to_f32_lut{
 
 namespace {
 
-constexpr uint8_t f4e2m1_e_size = 2;     // f4e2m1 exponent bit size
-constexpr uint8_t f4e2m1_e_mask = 0x06;  // f4e2m1 exponent bit mask
-constexpr uint8_t f4e2m1_e_bias = 1;     // f4e2m1 exponent bias
-constexpr uint8_t f4e2m1_e_max = 0x03;   // f4e2m1 exponent max value
-constexpr uint8_t f4e2m1_m_size = 1;     // f4e2m1 mantissa bits size
-constexpr uint8_t f4e2m1_m_mask = 0x01;  // f4e2m1 mantissa bit mask
+constexpr uint8_t f4e2m1_e_bias = 1;              // f4e2m1 exponent bias
+constexpr uint8_t f4e2m1_e_max = 0x03;            // f4e2m1 exponent max value
+constexpr uint8_t f4e2m1_m_size = 1;              // f4e2m1 mantissa bits size
+constexpr uint32_t f32_m_size = 23;               // f32 mantissa bits size
+constexpr uint32_t f32_e_mask = 0x7F800000;       // f32 exponent bits mask
+constexpr uint32_t f32_m_mask = 0x007FFFFF;       // f32 mantissa bits mask
+constexpr uint32_t f32_e_bias = 127;              // f32 exponent bias
+constexpr uint32_t f32_m_round_even = 0x200000U;  // f32 mantissa round even
 
-uint8_t f32_to_f4e2m1_bits(const float value) {
-    constexpr uint32_t f32_s_mask = 0x80000000;  // f32 sign bit mask
-    constexpr uint32_t f32_e_mask = 0x7F800000;  // f32 exponent bits mask
-    constexpr uint32_t f32_e_bias = 127;         // f32 exponent bias
-    constexpr uint32_t f32_e_size = 8;           // f32 exponent bits size
-    constexpr uint32_t f32_m_mask = 0x007fffff;  // f32 mantissa bits mask
-    constexpr uint32_t f32_m_size = 23;          // f32 mantissa bits size
+// clang-format off
+/**
+ * @brief Converts a 32-bit float value to its corresponding 4-bit f4e2m1 representation.
+ *
+ * The f4e2m1 format uses:
+ * - 1 sign bit
+ * - 2 exponent bits (with bias 1)
+ * - 1 mantissa bit
+ *
+ * The conversion logic is based on the boundaries and encoding rules for f4e2m1:
+ * - Specific ranges are mapped to mantissa and exponent combinations according to the format's specification.
+ * - Handles positive and negative values, and clamps exponent values to the maximum allowed.
+ *
+ * Mapping:
+ * | Input: abs(value) |  Result
+ * |-------------------+-----------------------
+ * |     <= 0.25       |  ( sign_bit | 0b000 )
+ * |     <  0.75       |  ( sign_bit | 0b001 )
+ * |     <= 1.25       |  ( sign_bit | 0b010 )
+ * |     <  1.75       |  ( sign_bit | 0b011 )
+ * |     <= 2.5        |  ( sign_bit | 0b100 )
+ * |     <  3.5        |  ( sign_bit | 0b101 )
+ * |     <= 5.0        |  ( sign_bit | 0b110 )
+ * |     >  5.0        |  ( sign_bit | 0b111 )
+ *
+ * Boundary values for f4e2m1:
+ * | Value | Hex	    |  Binary (32 bits)	                  | Sign   | Exponent (8 bits) | Mantissa (23 bits)	     | Mantissa (Hex)
+ * |-------|------------|-------------------------------------|--------|-------------------|-------------------------|----------
+ * | 0.25f | 0x3E800000 | 00111110 10000000 00000000 00000000 | 0	   | 01111101 (125)	   | 00000000000000000000000 | 0x000000
+ * | 0.75f | 0x3F400000 | 00111111 01000000 00000000 00000000 | 0	   | 01111110 (126)	   | 10000000000000000000000 | 0x400000
+ * | 1.25f | 0x3FA00000 | 00111111 10100000 00000000 00000000 | 0	   | 01111111 (127)	   | 01000000000000000000000 | 0x200000
+ * | 1.75f | 0x3FE00000 | 00111111 11100000 00000000 00000000 | 0	   | 01111111 (127)	   | 11000000000000000000000 | 0x600000
+ * | 2.5f  | 0x40200000 | 01000000 00100000 00000000 00000000 | 0	   | 10000000 (128)	   | 01000000000000000000000 | 0x200000
+ * | 3.5f  | 0x40600000 | 01000000 01100000 00000000 00000000 | 0	   | 10000000 (128)	   | 11000000000000000000000 | 0x600000
+ * | 5.0f  | 0x40A00000 | 01000000 10100000 00000000 00000000 | 0	   | 10000001 (129)	   | 01000000000000000000000 | 0x200000
+ *
+ *
+ * @param value The 32-bit float value to convert.
+ * @return The 4-bit f4e2m1 representation as a uint8_t.
+ */
+// clang-format on
+uint8_t f32_to_f4e2m1_bits(float value) {
+    const uint32_t bits = util::f32_to_u32_bits(value);
+    const uint8_t f32_exp = (bits & f32_e_mask) >> f32_m_size;  // Extract exponent
+    const uint32_t f32_mantissa = bits & f32_m_mask;            // 23 bits
+    const int32_t unbiased_exp = f32_exp - f32_e_bias;
 
-    constexpr uint32_t f_e_mask = f4e2m1_e_mask << three_bytes_shift;  // f4 exponent bits mask (on u32)
-    constexpr uint32_t f_m_mask = f4e2m1_m_mask << three_bytes_shift;  // f4 mantissa bits mask (on u32)
-    constexpr uint32_t f_m_hidden_one_mask = 0x02000000;               // f4 mantissa hidden one bits mask (on u32)
+    /*
+        The f4e2m1 exponent mapping based on the unbiased exponent:
+        f32_exp      | f4e2m1_exp
+        -------------+-----------
+        125 and less | (0b0000)
+        126	         | (0b0000)
+        127	         | (0b0010)
+        128	         | (0b0100)
+        129 and more | (0b0110)
+    */
+    int32_t f4e2m1_exp = unbiased_exp + f4e2m1_e_bias;
+    if (f4e2m1_exp < 0) {
+        f4e2m1_exp = 0;
+    }
+    if (f4e2m1_exp > f4e2m1_e_max) {
+        f4e2m1_exp = f4e2m1_e_max;
+    }
+    f4e2m1_exp <<= f4e2m1_m_size;
 
-    constexpr uint32_t round_half = 0x01ffffff;  // value for half to even round for f4
-    constexpr uint32_t round_norm = 0x07ffffff;  // value for normal round for f4
-    constexpr uint32_t round_even = 0x00800000;  // value for half to even round for f4
-    constexpr uint32_t round_odd = 0x01800000;   // value for an non-half to even round for f4
+    const auto abs_val = std::abs(value);
+    const uint8_t f4_sign_bit = std::signbit(value) ? 0b1000 : 0b0000;
 
-    const auto input = util::f32_to_u32_bits(value);
-    auto f4_bits = static_cast<uint8_t>((input & f32_s_mask) >> (three_bytes_shift + 4U));
-
-    uint32_t f32_e_field = input & f32_e_mask;
-
-    if (f32_e_field == f32_e_mask) {
-        f4_bits |= (f4e2m1_e_mask | f4e2m1_m_mask);
-    } else if (f32_e_field != 0) {
-        int32_t target_f_biased_exp = (f32_e_field >> f32_m_size) - (f32_e_bias - f4e2m1_e_bias);
-        uint32_t fractional = (input & f32_m_mask) << (f32_e_size - f4e2m1_e_size - 4U);
-
-        // for normalized values round apply rounding change target fractional and biased exponent
-        if ((fractional & round_half) == round_odd || (fractional & round_norm) != 0) {
-            fractional += round_even;
-            if (0 != (fractional & f_e_mask)) {
-                fractional &= f_e_mask;
-                ++target_f_biased_exp;
-            }
-        }
-        fractional &= f_m_mask;
-
-        // set exponent and mantissa on target bits
-        if (target_f_biased_exp > f4e2m1_e_max) {
-            // Use NAN as this type has no infinity
-            f4_bits |= (f4e2m1_e_mask | f4e2m1_m_mask);
-        } else if (target_f_biased_exp > 0) {
-            f4_bits |= (target_f_biased_exp << f4e2m1_m_size) | (fractional >> (three_bytes_shift));
-        } else {
-            // Restore the hidden 1 in target mantissa for subnormal calculation
-            fractional = f_m_hidden_one_mask | (input & f32_m_mask) << (f32_e_size - f4e2m1_e_size - 4U);
-            // Will any bits be shifted off?
-            int32_t shift = (1U << (1 - target_f_biased_exp));
-            uint32_t sticky = (fractional & (shift - 1)) ? 1 : 0;
-
-            fractional = fractional >> (1 - target_f_biased_exp);
-            fractional |= sticky;
-            // apply rounding
-            if (((fractional & round_half) == round_odd) || ((fractional & round_norm) != 0)) {
-                fractional += round_even;
-            }
-            f4_bits |= fractional >> three_bytes_shift;
-        }
+    if (abs_val <= 0.25f) {
+        return f4_sign_bit;
     }
 
-    return f4_bits;
+    else if (0.75f <= abs_val && abs_val < 1.0f || 1.75f <= abs_val && abs_val < 2.0f ||
+             3.5f <= abs_val && abs_val < 4.0f) {
+        return (f4_sign_bit | f4e2m1_exp) + 2;  // mantissa affect exponent bits
+    }
+
+    else if ((f32_exp == 127 || f32_exp == 128 || f32_exp == 129) && f32_mantissa <= f32_m_round_even) {
+        // 1.0f <= abs_val <= 1.25f || 2.0f <= abs_val <= 2.5f || 4.0f <= abs_val <= 5.0f
+        return (f4_sign_bit | f4e2m1_exp) + 0;
+    }
+
+    else {
+        // 0.25f < abs_val < 0.75f || 1.25f < abs_val < 1.75f || 2.5f < abs_val < 3.5f || 5.0f < abs_val
+        return (f4_sign_bit | f4e2m1_exp) + 1;
+    }
 }
+
 }  // namespace
 
 float4_e2m1::float4_e2m1(const float value) : m_value(f32_to_f4e2m1_bits(value)) {};

--- a/src/core/tests/float4_e2m1.cpp
+++ b/src/core/tests/float4_e2m1.cpp
@@ -46,7 +46,7 @@ TEST(F4E2M1Test, f32_gt_zero_round_to_f4_zero) {
 TEST(F4E2M1Test, f32_gt_zero_round_to_f4_lowest_subnormal) {
     const auto f4 = ov::float4_e2m1(0.21875f);
 
-    EXPECT_EQ(f4.to_bits(), 0b0001);
+    EXPECT_EQ(f4.to_bits(), 0b0000);
 }
 
 TEST(F4E2M1Test, f32_normal_fractional_rounding) {
@@ -254,5 +254,84 @@ TEST(F4E2M1Test, f32_sig_nan) {
     EXPECT_EQ(f4.to_bits(), 0b0111);
     EXPECT_EQ(0, std::numeric_limits<ov::float4_e2m1>::signaling_NaN().to_bits());
 }
+
+using rounding_params = std::tuple<float, uint8_t, float>;
+
+class F32ToF4E2M1RoundingTest : public ::testing::TestWithParam<rounding_params> {};
+
+INSTANTIATE_TEST_SUITE_P(boundary_params,
+                         F32ToF4E2M1RoundingTest,
+                         ::testing::Values(rounding_params{0.24f, 0b0000, 0.0f},
+                                           rounding_params{0.25f, 0b0000, 0.0f},
+                                           rounding_params{0.26f, 0b0001, 0.5f},
+
+                                           rounding_params{0.74f, 0b0001, 0.5f},
+                                           rounding_params{0.75f, 0b0010, 1.0f},
+                                           rounding_params{0.76f, 0b0010, 1.0f},
+
+                                           rounding_params{1.24f, 0b0010, 1.0f},
+                                           rounding_params{1.25f, 0b0010, 1.0f},
+                                           rounding_params{1.26f, 0b0011, 1.5f},
+
+                                           rounding_params{1.74f, 0b0011, 1.5f},
+                                           rounding_params{1.75f, 0b0100, 2.0f},
+                                           rounding_params{1.76f, 0b0100, 2.0f},
+
+                                           rounding_params{2.49f, 0b0100, 2.0f},
+                                           rounding_params{2.50f, 0b0100, 2.0f},
+                                           rounding_params{2.51f, 0b0101, 3.0f},
+
+                                           rounding_params{3.49f, 0b0101, 3.0f},
+                                           rounding_params{3.50f, 0b0110, 4.0f},
+                                           rounding_params{3.51f, 0b0110, 4.0f},
+
+                                           rounding_params{4.99f, 0b0110, 4.0f},
+                                           rounding_params{5.00f, 0b0110, 4.0f},
+                                           rounding_params{5.01f, 0b0111, 6.0f}),
+                         ::testing::PrintToStringParamName());
+
+INSTANTIATE_TEST_SUITE_P(rounding_params,
+                         F32ToF4E2M1RoundingTest,
+                         ::testing::Values(rounding_params{-0.10f, 0b1000, -0.0f},
+                                           rounding_params{0.00f, 0b0000, 0.0f},
+                                           rounding_params{0.01f, 0b0000, 0.0f},
+
+                                           rounding_params{0.49f, 0b0001, 0.5f},
+                                           rounding_params{0.50f, 0b0001, 0.5f},
+                                           rounding_params{0.51f, 0b0001, 0.5f},
+
+                                           rounding_params{0.99f, 0b0010, 1.0f},
+                                           rounding_params{1.00f, 0b0010, 1.0f},
+                                           rounding_params{1.01f, 0b0010, 1.0f},
+
+                                           rounding_params{1.49f, 0b0011, 1.5f},
+                                           rounding_params{1.50f, 0b0011, 1.5f},
+                                           rounding_params{1.51f, 0b0011, 1.5f},
+
+                                           rounding_params{1.99f, 0b0100, 2.0f},
+                                           rounding_params{2.00f, 0b0100, 2.0f},
+                                           rounding_params{2.01f, 0b0100, 2.0f},
+
+                                           rounding_params{2.99f, 0b0101, 3.0f},
+                                           rounding_params{3.00f, 0b0101, 3.0f},
+                                           rounding_params{3.01f, 0b0101, 3.0f},
+
+                                           rounding_params{3.99f, 0b0110, 4.0f},
+                                           rounding_params{4.00f, 0b0110, 4.0f},
+                                           rounding_params{4.50f, 0b0110, 4.0f},
+
+                                           rounding_params{5.50f, 0b0111, 6.0f},
+                                           rounding_params{6.00f, 0b0111, 6.0f},
+                                           rounding_params{6.01f, 0b0111, 6.0f}),
+                         ::testing::PrintToStringParamName());
+
+TEST_P(F32ToF4E2M1RoundingTest, round_behavior) {
+    auto [input, expected_bits, expected_float] = GetParam();
+
+    const auto f4 = ov::float4_e2m1(input);
+    EXPECT_EQ(f4.to_bits(), expected_bits);
+    EXPECT_EQ(static_cast<float>(f4), expected_float);
+}
+
 }  // namespace test
 }  // namespace ov


### PR DESCRIPTION
### Details:
 - Rewtire function: f32_to_f4e2m1_bits
 - add tests
- benchmark: https://quick-bench.com/q/TEIGVVzHGDtlGan42Qdkti3sgKo
### Tickets:
 - *[169310](https://jira.devtools.intel.com/browse/CVS-169310)*
