### PR TITLE
[GHA] Remove unknown 'exclude' option for reviewdog/action-suggester

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -42,9 +42,6 @@ jobs:
           level: warning
           fail_level: error
           filter_mode: nofilter
-          exclude: |
-              "*/thirdparty/*"
-              "./temp/*"
 
   clang-format-aarch64:
     runs-on: ubuntu-24.04
@@ -81,9 +78,6 @@ jobs:
           level: warning
           fail_level: error
           filter_mode: nofilter
-          exclude: |
-              "*/thirdparty/*"
-              "./temp/*"
 
   clang-format-riscv64:
     runs-on: ubuntu-24.04
@@ -119,9 +113,6 @@ jobs:
           level: warning
           fail_level: error
           filter_mode: nofilter
-          exclude: |
-              "*/thirdparty/*"
-              "./temp/*"
 
   ShellCheck:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Details:
`reviewdog/action-suggester` action constantly reports a warning in CI jobs:
```
Warning: Unexpected input(s) 'exclude', valid inputs are ['github_token', 'tool_name', 'level', 'filter_mode', 'fail_level', 'fail_on_error', 'reviewdog_flags', 'cleanup']
```

### Tickets:
 - N/A
