### PR TITLE
[GPU] arg max min use internal buffer for large result buffer

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/arg_max_min_axis.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/arg_max_min_axis.cl
@@ -119,7 +119,7 @@ KERNEL(arg_max_min_modified)(
 #ifdef OUTPUT1_TYPE
     ,__global OUTPUT1_TYPE* second_output
 #endif
-#ifdef IS_DYNAMIC
+#ifdef USE_INTERNAL_BUFFERS
     ,__global INPUT0_TYPE* tmp_buffer0
     ,__global INPUT0_TYPE* tmp_buffer1
     ,__global INPUT0_TYPE* tmp_buffer2
@@ -133,7 +133,7 @@ KERNEL(arg_max_min_modified)(
 #elif TOP_K == 1
     iav_type result[TOP_K];
 #else
-#ifdef IS_DYNAMIC
+#ifdef USE_INTERNAL_BUFFERS
     const uint iav_type_size = INPUT0_TYPE_SIZE + 4;
     const uint buffer_size = iav_type_size * VALUES_NUM;
     const uint buffer_offset = buffer_size * OPERATION_NUM;
@@ -378,7 +378,7 @@ KERNEL(arg_max_min_modified)(
             }
         }
 
-    #ifdef IS_DYNAMIC
+    #ifdef USE_INTERNAL_BUFFERS
         const uint counter_size = group_num * 4;
         const uint counter_offset = counter_size * OPERATION_NUM;
         __global uint* merge_counter = OFFSET_GLOBAL_PTR(uint, tmp_buffer1, output_idx * counter_size);

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/arg_max_min/arg_max_min_kernel_axis.cpp
@@ -168,7 +168,7 @@ KernelsData ArgMaxMinKernelAxis::GetKernelsData(const Params& params) const {
                      orgParams.outputs_num,
                      orgParams.is_shape_agnostic);
 
-    if (is_dynamic) {
+    if (is_dynamic || getSortSize(orgParams) * orgParams.inputs[0].ElementSize() > 4096) {
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 0});
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 1});
         kernel.params.arguments.push_back({ArgumentDescriptor::Types::INTERNAL_BUFFER, 2});
@@ -202,6 +202,10 @@ JitConstants ArgMaxMinKernelAxis::GetJitConstants(const arg_max_min_params& para
 
     if (params.values_first)
         jit.AddConstant(MakeJitConstant("TOP_K_ORDER", 1));
+
+    if (params.has_dynamic_tensors() || getSortSize(params) * params.inputs[0].ElementSize() > 4096) {
+        jit.AddConstant(MakeJitConstant("USE_INTERNAL_BUFFERS", 1));
+    }
 
     return jit;
 }

--- a/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/arg_max_gpu_test.cpp
@@ -706,6 +706,35 @@ TEST(arg_max_gpu_min_axis_y_yxfb_topk_2, sort_by_indices) {
     }
 }
 
+TEST(arg_max_gpu_min_large_output_size, sort_by_indices) {
+    static const int32_t x_size = 1, y_size = 1, feature_num = 1, batch_num = 20000;
+    auto& engine = get_test_engine();
+    const int top_k = 6000;
+    auto input = engine.allocate_memory({data_types::f32, format::yxfb, {batch_num, feature_num, x_size, y_size}});
+    topology topology;
+    topology.add(input_layout("input", input->get_layout()));
+
+    topology.add(arg_max_min("arg_max",
+                             { input_info("input") },
+                             ov::op::TopKMode::MAX,
+                             top_k,
+                             0,
+                             ov::op::TopKSortType::SORT_INDICES,
+                             false,
+                             false,
+                             data_types::f32));
+
+    network network(engine, topology, get_test_default_config(engine));
+
+    network.set_input_data("input", input);
+    auto outputs = network.execute();
+
+    ASSERT_EQ(outputs.size(), size_t(1));
+    ASSERT_EQ(outputs.begin()->first, "arg_max");
+
+    // No data checking.  The test will fail to compile if kernel not switch to use global memory
+}
+
 template <typename T>
 void test_top_k_layer_tests_sort_probabilities_by_indices(bool is_caching_test) {
     static const int32_t x_size = 10, y_size = 1, feature_num = 1, batch_num = 1;


### PR DESCRIPTION
Arg max min fail to compile due to not sufficient hardware registers. There are about 4K registers per thread, switch to use global memory if result buffer exceeds register counts.

CVS-170417
