### PR TITLE
[CPU]Add bf16saturation for powerStatic gamma

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -551,7 +551,7 @@ void Eltwise::init() {
         float max = static_cast<float>(std::numeric_limits<ov::bfloat16>::max());
         auto& gamma = m_attrs.data.gamma;
 
-        if (gamma  < lowest) {
+        if (gamma < lowest) {
             gamma = lowest;
         }
 
@@ -559,7 +559,6 @@ void Eltwise::init() {
             gamma = max;
         }
     }
-
 }
 
 void Eltwise::getSupportedDescriptors() {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -546,6 +546,8 @@ bool Eltwise::isWithBroadcast() {
 }
 
 void Eltwise::init() {
+    // Bf16 saturation handling for gamma parameter when input precision is bf16 to make sure it stays within the valid
+    // range for bfloat16.
     if (m_attrs.data.algo == Algorithm::EltwisePowerStatic && getOriginalInputPrecisionAtPort(0) == ov::element::bf16) {
         const float lowest = static_cast<float>(std::numeric_limits<ov::bfloat16>::lowest());
         const float max = static_cast<float>(std::numeric_limits<ov::bfloat16>::max());

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -547,8 +547,8 @@ bool Eltwise::isWithBroadcast() {
 
 void Eltwise::init() {
     if (m_attrs.data.algo == Algorithm::EltwisePowerStatic && getOriginalInputPrecisionAtPort(0) == ov::element::bf16) {
-        float lowest = static_cast<float>(std::numeric_limits<ov::bfloat16>::lowest());
-        float max = static_cast<float>(std::numeric_limits<ov::bfloat16>::max());
+        const float lowest = static_cast<float>(std::numeric_limits<ov::bfloat16>::lowest());
+        const float max = static_cast<float>(std::numeric_limits<ov::bfloat16>::max());
         auto& gamma = m_attrs.data.gamma;
 
         if (gamma < lowest) {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -19,6 +19,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <vector>
+#include <limits>
 
 #include "config.h"
 #include "cpu_memory.h"
@@ -45,6 +46,7 @@
 #include "openvino/core/node.hpp"
 #include "openvino/core/shape.hpp"
 #include "openvino/core/type.hpp"
+#include "openvino/core/type/bfloat16.hpp"
 #include "openvino/core/type/element_type.hpp"
 #include "openvino/op/abs.hpp"
 #include "openvino/op/add.hpp"
@@ -105,7 +107,6 @@
 #include "transformations/cpu_opset/common/op/leaky_relu.hpp"
 #include "transformations/cpu_opset/common/op/power_static.hpp"
 #include "transformations/cpu_opset/common/op/swish_cpu.hpp"
-#include "utils/bfloat16.hpp"
 #include "utils/general_utils.h"
 #include "utils/ngraph_utils.hpp"
 

--- a/src/plugins/intel_cpu/src/nodes/eltwise.h
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.h
@@ -105,6 +105,7 @@ private:
     static EltwiseBroadcastingPolicy determineBroadcastingPolicy(const std::shared_ptr<ov::Node>& op);
 
     size_t getOpInputsNum() const;
+    void init() override;
 
     void appendMemory(const std::vector<float>& data, MemoryPtr& memPtr, std::vector<MemoryPtr>& postOpsMem);
     static void appendMemory(const std::vector<float>& data,

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/powerstatic_bf16_saturation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/powerstatic_bf16_saturation.cpp
@@ -1,0 +1,91 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "common_test_utils/ov_tensor_utils.hpp"
+#include "internal_properties.hpp"
+#include "openvino/op/add.hpp"
+#include "openvino/op/concat.hpp"
+#include "openvino/op/matmul.hpp"
+#include "openvino/op/multiply.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "utils/fusing_test_utils.hpp"
+
+using namespace CPUTestUtils;
+namespace ov {
+namespace test {
+
+/*  Bf16 saturation handling for the PowerStatic gamma parameter when input precision is bf16
+
+       Param0     Param1
+         |          |
+       matmul0     matmul1
+         \          /
+          \        /
+           concat
+              |
+              |  /const(-3.40282e+38)
+            add /
+              |
+              |
+            result
+*/
+
+class PowerStaticBF16Saturation : virtual public SubgraphBaseTest, public CpuTestWithFusing {
+protected:
+    void SetUp() override {
+        abs_threshold = 0;
+        targetDevice = ov::test::utils::DEVICE_CPU;
+        InputShape input0 = {{-1, -1}, {{1, 1}}};
+        InputShape input1 = {{-1, -1}, {{1, 1}}};
+
+        init_input_shapes({input0, input1});
+        ov::ParameterVector parameters;
+        auto param0 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1});
+        auto param1 = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, ov::PartialShape{-1, -1});
+        parameters.push_back(param0);
+        parameters.push_back(param1);
+
+        const auto constMatmul0 = std::make_shared<ov::op::v0::Constant>(ov::element::f32,
+                                                                         ov::Shape{1, 1},
+                                                                         std::vector<double>({3.40282e+38}));
+        const auto constMatmul1 = std::make_shared<ov::op::v0::Constant>(ov::element::f32,
+                                                                         ov::Shape{1, 1},
+                                                                         std::vector<double>({3.40282e+38}));
+        const auto matMul0 = std::make_shared<ov::op::v0::MatMul>(parameters[0], constMatmul0, false, false);
+        const auto matMul1 = std::make_shared<ov::op::v0::MatMul>(parameters[1], constMatmul1, false, false);
+        const auto concat = std::make_shared<ov::op::v0::Concat>(OutputVector{matMul0, matMul1}, 0);
+
+        const auto constAdd = std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape{}, -3.40282e+38);
+        const auto add = std::make_shared<ov::op::v1::Add>(concat, constAdd);
+
+        function = makeNgraphFunction(ElementType::f32, parameters, add, "PowerStaticBF16Saturation");
+        configuration.insert({ov::hint::inference_precision(ov::element::bf16)});
+        configuration.insert(ov::intel_cpu::snippets_mode(ov::intel_cpu::SnippetsMode::DISABLE));
+    }
+
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override {
+        inputs.clear();
+        const auto& modelInputs = function->inputs();
+        ov::test::utils::InputGenerateData in_data;
+        in_data.start_from = 1;
+        in_data.range = 1;
+        in_data.resolution = 1;
+        auto tensor0 = ov::test::utils::create_and_fill_tensor(modelInputs[0].get_element_type(),
+                                                               targetInputStaticShapes[0],
+                                                               in_data);
+        auto tensor1 = ov::test::utils::create_and_fill_tensor(modelInputs[1].get_element_type(),
+                                                               targetInputStaticShapes[1],
+                                                               in_data);
+
+        inputs.insert({modelInputs[0].get_node_shared_ptr(), tensor0});
+        inputs.insert({modelInputs[1].get_node_shared_ptr(), tensor1});
+    }
+};
+
+TEST_F(PowerStaticBF16Saturation, CompareWithRefs) {
+    run();
+}
+
+}  // namespace test
+}  // namespace ov


### PR DESCRIPTION
### Details:
 - *Add bf16 saturation for powerStatic gamma if input precision is bf16*

### Tickets:
 - *[CVS-165421](https://jira.devtools.intel.com/browse/CVS-165421)*
