### PR TITLE
[GPU] Fix missing input idx in lstmseq primitive desc and weights optimizat

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/rnn.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/rnn.hpp
@@ -61,10 +61,10 @@ struct RNNParams : public primitive_base<PType> {
         activation_params(activation_params),
         offset_order(offset_order),
         direction(direction) {
-        std::vector<std::string> pids{initial_hidden_state.pid, initial_cell_state.pid, W.pid, R.pid, B.pid, seq_lenghts.pid};
-        for (auto pid : pids) {
-            if (!pid.empty()) {
-                primitive_base<PType>::input.push_back(pid);
+        std::vector<input_info> infos{initial_hidden_state, initial_cell_state, W, R, B, seq_lenghts};
+        for (const auto& info : infos) {
+            if (!info.pid.empty()) {
+                primitive_base<PType>::input.push_back(info);
             }
         }
     }

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp
@@ -125,9 +125,9 @@ void post_optimize_weights::optimize_weights(T& node, program& p) {
                 if (node.type() == lstm_seq::type_id()) {
                     program_node& prev_node = node.get_dependency(i);
                     if (i == 5) {
-                        add_lstm_bias_reorder(prev_node.id(), weights_reorder_params, p, prev_node, node);
+                        add_lstm_bias_reorder(prev_node.id() + node.id(), weights_reorder_params, p, prev_node, node);
                     } else {
-                        add_lstm_weights_reorder(prev_node.id(), weights_reorder_params, p, prev_node, node, i);
+                        add_lstm_weights_reorder(prev_node.id() + node.id(), weights_reorder_params, p, prev_node, node, i);
                     }
                     auto& weights_reorder_node = node.get_dependency(i);
                     weights_reorder_node.get_output_layout(false);


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - LSTMSequence primitive desc has missing idx information for inputs. It causes wrong input/output shapes. Fix by adding pid and idx information together during primitive desc construction.
 - LSTMSequence weights/bias optimization doesn't consider . Fix by generating different node name of optimization subgraph per LSTMSequence. There is no performance impact because those optimization subgraphs are being constant folded in propagate constant pass.

#### The code and line that caused this issue (if it is not changed directly)
 -(https://github.com/openvinotoolkit/openvino/blob/13fb8b688a932f633897e5f475738a9436e49381/src/plugins/intel_gpu/include/intel_gpu/primitives/rnn.hpp#L67)
 - https://github.com/openvinotoolkit/openvino/blob/13fb8b688a932f633897e5f475738a9436e49381/src/plugins/intel_gpu/src/graph/graph_optimizer/post_optimize_weights.cpp#L185

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - $ benchmark_app -d GPU.0 -m ~/task/cvs170819/neb_dw_new.xml


#### Problematic graph
 - In IR mode, one LSTMSequence has initial_hidden_state/initial_cell_state inputs from previous LSTMSequence output[1] and output[2]. Current openvino doesn't keep output port index information in primitive desc.
 
<img width="1810" height="307" alt="image" src="https://github.com/user-attachments/assets/e979664a-53d9-4307-9b0e-3012ff8f3497" />

 - Current LSTMSequence weights/bias optimization doesn't consider single constant for multiple LSTMSequence. And multiple connections are created in optimization subgraph
 
<img width="1090" height="788" alt="image" src="https://github.com/user-attachments/assets/3516add6-b22c-4777-ac38-d1662a7ebd03" />


#### Checklist
 - [v] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [v] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - *id*