### PR TITLE
Temporarily skip failing TestEdsrConvertModel test case in precommit

### DIFF
--- a/tests/model_hub_tests/pytorch/test_edsr.py
+++ b/tests/model_hub_tests/pytorch/test_edsr.py
@@ -57,6 +57,7 @@ class TestEdsrConvertModel(TestTorchConvertModel):
             cleanup_dir(hf_cache_dir)
         super().teardown_method()
 
+    @pytest.mark.skip(reason="CVS-171175")
     @pytest.mark.parametrize("name", ["edsr"])
     @pytest.mark.precommit
     def test_convert_model_precommit(self, name, ie_device):


### PR DESCRIPTION
### Details:
The whole repository from where the input image for this test case was taken was deleted (emptied): https://github.com/paperswithcode/paperswithcode
https://github.com/paperswithcode/paperswithcode/issues/3

### Tickets:
 - CVS-171175
