### PR TITLE
[PyOV] Skip a `pybind11-stubgen` error

### DIFF
--- a/src/bindings/python/scripts/generate_pyapi_stubs.py
+++ b/src/bindings/python/scripts/generate_pyapi_stubs.py
@@ -24,6 +24,7 @@ UNRESOLVED_NAMES = [
     "RemoteTensorWrapper",                    # In openvino._pyopenvino.Tensor.copy_* : Can't find/import 'RemoteTensorWrapper'
     "capsule",                                # In openvino._pyopenvino.VAContext.__init__ : Can't find/import 'capsule'
     "VASurfaceTensorWrapper",                 # In openvino._pyopenvino.VAContext.create_tensor : Can't find/import 'VASurfaceTensorWrapper'
+    "typing_extensions.CapsuleType",          # In openvino._pyopenvino.VAContext.__init__ : Can't find/import 'typing_extensions.CapsuleType'
     "_abc._abc_data",                         # In openvino.utils.data_helpers.wrappers.OVDict : Can't find/import '_abc._abc_data'
     "openvino._ov_api.undefined_deprecated",  # In openvino._ov_api : Can't find/import 'openvino._ov_api.undefined_deprecated'
     "InputCutInfo",                           # In openvino.tools.ovc.cli_parser : Can't find/import 'InputCutInfo'


### PR DESCRIPTION
### Details:
 - `pybind11-stubgen` currently fails due to this error
 - it's most likely related to `pybind` version bump
 - tickets for fixing these errors already exist, no need to create a new one

```bash
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.VAContext.__init__ : Can't find/import 'typing_extensions.CapsuleType'
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.util.numpy_to_c : Can't find/import 'typing_extensions.CapsuleType'
pybind11_stubgen - [   INFO] Terminating due to previous errors
Error: pybind11-stubgen failed with error: Command '['python', '-m', 'pybind11_stubgen', '--output-dir', '/home/runner/work/openvino/openvino/src/bindings/python/src', '--root-suffix', '', '--ignore-invalid-expressions', "ov::Node|ov::Input<ov::Node>|ov::descriptor::Tensor|ov::Output<ov::Node\\ const>|ov::float16|ov::EncryptionCallbacks|ov::streams::Num|ov::pass::pattern::PatternSymbolValue|<Dimension:|<RTMap>|<Type:\\ 'dynamic'>", '--ignore-invalid-identifiers', '<locals>', '--ignore-unresolved-names', 'InferRequestWrapper|RemoteTensorWrapper|capsule|VASurfaceTensorWrapper|_abc\\._abc_data|openvino\\._ov_api\\.undefined_deprecated|InputCutInfo|ParamData', '--numpy-array-use-type-var', '--exit-code', 'openvino']' returned non-zero exit status 1.
```

### Tickets:
 - N/A
