### PR TITLE
Reproduce CPU cache

### DIFF
--- a/samples/cpp/benchmark_app/main.cpp
+++ b/samples/cpp/benchmark_app/main.cpp
@@ -13,6 +13,7 @@
 
 // clang-format off
 #include "openvino/openvino.hpp"
+#include "openvino/pass/sdpa_to_paged_attention.hpp"
 #include "openvino/pass/serialize.hpp"
 
 #ifndef IN_OV_COMPONENT
@@ -838,6 +839,7 @@ int main(int argc, char* argv[]) {
             // ----------------- 7. Loading the model to the device
             // --------------------------------------------------------
             next_step();
+            // ov::pass::SDPAToPagedAttention(/*use_block_indices_inputs = */ false, /*use_score_outputs = */ false, /* allow_score_aggregation = */ true, /*allow_cache_rotation = */ false).run_on_model(model);
             auto compile_model_mem_start = get_peak_memory_usage();
             startTime = Time::now();
             compiledModel = core.compile_model(model, device_name, device_config);


### PR DESCRIPTION
Run: `benchmark_app --cache_dir ./ -m ../g/i/Mistral-7B-v0.3-int4/openvino_model.xml -niter 1 -d CPU --data_shape input_ids[1,1],attention_mask[1,1],position_ids[1,1],beam_idx[1]`

Ticket 168337