### PR TITLE
[Performance] Solve high memory usage issue  during  model compilation using OpenVINO backend on Keras 3

### DIFF
--- a/src/common/transformations/include/transformations/op_conversions/einsum_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/einsum_decomposition.hpp
@@ -25,8 +25,8 @@ class TRANSFORMATIONS_API EinsumDecomposition;
 class ov::pass::EinsumDecomposition : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("EinsumDecomposition");
-    EinsumDecomposition(bool check_const=false);
+    EinsumDecomposition(bool check_const = false);
 
 private:
-    bool m_check_const; // store the flag
+    bool m_check_const;  // store the flag
 };

--- a/src/common/transformations/include/transformations/op_conversions/einsum_decomposition.hpp
+++ b/src/common/transformations/include/transformations/op_conversions/einsum_decomposition.hpp
@@ -25,5 +25,8 @@ class TRANSFORMATIONS_API EinsumDecomposition;
 class ov::pass::EinsumDecomposition : public ov::pass::MatcherPass {
 public:
     OPENVINO_MATCHER_PASS_RTTI("EinsumDecomposition");
-    EinsumDecomposition();
+    EinsumDecomposition(bool check_const=false);
+
+private:
+    bool m_check_const; // store the flag
 };

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -165,11 +165,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     REGISTER_PASS(manager, ConstantFolding)
     REGISTER_PASS(manager, Validate)
     // the order is important
-    const char* enable_einsum = std::getenv("OV_ENABLE_EINSUM_DECOMPOSITION");
-    if (enable_einsum) {
-        REGISTER_PASS(manager, EinsumDecomposition)
-    }
-
+    REGISTER_PASS(manager, EinsumDecomposition, true)
     // FusedFilteringBoxesBySize transformation has the complex pattern
     // which can be affected by further transformations. So we have to
     // execute it at the beginning of the pipeline. Also, this pass resolves

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -164,7 +164,11 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     REGISTER_PASS(manager, PushConstantToSubgraph)
     REGISTER_PASS(manager, ConstantFolding)
     REGISTER_PASS(manager, Validate)
-    REGISTER_PASS(manager, EinsumDecomposition)
+    // the order is important
+    const char* enable_einsum = std::getenv("OV__ENABLE_EINSUM_DECOMPOSITION");
+    if (enable_einsum) {
+        REGISTER_PASS(manager, EinsumDecomposition)
+    }
 
     // FusedFilteringBoxesBySize transformation has the complex pattern
     // which can be affected by further transformations. So we have to

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -164,8 +164,14 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     REGISTER_PASS(manager, PushConstantToSubgraph)
     REGISTER_PASS(manager, ConstantFolding)
     REGISTER_PASS(manager, Validate)
-    // the order is important
+
+    // EinsumDecomposition should be called after ConstantFolding
+    // for better performance and memory usage.
+    // ConstantFolding creates constant inputs to Einsum operations,
+    // which EinsumDecomposition can then decompose more efficiently with
+    // reduced memory consumption.
     REGISTER_PASS(manager, EinsumDecomposition, true)
+
     // FusedFilteringBoxesBySize transformation has the complex pattern
     // which can be affected by further transformations. So we have to
     // execute it at the beginning of the pipeline. Also, this pass resolves

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -165,7 +165,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     REGISTER_PASS(manager, ConstantFolding)
     REGISTER_PASS(manager, Validate)
     // the order is important
-    const char* enable_einsum = std::getenv("OV__ENABLE_EINSUM_DECOMPOSITION");
+    const char* enable_einsum = std::getenv("OV_ENABLE_EINSUM_DECOMPOSITION");
     if (enable_einsum) {
         REGISTER_PASS(manager, EinsumDecomposition)
     }

--- a/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
+++ b/src/common/transformations/src/transformations/common_optimizations/moc_transformations.cpp
@@ -90,6 +90,7 @@
 #include "transformations/op_conversions/convert_scatter_elements_to_scatter.hpp"
 #include "transformations/op_conversions/convert_subtract.hpp"
 #include "transformations/op_conversions/convert_ti_to_sequences.hpp"
+#include "transformations/op_conversions/einsum_decomposition.hpp"
 #include "transformations/resolve_names_collisions.hpp"
 #include "transformations/smart_reshape/lstm_states_broadcast.hpp"
 #include "transformations/smart_reshape/matmul_sr.hpp"
@@ -163,6 +164,7 @@ bool ov::pass::MOCTransformations::run_on_model(const std::shared_ptr<ov::Model>
     REGISTER_PASS(manager, PushConstantToSubgraph)
     REGISTER_PASS(manager, ConstantFolding)
     REGISTER_PASS(manager, Validate)
+    REGISTER_PASS(manager, EinsumDecomposition)
 
     // FusedFilteringBoxesBySize transformation has the complex pattern
     // which can be affected by further transformations. So we have to

--- a/src/common/transformations/src/transformations/op_conversions/einsum_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/einsum_decomposition.cpp
@@ -1291,8 +1291,7 @@ void fix_inputs_with_0d_ellipsis(ov::OutputVector& input_nodes,
 /// 8. Transpose dimensions to match the layout required by the output subscript.
 /// 9. Replace the original Einsum node with the last node from the decomposed sub-graph,
 ///    preserving the original node's name and runtime information.
-ov::pass::EinsumDecomposition::EinsumDecomposition(bool check_const)
-    : m_check_const(check_const) {
+ov::pass::EinsumDecomposition::EinsumDecomposition(bool check_const) : m_check_const(check_const) {
     MATCHER_SCOPE(EinsumDecomposition);
     auto einsum = ov::pass::pattern::wrap_type<ov::op::v7::Einsum>();
     matcher_pass_callback callback = [=](ov::pass::pattern::Matcher& m) {
@@ -1309,9 +1308,9 @@ ov::pass::EinsumDecomposition::EinsumDecomposition(bool check_const)
                 if (constant_ptr) {
                     has_const = true;
                     break;
-                } 
+                }
             }
-            if (!has_const) 
+            if (!has_const)
                 return false;
         }
 


### PR DESCRIPTION
@rkazants 
@itikhono 

Solving Issue #31390, and back to #30934
Adding `EinsumDecomposition` to `MOC transformations` helped reduce memory usage during model compilation.
Running this script using memory profiling form https://github.com/openvinotoolkit/openvino/pull/31516:
Use keras source https://github.com/keras-team/keras.git
Also use this PR from keras_hub: https://github.com/keras-team/keras-hub/pull/2350
Then run the following script.
Then Enable `os.environ["OV_ENABLE_MEMORY_PROFILING"] = "1"` by uncommentinng it.
```python
import os
backend = "openvino"
os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
os.environ["KERAS_BACKEND"] = backend
# os.environ["OV_ENABLE_MEMORY_PROFILING"] = "1"
os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"

import warnings
warnings.filterwarnings("ignore")

import gc
import time
import psutil
import threading

try:
    from tabulate import tabulate
    TABULATE_AVAILABLE = True
except ImportError:
    TABULATE_AVAILABLE = False
    print("⚠️  tabulate not available. Install with: pip install tabulate")


def record_stage(stage_name, description=""):
    """Record stage with current memory consumption"""
    gc.collect()
    process = psutil.Process(os.getpid())
    mem_info = process.memory_full_info()
    current_memory = mem_info.rss / (1024 ** 2)
    swap_memory = mem_info.swap / (1024 ** 2)
    print(f"[STAGE] {stage_name}: {current_memory:.2f} MB (swap: {swap_memory:.2f} MB) - {description}")
    return current_memory, swap_memory


def main():
    """Main test function"""

    print("=" * 80)
    print(f"FIXED MEMORY TEST: KERAS GPT2 + {backend.upper()}")
    print("=" * 80)

    # Now import keras and keras_hub
    import keras
    import keras_hub

    # Global variables for memory monitoring
    process = psutil.Process(os.getpid())
    peak_memory = [0]
    peak_swap = [0]
    done = [False]

    def monitor_memory():
        """Continuous memory monitoring"""
        while not done[0]:
            mem_info = process.memory_full_info()
            mem_now = mem_info.rss / (1024 ** 2)
            swap_now = mem_info.swap / (1024 ** 2)
            if mem_now > peak_memory[0]:
                peak_memory[0] = mem_now
            if swap_now > peak_swap[0]:
                peak_swap[0] = swap_now
            time.sleep(0.02)

    # Stage 0: Initial state
    mem_initial, swap_initial = record_stage("0_INITIAL", "Initial state after imports")
    peak_memory[0] = mem_initial
    peak_swap[0] = swap_initial

    # Start monitoring
    monitor_thread = threading.Thread(target=monitor_memory, daemon=True)
    monitor_thread.start()

    # Stage 1: Model loading
    print("\n>>> Loading GPT2 model from preset...")
    start_load = time.perf_counter()

    try:
        causal_lm = keras_hub.models.GPT2CausalLM.from_preset("gpt2_medium_en", dtype="float32")
        model_name = "gpt2_medium_en"

        end_load = time.perf_counter()
        mem_after_load, swap_after_load = record_stage("1_MODEL_LOADED", 
                                    f"{model_name} model loaded ({end_load-start_load:.1f}s)")
    except Exception as e:
        print(f"❌ Model loading error: {e}")
        return False

    # Stage 2: Preparation for inference
    mem_before_inference, swap_before_inference = record_stage("2_BEFORE_INFERENCE", "Before first inference")

    # Stage 3: First inference
    print("\n>>> Running first inference (compilation + execution)...")
    print(f"    ⏳ Converting Keras -> {backend.upper()} and compiling...")

    start_time = time.perf_counter()

    try:
        # Try inference with temporary ellipsis fix during generation only
        import numpy as np
        
        # Method 1: Try simple generate call
        inference_success = False
        try:
            output = causal_lm.generate("Hello", max_length=10)
            generation_method = "generate"
            inference_success = True
        except Exception as e1:
            print(f"Generate failed: {str(e1)[:100]}")
            # Method 2: Try using backbone directly for memory test
            try:
                import tensorflow as tf
                # Create simple input tensor
                input_tokens = tf.constant([[1, 2, 3, 4, 5]], dtype=tf.int32)
                # Get backbone prediction to trigger backend compilation
                logits = causal_lm.backbone(input_tokens)
                output = f"Direct backbone inference: shape {logits.shape}"
                generation_method = "backbone"
                inference_success = True
            except Exception as e2:
                print(f"Backbone inference failed: {str(e2)[:100]}")
                # Method 3: Just compile the model without full inference
                try:
                    # Force model build and compilation
                    causal_lm.backbone.build((None, None))
                    output = "Model build and compile successful"
                    generation_method = "compile_only"
                    # Do NOT set inference_success = True here!
                except Exception as e3:
                    print(f"Model compile failed: {str(e3)[:100]}")
                    raise e1  # Re-raise original error
        end_time = time.perf_counter()
        if generation_method == "compile_only" and not inference_success:
            mem_after_inference, swap_after_inference = record_stage("3_FIRST_INFERENCE", 
                                              f"First inference failed via compile_only ({end_time-start_time:.1f}s)")
        else:
            mem_after_inference, swap_after_inference = record_stage("3_FIRST_INFERENCE", 
                                              f"First inference completed via {generation_method} ({end_time-start_time:.1f}s)")
        # Stage 4: Second inference
        print("\n>>> Second inference (no compilation)...")
        start_time2 = time.perf_counter()
        try:
            if generation_method == "generate":
                output2 = causal_lm.generate("Test", max_length=10)
            elif generation_method == "backbone":
                logits2 = causal_lm.backbone(input_tokens)
                output2 = f"Second backbone inference: shape {logits2.shape}"
            else:
                output2 = "Second compile test successful"
        except:
            output2 = f"Second {generation_method} inference"
        end_time2 = time.perf_counter()
        mem_after_second, swap_after_second = record_stage("4_SECOND_INFERENCE", 
                                    f"Second inference ({end_time2-start_time2:.1f}s)")
        
    except Exception as e:
        print(f"❌ All inference methods failed: {e}")
        import traceback
        print(f"Error details: {traceback.format_exc()}")
        mem_after_inference, swap_after_inference = record_stage("3_INFERENCE_FAILED", f"All inference failed: {str(e)[:50]}...")
        mem_after_second, swap_after_second = mem_after_inference, swap_after_inference
        output = "FAILED"
        output2 = "FAILED"
        inference_success = False
        end_time = start_time
        end_time2 = start_time

    # Stop monitoring
    done[0] = True
    monitor_thread.join(timeout=1.0)

    # Final stage
    mem_final, swap_final = record_stage("5_FINAL", "Final state")

    # Results analysis
    print("\n" + "=" * 80)
    print("PERFORMANCE RESULTS")
    print("=" * 80)

    if inference_success:
        latency = end_time - start_time
        latency2 = end_time2 - start_time2
        tokens_generated = len(output.split()) if output != "FAILED" else 0
        throughput = tokens_generated / latency if latency > 0 else 0
        
        print(f"✅ Generated text: '{output}'")
        print(f"✅ Second generation: '{output2}'")
        print(f"Backend: {keras.backend.backend()}")
        print(f"First inference latency: {latency:.2f}s")
        print(f"Second inference latency: {latency2:.3f}s") 
        print(f"Throughput: {throughput:.2f} tokens/sec")
        print(f"Speedup: {latency/latency2:.1f}x" if latency2 > 0 else "Speedup: N/A")
    else:
        print("❌ Inference failed")

    # Memory analysis
    model_loading = mem_after_load - mem_initial
    compilation = mem_after_inference - mem_before_inference if inference_success else 0
    total_usage = mem_final - mem_initial
    peak_usage = peak_memory[0] - mem_initial

    # Calculate swap changes
    swap_model_loading = swap_after_load - swap_initial
    swap_compilation = swap_after_inference - swap_before_inference if inference_success else 0
    swap_total = swap_final - swap_initial
    peak_swap_usage = peak_swap[0] - swap_initial

    print(f"\n📊 DETAILED MEMORY ANALYSIS:")
    
    if TABULATE_AVAILABLE:
        # Create table data
        table_data = []
        
        # Initial row
        table_data.append(["Initial", f"{mem_initial:.1f}", f"{swap_initial:.1f}", "-", "-"])
        
        # After model load
        table_data.append(["After model load", f"{mem_after_load:.1f}", f"{swap_after_load:.1f}", 
                          f"{model_loading:+.1f}", f"{swap_model_loading:+.1f}"])
        
        # Before inference
        table_data.append(["Before inference", f"{mem_before_inference:.1f}", f"{swap_before_inference:.1f}", 
                          f"{mem_before_inference-mem_after_load:+.1f}", f"{swap_before_inference-swap_after_load:+.1f}"])
        
        if inference_success:
            # After 1st inference
            table_data.append(["After 1st inference", f"{mem_after_inference:.1f}", f"{swap_after_inference:.1f}", 
                              f"{compilation:+.1f}", f"{swap_compilation:+.1f}"])
            
            # After 2nd inference
            table_data.append(["After 2nd inference", f"{mem_after_second:.1f}", f"{swap_after_second:.1f}", 
                              f"{mem_after_second-mem_after_inference:+.1f}", f"{swap_after_second-swap_after_inference:+.1f}"])
            
            # Final
            table_data.append(["Final", f"{mem_final:.1f}", f"{swap_final:.1f}", 
                              f"{mem_final-mem_after_second:+.1f}", f"{swap_final-swap_after_second:+.1f}"])
        else:
            # After failure
            table_data.append(["After failure", f"{mem_after_inference:.1f}", f"{swap_after_inference:.1f}", 
                              f"{compilation:+.1f}", f"{swap_compilation:+.1f}"])
            
            # Final
            table_data.append(["Final", f"{mem_final:.1f}", f"{swap_final:.1f}", 
                              f"{mem_final-mem_after_inference:+.1f}", f"{swap_final-swap_after_inference:+.1f}"])
        
        # Peak recorded
        table_data.append(["Peak recorded", f"{peak_memory[0]:.1f}", f"{peak_swap[0]:.1f}", f"{peak_usage:+.1f}", f"{peak_swap_usage:+.1f}"])
        
        # Headers
        headers = ["STAGE", "RAM (MB)", "SWAP (MB)", "RAM CHANGE", "SWAP CHANGE"]
        
        # Print beautiful table
        print(tabulate(table_data, headers=headers, tablefmt="grid", stralign="left", numalign="right"))
        
    else:
        # Fallback to manual formatting if tabulate not available
        print(f"{'='*85}")
        print(f"{'STAGE':<25} {'RAM (MB)':<12} {'SWAP (MB)':<12} {'RAM CHANGE':<12} {'SWAP CHANGE':<12}")
        print(f"{'-'*85}")
        print(f"{'Initial':<25} {mem_initial:<12.1f} {swap_initial:<12.1f} {'-':<12} {'-':<12}")
        print(f"{'After model load':<25} {mem_after_load:<12.1f} {swap_after_load:<12.1f} {model_loading:+12.1f} {swap_model_loading:+12.1f}")
        print(f"{'Before inference':<25} {mem_before_inference:<12.1f} {swap_before_inference:<12.1f} {mem_before_inference-mem_after_load:+12.1f} {swap_before_inference-swap_after_load:+12.1f}")

        if inference_success:
            print(f"{'After 1st inference':<25} {mem_after_inference:<12.1f} {swap_after_inference:<12.1f} {compilation:+12.1f} {swap_compilation:+12.1f}")
            print(f"{'After 2nd inference':<25} {mem_after_second:<12.1f} {swap_after_second:<12.1f} {mem_after_second-mem_after_inference:+12.1f} {swap_after_second-swap_after_inference:+12.1f}")
        else:
            print(f"{'After failure':<25} {mem_after_inference:<12.1f} {swap_after_inference:<12.1f} {compilation:+12.1f} {swap_compilation:+12.1f}")

        print(f"{'Final':<25} {mem_final:<12.1f} {swap_final:<12.1f} {mem_final-mem_after_second if inference_success else mem_final-mem_after_inference:+12.1f} {swap_final-(swap_after_second if inference_success else swap_after_inference):+12.1f}")
        print(f"{'Peak recorded':<25} {peak_memory[0]:<12.1f} {peak_swap[0]:<12.1f} {peak_usage:+12.1f} {peak_swap_usage:+12.1f}")
        print(f"{'-'*85}")

    print(f"\n🔍 MAIN MEMORY CONSUMERS:")
    print(f"   📚 Model loading:        {model_loading:+8.1f} MB RAM  {swap_model_loading:+8.1f} MB swap  ({model_loading/total_usage*100 if total_usage != 0 else 0:.1f}% of total)")
    if inference_success and compilation != 0:
        print(f"   ⚡ Compilation/inference: {compilation:+8.1f} MB RAM  {swap_compilation:+8.1f} MB swap  ({compilation/total_usage*100 if total_usage != 0 else 0:.1f}% of total)")

    print(f"\n📈 SUMMARY:")
    print(f"   💾 Total RAM growth:     {total_usage:+8.1f} MB")
    print(f"   💿 Total swap change:    {swap_total:+8.1f} MB")
    print(f"   📊 Peak RAM consumption: {peak_usage:+8.1f} MB above initial")
    print(f"   🔥 Highest RAM recorded: {peak_memory[0]:.1f} MB")
    print(f"   💿 Peak swap consumption: {peak_swap_usage:+8.1f} MB above initial")
    print(f"   🔥 Highest swap recorded: {peak_swap[0]:.1f} MB")

    # Enhanced status assessment
    total_memory_impact = peak_memory[0] + peak_swap[0]
    print(f"\n🎯 MEMORY HEALTH CHECK:")
    if peak_usage > 2000:
        print(f"   ❌ CRITICAL: RAM usage {peak_usage:.0f} MB is very high (target <1GB)")
    elif peak_usage > 1000:
        print(f"   ⚠️  WARNING: RAM usage {peak_usage:.0f} MB is quite high")
    else:
        print(f"   ✅ GOOD: RAM usage {peak_usage:.0f} MB is reasonable")
    
    if peak_swap[0] > 1000:
        print(f"   ⚠️  WARNING: Peak swap usage {peak_swap[0]:.0f} MB indicates memory pressure")
    elif peak_swap[0] > 100:
        print(f"   ℹ️  INFO: Moderate peak swap usage {peak_swap[0]:.0f} MB")
    else:
        print(f"   ✅ GOOD: Low peak swap usage {peak_swap[0]:.0f} MB")

    if total_memory_impact > 4000:
        print(f"   🚨 ALERT: Combined memory impact {total_memory_impact:.0f} MB is very high")

    return {
        'success': inference_success,
        'model_loading_mb': model_loading,
        'compilation_mb': compilation,
        'total_mb': total_usage,
        'peak_mb': peak_usage,
        'peak_swap_mb': peak_swap_usage
    }

try:
    results = main()
    print(f"\n🎯 Test completed: {results}")
except Exception as e:
    print(f"\n❌ Critical error: {e}")
    import traceback
    print(traceback.format_exc())
```
without fix:
```
[MEMORY] PassManager CPU:DecompressionHandling started: 2225.85 MB
[MEMORY] ov::pass::InitNodeInfo: 2225.85 -> 2228.95 MB (+3.09375 MB) [NO CHANGE]
[MEMORY] ov::pass::MarkShapeOfSubgraphs: 2229.1 -> 2229.1 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CPU:DecompressionHandling finished: 2229.1 MB (total: +3.25 MB)
[MEMORY] PassManager Plugin:CPU started: 2229.57 MB
[MEMORY] PassManager SDPASubgraphFusion started: 2230.04 MB
[MEMORY] PassManager SDPASubgraphFusion finished: 2230.2 MB (total: +0.15625 MB)
[MEMORY] PassManager CommonOptimizations started: 2230.66 MB
[MEMORY] PassManager MOC started: 2233.63 MB
[MEMORY] EliminateConvert: 2234.1 -> 2234.1 MB (+0 MB) [CHANGED]
[MEMORY] EliminateLoopInputsOutputs: 2234.1 -> 2234.1 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::ConstantFolding: 2234.1 -> 2452.45 MB (+218.344 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph started: 2452.45 MB
[MEMORY] ov::pass::SharedOpOptimization: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::NopElimination: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph finished: 2452.45 MB (total: +0 MB)
[MEMORY] PassManager StridedSliceOptimization started: 2452.45 MB
[MEMORY] PassManager StridedSliceOptimization finished: 2452.45 MB (total: +0 MB)
[MEMORY] ov::pass::GraphRewrite: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::LinOpSequenceFusion: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] PassManager ReverseInputChannelsFusion started: 2452.45 MB
[MEMORY] PassManager ReverseInputChannelsFusion finished: 2452.45 MB (total: +0 MB)
[MEMORY] PassManager Symbolic started: 2452.45 MB
[MEMORY] ov::pass::SymbolicPropagation: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::OptimizeSymbolsUsedAsValues: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] ReshapeOptimizations: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph started: 2452.45 MB
[MEMORY] ov::pass::SharedOpOptimization: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph finished: 2452.45 MB (total: +0 MB)
[MEMORY] PassManager Symbolic finished: 2452.45 MB (total: +0 MB)
[MEMORY] ov::pass::SymbolicOptimizations: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] PassManager MOC finished: 2452.45 MB (total: +218.812 MB)
[MEMORY] ov::pass::MOCTransformations: 2230.66 -> 2452.45 MB (+221.781 MB) [NO CHANGE]
[MEMORY] ov::pass::MarkDividesInShapeSubgraphs: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::CommonDecompositions: 2452.45 -> 2452.45 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::ConstantFolding: 2452.45 -> 3208.88 MB (+756.43 MB) [CHANGED]
[MEMORY] ConvertSoftMax8ToSoftMax1: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::StridesOptimization: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CommonOptimizations finished: 3208.88 MB (total: +978.211 MB)
[MEMORY] ov::pass::CommonOptimizations: 2230.2 -> 3208.88 MB (+978.68 MB) [NO CHANGE]
[MEMORY] PassManager ConvertOpSet2ToOpSet1 started: 3208.88 MB
[MEMORY] PassManager ConvertOpSet2ToOpSet1 finished: 3208.88 MB (total: +0 MB)
[MEMORY] ConvertShapeOf3: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Plugin:CPU finished: 3208.88 MB (total: +979.305 MB)
[MEMORY] PassManager CPU:PostLPT started: 3208.88 MB
[MEMORY] ConvertBroadcast3: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::UnrollTensorIterator: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::MoveEltwiseUpThroughDataMov: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic started: 3208.88 MB
[MEMORY] ov::pass::SymbolicPropagation: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic finished: 3208.88 MB (total: +0 MB)
[MEMORY] ov::pass::RoPEFusion: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic started: 3208.88 MB
[MEMORY] ov::pass::SymbolicPropagation: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic finished: 3208.88 MB (total: +0 MB)
[MEMORY] ov::pass::SymbolicOptimizations: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CPU:PostLPT finished: 3208.88 MB (total: +0 MB)
[MEMORY] PassManager CPU:Snippets started: 3208.88 MB
[MEMORY] ov::intel_cpu::SnippetsMarkSkipped: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Snippets:Tokenization started: 3208.88 MB
[MEMORY] ov::snippets::pass::EnumerateNodes: 3208.88 -> 3208.88 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Snippets:Tokenization finished: 3209.06 MB (total: +0.1875 MB)
[MEMORY] PassManager CPU:Snippets finished: 3209.06 MB (total: +0.1875 MB)
[MEMORY] PassManager CPU:PostSnippets started: 3209.06 MB
[MEMORY] PassManager CPU:PostSnippets finished: 3209.06 MB (total: +0 MB)
[MEMORY] PassManager CPU:ConvertToCPUSpecificOpset started: 3209.06 MB
[MEMORY] ConvertMatMulToFC: 3209.06 -> 3209.06 MB (+0 MB) [CHANGED]
[MEMORY] FullyConnectedBiasFusion: 3209.06 -> 3209.06 MB (+0 MB) [CHANGED]
[MEMORY] ConvertToPowerStatic: 3209.25 -> 3209.25 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CPU:ConvertToCPUSpecificOpset finished: 3209.25 MB (total: +0.1875 MB)
```
with fix
by adding:
```python
os.environ["OV__ENABLE_EINSUM_DECOMPOSITION"] = "1"
```
```
[MEMORY] PassManager CPU:DecompressionHandling started: 2226.22 MB
[MEMORY] ov::pass::InitNodeInfo: 2226.22 -> 2230.22 MB (+4 MB) [NO CHANGE]
[MEMORY] ov::pass::MarkShapeOfSubgraphs: 2230.22 -> 2230.22 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CPU:DecompressionHandling finished: 2230.22 MB (total: +4 MB)
[MEMORY] PassManager Plugin:CPU started: 2230.22 MB
[MEMORY] KeepDecompressionsInFP32Matcher: 2230.22 -> 2232.22 MB (+2 MB) [NO CHANGE]
[MEMORY] PassManager SDPASubgraphFusion started: 2232.22 MB
[MEMORY] PassManager SDPASubgraphFusion finished: 2232.22 MB (total: +0 MB)
[MEMORY] PassManager CommonOptimizations started: 2232.22 MB
[MEMORY] PassManager MOC started: 2234.22 MB
[MEMORY] ov::pass::InitNodeInfo: 2234.22 -> 2236.22 MB (+2 MB) [NO CHANGE]
[MEMORY] EliminateConvert: 2236.22 -> 2236.22 MB (+0 MB) [CHANGED]
[MEMORY] EliminateLoopInputsOutputs: 2236.22 -> 2236.22 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::ConstantFolding: 2236.22 -> 2452.5 MB (+216.281 MB) [CHANGED]
[MEMORY] EinsumDecomposition: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph started: 2452.5 MB
[MEMORY] ov::pass::SharedOpOptimization: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::NopElimination: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph finished: 2452.5 MB (total: +0 MB)
[MEMORY] PassManager StridedSliceOptimization started: 2452.5 MB
[MEMORY] PassManager StridedSliceOptimization finished: 2452.5 MB (total: +0 MB)
[MEMORY] ov::pass::ConstantFolding: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::GraphRewrite: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::LinOpSequenceFusion: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager ReverseInputChannelsFusion started: 2452.5 MB
[MEMORY] PassManager ReverseInputChannelsFusion finished: 2452.5 MB (total: +0 MB)
[MEMORY] ov::pass::SharedOpOptimization: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic started: 2452.5 MB
[MEMORY] ov::pass::SymbolicPropagation: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::OptimizeSymbolsUsedAsValues: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ReshapeOptimizations: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph started: 2452.5 MB
[MEMORY] ov::pass::SharedOpOptimization: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager SimplifyShapeOfSubGraph finished: 2452.5 MB (total: +0 MB)
[MEMORY] PassManager Symbolic finished: 2452.5 MB (total: +0 MB)
[MEMORY] ov::pass::SymbolicOptimizations: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager MOC finished: 2452.5 MB (total: +218.281 MB)
[MEMORY] ov::pass::MOCTransformations: 2232.22 -> 2452.5 MB (+220.281 MB) [NO CHANGE]
[MEMORY] ov::pass::MarkDividesInShapeSubgraphs: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::CommonDecompositions: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::ConstantFolding: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ConvertSoftMax8ToSoftMax1: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::StridesOptimization: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CommonOptimizations finished: 2452.5 MB (total: +220.281 MB)
[MEMORY] ov::pass::CommonOptimizations: 2232.22 -> 2452.5 MB (+220.281 MB) [NO CHANGE]
[MEMORY] PassManager ConvertOpSet2ToOpSet1 started: 2452.5 MB
[MEMORY] PassManager ConvertOpSet2ToOpSet1 finished: 2452.5 MB (total: +0 MB)
[MEMORY] ConvertShapeOf3: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Plugin:CPU finished: 2452.5 MB (total: +222.281 MB)
[MEMORY] PassManager CPU:PostLPT started: 2452.5 MB
[MEMORY] ConvertBroadcast3: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::UnrollTensorIterator: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ov::pass::MoveEltwiseUpThroughDataMov: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic started: 2452.5 MB
[MEMORY] ov::pass::SymbolicPropagation: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic finished: 2452.5 MB (total: +0 MB)
[MEMORY] ov::pass::RoPEFusion: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic started: 2452.5 MB
[MEMORY] ov::pass::SymbolicPropagation: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Symbolic finished: 2452.5 MB (total: +0 MB)
[MEMORY] ov::pass::SymbolicOptimizations: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CPU:PostLPT finished: 2452.5 MB (total: +0 MB)
[MEMORY] PassManager CPU:Snippets started: 2452.5 MB
[MEMORY] ov::intel_cpu::SnippetsMarkSkipped: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Snippets:Tokenization started: 2452.5 MB
[MEMORY] ov::snippets::pass::EnumerateNodes: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] PassManager Snippets:Tokenization finished: 2452.5 MB (total: +0 MB)
[MEMORY] PassManager CPU:Snippets finished: 2452.5 MB (total: +0 MB)
[MEMORY] PassManager CPU:PostSnippets started: 2452.5 MB
[MEMORY] PassManager CPU:PostSnippets finished: 2452.5 MB (total: +0 MB)
[MEMORY] PassManager CPU:ConvertToCPUSpecificOpset started: 2452.5 MB
[MEMORY] ConvertMatMulToFC: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] FullyConnectedBiasFusion: 2452.5 -> 2452.5 MB (+0 MB) [CHANGED]
[MEMORY] ConvertToPowerStatic: 2452.7 -> 2452.7 MB (+0 MB) [CHANGED]
[MEMORY] PassManager CPU:ConvertToCPUSpecificOpset finished: 2452.7 MB (total: +0.195312 MB)
```
**Note**: the order of its postion is important.
I am still exploring what else can help reduce memory usage further.  I would appreciate any suggestions or recommendations.