### PR TITLE
[GPU] Fix memory reallocation logic for optimized out concat

### DIFF
--- a/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
+++ b/src/plugins/intel_gpu/src/graph/include/primitive_inst.h
@@ -42,6 +42,7 @@ class primitive_inst;
 template <class PType>
 class typed_primitive_inst;
 
+class PrimitiveInstTestHelper;
 struct ImplementationManager;
 
 struct BufferDescriptor {
@@ -167,6 +168,7 @@ struct ImplementationsFactory {
 class primitive_inst {
     template <class PType>
     friend class typed_primitive_inst;
+    friend class PrimitiveInstTestHelper;
 
 public:
     primitive_inst(network& network);

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -32,6 +32,7 @@
 #include "openvino/op/interpolate.hpp"
 
 #include "program_wrapper.h"
+#include "primitive_inst_test_helper.h"
 
 #include <memory>
 
@@ -224,6 +225,93 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic) {
     ASSERT_EQ(concat_mem.get(), permute2_mem.get());
     for (size_t x = 0; x < out_l.count(); ++x) {
         ASSERT_EQ(ref_output[x], output_ptr[x]);
+    }
+}
+
+TEST(prepare_buffer_fusing, in_place_concat_dynamic_memory_reallocation) {
+    tests::random_generator rg(GET_SUITE_NAME);
+    auto& engine = get_test_engine();
+
+    auto input_dynamic_layout = layout{ ov::PartialShape::dynamic(4), data_types::f32, format::bfyx };
+
+    topology t;
+    t.add(input_layout("input1", input_dynamic_layout));
+    t.add(input_layout("input2", input_dynamic_layout));
+    t.add(reorder("input1_reordered", input_info("input1"), format::bfyx, data_types::f16));
+    t.add(reorder("input2_reordered", input_info("input2"), format::bfyx, data_types::f16));
+    t.add(concatenation("concat", { input_info("input1_reordered"), input_info("input2_reordered") }, 1));
+    t.add(reorder("output", input_info("concat"), format::bfyx, data_types::f32));
+
+    ExecutionConfig config = get_test_default_config(engine);
+    config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
+
+    auto net = cldnn::network(program::build_program(engine, t, config, false, false));
+
+    std::vector<ov::Shape> input_shapes =
+    { ov::Shape{1, 32, 8, 6},
+      ov::Shape{1, 32, 8, 6},
+      ov::Shape{1, 32, 12, 9},
+      ov::Shape{1, 32, 12, 9},
+      ov::Shape{1, 32, 6, 11},
+      ov::Shape{1, 32, 6, 11},
+      ov::Shape{1, 32, 9, 16},
+      ov::Shape{1, 32, 9, 16} };
+
+    auto prev_concat_mem = memory_ptr{nullptr};
+    auto prev_shape = ov::Shape{};
+
+    for (const auto& input_shape : input_shapes) {
+        auto input_layout = input_dynamic_layout.clone_with_other_shape(input_shape);
+        auto input_memory1 = engine.allocate_memory(input_layout);
+        auto input_memory2 = engine.allocate_memory(input_layout);
+
+        auto input_data1 = rg.generate_random_1d<float>(input_layout.count(), 0, 1);
+        auto input_data2 = rg.generate_random_1d<float>(input_layout.count(), 0, 1);
+
+        set_values<float>(input_memory1, input_data1);
+        set_values<float>(input_memory2, input_data2);
+
+        net.set_input_data("input1", input_memory1);
+        net.set_input_data("input2", input_memory2);
+
+        std::map<cldnn::primitive_id, cldnn::network_output> output;
+        EXPECT_NO_THROW(output = net.execute());
+
+        auto out_mem = output.at("output").get_memory();
+        cldnn::mem_lock<float> output_ptr(out_mem, get_test_stream());
+
+        const auto& reorder_inst = net.get_primitive("input1_reordered");
+        const auto& concat_inst = net.get_primitive("concat");
+        auto reorder1_mem = net.get_primitive("input1_reordered")->output_memory_ptr();
+        auto reorder2_mem = net.get_primitive("input2_reordered")->output_memory_ptr();
+        auto concat_mem = net.get_primitive("concat")->output_memory_ptr();
+
+        ASSERT_TRUE(concat_inst->get_node().can_be_optimized());
+        ASSERT_TRUE(engine.is_the_same_buffer(*concat_mem, *reorder1_mem));
+        ASSERT_TRUE(engine.is_the_same_buffer(*concat_mem, *reorder2_mem));
+
+        if (prev_concat_mem) {
+            const auto can_reuse_mem = ov::shape_size(input_shape) <= ov::shape_size(prev_shape);
+            ASSERT_EQ(engine.is_the_same_buffer(*prev_concat_mem, *concat_mem), can_reuse_mem);
+        }
+
+        // Under certain circumstances (e.g., asynchronous compilation for some primitives), `allocation_done_by_other` flag
+        // might be incorrectly set or unset for the concat primitive. This can lead to incorrect memory assignment:
+        // if the flag remains set without being properly reset, concat may reuse a smaller buffer than required.
+        // Manually forcing the flag value ensures it can be correctly reconfigured for each execution iteration
+        PrimitiveInstTestHelper::set_allocation_done_by_other(concat_inst, true);
+
+        prev_concat_mem = concat_mem;
+        prev_shape = input_shape;
+
+        for (size_t i = 0; i < input_data1.size(); ++i) {
+            ASSERT_EQ(output_ptr[i], input_data1[i]);
+        }
+
+        for (size_t i = 0; i < input_data2.size(); ++i) {
+            ASSERT_EQ(output_ptr[input_data1.size() + i], input_data2[i]);
+        }
     }
 }
 
@@ -1525,7 +1613,7 @@ TEST(prepare_buffer_fusing, inner_axis_data_offset_with_gemm_user) {
 
     auto input_memory = engine.allocate_memory(in_layout);
     auto input_data = rg.generate_random_1d<float>(input_memory->count(), -1, 1);
-    
+
     auto offsets1 = tensor{0, 0, 0, 0};
     auto offsets2 = tensor{0, 0, 8, 0};
 

--- a/src/plugins/intel_gpu/tests/unit/test_utils/primitive_inst_test_helper.h
+++ b/src/plugins/intel_gpu/tests/unit/test_utils/primitive_inst_test_helper.h
@@ -1,0 +1,18 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "graph/include/primitive_inst.h"
+
+namespace cldnn {
+// This class is intended to allow using private methods from primitive_inst within tests_core_internal project.
+// Once needed, more methods wrapper should be added here.
+class PrimitiveInstTestHelper {
+public:
+    static void set_allocation_done_by_other(const std::shared_ptr<primitive_inst>& inst, bool val) {
+        inst->_allocation_done_by_other = val;
+    }
+};
+}  // namespace cldnn


### PR DESCRIPTION
### Details:
This PR addresses the issue of the optimized out concat primitive where incorrect memory reuse could occur due to improper handling of the `allocation_done_by_other` flag. The affected subgraph looks like this:
```
   Conv   Add
     \    /
     Concat (optimized_out)
```
The issue arises due to improper management of the `allocation_done_by_other` flag across iterations:
_Iteration N_: Input shape changes. Conv calls concat's `reallocate_if_needed()` and sets `allocation_done_by_other = true`. During `execute()` call, Concat resets the flag to false.
_Iteration N+1_: Input shape remains the same. Conv calls Concat's `reallocate_if_needed()` and sets the flag again, but Concat does not reset it since shape wasn't changed.
_Iteration N+2_: Input shape increases. Since the flag was not reset in the previous iteration, Conv skips Concat's reallocation, causing Concat to reuse smaller buffer, leading to incorrect behavior.


### Tickets:
 - [CVS-169845](https://jira.devtools.intel.com/browse/CVS-169845)
