### PR TITLE
[Snippets] Apply 'bugprone-narrowing-conversions' and 'cppcoreguidelines-narrowing-conversions' clang-tidy remarks

### DIFF
--- a/src/common/snippets/.clang-tidy
+++ b/src/common/snippets/.clang-tidy
@@ -30,14 +30,12 @@
 # -readability-uppercase-literal-suffix. 
 #
 ### Checks that are turned off but better be enabled later:
-# -bugprone-narrowing-conversions
 # -bugprone-easily-swappable-parameters
 # -bugprone-exception-escape. There are a lot of legacy code which does not handle exceptions properly and just catches them all. Major refactoring is required to correct this.
 # -bugprone-implicit-widening-of-multiplication-result
 # -bugprone-incorrect-roundings. There are explicit ways to perform rounding (i.e. std::floor(), std::round(), etc). Requires careful updates case by case
 # -bugprone-signed-char-misuse. The source code contains valid logic when pointer to the data is interpreted as int8_t (i.e. weights tensor)
 # -cppcoreguidelines-avoid-const-or-ref-data-members
-# -cppcoreguidelines-narrowing-conversions
 # -google-default-arguments,
 # -google-explicit-constructor,
 # -google-readability-casting,
@@ -66,7 +64,6 @@ Checks: >
   -bugprone-exception-escape,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-incorrect-roundings,
-  -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
@@ -75,7 +72,6 @@ Checks: >
   -cppcoreguidelines-explicit-virtual-functions,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-misleading-capture-default-by-value,
-  -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
@@ -113,6 +109,10 @@ WarningsAsErrors: '*'
 FormatStyle: file
 HeaderFilterRegex: 'src/common/snippets/.*\.h(pp)?$'
 CheckOptions:
+  - key: bugprone-narrowing-conversions.IgnoreConversionFromTypes
+    value: "size_t;ptrdiff_t;size_type;difference_type;value_type;uint32_t;uint64_t;unsigned long;unsigned int;ov::intel_cpu::Dim"
+  - key: cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes
+    value: "size_t;ptrdiff_t;size_type;difference_type;value_type;uint32_t;uint64_t;unsigned long;unsigned int;ov::intel_cpu::Dim"
   - key: cppcoreguidelines-avoid-do-while.IgnoreMacros
     value: true
   # use = instead of {} for initialization

--- a/src/common/snippets/src/lowered/pass/solve_buffer_memory.cpp
+++ b/src/common/snippets/src/lowered/pass/solve_buffer_memory.cpp
@@ -119,7 +119,7 @@ std::vector<ov::MemorySolver::Box> SolveBufferMemory::init_boxes(const Buffers& 
     for (auto& p : map_boxes) {
         auto& box = p.second;
         // Align with cache line size. The experiments show that it affects performance.
-        box.size = utils::div_up(box.size, byte_alignment);
+        box.size = static_cast<int64_t>(utils::div_up(box.size, byte_alignment));
 
         boxes.push_back(box);
     }


### PR DESCRIPTION
### Details:
 - Fix "bugprone-narrowing-conversions" and "cppcoreguidelines-narrowing-conversions" remarks reported by clang-tidy
 - Enable "bugprone-narrowing-conversions" and "cppcoreguidelines-narrowing-conversions" clang-tidy checks on CI by default

### Tickets:
 - N/A
