### PR TITLE
[GPU] Use tensor value_type int64_t.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
@@ -32,8 +32,8 @@ struct roll : primitive_base<roll> {
     /// @param raw_axes raw axes vector
     roll(const primitive_id& id,
          const input_info& input,
-         const std::vector<int32_t>& raw_shift,
-         const std::vector<int32_t>& raw_axes)
+         const std::vector<tensor::value_type>& raw_shift,
+         const std::vector<tensor::value_type>& raw_axes)
         : primitive_base(id, {input}),
           raw_shift(raw_shift), raw_axes(raw_axes) {}
 
@@ -41,8 +41,8 @@ struct roll : primitive_base<roll> {
     tensor shift;
 
     /// @brief Raw shift/axes vector to calculate normalized shift when input shape becomes static
-    std::vector<int32_t> raw_shift;
-    std::vector<int32_t> raw_axes;
+    std::vector<tensor::value_type> raw_shift;
+    std::vector<tensor::value_type> raw_axes;
 
     size_t hash() const override {
         size_t seed = primitive::hash();

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/roll.hpp
@@ -32,8 +32,8 @@ struct roll : primitive_base<roll> {
     /// @param raw_axes raw axes vector
     roll(const primitive_id& id,
          const input_info& input,
-         const std::vector<tensor::value_type>& raw_shift,
-         const std::vector<tensor::value_type>& raw_axes)
+         const std::vector<ov::Dimension::value_type>& raw_shift,
+         const std::vector<ov::Dimension::value_type>& raw_axes)
         : primitive_base(id, {input}),
           raw_shift(raw_shift), raw_axes(raw_axes) {}
 
@@ -41,8 +41,8 @@ struct roll : primitive_base<roll> {
     tensor shift;
 
     /// @brief Raw shift/axes vector to calculate normalized shift when input shape becomes static
-    std::vector<tensor::value_type> raw_shift;
-    std::vector<tensor::value_type> raw_axes;
+    std::vector<ov::Dimension::value_type> raw_shift;
+    std::vector<ov::Dimension::value_type> raw_axes;
 
     size_t hash() const override {
         size_t seed = primitive::hash();

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -141,15 +141,15 @@ struct padding {
     using DynamicDimsMask = std::bitset<SHAPE_RANK_MAX>;
     static constexpr DynamicDimsMask EMPTY_MASK{0x0};
 
-    std::array<int32_t, SHAPE_RANK_MAX> _lower_size = {0};  ///< Lower padding sizes. For spatials, it means size of left (X) and top (Y) padding.
-    std::array<int32_t, SHAPE_RANK_MAX> _upper_size = {0};  ///< Upper padding sizes. For spatials, it means size of right (X) and bottom (Y) padding.
+    std::array<tensor::value_type, SHAPE_RANK_MAX> _lower_size = {0};  ///< Lower padding sizes. For spatials, it means size of left (X) and top (Y) padding.
+    std::array<tensor::value_type, SHAPE_RANK_MAX> _upper_size = {0};  ///< Upper padding sizes. For spatials, it means size of right (X) and bottom (Y) padding.
     DynamicDimsMask _dynamic_dims_mask = EMPTY_MASK;         ///< A mask saying which dimension has dynamic pad
 
     /// @brief
     /// @param lower_sizes Top-left padding sizes, in the same size and order as shape.
     /// @param upper_sizes Bottom-right padding sizes, in the same size and order as shape.
-    padding(const std::vector<int32_t>& lower_sizes,
-            const std::vector<int32_t>& upper_sizes,
+    padding(const std::vector<tensor::value_type>& lower_sizes,
+            const std::vector<tensor::value_type>& upper_sizes,
             const DynamicDimsMask& dynamic_pad_dims = EMPTY_MASK) {
             // paddings
             OPENVINO_ASSERT(lower_sizes.size() <= SHAPE_RANK_MAX);
@@ -161,7 +161,7 @@ struct padding {
 
     /// @brief Constrcuts symmetric padding.
     /// @param sizes Top-left and bottom-right padding sizes, in the same size and order as shape.
-    explicit padding(const std::vector<int32_t>& sizes,
+    explicit padding(const std::vector<tensor::value_type>& sizes,
                      const DynamicDimsMask& dynamic_pad_dims = EMPTY_MASK)
         : padding(sizes, sizes, dynamic_pad_dims) {}
 
@@ -170,8 +170,8 @@ struct padding {
 
     /// @brief Returns true if padding size is not zero.
     explicit operator bool() const {
-        return std::any_of(_lower_size.begin(), _lower_size.end(), [](int32_t i){ return i > 0; }) ||
-               std::any_of(_upper_size.begin(), _upper_size.end(), [](int32_t i){ return i > 0; });
+        return std::any_of(_lower_size.begin(), _lower_size.end(), [](tensor::value_type i){ return i > 0; }) ||
+               std::any_of(_upper_size.begin(), _upper_size.end(), [](tensor::value_type i){ return i > 0; });
     }
 
     bool is_dynamic() const {
@@ -215,19 +215,19 @@ struct padding {
     }
 
     void save(BinaryOutputBuffer& ob) const {
-        std::vector<int32_t> sizes;
+        std::vector<tensor::value_type> sizes;
         sizes.assign(_lower_size.begin(), _lower_size.end());
         ob << sizes;
         sizes.assign(_upper_size.begin(), _upper_size.end());
         ob << sizes;
         OPENVINO_ASSERT(sizes.size() == _dynamic_dims_mask.size(), "invalid size.");
         for (size_t i = 0; i < _dynamic_dims_mask.size(); i++)
-            sizes[i] = static_cast<int32_t>(_dynamic_dims_mask[i]);
+            sizes[i] = static_cast<tensor::value_type>(_dynamic_dims_mask[i]);
         ob << sizes;
     }
 
     void load(BinaryInputBuffer& ib) {
-        std::vector<int32_t> sizes;
+        std::vector<tensor::value_type> sizes;
         ib >> sizes;
         std::copy_n(sizes.begin(), sizes.size(), _lower_size.begin());
         ib >> sizes;
@@ -442,10 +442,10 @@ struct layout {
     /// @param _sizes an array that supports operator[] and stores data in the same order as shape.
     /// e.g. it could be std::vector, std::array, or std::bitset, etc.
     template <class TArray>
-    inline static std::vector<int32_t> format_sizes(const TArray _sizes, const cldnn::format &fmt,
-                                                    const int32_t default_val = 1) {
+    inline static std::vector<tensor::value_type> format_sizes(const TArray _sizes, const cldnn::format &fmt,
+                                                               const tensor::value_type default_val = 1) {
         const auto& output_order = fmt.order();
-        std::vector<int32_t> sizes(output_order.size(), default_val);
+        std::vector<tensor::value_type> sizes(output_order.size(), default_val);
 
         auto default_fmt = format::get_default_format(sizes.size(), format::is_weights_format(fmt), format::is_grouped(fmt));
         const auto& default_order = default_fmt.order();
@@ -455,7 +455,7 @@ struct layout {
             auto pos = default_order.find(c);
             OPENVINO_ASSERT(pos != std::string::npos, "[GPU] Unknown coord type: ", c);
 
-            sizes[i] = static_cast<int32_t>(_sizes[pos]);
+            sizes[i] = static_cast<tensor::value_type>(_sizes[pos]);
         }
 
         return sizes;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/layout.hpp
@@ -141,15 +141,15 @@ struct padding {
     using DynamicDimsMask = std::bitset<SHAPE_RANK_MAX>;
     static constexpr DynamicDimsMask EMPTY_MASK{0x0};
 
-    std::array<tensor::value_type, SHAPE_RANK_MAX> _lower_size = {0};  ///< Lower padding sizes. For spatials, it means size of left (X) and top (Y) padding.
-    std::array<tensor::value_type, SHAPE_RANK_MAX> _upper_size = {0};  ///< Upper padding sizes. For spatials, it means size of right (X) and bottom (Y) padding.
+    std::array<ov::Dimension::value_type, SHAPE_RANK_MAX> _lower_size = {0};  ///< Lower padding sizes. For spatials, it means size of left (X) and top (Y) padding.
+    std::array<ov::Dimension::value_type, SHAPE_RANK_MAX> _upper_size = {0};  ///< Upper padding sizes. For spatials, it means size of right (X) and bottom (Y) padding.
     DynamicDimsMask _dynamic_dims_mask = EMPTY_MASK;         ///< A mask saying which dimension has dynamic pad
 
     /// @brief
     /// @param lower_sizes Top-left padding sizes, in the same size and order as shape.
     /// @param upper_sizes Bottom-right padding sizes, in the same size and order as shape.
-    padding(const std::vector<tensor::value_type>& lower_sizes,
-            const std::vector<tensor::value_type>& upper_sizes,
+    padding(const std::vector<ov::Dimension::value_type>& lower_sizes,
+            const std::vector<ov::Dimension::value_type>& upper_sizes,
             const DynamicDimsMask& dynamic_pad_dims = EMPTY_MASK) {
             // paddings
             OPENVINO_ASSERT(lower_sizes.size() <= SHAPE_RANK_MAX);
@@ -161,7 +161,7 @@ struct padding {
 
     /// @brief Constrcuts symmetric padding.
     /// @param sizes Top-left and bottom-right padding sizes, in the same size and order as shape.
-    explicit padding(const std::vector<tensor::value_type>& sizes,
+    explicit padding(const std::vector<ov::Dimension::value_type>& sizes,
                      const DynamicDimsMask& dynamic_pad_dims = EMPTY_MASK)
         : padding(sizes, sizes, dynamic_pad_dims) {}
 
@@ -170,8 +170,8 @@ struct padding {
 
     /// @brief Returns true if padding size is not zero.
     explicit operator bool() const {
-        return std::any_of(_lower_size.begin(), _lower_size.end(), [](tensor::value_type i){ return i > 0; }) ||
-               std::any_of(_upper_size.begin(), _upper_size.end(), [](tensor::value_type i){ return i > 0; });
+        return std::any_of(_lower_size.begin(), _lower_size.end(), [](ov::Dimension::value_type i){ return i > 0; }) ||
+               std::any_of(_upper_size.begin(), _upper_size.end(), [](ov::Dimension::value_type i){ return i > 0; });
     }
 
     bool is_dynamic() const {
@@ -215,19 +215,19 @@ struct padding {
     }
 
     void save(BinaryOutputBuffer& ob) const {
-        std::vector<tensor::value_type> sizes;
+        std::vector<ov::Dimension::value_type> sizes;
         sizes.assign(_lower_size.begin(), _lower_size.end());
         ob << sizes;
         sizes.assign(_upper_size.begin(), _upper_size.end());
         ob << sizes;
         OPENVINO_ASSERT(sizes.size() == _dynamic_dims_mask.size(), "invalid size.");
         for (size_t i = 0; i < _dynamic_dims_mask.size(); i++)
-            sizes[i] = static_cast<tensor::value_type>(_dynamic_dims_mask[i]);
+            sizes[i] = static_cast<ov::Dimension::value_type>(_dynamic_dims_mask[i]);
         ob << sizes;
     }
 
     void load(BinaryInputBuffer& ib) {
-        std::vector<tensor::value_type> sizes;
+        std::vector<ov::Dimension::value_type> sizes;
         ib >> sizes;
         std::copy_n(sizes.begin(), sizes.size(), _lower_size.begin());
         ib >> sizes;
@@ -314,7 +314,7 @@ struct layout {
     /// Number of elements to be stored in this layout
     size_t count() const;
 
-    std::vector<tensor::value_type> get_pitches() const;
+    std::vector<ov::Dimension::value_type> get_pitches() const;
 
     // @brief Calculates position within buffer of the data element pointed by the provided tensor.
     // element == { 0,0,0,0 } means first no-padding (i.e. data) element
@@ -351,25 +351,25 @@ struct layout {
 
     size_t get_spatial_rank() const;
 
-    tensor::value_type get_dim(size_t idx) const;
+    ov::Dimension::value_type get_dim(size_t idx) const;
 
-    tensor::value_type batch() const;
+    ov::Dimension::value_type batch() const;
 
-    tensor::value_type feature() const;
+    ov::Dimension::value_type feature() const;
 
-    tensor::value_type spatial(size_t spatial_idx) const;
+    ov::Dimension::value_type spatial(size_t spatial_idx) const;
 
-    tensor::value_type group() const;
+    ov::Dimension::value_type group() const;
 
-    tensor::value_type ofm() const;
+    ov::Dimension::value_type ofm() const;
 
-    tensor::value_type ifm() const;
+    ov::Dimension::value_type ifm() const;
 
-    std::vector<tensor::value_type> get_dims() const;
+    std::vector<ov::Dimension::value_type> get_dims() const;
 
-    std::vector<tensor::value_type> get_padded_dims() const;
+    std::vector<ov::Dimension::value_type> get_padded_dims() const;
 
-    std::vector<tensor::value_type> get_ordered_dims() const;
+    std::vector<ov::Dimension::value_type> get_ordered_dims() const;
 
     std::vector<size_t> get_dims_order() const;
 
@@ -442,10 +442,10 @@ struct layout {
     /// @param _sizes an array that supports operator[] and stores data in the same order as shape.
     /// e.g. it could be std::vector, std::array, or std::bitset, etc.
     template <class TArray>
-    inline static std::vector<tensor::value_type> format_sizes(const TArray _sizes, const cldnn::format &fmt,
-                                                               const tensor::value_type default_val = 1) {
+    inline static std::vector<ov::Dimension::value_type> format_sizes(const TArray _sizes, const cldnn::format &fmt,
+                                                               const ov::Dimension::value_type default_val = 1) {
         const auto& output_order = fmt.order();
-        std::vector<tensor::value_type> sizes(output_order.size(), default_val);
+        std::vector<ov::Dimension::value_type> sizes(output_order.size(), default_val);
 
         auto default_fmt = format::get_default_format(sizes.size(), format::is_weights_format(fmt), format::is_grouped(fmt));
         const auto& default_order = default_fmt.order();
@@ -455,7 +455,7 @@ struct layout {
             auto pos = default_order.find(c);
             OPENVINO_ASSERT(pos != std::string::npos, "[GPU] Unknown coord type: ", c);
 
-            sizes[i] = static_cast<tensor::value_type>(_sizes[pos]);
+            sizes[i] = static_cast<ov::Dimension::value_type>(_sizes[pos]);
         }
 
         return sizes;

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -123,7 +123,8 @@ struct tensor {
     friend class details::dim_vec_kind_init<details::dim_vec_kind::spatial>;
     friend class details::dim_vec_kind_init<details::dim_vec_kind::group>;
 
-    typedef int32_t value_type;  ///< Values type stored in tensor.
+    // typedef int32_t value_type;  ///< Values type stored in tensor.
+    typedef int64_t value_type;  ///< Values type stored in tensor.
     // TODO find the way to prevent direct change of following fields.
     mutable_array_ref<value_type> raw;      ///< Raw representation of all dimensions.
     mutable_array_ref<value_type> batch;    ///< Batch dimensions.

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -123,7 +123,6 @@ struct tensor {
     friend class details::dim_vec_kind_init<details::dim_vec_kind::spatial>;
     friend class details::dim_vec_kind_init<details::dim_vec_kind::group>;
 
-    // typedef int32_t value_type;  ///< Values type stored in tensor.
     typedef int64_t value_type;  ///< Values type stored in tensor.
     // TODO find the way to prevent direct change of following fields.
     mutable_array_ref<value_type> raw;      ///< Raw representation of all dimensions.

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/tensor.hpp
@@ -123,7 +123,7 @@ struct tensor {
     friend class details::dim_vec_kind_init<details::dim_vec_kind::spatial>;
     friend class details::dim_vec_kind_init<details::dim_vec_kind::group>;
 
-    typedef int64_t value_type;  ///< Values type stored in tensor.
+    typedef ov::Dimension::value_type value_type;   ///< Values type stored in tensor.
     // TODO find the way to prevent direct change of following fields.
     mutable_array_ref<value_type> raw;      ///< Raw representation of all dimensions.
     mutable_array_ref<value_type> batch;    ///< Batch dimensions.

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -47,7 +47,7 @@ template <class T>
 void dump(memory::ptr mem, stream& stream, std::ofstream& file_stream, bool dump_raw) {
     auto&& size = mem->get_layout().get_tensor();
 
-    auto batch_size = std::max(std::min(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
+    auto batch_size = std::max<tensor::value_type>(std::min<tensor::value_type>(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
     tensor tmp_size(size);
     tmp_size.batch[0] = batch_size;
     if (tmp_size == size) {
@@ -123,7 +123,7 @@ void unpack(cldnn::data_types type, uint8_t input, int8_t &v0, int8_t &v1) {
 void dump_i4u4(cldnn::data_types type, memory::ptr mem, stream& stream, std::ofstream& file_stream, bool dump_raw) {
     auto&& size = mem->get_layout().get_tensor();
 
-    auto batch_size = std::max(std::min(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
+    auto batch_size = std::max<tensor::value_type>(std::min<tensor::value_type>(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
     tensor tmp_size(size);
     tmp_size.batch[0] = batch_size;
     if (tmp_size == size) {

--- a/src/plugins/intel_gpu/src/graph/debug_helper.cpp
+++ b/src/plugins/intel_gpu/src/graph/debug_helper.cpp
@@ -47,7 +47,7 @@ template <class T>
 void dump(memory::ptr mem, stream& stream, std::ofstream& file_stream, bool dump_raw) {
     auto&& size = mem->get_layout().get_tensor();
 
-    auto batch_size = std::max<tensor::value_type>(std::min<tensor::value_type>(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
+    auto batch_size = std::max<ov::Dimension::value_type>(std::min<ov::Dimension::value_type>(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
     tensor tmp_size(size);
     tmp_size.batch[0] = batch_size;
     if (tmp_size == size) {
@@ -76,16 +76,16 @@ void dump(memory::ptr mem, stream& stream, std::ofstream& file_stream, bool dump
     std::stringstream buffer;
 
     if (!dump_raw) {
-        for (cldnn::tensor::value_type g = 0; g < size.group[0]; ++g) {
-            for (cldnn::tensor::value_type b = 0; b < batch_size; ++b) {
-                for (cldnn::tensor::value_type f = 0; f < size.feature[0]; ++f) {
-                    for (cldnn::tensor::value_type w = 0; w < size.spatial[3]; ++w) {
-                        for (cldnn::tensor::value_type z = 0; z < size.spatial[2]; ++z) {
-                            for (cldnn::tensor::value_type y = 0; y < size.spatial[1]; ++y) {
+        for (ov::Dimension::value_type g = 0; g < size.group[0]; ++g) {
+            for (ov::Dimension::value_type b = 0; b < batch_size; ++b) {
+                for (ov::Dimension::value_type f = 0; f < size.feature[0]; ++f) {
+                    for (ov::Dimension::value_type w = 0; w < size.spatial[3]; ++w) {
+                        for (ov::Dimension::value_type z = 0; z < size.spatial[2]; ++z) {
+                            for (ov::Dimension::value_type y = 0; y < size.spatial[1]; ++y) {
                                 cldnn::tensor t(cldnn::group(g), cldnn::batch(b), cldnn::feature(f), cldnn::spatial(0, y, z, w));
                                 size_t input_it = mem->get_layout().get_linear_offset(t);
 
-                                for (cldnn::tensor::value_type x = 0; x < size.spatial[0]; ++x, input_it += x_pitch) {
+                                for (ov::Dimension::value_type x = 0; x < size.spatial[0]; ++x, input_it += x_pitch) {
                                     buffer << std::fixed << std::setprecision(6) << convert_element(mem_ptr[input_it]) << std::endl;
                                 }
                             }
@@ -123,7 +123,7 @@ void unpack(cldnn::data_types type, uint8_t input, int8_t &v0, int8_t &v1) {
 void dump_i4u4(cldnn::data_types type, memory::ptr mem, stream& stream, std::ofstream& file_stream, bool dump_raw) {
     auto&& size = mem->get_layout().get_tensor();
 
-    auto batch_size = std::max<tensor::value_type>(std::min<tensor::value_type>(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
+    auto batch_size = std::max<ov::Dimension::value_type>(std::min<ov::Dimension::value_type>(ExecutionConfig::get_dump_batch_limit(), size.batch[0]), 1);
     tensor tmp_size(size);
     tmp_size.batch[0] = batch_size;
     if (tmp_size == size) {

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_topk_rois.cpp
@@ -32,7 +32,7 @@ layout experimental_detectron_topk_rois_inst::calc_output_layout(
     auto input_layout = impl_param.get_input_layout();
     auto desc = impl_param.typed_desc<experimental_detectron_topk_rois>();
 
-    tensor::value_type roi_num = std::min(input_layout.get_tensor().sizes()[0], static_cast<tensor::value_type>(desc->max_rois));
+    ov::Dimension::value_type roi_num = std::min(input_layout.get_tensor().sizes()[0], static_cast<ov::Dimension::value_type>(desc->max_rois));
 
     return {input_layout.data_type, input_layout.format,
             {roi_num, input_layout.get_tensor().sizes()[1], 1, 1 }};

--- a/src/plugins/intel_gpu/src/graph/experimental_detectron_topk_rois.cpp
+++ b/src/plugins/intel_gpu/src/graph/experimental_detectron_topk_rois.cpp
@@ -32,10 +32,10 @@ layout experimental_detectron_topk_rois_inst::calc_output_layout(
     auto input_layout = impl_param.get_input_layout();
     auto desc = impl_param.typed_desc<experimental_detectron_topk_rois>();
 
-    int32_t roi_num = std::min(input_layout.get_tensor().sizes()[0], static_cast<int32_t>(desc->max_rois));
+    tensor::value_type roi_num = std::min(input_layout.get_tensor().sizes()[0], static_cast<tensor::value_type>(desc->max_rois));
 
-    return {input_layout.data_type, input_layout.format,  {roi_num,
-                                                                 input_layout.get_tensor().sizes()[1], 1, 1 }};
+    return {input_layout.data_type, input_layout.format,
+            {roi_num, input_layout.get_tensor().sizes()[1], 1, 1 }};
 }
 
 std::string experimental_detectron_topk_rois_inst::to_string(experimental_detectron_topk_rois_node const &node) {

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -154,8 +154,8 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
             return input_padding;
         }
 
-        std::vector<tensor::value_type> pad_low(input_padding._lower_size.begin(), input_padding._lower_size.begin() + input_rank);
-        std::vector<tensor::value_type> pad_up(input_padding._upper_size.begin(), input_padding._upper_size.begin() + input_rank);
+        std::vector<ov::Dimension::value_type> pad_low(input_padding._lower_size.begin(), input_padding._lower_size.begin() + input_rank);
+        std::vector<ov::Dimension::value_type> pad_up(input_padding._upper_size.begin(), input_padding._upper_size.begin() + input_rank);
 
         if (input_rank == 1) {
             if (first_input) {

--- a/src/plugins/intel_gpu/src/graph/gemm.cpp
+++ b/src/plugins/intel_gpu/src/graph/gemm.cpp
@@ -154,8 +154,8 @@ std::vector<layout> gemm_inst::transform_input_layouts(const std::shared_ptr<con
             return input_padding;
         }
 
-        std::vector<int32_t> pad_low(input_padding._lower_size.begin(), input_padding._lower_size.begin() + input_rank);
-        std::vector<int32_t> pad_up(input_padding._upper_size.begin(), input_padding._upper_size.begin() + input_rank);
+        std::vector<tensor::value_type> pad_low(input_padding._lower_size.begin(), input_padding._lower_size.begin() + input_rank);
+        std::vector<tensor::value_type> pad_up(input_padding._upper_size.begin(), input_padding._upper_size.begin() + input_rank);
 
         if (input_rank == 1) {
             if (first_input) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -637,12 +637,12 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
         opt_lower_pad += dep_pad._lower_size[1];
         opt_upper_pad += dep_pad._upper_size[1];
     }
-    std::vector<int32_t> lower_sizes;
+    std::vector<tensor::value_type> lower_sizes;
     lower_sizes.push_back(out_pad._lower_size[0]);
     lower_sizes.push_back(opt_lower_pad);
     lower_sizes.push_back(out_pad._lower_size[2]);
     lower_sizes.push_back(out_pad._lower_size[3]);
-    std::vector<int32_t> upper_sizes;
+    std::vector<tensor::value_type> upper_sizes;
     upper_sizes.push_back(out_pad._upper_size[0]);
     upper_sizes.push_back(opt_upper_pad);
     upper_sizes.push_back(out_pad._upper_size[2]);
@@ -707,13 +707,13 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
 
     const auto& crop_size = crop_layout.get_tensor();
 
-    std::vector<int32_t> lower_sizes;
+    std::vector<tensor::value_type> lower_sizes;
     lower_sizes.push_back(offsets.batch[0]);
     lower_sizes.push_back(offsets.feature[0]);
     for (int32_t i = static_cast<int32_t>(input_layout.get_spatial_rank() - 1); i >= 0; i--) {
         lower_sizes.push_back(offsets.spatial[i]);
     }
-    std::vector<int32_t> upper_sizes;
+    std::vector<tensor::value_type> upper_sizes;
     upper_sizes.push_back(input_layout.batch() - offsets.batch[0] - crop_size.batch[0]);
     upper_sizes.push_back(input_layout.feature() - offsets.feature[0] - crop_size.feature[0]);
     for (int32_t i = static_cast<int32_t>(input_layout.get_spatial_rank() - 1); i >= 0; i--) {
@@ -744,8 +744,8 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                 reshape_axis -= 1;
 
                 const auto output_rank = std::max(reshape_ps.size(), static_cast<size_t>(4));
-                std::vector<int32_t> reshape_lower_sizes(output_rank, 0);
-                std::vector<int32_t> reshape_upper_sizes(output_rank, 0);
+                std::vector<tensor::value_type> reshape_lower_sizes(output_rank, 0);
+                std::vector<tensor::value_type> reshape_upper_sizes(output_rank, 0);
                 padding::DynamicDimsMask reshape_dyn_pad_mask;
 
                 reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
@@ -770,8 +770,8 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                 }
 
                 const auto output_rank = std::max(reshape_ps.size(), static_cast<size_t>(4));
-                std::vector<int32_t> reshape_lower_sizes(output_rank, 0);
-                std::vector<int32_t> reshape_upper_sizes(output_rank, 0);
+                std::vector<tensor::value_type> reshape_lower_sizes(output_rank, 0);
+                std::vector<tensor::value_type> reshape_upper_sizes(output_rank, 0);
                 padding::DynamicDimsMask reshape_dyn_pad_mask;
 
                 reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
@@ -869,8 +869,8 @@ void prepare_buffer_fusing::run(program& p) {
                 if (!allow_new_shape_infer && user->is_type<gemm>() && user->get_dependency(1).id().compare(node.id()) == 0) {
                     auto input_rank = user->get_kernel_impl_params()->typed_desc<gemm>()->weight_rank;
                     if (input_rank < TDIM) {
-                        std::vector<int32_t> l_pad = {0, 0, 0, 0};
-                        std::vector<int32_t> u_pad = {0, 0, 0, 0};
+                        std::vector<tensor::value_type> l_pad = {0, 0, 0, 0};
+                        std::vector<tensor::value_type> u_pad = {0, 0, 0, 0};
 
                         //shift right
                         size_t shift_right = TDIM - input_rank;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -304,7 +304,7 @@ void concat_in_place_optimization::update_in_place_concat_paddings(
         padd = padding::max(padd, inputPadding);
     }
 
-    std::vector<tensor::value_type> lower_padd, upper_padd;
+    std::vector<ov::Dimension::value_type> lower_padd, upper_padd;
     for (size_t i = 0; i < concat_out_layout.get_rank(); i++) {
         lower_padd.push_back(padd._lower_size[i]);
         upper_padd.push_back(padd._upper_size[i]);
@@ -637,12 +637,12 @@ void crop_in_place_optimization::update_in_place_crop_padding_along_feature(cons
         opt_lower_pad += dep_pad._lower_size[1];
         opt_upper_pad += dep_pad._upper_size[1];
     }
-    std::vector<tensor::value_type> lower_sizes;
+    std::vector<ov::Dimension::value_type> lower_sizes;
     lower_sizes.push_back(out_pad._lower_size[0]);
     lower_sizes.push_back(opt_lower_pad);
     lower_sizes.push_back(out_pad._lower_size[2]);
     lower_sizes.push_back(out_pad._lower_size[3]);
-    std::vector<tensor::value_type> upper_sizes;
+    std::vector<ov::Dimension::value_type> upper_sizes;
     upper_sizes.push_back(out_pad._upper_size[0]);
     upper_sizes.push_back(opt_upper_pad);
     upper_sizes.push_back(out_pad._upper_size[2]);
@@ -707,13 +707,13 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
 
     const auto& crop_size = crop_layout.get_tensor();
 
-    std::vector<tensor::value_type> lower_sizes;
+    std::vector<ov::Dimension::value_type> lower_sizes;
     lower_sizes.push_back(offsets.batch[0]);
     lower_sizes.push_back(offsets.feature[0]);
     for (int32_t i = static_cast<int32_t>(input_layout.get_spatial_rank() - 1); i >= 0; i--) {
         lower_sizes.push_back(offsets.spatial[i]);
     }
-    std::vector<tensor::value_type> upper_sizes;
+    std::vector<ov::Dimension::value_type> upper_sizes;
     upper_sizes.push_back(input_layout.batch() - offsets.batch[0] - crop_size.batch[0]);
     upper_sizes.push_back(input_layout.feature() - offsets.feature[0] - crop_size.feature[0]);
     for (int32_t i = static_cast<int32_t>(input_layout.get_spatial_rank() - 1); i >= 0; i--) {
@@ -744,8 +744,8 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                 reshape_axis -= 1;
 
                 const auto output_rank = std::max(reshape_ps.size(), static_cast<size_t>(4));
-                std::vector<tensor::value_type> reshape_lower_sizes(output_rank, 0);
-                std::vector<tensor::value_type> reshape_upper_sizes(output_rank, 0);
+                std::vector<ov::Dimension::value_type> reshape_lower_sizes(output_rank, 0);
+                std::vector<ov::Dimension::value_type> reshape_upper_sizes(output_rank, 0);
                 padding::DynamicDimsMask reshape_dyn_pad_mask;
 
                 reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
@@ -770,8 +770,8 @@ void crop_in_place_optimization::update_in_place_crop_padding_simple_data_format
                 }
 
                 const auto output_rank = std::max(reshape_ps.size(), static_cast<size_t>(4));
-                std::vector<tensor::value_type> reshape_lower_sizes(output_rank, 0);
-                std::vector<tensor::value_type> reshape_upper_sizes(output_rank, 0);
+                std::vector<ov::Dimension::value_type> reshape_lower_sizes(output_rank, 0);
+                std::vector<ov::Dimension::value_type> reshape_upper_sizes(output_rank, 0);
                 padding::DynamicDimsMask reshape_dyn_pad_mask;
 
                 reshape_lower_sizes[reshape_axis] = lower_sizes[crop_axis];
@@ -869,8 +869,8 @@ void prepare_buffer_fusing::run(program& p) {
                 if (!allow_new_shape_infer && user->is_type<gemm>() && user->get_dependency(1).id().compare(node.id()) == 0) {
                     auto input_rank = user->get_kernel_impl_params()->typed_desc<gemm>()->weight_rank;
                     if (input_rank < TDIM) {
-                        std::vector<tensor::value_type> l_pad = {0, 0, 0, 0};
-                        std::vector<tensor::value_type> u_pad = {0, 0, 0, 0};
+                        std::vector<ov::Dimension::value_type> l_pad = {0, 0, 0, 0};
+                        std::vector<ov::Dimension::value_type> u_pad = {0, 0, 0, 0};
 
                         //shift right
                         size_t shift_right = TDIM - input_rank;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_padding.cpp
@@ -34,7 +34,7 @@ void prepare_padding::run(program& p) {
                 auto weight_layout = weight_node.get_output_layout(0);
                 const auto const_shape = weight_layout.get_partial_shape().to_shape();
                 OPENVINO_ASSERT(const_shape.size() > 0, "Data padding for int4 type data with an odd innermost dimension does not support zero dimension.");
-                auto inner_most_idx = static_cast<tensor::value_type>(const_shape.size()) - 1;
+                auto inner_most_idx = static_cast<ov::Dimension::value_type>(const_shape.size()) - 1;
                 if (!allow_new_shape_infer) {
                     // Get the innermost index after trimming trailing elements in the canonicalized legacy shape such as [4, 64, 1, 1].
                     while (inner_most_idx > 0 && const_shape[inner_most_idx] == 1) {
@@ -46,7 +46,7 @@ void prepare_padding::run(program& p) {
                 if (const_shape[inner_most_idx] % alignment != 0) {
                     auto weight_in_layout  = weight_layout.convert_to_weights_layout(false);
                     auto weight_out_layout = weight_in_layout;
-                    std::vector<tensor::value_type> new_paddings(const_shape.size(), 0);
+                    std::vector<ov::Dimension::value_type> new_paddings(const_shape.size(), 0);
                     new_paddings[inner_most_idx] = 1;
                     weight_out_layout.data_padding = padding::max(weight_out_layout.data_padding, padding({0}, new_paddings));
                     auto weights_reorder_params = std::make_shared<WeightsReorderParams>(weight_in_layout, weight_out_layout, false, false);
@@ -114,18 +114,18 @@ void prepare_padding::run(program& p) {
                 auto padding_begin = prim->padding_begin;
                 auto padding_end = prim->padding_end;
 
-                tensor::value_type pb_z = std::max<std::ptrdiff_t>(padding_begin.size() >= 3 ? padding_begin[padding_begin.size() - 3] : 0, 0);
-                tensor::value_type pb_y = std::max<std::ptrdiff_t>(padding_begin.size() >= 2 ? padding_begin[padding_begin.size() - 2] : 0, 0);
-                tensor::value_type pb_x = std::max<std::ptrdiff_t>(padding_begin.size() >= 1 ? padding_begin[padding_begin.size() - 1] : 0, 0);
+                ov::Dimension::value_type pb_z = std::max<std::ptrdiff_t>(padding_begin.size() >= 3 ? padding_begin[padding_begin.size() - 3] : 0, 0);
+                ov::Dimension::value_type pb_y = std::max<std::ptrdiff_t>(padding_begin.size() >= 2 ? padding_begin[padding_begin.size() - 2] : 0, 0);
+                ov::Dimension::value_type pb_x = std::max<std::ptrdiff_t>(padding_begin.size() >= 1 ? padding_begin[padding_begin.size() - 1] : 0, 0);
 
-                tensor::value_type pe_z = std::max<std::ptrdiff_t>(padding_end.size() >= 3 ? padding_end[padding_end.size() - 3] : 0, 0);
-                tensor::value_type pe_y = std::max<std::ptrdiff_t>(padding_end.size() >= 2 ? padding_end[padding_end.size() - 2] : 0, 0);
-                tensor::value_type pe_x = std::max<std::ptrdiff_t>(padding_end.size() >= 1 ? padding_end[padding_end.size() - 1] : 0, 0);
+                ov::Dimension::value_type pe_z = std::max<std::ptrdiff_t>(padding_end.size() >= 3 ? padding_end[padding_end.size() - 3] : 0, 0);
+                ov::Dimension::value_type pe_y = std::max<std::ptrdiff_t>(padding_end.size() >= 2 ? padding_end[padding_end.size() - 2] : 0, 0);
+                ov::Dimension::value_type pe_x = std::max<std::ptrdiff_t>(padding_end.size() >= 1 ? padding_end[padding_end.size() - 1] : 0, 0);
 
                 const auto& lower_sizes = in_layout.data_padding._lower_size;
                 const auto& upper_sizes = in_layout.data_padding._upper_size;
 
-                std::vector<tensor::value_type> needed_lpad, needed_upad;
+                std::vector<ov::Dimension::value_type> needed_lpad, needed_upad;
                 needed_lpad.push_back(lower_sizes[0]);
                 needed_lpad.push_back(lower_sizes[1]);
 
@@ -183,7 +183,7 @@ void prepare_padding::run(program& p) {
                 // WA for this format. sliding window needs to be fixed --perf degradation for IncepctionV1 type models
                 tensor size(1);
                 for (size_t i = 0; i < prim->size.size(); i++) {
-                    size.spatial[i] = static_cast<tensor::value_type>(prim->size[prim->size.size() - i - 1]);
+                    size.spatial[i] = static_cast<ov::Dimension::value_type>(prim->size[prim->size.size() - i - 1]);
                 }
 
                 if (node->get_output_layout().format == format::b_fs_yx_fsv16)
@@ -293,25 +293,25 @@ cldnn::padding prepare_padding::get_needed_padding_for_convolution(convolution_n
     uint32_t dilation_y = dilation.size() >= 2 ? static_cast<uint32_t>(dilation[dilation.size() - 2]) : 1;
     uint32_t dilation_x = dilation.size() >= 1 ? static_cast<uint32_t>(dilation[dilation.size() - 1]) : 1;
 
-    tensor::value_type pad_z = padding_begin.size() >= 3 ? padding_begin[padding_begin.size() - 3] : 0;
-    tensor::value_type pad_y = padding_begin.size() >= 2 ? padding_begin[padding_begin.size() - 2] : 0;
-    tensor::value_type pad_x = padding_begin.size() >= 1 ? padding_begin[padding_begin.size() - 1] : 0;
+    ov::Dimension::value_type pad_z = padding_begin.size() >= 3 ? padding_begin[padding_begin.size() - 3] : 0;
+    ov::Dimension::value_type pad_y = padding_begin.size() >= 2 ? padding_begin[padding_begin.size() - 2] : 0;
+    ov::Dimension::value_type pad_x = padding_begin.size() >= 1 ? padding_begin[padding_begin.size() - 1] : 0;
 
-    tensor::value_type padding_begin_x, padding_begin_y, padding_begin_z;
-    tensor::value_type padding_end_x, padding_end_y, padding_end_z;
+    ov::Dimension::value_type padding_begin_x, padding_begin_y, padding_begin_z;
+    ov::Dimension::value_type padding_end_x, padding_end_y, padding_end_z;
 
     if (node.get_program().is_new_shape_infer() && node.use_explicit_padding()) {
-        padding_begin_x = std::max<tensor::value_type>(pad_x, 0);
-        padding_begin_y = std::max<tensor::value_type>(pad_y, 0);
-        padding_begin_z = std::max<tensor::value_type>(pad_z, 0);
+        padding_begin_x = std::max<ov::Dimension::value_type>(pad_x, 0);
+        padding_begin_y = std::max<ov::Dimension::value_type>(pad_y, 0);
+        padding_begin_z = std::max<ov::Dimension::value_type>(pad_z, 0);
 
         pad_z = padding_end.size() >= 3 ? padding_end[padding_end.size() - 3] : 0;
         pad_y = padding_end.size() >= 2 ? padding_end[padding_end.size() - 2] : 0;
         pad_x = padding_end.size() >= 1 ? padding_end[padding_end.size() - 1] : 0;
 
-        padding_end_x = std::max<tensor::value_type>(pad_x, 0);
-        padding_end_y = std::max<tensor::value_type>(pad_y, 0);
-        padding_end_z = std::max<tensor::value_type>(pad_z, 0);
+        padding_end_x = std::max<ov::Dimension::value_type>(pad_x, 0);
+        padding_end_y = std::max<ov::Dimension::value_type>(pad_y, 0);
+        padding_end_z = std::max<ov::Dimension::value_type>(pad_z, 0);
     } else {
         auto input_limit_x = -pad_x + (conv_layout.spatial(0) - 1) * stride_x +
                             (filter_layout.spatial(0) - 1) * dilation_x + 1;
@@ -320,17 +320,17 @@ cldnn::padding prepare_padding::get_needed_padding_for_convolution(convolution_n
         auto input_limit_z = -pad_z + (conv_layout.spatial(2) - 1) * stride_z +
                             (filter_layout.spatial(2) - 1) * dilation_z + 1;
 
-        padding_begin_x = std::max<tensor::value_type>(pad_x, 0);
-        padding_begin_y = std::max<tensor::value_type>(pad_y, 0);
-        padding_begin_z = std::max<tensor::value_type>(pad_z, 0);
-        padding_end_x = std::max<tensor::value_type>(input_limit_x - prev_prim_output_layout.spatial(0), 0);
-        padding_end_y = std::max<tensor::value_type>(input_limit_y - prev_prim_output_layout.spatial(1), 0);
-        padding_end_z = std::max<tensor::value_type>(input_limit_z - prev_prim_output_layout.spatial(2), 0);
+        padding_begin_x = std::max<ov::Dimension::value_type>(pad_x, 0);
+        padding_begin_y = std::max<ov::Dimension::value_type>(pad_y, 0);
+        padding_begin_z = std::max<ov::Dimension::value_type>(pad_z, 0);
+        padding_end_x = std::max<ov::Dimension::value_type>(input_limit_x - prev_prim_output_layout.spatial(0), 0);
+        padding_end_y = std::max<ov::Dimension::value_type>(input_limit_y - prev_prim_output_layout.spatial(1), 0);
+        padding_end_z = std::max<ov::Dimension::value_type>(input_limit_z - prev_prim_output_layout.spatial(2), 0);
     }
 
     // Adjust right padding, so entire buffer size in X dimension is properly aligned.
     // TODO: NOTE: Will be reenabled with next check-in once heuristic for line-aligned algorithm will be added.
-    // auto needed_buffer_size_x = static_cast<cldnn::tensor::value_type>(
+    // auto needed_buffer_size_x = static_cast<cldnn::ov::Dimension::value_type>(
     //    round_up_to(left_padding + prev_prim_output_layout.spatial(0) + right_padding, 16));
     // right_padding = needed_buffer_size_x - left_padding - prev_prim_output_layout.spatial(0);
 

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -282,7 +282,7 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
                 continue;
             }
         } else {
-            cldnn::tensor::value_type out_features = node->get_output_layout().feature();
+            ov::Dimension::value_type out_features = node->get_output_layout().feature();
             bool is_3d_fc = false;
 
             // Change out_features value to proper dimension for 3D FC case

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -334,9 +334,9 @@ void remove_redundant_reorders::run(program& p) {
                 r_node.can_be_optimized(true);
                 r_node.requires_reinterpret(true);
 
-                std::vector<tensor::value_type> pad_lo(o_layout.data_padding._lower_size.begin(),
+                std::vector<ov::Dimension::value_type> pad_lo(o_layout.data_padding._lower_size.begin(),
                                                        o_layout.data_padding._lower_size.begin() + o_layout.get_rank());
-                std::vector<tensor::value_type> pad_hi(o_layout.data_padding._upper_size.begin(),
+                std::vector<ov::Dimension::value_type> pad_hi(o_layout.data_padding._upper_size.begin(),
                                                        o_layout.data_padding._upper_size.begin() + o_layout.get_rank());
 
                 pad_lo[0] = i_layout.data_padding._lower_size[0];

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -334,10 +334,10 @@ void remove_redundant_reorders::run(program& p) {
                 r_node.can_be_optimized(true);
                 r_node.requires_reinterpret(true);
 
-                std::vector<int32_t> pad_lo(o_layout.data_padding._lower_size.begin(),
-                                            o_layout.data_padding._lower_size.begin() + o_layout.get_rank());
-                std::vector<int32_t> pad_hi(o_layout.data_padding._upper_size.begin(),
-                                            o_layout.data_padding._upper_size.begin() + o_layout.get_rank());
+                std::vector<tensor::value_type> pad_lo(o_layout.data_padding._lower_size.begin(),
+                                                       o_layout.data_padding._lower_size.begin() + o_layout.get_rank());
+                std::vector<tensor::value_type> pad_hi(o_layout.data_padding._upper_size.begin(),
+                                                       o_layout.data_padding._upper_size.begin() + o_layout.get_rank());
 
                 pad_lo[0] = i_layout.data_padding._lower_size[0];
                 pad_hi[0] = i_layout.data_padding._upper_size[0];

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -74,8 +74,8 @@ public:
         } else {
             for (size_t i = 0; i < params.inputs.size(); i++) {
                 if (!params.inputs[i].SameDims(params.outputs[0])) {
-                    std::vector<int32_t> input_size = impl_param.input_layouts[i].get_tensor().raw.vector();
-                    std::vector<int32_t> output_size = impl_param.get_output_layout().get_tensor().raw.vector();
+                    std::vector<tensor::value_type> input_size = impl_param.input_layouts[i].get_tensor().raw.vector();
+                    std::vector<tensor::value_type> output_size = impl_param.get_output_layout().get_tensor().raw.vector();
                     bool broadcast = false;
                     for (size_t d = 0; d < output_size.size(); d++) {
                         if (output_size[d] != 1 && input_size[d] == 1)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -74,8 +74,8 @@ public:
         } else {
             for (size_t i = 0; i < params.inputs.size(); i++) {
                 if (!params.inputs[i].SameDims(params.outputs[0])) {
-                    std::vector<tensor::value_type> input_size = impl_param.input_layouts[i].get_tensor().raw.vector();
-                    std::vector<tensor::value_type> output_size = impl_param.get_output_layout().get_tensor().raw.vector();
+                    std::vector<ov::Dimension::value_type> input_size = impl_param.input_layouts[i].get_tensor().raw.vector();
+                    std::vector<ov::Dimension::value_type> output_size = impl_param.get_output_layout().get_tensor().raw.vector();
                     bool broadcast = false;
                     for (size_t d = 0; d < output_size.size(); d++) {
                         if (output_size[d] != 1 && input_size[d] == 1)

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -41,7 +41,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
             auto shift_raw = primitive->raw_shift;
 
             // Normalize axes and sum shift
-            std::vector<tensor::value_type> shift(default_rank);
+            std::vector<ov::Dimension::value_type> shift(default_rank);
             for (size_t a = 0; a < axes_raw.size(); ++a) {
                 auto& axis = axes_raw[a];
                 if (axis < 0) {
@@ -56,7 +56,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
             // Normalize shift
             for (int s = 0; s < rank; ++s) {
                 auto& sh = shift[s];
-                const auto dim = static_cast<tensor::value_type>(input_shape[s]);
+                const auto dim = static_cast<ov::Dimension::value_type>(input_shape[s]);
                 sh %= dim;
                 if (sh < 0) {
                     sh += dim;

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/roll.cpp
@@ -41,7 +41,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
             auto shift_raw = primitive->raw_shift;
 
             // Normalize axes and sum shift
-            std::vector<int32_t> shift(default_rank);
+            std::vector<tensor::value_type> shift(default_rank);
             for (size_t a = 0; a < axes_raw.size(); ++a) {
                 auto& axis = axes_raw[a];
                 if (axis < 0) {
@@ -56,7 +56,7 @@ struct roll_impl : typed_primitive_impl_ocl<roll> {
             // Normalize shift
             for (int s = 0; s < rank; ++s) {
                 auto& sh = shift[s];
-                const auto dim = static_cast<int32_t>(input_shape[s]);
+                const auto dim = static_cast<tensor::value_type>(input_shape[s]);
                 sh %= dim;
                 if (sh < 0) {
                     sh += dim;

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -168,8 +168,8 @@ protected:
         // Transform weights_layout according to input layout
         {
             ov::PartialShape new_weights_pshape;
-            std::vector<int32_t> lower_sizes;
-            std::vector<int32_t> upper_sizes;
+            std::vector<tensor::value_type> lower_sizes;
+            std::vector<tensor::value_type> upper_sizes;
 
             for (size_t i = 0; i < (prim_input_size - prim_weights_rank); i++) {
                 new_weights_pshape.push_back(1);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -168,8 +168,8 @@ protected:
         // Transform weights_layout according to input layout
         {
             ov::PartialShape new_weights_pshape;
-            std::vector<tensor::value_type> lower_sizes;
-            std::vector<tensor::value_type> upper_sizes;
+            std::vector<ov::Dimension::value_type> lower_sizes;
+            std::vector<ov::Dimension::value_type> upper_sizes;
 
             for (size_t i = 0; i < (prim_input_size - prim_weights_rank); i++) {
                 new_weights_pshape.push_back(1);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -61,7 +61,7 @@ dnnl::memory::dims convert_gemm_tensor(cldnn::tensor t, size_t dims, bool batche
     return res;
 }
 
-dnnl::memory::dims convert_gemm_dims(const std::vector<tensor::value_type> &sizes, size_t dims, bool batched_dims_can_be_removed) {
+dnnl::memory::dims convert_gemm_dims(const std::vector<ov::Dimension::value_type> &sizes, size_t dims, bool batched_dims_can_be_removed) {
     dnnl::memory::dims res(sizes.begin(), sizes.end());
     if (dims > 4) {
         for (size_t i = 0; i < dims - 4; i++) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -61,7 +61,7 @@ dnnl::memory::dims convert_gemm_tensor(cldnn::tensor t, size_t dims, bool batche
     return res;
 }
 
-dnnl::memory::dims convert_gemm_dims(const std::vector<int32_t> &sizes, size_t dims, bool batched_dims_can_be_removed) {
+dnnl::memory::dims convert_gemm_dims(const std::vector<tensor::value_type> &sizes, size_t dims, bool batched_dims_can_be_removed) {
     dnnl::memory::dims res(sizes.begin(), sizes.end());
     if (dims > 4) {
         for (size_t i = 0; i < dims - 4; i++) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -26,7 +26,7 @@ void combine_bf_with_first_spatial_dim(cldnn::layout& l);
 // cldnn -> onednn
 dnnl::memory::dims convert_tensor(cldnn::tensor t, size_t dims = 2, bool is_grouped = false);
 dnnl::memory::dims convert_gemm_tensor(cldnn::tensor t, size_t dims, bool batched_dims_can_be_removed);
-dnnl::memory::dims convert_gemm_dims(const std::vector<int32_t> &sizes, size_t dims, bool batched_dims_can_be_removed);
+dnnl::memory::dims convert_gemm_dims(const std::vector<tensor::value_type> &sizes, size_t dims, bool batched_dims_can_be_removed);
 dnnl::memory::dims convert_spatials(cldnn::tensor t, size_t dims = 2);
 dnnl::memory::dims flatten_tensor(cldnn::tensor t);
 dnnl::memory::dims get_strides(dnnl::memory::dims dims);

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.hpp
@@ -26,7 +26,7 @@ void combine_bf_with_first_spatial_dim(cldnn::layout& l);
 // cldnn -> onednn
 dnnl::memory::dims convert_tensor(cldnn::tensor t, size_t dims = 2, bool is_grouped = false);
 dnnl::memory::dims convert_gemm_tensor(cldnn::tensor t, size_t dims, bool batched_dims_can_be_removed);
-dnnl::memory::dims convert_gemm_dims(const std::vector<tensor::value_type> &sizes, size_t dims, bool batched_dims_can_be_removed);
+dnnl::memory::dims convert_gemm_dims(const std::vector<ov::Dimension::value_type> &sizes, size_t dims, bool batched_dims_can_be_removed);
 dnnl::memory::dims convert_spatials(cldnn::tensor t, size_t dims = 2);
 dnnl::memory::dims flatten_tensor(cldnn::tensor t);
 dnnl::memory::dims get_strides(dnnl::memory::dims dims);

--- a/src/plugins/intel_gpu/src/graph/include/sliding_window_utils.hpp
+++ b/src/plugins/intel_gpu/src/graph/include/sliding_window_utils.hpp
@@ -122,15 +122,15 @@ inline tensor calc_sliding_window_output_range<swor_mode::all>(const tensor& inp
     //
     // output_range = max {i | lpos(i) < input_size + pad} + 1,      if sym_pad is true
     // output_range = max {i | lpos(i) < input_size} + 1,            if sym_pad is false
-    auto output_range_x = static_cast<cldnn::tensor::value_type>(
+    auto output_range_x = static_cast<ov::Dimension::value_type>(
         off_factor * pad_x + wnd_ext_size.spatial[0] <= input_size.spatial[0]
             ? (input_size.spatial[0] - off_factor * pad_x - wnd_ext_size.spatial[0]) / stride_x + 1
             : degen_val);
-    auto output_range_y = static_cast<cldnn::tensor::value_type>(
+    auto output_range_y = static_cast<ov::Dimension::value_type>(
         off_factor * pad_y + wnd_ext_size.spatial[1] <= input_size.spatial[1]
             ? (input_size.spatial[1] - off_factor * pad_y - wnd_ext_size.spatial[1]) / stride_y + 1
             : degen_val);
-    auto output_range_z = static_cast<cldnn::tensor::value_type>(
+    auto output_range_z = static_cast<ov::Dimension::value_type>(
         off_factor * pad_z + wnd_ext_size.spatial[2] <= input_size.spatial[2]
             ? (input_size.spatial[2] - off_factor * pad_z - wnd_ext_size.spatial[2]) / stride_z + 1
             : degen_val);
@@ -182,19 +182,19 @@ inline tensor calc_sliding_window_output_range<swor_mode::exceed_once>(const ten
     // output_range = max {i | lpos(i) < input_size + pad - 1 and fpos(i + 1) < input_size + pad} + 2,   if
     // sym_pad is true output_range = max {i | lpos(i) < input_size - 1          and fpos(i + 1) < input_size} + 2,
     // if sym_pad is false
-    auto output_range_x = static_cast<cldnn::tensor::value_type>(
+    auto output_range_x = static_cast<ov::Dimension::value_type>(
         off_factor * pad_x + extend.spatial[0] <= input_size.spatial[0] + stride_x - 1
             ? (input_size.spatial[0] - off_factor * pad_x - extend.spatial[0] + stride_x - 1) /
                       stride_x +
                   1
             : degen_val);
-    auto output_range_y = static_cast<cldnn::tensor::value_type>(
+    auto output_range_y = static_cast<ov::Dimension::value_type>(
         off_factor * pad_y + extend.spatial[1] <= input_size.spatial[1] + stride_y - 1
             ? (input_size.spatial[1] - off_factor * pad_y - extend.spatial[1] + stride_y - 1) /
                       stride_y +
                   1
             : degen_val);
-    auto output_range_z = static_cast<cldnn::tensor::value_type>(
+    auto output_range_z = static_cast<ov::Dimension::value_type>(
         off_factor * pad_z + extend.spatial[2] <= input_size.spatial[2] + stride_z - 1
             ? (input_size.spatial[2] - off_factor * pad_z - extend.spatial[2] + stride_z - 1) /
                       stride_z +
@@ -235,15 +235,15 @@ inline tensor calc_sliding_window_output_range<swor_mode::any>(const tensor& inp
     //
     // output_range = max {i | fpos(i) < input_size + pad} + 1,      if sym_pad is true
     // output_range = max {i | fpos(i) < input_size} + 1,            if sym_pad is false
-    auto output_range_x = static_cast<cldnn::tensor::value_type>(
+    auto output_range_x = static_cast<ov::Dimension::value_type>(
         off_factor * pad_x <= input_size.spatial[0] - 1
             ? (input_size.spatial[0] - off_factor * pad_x - 1) / stride_x + 1
             : degen_val);
-    auto output_range_y = static_cast<cldnn::tensor::value_type>(
+    auto output_range_y = static_cast<ov::Dimension::value_type>(
         off_factor * pad_y <= input_size.spatial[1] - 1
             ? (input_size.spatial[1] - off_factor * pad_y - 1) / stride_y + 1
             : degen_val);
-    auto output_range_z = static_cast<cldnn::tensor::value_type>(
+    auto output_range_z = static_cast<ov::Dimension::value_type>(
         off_factor * pad_z <= input_size.spatial[2] - 1
             ? (input_size.spatial[2] - off_factor * pad_z - 1) / stride_z + 1
             : degen_val);

--- a/src/plugins/intel_gpu/src/graph/matrix_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/matrix_nms.cpp
@@ -71,15 +71,15 @@ layout matrix_nms_inst::calc_output_layout(const matrix_nms_node& node, const ke
     const auto boxes_num = boxes_layout.feature();
 
     if (primitive->attribs.background_class >= 0 && primitive->attribs.background_class < classes_num)
-        classes_num = std::max<tensor::value_type>(1, classes_num - 1);
+        classes_num = std::max<ov::Dimension::value_type>(1, classes_num - 1);
 
     auto max_output_boxes_per_class{boxes_num};
     if (primitive->attribs.nms_top_k >= 0)
-        max_output_boxes_per_class = std::min<tensor::value_type>(max_output_boxes_per_class, primitive->attribs.nms_top_k);
+        max_output_boxes_per_class = std::min<ov::Dimension::value_type>(max_output_boxes_per_class, primitive->attribs.nms_top_k);
 
     auto max_output_boxes_per_batch = max_output_boxes_per_class * classes_num;
     if (primitive->attribs.keep_top_k >= 0)
-        max_output_boxes_per_batch = std::min<tensor::value_type>(max_output_boxes_per_batch, primitive->attribs.keep_top_k);
+        max_output_boxes_per_batch = std::min<ov::Dimension::value_type>(max_output_boxes_per_batch, primitive->attribs.keep_top_k);
 
     auto output_num = max_output_boxes_per_batch * batches_num;
 

--- a/src/plugins/intel_gpu/src/graph/matrix_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/matrix_nms.cpp
@@ -71,15 +71,15 @@ layout matrix_nms_inst::calc_output_layout(const matrix_nms_node& node, const ke
     const auto boxes_num = boxes_layout.feature();
 
     if (primitive->attribs.background_class >= 0 && primitive->attribs.background_class < classes_num)
-        classes_num = std::max(1, classes_num - 1);
+        classes_num = std::max<tensor::value_type>(1, classes_num - 1);
 
-    int max_output_boxes_per_class{boxes_num};
+    auto max_output_boxes_per_class{boxes_num};
     if (primitive->attribs.nms_top_k >= 0)
-        max_output_boxes_per_class = std::min(max_output_boxes_per_class, primitive->attribs.nms_top_k);
+        max_output_boxes_per_class = std::min<tensor::value_type>(max_output_boxes_per_class, primitive->attribs.nms_top_k);
 
     auto max_output_boxes_per_batch = max_output_boxes_per_class * classes_num;
     if (primitive->attribs.keep_top_k >= 0)
-        max_output_boxes_per_batch = std::min(max_output_boxes_per_batch, primitive->attribs.keep_top_k);
+        max_output_boxes_per_batch = std::min<tensor::value_type>(max_output_boxes_per_batch, primitive->attribs.keep_top_k);
 
     auto output_num = max_output_boxes_per_batch * batches_num;
 

--- a/src/plugins/intel_gpu/src/graph/multiclass_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/multiclass_nms.cpp
@@ -54,19 +54,19 @@ layout multiclass_nms_inst::calc_output_layout(const multiclass_nms_node& node, 
 
     // see shape_infer() call in MulticlassNmsIEInternal::validate_and_infer_types() - ignore_bg_class == true
     if (attrs.background_class >= 0 && attrs.background_class < num_classes) {
-        num_classes = std::max<tensor::value_type>(1, num_classes - 1);
+        num_classes = std::max<ov::Dimension::value_type>(1, num_classes - 1);
     }
 
     int max_output_boxes_per_class = 0;
     if (attrs.nms_top_k >= 0) {
-        max_output_boxes_per_class = std::min<tensor::value_type>(num_boxes, attrs.nms_top_k);
+        max_output_boxes_per_class = std::min<ov::Dimension::value_type>(num_boxes, attrs.nms_top_k);
     } else {
         max_output_boxes_per_class = num_boxes;
     }
 
     auto max_output_boxes_per_batch = max_output_boxes_per_class * num_classes;
     if (attrs.keep_top_k >= 0) {
-        max_output_boxes_per_batch = std::min<tensor::value_type>(max_output_boxes_per_batch, attrs.keep_top_k);
+        max_output_boxes_per_batch = std::min<ov::Dimension::value_type>(max_output_boxes_per_batch, attrs.keep_top_k);
     }
 
     const auto dim = max_output_boxes_per_batch * num_batches;

--- a/src/plugins/intel_gpu/src/graph/multiclass_nms.cpp
+++ b/src/plugins/intel_gpu/src/graph/multiclass_nms.cpp
@@ -54,19 +54,19 @@ layout multiclass_nms_inst::calc_output_layout(const multiclass_nms_node& node, 
 
     // see shape_infer() call in MulticlassNmsIEInternal::validate_and_infer_types() - ignore_bg_class == true
     if (attrs.background_class >= 0 && attrs.background_class < num_classes) {
-        num_classes = std::max(1, num_classes - 1);
+        num_classes = std::max<tensor::value_type>(1, num_classes - 1);
     }
 
     int max_output_boxes_per_class = 0;
     if (attrs.nms_top_k >= 0) {
-        max_output_boxes_per_class = std::min(num_boxes, attrs.nms_top_k);
+        max_output_boxes_per_class = std::min<tensor::value_type>(num_boxes, attrs.nms_top_k);
     } else {
         max_output_boxes_per_class = num_boxes;
     }
 
     auto max_output_boxes_per_batch = max_output_boxes_per_class * num_classes;
     if (attrs.keep_top_k >= 0) {
-        max_output_boxes_per_batch = std::min(max_output_boxes_per_batch, attrs.keep_top_k);
+        max_output_boxes_per_batch = std::min<tensor::value_type>(max_output_boxes_per_batch, attrs.keep_top_k);
     }
 
     const auto dim = max_output_boxes_per_batch * num_batches;

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -275,8 +275,8 @@ int64_t number_of_priors(const std::vector<float>& aspect_ratio,
     return num_priors;
 }
 
-tensor get_output_shape(tensor::value_type height, tensor::value_type width, tensor::value_type number_of_priors) {
-    return tensor{std::vector<tensor::value_type>{2, 4 * height * width * number_of_priors}};
+tensor get_output_shape(ov::Dimension::value_type height, ov::Dimension::value_type width, ov::Dimension::value_type number_of_priors) {
+    return tensor{std::vector<ov::Dimension::value_type>{2, 4 * height * width * number_of_priors}};
 }
 }  // namespace
 

--- a/src/plugins/intel_gpu/src/graph/prior_box.cpp
+++ b/src/plugins/intel_gpu/src/graph/prior_box.cpp
@@ -275,8 +275,8 @@ int64_t number_of_priors(const std::vector<float>& aspect_ratio,
     return num_priors;
 }
 
-tensor get_output_shape(int32_t height, int32_t width, int32_t number_of_priors) {
-    return tensor{std::vector<int32_t>{2, 4 * height * width * number_of_priors}};
+tensor get_output_shape(tensor::value_type height, tensor::value_type width, tensor::value_type number_of_priors) {
+    return tensor{std::vector<tensor::value_type>{2, 4 * height * width * number_of_priors}};
 }
 }  // namespace
 

--- a/src/plugins/intel_gpu/src/graph/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/reduce.cpp
@@ -55,7 +55,7 @@ layout reduce_inst::calc_output_layout(reduce_node const& node, kernel_impl_para
         in_dims[reduce_axes[a]] = 1;
     }
 
-    std::vector<tensor::value_type> updated_dims;
+    std::vector<ov::Dimension::value_type> updated_dims;
     if (!desc->keep_dims) {
         // Get unreduced from b-f and x-w range
         for (size_t b_f_index = 0; b_f_index < 2; b_f_index++) {

--- a/src/plugins/intel_gpu/src/graph/reduce.cpp
+++ b/src/plugins/intel_gpu/src/graph/reduce.cpp
@@ -55,7 +55,7 @@ layout reduce_inst::calc_output_layout(reduce_node const& node, kernel_impl_para
         in_dims[reduce_axes[a]] = 1;
     }
 
-    std::vector<int32_t> updated_dims;
+    std::vector<tensor::value_type> updated_dims;
     if (!desc->keep_dims) {
         // Get unreduced from b-f and x-w range
         for (size_t b_f_index = 0; b_f_index < 2; b_f_index++) {

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -43,9 +43,9 @@ padding propagate_padding(const layout& in_layout, const ov::PartialShape& out_s
     auto pad_upper = layout::format_sizes(in_pad._upper_size, default_format);
     auto pad_mask = layout::format_sizes(in_pad._dynamic_dims_mask, default_format);
 
-    std::vector<int32_t> update_pad_lower;
-    std::vector<int32_t> update_pad_upper;
-    std::vector<int32_t> update_pad_mask;
+    std::vector<tensor::value_type> update_pad_lower;
+    std::vector<tensor::value_type> update_pad_upper;
+    std::vector<tensor::value_type> update_pad_mask;
 
     if (mode == reshape::reshape_mode::unsqueeze) {
         update_pad_lower = pad_lower;

--- a/src/plugins/intel_gpu/src/graph/reshape.cpp
+++ b/src/plugins/intel_gpu/src/graph/reshape.cpp
@@ -43,9 +43,9 @@ padding propagate_padding(const layout& in_layout, const ov::PartialShape& out_s
     auto pad_upper = layout::format_sizes(in_pad._upper_size, default_format);
     auto pad_mask = layout::format_sizes(in_pad._dynamic_dims_mask, default_format);
 
-    std::vector<tensor::value_type> update_pad_lower;
-    std::vector<tensor::value_type> update_pad_upper;
-    std::vector<tensor::value_type> update_pad_mask;
+    std::vector<ov::Dimension::value_type> update_pad_lower;
+    std::vector<ov::Dimension::value_type> update_pad_upper;
+    std::vector<ov::Dimension::value_type> update_pad_mask;
 
     if (mode == reshape::reshape_mode::unsqueeze) {
         update_pad_lower = pad_lower;

--- a/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
@@ -86,13 +86,19 @@ static void rearrange_cache(cldnn::memory::ptr kv_in_mem, cldnn::memory::ptr bt_
         for (size_t f = 0; f < kv_shape[1]; f++) {
             for (size_t y = 0; y < kv_shape[2]; y++) {
                 for (size_t x = 0; x < kv_shape[3]; x++) {
-                    auto out_idx = std::vector<int>{static_cast<int>(b), static_cast<int>(f), static_cast<int>(y), static_cast<int>(x)};
+                    auto out_idx = std::vector<cldnn::tensor::value_type>{static_cast<cldnn::tensor::value_type>(b),
+                                                                          static_cast<cldnn::tensor::value_type>(f),
+                                                                          static_cast<cldnn::tensor::value_type>(y),
+                                                                          static_cast<cldnn::tensor::value_type>(x)};
 
                     size_t b_kv = bt_in_ptr[b * kv_shape[concat_axis] + out_idx[concat_axis]]; // bt_idx = b * total_seq_len + seq_len_idx
-                    auto in_idx = std::vector<int>{static_cast<int>(b_kv), static_cast<int>(f), static_cast<int>(y), static_cast<int>(x)};
+                    auto in_idx = std::vector<cldnn::tensor::value_type>{static_cast<cldnn::tensor::value_type>(b_kv),
+                                                                         static_cast<cldnn::tensor::value_type>(f),
+                                                                         static_cast<cldnn::tensor::value_type>(y),
+                                                                         static_cast<cldnn::tensor::value_type>(x)};
 
-                    cldnn::tensor in(cldnn::format::bfyx, in_idx, 0);
-                    cldnn::tensor out(cldnn::format::bfyx, out_idx, 0);
+                    cldnn::tensor in(cldnn::format::bfyx, in_idx, static_cast<cldnn::tensor::value_type>(0));
+                    cldnn::tensor out(cldnn::format::bfyx, out_idx, static_cast<cldnn::tensor::value_type>(0));
 
                     size_t out_offset = kv_out_mem->get_layout().get_linear_offset(out);
                     size_t in_offset = kv_layout.get_linear_offset(in);

--- a/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/multi_tensor_variable_state.cpp
@@ -86,19 +86,19 @@ static void rearrange_cache(cldnn::memory::ptr kv_in_mem, cldnn::memory::ptr bt_
         for (size_t f = 0; f < kv_shape[1]; f++) {
             for (size_t y = 0; y < kv_shape[2]; y++) {
                 for (size_t x = 0; x < kv_shape[3]; x++) {
-                    auto out_idx = std::vector<cldnn::tensor::value_type>{static_cast<cldnn::tensor::value_type>(b),
-                                                                          static_cast<cldnn::tensor::value_type>(f),
-                                                                          static_cast<cldnn::tensor::value_type>(y),
-                                                                          static_cast<cldnn::tensor::value_type>(x)};
+                    auto out_idx = std::vector<ov::Dimension::value_type>{static_cast<ov::Dimension::value_type>(b),
+                                                                          static_cast<ov::Dimension::value_type>(f),
+                                                                          static_cast<ov::Dimension::value_type>(y),
+                                                                          static_cast<ov::Dimension::value_type>(x)};
 
                     size_t b_kv = bt_in_ptr[b * kv_shape[concat_axis] + out_idx[concat_axis]]; // bt_idx = b * total_seq_len + seq_len_idx
-                    auto in_idx = std::vector<cldnn::tensor::value_type>{static_cast<cldnn::tensor::value_type>(b_kv),
-                                                                         static_cast<cldnn::tensor::value_type>(f),
-                                                                         static_cast<cldnn::tensor::value_type>(y),
-                                                                         static_cast<cldnn::tensor::value_type>(x)};
+                    auto in_idx = std::vector<ov::Dimension::value_type>{static_cast<ov::Dimension::value_type>(b_kv),
+                                                                         static_cast<ov::Dimension::value_type>(f),
+                                                                         static_cast<ov::Dimension::value_type>(y),
+                                                                         static_cast<ov::Dimension::value_type>(x)};
 
-                    cldnn::tensor in(cldnn::format::bfyx, in_idx, static_cast<cldnn::tensor::value_type>(0));
-                    cldnn::tensor out(cldnn::format::bfyx, out_idx, static_cast<cldnn::tensor::value_type>(0));
+                    cldnn::tensor in(cldnn::format::bfyx, in_idx, static_cast<ov::Dimension::value_type>(0));
+                    cldnn::tensor out(cldnn::format::bfyx, out_idx, static_cast<ov::Dimension::value_type>(0));
 
                     size_t out_offset = kv_out_mem->get_layout().get_linear_offset(out);
                     size_t in_offset = kv_layout.get_linear_offset(in);

--- a/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
@@ -36,7 +36,7 @@ static void CreateBatchToSpaceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         for (size_t i = 1; i < 4; ++i) {
             auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
 
-            std::vector<int64_t> sizes = inConst->cast_vector<cldnn::tensor::value_type>();
+            std::vector<int64_t> sizes = inConst->cast_vector<ov::Dimension::value_type>();
             int64_t default_size = i == 1 ? 1 : 0;
             for (size_t s = sizes.size(); s < format.dimension(); s++) {
                 sizes.push_back(default_size);

--- a/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/batch_to_space.cpp
@@ -36,8 +36,8 @@ static void CreateBatchToSpaceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         for (size_t i = 1; i < 4; ++i) {
             auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
 
-            std::vector<int32_t> sizes = inConst->cast_vector<int32_t>();
-            int32_t default_size = i == 1 ? 1 : 0;
+            std::vector<int64_t> sizes = inConst->cast_vector<cldnn::tensor::value_type>();
+            int64_t default_size = i == 1 ? 1 : 0;
             for (size_t s = sizes.size(); s < format.dimension(); s++) {
                 sizes.push_back(default_size);
             }

--- a/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/constant.cpp
@@ -32,7 +32,7 @@
 namespace ov::intel_gpu {
 
 static cldnn::tensor getConstTensor(const ov::Shape constDims) {
-    std::vector<cldnn::tensor::value_type> shuffled_dims(constDims.size());
+    std::vector<ov::Dimension::value_type> shuffled_dims(constDims.size());
 
     // cldnn tensor c-tor expects constants be in a reversed order (x, y, z, w, u, v)
     for (size_t i = 0; i < constDims.size(); i++) {
@@ -77,7 +77,7 @@ static void create_data(ProgramBuilder& p, const ov::Shape& const_shape, const s
     auto constFormat = cldnn::format::get_default_format(const_shape.size());
 
     if (props.needsBatchInterpretation) {
-        constTensor.batch[0] = static_cast<cldnn::tensor::value_type>(constTensor.count());
+        constTensor.batch[0] = static_cast<ov::Dimension::value_type>(constTensor.count());
         constTensor.feature[0] = 1;
     }
 

--- a/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
@@ -23,23 +23,23 @@ void CreateRollOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v7::Roll>& op
 
     auto shift_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     OPENVINO_ASSERT(shift_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
-    const auto shift_raw = shift_constant->cast_vector<cldnn::tensor::value_type>();
+    const auto shift_raw = shift_constant->cast_vector<ov::Dimension::value_type>();
 
     auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
-    auto axes_raw = axes_constant->cast_vector<cldnn::tensor::value_type>();
+    auto axes_raw = axes_constant->cast_vector<ov::Dimension::value_type>();
 
     if (input_pshape.is_dynamic()) {
         const cldnn::roll roll_prim(layer_name, inputs.front(), shift_raw, axes_raw);
         p.add_primitive(*op, roll_prim);
     } else {
         const auto& input_shape = input_pshape.to_shape();
-        const auto rank = static_cast<cldnn::tensor::value_type>(input_shape.size());
+        const auto rank = static_cast<ov::Dimension::value_type>(input_shape.size());
         const auto format = cldnn::format::get_default_format(rank);
         const auto default_rank = format.dimension();
 
         // Normalize axes and sum shift
-        std::vector<cldnn::tensor::value_type> shift(default_rank);
+        std::vector<ov::Dimension::value_type> shift(default_rank);
         for (size_t a = 0; a < axes_raw.size(); ++a) {
             auto& axis = axes_raw[a];
             if (axis < 0) {
@@ -54,7 +54,7 @@ void CreateRollOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v7::Roll>& op
         // Normalize shift
         for (int s = 0; s < rank; ++s) {
             auto& sh = shift[s];
-            const auto dim = static_cast<cldnn::tensor::value_type>(input_shape[s]);
+            const auto dim = static_cast<ov::Dimension::value_type>(input_shape[s]);
             sh %= dim;
             if (sh < 0) {
                 sh += dim;

--- a/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/roll.cpp
@@ -23,23 +23,23 @@ void CreateRollOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v7::Roll>& op
 
     auto shift_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(1));
     OPENVINO_ASSERT(shift_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
-    const auto shift_raw = shift_constant->cast_vector<int32_t>();
+    const auto shift_raw = shift_constant->cast_vector<cldnn::tensor::value_type>();
 
     auto axes_constant = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(2));
     OPENVINO_ASSERT(axes_constant != nullptr, "[GPU] Unsupported parameter nodes type in ", op_friendly_name, " (", op->get_type_name(), ")");
-    auto axes_raw = axes_constant->cast_vector<int32_t>();
+    auto axes_raw = axes_constant->cast_vector<cldnn::tensor::value_type>();
 
     if (input_pshape.is_dynamic()) {
         const cldnn::roll roll_prim(layer_name, inputs.front(), shift_raw, axes_raw);
         p.add_primitive(*op, roll_prim);
     } else {
         const auto& input_shape = input_pshape.to_shape();
-        const auto rank = static_cast<int>(input_shape.size());
+        const auto rank = static_cast<cldnn::tensor::value_type>(input_shape.size());
         const auto format = cldnn::format::get_default_format(rank);
         const auto default_rank = format.dimension();
 
         // Normalize axes and sum shift
-        std::vector<int32_t> shift(default_rank);
+        std::vector<cldnn::tensor::value_type> shift(default_rank);
         for (size_t a = 0; a < axes_raw.size(); ++a) {
             auto& axis = axes_raw[a];
             if (axis < 0) {
@@ -54,7 +54,7 @@ void CreateRollOp(ProgramBuilder& p, const std::shared_ptr<ov::op::v7::Roll>& op
         // Normalize shift
         for (int s = 0; s < rank; ++s) {
             auto& sh = shift[s];
-            const auto dim = static_cast<int32_t>(input_shape[s]);
+            const auto dim = static_cast<cldnn::tensor::value_type>(input_shape[s]);
             sh %= dim;
             if (sh < 0) {
                 sh += dim;

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
@@ -36,8 +36,8 @@ static void CreateSpaceToBatchOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         for (size_t i = 1; i < 4; ++i) {
             auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
 
-            std::vector<int32_t> sizes = inConst->cast_vector<int32_t>();
-            int32_t default_size = i == 1 ? 1 : 0;
+            std::vector<cldnn::tensor::value_type> sizes = inConst->cast_vector<cldnn::tensor::value_type>();
+            cldnn::tensor::value_type default_size = i == 1 ? 1 : 0;
             for (size_t s = sizes.size(); s < format.dimension(); s++) {
                 sizes.push_back(default_size);
             }

--- a/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/space_to_batch.cpp
@@ -36,8 +36,8 @@ static void CreateSpaceToBatchOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         for (size_t i = 1; i < 4; ++i) {
             auto inConst = ov::as_type_ptr<ov::op::v0::Constant>(op->get_input_node_shared_ptr(i));
 
-            std::vector<cldnn::tensor::value_type> sizes = inConst->cast_vector<cldnn::tensor::value_type>();
-            cldnn::tensor::value_type default_size = i == 1 ? 1 : 0;
+            std::vector<ov::Dimension::value_type> sizes = inConst->cast_vector<ov::Dimension::value_type>();
+            ov::Dimension::value_type default_size = i == 1 ? 1 : 0;
             for (size_t s = sizes.size(); s < format.dimension(); s++) {
                 sizes.push_back(default_size);
             }

--- a/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
+++ b/src/plugins/intel_gpu/src/plugin/ops/strided_slice.cpp
@@ -225,10 +225,10 @@ static void CreateStridedSliceOp(ProgramBuilder& p, const std::shared_ptr<ov::op
         auto data_output = op->input_value(0);
         auto data_node_shape = data_output.get_shape();
 
-        std::vector<cldnn::tensor::value_type> offset_tensor{ 0, 0, 0, 0 };
+        std::vector<ov::Dimension::value_type> offset_tensor{ 0, 0, 0, 0 };
         for (size_t i = 0; i < axes.size(); i++) {
             OPENVINO_ASSERT(axes[i] < 4, "[GPU] Invalid crop axis: ", axes[i], " in op ", op->get_friendly_name());
-            offset_tensor[axes[i]] = static_cast<cldnn::tensor::value_type>(offset[i]);
+            offset_tensor[axes[i]] = static_cast<ov::Dimension::value_type>(offset[i]);
         }
 
         ov::Shape crop_shape(reshape_pattern);

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -62,8 +62,8 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
     for (size_t i = 0; i < src_rank; i++) {
         dynamic_pad_dims[i] = m_layout.data_padding._dynamic_dims_mask[i];
     }
-    m_layout.data_padding = cldnn::padding(std::vector<int32_t>(src_rank, 0),
-                                           std::vector<int32_t>(src_rank, 0),
+    m_layout.data_padding = cldnn::padding(std::vector<cldnn::tensor::value_type>(src_rank, 0),
+                                           std::vector<cldnn::tensor::value_type>(src_rank, 0),
                                            dynamic_pad_dims);
     auto src_stride = state->get_strides();
     for (size_t i = 0; i < src_rank; ++i) {
@@ -79,8 +79,8 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
 
     // check whether the src tensor is padded
     std::vector<size_t> src_stride_no_pad(src_rank, 1);
-    std::vector<int32_t> upper_pad(src_rank, 0);
-    std::vector<int32_t> lower_pad(src_rank, 0);
+    std::vector<cldnn::tensor::value_type> upper_pad(src_rank, 0);
+    std::vector<cldnn::tensor::value_type> lower_pad(src_rank, 0);
     for (int32_t i = static_cast<int32_t>(src_stride.size()) - 1; i >= 0; --i) {
         if (i <= static_cast<int32_t>(src_stride.size()) - 2)
             src_stride_no_pad[i] = src_stride_no_pad[i + 1] * src_shape[i + 1];
@@ -88,8 +88,8 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
             OPENVINO_ASSERT(src_stride[i] > src_stride_no_pad[i]);
             size_t padded_size = src_stride[i] / src_stride[i + 1];
             size_t non_padded_size = src_stride_no_pad[i] / src_stride_no_pad[i + 1];
-            int32_t pad_dim = i + 1;
-            upper_pad[pad_dim] = static_cast<int32_t>(padded_size) - static_cast<int32_t>(non_padded_size);
+            cldnn::tensor::value_type pad_dim = i + 1;
+            upper_pad[pad_dim] = static_cast<cldnn::tensor::value_type>(padded_size) - static_cast<cldnn::tensor::value_type>(non_padded_size);
         }
     }
     cldnn::padding src_padd = cldnn::padding(lower_pad, upper_pad, 0.f);

--- a/src/plugins/intel_gpu/src/plugin/variable_state.cpp
+++ b/src/plugins/intel_gpu/src/plugin/variable_state.cpp
@@ -62,8 +62,8 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
     for (size_t i = 0; i < src_rank; i++) {
         dynamic_pad_dims[i] = m_layout.data_padding._dynamic_dims_mask[i];
     }
-    m_layout.data_padding = cldnn::padding(std::vector<cldnn::tensor::value_type>(src_rank, 0),
-                                           std::vector<cldnn::tensor::value_type>(src_rank, 0),
+    m_layout.data_padding = cldnn::padding(std::vector<ov::Dimension::value_type>(src_rank, 0),
+                                           std::vector<ov::Dimension::value_type>(src_rank, 0),
                                            dynamic_pad_dims);
     auto src_stride = state->get_strides();
     for (size_t i = 0; i < src_rank; ++i) {
@@ -79,8 +79,8 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
 
     // check whether the src tensor is padded
     std::vector<size_t> src_stride_no_pad(src_rank, 1);
-    std::vector<cldnn::tensor::value_type> upper_pad(src_rank, 0);
-    std::vector<cldnn::tensor::value_type> lower_pad(src_rank, 0);
+    std::vector<ov::Dimension::value_type> upper_pad(src_rank, 0);
+    std::vector<ov::Dimension::value_type> lower_pad(src_rank, 0);
     for (int32_t i = static_cast<int32_t>(src_stride.size()) - 1; i >= 0; --i) {
         if (i <= static_cast<int32_t>(src_stride.size()) - 2)
             src_stride_no_pad[i] = src_stride_no_pad[i + 1] * src_shape[i + 1];
@@ -88,8 +88,8 @@ void VariableState::set_state(const ov::SoPtr<ov::ITensor>& state) {
             OPENVINO_ASSERT(src_stride[i] > src_stride_no_pad[i]);
             size_t padded_size = src_stride[i] / src_stride[i + 1];
             size_t non_padded_size = src_stride_no_pad[i] / src_stride_no_pad[i + 1];
-            cldnn::tensor::value_type pad_dim = i + 1;
-            upper_pad[pad_dim] = static_cast<cldnn::tensor::value_type>(padded_size) - static_cast<cldnn::tensor::value_type>(non_padded_size);
+            ov::Dimension::value_type pad_dim = i + 1;
+            upper_pad[pad_dim] = static_cast<ov::Dimension::value_type>(padded_size) - static_cast<ov::Dimension::value_type>(non_padded_size);
         }
     }
     cldnn::padding src_padd = cldnn::padding(lower_pad, upper_pad, 0.f);

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -129,7 +129,7 @@ public:
 
     layout get_input_layout(convolution_test_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -183,7 +183,7 @@ public:
 
     layout get_input_layout(convolution_test_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -236,7 +236,7 @@ public:
 
     layout get_input_layout(conv_eltw_test_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -284,7 +284,7 @@ class ConvFusingForceKernelTest : public BaseFusingTest<bc_force_kernel_params> 
 
     layout get_input_layout(bc_force_kernel_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/convolution_fusion_test.cpp
@@ -129,7 +129,7 @@ public:
 
     layout get_input_layout(convolution_test_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -183,7 +183,7 @@ public:
 
     layout get_input_layout(convolution_test_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -236,7 +236,7 @@ public:
 
     layout get_input_layout(conv_eltw_test_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -284,7 +284,7 @@ class ConvFusingForceKernelTest : public BaseFusingTest<bc_force_kernel_params> 
 
     layout get_input_layout(bc_force_kernel_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
@@ -104,7 +104,7 @@ public:
 
     layout get_input_layout(deconv_test_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.data_type, p.input_format, p.in_shape, padding{ pad_ } };
     }
 
@@ -154,7 +154,7 @@ public:
 
     layout get_input_layout(deconv_new_shape_infer_test_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -196,7 +196,7 @@ public:
 
     layout get_input_layout(deconv_eltw_test_params& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.data_type, p.input_format, p.in_shape, padding{ pad_ } };
     }
 

--- a/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/fusions/deconvolution_fusion_test.cpp
@@ -104,7 +104,7 @@ public:
 
     layout get_input_layout(deconv_test_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.data_type, p.input_format, p.in_shape, padding{ pad_ } };
     }
 
@@ -154,7 +154,7 @@ public:
 
     layout get_input_layout(deconv_new_shape_infer_test_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[0] };
         return layout{ p.in_shape, p.data_type, p.input_format, padding{ pad_ } };
     }
 
@@ -196,7 +196,7 @@ public:
 
     layout get_input_layout(deconv_eltw_test_params& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
         return layout{ p.data_type, p.input_format, p.in_shape, padding{ pad_ } };
     }
 

--- a/src/plugins/intel_gpu/tests/unit/module_tests/layout_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/layout_test.cpp
@@ -37,9 +37,9 @@ TEST_P(data_layout_test, size_check) {
 
     auto l = layout(p.dt, p.fmt, tensor{default_fmt, p.size}, p.padd);
 
-    size_t expected_count = std::accumulate(p.size.begin(), p.size.end(), 1, std::multiplies<int>());
-    size_t expected_bytes_count = std::accumulate(p.expected_aligned_size.begin(), p.expected_aligned_size.end(), 1, std::multiplies<int>()) *
-                                  data_type_traits::size_of(p.dt);
+    size_t expected_count = std::accumulate(p.size.begin(), p.size.end(), static_cast<size_t>(1), std::multiplies<cldnn::tensor::value_type>());
+    size_t expected_bytes_count = std::accumulate(p.expected_aligned_size.begin(), p.expected_aligned_size.end(), static_cast<size_t>(1),
+                                                  std::multiplies<cldnn::tensor::value_type>()) * data_type_traits::size_of(p.dt);
 
     ASSERT_EQ(l.bytes_count(), expected_bytes_count);
     ASSERT_EQ(l.count(), expected_count);
@@ -104,6 +104,7 @@ INSTANTIATE_TEST_SUITE_P(smoke, data_layout_test,
         {data_types::f32, format::bs_fs_yx_bsv4_fsv4, {2, 33, 3, 5}, {4, 36, 3, 5}, {0, 1, 2, 3}, {}, {495, 15, 5, 1}},
         {data_types::f32, format::bfzyx, {3, 2, 2, 2, 2}, {3, 2, 2, 2, 2}, {0, 1, 2, 3, 4}, {}, {16, 8, 4, 2, 1}},
         {data_types::f32, format::bzyxf, {3, 2, 2, 2, 2}, {3, 2, 2, 2, 2}, {0, 2, 3, 4, 1}, {}, {16, 1, 8, 4, 2}},
+        {data_types::u8, format::bfyx, {2150615040, 1, 1, 1}, {2150615040, 1, 1, 1}, {0, 1, 2, 3}, {}, {1, 1, 1, 1}},
     }));
 
 class weights_layout_test : public testing::TestWithParam<layout_test_params> { };

--- a/src/plugins/intel_gpu/tests/unit/module_tests/layout_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/module_tests/layout_test.cpp
@@ -37,9 +37,9 @@ TEST_P(data_layout_test, size_check) {
 
     auto l = layout(p.dt, p.fmt, tensor{default_fmt, p.size}, p.padd);
 
-    size_t expected_count = std::accumulate(p.size.begin(), p.size.end(), static_cast<size_t>(1), std::multiplies<cldnn::tensor::value_type>());
+    size_t expected_count = std::accumulate(p.size.begin(), p.size.end(), static_cast<size_t>(1), std::multiplies<ov::Dimension::value_type>());
     size_t expected_bytes_count = std::accumulate(p.expected_aligned_size.begin(), p.expected_aligned_size.end(), static_cast<size_t>(1),
-                                                  std::multiplies<cldnn::tensor::value_type>()) * data_type_traits::size_of(p.dt);
+                                                  std::multiplies<ov::Dimension::value_type>()) * data_type_traits::size_of(p.dt);
 
     ASSERT_EQ(l.bytes_count(), expected_bytes_count);
     ASSERT_EQ(l.count(), expected_count);

--- a/src/plugins/intel_gpu/tests/unit/passes/test_module_fusing_reorder.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/test_module_fusing_reorder.cpp
@@ -145,7 +145,7 @@ public:
 
     layout get_input_layout(T& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
         return layout{ p.data_type, p.input_format, p.in_shape, padding{pad_} };
     }
 

--- a/src/plugins/intel_gpu/tests/unit/passes/test_module_fusing_reorder.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/test_module_fusing_reorder.cpp
@@ -145,7 +145,7 @@ public:
 
     layout get_input_layout(T& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
         return layout{ p.data_type, p.input_format, p.in_shape, padding{pad_} };
     }
 

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
@@ -31,8 +31,8 @@ struct reshape_test_params {
 };
 
 inline padding get_pad(format fmt, std::vector<int64_t> axes, bool is_dynamic) {
-    std::vector<int32_t> lower(fmt.dimension(), 0);
-    std::vector<int32_t> upper(fmt.dimension(), 0);
+    std::vector<cldnn::tensor::value_type> lower(fmt.dimension(), 0);
+    std::vector<cldnn::tensor::value_type> upper(fmt.dimension(), 0);
     padding::DynamicDimsMask mask; // empty mask resetted
 
     auto start_pad_val = 13;

--- a/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/shape_infer/reshape_si_test.cpp
@@ -31,8 +31,8 @@ struct reshape_test_params {
 };
 
 inline padding get_pad(format fmt, std::vector<int64_t> axes, bool is_dynamic) {
-    std::vector<cldnn::tensor::value_type> lower(fmt.dimension(), 0);
-    std::vector<cldnn::tensor::value_type> upper(fmt.dimension(), 0);
+    std::vector<ov::Dimension::value_type> lower(fmt.dimension(), 0);
+    std::vector<ov::Dimension::value_type> upper(fmt.dimension(), 0);
     padding::DynamicDimsMask mask; // empty mask resetted
 
     auto start_pad_val = 13;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
@@ -1884,7 +1884,7 @@ TEST(border_gpu, basic_zero_input) {
     layout zero_input_layout = {{0, 1}, data_types::f32, format::bfyx};
     input = engine.reinterpret_buffer(*input, zero_input_layout);
 
-    std::vector<cldnn::tensor::value_type> pads_begin = {4, 0};
+    std::vector<ov::Dimension::value_type> pads_begin = {4, 0};
     ov::PartialShape pads_begin_shape = { ov::Dimension(pads_begin.size()) };
     auto pads_begin_input = engine.allocate_memory({pads_begin_shape, data_types::i32, format::bfyx});
     set_values(pads_begin_input, pads_begin);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/border_gpu_test.cpp
@@ -1884,7 +1884,7 @@ TEST(border_gpu, basic_zero_input) {
     layout zero_input_layout = {{0, 1}, data_types::f32, format::bfyx};
     input = engine.reinterpret_buffer(*input, zero_input_layout);
 
-    std::vector<int> pads_begin = {4, 0};
+    std::vector<cldnn::tensor::value_type> pads_begin = {4, 0};
     ov::PartialShape pads_begin_shape = { ov::Dimension(pads_begin.size()) };
     auto pads_begin_input = engine.allocate_memory({pads_begin_shape, data_types::i32, format::bfyx});
     set_values(pads_begin_input, pads_begin);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -7531,8 +7531,8 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
     ov::CoordinateDiff pad = { 0, 0 };
     ov::Strides dilation = { 1, 1 };
     auto output_size = tensor{ 1, num_groups, 1, 2 };
-    auto input_lower_sizes = { 0, 16, 0, 0 };
-    auto input_upper_sizes = { 0, 64, 0, 0 };
+    std::vector<cldnn::tensor::value_type> input_lower_sizes = { 0, 16, 0, 0 };
+    std::vector<cldnn::tensor::value_type> input_upper_sizes = { 0, 64, 0, 0 };
 
     auto& engine = get_test_engine();
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/convolution_gpu_test.cpp
@@ -7531,8 +7531,8 @@ TEST(convolution_depthwise_gpu_fsv16, depthwise_conv_b_fs_yx_fsv16_in_feature_pa
     ov::CoordinateDiff pad = { 0, 0 };
     ov::Strides dilation = { 1, 1 };
     auto output_size = tensor{ 1, num_groups, 1, 2 };
-    std::vector<cldnn::tensor::value_type> input_lower_sizes = { 0, 16, 0, 0 };
-    std::vector<cldnn::tensor::value_type> input_upper_sizes = { 0, 64, 0, 0 };
+    std::vector<ov::Dimension::value_type> input_lower_sizes = { 0, 16, 0, 0 };
+    std::vector<ov::Dimension::value_type> input_upper_sizes = { 0, 64, 0, 0 };
 
     auto& engine = get_test_engine();
 
@@ -9489,9 +9489,9 @@ public:
         auto output_features = weights_size.batch[0];
 
         return cldnn::tensor(input_size.batch[0],
-                             static_cast<cldnn::tensor::value_type>(output_features),
-                             static_cast<cldnn::tensor::value_type>(output_size_x),
-                             static_cast<cldnn::tensor::value_type>(output_size_y));
+                             static_cast<ov::Dimension::value_type>(output_features),
+                             static_cast<ov::Dimension::value_type>(output_size_x),
+                             static_cast<ov::Dimension::value_type>(output_size_y));
     }
 
     void prepare_input_for_test(std::vector<cldnn::memory::ptr>& inputs) override {

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
@@ -1053,10 +1053,10 @@ TEST(NegativeDepthConcatenateTest, DISABLED_TestAll) {
 
     auto f = format::bfyx;
 
-    std::vector<int> t{1, 2, 3, 4};
-    std::vector<int> t0{7, 2, 3, 4};
-    std::vector<int> t1{1, 2, 7, 4};
-    std::vector<int> t2{1, 2, 3, 7};
+    std::vector<cldnn::tensor::value_type> t{1, 2, 3, 4};
+    std::vector<cldnn::tensor::value_type> t0{7, 2, 3, 4};
+    std::vector<cldnn::tensor::value_type> t1{1, 2, 7, 4};
+    std::vector<cldnn::tensor::value_type> t2{1, 2, 3, 7};
 
     //TODO: should be ASSERT_THROW(statement, exception_type) - but what exception type?
     ASSERT_ANY_THROW(setup_depth_concatatenate_network({}, {}, {}));

--- a/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/depth_concatenate_gpu_test.cpp
@@ -1053,10 +1053,10 @@ TEST(NegativeDepthConcatenateTest, DISABLED_TestAll) {
 
     auto f = format::bfyx;
 
-    std::vector<cldnn::tensor::value_type> t{1, 2, 3, 4};
-    std::vector<cldnn::tensor::value_type> t0{7, 2, 3, 4};
-    std::vector<cldnn::tensor::value_type> t1{1, 2, 7, 4};
-    std::vector<cldnn::tensor::value_type> t2{1, 2, 3, 7};
+    std::vector<ov::Dimension::value_type> t{1, 2, 3, 4};
+    std::vector<ov::Dimension::value_type> t0{7, 2, 3, 4};
+    std::vector<ov::Dimension::value_type> t1{1, 2, 7, 4};
+    std::vector<ov::Dimension::value_type> t2{1, 2, 3, 7};
 
     //TODO: should be ASSERT_THROW(statement, exception_type) - but what exception type?
     ASSERT_ANY_THROW(setup_depth_concatatenate_network({}, {}, {}));
@@ -1190,7 +1190,7 @@ public:
     }
 
     cldnn::tensor get_expected_output_tensor() override {
-        cldnn::tensor::value_type features = 0;
+        ov::Dimension::value_type features = 0;
         for (const auto& t : generic_params->input_layouts) {
             features += t.feature();
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dft_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dft_gpu_test.cpp
@@ -78,7 +78,7 @@ float getThreshold<ov::float16>(dft_type type) {
 }
 
 struct dft_params {
-    std::vector<cldnn::tensor::value_type> input_shape;
+    std::vector<ov::Dimension::value_type> input_shape;
     std::vector<size_t> output_shape;
     std::vector<int64_t> axes;
     std::vector<int64_t> signal_size;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/dft_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/dft_gpu_test.cpp
@@ -78,7 +78,7 @@ float getThreshold<ov::float16>(dft_type type) {
 }
 
 struct dft_params {
-    std::vector<int32_t> input_shape;
+    std::vector<cldnn::tensor::value_type> input_shape;
     std::vector<size_t> output_shape;
     std::vector<int64_t> axes;
     std::vector<int64_t> signal_size;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -4372,7 +4372,7 @@ INSTANTIATE_TEST_SUITE_P(eltwise_same_input,
                         ));
 
 // mode, input type, input sizes
-using eltwise_test_params = std::tuple<eltwise_mode, data_types, std::vector<std::vector<int32_t>>>;
+using eltwise_test_params = std::tuple<eltwise_mode, data_types, std::vector<std::vector<cldnn::tensor::value_type>>>;
 
 template<typename T>
 class BaseEltwiseTest : public ::testing::TestWithParam<T> {
@@ -4504,7 +4504,7 @@ TEST_P(eltwise_test, fsv16) {
 
 static std::vector<eltwise_mode> modes = {eltwise_mode::sum, eltwise_mode::prod};
 static std::vector<data_types> types = {data_types::f32, data_types::f16};
-static std::vector<std::vector<std::vector<int32_t>>> inputs = {
+static std::vector<std::vector<std::vector<cldnn::tensor::value_type>>> inputs = {
         {{1, 2, 3, 4}, {1, 2, 3, 4}},
         {{1, 16, 8, 2}, {1, 16, 8, 2}},
         {{1, 128, 16, 8}, {1, 1, 16, 8}},
@@ -4608,7 +4608,7 @@ TEST_P(eltwise_test_6d, bfwzyx) {
     }
 }
 
-static std::vector<std::vector<std::vector<int32_t>>> inputs_6d = {
+static std::vector<std::vector<std::vector<cldnn::tensor::value_type>>> inputs_6d = {
         {{1, 2, 3, 4, 5, 6},  {1, 2, 3, 4, 5, 6}},
         {{1, 32, 1, 1, 1, 1}, {8, 32, 4, 5, 6, 7}},
         {{1, 32, 1, 1, 1, 7}, {8, 32, 4, 5, 6, 7}},
@@ -4706,8 +4706,8 @@ INSTANTIATE_TEST_SUITE_P(eltwise, eltwise_test_mixed_precision,
 
 struct eltwise_layout_test_params {
     eltwise_mode mode;
-    std::vector<int32_t> input0_size;
-    std::vector<int32_t> input1_size;
+    std::vector<cldnn::tensor::value_type> input0_size;
+    std::vector<cldnn::tensor::value_type> input1_size;
     format input0_format;
     format input1_format;
     std::string selected_kernel_name;
@@ -4751,15 +4751,15 @@ TEST_P(eltwise_test_mixed_layout, mixed_layout) {
     auto format1 = p.input1_format;
     auto selected_kernel = p.selected_kernel_name;
 
-    int b0 = input0_size[0];
-    int f0 = input0_size[1];
-    int y0 = input0_size[2];
-    int x0 = input0_size[3];
+    auto b0 = input0_size[0];
+    auto f0 = input0_size[1];
+    auto y0 = input0_size[2];
+    auto x0 = input0_size[3];
 
-    int b1 = input1_size[0];
-    int f1 = input1_size[1];
-    int y1 = input1_size[2];
-    int x1 = input1_size[3];
+    auto b1 = input1_size[0];
+    auto f1 = input1_size[1];
+    auto y1 = input1_size[2];
+    auto x1 = input1_size[3];
 
     int min_random = -2, max_random = 2;
     VVVVVVF<float> input1_rnd = rg.generate_random_6d<float>(b0, f0, 1, 1, y0, x0, min_random, max_random);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eltwise_gpu_test.cpp
@@ -4372,7 +4372,7 @@ INSTANTIATE_TEST_SUITE_P(eltwise_same_input,
                         ));
 
 // mode, input type, input sizes
-using eltwise_test_params = std::tuple<eltwise_mode, data_types, std::vector<std::vector<cldnn::tensor::value_type>>>;
+using eltwise_test_params = std::tuple<eltwise_mode, data_types, std::vector<std::vector<ov::Dimension::value_type>>>;
 
 template<typename T>
 class BaseEltwiseTest : public ::testing::TestWithParam<T> {
@@ -4504,7 +4504,7 @@ TEST_P(eltwise_test, fsv16) {
 
 static std::vector<eltwise_mode> modes = {eltwise_mode::sum, eltwise_mode::prod};
 static std::vector<data_types> types = {data_types::f32, data_types::f16};
-static std::vector<std::vector<std::vector<cldnn::tensor::value_type>>> inputs = {
+static std::vector<std::vector<std::vector<ov::Dimension::value_type>>> inputs = {
         {{1, 2, 3, 4}, {1, 2, 3, 4}},
         {{1, 16, 8, 2}, {1, 16, 8, 2}},
         {{1, 128, 16, 8}, {1, 1, 16, 8}},
@@ -4608,7 +4608,7 @@ TEST_P(eltwise_test_6d, bfwzyx) {
     }
 }
 
-static std::vector<std::vector<std::vector<cldnn::tensor::value_type>>> inputs_6d = {
+static std::vector<std::vector<std::vector<ov::Dimension::value_type>>> inputs_6d = {
         {{1, 2, 3, 4, 5, 6},  {1, 2, 3, 4, 5, 6}},
         {{1, 32, 1, 1, 1, 1}, {8, 32, 4, 5, 6, 7}},
         {{1, 32, 1, 1, 1, 7}, {8, 32, 4, 5, 6, 7}},
@@ -4706,8 +4706,8 @@ INSTANTIATE_TEST_SUITE_P(eltwise, eltwise_test_mixed_precision,
 
 struct eltwise_layout_test_params {
     eltwise_mode mode;
-    std::vector<cldnn::tensor::value_type> input0_size;
-    std::vector<cldnn::tensor::value_type> input1_size;
+    std::vector<ov::Dimension::value_type> input0_size;
+    std::vector<ov::Dimension::value_type> input1_size;
     format input0_format;
     format input1_format;
     std::string selected_kernel_name;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eye.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eye.cpp
@@ -21,7 +21,7 @@ using eye_test_param = std::tuple<format,                    // Input and output
                                   InputType,                 // rows number
                                   InputType,                 // diagonal index
                                   std::vector<InputType>,    // batch shape
-                                  std::vector<int32_t>,      // output shape
+                                  std::vector<cldnn::tensor::value_type>,      // output shape
                                   std::vector<OutputType>,   // expected values
                                   bool>;                     // is_caching_test
 
@@ -34,7 +34,7 @@ public:
         InputType rows{};
         InputType diag{};
         std::vector<InputType> batch_shape;
-        std::vector<int32_t> output_shape;
+        std::vector<cldnn::tensor::value_type> output_shape;
         std::vector<OutputType> expected_values;
         bool is_caching_test;
         std::tie(fmt, cols, rows, diag, batch_shape, output_shape, expected_values, is_caching_test) = this->GetParam();
@@ -124,7 +124,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(0),
                      testing::ValuesIn(std::vector<std::vector<int32_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<int32_t>{1, 1, 2, 3}),
+                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 2, 3}),
                      testing::Values(std::vector<float>{1, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -138,7 +138,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(0),
                      testing::ValuesIn(std::vector<std::vector<int32_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<int32_t>{1, 1, 2, 3}),
+                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 2, 3}),
                      testing::Values(std::vector<int64_t>{1, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -152,7 +152,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(-1),
                      testing::ValuesIn(std::vector<std::vector<int64_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<int32_t>{1, 1, 4, 3}),
+                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 4, 3}),
                      testing::Values(std::vector<uint8_t>{0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -166,7 +166,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(4),
                      testing::ValuesIn(std::vector<std::vector<int64_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<int32_t>{1, 1, 4, 3}),
+                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 4, 3}),
                      testing::Values(std::vector<int8_t>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
                      testing::Values(false)));
 
@@ -180,7 +180,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(2),
                      testing::Values(1),
                      testing::ValuesIn(std::vector<std::vector<int32_t>>{{2, 2}}),
-                     testing::Values(std::vector<int32_t>{2, 2, 2, 2}),
+                     testing::Values(std::vector<cldnn::tensor::value_type>{2, 2, 2, 2}),
                      testing::Values(std::vector<int32_t>{0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -203,7 +203,7 @@ INSTANTIATE_TEST_SUITE_P(eye_test_5d_float_int32,
                                           testing::Values(2),
                                           testing::Values(0),
                                           testing::ValuesIn(std::vector<std::vector<int32_t>>{{2, 2, 2}}),
-                                          testing::Values(std::vector<int32_t>{2, 2, 2, 2, 2}),
+                                          testing::Values(std::vector<cldnn::tensor::value_type>{2, 2, 2, 2, 2}),
                                           testing::Values(std::vector<float>{
                                               1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
 
@@ -218,7 +218,7 @@ INSTANTIATE_TEST_SUITE_P(export_import,
                                           testing::Values(2),
                                           testing::Values(0),
                                           testing::ValuesIn(std::vector<std::vector<int32_t>>{{2, 2, 2}}),
-                                          testing::Values(std::vector<int32_t>{2, 2, 2, 2, 2}),
+                                          testing::Values(std::vector<cldnn::tensor::value_type>{2, 2, 2, 2, 2}),
                                           testing::Values(std::vector<float>{
                                               1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/eye.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/eye.cpp
@@ -21,7 +21,7 @@ using eye_test_param = std::tuple<format,                    // Input and output
                                   InputType,                 // rows number
                                   InputType,                 // diagonal index
                                   std::vector<InputType>,    // batch shape
-                                  std::vector<cldnn::tensor::value_type>,      // output shape
+                                  std::vector<ov::Dimension::value_type>,      // output shape
                                   std::vector<OutputType>,   // expected values
                                   bool>;                     // is_caching_test
 
@@ -34,7 +34,7 @@ public:
         InputType rows{};
         InputType diag{};
         std::vector<InputType> batch_shape;
-        std::vector<cldnn::tensor::value_type> output_shape;
+        std::vector<ov::Dimension::value_type> output_shape;
         std::vector<OutputType> expected_values;
         bool is_caching_test;
         std::tie(fmt, cols, rows, diag, batch_shape, output_shape, expected_values, is_caching_test) = this->GetParam();
@@ -124,7 +124,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(0),
                      testing::ValuesIn(std::vector<std::vector<int32_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 2, 3}),
+                     testing::Values(std::vector<ov::Dimension::value_type>{1, 1, 2, 3}),
                      testing::Values(std::vector<float>{1, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -138,7 +138,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(0),
                      testing::ValuesIn(std::vector<std::vector<int32_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 2, 3}),
+                     testing::Values(std::vector<ov::Dimension::value_type>{1, 1, 2, 3}),
                      testing::Values(std::vector<int64_t>{1, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -152,7 +152,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(-1),
                      testing::ValuesIn(std::vector<std::vector<int64_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 4, 3}),
+                     testing::Values(std::vector<ov::Dimension::value_type>{1, 1, 4, 3}),
                      testing::Values(std::vector<uint8_t>{0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -166,7 +166,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(3),
                      testing::Values(4),
                      testing::ValuesIn(std::vector<std::vector<int64_t>>{{}, {1}, {1, 1}, {1, 1, 1}}),
-                     testing::Values(std::vector<cldnn::tensor::value_type>{1, 1, 4, 3}),
+                     testing::Values(std::vector<ov::Dimension::value_type>{1, 1, 4, 3}),
                      testing::Values(std::vector<int8_t>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
                      testing::Values(false)));
 
@@ -180,7 +180,7 @@ INSTANTIATE_TEST_SUITE_P(
                      testing::Values(2),
                      testing::Values(1),
                      testing::ValuesIn(std::vector<std::vector<int32_t>>{{2, 2}}),
-                     testing::Values(std::vector<cldnn::tensor::value_type>{2, 2, 2, 2}),
+                     testing::Values(std::vector<ov::Dimension::value_type>{2, 2, 2, 2}),
                      testing::Values(std::vector<int32_t>{0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0}),
                      testing::Values(false)));
 
@@ -203,7 +203,7 @@ INSTANTIATE_TEST_SUITE_P(eye_test_5d_float_int32,
                                           testing::Values(2),
                                           testing::Values(0),
                                           testing::ValuesIn(std::vector<std::vector<int32_t>>{{2, 2, 2}}),
-                                          testing::Values(std::vector<cldnn::tensor::value_type>{2, 2, 2, 2, 2}),
+                                          testing::Values(std::vector<ov::Dimension::value_type>{2, 2, 2, 2, 2}),
                                           testing::Values(std::vector<float>{
                                               1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
 
@@ -218,7 +218,7 @@ INSTANTIATE_TEST_SUITE_P(export_import,
                                           testing::Values(2),
                                           testing::Values(0),
                                           testing::ValuesIn(std::vector<std::vector<int32_t>>{{2, 2, 2}}),
-                                          testing::Values(std::vector<cldnn::tensor::value_type>{2, 2, 2, 2, 2}),
+                                          testing::Values(std::vector<ov::Dimension::value_type>{2, 2, 2, 2, 2}),
                                           testing::Values(std::vector<float>{
                                               1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -66,7 +66,7 @@ const std::vector<data_types> all_types = {
 };
 
 typedef std::tuple<
-std::vector<std::vector<cldnn::tensor::value_type>>,
+std::vector<std::vector<ov::Dimension::value_type>>,
 std::vector<std::vector<float>>,
 format,
 data_types,
@@ -82,7 +82,7 @@ class GemmGPUTest : public ::testing::TestWithParam<GemmParams> {
 protected:
     std::vector<std::vector<float>> input_data;
     std::vector<float> out_data;
-    std::vector<std::vector<cldnn::tensor::value_type>> shapes;
+    std::vector<std::vector<ov::Dimension::value_type>> shapes;
     format fmt{format::bfyx};
     data_types type;
     bool transpose_input0;
@@ -233,7 +233,7 @@ TEST_P(GemmGPUTestRandom, basic) {
 INSTANTIATE_TEST_SUITE_P(
     GemmGPUTest_basic_t1, GemmGPUTestRandom,
     ::testing::Combine(
-        ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{1, 1, 3, 4},
+        ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{1, 1, 3, 4},
                                                                               {1, 1, 1, 4}}),
         ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
         ::testing::ValuesIn(planar_formats), ::testing::ValuesIn(float_types),
@@ -244,7 +244,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GemmGPUTest_basic_t2, GemmGPUTestRandom,
     ::testing::Combine(
-        ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{1, 1, 4, 3},
+        ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{1, 1, 4, 3},
                                                                               {1, 1, 4, 1}}),
         ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
         ::testing::ValuesIn(planar_formats), ::testing::ValuesIn(float_types),
@@ -378,10 +378,10 @@ public:
             cldnn::mem_lock<ov::float16> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];
@@ -545,10 +545,10 @@ public:
             cldnn::mem_lock<ov::float16> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];
@@ -886,10 +886,10 @@ public:
             cldnn::mem_lock<float> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];
@@ -1032,10 +1032,10 @@ public:
             cldnn::mem_lock<float> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];
@@ -1176,10 +1176,10 @@ public:
             cldnn::mem_lock<ov::float16> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];
@@ -1847,7 +1847,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_t1t2,
         GemmGPUTestRandom,
         ::testing::Combine(
-            ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{2, 1, 3, 4}, {2, 1, 4, 1}}),
+            ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{2, 1, 3, 4}, {2, 1, 4, 1}}),
             ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
             ::testing::ValuesIn(planar_formats),
             ::testing::ValuesIn(float_types),
@@ -1862,7 +1862,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GemmGPUTest_basic_input3, GemmGPUTest,
     ::testing::Combine(
-        ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{
+        ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{
             {1, 1, 3, 2}, {1, 1, 2, 3}, {1, 1, 2, 2}}),
         ::testing::Values(std::vector<std::vector<float>>{
             {1.0f, 2.0f, 3.0f, 1.0f, 0.0f, 1.0f},
@@ -1889,7 +1889,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_t1t2,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 4, 3 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 1, 1, 4, 3 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 2.0f, 3.0f, 4.0f,
@@ -1927,7 +1927,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_1,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 3, 4 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 1, 1, 3, 4 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 1.0f, 0.0f,
@@ -1968,7 +1968,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_t2,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 3, 4 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 1, 1, 3, 4 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 1.0f, 0.0f,
@@ -2008,7 +2008,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_t1,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 4, 3 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 1, 1, 4, 3 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 2.0f, 3.0f, 4.0f,
@@ -2047,7 +2047,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_basic,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 2, 1, 4, 3 }, { 2, 1, 1, 4 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 2, 1, 4, 3 }, { 2, 1, 1, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(planar_formats),
                     ::testing::ValuesIn(float_types),
@@ -2064,7 +2064,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_basic3_bfyx,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 5, 1, 500, 9 }, { 5, 1, 1, 500 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 5, 1, 500, 9 }, { 5, 1, 1, 500 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(planar_formats),
                     ::testing::ValuesIn(float_types),
@@ -2080,7 +2080,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_basic_smarcink2,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 2, 1, 3, 2 }, { 2, 1, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 2, 1, 3, 2 }, { 2, 1, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(planar_formats),
                     ::testing::ValuesIn(float_types),
@@ -2096,7 +2096,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_f_block_4d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 32, 3, 2 }, { 1, 32, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 1, 32, 3, 2 }, { 1, 32, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(f_blocked_4d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2112,7 +2112,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_b_block_4d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 32, 1, 3, 2 }, { 32, 1, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 32, 1, 3, 2 }, { 32, 1, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(b_blocked_4d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2128,7 +2128,7 @@ INSTANTIATE_TEST_SUITE_P(
         DISABLED_GemmGPUTest_f_block_5d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 16, 2, 3, 2 }, { 1, 16, 2, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 1, 16, 2, 3, 2 }, { 1, 16, 2, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(f_blocked_5d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2144,7 +2144,7 @@ INSTANTIATE_TEST_SUITE_P(
         DISABLED_GemmGPUTest_b_block_5d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 16, 1, 2, 3, 2 }, { 16, 1, 2, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<ov::Dimension::value_type>>{{ 16, 1, 2, 3, 2 }, { 16, 1, 2, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(b_blocked_5d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2721,7 +2721,7 @@ public:
 
     layout get_input_layout(T& p, int in_no) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
         if (in_no == 0)
             return layout{ p.data_type_in0, p.input_format, p.in_shapes.at(0), padding{ pad_ } };
         else if (in_no == 1)
@@ -2948,10 +2948,10 @@ public:
             cldnn::mem_lock<ov::float16> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];
@@ -3114,10 +3114,10 @@ public:
             cldnn::mem_lock<ov::float16> mem_ptr(mem, get_test_stream());
             auto&& l = mem->get_layout();
             auto data_idx = 0;
-            for (cldnn::tensor::value_type b = 0; b < l.batch(); ++b) {
-                for (cldnn::tensor::value_type f = 0; f < l.feature(); ++f) {
-                    for (cldnn::tensor::value_type y = 0; y < l.spatial(1); ++y) {
-                        for (cldnn::tensor::value_type x = 0; x < l.spatial(0); ++x) {
+            for (ov::Dimension::value_type b = 0; b < l.batch(); ++b) {
+                for (ov::Dimension::value_type f = 0; f < l.feature(); ++f) {
+                    for (ov::Dimension::value_type y = 0; y < l.spatial(1); ++y) {
+                        for (ov::Dimension::value_type x = 0; x < l.spatial(0); ++x) {
                             auto tensor_coord = cldnn::tensor{{b, f, x, y}, 0};
                             auto buffer_idx = l.get_linear_offset(tensor_coord);
                             mem_ptr[buffer_idx] = data[data_idx++];

--- a/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/gemm_gpu_test.cpp
@@ -66,7 +66,7 @@ const std::vector<data_types> all_types = {
 };
 
 typedef std::tuple<
-std::vector<std::vector<int32_t>>,
+std::vector<std::vector<cldnn::tensor::value_type>>,
 std::vector<std::vector<float>>,
 format,
 data_types,
@@ -82,7 +82,7 @@ class GemmGPUTest : public ::testing::TestWithParam<GemmParams> {
 protected:
     std::vector<std::vector<float>> input_data;
     std::vector<float> out_data;
-    std::vector<std::vector<int32_t>> shapes;
+    std::vector<std::vector<cldnn::tensor::value_type>> shapes;
     format fmt{format::bfyx};
     data_types type;
     bool transpose_input0;
@@ -233,8 +233,8 @@ TEST_P(GemmGPUTestRandom, basic) {
 INSTANTIATE_TEST_SUITE_P(
     GemmGPUTest_basic_t1, GemmGPUTestRandom,
     ::testing::Combine(
-        ::testing::Values(std::vector<std::vector<int32_t>>{{1, 1, 3, 4},
-                                                            {1, 1, 1, 4}}),
+        ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{1, 1, 3, 4},
+                                                                              {1, 1, 1, 4}}),
         ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
         ::testing::ValuesIn(planar_formats), ::testing::ValuesIn(float_types),
         ::testing::Values(std::vector<float>{}),
@@ -244,8 +244,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GemmGPUTest_basic_t2, GemmGPUTestRandom,
     ::testing::Combine(
-        ::testing::Values(std::vector<std::vector<int32_t>>{{1, 1, 4, 3},
-                                                            {1, 1, 4, 1}}),
+        ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{1, 1, 4, 3},
+                                                                              {1, 1, 4, 1}}),
         ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
         ::testing::ValuesIn(planar_formats), ::testing::ValuesIn(float_types),
         ::testing::Values(std::vector<float>{}),
@@ -1847,7 +1847,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_t1t2,
         GemmGPUTestRandom,
         ::testing::Combine(
-            ::testing::Values(std::vector<std::vector<int32_t>>{{2, 1, 3, 4}, {2, 1, 4, 1}}),
+            ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{2, 1, 3, 4}, {2, 1, 4, 1}}),
             ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
             ::testing::ValuesIn(planar_formats),
             ::testing::ValuesIn(float_types),
@@ -1862,7 +1862,7 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GemmGPUTest_basic_input3, GemmGPUTest,
     ::testing::Combine(
-        ::testing::Values(std::vector<std::vector<int32_t>>{
+        ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{
             {1, 1, 3, 2}, {1, 1, 2, 3}, {1, 1, 2, 2}}),
         ::testing::Values(std::vector<std::vector<float>>{
             {1.0f, 2.0f, 3.0f, 1.0f, 0.0f, 1.0f},
@@ -1889,7 +1889,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_t1t2,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 1, 1, 4, 3 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 4, 3 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 2.0f, 3.0f, 4.0f,
@@ -1927,7 +1927,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_1,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 1, 1, 3, 4 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 3, 4 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 1.0f, 0.0f,
@@ -1968,7 +1968,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_t2,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 1, 1, 3, 4 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 3, 4 }, { 1, 1, 3, 2 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 1.0f, 0.0f,
@@ -2008,7 +2008,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_input3_t1,
         GemmGPUTest,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 1, 1, 4, 3 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 1, 4, 3 }, { 1, 1, 2, 3 }, { 1, 1, 2, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{
                         {
                             1.0f, 2.0f, 3.0f, 4.0f,
@@ -2047,7 +2047,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_basic,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 2, 1, 4, 3 }, { 2, 1, 1, 4 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 2, 1, 4, 3 }, { 2, 1, 1, 4 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(planar_formats),
                     ::testing::ValuesIn(float_types),
@@ -2064,7 +2064,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_basic3_bfyx,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 5, 1, 500, 9 }, { 5, 1, 1, 500 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 5, 1, 500, 9 }, { 5, 1, 1, 500 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(planar_formats),
                     ::testing::ValuesIn(float_types),
@@ -2080,7 +2080,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_basic_smarcink2,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 2, 1, 3, 2 }, { 2, 1, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 2, 1, 3, 2 }, { 2, 1, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(planar_formats),
                     ::testing::ValuesIn(float_types),
@@ -2096,7 +2096,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_f_block_4d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 1, 32, 3, 2 }, { 1, 32, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 32, 3, 2 }, { 1, 32, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(f_blocked_4d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2112,7 +2112,7 @@ INSTANTIATE_TEST_SUITE_P(
         GemmGPUTest_b_block_4d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 32, 1, 3, 2 }, { 32, 1, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 32, 1, 3, 2 }, { 32, 1, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(b_blocked_4d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2128,7 +2128,7 @@ INSTANTIATE_TEST_SUITE_P(
         DISABLED_GemmGPUTest_f_block_5d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 1, 16, 2, 3, 2 }, { 1, 16, 2, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 1, 16, 2, 3, 2 }, { 1, 16, 2, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(f_blocked_5d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2144,7 +2144,7 @@ INSTANTIATE_TEST_SUITE_P(
         DISABLED_GemmGPUTest_b_block_5d_formats,
         GemmGPUTestRandom,
                 ::testing::Combine(
-                    ::testing::Values(std::vector<std::vector<int32_t>>{{ 16, 1, 2, 3, 2 }, { 16, 1, 2, 2, 3 }}),
+                    ::testing::Values(std::vector<std::vector<cldnn::tensor::value_type>>{{ 16, 1, 2, 3, 2 }, { 16, 1, 2, 2, 3 }}),
                     ::testing::Values(std::vector<std::vector<float>>{{}, {}}),
                     ::testing::ValuesIn(b_blocked_5d_formats),
                     ::testing::ValuesIn(float_types),
@@ -2721,7 +2721,7 @@ public:
 
     layout get_input_layout(T& p, int in_no) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad.spatial[0], pad.spatial[1] };
         if (in_no == 0)
             return layout{ p.data_type_in0, p.input_format, p.in_shapes.at(0), padding{ pad_ } };
         else if (in_no == 1)

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -23,12 +23,12 @@ using namespace ::tests;
 namespace {
 
 typedef std::tuple<
-    std::vector<std::int32_t>,  // Input shape
-    std::size_t,                // Number of groups
-    double,                     // Epsilon
-    format,                     // First input layout
-    format,                     // Output layout
-    padding                     // Output padding
+    std::vector<cldnn::tensor::value_type>, // Input shape
+    std::size_t,                            // Number of groups
+    double,                                 // Epsilon
+    format,                                 // First input layout
+    format,                                 // Output layout
+    padding                                 // Output padding
 >
 GroupNormalizationParams;
 
@@ -37,7 +37,7 @@ public:
     GroupNormalizationGPUTest() = default;
 
     void SetUp() override {
-        std::vector<std::int32_t> input_shape;
+        std::vector<cldnn::tensor::value_type> input_shape;
         const auto& params = GetParam();
         std::tie(input_shape, num_groups_, epsilon_, in_format_, out_format_, output_pad_) = params;
         std::copy(std::begin(input_shape), std::end(input_shape), std::back_inserter(data_shape_));
@@ -166,7 +166,8 @@ const std::vector<cldnn::format> f_planar_5d_formats {
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_planar_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}, std::vector<int32_t>{1, 1536, 151, 1}, std::vector<int32_t>{1, 12, 2175, 1}}),
+        ::testing::ValuesIn({std::vector<cldnn::tensor::value_type>{3, 64, 32, 64}, std::vector<cldnn::tensor::value_type>{3, 124, 97, 61},
+                             std::vector<cldnn::tensor::value_type>{1, 1536, 151, 1}, std::vector<cldnn::tensor::value_type>{1, 12, 2175, 1}}),
         ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_4d_formats),
@@ -176,7 +177,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_blocked_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 32, 64}, std::vector<int32_t>{3, 124, 97, 61}, std::vector<int32_t>{1, 1536, 151, 1}, std::vector<int32_t>{1, 12, 2175, 1}}),
+        ::testing::ValuesIn({std::vector<cldnn::tensor::value_type>{3, 64, 32, 64}, std::vector<cldnn::tensor::value_type>{3, 124, 97, 61},
+                             std::vector<cldnn::tensor::value_type>{1, 1536, 151, 1}, std::vector<cldnn::tensor::value_type>{1, 12, 2175, 1}}),
         ::testing::ValuesIn(std::vector<size_t>{1, 2, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_blocked_4d_formats),
@@ -186,7 +188,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_planar_layouts_support_5d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<int32_t>{3, 64, 28, 32, 12}, std::vector<int32_t>{3, 124, 10, 97, 61}, std::vector<int32_t>{1, 1536, 9, 151, 1}, std::vector<int32_t>{1, 12, 8, 2175, 1}}),
+        ::testing::ValuesIn({std::vector<cldnn::tensor::value_type>{3, 64, 28, 32, 12}, std::vector<cldnn::tensor::value_type>{3, 124, 10, 97, 61},
+                             std::vector<cldnn::tensor::value_type>{1, 1536, 9, 151, 1}, std::vector<cldnn::tensor::value_type>{1, 12, 8, 2175, 1}}),
         ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_5d_formats),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/group_normalization_gpu_test.cpp
@@ -23,7 +23,7 @@ using namespace ::tests;
 namespace {
 
 typedef std::tuple<
-    std::vector<cldnn::tensor::value_type>, // Input shape
+    std::vector<ov::Dimension::value_type>, // Input shape
     std::size_t,                            // Number of groups
     double,                                 // Epsilon
     format,                                 // First input layout
@@ -37,7 +37,7 @@ public:
     GroupNormalizationGPUTest() = default;
 
     void SetUp() override {
-        std::vector<cldnn::tensor::value_type> input_shape;
+        std::vector<ov::Dimension::value_type> input_shape;
         const auto& params = GetParam();
         std::tie(input_shape, num_groups_, epsilon_, in_format_, out_format_, output_pad_) = params;
         std::copy(std::begin(input_shape), std::end(input_shape), std::back_inserter(data_shape_));
@@ -166,8 +166,8 @@ const std::vector<cldnn::format> f_planar_5d_formats {
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_planar_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<cldnn::tensor::value_type>{3, 64, 32, 64}, std::vector<cldnn::tensor::value_type>{3, 124, 97, 61},
-                             std::vector<cldnn::tensor::value_type>{1, 1536, 151, 1}, std::vector<cldnn::tensor::value_type>{1, 12, 2175, 1}}),
+        ::testing::ValuesIn({std::vector<ov::Dimension::value_type>{3, 64, 32, 64}, std::vector<ov::Dimension::value_type>{3, 124, 97, 61},
+                             std::vector<ov::Dimension::value_type>{1, 1536, 151, 1}, std::vector<ov::Dimension::value_type>{1, 12, 2175, 1}}),
         ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_4d_formats),
@@ -177,8 +177,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_blocked_layouts_support_4d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<cldnn::tensor::value_type>{3, 64, 32, 64}, std::vector<cldnn::tensor::value_type>{3, 124, 97, 61},
-                             std::vector<cldnn::tensor::value_type>{1, 1536, 151, 1}, std::vector<cldnn::tensor::value_type>{1, 12, 2175, 1}}),
+        ::testing::ValuesIn({std::vector<ov::Dimension::value_type>{3, 64, 32, 64}, std::vector<ov::Dimension::value_type>{3, 124, 97, 61},
+                             std::vector<ov::Dimension::value_type>{1, 1536, 151, 1}, std::vector<ov::Dimension::value_type>{1, 12, 2175, 1}}),
         ::testing::ValuesIn(std::vector<size_t>{1, 2, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_blocked_4d_formats),
@@ -188,8 +188,8 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     GroupNormalizationGPUTest_planar_layouts_support_5d, GroupNormalizationGPUTest,
     ::testing::Combine(
-        ::testing::ValuesIn({std::vector<cldnn::tensor::value_type>{3, 64, 28, 32, 12}, std::vector<cldnn::tensor::value_type>{3, 124, 10, 97, 61},
-                             std::vector<cldnn::tensor::value_type>{1, 1536, 9, 151, 1}, std::vector<cldnn::tensor::value_type>{1, 12, 8, 2175, 1}}),
+        ::testing::ValuesIn({std::vector<ov::Dimension::value_type>{3, 64, 28, 32, 12}, std::vector<ov::Dimension::value_type>{3, 124, 10, 97, 61},
+                             std::vector<ov::Dimension::value_type>{1, 1536, 9, 151, 1}, std::vector<ov::Dimension::value_type>{1, 12, 8, 2175, 1}}),
         ::testing::ValuesIn(std::vector<size_t>{1, 4}),
         ::testing::Values(0.0025),
         ::testing::ValuesIn(f_planar_5d_formats),

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -49,7 +49,7 @@ TEST(permute_gpu_f32, output_ordering_test)
 {
     auto& engine = get_test_engine();
 
-    std::vector<std::vector<cldnn::tensor::value_type>> input_tensors = {
+    std::vector<std::vector<ov::Dimension::value_type>> input_tensors = {
         { 10, 5, 15, 2 },
         { 2, 4, 6, 8 },
         { 2, 2, 3, 2 },
@@ -63,9 +63,9 @@ TEST(permute_gpu_f32, output_ordering_test)
     };
     std::vector<format> input_formats = { format::bfyx, format::yxfb };
 
-    auto get_permutation = [&](const std::vector<cldnn::tensor::value_type>& inp1, const std::vector<uint16_t>& order) -> std::vector<cldnn::tensor::value_type> {
+    auto get_permutation = [&](const std::vector<ov::Dimension::value_type>& inp1, const std::vector<uint16_t>& order) -> std::vector<ov::Dimension::value_type> {
         EXPECT_EQ(inp1.size(), order.size());
-        std::vector<cldnn::tensor::value_type> output;
+        std::vector<ov::Dimension::value_type> output;
         for (auto const& o : order) {
             output.push_back(inp1.at(o));
         }
@@ -1869,7 +1869,7 @@ TEST(permute_gpu_f32_tile_8x8_4x4, xf_remainder_bfwzyx_0_2_3_4_5_1) {
 }
 
 struct TiledPermuteParam {
-    std::vector<cldnn::tensor::value_type> sizes;
+    std::vector<ov::Dimension::value_type> sizes;
     cldnn::format format_fsv;
 };
 
@@ -1889,7 +1889,7 @@ public:
     }
 
     template<data_types Data_Type>
-    void run_test(const std::vector<cldnn::tensor::value_type>& sizes, cldnn::format format_fsv,
+    void run_test(const std::vector<ov::Dimension::value_type>& sizes, cldnn::format format_fsv,
                   const std::string & permute_opt = "permute_tile_8x8_4x4_fsv",
                   std::vector<uint16_t> permute_order = {}, bool is_caching_test = false);
 
@@ -1924,14 +1924,14 @@ void TiledPermuteTest::set_random_values<int8_t>(const cldnn::memory::ptr mem) c
 }
 
 template<data_types Data_Type>
-void TiledPermuteTest::run_test(const std::vector<cldnn::tensor::value_type>& sizes, cldnn::format format_fsv,
+void TiledPermuteTest::run_test(const std::vector<ov::Dimension::value_type>& sizes, cldnn::format format_fsv,
                                 const std::string & permute_opt, std::vector<uint16_t> permute_order, bool is_caching_test)
 {
     // convert ov::float16 to ov::float16
     using type_ = typename ov::element_type_traits<Data_Type>::value_type;
     using type = typename std::conditional<std::is_same<type_, ov::float16>::value, ov::float16, type_>::type;
 
-    std::vector<cldnn::tensor::value_type> internal_sizes(sizes);
+    std::vector<ov::Dimension::value_type> internal_sizes(sizes);
     std::swap(internal_sizes.at(2), internal_sizes.back());
     cldnn::tensor tensor(internal_sizes);
 
@@ -2434,14 +2434,14 @@ struct TiledPerformancePermuteTest : TiledPermuteTest
     }
     
     template<data_types Data_Type>
-    void execute_perf_test(const std::vector<cldnn::tensor::value_type>& sizes, cldnn::format format_fsv,
+    void execute_perf_test(const std::vector<ov::Dimension::value_type>& sizes, cldnn::format format_fsv,
                             const std::string & kernel_name, std::vector<uint16_t> permute_order)
     {
         auto& engine = get_test_engine();
         // convert half_t to FLOAT16
         using type = typename ov::element_type_traits<Data_Type>::value_type;
 
-        std::vector<cldnn::tensor::value_type> internal_sizes(sizes);
+        std::vector<ov::Dimension::value_type> internal_sizes(sizes);
         std::swap(internal_sizes.at(2), internal_sizes.back());
         cldnn::tensor tensor(internal_sizes);
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/permute_gpu_test.cpp
@@ -49,7 +49,7 @@ TEST(permute_gpu_f32, output_ordering_test)
 {
     auto& engine = get_test_engine();
 
-    std::vector<std::vector<int32_t>> input_tensors = {
+    std::vector<std::vector<cldnn::tensor::value_type>> input_tensors = {
         { 10, 5, 15, 2 },
         { 2, 4, 6, 8 },
         { 2, 2, 3, 2 },
@@ -63,9 +63,9 @@ TEST(permute_gpu_f32, output_ordering_test)
     };
     std::vector<format> input_formats = { format::bfyx, format::yxfb };
 
-    auto get_permutation = [&](const std::vector<int32_t>& inp1, const std::vector<uint16_t>& order) -> std::vector<int32_t> {
+    auto get_permutation = [&](const std::vector<cldnn::tensor::value_type>& inp1, const std::vector<uint16_t>& order) -> std::vector<cldnn::tensor::value_type> {
         EXPECT_EQ(inp1.size(), order.size());
-        std::vector<int32_t> output;
+        std::vector<cldnn::tensor::value_type> output;
         for (auto const& o : order) {
             output.push_back(inp1.at(o));
         }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -3168,7 +3168,7 @@ public:
 
     layout get_input_layout(T& p) {
         auto pad = p.pad;
-        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
+        std::vector<ov::Dimension::value_type> pad_ = { 0, 0, pad[1], pad[0] };
     return layout{ p.data_type, p.input_format, p.in_shape, padding{pad_} };
     }
 
@@ -3329,7 +3329,7 @@ class testing_removal_1d_reorder : public ReorderTest<redundant_reorder_test_par
 TEST_P(testing_removal_1d_reorder, removal_reorder_1d_along_f_mixed_format) {
     auto p = GetParam();
 
-    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
+    std::vector<ov::Dimension::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     create_topologies(input_layout("input", in_layout),
@@ -3351,7 +3351,7 @@ TEST_P(testing_removal_1d_reorder, removal_reorder_1d_along_f_mixed_format) {
 TEST_P(testing_removal_1d_reorder, padded_reorder_1d_along_f_mixed_format) {
     auto p = GetParam();
 
-    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
+    std::vector<ov::Dimension::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     layout reorder_layout(data_types::f16, format::b_fs_yx_fsv32, p.out_shape, padding({0, 0, 1, 1}, 0));
@@ -3381,7 +3381,7 @@ class testing_removal_feature_aligned_reorder : public ReorderTest<redundant_reo
 TEST_P(testing_removal_feature_aligned_reorder, removal_reorder_aligned_mixed_format) {
     auto p = GetParam();
 
-    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
+    std::vector<ov::Dimension::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     create_topologies(input_layout("input", in_layout),
@@ -3401,7 +3401,7 @@ TEST_P(testing_removal_feature_aligned_reorder, removal_reorder_aligned_mixed_fo
 TEST_P(testing_removal_feature_aligned_reorder, padded_reorder_aligned_mixed_format) {
     auto p = GetParam();
 
-    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
+    std::vector<ov::Dimension::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     layout reorder_layout(data_types::f16, format::b_fs_yx_fsv32, p.out_shape, padding({0, 0, 1, 1}, 0));
@@ -3704,7 +3704,7 @@ TEST(reorder_gpu_fp32, test_needs_completion_events) {
     }
 }
 
-static void run_reorder_weight_int4(const ov::Shape in_shape, const std::vector<cldnn::tensor::value_type> upper_size) {
+static void run_reorder_weight_int4(const ov::Shape in_shape, const std::vector<ov::Dimension::value_type> upper_size) {
     auto& engine = get_test_engine();
 
     layout in_layout({in_shape, data_types::i4, format::bfyx});

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reorder_gpu_test.cpp
@@ -3168,7 +3168,7 @@ public:
 
     layout get_input_layout(T& p) {
         auto pad = p.pad;
-        std::vector<int> pad_ = { 0, 0, static_cast<int>(pad[1]), static_cast<int>(pad[0]) };
+        std::vector<cldnn::tensor::value_type> pad_ = { 0, 0, pad[1], pad[0] };
     return layout{ p.data_type, p.input_format, p.in_shape, padding{pad_} };
     }
 
@@ -3329,7 +3329,7 @@ class testing_removal_1d_reorder : public ReorderTest<redundant_reorder_test_par
 TEST_P(testing_removal_1d_reorder, removal_reorder_1d_along_f_mixed_format) {
     auto p = GetParam();
 
-    std::vector<int> pad = { 0, 0, static_cast<int>(p.pad[1]), static_cast<int>(p.pad[0]) };
+    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     create_topologies(input_layout("input", in_layout),
@@ -3351,7 +3351,7 @@ TEST_P(testing_removal_1d_reorder, removal_reorder_1d_along_f_mixed_format) {
 TEST_P(testing_removal_1d_reorder, padded_reorder_1d_along_f_mixed_format) {
     auto p = GetParam();
 
-    std::vector<int> pad = { 0, 0, static_cast<int>(p.pad[1]), static_cast<int>(p.pad[0]) };
+    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     layout reorder_layout(data_types::f16, format::b_fs_yx_fsv32, p.out_shape, padding({0, 0, 1, 1}, 0));
@@ -3381,7 +3381,7 @@ class testing_removal_feature_aligned_reorder : public ReorderTest<redundant_reo
 TEST_P(testing_removal_feature_aligned_reorder, removal_reorder_aligned_mixed_format) {
     auto p = GetParam();
 
-    std::vector<int> pad = { 0, 0, static_cast<int>(p.pad[1]), static_cast<int>(p.pad[0]) };
+    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     create_topologies(input_layout("input", in_layout),
@@ -3401,7 +3401,7 @@ TEST_P(testing_removal_feature_aligned_reorder, removal_reorder_aligned_mixed_fo
 TEST_P(testing_removal_feature_aligned_reorder, padded_reorder_aligned_mixed_format) {
     auto p = GetParam();
 
-    std::vector<int> pad = { 0, 0, static_cast<int>(p.pad[1]), static_cast<int>(p.pad[0]) };
+    std::vector<cldnn::tensor::value_type> pad = { 0, 0, p.pad[1], p.pad[0] };
     layout in_layout{ p.data_type, p.input_format, p.in_shape, padding{pad} };
 
     layout reorder_layout(data_types::f16, format::b_fs_yx_fsv32, p.out_shape, padding({0, 0, 1, 1}, 0));
@@ -3704,7 +3704,7 @@ TEST(reorder_gpu_fp32, test_needs_completion_events) {
     }
 }
 
-static void run_reorder_weight_int4(const ov::Shape in_shape, const std::vector<int32_t> upper_size) {
+static void run_reorder_weight_int4(const ov::Shape in_shape, const std::vector<cldnn::tensor::value_type> upper_size) {
     auto& engine = get_test_engine();
 
     layout in_layout({in_shape, data_types::i4, format::bfyx});

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -223,7 +223,7 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd) {
         tensor(1, 1, 8, 1),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 1, 1}));
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 1, 1}));
 }
 
 TEST(reshape_gpu_f16, basic_2dim_output_padd) {
@@ -233,7 +233,7 @@ TEST(reshape_gpu_f16, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}));
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_i8, basic_2dim_output_padd) {
@@ -243,7 +243,7 @@ TEST(reshape_gpu_i8, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}));
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_i32, basic_2dim_output_padd) {
@@ -253,7 +253,7 @@ TEST(reshape_gpu_i32, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}));
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_i64, basic_2dim_output_padd) {
@@ -263,7 +263,7 @@ TEST(reshape_gpu_i64, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}));
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_f32, basic_2dim_input_padd) {
@@ -1008,7 +1008,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const) {
     ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
     ASSERT_EQ(output->get_layout().format, format::bfyx);
     ASSERT_TRUE(output->get_layout().is_static());
-    std::vector<int32_t> ref_dims = {12, 3, 1, 1};
+    std::vector<cldnn::tensor::value_type> ref_dims = {12, 3, 1, 1};
     ASSERT_EQ(output->get_layout().get_dims(), ref_dims);
     ov::PartialShape ref_pshape = {12, 3};
     ASSERT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
@@ -1065,7 +1065,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const_optimized_out) {
     ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
     ASSERT_EQ(output->get_layout().format, format::bfyx);
     ASSERT_TRUE(output->get_layout().is_static());
-    std::vector<int32_t> ref_dims = {12, 3, 1, 1};
+    std::vector<cldnn::tensor::value_type> ref_dims = {12, 3, 1, 1};
     ASSERT_EQ(output->get_layout().get_dims(), ref_dims);
     ov::PartialShape ref_pshape = {12, 3};
     ASSERT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
@@ -1393,7 +1393,7 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd_cached) {
         tensor(1, 1, 8, 1),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 1, 1}),
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 1, 1}),
         true);
 }
 
@@ -1404,7 +1404,7 @@ TEST(reshape_gpu_f16, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}),
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
         true);
 }
 
@@ -1415,7 +1415,7 @@ TEST(reshape_gpu_i8, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}),
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
         true);
 }
 
@@ -1426,7 +1426,7 @@ TEST(reshape_gpu_i32, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}),
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
         true);
 }
 
@@ -1437,7 +1437,7 @@ TEST(reshape_gpu_i64, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<int>{0, 0, 2, 2}),
+        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
         true);
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/reshape_gpu_test.cpp
@@ -223,7 +223,7 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd) {
         tensor(1, 1, 8, 1),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 1, 1}));
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 1, 1}));
 }
 
 TEST(reshape_gpu_f16, basic_2dim_output_padd) {
@@ -233,7 +233,7 @@ TEST(reshape_gpu_f16, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_i8, basic_2dim_output_padd) {
@@ -243,7 +243,7 @@ TEST(reshape_gpu_i8, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_i32, basic_2dim_output_padd) {
@@ -253,7 +253,7 @@ TEST(reshape_gpu_i32, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_i64, basic_2dim_output_padd) {
@@ -263,7 +263,7 @@ TEST(reshape_gpu_i64, basic_2dim_output_padd) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}));
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}));
 }
 
 TEST(reshape_gpu_f32, basic_2dim_input_padd) {
@@ -1008,7 +1008,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const) {
     ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
     ASSERT_EQ(output->get_layout().format, format::bfyx);
     ASSERT_TRUE(output->get_layout().is_static());
-    std::vector<cldnn::tensor::value_type> ref_dims = {12, 3, 1, 1};
+    std::vector<ov::Dimension::value_type> ref_dims = {12, 3, 1, 1};
     ASSERT_EQ(output->get_layout().get_dims(), ref_dims);
     ov::PartialShape ref_pshape = {12, 3};
     ASSERT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
@@ -1065,7 +1065,7 @@ TEST(reshape_gpu_f32, basic_runtime_dynamic_shape_with_const_optimized_out) {
     ASSERT_EQ(output->get_layout().data_type, input->get_layout().data_type);
     ASSERT_EQ(output->get_layout().format, format::bfyx);
     ASSERT_TRUE(output->get_layout().is_static());
-    std::vector<cldnn::tensor::value_type> ref_dims = {12, 3, 1, 1};
+    std::vector<ov::Dimension::value_type> ref_dims = {12, 3, 1, 1};
     ASSERT_EQ(output->get_layout().get_dims(), ref_dims);
     ov::PartialShape ref_pshape = {12, 3};
     ASSERT_EQ(output->get_layout().get_partial_shape(), ref_pshape);
@@ -1393,7 +1393,7 @@ TEST(reshpape_gpu_f32, basic_2dim_output_padd_cached) {
         tensor(1, 1, 8, 1),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 1, 1}),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 1, 1}),
         true);
 }
 
@@ -1404,7 +1404,7 @@ TEST(reshape_gpu_f16, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}),
         true);
 }
 
@@ -1415,7 +1415,7 @@ TEST(reshape_gpu_i8, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}),
         true);
 }
 
@@ -1426,7 +1426,7 @@ TEST(reshape_gpu_i32, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}),
         true);
 }
 
@@ -1437,7 +1437,7 @@ TEST(reshape_gpu_i64, basic_2dim_output_padd_cached) {
         tensor(1, 1, 2, 6),
         false,
         padding(),
-        padding(std::vector<cldnn::tensor::value_type>{0, 0, 2, 2}),
+        padding(std::vector<ov::Dimension::value_type>{0, 0, 2, 2}),
         true);
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/roll_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/roll_gpu_test.cpp
@@ -26,9 +26,9 @@ std::string vec2str(const std::vector<vecElementType>& vec) {
 
 template <class T>
 struct roll_test_input {
-    std::vector<int32_t> input_shape;
+    std::vector<cldnn::tensor::value_type> input_shape;
     std::vector<T> input_values;
-    std::vector<int32_t> shift;
+    std::vector<cldnn::tensor::value_type> shift;
     std::vector<T> expected_values;
 };
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/roll_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/roll_gpu_test.cpp
@@ -26,9 +26,9 @@ std::string vec2str(const std::vector<vecElementType>& vec) {
 
 template <class T>
 struct roll_test_input {
-    std::vector<cldnn::tensor::value_type> input_shape;
+    std::vector<ov::Dimension::value_type> input_shape;
     std::vector<T> input_values;
-    std::vector<cldnn::tensor::value_type> shift;
+    std::vector<ov::Dimension::value_type> shift;
     std::vector<T> expected_values;
 };
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved) 
 - Overflow happens when internal buffer5 in PA bigger than max of int32_t. (kv_cache [21504,4,132,16]) 
 - Use tensor value_type int64_t instead of int32_t.
 - Use ov::Dimension::value_type instead tensor value_type. (Plan to drop tensor value_type in the future)
 - Fixed build errors for hard-coded int32_t usages. Use ov::Dimension::value_type instead int32_t.

#### The code and line that caused this issue (if it is not changed directly) 
- intel_gpu/include/intel_gpu/runtime/tensor.hpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
- It can be reproduced E2E python test app by running Approx. 1hours increasing kv_cache.
- Please check the defail in Jira tickets.
 
#### Problematic graph 
 - No graph related.
 
#### Checklist 
 - [O] Is it a proper fix? (not a workaround) 
 - [O] Did you include test case for this fix, if necessary? 
 - [O] Did you review existing test that can be extended to cover this scenario? Which test did you review? layout_test.cpp

 
### Tickets: 
 - *170106* 
