### PR TITLE
[LPT] TransparentBaseTransformation: canBeTransformed extension

### DIFF
--- a/src/common/low_precision_transformations/src/broadcast.cpp
+++ b/src/common/low_precision_transformations/src/broadcast.cpp
@@ -33,7 +33,7 @@ BroadcastTransformation::BroadcastTransformation(const Params& params) : Transpa
 }
 
 bool BroadcastTransformation::canBeTransformed(const std::shared_ptr<ov::Node>& layer) const {
-    if (!LayerTransformation::canBeTransformed(layer)) {
+    if (!TransparentBaseTransformation::canBeTransformed(layer)) {
         return false;
     }
 

--- a/src/common/low_precision_transformations/src/depth_to_space.cpp
+++ b/src/common/low_precision_transformations/src/depth_to_space.cpp
@@ -29,7 +29,7 @@ DepthToSpaceTransformation::DepthToSpaceTransformation(const Params& params) : T
 }
 
 bool DepthToSpaceTransformation::canBeTransformed(const std::shared_ptr<ov::Node>& layer) const {
-    if (!LayerTransformation::canBeTransformed(layer)) {
+    if (!TransparentBaseTransformation::canBeTransformed(layer)) {
         return false;
     }
 

--- a/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/broadcast.hpp
+++ b/src/tests/ov_helpers/ov_lpt_models/include/ov_lpt_models/broadcast.hpp
@@ -19,7 +19,7 @@ public:
         const ov::PartialShape& inputShape,
         const ov::element::Type precisionBeforeDequantization,
         const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
-        const Shape& tagetShape,
+        const Shape& targetShape,
         const Shape& axesMapping,
         const ov::builder::subgraph::DequantizationOperations& dequantizationAfter);
 };

--- a/src/tests/ov_helpers/ov_lpt_models/src/broadcast.cpp
+++ b/src/tests/ov_helpers/ov_lpt_models/src/broadcast.cpp
@@ -18,16 +18,16 @@ namespace subgraph {
 namespace {
 template <typename T>
 std::shared_ptr<ov::Node> make_broadcast(const std::shared_ptr<ov::Node>& parent,
-                                         const Shape& tagetShape,
+                                         const Shape& targetShape,
                                          const Shape& axesMapping) {
     if (axesMapping.empty()) {
         return std::make_shared<T>(
             parent,
-            std::make_shared<ov::opset1::Constant>(ov::element::i32, Shape{tagetShape.size()}, tagetShape));
+            std::make_shared<ov::opset1::Constant>(ov::element::i32, Shape{targetShape.size()}, targetShape));
     }
     return std::make_shared<T>(
         parent,
-        std::make_shared<ov::opset1::Constant>(ov::element::i32, Shape{tagetShape.size()}, tagetShape),
+        std::make_shared<ov::opset1::Constant>(ov::element::i32, Shape{targetShape.size()}, targetShape),
         std::make_shared<ov::opset1::Constant>(ov::element::i32, Shape{axesMapping.size()}, axesMapping));
 }
 } // namespace
@@ -37,32 +37,20 @@ std::shared_ptr<ov::Model> BroadcastFunction::get(
     const ov::PartialShape& inputShape,
     const ov::element::Type precisionBeforeDequantization,
     const ov::builder::subgraph::DequantizationOperations& dequantizationBefore,
-    const Shape& tagetShape,
+    const Shape& targetShape,
     const Shape& axesMapping,
     const ov::builder::subgraph::DequantizationOperations& dequantizationAfter) {
     const auto input = std::make_shared<ov::opset1::Parameter>(precisionBeforeDequantization, inputShape);
-    std::shared_ptr<ov::Node> parent = input;
+    const auto dq_before = makeDequantization(input, dequantizationBefore);
 
-    if (!dequantizationBefore.empty()) {
-        parent = makeDequantization(parent, dequantizationBefore);
-    }
+    const auto bcast = v1 ? make_broadcast<ov::opset1::Broadcast>(dq_before, targetShape, axesMapping)
+                          : make_broadcast<ov::opset3::Broadcast>(dq_before, targetShape, axesMapping);
+    bcast->set_friendly_name("broadcast");
 
-    parent = v1 ?
-        make_broadcast<ov::opset1::Broadcast>(parent, tagetShape, axesMapping) :
-        make_broadcast<ov::opset3::Broadcast>(parent, tagetShape, axesMapping);
-    parent->set_friendly_name("broadcast");
-
-    if (!dequantizationAfter.empty()) {
-        parent = makeDequantization(parent, dequantizationAfter);
-    }
-
-    const std::shared_ptr<ov::opset1::Result> result = std::make_shared<ov::opset1::Result>(parent);
-
-    const std::shared_ptr<ov::Model> function = std::make_shared<ov::Model>(
-        ov::ResultVector{ result },
-        std::vector<std::shared_ptr<ov::op::v0::Parameter>> { input },
-        "BroadcastTransformation");
-    return function;
+    const auto dq_after = makeDequantization(bcast, dequantizationAfter);
+    const auto model =
+        std::make_shared<ov::Model>(ov::OutputVector{dq_after}, ov::ParameterVector{input}, "BroadcastTransformation");
+    return model;
 }
 
 }  // namespace subgraph


### PR DESCRIPTION
### Details:
`TransparentBaseTransformation::canBeTransformed` is updated to avoid dequantization ops propagation if:
1. DQ are placed on constant path
2. DQ don't change precision

### Tickets:
 - *CVS-170603*
