### PR TITLE
Added weightless cache attributes for intel GPU plugin.

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -291,7 +291,7 @@ public:
 
     void save(cldnn::BinaryOutputBuffer& ob) const;
     void load(cldnn::BinaryInputBuffer& ib, std::shared_ptr<const ov::Model> model_ptr = nullptr,
-              std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheAttr> cache_attr = nullptr);
+              std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheMap> cache_attr_map = nullptr);
     
     bool is_loaded_from_cache() const { return _loaded_from_cache; }
 

--- a/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/graph/program.hpp
@@ -11,6 +11,7 @@
 #include "intel_gpu/runtime/lru_cache.hpp"
 #include "intel_gpu/runtime/execution_config.hpp"
 #include "intel_gpu/graph/kernel_impl_params.hpp"
+#include "intel_gpu/runtime/internal_properties.hpp"
 
 #include <list>
 #include <string>
@@ -289,7 +290,9 @@ public:
     static std::shared_ptr<ICompilationContext> make_compilation_context(const ExecutionConfig& config);
 
     void save(cldnn::BinaryOutputBuffer& ob) const;
-    void load(cldnn::BinaryInputBuffer& ib, std::shared_ptr<const ov::Model> model_ptr = nullptr);
+    void load(cldnn::BinaryInputBuffer& ib, std::shared_ptr<const ov::Model> model_ptr = nullptr,
+              std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheAttr> cache_attr = nullptr);
+    
     bool is_loaded_from_cache() const { return _loaded_from_cache; }
 
     bool is_new_shape_infer() const { return new_shape_infer; }

--- a/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/plugin/plugin.hpp
@@ -30,6 +30,9 @@ private:
                                                          const std::shared_ptr<RemoteContextImpl>& context) const;
     void transform_model(std::shared_ptr<ov::Model>& model, const ExecutionConfig& config, const std::shared_ptr<RemoteContextImpl>& context) const;
     void register_primitives() const;
+    bool is_weightless_cache_attributes_set(const std::shared_ptr<const ov::Model>& model) const;
+    void set_weightless_cache_attributes(const std::shared_ptr<const ov::Model>& model) const;
+    void create_weightless_cache_attributes(const std::shared_ptr<const ov::Model>& model, ExecutionConfig& config) const;
     std::string get_device_id_from_config(const ov::AnyMap& config) const;
     std::string get_device_id(const ov::AnyMap& config) const;
     std::shared_ptr<RemoteContextImpl> get_default_context(const std::string& device_id, bool initialize = true) const;

--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/data.hpp
@@ -53,13 +53,9 @@ namespace cldnn {
 
 class WeightsMemory {
 public:
-    WeightsMemory(std::shared_ptr<const ov::Model> model) : weights_memory(model) {
-        fill_offset_to_constant_map(model);
-    }
-
     WeightsMemory(std::shared_ptr<const ov::Model> model, 
-                  std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheAttr> cache_attr) : weights_memory(model) {
-        fill_offset_to_constant_map(model, cache_attr);
+                  std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheMap> cache_attr_map = nullptr) : weights_memory(model) {
+        fill_offset_to_constant_map(model, cache_attr_map);
     }
 
     WeightsMemory(std::shared_ptr<ov::MappedMemory> mapped_memory) : weights_memory(mapped_memory) {}
@@ -83,40 +79,35 @@ public:
     }
 
 private:
-    void fill_offset_to_constant_map(std::shared_ptr<const ov::Model> model) {
-        const auto& ops = model->get_ops();
-        for (const auto& node : ops) {
-            if (ov::op::util::is_constant(node)) {
-                auto rt_info = node->get_rt_info();
-                auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
-                if (weightless_cache_attr != rt_info.end()) {
-                    auto& attr = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>();
-                    auto const_ptr = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
-                    offset_to_constant_map.emplace(attr.bin_offset, const_ptr);
-                }
-            } else if (auto ti = ov::as_type<const ov::op::v0::TensorIterator>(node.get())) {
-                auto ti_body = ti->get_body();
-                fill_offset_to_constant_map(ti_body);
-            }
-        }
-    }
-
     void fill_offset_to_constant_map(std::shared_ptr<const ov::Model> model, 
-                                     std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheAttr> cache_attr) {
+                                     std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheMap> cache_attr_map = nullptr) {
         const auto& ops = model->get_ops();
         
-        for (const auto& node : ops) {
-            if (ov::op::util::is_constant(node)) {
-                auto it = cache_attr->find(node->get_instance_id());
-                
-                if (it != cache_attr->end()) {
-                    auto attr = it->second;
-                    auto const_ptr = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
-                    offset_to_constant_map.emplace(attr.bin_offset, const_ptr);
+        if (cache_attr_map != nullptr && cache_attr_map->size() > 0) {
+            for (const auto& node : ops) {
+                if (ov::op::util::is_constant(node)) {
+                    auto it = cache_attr_map->find(node->get_instance_id());
+                    if (it != cache_attr_map->end()) {
+                        auto attr = it->second;
+                        auto const_ptr = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+                        offset_to_constant_map.emplace(attr.bin_offset, const_ptr);
+                    }
                 }
-            } else if (auto ti = ov::as_type<const ov::op::v0::TensorIterator>(node.get())) {
-                auto ti_body = ti->get_body();
-                fill_offset_to_constant_map(ti_body);
+            }
+        } else {
+            for (const auto& node : ops) {
+                if (ov::op::util::is_constant(node)) {
+                    auto rt_info = node->get_rt_info();
+                    auto weightless_cache_attr = rt_info.find(ov::WeightlessCacheAttribute::get_type_info_static());
+                    if (weightless_cache_attr != rt_info.end()) {
+                        auto& attr = weightless_cache_attr->second.as<ov::WeightlessCacheAttribute>();
+                        auto const_ptr = std::dynamic_pointer_cast<ov::op::v0::Constant>(node);
+                        offset_to_constant_map.emplace(attr.bin_offset, const_ptr);
+                    }
+                } else if (auto ti = ov::as_type<const ov::op::v0::TensorIterator>(node.get())) {
+                    auto ti_body = ti->get_body();
+                    fill_offset_to_constant_map(ti_body);
+                }
             }
         }
     }

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -115,8 +115,8 @@ inline std::istream& operator>>(std::istream& is, DumpTensors& val) {
     return is;
 }
 
-using GpuWeightlessCacheAttr = std::map<size_t, ov::WeightlessCacheAttribute>;
-static constexpr Property<std::shared_ptr<GpuWeightlessCacheAttr>, PropertyMutability::RW> weightless_attr{"GPU_WEIGHTLESS_ATTR"};
+using GpuWeightlessCacheMap = std::unordered_map<size_t, ov::WeightlessCacheAttribute>;
+static constexpr Property<std::shared_ptr<GpuWeightlessCacheMap>, PropertyMutability::RW> weightless_attr{"GPU_WEIGHTLESS_ATTR"};
 
 /**
  * @brief Defines queue type that must be used for model execution

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/internal_properties.hpp
@@ -9,6 +9,8 @@
 #include "openvino/runtime/intel_gpu/properties.hpp"
 
 #include "intel_gpu/primitives/implementation_desc.hpp"
+#include "openvino/core/rt_info/weightless_caching_attributes.hpp"
+
 namespace ov::intel_gpu {
 
 /**
@@ -112,6 +114,9 @@ inline std::istream& operator>>(std::istream& is, DumpTensors& val) {
     }
     return is;
 }
+
+using GpuWeightlessCacheAttr = std::map<size_t, ov::WeightlessCacheAttribute>;
+static constexpr Property<std::shared_ptr<GpuWeightlessCacheAttr>, PropertyMutability::RW> weightless_attr{"GPU_WEIGHTLESS_ATTR"};
 
 /**
  * @brief Defines queue type that must be used for model execution

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -54,7 +54,7 @@ OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, impls_cache_capacity, 300, "Con
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, asym_dynamic_quantization, false, "Enforce asymmetric mode for dynamically quantized activations")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, could_use_flashattn_v2, true, "Enable/Disable SDPA primitive executing with FlashAttenV2 online softmax tricks.")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, dynamic_quantization_threshold, 64, "Apply dynamic quantization only when batch size is larger than this value in OneDNN")
-OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, weightless_attr, nullptr, "Send weightless cache attributes to cldnn::program")
+OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, weightless_attr, nullptr, "Used to configure ov::WeightlessCacheAttribute for constants that are not loaded from a .bin file. This typically applies to non-IR inputs (e.g., ORT)")
 
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, help, false, "Print help message for all config options")
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, verbose, 0, "Enable logging for debugging purposes. The higher value the more verbose output. 0 - Disabled, 4 - Maximum verbosity")

--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -54,6 +54,7 @@ OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, impls_cache_capacity, 300, "Con
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, asym_dynamic_quantization, false, "Enforce asymmetric mode for dynamically quantized activations")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, could_use_flashattn_v2, true, "Enable/Disable SDPA primitive executing with FlashAttenV2 online softmax tricks.")
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, dynamic_quantization_threshold, 64, "Apply dynamic quantization only when batch size is larger than this value in OneDNN")
+OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, weightless_attr, nullptr, "Send weightless cache attributes to cldnn::program")
 
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, help, false, "Print help message for all config options")
 OV_CONFIG_DEBUG_GLOBAL_OPTION(ov::intel_gpu, verbose, 0, "Enable logging for debugging purposes. The higher value the more verbose output. 0 - Disabled, 4 - Maximum verbosity")

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1862,15 +1862,15 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
 
 void program::load(cldnn::BinaryInputBuffer& ib,
                    std::shared_ptr<const ov::Model> model_ptr,
-                   std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheAttr> cache_attr) {
+                   std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheMap> cache_attr_map) {
     init_program();
 
     std::shared_ptr<WeightsMemory> weights_memory = nullptr;
     std::string weights_path = _config.get_weights_path();
     if (_config.get_cache_mode() == ov::CacheMode::OPTIMIZE_SIZE) {
         if (model_ptr) {
-            if (cache_attr) {
-                weights_memory = std::make_shared<WeightsMemory>(model_ptr, cache_attr);
+            if (cache_attr_map) {
+                weights_memory = std::make_shared<WeightsMemory>(model_ptr, cache_attr_map);
             } else {
                 weights_memory = std::make_shared<WeightsMemory>(model_ptr);
             }

--- a/src/plugins/intel_gpu/src/graph/program.cpp
+++ b/src/plugins/intel_gpu/src/graph/program.cpp
@@ -1860,14 +1860,20 @@ void program::save(cldnn::BinaryOutputBuffer& ob) const {
     }
 }
 
-void program::load(cldnn::BinaryInputBuffer& ib, std::shared_ptr<const ov::Model> model_ptr) {
+void program::load(cldnn::BinaryInputBuffer& ib,
+                   std::shared_ptr<const ov::Model> model_ptr,
+                   std::shared_ptr<ov::intel_gpu::GpuWeightlessCacheAttr> cache_attr) {
     init_program();
 
     std::shared_ptr<WeightsMemory> weights_memory = nullptr;
     std::string weights_path = _config.get_weights_path();
     if (_config.get_cache_mode() == ov::CacheMode::OPTIMIZE_SIZE) {
         if (model_ptr) {
-            weights_memory = std::make_shared<WeightsMemory>(model_ptr);
+            if (cache_attr) {
+                weights_memory = std::make_shared<WeightsMemory>(model_ptr, cache_attr);
+            } else {
+                weights_memory = std::make_shared<WeightsMemory>(model_ptr);
+            }
         } else if (!weights_path.empty()) {
             ov::util::validate_weights_path(weights_path);
             weights_memory = std::make_shared<WeightsMemory>(ov::load_mmap_object(weights_path));

--- a/src/plugins/intel_gpu/src/plugin/graph.cpp
+++ b/src/plugins/intel_gpu/src/plugin/graph.cpp
@@ -97,7 +97,7 @@ Graph::Graph(cldnn::BinaryInputBuffer &ib, const RemoteContextImpl::Ptr& context
 
     auto imported_prog = std::make_shared<cldnn::program>(get_engine(), m_config);
     // Not passing MODEL_PTR through m_config because values in m_config are immutable after config finalization.
-    imported_prog->load(ib, config.get_model());
+    imported_prog->load(ib, config.get_model(), config.get_weightless_attr());
     build(imported_prog);
 }
 

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -120,16 +120,16 @@ void Plugin::set_weightless_cache_attributes(const std::shared_ptr<const ov::Mod
 void Plugin::create_weightless_cache_attributes(const std::shared_ptr<const ov::Model>& model, ExecutionConfig& config) const {
     uint32_t offset = 0;
     
-    std::shared_ptr<GpuWeightlessCacheAttr>cache_attributes = std::make_shared<GpuWeightlessCacheAttr>();
+    std::shared_ptr<GpuWeightlessCacheMap>cache_attr_map = std::make_shared<GpuWeightlessCacheMap>();
 
     for (const auto& node : model->get_ordered_ops()) {
         if (ov::op::util::is_constant(node)) {            
             // Offset behaves as a unique key for each constant. Size = 1 is used as dummy.
-            cache_attributes->emplace(node->get_instance_id(), ov::WeightlessCacheAttribute(1, offset++, node->get_element_type()));
+            cache_attr_map->emplace(node->get_instance_id(), ov::WeightlessCacheAttribute(1, offset++, node->get_element_type()));
         }
     }
 
-    config.set_property(ov::intel_gpu::weightless_attr(cache_attributes));
+    config.set_property(ov::intel_gpu::weightless_attr(cache_attr_map));
 }
 
 void Plugin::transform_model(std::shared_ptr<ov::Model>& model, const ExecutionConfig& config, const std::shared_ptr<RemoteContextImpl>& context) const {

--- a/src/plugins/intel_gpu/src/plugin/plugin.cpp
+++ b/src/plugins/intel_gpu/src/plugin/plugin.cpp
@@ -42,6 +42,8 @@
 #include "transformations/init_node_info.hpp"
 #include "transformations/rt_info/fused_names_attribute.hpp"
 #include "transformations/utils/utils.hpp"
+#include "openvino/op/util/op_types.hpp"
+
 
 // Undef DEVICE_TYPE macro which can be defined somewhere in windows headers as DWORD and conflict with our metric
 #ifdef DEVICE_TYPE
@@ -85,6 +87,51 @@ std::string Plugin::get_device_id(const ov::AnyMap& config) const {
     return id;
 }
 
+bool Plugin::is_weightless_cache_attributes_set(const std::shared_ptr<const ov::Model>& model) const {
+    const auto& type_info = ov::WeightlessCacheAttribute::get_type_info_static();
+    
+    for (const auto& node : model->get_ordered_ops()) {        
+        if (ov::op::util::is_constant(node)) {
+            auto& rtInfo = node->get_rt_info();
+            const auto& it = rtInfo.find(type_info);
+
+            if (it != rtInfo.end())
+                return true;
+        }
+    }
+
+    return false;
+}
+
+void Plugin::set_weightless_cache_attributes(const std::shared_ptr<const ov::Model>& model) const {
+    uint32_t offset = 0;
+    const auto& type_info = ov::WeightlessCacheAttribute::get_type_info_static();
+    
+    for (const auto& node : model->get_ordered_ops()) {
+        if (ov::op::util::is_constant(node)) {
+            auto& rtInfo = node->get_rt_info();    
+
+            // Offset behaves as a unique key for each constant. Size = 1 is used as dummy.
+            rtInfo[type_info] = ov::WeightlessCacheAttribute(1, offset++, node->get_element_type());
+        }
+    }
+}
+
+void Plugin::create_weightless_cache_attributes(const std::shared_ptr<const ov::Model>& model, ExecutionConfig& config) const {
+    uint32_t offset = 0;
+    
+    std::shared_ptr<GpuWeightlessCacheAttr>cache_attributes = std::make_shared<GpuWeightlessCacheAttr>();
+
+    for (const auto& node : model->get_ordered_ops()) {
+        if (ov::op::util::is_constant(node)) {            
+            // Offset behaves as a unique key for each constant. Size = 1 is used as dummy.
+            cache_attributes->emplace(node->get_instance_id(), ov::WeightlessCacheAttribute(1, offset++, node->get_element_type()));
+        }
+    }
+
+    config.set_property(ov::intel_gpu::weightless_attr(cache_attributes));
+}
+
 void Plugin::transform_model(std::shared_ptr<ov::Model>& model, const ExecutionConfig& config, const std::shared_ptr<RemoteContextImpl>& context) const {
     OV_ITT_SCOPED_TASK(itt::domains::intel_gpu_plugin, "Plugin::transform_model");
     TransformationsPipeline transformations(config, context);
@@ -119,6 +166,17 @@ std::shared_ptr<ov::Model> Plugin::clone_and_transform_model(const std::shared_p
     GPU_DEBUG_IF(!dump_path.empty()) {
         auto path_base = dump_path + "/" + cloned_model->get_name();
         ov::pass::VisualizeTree(path_base + ".svg").run_on_model(cloned_model);
+    }
+
+    ov::CacheMode cache_mode = config.get_cache_mode();
+
+    // Set weighless cache attribute only for non IR (e.g. onnxruntime) models
+    // This is a temporary solution. A common way of handling weightless caching will be defined later.
+    if (cache_mode == ov::CacheMode::OPTIMIZE_SIZE) {
+        const std::string& weights_path = config.get_weights_path();
+
+        if (!ov::util::validate_weights_path(weights_path) && !is_weightless_cache_attributes_set(cloned_model))
+            set_weightless_cache_attributes(cloned_model);
     }
 
     transform_model(cloned_model, config_copy, context);
@@ -357,10 +415,24 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model,
         return nullptr;
     }
 
-    std::string weights_path = config.get_weights_path();
     if (config.get_cache_mode() == ov::CacheMode::OPTIMIZE_SIZE) {
-        if (!ov::util::validate_weights_path(weights_path) && config.get_model() == nullptr) {
-            return nullptr;
+        const std::string& weights_path = config.get_weights_path();
+
+        if (!ov::util::validate_weights_path(weights_path)) {
+            // This is non IR case, e.g. onnxruntime.
+            // This may not be required. Constant nodes should have the information already.
+            // This is a temporary solution. A more robust solution will be implemented in future. 
+            
+            // If some app modifies ov::Model before compile_model(), and 
+            // the constants are changed, and such modification is not done before import_model(), 
+            // weightless caching will not produce correct result.
+            if (auto& orig_model = config.get_model(); orig_model != nullptr) {
+                if (!is_weightless_cache_attributes_set(orig_model)) {
+                    create_weightless_cache_attributes(orig_model, config);
+                }
+            } else {
+                return nullptr;
+            }
         }
     }
 


### PR DESCRIPTION
Weightless cache attributes are added when the weights are not coming from bin file. That happens for non-IR inputs like ORT.

https://jira.devtools.intel.com/browse/CVS-167691