### PR TITLE
[CPU] fix segment fault issue during model Compile

### DIFF
--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -2250,7 +2250,7 @@ void GraphOptimizer::ShareReorders(Graph& graph) {
 void GraphOptimizer::DropDoubleReorders(Graph& graph) {
     std::set<NodePtr> processed;
 
-    auto& nodes = graph.GetNodes();
+    const auto& nodes = graph.GetNodes();
     for (size_t i = 0; i < nodes.size(); ++i) {  // NOLINT(modernize-loop-convert)
         auto node = nodes[i];
 

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -2250,11 +2250,10 @@ void GraphOptimizer::ShareReorders(Graph& graph) {
 void GraphOptimizer::DropDoubleReorders(Graph& graph) {
     std::set<NodePtr> processed;
 
-    const auto& nodes = graph.GetNodes();
-    for (const auto& node : nodes) {
-        if (!node) {
-            continue;
-        }
+    auto& nodes = graph.GetNodes();
+    for (size_t i = 0; i < nodes.size(); ++i) {  // NOLINT(modernize-loop-convert)
+        auto node = nodes[i];
+
         if (processed.find(node) == processed.end() && node->getType() == Type::Reorder &&
             node->getChildEdges().size() == 1 && node->getChildEdgeAt(0)->getChild()->getType() == Type::Reorder) {
             auto nextNode = node->getChildEdgeAt(0)->getChild();

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -2252,6 +2252,9 @@ void GraphOptimizer::DropDoubleReorders(Graph& graph) {
 
     const auto& nodes = graph.GetNodes();
     for (const auto& node : nodes) {
+        if (!node) {
+            continue;
+        }
         if (processed.find(node) == processed.end() && node->getType() == Type::Reorder &&
             node->getChildEdges().size() == 1 && node->getChildEdgeAt(0)->getChild()->getType() == Type::Reorder) {
             auto nextNode = node->getChildEdgeAt(0)->getChild();


### PR DESCRIPTION
### Details:
 - *this kind of segment fault issue during model Compile comes from 'DropDoubleReorders' pass stage, during the process a new reorder node may be inserted, that will led to an UB since the range based for loop is used and the nodes vector is modified at the same time. for this kind of cases, we should switch to index based nodes vector traversal. This approach will avoids iterator invalidation issues, ensuring safe handling of nodes during the optimization process.*


### Tickets:
 - *CVS-170814 CVS-170818 CVS-170815 CVS-170816 CVS-170817*
