### PR TITLE
[GPU] Disable onednn FC dynamic quantization for 4D FC

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -370,7 +370,7 @@ public:
         if (prim->compressed_weights) {
             bool is_dyn_quan_input = impl_params.get_input_layout(0).data_type == data_types::i8 || impl_params.get_input_layout(0).data_type == data_types::u8;
             if (is_dyn_quan_input) {
-                OPENVINO_ASSERT(prim->input_size <= 3, "Dynamic quantization for 4D matmul is not implemented");
+                OPENVINO_ASSERT(prim->input_size <= 3, "[GPU] Dynamic quantization for 4D matmul is not implemented");
             } else {
                 attr->set_fpmath_mode(dnnl::fpmath_mode::f16, true);
             }
@@ -388,7 +388,7 @@ public:
                 auto ngroups = scale_layout.get_dim(1);
                 group_size = ifm / ngroups;
                 OPENVINO_ASSERT((group_size == 1 || ngroups == 1 || group_size % 32 == 0),
-                    "group_size should be aligned to 32 if it is not a single scale group or the group_size is not one.");
+                    "[GPU] group_size should be aligned to 32 if it is not a single scale group or the group_size is not one.");
                 if (scale_layout.count() == 1) {
                     attr->set_scales(DNNL_ARG_WEIGHTS, COMMON, dnnl::memory::dims{}, ds_data_type);
                 } else if (ngroups == 1) {

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp
@@ -369,11 +369,13 @@ public:
         // so use MatMul only for weights compression and IP for all other cases.
         if (prim->compressed_weights) {
             bool is_dyn_quan_input = impl_params.get_input_layout(0).data_type == data_types::i8 || impl_params.get_input_layout(0).data_type == data_types::u8;
-            if (!is_dyn_quan_input)
+            if (is_dyn_quan_input) {
+                OPENVINO_ASSERT(prim->input_size <= 3, "Dynamic quantization for 4D matmul is not implemented");
+            } else {
                 attr->set_fpmath_mode(dnnl::fpmath_mode::f16, true);
+            }
 
             auto weights_layout = impl_params.get_input_layout(1);
-            OPENVINO_ASSERT(prim->input_size <= 3, "not implemented for 4d matmul");
             auto shift_size = std::max<size_t>(prim->input_size - 2, 0);
             int per_oc = PER_OC << shift_size;
             int grouped = GROUPED | (1 << (prim->input_size - 1));

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1226,7 +1226,7 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     }
                 }
 
-                auto input_shape = root->get_input_partial_shape(0);
+                const auto& input_shape = root->get_input_partial_shape(0);
                 const size_t input_rank = input_shape.size();
                 if (input_rank > 3) {
                     GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off: input rank is not supported" << std::endl;

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -1226,6 +1226,13 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
                     }
                 }
 
+                auto input_shape = root->get_input_partial_shape(0);
+                const size_t input_rank = input_shape.size();
+                if (input_rank > 3) {
+                    GPU_DEBUG_TRACE << root->get_friendly_name() << "  dyn_quan is turned off: input rank is not supported" << std::endl;
+                    return true;
+                }
+
                 auto weight_shape = root->get_input_partial_shape(1);
                 const size_t innermost_size = weight_shape[weight_shape.size() - 1].get_length();
                 const size_t simd = 16;


### PR DESCRIPTION
### Details:
 - After this PR(https://github.com/openvinotoolkit/openvino/pull/30979) is applied,  runtime assertion error always occurs for 4D FC with weight compression during onednn FC impl creation
 - Accuracy issue also occurs if dynamic quantization is applied to 4D FC
 - Disable onednn FC dynamic quantization for 4D FC

#### The code and line that caused this issue
- https://github.com/openvinotoolkit/openvino/blob/6cf44c3fc52ca27504341e0e4ad9f5aa97e8c643/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp#L376
- https://github.com/openvinotoolkit/openvino/blob/6cf44c3fc52ca27504341e0e4ad9f5aa97e8c643/src/plugins/intel_gpu/src/graph/impls/onednn/fully_connected_onednn.cpp#L379

#### Reproduction step and snapshot
- ./benchmark_app -m swin_small_patch4_window7_224-int8.xml -d GPU -hint none -niter 1 -nireq 1 -shape input[1,3,224,224]

#### Problematic graph
<img width="1146" height="698" alt="image" src="https://github.com/user-attachments/assets/75721b48-a603-4cab-bb43-78737dbee7a2" />

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 170864
