### PR TITLE
[GPU] Added make_jit_constant override for CM kernels

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/cm/primitive_cm_base.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/cm/primitive_cm_base.hpp
@@ -12,4 +12,18 @@ namespace ov::intel_gpu::cm {
 using PrimitiveImplCM = ov::intel_gpu::ocl::PrimitiveImplOCL;
 using Stage = ov::intel_gpu::ocl::Stage;
 
+template <typename T>
+JitConstant make_jit_constant(const std::string& name, T value) {
+    if constexpr (std::is_floating_point<T>::value) {
+        return JitConstant(name, std::to_string(value));
+    } else {
+        return ov::intel_gpu::make_jit_constant(name, value);
+    }
+}
+
+template <typename T>
+JitConstant make_jit_constant(const JitTerm& name, T value) {
+    return make_jit_constant(name.str(), value);
+}
+
 }  // namespace ov::intel_gpu::cm


### PR DESCRIPTION
### Details:
 - *Previous behavior of the `to_code_string()` for floating point numbers used `as_float()/as_double()` functions, which is not supported by CM kernels.*
