### PR TITLE
[GPU] set mem_flags::need_blocked for conv/deconv postops

### DIFF
--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -1635,7 +1635,8 @@ void program_node::create_onednn_primitive_attributes(
                     post_ops.append_binary(alg, dnnl::memory::desc(dims, dt, fmt));
                     update_onednn_post_op_list(op_type, dep_idx, fmt, false, dims, dt);
                 } else {
-                    auto mem_desc = onednn::layout_to_memory_desc(in);
+                    auto mem_flag = cldnn::format::is_blocked(get_output_layout().format) ? onednn::mem_flags::need_blocked : onednn::mem_flags::None;
+                    auto mem_desc = onednn::layout_to_memory_desc(in, dnnl::memory::format_tag::undef, mem_flag);
                     post_ops.append_binary(alg, mem_desc);
                     update_onednn_post_op_list(op_type, dep_idx, onednn::convert_data_format(in.format), false,
                             mem_desc.get_dims(), mem_desc.get_data_type());


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
**convolution in/out tensor**
input tensor: f16:b_fs_yx_fsv16:1x512x78:nopad
input tensor: f16:bfyx:512x512x3:nopad
input tensor: f16:bfyx:1x512x1:nopad
input tensor: f16:b_fs_yx_fsv16:1x512x78:nopad   --> binary_add
input tensor: f16:b_fs_yx_fsv16:1x1x1:nopad      --> binary_mul
output tensor: f16:b_fs_yx_fsv16:1x512x78:nopad

 - onednn memory desc of conv/deconv needs setting onednn::mem_flags::need_blocked if the format is blocked.

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/thirdparty/onednn_gpu/src/common/primitive_attr.cpp (validate_binary)

#### Reproduction step and snapshot (model is attached in the ticket)
 - benchmark_app.exe -d GPU --hint latency -niter 1 -m kokoro.xml -shape "ref_s[1,256],input_ids[1,78]"

#### Problematic graph
 - This issue could not check with graph.

#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?


### Tickets:
 - 169876
