### PR TITLE
[CPU][TESTS] Replace 'std::tie' with structured bindings where possible

### DIFF
--- a/src/plugins/intel_cpu/src/utils/general_utils.h
+++ b/src/plugins/intel_cpu/src/utils/general_utils.h
@@ -210,4 +210,14 @@ inline bool contains(const std::vector<T>& v, const T& value) {
     });
 }
 
+template <class Map>
+bool contains_key_value(const Map& m, const typename Map::value_type& kv) {
+    const auto& [k, v] = kv;
+    if (auto it = m.find(k); it != m.end()) {
+        return it->second == v;
+    }
+
+    return false;
+}
+
 }  // namespace ov::intel_cpu

--- a/src/plugins/intel_cpu/tests/functional/custom/behavior/export_import.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/behavior/export_import.cpp
@@ -38,9 +38,7 @@ TEST_P(ExportOptimalNumStreams, OptimalNumStreams) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     auto original_model = MakeMatMulModel();
     ov::Core core;
-    std::string device_name;
-    std::vector<ov::AnyMap> properties;
-    std::tie(device_name, properties) = GetParam();
+    const auto& [device_name, properties] = GetParam();
     auto original_properties_input = properties[0];
     auto new_properties_input = properties[1];
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/adaptive_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/adaptive_pooling.cpp
@@ -31,18 +31,9 @@ class AdaPoolLayerCPUTest : public testing::WithParamInterface<AdaPoolLayerCPUTe
                             public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<AdaPoolLayerCPUTestParamsSet> obj) {
-        AdaPoolLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ElementType netPr;
-        bool isStatic;
-        AdaPoolSpecificParams adaPar;
-        std::vector<int> pooledSpatialShape;
-        std::vector<InputShape> inputShape;
-        std::string mode;
-        std::tie(adaPar, mode, isStatic, netPr, td) = basicParamsSet;
-        std::tie(pooledSpatialShape, inputShape) = adaPar;
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [adaPar, mode, isStatic, netPr, td] = basicParamsSet;
+        const auto& [pooledSpatialShape, inputShape] = adaPar;
         std::ostringstream result;
         result << "AdaPoolTest_";
         result << "IS=(";
@@ -65,18 +56,13 @@ public:
 
 protected:
     void SetUp() override {
-        AdaPoolLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        AdaPoolSpecificParams adaPoolParams;
-        ElementType netPrecision;
-        bool isStatic;
-        std::vector<InputShape> inputShape;
-        std::tie(adaPoolParams, mode, isStatic, netPrecision, targetDevice) = basicParamsSet;
-        std::tie(pooledVector, inputShape) = adaPoolParams;
-
+        const auto& [adaPoolParams, _mode, isStatic, netPrecision, _targetDevice] = basicParamsSet;
+        mode = _mode;
+        targetDevice = _targetDevice;
+        const auto& [_pooledVector, inputShape] = adaPoolParams;
+        pooledVector = _pooledVector;
         init_input_shapes(inputShape);
         if (!isStatic) {
             for (auto& target : targetStaticShapes) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/augru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/augru_cell.cpp
@@ -6,6 +6,7 @@
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 
@@ -27,23 +28,8 @@ class AUGRUCellCPUTest : public testing::WithParamInterface<AUGRUCellCpuSpecific
                          public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<AUGRUCellCpuSpecificParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        bool decompose, linearBeforeReset;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 decompose,
-                 activations,
-                 clip,
-                 linearBeforeReset,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = obj.param;
-
+        const auto &[inputShapes, decompose, activations, clip, linearBeforeReset, netPrecision, cpuParams,
+                     additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -76,22 +62,8 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        bool decompose, linearBeforeReset;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 decompose,
-                 activations,
-                 clip,
-                 linearBeforeReset,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = this->GetParam();
+        const auto &[inputShapes, decompose, activations, clip, linearBeforeReset, netPrecision, cpuParams,
+                     additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -102,7 +74,7 @@ protected:
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
             abs_threshold = 2e-2;
         } else {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/augru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/augru_sequence.cpp
@@ -8,6 +8,7 @@
 #include "transformations/op_conversions/bidirectional_sequences_decomposition.hpp"
 #include "transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 
@@ -31,26 +32,8 @@ class AUGRUSequenceCPUTest : public testing::WithParamInterface<AUGRUSequenceCpu
                              public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<AUGRUSequenceCpuSpecificParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        ov::test::utils::SequenceTestsMode seqMode;
-        std::vector<std::string> activations;
-        float clip;
-        bool linearBeforeRest;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 seqMode,
-                 activations,
-                 clip,
-                 linearBeforeRest,
-                 direction,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = obj.param;
-
+        const auto &[inputShapes, seqMode, activations, clip, linearBeforeRest, direction, netPrecision, cpuParams,
+                     additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -84,25 +67,8 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        ov::test::utils::SequenceTestsMode seqMode;
-        std::vector<std::string> activations;
-        float clip;
-        bool linearBeforeReset;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 seqMode,
-                 activations,
-                 clip,
-                 linearBeforeReset,
-                 direction,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = this->GetParam();
+        const auto &[inputShapes, seqMode, activations, clip, linearBeforeReset, direction, netPrecision, cpuParams,
+                     additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -117,7 +83,7 @@ protected:
         const size_t inputSize = targetStaticShapes.front()[0][2];
         const size_t numDirections = direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/batch_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/batch_to_space.cpp
@@ -29,10 +29,10 @@ class BatchToSpaceCPULayerTest : public testing::WithParamInterface<BatchToSpace
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<BatchToSpaceLayerTestCPUParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        ov::element::Type model_type;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapes, blockShape, cropsBegin, cropsEnd, model_type, cpuParams) = obj.param;
+        const auto& [inputShapes, _blockShape, _cropsBegin, _cropsEnd, model_type, cpuParams] = obj.param;
+        blockShape = _blockShape;
+        cropsBegin = _cropsBegin;
+        cropsEnd = _cropsEnd;
         std::ostringstream result;
         if (inputShapes.front().first.size() != 0) {
             result << "IS=(";
@@ -99,11 +99,10 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        ov::element::Type model_type;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapes, blockShape, cropsBegin, cropsEnd, model_type, cpuParams) = this->GetParam();
+        const auto& [inputShapes, _blockShape, _cropsBegin, _cropsEnd, model_type, cpuParams] = this->GetParam();
+        blockShape = _blockShape;
+        cropsBegin = _cropsBegin;
+        cropsEnd = _cropsEnd;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         init_input_shapes(inputShapes);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/broadcast.cpp
@@ -28,19 +28,9 @@ class BroadcastLayerCPUTest : public testing::WithParamInterface<BroadcastLayerC
                               public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<BroadcastLayerCPUTestParamsSet> obj) {
-        BroadcastLayerTestParamsSet basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-
-        std::vector<ov::test::InputShape> inputShapes;
-        std::vector<int64_t> targetShapes, axesMapping;
-        ov::op::BroadcastType mode;
-        ov::element::Type_t netPrecision;
-        std::vector<bool> isConstInputs;
-        std::string deviceName;
-        std::tie(inputShapes, targetShapes, axesMapping, mode, netPrecision, isConstInputs, deviceName) =
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [inputShapes, targetShapes, axesMapping, mode, netPrecision, isConstInputs, deviceName] =
             basicParamsSet;
-
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -67,16 +57,12 @@ public:
 
 protected:
     void SetUp() override {
-        BroadcastLayerTestParamsSet basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-
-        std::vector<ov::test::InputShape> inputShapes;
-        ov::op::BroadcastType mode;
-        ov::element::Type_t netPrecision;
-        std::vector<bool> isConstInput;
-        std::tie(inputShapes, targetShape, axesMapping, mode, netPrecision, isConstInput, targetDevice) =
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
+        const auto& [inputShapes, _targetShape, _axesMapping, mode, netPrecision, isConstInput, _targetDevice] =
             basicParamsSet;
+        targetShape = _targetShape;
+        axesMapping = _axesMapping;
+        targetDevice = _targetDevice;
         bool isTargetShapeConst = isConstInput[0], isAxesMapConst = isConstInput[1];
         const auto targetShapeRank = targetShape.size();
         const auto axesMappingRank = axesMapping.size();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/bucketize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/bucketize.cpp
@@ -25,15 +25,7 @@ class BucketizeLayerCPUTest : public testing::WithParamInterface<BucketizeCPUPar
                               virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<BucketizeCPUParamsTuple>& obj) {
-        InputShape dataShape;
-        InputShape bucketsShape;
-        bool with_right_bound;
-        ElementType inDataPrc;
-        ElementType inBucketsPrc;
-        ElementType netPrc;
-
-        std::tie(dataShape, bucketsShape, with_right_bound, inDataPrc, inBucketsPrc, netPrc) = obj.param;
-
+        const auto& [dataShape, bucketsShape, with_right_bound, inDataPrc, inBucketsPrc, netPrc] = obj.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({dataShape.first}) << "_"
                << ov::test::utils::partialShape2str({bucketsShape.first}) << "_";
@@ -78,15 +70,8 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape dataShape;
-        InputShape bucketsShape;
-        bool with_right_bound;
-        ElementType inDataPrc;
-        ElementType inBucketsPrc;
-        ElementType netPrc;
-
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::tie(dataShape, bucketsShape, with_right_bound, inDataPrc, inBucketsPrc, netPrc) = this->GetParam();
+        const auto& [dataShape, bucketsShape, with_right_bound, inDataPrc, inBucketsPrc, netPrc] = this->GetParam();
         init_input_shapes({dataShape, bucketsShape});
 
         auto data = std::make_shared<ov::op::v0::Parameter>(inDataPrc, inputDynamicShapes[0]);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/activation.cpp
@@ -18,15 +18,8 @@ using namespace ov::test::utils;
 namespace ov {
 namespace test {
 std::string ActivationLayerCPUTest::getTestCaseName(const testing::TestParamInfo<ActivationLayerCPUTestParamSet> &obj) {
-    std::vector<ov::test::InputShape> inputShapes;
-    std::vector<size_t> activationShapes;
-    std::pair<utils::ActivationTypes, std::vector<float>> activationTypeAndConstValue;
-    ov::element::Type netPrecision, inPrecision, outPrecision;
-    CPUTestUtils::CPUSpecificParams cpuParams;
-    bool enforceSnippets;
-    std::tie(inputShapes, activationShapes, activationTypeAndConstValue, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets) =
-             obj.param;
-
+    const auto& [inputShapes, activationShapes, activationTypeAndConstValue, netPrecision, inPrecision, outPrecision,
+                 cpuParams, enforceSnippets] = obj.param;
     std::ostringstream result;
     result << activationNames[activationTypeAndConstValue.first] << "_";
     if (inputShapes.front().first.size() != 0) {
@@ -118,15 +111,9 @@ void ActivationLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& targe
 
 void ActivationLayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    std::vector<ov::test::InputShape> inputShapes;
-    std::vector<size_t> activationShapes;
-    std::pair<utils::ActivationTypes, std::vector<float>> activationTypeAndConstValue;
-    ov::element::Type inPrecision, outPrecision;
-    CPUTestUtils::CPUSpecificParams cpuParams;
-    bool enforceSnippets;
-    std::tie(inputShapes, activationShapes, activationTypeAndConstValue, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets) =
-             this->GetParam();
+    const auto& [inputShapes, activationShapes, activationTypeAndConstValue, _netPrecision, inPrecision, outPrecision,
+                 cpuParams, enforceSnippets] = this->GetParam();
+    netPrecision = _netPrecision;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     activationType = activationTypeAndConstValue.first;
     auto constantsValue = activationTypeAndConstValue.second;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/bitwise_shift.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/bitwise_shift.cpp
@@ -21,13 +21,7 @@ using ov::test::utils::InputLayerType;
 using ov::test::utils::OpType;
 
 std::string BitwiseShiftLayerCPUTest::getTestCaseName(testing::TestParamInfo<BitshiftLayerCPUTestParamsSet> obj) {
-    EltwiseTestParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    bool enforceSnippets;
-    ov::AnyMap val_map;
-    std::tie(basicParamsSet, cpuParams, fusingParams, enforceSnippets, val_map) = obj.param;
-
+    const auto& [basicParamsSet, cpuParams, fusingParams, enforceSnippets, val_map] = obj.param;
     std::ostringstream result;
     result << EltwiseLayerTest::getTestCaseName(testing::TestParamInfo<EltwiseTestParams>(basicParamsSet, 0));
     result << CPUTestsBase::getTestCaseName(cpuParams);
@@ -62,32 +56,18 @@ void BitwiseShiftLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& tar
 }
 
 void BitwiseShiftLayerCPUTest::SetUp() {
-    EltwiseTestParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    bool enforceSnippets;
-    ov::AnyMap val_map;
-    std::tie(basicParamsSet, cpuParams, fusingParams, enforceSnippets, val_map) = this->GetParam();
-    std::vector<InputShape> shapes;
-    ElementType netType;
-    utils::InputLayerType secondaryInputType;
-    ov::test::utils::OpType opType;
-    ov::AnyMap additionalConfig;
-
-    std::tie(shapes,
-             eltwiseType,
-             secondaryInputType,
-             opType,
-             netType,
-             inType,
-             outType,
-             targetDevice,
-             additionalConfig) = basicParamsSet;
+    const auto& [basicParamsSet, cpuParams, fusingParams, enforceSnippets, val_map] = this->GetParam();
+    const auto& [_shapes, _eltwiseType, secondaryInputType, opType, netType, _inType, _outType, _targetDevice,
+                 additionalConfig] = basicParamsSet;
+    eltwiseType = _eltwiseType;
+    inType = _inType;
+    outType = _outType;
+    targetDevice = _targetDevice;
     abs_threshold = 0;
 
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     std::tie(postOpMgrPtr, fusedOps) = fusingParams;
-
+    auto shapes = _shapes;
     shapes.resize(2);
     switch (opType) {
     case ov::test::utils::OpType::SCALAR: {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/col2im.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/col2im.cpp
@@ -15,32 +15,17 @@ namespace ov {
 namespace test {
 namespace Col2Im {
 std::string Col2ImLayerCPUTest::getTestCaseName(testing::TestParamInfo<Col2ImLayerCPUTestParamsSet> obj) {
-        Col2ImLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ElementType netPrecision;
-        ElementType indexPrecision;
-        Col2ImSpecificParams col2ImPar;
-        std::tie(col2ImPar, netPrecision, indexPrecision, td) = basicParamsSet;
-
-        InputShape inputShape;
-        std::vector<int64_t> outputSize;
-        std::vector<int64_t> kernelSize;
-        ov::Strides strides;
-        ov::Strides dilations;
-        ov::Shape pads_begin;
-        ov::Shape pads_end;
-        std::tie(inputShape, outputSize, kernelSize, strides, dilations, pads_begin, pads_end) = col2ImPar;
-        std::ostringstream result;
-
-        result << netPrecision << "_IS=";
-        result << ov::test::utils::partialShape2str({ inputShape.first }) << "_";
-        result << "TS=";
-        result << "(";
-        for (const auto& targetShape : inputShape.second) {
-            result << ov::test::utils::vec2str(targetShape) << "_";
-        }
+    const auto& [basicParamsSet, cpuParams] = obj.param;
+    const auto& [col2ImPar, netPrecision, indexPrecision, td] = basicParamsSet;
+    const auto& [inputShape, outputSize, kernelSize, strides, dilations, pads_begin, pads_end] = col2ImPar;
+    std::ostringstream result;
+    result << netPrecision << "_IS=";
+    result << ov::test::utils::partialShape2str({inputShape.first}) << "_";
+    result << "TS=";
+    result << "(";
+    for (const auto& targetShape : inputShape.second) {
+        result << ov::test::utils::vec2str(targetShape) << "_";
+    }
         result << ")_";
         result << "outputSize=" << ov::test::utils::vec2str(outputSize) << "_";
         result << "kernelSize=" << ov::test::utils::vec2str(kernelSize) << "_";
@@ -71,45 +56,23 @@ void Col2ImLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& targetInp
     }
 
 void Col2ImLayerCPUTest::SetUp() {
-        Col2ImLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        Col2ImSpecificParams Col2ImParams;
-        ElementType inputPrecision;
-        ElementType indexPrecision;
-        std::tie(Col2ImParams, inputPrecision, indexPrecision, targetDevice) = basicParamsSet;
-
-        InputShape dataInputShape;
-        std::vector<int64_t> outputSize;
-        std::vector<int64_t> kernelSize;
-        ov::Strides strides;
-        ov::Strides dilations;
-        ov::Shape pads_begin;
-        ov::Shape pads_end;
-        std::tie(dataInputShape, outputSize, kernelSize, strides, dilations, pads_begin, pads_end) = Col2ImParams;
-
-        auto image2DSpatialShape = InputShape{{}, {{2}}};
-        init_input_shapes({dataInputShape, image2DSpatialShape, image2DSpatialShape});
-        auto dataParameter = std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputDynamicShapes[0]);
-        auto outputSizeConst = std::make_shared<ov::op::v0::Constant>(indexPrecision, ov::Shape{ 2 }, outputSize);
-        auto kernelSizeConst = std::make_shared<ov::op::v0::Constant>(indexPrecision, ov::Shape{ 2 }, kernelSize);
-
-        auto Col2Im = std::make_shared<ov::op::v15::Col2Im>(dataParameter,
-                                                            outputSizeConst,
-                                                            kernelSizeConst,
-                                                            strides,
-                                                            dilations,
-                                                            pads_begin,
-                                                            pads_end);
-
-        ov::ParameterVector params{ dataParameter };
-        function = makeNgraphFunction(inputPrecision, params, Col2Im, "Col2Im");
-
-        if (inputPrecision == ov::element::bf16) {
-            rel_threshold = 0.02;
-        }
+    const auto& [basicParamsSet, cpuParams] = this->GetParam();
+    std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+    const auto& [Col2ImParams, inputPrecision, indexPrecision, _targetDevice] = basicParamsSet;
+    targetDevice = _targetDevice;
+    const auto& [dataInputShape, outputSize, kernelSize, strides, dilations, pads_begin, pads_end] = Col2ImParams;
+    auto image2DSpatialShape = InputShape{{}, {{2}}};
+    init_input_shapes({dataInputShape, image2DSpatialShape, image2DSpatialShape});
+    auto dataParameter = std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputDynamicShapes[0]);
+    auto outputSizeConst = std::make_shared<ov::op::v0::Constant>(indexPrecision, ov::Shape{2}, outputSize);
+    auto kernelSizeConst = std::make_shared<ov::op::v0::Constant>(indexPrecision, ov::Shape{2}, kernelSize);
+    auto Col2Im = std::make_shared<ov::op::v15::Col2Im>(dataParameter, outputSizeConst, kernelSizeConst, strides,
+                                                        dilations, pads_begin, pads_end);
+    ov::ParameterVector params{dataParameter};
+    function = makeNgraphFunction(inputPrecision, params, Col2Im, "Col2Im");
+    if (inputPrecision == ov::element::bf16) {
+        rel_threshold = 0.02;
+    }
 }
 
 TEST_P(Col2ImLayerCPUTest, CompareWithRefs) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/conversion.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/conversion.cpp
@@ -51,14 +51,8 @@ static void modify_value(ov::Tensor& tensor, const ov::test::SpecialValue& speci
 }
 
 std::string ConvertCPULayerTest::getTestCaseName(testing::TestParamInfo<convertLayerTestParamsSet> obj) {
-    InputShape inputShape;
-    ov::element::Type inPrc, outPrc;
-    ov::test::SpecialValue special_value;
-    CPUSpecificParams cpuParams;
-    std::tie(inputShape, inPrc, outPrc, special_value, cpuParams) = obj.param;
-
+    const auto& [inputShape, inPrc, outPrc, special_value, cpuParams] = obj.param;
     std::ostringstream result;
-
     result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_";
     result << "TS=";
     for (const auto& shape : inputShape.second) {
@@ -93,11 +87,10 @@ bool ConvertCPULayerTest::isInOutPrecisionSupported(ov::element::Type inPrc, ov:
 
 void ConvertCPULayerTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    InputShape shapes;
-    CPUSpecificParams cpuParams;
-    std::tie(shapes, inPrc, outPrc, special_value, cpuParams) = GetParam();
-
+    const auto& [shapes, _inPrc, _outPrc, _special_value, cpuParams] = GetParam();
+    inPrc = _inPrc;
+    outPrc = _outPrc;
+    special_value = _special_value;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     auto primitive = selectedType;
     if (primitive.empty())

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution.cpp
@@ -160,12 +160,10 @@ void ConvolutionLayerCPUTest::SetUp() {
 
     if (postOpMgrPtr)
         isBias = (postOpMgrPtr->getFusedOpsNames() == "Add(PerChannel)" && selectedType != "jit_avx512_winograd");
-
-    convSpecificParams convParams;
-    InputShape inputShape;
-    auto netType = ElementType::dynamic;
-    std::tie(convParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
-
+    const auto& [convParams, netType, _inType, _outType, inputShape, _targetDevice] = basicParamsSet;
+    inType = _inType;
+    outType = _outType;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape});
 
     auto it = configuration.find(ov::hint::inference_precision.name());
@@ -186,13 +184,9 @@ void ConvolutionLayerCPUTest::SetUp() {
     } else {
         selectedType = makeSelectedTypeStr(selectedType, netType);
     }
-
-    ov::op::PadType padType;
-    ov::Shape stride;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
-
+    const auto& [_kernel, stride, padBegin, padEnd, _dilation, convOutChannels, padType] = convParams;
+    kernel = _kernel;
+    dilation = _dilation;
     ov::ParameterVector inputParams;
     for (auto&& shape : inputDynamicShapes)
         inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(ov::element::f32, shape));

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/convolution_backprop_data.cpp
@@ -8,25 +8,9 @@ using namespace CPUTestUtils;
 using namespace ov::test;
 
 std::string DeconvolutionLayerCPUTest::getTestCaseName(testing::TestParamInfo<DeconvLayerCPUTestParamsSet> obj) {
-    DeconvSpecParams basicParamsSet;
-    DeconvInputData inputData;
-    ElementType prec;
-    fusingSpecificParams fusingParams;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = obj.param;
-
-    ov::op::PadType padType;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
-    size_t convOutChannels;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding) = basicParamsSet;
-
-    InputShape inputShape;
-    ov::test::utils::InputLayerType outShapeType;
-    std::vector<std::vector<int32_t>> outShapeData;
-    std::tie(inputShape, outShapeType, outShapeData) = inputData;
-
+    const auto& [basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig] = obj.param;
+    const auto& [kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outPadding] = basicParamsSet;
+    const auto& [inputShape, outShapeType, outShapeData] = inputData;
     std::ostringstream result;
     result << "IS=";
     result << ov::test::utils::partialShape2str({inputShape.first}) << "_";
@@ -178,18 +162,10 @@ void DeconvolutionLayerCPUTest::SetUp() {
     rel_threshold = 1e-4f;
 
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    DeconvSpecParams basicParamsSet;
-    DeconvInputData inputData;
-    fusingSpecificParams fusingParams;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = this->GetParam();
-
-    InputShape inputShape;
-    ov::test::utils::InputLayerType outShapeType;
-    std::tie(inputShape, outShapeType, outShapeData) = inputData;
-
+    const auto& [basicParamsSet, inputData, _prec, fusingParams, cpuParams, additionalConfig] = this->GetParam();
+    prec = _prec;
+    const auto& [inputShape, outShapeType, _outShapeData] = inputData;
+    outShapeData = _outShapeData;
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     std::tie(postOpMgrPtr, fusedOps) = fusingParams;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/eltwise.cpp
@@ -22,12 +22,7 @@ namespace ov {
 namespace test {
 
 std::string EltwiseLayerCPUTest::getTestCaseName(testing::TestParamInfo<EltwiseLayerCPUTestParamsSet> obj) {
-    EltwiseTestParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    bool enforceSnippets;
-    std::tie(basicParamsSet, cpuParams, fusingParams, enforceSnippets) = obj.param;
-
+    const auto& [basicParamsSet, cpuParams, fusingParams, enforceSnippets] = obj.param;
     std::ostringstream result;
     result << EltwiseLayerTest::getTestCaseName(testing::TestParamInfo<EltwiseTestParams>(
                                                               basicParamsSet, 0));
@@ -132,21 +127,19 @@ void EltwiseLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& targetIn
 }
 
 void EltwiseLayerCPUTest::SetUp() {
-    EltwiseTestParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    bool enforceSnippets;
-    std::tie(basicParamsSet, cpuParams, fusingParams, enforceSnippets) = this->GetParam();
-    std::vector<InputShape> shapes;
-    ElementType netType;
-    utils::InputLayerType secondaryInputType;
-    ov::test::utils::OpType opType;
-    ov::AnyMap additionalConfig;
-    std::tie(shapes, eltwiseType, secondaryInputType, opType, netType, inType, outType, targetDevice, additionalConfig) = basicParamsSet;
+    const auto& [basicParamsSet, cpuParams, fusingParams, enforceSnippets] = this->GetParam();
+    const auto& [_shapes, _eltwiseType, secondaryInputType, opType, _netType, _inType, _outType, _targetDevice,
+                 additionalConfig] = basicParamsSet;
+    auto shapes = _shapes;
+    eltwiseType = _eltwiseType;
+    inType = _inType;
+    outType = _outType;
+    targetDevice = _targetDevice;
+    auto netType = _netType;
     // we have to change model precision as well, otherwise inference precision won't affect single-node graph
     // due to enforce inference precision optimization for the eltwise as first node of the model
     if (ov::element::Type(netType).is_real() && additionalConfig.count(ov::hint::inference_precision.name())) {
-        netType = additionalConfig[ov::hint::inference_precision.name()].as<ov::element::Type>();
+        netType = additionalConfig.at(ov::hint::inference_precision.name()).as<ov::element::Type>();
     }
 
     if (ElementType::bf16 == netType) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/extremum.cpp
@@ -17,12 +17,8 @@ using namespace CPUTestUtils;
 using namespace ov::test::utils;
 
 std::string ExtremumLayerCPUTest::getTestCaseName(const testing::TestParamInfo<ExtremumLayerCPUTestParamSet> &obj) {
-    std::vector<ov::test::InputShape> inputShapes;
-    utils::MinMaxOpType extremumType;
-    ov::element::Type netPrecision, inPrecision, outPrecision;
-    CPUTestUtils::CPUSpecificParams cpuParams;
-    bool enforceSnippets;
-    std::tie(inputShapes, extremumType, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets) = obj.param;
+    const auto& [inputShapes, extremumType, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets] =
+        obj.param;
     std::ostringstream result;
     result << extremumNames[extremumType] << "_";
     if (inputShapes.front().first.size() != 0) {
@@ -50,13 +46,8 @@ std::string ExtremumLayerCPUTest::getTestCaseName(const testing::TestParamInfo<E
 
 void ExtremumLayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    std::vector<ov::test::InputShape> inputShapes;
-    utils::MinMaxOpType extremumType;
-    ov::element::Type netPrecision, inPrecision, outPrecision;
-    CPUTestUtils::CPUSpecificParams cpuParams;
-    bool enforceSnippets;
-    std::tie(inputShapes, extremumType, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets) = this->GetParam();
+    const auto& [inputShapes, extremumType, netPrecision, inPrecision, outPrecision, cpuParams, enforceSnippets] =
+        this->GetParam();
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
     inType  = inPrecision;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/matmul.cpp
@@ -15,22 +15,9 @@ namespace ov {
 namespace test {
 
 std::string MatMulLayerCPUTest::getTestCaseName(const testing::TestParamInfo<MatMulLayerCPUTestParamSet>& obj) {
-    MatMulLayerTestParamsSet basicParamsSet;
-    MatMulNodeType nodeType;
-    fusingSpecificParams fusingParams;
-    CPUSpecificParams cpuParams;
-
-    std::tie(basicParamsSet, nodeType, fusingParams, cpuParams) = obj.param;
-
-    ElementType netType;
-    ElementType inType, outType;
-    ShapeRelatedParams shapeRelatedParams;
-    utils::InputLayerType secondaryInputType;
-    TargetDevice targetDevice;
-    ov::AnyMap additionalConfig;
-    std::tie(shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig) =
+    const auto& [basicParamsSet, nodeType, fusingParams, cpuParams] = obj.param;
+    const auto& [shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig] =
         basicParamsSet;
-
     std::ostringstream result;
     result << (nodeType == MatMulNodeType::MatMul ? "MatMul_" : "FullyConnected_");
     result << "IS=";
@@ -73,21 +60,13 @@ void MatMulLayerCPUTest::transpose(T& shape) {
 }
 
 void MatMulLayerCPUTest::SetUp() {
-    MatMulLayerTestParamsSet basicParamsSet;
-    MatMulNodeType nodeType;
-    fusingSpecificParams fusingParams;
-    CPUSpecificParams cpuParams;
-
-    std::tie(basicParamsSet, nodeType, fusingParams, cpuParams) = this->GetParam();
+    const auto& [basicParamsSet, nodeType, fusingParams, cpuParams] = this->GetParam();
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-    ShapeRelatedParams shapeRelatedParams;
-    ElementType netType;
-    utils::InputLayerType secondaryInputType;
-    ov::AnyMap additionalConfig;
-
-    std::tie(shapeRelatedParams, netType, inType, outType, secondaryInputType, targetDevice, additionalConfig) = basicParamsSet;
-
+    const auto& [shapeRelatedParams, _netType, _inType, _outType, secondaryInputType, _targetDevice, additionalConfig] =
+        basicParamsSet;
+    inType = _inType;
+    outType = _outType;
+    targetDevice = _targetDevice;
     init_input_shapes(shapeRelatedParams.inputShapes);
 
     bool transpA = shapeRelatedParams.transpose.first;
@@ -120,6 +99,7 @@ void MatMulLayerCPUTest::SetUp() {
     auto it = additionalConfig.find(ov::hint::inference_precision.name());
     ov::element::Type inference_precision =
         (it != additionalConfig.end()) ? it->second.as<ov::element::Type>() : ov::element::dynamic;
+    auto netType = _netType;
     if (inference_precision == ov::element::bf16) {
         inType = outType = netType = ElementType::bf16;
         rel_threshold = abs_threshold = 1e-2f;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/mvn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/mvn.cpp
@@ -15,20 +15,9 @@ namespace ov {
 namespace test {
 
 std::string MvnLayerCPUTest::getTestCaseName(testing::TestParamInfo<MvnLayerCPUTestParamSet> obj) {
-    basicCpuMvnParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    ElementType inputPrecision, outputPrecision;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, cpuParams, fusingParams, inputPrecision, outputPrecision, additionalConfig) = obj.param;
-
-    InputShape inputShapes;
-    ElementType netPrecision;
-    ov::AxisSet axes;
-    bool acrossChanels, normalizeVariance;
-    double eps;
-    std::tie(inputShapes, netPrecision, axes, acrossChanels, normalizeVariance, eps) = basicParamsSet;
-
+    const auto& [basicParamsSet, cpuParams, fusingParams, inputPrecision, outputPrecision, additionalConfig] =
+        obj.param;
+    const auto& [inputShapes, netPrecision, axes, acrossChanels, normalizeVariance, eps] = basicParamsSet;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::partialShape2str({inputShapes.first}) << "_";
     result << "TS=";
@@ -64,25 +53,11 @@ std::string MvnLayerCPUTest::getTestCaseName(testing::TestParamInfo<MvnLayerCPUT
 
 void MvnLayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    basicCpuMvnParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    ElementType inPrc;
-    ElementType outPrc;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, cpuParams, fusingParams, inPrc, outPrc, additionalConfig) = this->GetParam();
-
+    const auto& [basicParamsSet, cpuParams, fusingParams, inPrc, outPrc, additionalConfig] = this->GetParam();
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     std::tie(postOpMgrPtr, fusedOps) = fusingParams;
-
-    InputShape inputShapes;
-    ElementType netPrecision;
-    ov::AxisSet axes;
-    bool normalizeVariance;
-    double eps;
-    std::tie(inputShapes, netPrecision, axes, acrossChanels, normalizeVariance, eps) = basicParamsSet;
-
+    const auto& [inputShapes, netPrecision, axes, _acrossChanels, normalizeVariance, eps] = basicParamsSet;
+    acrossChanels = _acrossChanels;
     init_input_shapes({inputShapes});
 
     ov::ParameterVector params;
@@ -105,7 +80,8 @@ void MvnLayerCPUTest::SetUp() {
     }
 
     rel_threshold = 5e-4;
-    if (any_of(additionalConfig[ov::hint::inference_precision.name()], ov::element::f16, ov::element::bf16)) {
+    if (auto it = additionalConfig.find(ov::hint::inference_precision.name()); it != additionalConfig.end()
+        && any_of(it->second, ov::element::f16, ov::element::bf16)) {
         rel_threshold = 1e-2;
         abs_threshold = .03f;
     }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/pooling.cpp
@@ -14,23 +14,8 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 std::string PoolingLayerCPUTest::getTestCaseName(const testing::TestParamInfo<poolLayerCpuTestParamsSet>& obj) {
-    ov::test::poolSpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    bool isInt8;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig) = obj.param;
-
-    utils::PoolingTypes poolType;
-    std::vector<size_t> kernel, stride;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    bool excludePad;
-    std::tie(poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad) = basicParamsSet;
-
+    const auto& [basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig] = obj.param;
+    const auto& [poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad] = basicParamsSet;
     std::ostringstream results;
     results << "IS=(";
     results << ov::test::utils::partialShape2str({inputShapes.first}) << ")_";
@@ -69,25 +54,10 @@ std::string PoolingLayerCPUTest::getTestCaseName(const testing::TestParamInfo<po
 
 void PoolingLayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    poolSpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    bool isInt8;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig) = this->GetParam();
+    const auto& [basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig] =
+        this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
-
-    utils::PoolingTypes poolType;
-    std::vector<size_t> kernel, stride;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    bool excludePad;
-    std::tie(poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad) = basicParamsSet;
-
+    const auto& [poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad] = basicParamsSet;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
@@ -124,23 +94,8 @@ void PoolingLayerCPUTest::SetUp() {
 }
 
 std::string AvgPoolingV14LayerCPUTest::getTestCaseName(const testing::TestParamInfo<poolLayerCpuTestParamsSet>& obj) {
-    ov::test::poolSpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    bool isInt8;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig) = obj.param;
-
-    utils::PoolingTypes poolType;
-    std::vector<size_t> kernel, stride;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    bool excludePad;
-    std::tie(poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad) = basicParamsSet;
-
+    const auto& [basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig] = obj.param;
+    const auto& [poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad] = basicParamsSet;
     std::ostringstream results;
     results << "IS=(";
     results << ov::test::utils::partialShape2str({inputShapes.first}) << ")_";
@@ -171,25 +126,10 @@ std::string AvgPoolingV14LayerCPUTest::getTestCaseName(const testing::TestParamI
 
 void AvgPoolingV14LayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    poolSpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    bool isInt8;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig) = this->GetParam();
+    const auto& [basicParamsSet, inputShapes, inPrc, isInt8, cpuParams, fusingParams, additionalConfig] =
+        this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
-
-    utils::PoolingTypes poolType;
-    std::vector<size_t> kernel, stride;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    bool excludePad;
-    std::tie(poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad) = basicParamsSet;
-
+    const auto& [poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad] = basicParamsSet;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
@@ -222,22 +162,9 @@ void AvgPoolingV14LayerCPUTest::SetUp() {
 
 std::string MaxPoolingV8LayerCPUTest::getTestCaseName(
     const testing::TestParamInfo<maxPoolV8LayerCpuTestParamsSet>& obj) {
-    maxPoolV8SpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig) = obj.param;
-
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    ov::element::Type indexElementType;
-    int64_t axis;
-    std::tie(kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType) =
+    const auto& [basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig] = obj.param;
+    const auto& [kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType] =
         basicParamsSet;
-
     std::ostringstream results;
     results << "IS=(";
     results << ov::test::utils::partialShape2str({inputShapes.first}) << ")_";
@@ -267,22 +194,9 @@ std::string MaxPoolingV8LayerCPUTest::getTestCaseName(
 
 void MaxPoolingV8LayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    maxPoolV8SpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig) = this->GetParam();
+    const auto& [basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig] = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
-
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    ov::element::Type indexElementType;
-    int64_t axis;
-    std::tie(kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType) =
+    const auto& [kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType] =
         basicParamsSet;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     if (selectedType.empty()) {
@@ -313,22 +227,9 @@ void MaxPoolingV8LayerCPUTest::SetUp() {
 
 std::string MaxPoolingV14LayerCPUTest::getTestCaseName(
 const testing::TestParamInfo<maxPoolV8LayerCpuTestParamsSet>& obj) {
-    maxPoolV8SpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig) = obj.param;
-
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    ov::element::Type indexElementType;
-    int64_t axis;
-    std::tie(kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType) =
+    const auto& [basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig] = obj.param;
+    const auto& [kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType] =
         basicParamsSet;
-
     std::ostringstream results;
     results << "IS=(";
     results << ov::test::utils::partialShape2str({inputShapes.first}) << ")_";
@@ -358,22 +259,9 @@ const testing::TestParamInfo<maxPoolV8LayerCpuTestParamsSet>& obj) {
 
 void MaxPoolingV14LayerCPUTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    maxPoolV8SpecificParams basicParamsSet;
-    InputShape inputShapes;
-    ElementType inPrc;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig) = this->GetParam();
+    const auto& [basicParamsSet, inputShapes, inPrc, cpuParams, additionalConfig] = this->GetParam();
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
-
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<size_t> padBegin, padEnd;
-    ov::op::PadType padType;
-    ov::op::RoundingType roundingType;
-    ov::element::Type indexElementType;
-    int64_t axis;
-    std::tie(kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType) =
+    const auto& [kernel, stride, dilation, padBegin, padEnd, indexElementType, axis, roundingType, padType] =
         basicParamsSet;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     if (selectedType.empty()) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/reduce.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/reduce.cpp
@@ -16,21 +16,8 @@ namespace ov {
 namespace test {
 
 std::string ReduceCPULayerTest::getTestCaseName(testing::TestParamInfo<ReduceLayerCPUTestParamSet> obj) {
-    basicReduceParams basicParams;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    std::map<std::string, ov::element::Type> additionalConfig;
-    std::tie(basicParams, cpuParams, fusingParams, additionalConfig) = obj.param;
-
-    std::vector<int> axes;
-    ov::test::utils::OpType opType;
-    bool keepDims;
-    ov::test::utils::ReductionType reductionType;
-    ElementType netPrecision, inPrc, outPrc;
-    std::vector<InputShape> inputShapes;
-
-    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc, outPrc, inputShapes) = basicParams;
-
+    const auto& [basicParams, cpuParams, fusingParams, additionalConfig] = obj.param;
+    const auto& [axes, opType, keepDims, reductionType, netPrecision, inPrc, outPrc, inputShapes] = basicParams;
     std::ostringstream result;
     result << "IS=(";
     for (const auto& shape : inputShapes) {
@@ -68,27 +55,12 @@ std::string ReduceCPULayerTest::getTestCaseName(testing::TestParamInfo<ReduceLay
 
 void ReduceCPULayerTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    basicReduceParams basicParams;
-    CPUSpecificParams cpuParams;
-    fusingSpecificParams fusingParams;
-    std::map<std::string, ov::element::Type> additionalConfig;
-    std::tie(basicParams, cpuParams, fusingParams, additionalConfig) = this->GetParam();
-
+    const auto& [basicParams, cpuParams, fusingParams, additionalConfig] = this->GetParam();
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     std::tie(postOpMgrPtr, fusedOps) = fusingParams;
-
-    std::vector<int> axes;
-    ov::test::utils::OpType opType;
-    bool keepDims;
-    ElementType inPrc, outPrc;
-    std::vector<InputShape> inputShapes;
-
-    std::tie(axes, opType, keepDims, reductionType, netPrecision, inPrc, outPrc, inputShapes) = basicParams;
-    if (netPrecision == ElementType::boolean) {
-        inPrc = outPrc = netPrecision;
-    }
-
+    const auto& [axes, opType, keepDims, _reductionType, _netPrecision, inPrc, outPrc, inputShapes] = basicParams;
+    reductionType = _reductionType;
+    netPrecision = _netPrecision;
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
     updateSelectedType(getPrimitiveType(), netPrecision == ElementType::boolean ? ElementType::i8 : netPrecision, configuration);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/rms_norm.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/rms_norm.cpp
@@ -18,12 +18,7 @@ namespace ov {
 namespace test {
 
 std::string RMSNormLayerCPUTest::getTestCaseName(const testing::TestParamInfo<RMSNormCPUTestParams>& obj) {
-    CPUSpecificParams cpuParams;
-    ElementType inType;
-    std::vector<InputShape> inputShapes;
-    std::string targetDevice;
-    std::tie(inType, inputShapes, targetDevice, cpuParams) = obj.param;
-
+    const auto& [inType, inputShapes, targetDevice, cpuParams] = obj.param;
     std::ostringstream result;
     result << "netPRC=" << inType << "_";
     result << "IS=";
@@ -90,11 +85,8 @@ void RMSNormLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& targetIn
 }
 
 void RMSNormLayerCPUTest::SetUp() {
-    ElementType inType;
-    CPUSpecificParams cpuParams;
-    std::vector<InputShape> inputShapes;
-    std::tie(inType, inputShapes, targetDevice, cpuParams) = this->GetParam();
-
+    const auto& [inType, inputShapes, _targetDevice, cpuParams] = this->GetParam();
+    targetDevice = _targetDevice;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     if (selectedType.empty()) {
         selectedType = getPrimitiveType();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/scaled_attn.cpp
@@ -16,15 +16,7 @@ namespace ov {
 namespace test {
 
 std::string ScaledAttnLayerCPUTest::getTestCaseName(const testing::TestParamInfo<ScaledAttnCPUTestParams>& obj) {
-    CPUSpecificParams cpuParams;
-    ElementType inType;
-    std::vector<InputShape> inputShapes;
-    bool is_causal;
-    bool has_attn;
-    bool has_scale;
-    std::string targetDevice;
-    std::tie(inType, inputShapes, is_causal, has_attn, has_scale, targetDevice, cpuParams) = obj.param;
-
+    const auto& [inType, inputShapes, is_causal, has_attn, has_scale, targetDevice, cpuParams] = obj.param;
     std::ostringstream result;
     result << "netPRC=" << inType << "_";
     result << "IS=";
@@ -48,11 +40,11 @@ std::string ScaledAttnLayerCPUTest::getTestCaseName(const testing::TestParamInfo
 }
 
 void ScaledAttnLayerCPUTest::SetUp() {
-    ElementType inType;
-    CPUSpecificParams cpuParams;
-    std::vector<InputShape> inputShapes;
-    std::tie(inType, inputShapes, is_causal, has_attn, has_scale, targetDevice, cpuParams) = this->GetParam();
-
+    const auto& [inType, inputShapes, _is_causal, _has_attn, _has_scale, _targetDevice, cpuParams] = this->GetParam();
+    is_causal = _is_causal;
+    has_attn = _has_attn;
+    has_scale = _has_scale;
+    targetDevice = _targetDevice;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
     if (selectedType.empty()) {
         selectedType = getPrimitiveType();
@@ -124,14 +116,7 @@ void ScaledAttnLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& targe
 }
 
 TEST_P(ScaledAttnLayerCPUTest, CompareWithRefs) {
-    CPUSpecificParams cpuParams;
-    ElementType inType;
-    std::vector<InputShape> inputShapes;
-    bool is_causal;
-    bool has_attn;
-    bool has_scale;
-    std::string targetDevice;
-    std::tie(inType, inputShapes, is_causal, has_attn, has_scale, targetDevice, cpuParams) = this->GetParam();
+    const auto& [inType, inputShapes, is_causal, has_attn, has_scale, targetDevice, cpuParams] = this->GetParam();
     if (inType == ElementType::bf16 && !ov::with_cpu_x86_bfloat16() && !with_cpu_x86_avx2_vnni_2())
         GTEST_SKIP();
     run();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/segment_max.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/segment_max.cpp
@@ -15,29 +15,16 @@ namespace ov {
 namespace test {
 namespace SegmentMax {
 std::string SegmentMaxLayerCPUTest::getTestCaseName(testing::TestParamInfo<SegmentMaxLayerCPUTestParamsSet> obj) {
-        SegmentMaxLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        SegmentMaxSpecificParams SegmentMaxPar;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ElementType dataPrecision;
-        bool useNumSegments;
-        ov::test::utils::InputLayerType secondaryInputType;
-        std::tie(SegmentMaxPar, dataPrecision, useNumSegments, secondaryInputType, td) = basicParamsSet;
-
-        InputShape dataShape;
-        std::vector<int64_t> segmentIdsValues;
-        int64_t numSegments;
-        ov::op::FillMode fillMode;
-        std::tie(dataShape, segmentIdsValues, numSegments, fillMode) = SegmentMaxPar;
-        std::ostringstream result;
-
-        result << ov::test::utils::partialShape2str({ dataShape.first }) << "_";
-        result << "TS=";
-        result << "(";
-        for (const auto& targetShape : dataShape.second) {
-            result << ov::test::utils::vec2str(targetShape);
-        }
+    const auto& [basicParamsSet, cpuParams] = obj.param;
+    const auto& [SegmentMaxPar, dataPrecision, useNumSegments, secondaryInputType, td] = basicParamsSet;
+    const auto& [dataShape, segmentIdsValues, numSegments, fillMode] = SegmentMaxPar;
+    std::ostringstream result;
+    result << ov::test::utils::partialShape2str({dataShape.first}) << "_";
+    result << "TS=";
+    result << "(";
+    for (const auto& targetShape : dataShape.second) {
+        result << ov::test::utils::vec2str(targetShape);
+    }
         result << ")";
         result << "_segmentIds=" << ov::test::utils::vec2str(segmentIdsValues);
         if (useNumSegments) {
@@ -84,33 +71,19 @@ void SegmentMaxLayerCPUTest::generate_inputs(const std::vector<ov::Shape>& targe
 }
 
 void SegmentMaxLayerCPUTest::SetUp() {
-        SegmentMaxLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        SegmentMaxSpecificParams SegmentMaxParams;
-        ElementType inputPrecision;
-        bool useNumSegments;
-        ov::test::utils::InputLayerType secondaryInputType;
-        std::tie(SegmentMaxParams, inputPrecision, useNumSegments, secondaryInputType, targetDevice) = basicParamsSet;
-
-        InputShape dataShape;
-        std::vector<int64_t> segmentIdsValues;
-        int64_t numSegmentsValue;
-        ov::op::FillMode fillMode;
-        std::tie(dataShape, segmentIdsValues, numSegmentsValue, fillMode) = SegmentMaxParams;
-        const ov::test::InputShape segmentIdsShape = {
-            ov::PartialShape{static_cast<ov::Dimension::value_type>(segmentIdsValues.size())}, std::vector<ov::Shape>{segmentIdsValues.size()}
-            };
-
-        std::vector<ov::test::InputShape> input_shapes = { dataShape, segmentIdsShape };
-        if (useNumSegments) {
-            const ov::test::InputShape numSegmentsShape = {
-                ov::PartialShape{}, std::vector<ov::Shape>{ov::Shape{}}
-            };
-            input_shapes.emplace_back(numSegmentsShape);
-        }
+    const auto& [basicParamsSet, cpuParams] = this->GetParam();
+    std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+    const auto& [SegmentMaxParams, inputPrecision, useNumSegments, secondaryInputType, _targetDevice] = basicParamsSet;
+    targetDevice = _targetDevice;
+    const auto& [dataShape, segmentIdsValues, numSegmentsValue, fillMode] = SegmentMaxParams;
+    const ov::test::InputShape segmentIdsShape = {
+        ov::PartialShape{static_cast<ov::Dimension::value_type>(segmentIdsValues.size())},
+        std::vector<ov::Shape>{segmentIdsValues.size()}};
+    std::vector<ov::test::InputShape> input_shapes = {dataShape, segmentIdsShape};
+    if (useNumSegments) {
+        const ov::test::InputShape numSegmentsShape = {ov::PartialShape{}, std::vector<ov::Shape>{ov::Shape{}}};
+        input_shapes.emplace_back(numSegmentsShape);
+    }
         init_input_shapes(input_shapes);
         auto dataParameter = std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputDynamicShapes[0]);
         ov::ParameterVector params{ dataParameter };

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/softmax.cpp
@@ -13,13 +13,7 @@ namespace ov {
 namespace test {
 
 std::string SoftMaxLayerCPUTest::getTestCaseName(const testing::TestParamInfo<softmaxCPUTestParams>& obj) {
-    CPUSpecificParams cpuParams;
-    ElementType inType;
-    SoftMaxConfig config;
-    std::string targetDevice;
-    ov::AnyMap additionalConfig;
-    std::tie(inType, config, targetDevice, cpuParams, additionalConfig) = obj.param;
-
+    const auto& [inType, config, targetDevice, cpuParams, additionalConfig] = obj.param;
     std::ostringstream result;
     result << "netPRC=" << inType << "_";
     result << "IS=" << ov::test::utils::partialShape2str({config.inputShape.first}) << "_";
@@ -43,11 +37,8 @@ std::string SoftMaxLayerCPUTest::getTestCaseName(const testing::TestParamInfo<so
 }
 
 void SoftMaxLayerCPUTest::SetUp() {
-    ElementType inType;
-    SoftMaxConfig config;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(inType, config, targetDevice, cpuParams, additionalConfig) = this->GetParam();
+    const auto& [inType, config, _targetDevice, cpuParams, additionalConfig] = this->GetParam();
+    targetDevice = _targetDevice;
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/sparse_fill_empty_rows.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/sparse_fill_empty_rows.cpp
@@ -14,21 +14,9 @@ using namespace CPUTestUtils;
 namespace ov::test::SparseFillEmptyRows {
 
 std::string SparseFillEmptyRowsLayerCPUTest::getTestCaseName(testing::TestParamInfo<SparseFillEmptyRowsLayerCPUTestParamsSet> obj) {
-    SparseFillEmptyRowsLayerTestParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    SparseFillEmptyRowsSpecificParams sparseFillEmptyRowsPar;
-    std::tie(basicParamsSet, cpuParams) = obj.param;
-    std::string td;
-    ElementType valuesPrecision;
-    ElementType indicesPrecision;
-    ov::test::utils::InputLayerType secondaryInputType;
-    std::tie(sparseFillEmptyRowsPar, valuesPrecision, indicesPrecision, secondaryInputType, td) = basicParamsSet;
-
-    InputShape valuesShape;
-    InputShape indicesShape;
-    std::vector<int64_t> denseShapeValues;
-    int64_t defaultValue;
-    std::tie(valuesShape, indicesShape, denseShapeValues, defaultValue) = sparseFillEmptyRowsPar;
+    const auto& [basicParamsSet, cpuParams] = obj.param;
+    const auto& [sparseFillEmptyRowsPar, valuesPrecision, indicesPrecision, secondaryInputType, td] = basicParamsSet;
+    const auto& [valuesShape, indicesShape, denseShapeValues, defaultValue] = sparseFillEmptyRowsPar;
     std::ostringstream result;
 
     result << "valuesShape=" << ov::test::utils::partialShape2str({valuesShape.first}) << "_";
@@ -120,23 +108,12 @@ void SparseFillEmptyRowsLayerCPUTest::generate_inputs(const std::vector<ov::Shap
 }
 
 void SparseFillEmptyRowsLayerCPUTest::SetUp() {
-    SparseFillEmptyRowsLayerTestParams basicParamsSet;
-    CPUSpecificParams cpuParams;
-    std::tie(basicParamsSet, cpuParams) = this->GetParam();
+    const auto& [basicParamsSet, cpuParams] = this->GetParam();
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-    SparseFillEmptyRowsSpecificParams sparseFillEmptyRowsParams;
-    ElementType valuesPrecision;
-    ElementType indicesPrecision;
-    ov::test::utils::InputLayerType secondaryInputType;
-    std::tie(sparseFillEmptyRowsParams, valuesPrecision, indicesPrecision, secondaryInputType, targetDevice) = basicParamsSet;
-
-    InputShape valuesShape;
-    InputShape indicesShape;
-    std::vector<int64_t> denseShapeValues;
-    int64_t defaultValue;
-    std::tie(valuesShape, indicesShape, denseShapeValues, defaultValue) = sparseFillEmptyRowsParams;
-
+    const auto& [sparseFillEmptyRowsParams, valuesPrecision, indicesPrecision, secondaryInputType, _targetDevice] =
+        basicParamsSet;
+    targetDevice = _targetDevice;
+    const auto& [valuesShape, indicesShape, denseShapeValues, defaultValue] = sparseFillEmptyRowsParams;
     std::vector<ov::test::InputShape> input_shapes = {
         valuesShape,
         {ov::PartialShape{static_cast<ov::Dimension::value_type>(denseShapeValues.size())},

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/string_tensor_pack.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/string_tensor_pack.cpp
@@ -15,25 +15,16 @@ namespace ov {
 namespace test {
 namespace StringTensorPack {
 std::string StringTensorPackLayerCPUTest::getTestCaseName(testing::TestParamInfo<StringTensorPackLayerCPUTestParamsSet> obj) {
-        StringTensorPackLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        StringTensorPackSpecificParams StringTensorPackPar;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ElementType indicesPrecision;
-        std::tie(StringTensorPackPar, indicesPrecision, td) = basicParamsSet;
-
-        InputShape indicesShape;
-        InputShape symbolsShape;
-        std::tie(indicesShape, symbolsShape) = StringTensorPackPar;
-        std::ostringstream result;
-
-        result << ov::test::utils::partialShape2str({ indicesShape.first }) << "_";
-        result << "TS=";
-        result << "(";
-        for (const auto& targetShape : indicesShape.second) {
-            result << ov::test::utils::vec2str(targetShape) << "_";
-        }
+    const auto& [basicParamsSet, cpuParams] = obj.param;
+    const auto& [StringTensorPackPar, indicesPrecision, td] = basicParamsSet;
+    const auto& [indicesShape, symbolsShape] = StringTensorPackPar;
+    std::ostringstream result;
+    result << ov::test::utils::partialShape2str({indicesShape.first}) << "_";
+    result << "TS=";
+    result << "(";
+    for (const auto& targetShape : indicesShape.second) {
+        result << ov::test::utils::vec2str(targetShape) << "_";
+    }
         result << ")";
         result << "_symbolsShape=";
         result << "(";
@@ -79,27 +70,19 @@ void StringTensorPackLayerCPUTest::generate_inputs(const std::vector<ov::Shape>&
 }
 
 void StringTensorPackLayerCPUTest::SetUp() {
-        StringTensorPackLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        StringTensorPackSpecificParams StringTensorPackParams;
-        ElementType indicesPrecision;
-        std::tie(StringTensorPackParams, indicesPrecision, targetDevice) = basicParamsSet;
-
-        InputShape indicesShape;
-        InputShape symbolsShape;
-        std::tie(indicesShape, symbolsShape) = StringTensorPackParams;
-
-        init_input_shapes({indicesShape, indicesShape, symbolsShape});
-        auto beginsParameter = std::make_shared<ov::op::v0::Parameter>(indicesPrecision, inputDynamicShapes[0]);
-        auto endsParameter = std::make_shared<ov::op::v0::Parameter>(indicesPrecision, inputDynamicShapes[1]);
-        auto symbolsParameter = std::make_shared<ov::op::v0::Parameter>(ov::element::u8, inputDynamicShapes[2]);
-        auto StringTensorPack = std::make_shared<ov::op::v15::StringTensorPack>(beginsParameter, endsParameter, symbolsParameter);
-
-        ov::ParameterVector params{ beginsParameter, endsParameter, symbolsParameter };
-        function = makeNgraphFunction(ov::element::string, params, StringTensorPack, "StringTensorPack");
+    const auto& [basicParamsSet, cpuParams] = this->GetParam();
+    std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+    const auto& [StringTensorPackParams, indicesPrecision, _targetDevice] = basicParamsSet;
+    targetDevice = _targetDevice;
+    const auto& [indicesShape, symbolsShape] = StringTensorPackParams;
+    init_input_shapes({indicesShape, indicesShape, symbolsShape});
+    auto beginsParameter = std::make_shared<ov::op::v0::Parameter>(indicesPrecision, inputDynamicShapes[0]);
+    auto endsParameter = std::make_shared<ov::op::v0::Parameter>(indicesPrecision, inputDynamicShapes[1]);
+    auto symbolsParameter = std::make_shared<ov::op::v0::Parameter>(ov::element::u8, inputDynamicShapes[2]);
+    auto StringTensorPack =
+        std::make_shared<ov::op::v15::StringTensorPack>(beginsParameter, endsParameter, symbolsParameter);
+    ov::ParameterVector params{beginsParameter, endsParameter, symbolsParameter};
+    function = makeNgraphFunction(ov::element::string, params, StringTensorPack, "StringTensorPack");
 }
 
 TEST_P(StringTensorPackLayerCPUTest, CompareWithRefs) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/string_tensor_unpack.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/string_tensor_unpack.cpp
@@ -15,23 +15,16 @@ namespace ov {
 namespace test {
 namespace StringTensorUnpack {
 std::string StringTensorUnpackLayerCPUTest::getTestCaseName(testing::TestParamInfo<StringTensorUnpackLayerCPUTestParamsSet> obj) {
-        StringTensorUnpackLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        StringTensorUnpackSpecificParams StringTensorUnpackPar;
-        std::tie(StringTensorUnpackPar, td) = basicParamsSet;
-
-        InputShape inputShape;
-        std::tie(inputShape) = StringTensorUnpackPar;
-        std::ostringstream result;
-
-        result << ov::test::utils::partialShape2str({ inputShape.first }) << "_";
-        result << "TS=";
-        result << "(";
-        for (const auto& targetShape : inputShape.second) {
-            result << ov::test::utils::vec2str(targetShape) << "_";
-        }
+    const auto& [basicParamsSet, cpuParams] = obj.param;
+    const auto& [StringTensorUnpackPar, td] = basicParamsSet;
+    const auto& [inputShape] = StringTensorUnpackPar;
+    std::ostringstream result;
+    result << ov::test::utils::partialShape2str({inputShape.first}) << "_";
+    result << "TS=";
+    result << "(";
+    for (const auto& targetShape : inputShape.second) {
+        result << ov::test::utils::vec2str(targetShape) << "_";
+    }
         result << ")";
         result << CPUTestsBase::getTestCaseName(cpuParams);
 
@@ -52,23 +45,16 @@ void StringTensorUnpackLayerCPUTest::generate_inputs(const std::vector<ov::Shape
     }
 
 void StringTensorUnpackLayerCPUTest::SetUp() {
-        StringTensorUnpackLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-        std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        StringTensorUnpackSpecificParams StringTensorUnpackParams;
-        std::tie(StringTensorUnpackParams, targetDevice) = basicParamsSet;
-
-        InputShape dataInputShape;
-        std::tie(dataInputShape) = StringTensorUnpackParams;
-
-        init_input_shapes({dataInputShape});
-        auto dataParameter = std::make_shared<ov::op::v0::Parameter>(ov::element::string, inputDynamicShapes[0]);
-        auto StringTensorUnpack = std::make_shared<ov::op::v15::StringTensorUnpack>(dataParameter);
-
-        ov::ParameterVector params{ dataParameter };
-        function = makeNgraphFunction(ov::element::string, params, StringTensorUnpack, "StringTensorUnpack");
+    const auto& [basicParamsSet, cpuParams] = this->GetParam();
+    std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
+    const auto& [StringTensorUnpackParams, _targetDevice] = basicParamsSet;
+    targetDevice = _targetDevice;
+    const auto& [dataInputShape] = StringTensorUnpackParams;
+    init_input_shapes({dataInputShape});
+    auto dataParameter = std::make_shared<ov::op::v0::Parameter>(ov::element::string, inputDynamicShapes[0]);
+    auto StringTensorUnpack = std::make_shared<ov::op::v15::StringTensorUnpack>(dataParameter);
+    ov::ParameterVector params{dataParameter};
+    function = makeNgraphFunction(ov::element::string, params, StringTensorUnpack, "StringTensorUnpack");
 }
 
 TEST_P(StringTensorUnpackLayerCPUTest, CompareWithRefs) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/transpose.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/classes/transpose.cpp
@@ -13,14 +13,7 @@ using namespace CPUTestUtils;
 namespace ov {
 namespace test {
 std::string TransposeLayerCPUTest::getTestCaseName(testing::TestParamInfo<TransposeLayerCPUTestParamSet> obj) {
-    ov::element::Type netPrecision;
-    InputShape inputShapes;
-    std::vector<size_t> inputOrder;
-    std::string targetDevice;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(inputShapes, inputOrder, netPrecision, targetDevice, additionalConfig, cpuParams) = obj.param;
-
+    const auto& [inputShapes, inputOrder, netPrecision, targetDevice, additionalConfig, cpuParams] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::partialShape2str({inputShapes.first}) << "_";
     result << "TS=(";
@@ -42,12 +35,8 @@ std::string TransposeLayerCPUTest::getTestCaseName(testing::TestParamInfo<Transp
 }
 
 void TransposeLayerCPUTest::SetUp() {
-    ov::element::Type netPrecision;
-    InputShape inputShapes;
-    std::vector<size_t> inputOrder;
-    CPUSpecificParams cpuParams;
-    ov::AnyMap additionalConfig;
-    std::tie(inputShapes, inputOrder, netPrecision, targetDevice, additionalConfig, cpuParams) = this->GetParam();
+    const auto& [inputShapes, inputOrder, netPrecision, _targetDevice, additionalConfig, cpuParams] = this->GetParam();
+    targetDevice = _targetDevice;
     configuration.insert(additionalConfig.begin(), additionalConfig.end());
     inType = netPrecision;
     outType = netPrecision;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/concat.cpp
@@ -22,12 +22,7 @@ class ConcatLayerCPUTest : public testing::WithParamInterface<concatCPUTestParam
                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<concatCPUTestParams> obj) {
-        int axis;
-        std::vector<InputShape> inputShapes;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(axis, inputShapes, netPrecision, cpuParams) = obj.param;
-
+        const auto& [axis, inputShapes, netPrecision, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=";
         for (const auto& shape : inputShapes) {
@@ -66,13 +61,7 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        int axis;
-        std::vector<InputShape> inputShape;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(axis, inputShape, netPrecision, cpuParams) = this->GetParam();
-
+        const auto& [axis, inputShape, netPrecision, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         selectedType += std::string("_") + ov::element::Type(netPrecision).get_type_name();
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/convert_to_plugin_specific_node.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/convert_to_plugin_specific_node.cpp
@@ -24,12 +24,7 @@ class ConvertToPluginSpecificNode : public testing::WithParamInterface<ConvertTo
                                     public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ConvertToPluginSpecificNodeParams> obj) {
-        ov::Shape nonConstShape, constShape;
-        ov::element::Type prc;
-        ov::test::utils::EltwiseTypes nodeType;
-        size_t port, constNodeNum;
-        std::tie(nonConstShape, constShape, prc, nodeType, port, constNodeNum) = obj.param;
-
+        const auto& [nonConstShape, constShape, prc, nodeType, port, constNodeNum] = obj.param;
         std::ostringstream result;
         result << "IS_NON_CONST=" << nonConstShape << "_";
         result << "IS_CONST=" << constShape << "_";
@@ -46,13 +41,8 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        ov::Shape nonConstShape, constShape;
-        ov::element::Type prc;
-        ov::test::utils::EltwiseTypes nodeType;
-        size_t port;
-
-        std::tie(nonConstShape, constShape, prc, nodeType, port, constNodeNum) = this->GetParam();
+        const auto& [nonConstShape, constShape, prc, nodeType, port, _constNodeNum] = this->GetParam();
+        constNodeNum = _constNodeNum;
         OPENVINO_ASSERT(shape_size(constShape) == 1);
 
         const auto param = std::make_shared<ov::op::v0::Parameter>(prc, ov::Shape(nonConstShape));

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/ctc_greedy_decoder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/ctc_greedy_decoder.cpp
@@ -31,18 +31,12 @@ class CTCGreedyDecoderLayerCPUTest : public testing::WithParamInterface<CTCGreed
                                      public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<CTCGreedyDecoderLayerCPUTestParams>& obj) {
-        ElementType inType;
-        bool mergeRepeated;
-        InputShapeParams shapes;
-        std::tie(shapes, inType, mergeRepeated) = obj.param;
+        const auto& [shapes, inType, mergeRepeated] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
         for (const auto& shape : shapes.second) {
-            size_t T;
-            size_t N;
-            size_t C;
-            std::tie(T, N, C) = shape;
+            const auto& [T, N, C] = shape;
             results << "{" << T << "," << N << "," << C << "}"
                     << "_";
         }
@@ -55,10 +49,7 @@ public:
 
 protected:
     void SetUp() override {
-        ElementType inType;
-        bool mergeRepeated;
-        InputShapeParams shapes;
-        std::tie(shapes, inType, mergeRepeated) = GetParam();
+        const auto& [shapes, inType, mergeRepeated] = GetParam();
         selectedType = "ref_any_f32";
         targetDevice = ov::test::utils::DEVICE_CPU;
         // construct input shapes
@@ -69,10 +60,7 @@ protected:
         inputDynamicShapes = {ov::PartialShape{in_dyn_T, in_dyn_N, in_dyc_C}, ov::PartialShape{in_dyn_T, in_dyn_N}};
 
         for (const auto& shape : shapes.second) {
-            size_t T;
-            size_t N;
-            size_t C;
-            std::tie(T, N, C) = shape;
+            const auto& [T, N, C] = shape;
             targetStaticShapes.push_back({{T, N, C}, {T, N}});
         }
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/ctc_greedy_decoder_seq_len.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/ctc_greedy_decoder_seq_len.cpp
@@ -34,19 +34,12 @@ class CTCGreedyDecoderSeqLenLayerCPUTest : public testing::WithParamInterface<CT
                                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<CTCGreedyDecoderSeqLenLayerCPUTestParams>& obj) {
-        InputElementParams inType;
-        bool mergeRepeated;
-        InputShapeParams shapes;
-        ElementType indexType;
-        std::tie(shapes, inType, indexType, mergeRepeated) = obj.param;
+        const auto& [shapes, inType, indexType, mergeRepeated] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
         for (const auto& shape : shapes.second) {
-            size_t N;
-            size_t T;
-            size_t C;
-            std::tie(N, T, C) = shape;
+            const auto& [N, T, C] = shape;
             results << "{" << N << "," << T << "," << C << "}"
                     << "_";
         }
@@ -63,11 +56,7 @@ public:
 
 protected:
     void SetUp() override {
-        InputElementParams inType;
-        bool mergeRepeated;
-        InputShapeParams shapes;
-        ElementType indexType;
-        std::tie(shapes, inType, indexType, mergeRepeated) = GetParam();
+        const auto& [shapes, inType, indexType, mergeRepeated] = GetParam();
         selectedType = "ref_any_f32";
         targetDevice = ov::test::utils::DEVICE_CPU;
         ASSERT_EQ(shapes.first.size(), 4);
@@ -83,10 +72,7 @@ protected:
         OPENVINO_ASSERT(inType.size() == inputDynamicShapes.size());
 
         for (auto& shape : shapes.second) {
-            size_t N;
-            size_t T;
-            size_t C;
-            std::tie(N, T, C) = shape;
+            const auto& [N, T, C] = shape;
             if (blank_rank == 0)
                 targetStaticShapes.push_back({{N, T, C}, {N}, {}});
             else

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/ctc_loss.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/ctc_loss.cpp
@@ -31,20 +31,13 @@ class CTCLossLayerCPUTest : public testing::WithParamInterface<CTCLossLayerCPUTe
                             public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<CTCLossLayerCPUTestParams>& obj) {
-        CTCLossShapeParams shapes;
-        int blank;
-        bool preprocessCollapseRepeated;
-        bool ctcMergeRepeated;
-        bool unique;
-        ov::element::Type fPrecision;
-        ov::element::Type iPrecision;
-        std::tie(shapes, blank, preprocessCollapseRepeated, ctcMergeRepeated, unique, fPrecision, iPrecision) =
+        const auto& [shapes, blank, preprocessCollapseRepeated, ctcMergeRepeated, unique, fPrecision, iPrecision] =
             obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
-        for (std::vector<ov::Shape>& staticShapes : shapes.second) {
-            for (ov::Shape& shape : staticShapes) {
+        for (const std::vector<ov::Shape>& staticShapes : shapes.second) {
+            for (const ov::Shape& shape : staticShapes) {
                 size_t N = shape[0];
                 size_t T = shape[1];
                 size_t C = shape[2];
@@ -65,27 +58,19 @@ public:
 
 protected:
     void SetUp() override {
-        CTCLossShapeParams shapes;
-        bool preprocessCollapseRepeated;
-        bool ctcMergeRepeated;
-        bool unique;
-        ov::element::Type fPrecision;
-        ov::element::Type iPrecision;
-        std::tie(shapes, blank, preprocessCollapseRepeated, ctcMergeRepeated, unique, fPrecision, iPrecision) =
+        const auto& [shapes, _blank, preprocessCollapseRepeated, ctcMergeRepeated, unique, fPrecision, iPrecision] =
             GetParam();
-
+        blank = _blank;
         targetDevice = ov::test::utils::DEVICE_CPU;
         selectedType = std::string("ref_any_f32");
-
-        for (std::vector<ov::Shape>& staticShapes : shapes.second) {
-            for (ov::Shape& shape : staticShapes) {
+        for (const std::vector<ov::Shape>& staticShapes : shapes.second) {
+            for (const ov::Shape& shape : staticShapes) {
                 size_t N = shape[0];
                 size_t T = shape[1];
                 size_t C = shape[2];
                 targetStaticShapes.push_back({{N, T, C}, {N}, {N, T}, {N}});
             }
         }
-
         auto inputDynamicShapesValues = shapes.first.front();
         ov::PartialShape shapeN{inputDynamicShapesValues[0]};
         ov::PartialShape shapeNT{inputDynamicShapesValues[0], inputDynamicShapesValues[1]};

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/cum_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/cum_sum.cpp
@@ -21,13 +21,7 @@ class CumSumLayerCPUTest : public testing::WithParamInterface<cumSumParams>,
                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<cumSumParams> obj) {
-        ov::element::Type inputPrecision;
-        InputShape shapes;
-        std::int64_t axis;
-        bool exclusive;
-        bool reverse;
-        std::tie(inputPrecision, shapes, axis, exclusive, reverse) = obj.param;
-
+        const auto& [inputPrecision, shapes, axis, exclusive, reverse] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -42,11 +36,8 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        InputShape shapes;
-        std::int64_t axis;
-        bool exclusive;
-        bool reverse;
-        std::tie(inType, shapes, axis, exclusive, reverse) = this->GetParam();
+        const auto& [_inType, shapes, axis, exclusive, reverse] = this->GetParam();
+        inType = _inType;
         if (inType == ElementType::bf16)
             rel_threshold = 0.05f;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/deformable_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/deformable_convolution.cpp
@@ -42,30 +42,15 @@ class DefConvLayerCPUTest : public testing::WithParamInterface<DefConvLayerCPUTe
 public:
     OffsetType offsetType;
     static std::string getTestCaseName(testing::TestParamInfo<DefConvLayerCPUTestParamsSet> obj) {
-        DefConvSpecificParams dcSpecificParams;
-        std::vector<InputShape> inputShape;
-        ov::element::Type netPrecision;
-        DefConvLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        AddSpatialParamsDyn addSpParams;
-        std::string td;
-        std::tie(addSpParams, inputShape, dcSpecificParams, netPrecision, td) = basicParamsSet;
-
-        ov::op::PadType padType;
-        std::vector<size_t> stride, dilation;
-        std::vector<ptrdiff_t> padBegin, padEnd;
-        std::tie(padType, padBegin, padEnd, stride, dilation) = addSpParams;
-
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [addSpParams, inputShape, dcSpecificParams, netPrecision, td] = basicParamsSet;
+        const auto& [padType, padBegin, padEnd, stride, dilation] = addSpParams;
         // gr * in_ch_per_gr / in_ch_per_gr
         size_t groups = inputShape[0].second[0][1] / inputShape[2].second[0][1];
         // dg * ker_spat_shape[0] * ker_spat_shape[1] * 2 / (ker_spat_shape[0] * ker_spat_shape[1] * 2)
         size_t deformableGroups =
             inputShape[1].second[0][1] / (inputShape[2].second[0][2] * inputShape[2].second[0][3] * 2);
-
-        bool withBilinearInterpolationPad, withModulation;
-        OffsetType offType;
-        std::tie(withBilinearInterpolationPad, withModulation, offType) = dcSpecificParams;
+        const auto& [withBilinearInterpolationPad, withModulation, offType] = dcSpecificParams;
         std::ostringstream result;
         result << "DefConvTest(";
         result << std::to_string(obj.index) << ")_";
@@ -151,29 +136,19 @@ protected:
         }
     }
     void SetUp() override {
-        DefConvSpecificParams dcSpecificParams;
-        std::vector<InputShape> inputShape;
-        ov::element::Type netPrecision;
-        DefConvLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-        AddSpatialParamsDyn addSpParams;
-        std::tie(addSpParams, inputShape, dcSpecificParams, netPrecision, targetDevice) = basicParamsSet;
+        const auto& [addSpParams, inputShape, dcSpecificParams, netPrecision, _targetDevice] = basicParamsSet;
+        targetDevice = _targetDevice;
         init_input_shapes(inputShape);
-
-        ov::op::PadType padType;
-        std::vector<size_t> stride, dilation;
-        std::vector<ptrdiff_t> padBegin, padEnd;
-        std::tie(padType, padBegin, padEnd, stride, dilation) = addSpParams;
-
+        const auto& [padType, padBegin, padEnd, stride, dilation] = addSpParams;
         // gr * in_ch_per_gr / in_ch_per_gr
         size_t groups = inputShape[0].second[0].at(1) / inputShape[2].second[0].at(1);
         // dg * ker_spat_shape[0] * ker_spat_shape[1] * 2 / (ker_spat_shape[0] * ker_spat_shape[1] * 2)
         size_t deformableGroups =
             inputShape[1].second[0].at(1) / (inputShape[2].second[0].at(2) * inputShape[2].second[0].at(3) * 2);
-        bool withBilinearInterpolationPad, withModulation;
-        std::tie(withBilinearInterpolationPad, withModulation, offsetType) = dcSpecificParams;
+        const auto& [withBilinearInterpolationPad, withModulation, _offsetType] = dcSpecificParams;
+        offsetType = _offsetType;
         ov::ParameterVector inputParams;
         for (auto&& shape : inputDynamicShapes) {
             inputParams.push_back(std::make_shared<ov::op::v0::Parameter>(netPrecision, shape));

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/depth_to_space.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/depth_to_space.cpp
@@ -23,13 +23,7 @@ class DepthToSpaceLayerCPUTest : public testing::WithParamInterface<DepthToSpace
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<DepthToSpaceLayerCPUTestParamSet> obj) {
-        InputShape shapes;
-        ElementType inType;
-        ov::op::v0::DepthToSpace::DepthToSpaceMode mode;
-        std::size_t blockSize;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, mode, blockSize, cpuParams) = obj.param;
-
+        const auto& [shapes, inType, mode, blockSize, cpuParams] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -55,12 +49,8 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        ov::op::v0::DepthToSpace::DepthToSpaceMode mode;
-        std::size_t blockSize;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, mode, blockSize, cpuParams) = this->GetParam();
-
+        const auto& [shapes, _inType, mode, blockSize, cpuParams] = this->GetParam();
+        inType = _inType;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/detection_output.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/detection_output.cpp
@@ -72,19 +72,10 @@ class DetectionOutputLayerCPUTest : public testing::WithParamInterface<Detection
                                     public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<DetectionOutputParamsDynamic>& obj) {
-        DetectionOutputAttributes commonAttrs;
-        ParamsWhichSizeDependsDynamic specificAttrs;
         ov::op::v0::DetectionOutput::Attributes attrs;
-        size_t batch;
-        bool replaceDynamicShapesToIntervals;
-        std::string targetDevice;
-        std::tie(commonAttrs,
-                 specificAttrs,
-                 batch,
-                 attrs.objectness_score,
-                 replaceDynamicShapesToIntervals,
-                 targetDevice) = obj.param;
-
+        const auto& [commonAttrs, specificAttrs, batch, _objectness_score, replaceDynamicShapesToIntervals,
+                     targetDevice] = obj.param;
+        attrs.objectness_score = _objectness_score;
         std::tie(attrs.num_classes,
                  attrs.background_label_id,
                  attrs.top_k,
@@ -168,17 +159,10 @@ public:
     }
 
     void SetUp() override {
-        DetectionOutputAttributes commonAttrs;
-        ParamsWhichSizeDependsDynamic specificAttrs;
-        size_t batch;
-        bool replaceDynamicShapesToIntervals;
-        std::tie(commonAttrs,
-                 specificAttrs,
-                 batch,
-                 attrs.objectness_score,
-                 replaceDynamicShapesToIntervals,
-                 targetDevice) = this->GetParam();
-
+        const auto& [commonAttrs, specificAttrs, batch, _objectness_score, replaceDynamicShapesToIntervals,
+                     _targetDevice] = this->GetParam();
+        attrs.objectness_score = _objectness_score;
+        targetDevice = _targetDevice;
         std::tie(attrs.num_classes,
                  attrs.background_label_id,
                  attrs.top_k,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets.cpp
@@ -34,18 +34,8 @@ class EmbeddingBagOffsetsLayerCPUTest : public testing::WithParamInterface<embed
 public:
     using Reduction = ov::op::util::EmbeddingBagOffsetsBase::Reduction;
     static std::string getTestCaseName(const testing::TestParamInfo<embeddingBagOffsetsLayerTestParamsSet>& obj) {
-        embeddingBagOffsetsParams params;
-        ElementType netPrecision, indPrecision;
-        std::string targetDevice;
-        std::tie(params, netPrecision, indPrecision, targetDevice) = obj.param;
-
-        InputShape inputShapes;
-        std::vector<size_t> indices, offsets;
-        size_t defaultIndex;
-        bool withWeights, withDefIndex;
-        Reduction reduction;
-        std::tie(inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex, reduction) = params;
-
+        const auto& [params, netPrecision, indPrecision, targetDevice] = obj.param;
+        const auto& [inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex, reduction] = params;
         std::ostringstream result;
         result << "IS=" << inputShapes << "_";
         result << "I" << ov::test::utils::vec2str(indices) << "_";
@@ -61,17 +51,10 @@ public:
     }
 
     void SetUp() override {
-        embeddingBagOffsetsParams embParams;
-        ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
-
-        InputShape inputShapes;
-        std::vector<size_t> indices, offsets;
-        bool withWeights, withDefIndex;
-        Reduction reduction;
-        size_t defaultIndex;
-        std::tie(inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex, reduction) = embParams;
-
+        const auto& [embParams, _inType, indPrecision, _targetDevice] = this->GetParam();
+        inType = _inType;
+        targetDevice = _targetDevice;
+        const auto& [inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex, reduction] = embParams;
         selectedType = makeSelectedTypeStr("ref", inType);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_offsets_sum.cpp
@@ -32,17 +32,8 @@ class EmbeddingBagOffsetsSumLayerCPUTest : public testing::WithParamInterface<em
                                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<embeddingBagOffsetsSumLayerTestParamsSet>& obj) {
-        embeddingBagOffsetsSumParams params;
-        ElementType netPrecision, indPrecision;
-        std::string targetDevice;
-        std::tie(params, netPrecision, indPrecision, targetDevice) = obj.param;
-
-        InputShape inputShapes;
-        std::vector<size_t> indices, offsets;
-        size_t defaultIndex;
-        bool withWeights, withDefIndex;
-        std::tie(inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex) = params;
-
+        const auto& [params, netPrecision, indPrecision, targetDevice] = obj.param;
+        const auto& [inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex] = params;
         std::ostringstream result;
         result << "IS=" << inputShapes << "_";
         result << "I" << ov::test::utils::vec2str(indices) << "_";
@@ -57,16 +48,10 @@ public:
     }
 
     void SetUp() override {
-        embeddingBagOffsetsSumParams embParams;
-        ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
-
-        InputShape inputShapes;
-        std::vector<size_t> indices, offsets;
-        bool withWeights, withDefIndex;
-        size_t defaultIndex;
-        std::tie(inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex) = embParams;
-
+        const auto& [embParams, _inType, indPrecision, _targetDevice] = this->GetParam();
+        inType = _inType;
+        targetDevice = _targetDevice;
+        const auto& [inputShapes, indices, offsets, defaultIndex, withWeights, withDefIndex] = embParams;
         selectedType = makeSelectedTypeStr("ref", inType);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed.cpp
@@ -32,17 +32,8 @@ class EmbeddingBagPackedLayerCPUTest : public testing::WithParamInterface<embedd
 public:
     using Reduction = ov::op::util::EmbeddingBagPackedBase::Reduction;
     static std::string getTestCaseName(const testing::TestParamInfo<embeddingBagPackedLayerTestParamsSet>& obj) {
-        embeddingBagPackedParams params;
-        ElementType netPrecision, indPrecision;
-        std::string targetDevice;
-        std::tie(params, netPrecision, indPrecision, targetDevice) = obj.param;
-
-        InputShape inputShapes;
-        std::vector<std::vector<size_t>> indices;
-        bool withWeights;
-        Reduction reduction;
-        std::tie(inputShapes, indices, withWeights, reduction) = params;
-
+        const auto& [params, netPrecision, indPrecision, targetDevice] = obj.param;
+        const auto& [inputShapes, indices, withWeights, reduction] = params;
         std::ostringstream result;
         result << "IS=" << inputShapes << "_";
         result << "I" << ov::test::utils::vec2str(indices) << "_";
@@ -56,16 +47,10 @@ public:
 
 protected:
     void SetUp() override {
-        embeddingBagPackedParams embParams;
-        ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
-
-        InputShape inputShapes;
-        std::vector<std::vector<size_t>> indices;
-        bool withWeights;
-        Reduction reduction;
-        std::tie(inputShapes, indices, withWeights, reduction) = embParams;
-
+        const auto& [embParams, _inType, indPrecision, _targetDevice] = this->GetParam();
+        inType = _inType;
+        targetDevice = _targetDevice;
+        const auto& [inputShapes, indices, withWeights, reduction] = embParams;
         selectedType = makeSelectedTypeStr("ref", inType);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_bag_packed_sum.cpp
@@ -29,16 +29,8 @@ class EmbeddingBagPackedSumLayerCPUTest : public testing::WithParamInterface<emb
                                           public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<embeddingBagPackedSumLayerTestParamsSet>& obj) {
-        embeddingBagPackedSumParams params;
-        ElementType netPrecision, indPrecision;
-        std::string targetDevice;
-        std::tie(params, netPrecision, indPrecision, targetDevice) = obj.param;
-
-        InputShape inputShapes;
-        std::vector<std::vector<size_t>> indices;
-        bool withWeights;
-        std::tie(inputShapes, indices, withWeights) = params;
-
+        const auto& [params, netPrecision, indPrecision, targetDevice] = obj.param;
+        const auto& [inputShapes, indices, withWeights] = params;
         std::ostringstream result;
         result << "IS=" << inputShapes << "_";
         result << "I" << ov::test::utils::vec2str(indices) << "_";
@@ -51,15 +43,10 @@ public:
 
 protected:
     void SetUp() override {
-        embeddingBagPackedSumParams embParams;
-        ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
-
-        InputShape inputShapes;
-        std::vector<std::vector<size_t>> indices;
-        bool withWeights;
-        std::tie(inputShapes, indices, withWeights) = embParams;
-
+        const auto& [embParams, _inType, indPrecision, _targetDevice] = this->GetParam();
+        inType = _inType;
+        targetDevice = _targetDevice;
+        const auto& [inputShapes, indices, withWeights] = embParams;
         selectedType = makeSelectedTypeStr("ref", inType);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_segments_sum.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/embedding_segments_sum.cpp
@@ -33,17 +33,8 @@ class EmbeddingSegmentsSumLayerCPUTest : public testing::WithParamInterface<embe
                                          public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<embeddingSegmentsSumLayerTestParamsSet>& obj) {
-        embeddingSegmentsSumParams params;
-        ElementType netPrecision, indPrecision;
-        std::string targetDevice;
-        std::tie(params, netPrecision, indPrecision, targetDevice) = obj.param;
-
-        InputShape inputShapes;
-        std::vector<size_t> indices, segmentIds;
-        size_t numSegments, defaultIndex;
-        bool withWeights, withDefIndex;
-        std::tie(inputShapes, indices, segmentIds, numSegments, defaultIndex, withWeights, withDefIndex) = params;
-
+        const auto& [params, netPrecision, indPrecision, targetDevice] = obj.param;
+        const auto& [inputShapes, indices, segmentIds, numSegments, defaultIndex, withWeights, withDefIndex] = params;
         std::ostringstream result;
         result << "IS=" << inputShapes << "_";
         result << "I" << ov::test::utils::vec2str(indices) << "_";
@@ -60,16 +51,11 @@ public:
 
 protected:
     void SetUp() override {
-        embeddingSegmentsSumParams embParams;
-        ElementType indPrecision;
-        std::tie(embParams, inType, indPrecision, targetDevice) = this->GetParam();
-
-        InputShape inputShapes;
-        std::vector<size_t> indices, segmentIds;
-        bool withWeights, withDefIndex;
-        size_t numSegments, defaultIndex;
-        std::tie(inputShapes, indices, segmentIds, numSegments, defaultIndex, withWeights, withDefIndex) = embParams;
-
+        const auto& [embParams, _inType, indPrecision, _targetDevice] = this->GetParam();
+        inType = _inType;
+        targetDevice = _targetDevice;
+        const auto& [inputShapes, indices, segmentIds, numSegments, defaultIndex, withWeights, withDefIndex] =
+            embParams;
         selectedType = makeSelectedTypeStr("ref", inType);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/extract_image_patches.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/extract_image_patches.cpp
@@ -21,14 +21,7 @@ class ExtractImagePatchesLayerCPUTest : public testing::WithParamInterface<extra
                                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<extractImagePatchesParams> obj) {
-        InputShape inputShapes;
-        ElementType inputPrecision;
-        ov::Shape kernelSize;
-        ov::Strides strides;
-        ov::Shape rates;
-        ov::op::PadType padType;
-        std::tie(inputShapes, inputPrecision, kernelSize, strides, rates, padType) = obj.param;
-
+        const auto& [inputShapes, inputPrecision, kernelSize, strides, rates, padType] = obj.param;
         std::ostringstream result;
         result << "netPRC=" << inputPrecision << "_"
                << "IS=" << ov::test::utils::partialShape2str({inputShapes.first}) << "_";
@@ -46,14 +39,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        InputShape inputShapes;
-        ElementType inputPrecision;
-        ov::Shape kernelSize;
-        ov::Strides strides;
-        ov::Shape rates;
-        ov::op::PadType padType;
-        std::tie(inputShapes, inputPrecision, kernelSize, strides, rates, padType) = this->GetParam();
-
+        const auto& [inputShapes, inputPrecision, kernelSize, strides, rates, padType] = this->GetParam();
         selectedType = makeSelectedTypeStr("ref_any", inputPrecision);
         if (inputPrecision == ElementType::bf16) {
             rel_threshold = 1e-2;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/eye.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/eye.cpp
@@ -30,13 +30,10 @@ class EyeLayerCPUTest : public testing::WithParamInterface<EyeLayerCPUTestParams
                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<EyeLayerCPUTestParamsSet> obj) {
-        EyeLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ElementType netPr;
-        std::vector<int> eyePar;
-        std::tie(inputShape, outBatchShape, eyePar, netPr, td) = basicParamsSet;
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [_inputShape, _outBatchShape, eyePar, netPr, td] = basicParamsSet;
+        inputShape = _inputShape;
+        outBatchShape = _outBatchShape;
         std::ostringstream result;
         result << "EyeTest_";
         result << "IS=(";
@@ -61,14 +58,12 @@ public:
 
 protected:
     void SetUp() override {
-        EyeLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        ElementType netPrecision;
-        std::vector<int> eyePar;
-        std::tie(inputShape, outBatchShape, eyePar, netPrecision, targetDevice) = basicParamsSet;
+        const auto& [_inputShape, _outBatchShape, eyePar, netPrecision, _targetDevice] = basicParamsSet;
+        inputShape = _inputShape;
+        outBatchShape = _outBatchShape;
+        targetDevice = _targetDevice;
         rowNum = eyePar[0];
         colNum = eyePar[1];
         shift = eyePar[2];

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/fake_quantize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/fake_quantize.cpp
@@ -33,25 +33,10 @@ class FakeQuantizeLayerCPUTest : public testing::WithParamInterface<fqLayerTestP
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<fqLayerTestParamsSet> obj) {
-        fqSpecificParams fqParams;
-        inputShapes testShapes;
-        ov::element::Type inPrec;
-        std::pair<std::vector<float>, std::vector<float>> inputRangesValues;
-        bool shouldBeDecomposed;
-        CPUSpecificParams cpuParams;
-        std::tie(fqParams, testShapes, inPrec, inputRangesValues, shouldBeDecomposed, cpuParams) = obj.param;
-
-        InputShape shapes;
-        std::vector<ov::Shape> ranges;
-        std::tie(shapes, ranges) = testShapes;
-
-        int64_t inDataLowBounds, inDataHighBounds;
-        std::vector<float> inputLow, inputHigh, outputLow, outputHigh;
-        size_t levels;
-        inputLow = inputRangesValues.first;
-        inputHigh = inputRangesValues.second;
-        std::tie(inDataLowBounds, inDataHighBounds, outputLow, outputHigh, levels) = fqParams;
-
+        const auto& [fqParams, testShapes, inPrec, inputRangesValues, shouldBeDecomposed, cpuParams] = obj.param;
+        const auto& [shapes, ranges] = testShapes;
+        const auto &[inputLow, inputHigh] = inputRangesValues;
+        const auto &[inDataLowBounds, inDataHighBounds, outputLow, outputHigh, levels] = fqParams;
         std::ostringstream result;
 
         result << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
@@ -83,31 +68,21 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        fqSpecificParams fqParams;
-        inputShapes testShapes;
-        ov::element::Type inPrec;
-        std::pair<std::vector<float>, std::vector<float>> inputRangesValues;
-        bool shouldBeDecomposed;
-        CPUSpecificParams cpuParams;
-        std::tie(fqParams, testShapes, inPrec, inputRangesValues, shouldBeDecomposed, cpuParams) = this->GetParam();
-
+        const auto& [fqParams, testShapes, inPrec, inputRangesValues, shouldBeDecomposed, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        InputShape shapes;
-        std::vector<ov::Shape> ranges;
-        std::tie(shapes, ranges) = testShapes;
-
+        const auto& [shapes, ranges] = testShapes;
         inputDynamicShapes.push_back(shapes.first);
         for (size_t i = 0; i < shapes.second.size(); i++) {
             targetStaticShapes.push_back(std::vector<ov::Shape>{shapes.second[i]});
         }
-
-        size_t levels;
         std::vector<std::vector<float>> rangesBounds(RANGES_INPUT_NUMBER);
         rangesBounds[0] = inputRangesValues.first;
         rangesBounds[1] = inputRangesValues.second;
-        std::tie(inDataLowBounds, inDataHighBounds, rangesBounds[2], rangesBounds[3], levels) = fqParams;
-
+        const auto& [_inDataLowBounds, _inDataHighBounds, _tmp, _tmp1, levels] = fqParams;
+        inDataLowBounds = _inDataLowBounds;
+        inDataHighBounds = _inDataHighBounds;
+        rangesBounds[2] = _tmp;
+        rangesBounds[3] = _tmp1;
         ov::ParameterVector params;
         for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(inPrec, shape));

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather.cpp
@@ -5,6 +5,7 @@
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "utils/general_utils.h"
 #include "openvino/op/gather.hpp"
 
 using namespace CPUTestUtils;
@@ -25,15 +26,8 @@ class GatherLayerTestCPU : public testing::WithParamInterface<GatherLayerTestCPU
                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GatherLayerTestCPUParams> obj) {
-        std::vector<InputShape> inputShapes;
-        std::tuple<int, int> axisAndBatchDims;
-        ElementType netPrecision;
-        bool isAxisConstant;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes, axisAndBatchDims, netPrecision, isAxisConstant, cpuParams, additionalConfig) = obj.param;
-
+        const auto& [inputShapes, axisAndBatchDims, netPrecision, isAxisConstant, cpuParams, additionalConfig] =
+            obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (size_t i = 0lu; i < inputShapes.size(); i++) {
@@ -68,15 +62,8 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        std::tuple<int, int> axisAndBatchDims;
-        ElementType netPrecision;
-        bool isAxisConstant;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
         const ElementType intInputsPrecision = ElementType::i64;
-
-        std::tie(inputShapes, axisAndBatchDims, netPrecision, isAxisConstant, cpuParams, additionalConfig) =
+        const auto &[inputShapes, axisAndBatchDims, netPrecision, isAxisConstant, cpuParams, additionalConfig] =
             this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         axis = std::get<0>(axisAndBatchDims);
@@ -85,7 +72,7 @@ protected:
         init_input_shapes(inputShapes);
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);
@@ -166,14 +153,7 @@ class GatherInPlaceLayerTestCPU : public testing::WithParamInterface<GatherInPla
                                   public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GatherInPlaceLayerTestCPUParams> obj) {
-        InputShape inputShapes;
-        std::vector<int64_t> indices;
-        int axis;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-
-        std::tie(inputShapes, indices, axis, netPrecision, cpuParams) = obj.param;
-
+        const auto &[inputShapes, indices, axis, netPrecision, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=(";
 
@@ -195,15 +175,9 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape inputShapes;
-        std::vector<int64_t> indices;
-        int axis;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
         constexpr ElementType intInputsPrecision = ElementType::i64;
         constexpr int batchDims = 0;
-
-        std::tie(inputShapes, indices, axis, netPrecision, cpuParams) = this->GetParam();
+        const auto &[inputShapes, indices, axis, netPrecision, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes({inputShapes});

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather_elements.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather_elements.cpp
@@ -26,12 +26,7 @@ class GatherElementsCPUTest : public testing::WithParamInterface<GatherElementsC
                               public CPUTestsBase {
 public:
     static std::string getTestCaseNameCommon(const testing::TestParamInfo<GatherElementsParams>& obj) {
-        std::vector<InputShape> shapes;
-        ElementType dPrecision, iPrecision;
-        int axis;
-        std::string device;
-        std::tie(shapes, axis, dPrecision, iPrecision, device) = obj.param;
-
+        const auto& [shapes, axis, dPrecision, iPrecision, device] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : shapes) {
@@ -52,10 +47,7 @@ public:
     }
 
     static std::string getTestCaseName(const testing::TestParamInfo<GatherElementsCPUTestParamSet>& obj) {
-        GatherElementsParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-
+        const auto& [basicParamsSet, cpuParams] = obj.param;
         std::ostringstream result;
         result << getTestCaseNameCommon(testing::TestParamInfo<GatherElementsParams>(basicParamsSet, 0));
 
@@ -82,16 +74,10 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> shapes;
-        ElementType dPrecision, iPrecision;
-        int axis;
-        GatherElementsParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        std::tie(shapes, axis, dPrecision, iPrecision, targetDevice) = basicParamsSet;
+        const auto& [shapes, axis, dPrecision, iPrecision, _targetDevice] = basicParamsSet;
+        targetDevice = _targetDevice;
         selectedType = std::string("ref_any_") + ov::element::Type(dPrecision).get_type_name();
         init_input_shapes(shapes);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather_nd.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather_nd.cpp
@@ -19,12 +19,7 @@ class GatherNDLayerCPUTest : public testing::WithParamInterface<GatherNDLayerCPU
                              virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GatherNDLayerCPUTestParamSet> obj) {
-        InputShape shapes;
-        std::pair<Shape, std::vector<int>> indexes;
-        ElementType dataElementType, idxElementType;
-        int batchDims;
-        std::tie(shapes, indexes, dataElementType, idxElementType, batchDims) = obj.param;
-
+        const auto& [shapes, indexes, dataElementType, idxElementType, batchDims] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -41,12 +36,7 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        std::pair<Shape, std::vector<int>> indexes;
-        ElementType dataElementType, idxElementType;
-        int batchDims;
-        std::tie(shapes, indexes, dataElementType, idxElementType, batchDims) = this->GetParam();
-
+        const auto& [shapes, indexes, dataElementType, idxElementType, batchDims] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes({shapes});
 
@@ -70,12 +60,7 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        std::pair<Shape, std::vector<int>> indexes;
-        ElementType dataElementType, idxElementType;
-        int batchDims;
-        std::tie(shapes, indexes, dataElementType, idxElementType, batchDims) = this->GetParam();
-
+        const auto& [shapes, indexes, dataElementType, idxElementType, batchDims] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes({shapes});
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather_tree.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gather_tree.cpp
@@ -27,14 +27,7 @@ class GatherTreeLayerCPUTest : public testing::WithParamInterface<GatherTreeCPUT
                                public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<GatherTreeCPUTestParams>& obj) {
-        InputShape inputShape;
-        ov::element::Type netPrecision;
-        ov::element::Type inPrc, outPrc;
-        ov::test::utils::InputLayerType secondaryInputType;
-        std::string targetName;
-
-        std::tie(inputShape, secondaryInputType, netPrecision, inPrc, outPrc, targetName) = obj.param;
-
+        const auto& [inputShape, secondaryInputType, netPrecision, inPrc, outPrc, targetName] = obj.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_";
         result << "TS=";
@@ -52,12 +45,8 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape inputShape;
-        ov::element::Type netPrecision;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ov::element::Type inPrc, outPrc;
-
-        std::tie(inputShape, secondaryInputType, netPrecision, inPrc, outPrc, targetDevice) = GetParam();
+        const auto& [inputShape, secondaryInputType, netPrecision, inPrc, outPrc, _targetDevice] = GetParam();
+        targetDevice = _targetDevice;
         InputShape parentShape{inputShape};
         InputShape::first_type maxSeqLenFirst;
         if (inputShape.first.is_dynamic()) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/grid_sample.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/grid_sample.cpp
@@ -5,6 +5,7 @@
 #include "common_test_utils/ov_tensor_utils.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "utils/general_utils.h"
 #include "openvino/op/grid_sample.hpp"
 
 using namespace CPUTestUtils;
@@ -28,23 +29,8 @@ class GridSampleLayerTestCPU : public testing::WithParamInterface<GridSampleLaye
                                public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GridSampleLayerTestCPUParams> obj) {
-        std::vector<InputShape> inputShapes;
-        ov::op::v9::GridSample::InterpolationMode interpolateMode;
-        ov::op::v9::GridSample::PaddingMode paddingMode;
-        bool alignCorners;
-        ElementType dataPrecision, gridPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 interpolateMode,
-                 paddingMode,
-                 alignCorners,
-                 dataPrecision,
-                 gridPrecision,
-                 cpuParams,
-                 additionalConfig) = obj.param;
-
+        const auto &[inputShapes, interpolateMode, paddingMode, alignCorners, dataPrecision, gridPrecision, cpuParams,
+                     additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (size_t i = 0lu; i < inputShapes.size(); i++) {
@@ -90,28 +76,14 @@ public:
 protected:
     void SetUp() override {
         abs_threshold = 0.0005;
-        std::vector<InputShape> inputShapes;
-        ov::op::v9::GridSample::InterpolationMode interpolateMode;
-        ov::op::v9::GridSample::PaddingMode paddingMode;
-        bool alignCorners;
-        ElementType dataPrecision, gridPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 interpolateMode,
-                 paddingMode,
-                 alignCorners,
-                 dataPrecision,
-                 gridPrecision,
-                 cpuParams,
-                 additionalConfig) = this->GetParam();
+        const auto &[inputShapes, interpolateMode, paddingMode, alignCorners, dataPrecision, gridPrecision, cpuParams,
+                     additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes(inputShapes);
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             auto execType = dataPrecision == ov::element::i32 ? ov::element::i32 : ov::element::f32;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/grn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/grn.cpp
@@ -22,14 +22,7 @@ class GRNLayerCPUTest : public testing::WithParamInterface<GRNCPUTestParams>,
                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GRNCPUTestParams> obj) {
-        ov::element::Type netPrecision;
-        ov::element::Type inPrc, outPrc;
-        InputShape inputShape;
-        float bias;
-        std::string targetDevice;
-
-        std::tie(netPrecision, inPrc, outPrc, inputShape, bias, targetDevice) = obj.param;
-
+        const auto& [netPrecision, inPrc, outPrc, inputShape, bias, targetDevice] = obj.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_";
         result << "TS=";
@@ -47,13 +40,8 @@ public:
 
 protected:
     void SetUp() override {
-        ov::element::Type netPrecision;
-        ov::element::Type inPrc, outPrc;
-        InputShape inputShape;
-        float bias;
-
-        std::tie(netPrecision, inPrc, outPrc, inputShape, bias, targetDevice) = GetParam();
-
+        const auto& [netPrecision, inPrc, outPrc, inputShape, bias, _targetDevice] = GetParam();
+        targetDevice = _targetDevice;
         init_input_shapes({inputShape});
 
         ov::ParameterVector paramsIn;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution.cpp
@@ -34,24 +34,9 @@ class GroupConvolutionLayerCPUTest : public testing::WithParamInterface<groupCon
                                      public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerCPUTestParamsSet> obj) {
-        groupConvLayerTestsParamsSet basicParamsSet;
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        ov::AnyMap additionalConfig;
-        std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = obj.param;
-
-        groupConvSpecificParams groupConvParams;
-        ElementType netType;
-        ElementType inType, outType;
-        InputShape inputShape;
-        std::string targetDevice;
-        std::tie(groupConvParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
-        ov::op::PadType padType;
-        std::vector<size_t> kernel, stride, dilation;
-        std::vector<ptrdiff_t> padBegin, padEnd;
-        size_t convOutChannels, numGroups;
-        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
-
+        const auto& [basicParamsSet, cpuParams, fusingParams, additionalConfig] = obj.param;
+        const auto& [groupConvParams, netType, inType, outType, inputShape, targetDevice] = basicParamsSet;
+        const auto& [kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType] = groupConvParams;
         std::ostringstream result;
         result << "IS=";
         result << ov::test::utils::partialShape2str({inputShape.first}) << "_";
@@ -156,13 +141,7 @@ protected:
 
     void SetUp() override {
         rel_threshold = 1e-4f;
-
-        groupConvLayerTestsParamsSet basicParamsSet;
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        ov::AnyMap additionalConfig;
-        std::tie(basicParamsSet, cpuParams, fusingParams, additionalConfig) = this->GetParam();
-
+        const auto& [basicParamsSet, cpuParams, fusingParams, additionalConfig] = this->GetParam();
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
@@ -170,12 +149,10 @@ protected:
 
         if (postOpMgrPtr)
             isBias = postOpMgrPtr->getFusedOpsNames() == "Add(PerChannel)";
-
-        groupConvSpecificParams groupConvParams;
-        InputShape inputShape;
-        auto netType = ElementType::dynamic;
-        std::tie(groupConvParams, netType, inType, outType, inputShape, targetDevice) = basicParamsSet;
-
+        const auto& [groupConvParams, netType, _inType, _outType, inputShape, _targetDevice] = basicParamsSet;
+        inType = _inType;
+        outType = _outType;
+        targetDevice = _targetDevice;
         init_input_shapes({inputShape});
         const auto& it = configuration.find(ov::hint::inference_precision.name());
         if (it != configuration.end()) {
@@ -192,13 +169,7 @@ protected:
         if (fusedOps.size() == 3 && fusedOps[1] == std::string("Elu") && fusedOps[2] == std::string("FakeQuantize")) {
             abs_threshold = 5e-3f;
         }
-
-        ov::op::PadType padType;
-        std::vector<size_t> kernel, stride, dilation;
-        std::vector<ptrdiff_t> padBegin, padEnd;
-        size_t convOutChannels, numGroups;
-        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
-
+        const auto& [kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType] = groupConvParams;
         ov::ParameterVector params;
         for (auto&& shape : inputDynamicShapes)
             params.push_back(std::make_shared<ov::op::v0::Parameter>(netType, shape));
@@ -1490,10 +1461,7 @@ std::vector<groupConvLayerCPUTestParamsSet> makeSingleGroupConvCPUTestCases(
     std::vector<groupConvLayerCPUTestParamsSet> retVector;
 
     for (auto& configRelatedParams : vecConfigRelatedParams) {
-        VecFusingParams fusingParams;
-        ov::AnyMap config;
-        std::tie(config, fusingParams) = configRelatedParams;
-
+        const auto& [config, fusingParams] = configRelatedParams;
         groupConvLayerTestsParamsSet basicParamsSet(specificParams,
                                                     ElementType::f32,
                                                     ElementType::dynamic,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/group_convolution_backprop_data.cpp
@@ -12,6 +12,7 @@
 #include "utils/cpu_test_utils.hpp"
 #include "utils/filter_cpu_info.hpp"
 #include "utils/fusing_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 namespace ov {
@@ -31,26 +32,10 @@ class GroupDeconvolutionLayerCPUTest : public testing::WithParamInterface<GroupD
                                        public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<GroupDeconvLayerCPUTestParamsSet> obj) {
-        GroupDeconvSpecParams basicParamsSet;
-        DeconvInputData inputData;
-        ElementType prec;
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        ov::AnyMap additionalConfig;
-        std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = obj.param;
-
-        ov::op::PadType padType;
-        std::vector<size_t> kernel, stride, dilation;
-        std::vector<ptrdiff_t> padBegin, padEnd, outPadding;
-        size_t convOutChannels, groupNum;
-        std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum, padType, outPadding) =
+        const auto &[basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig] = obj.param;
+        const auto &[kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum, padType, outPadding] =
             basicParamsSet;
-
-        InputShape inputShape;
-        ov::test::utils::InputLayerType outShapeType;
-        std::vector<std::vector<int32_t>> outShapeData;
-        std::tie(inputShape, outShapeType, outShapeData) = inputData;
-
+        const auto &[inputShape, outShapeType, outShapeData] = inputData;
         std::ostringstream result;
         result << "IS=";
         result << ov::test::utils::partialShape2str({inputShape.first}) << "_";
@@ -231,27 +216,18 @@ protected:
         rel_threshold = 1e-4f;
 
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        GroupDeconvSpecParams basicParamsSet;
-        DeconvInputData inputData;
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        ov::AnyMap additionalConfig;
-        std::tie(basicParamsSet, inputData, prec, fusingParams, cpuParams, additionalConfig) = this->GetParam();
-
+        const auto& [basicParamsSet, inputData, _prec, fusingParams, cpuParams, additionalConfig] = this->GetParam();
+        prec = _prec;
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
         std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, groupNum, padType, outPadding) =
             basicParamsSet;
-
-        InputShape inputShape;
-        ov::test::utils::InputLayerType outShapeType;
-        std::tie(inputShape, outShapeType, outShapeData) = inputData;
-
+        const auto& [inputShape, outShapeType, _outShapeData] = inputData;
+        outShapeData = _outShapeData;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             inType = outType = prec = ElementType::bf16;
             rel_threshold = 1e-2f;
         } else {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gru_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gru_cell.cpp
@@ -6,6 +6,7 @@
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 namespace ov {
@@ -26,23 +27,8 @@ class GRUCellCPUTest : public testing::WithParamInterface<GRUCellCpuSpecificPara
                        public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<GRUCellCpuSpecificParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        bool decompose, linearBeforeReset;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 decompose,
-                 activations,
-                 clip,
-                 linearBeforeReset,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = obj.param;
-
+        const auto& [inputShapes, decompose, activations, clip, linearBeforeReset, netPrecision, cpuParams,
+                     additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -75,22 +61,8 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        bool decompose, linearBeforeReset;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 decompose,
-                 activations,
-                 clip,
-                 linearBeforeReset,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = this->GetParam();
+        const auto &[inputShapes, decompose, activations, clip, linearBeforeReset, netPrecision, cpuParams,
+                     additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -101,7 +73,7 @@ protected:
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gru_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/gru_sequence.cpp
@@ -9,6 +9,7 @@
 #include "common_test_utils/node_builders/gru_cell.hpp"
 #include "openvino/pass/manager.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 namespace ov {
@@ -31,26 +32,8 @@ class GRUSequenceCPUTest : public testing::WithParamInterface<GRUSequenceCpuSpec
                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<GRUSequenceCpuSpecificParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        ov::test::utils::SequenceTestsMode seqMode;
-        std::vector<std::string> activations;
-        float clip;
-        bool linearBeforeRest;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 seqMode,
-                 activations,
-                 clip,
-                 linearBeforeRest,
-                 direction,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = obj.param;
-
+        const auto& [inputShapes, seqMode, activations, clip, linearBeforeRest, direction, netPrecision, cpuParams,
+                     additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -84,25 +67,8 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        ov::test::utils::SequenceTestsMode seqMode;
-        std::vector<std::string> activations;
-        float clip;
-        bool linearBeforeReset;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes,
-                 seqMode,
-                 activations,
-                 clip,
-                 linearBeforeReset,
-                 direction,
-                 netPrecision,
-                 cpuParams,
-                 additionalConfig) = this->GetParam();
+        const auto &[inputShapes, seqMode, activations, clip, linearBeforeReset, direction, netPrecision, cpuParams,
+                     additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -117,7 +83,7 @@ protected:
         const size_t inputSize = targetStaticShapes.front()[0][2];
         const size_t numDirections = direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/log_softmax.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/log_softmax.cpp
@@ -21,11 +21,7 @@ class LogSoftmaxLayerCPUTest
           public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<logSoftmaxLayerTestParams> obj) {
-        std::vector<InputShape> inputShapes;
-        ov::element::Type netPrecision;
-        int64_t axis;
-        std::tie(inputShapes, netPrecision, axis) = obj.param;
-
+        const auto& [inputShapes, netPrecision, axis] = obj.param;
         std::ostringstream result;
         if (inputShapes.front().first.size() != 0) {
             result << "IS=(";
@@ -49,12 +45,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        ov::element::Type netPrecision;
-        int64_t axis;
-        std::tie(inputShapes, netPrecision, axis) = this->GetParam();
-
+        const auto& [inputShapes, netPrecision, axis] = this->GetParam();
         auto ngPrc = netPrecision;
         inType = outType = ngPrc;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/logical.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/logical.cpp
@@ -21,10 +21,7 @@ class LogicalLayerCPUTest : public testing::WithParamInterface<LogicalLayerCPUTe
                             public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<LogicalLayerCPUTestParamSet> obj) {
-        ov::test::LogicalTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-
+        const auto& [basicParamsSet, cpuParams] = obj.param;
         std::ostringstream result;
         result << ov::test::LogicalLayerTest::getTestCaseName(
             testing::TestParamInfo<ov::test::LogicalTestParams>(basicParamsSet, 0));
@@ -36,20 +33,12 @@ public:
 
 protected:
     void SetUp() override {
-        ov::test::LogicalTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        std::vector<ov::test::InputShape> inputShapes;
-        ov::test::utils::LogicalTypes logicalOpType;
-        ov::test::utils::InputLayerType secondInputType;
-        ov::element::Type netPrecision;
         std::string targetName;
-        std::map<std::string, std::string> additional_config;
-        std::tie(inputShapes, logicalOpType, secondInputType, netPrecision, targetDevice, additional_config) =
+        const auto& [inputShapes, logicalOpType, secondInputType, netPrecision, _targetDevice, additional_config] =
             basicParamsSet;
+        targetDevice = _targetDevice;
         init_input_shapes(inputShapes);
 
         selectedType = getPrimitiveType() + "_" + ov::element::Type(inType).get_type_name();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/loop.cpp
@@ -36,14 +36,7 @@ class LoopLayerCPUTest : public testing::WithParamInterface<LoopParams>,
                          virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<LoopParams> obj) {
-        InputLayerType trip_count_type;
-        int64_t trip_count;
-        bool exec_cond;
-        std::vector<InputShape> shapes;
-        std::vector<LOOP_IN_TYPE> types;
-        ElementType netType;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, netType) = obj.param;
-
+        const auto& [trip_count_type, trip_count, exec_cond, shapes, types, netType] = obj.param;
         std::ostringstream result;
         for (size_t i = 0; i < shapes.size(); i++) {
             result << "Input" << i << "_";
@@ -93,14 +86,7 @@ protected:
     }
 
     void SetUp() override {
-        InputLayerType trip_count_type;
-        int64_t trip_count;
-        bool exec_cond;
-        std::vector<InputShape> shapes;
-        std::vector<LOOP_IN_TYPE> types;
-        ElementType netType;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, netType) = this->GetParam();
-
+        const auto& [trip_count_type, trip_count, exec_cond, shapes, types, netType] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes(shapes);
 
@@ -176,13 +162,8 @@ protected:
     //  i += 2
 
     void SetUp() override {
-        InputLayerType trip_count_type;
-        int64_t trip_count;
-        bool exec_cond;
-        std::vector<InputShape> shapes;
-        std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
-
+        const auto& [trip_count_type, trip_count, exec_cond, shapes, types, _inType] = this->GetParam();
+        inType = _inType;
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes(shapes);
         for (auto& target : targetStaticShapes)
@@ -249,13 +230,8 @@ class LoopForDiffShapesLayerCPUTest : public LoopLayerCPUTest {
 
 protected:
     void SetUp() override {
-        InputLayerType trip_count_type;
-        int64_t trip_count;
-        bool exec_cond;
-        std::vector<InputShape> shapes;
-        std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
-
+        const auto& [trip_count_type, trip_count, exec_cond, shapes, types, _inType] = this->GetParam();
+        inType = _inType;
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes(shapes);
 
@@ -327,13 +303,8 @@ class LoopForConcatLayerCPUTest : public LoopLayerCPUTest {
 
 protected:
     void SetUp() override {
-        InputLayerType trip_count_type;
-        int64_t trip_count;
-        bool exec_cond;
-        std::vector<InputShape> shapes;
-        std::vector<LOOP_IN_TYPE> types;
-        std::tie(trip_count_type, trip_count, exec_cond, shapes, types, inType) = this->GetParam();
-
+        const auto& [trip_count_type, trip_count, exec_cond, shapes, types, _inType] = this->GetParam();
+        inType = _inType;
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes(shapes);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/lrn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/lrn.cpp
@@ -23,13 +23,7 @@ using LRNParams = std::tuple<
 class LRNLayerCPUTest : public testing::WithParamInterface<LRNParams>, public ov::test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<LRNParams> obj) {
-        ElementType inputPrecision;
-        InputShape inputShapes;
-        double alpha, beta, bias;
-        size_t size;
-        std::vector<int64_t> axes;
-        std::tie(inputPrecision, inputShapes, alpha, beta, bias, size, axes) = obj.param;
-
+        const auto& [inputPrecision, inputShapes, alpha, beta, bias, size, axes] = obj.param;
         std::ostringstream result;
         result << inputPrecision << "_" << "IS=" << ov::test::utils::partialShape2str({ inputShapes.first }) << "_" << "TS=(";
         for (const auto& shape : inputShapes.second) {
@@ -43,13 +37,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        ElementType inputPrecision;
-        InputShape inputShapes;
-        double alpha, beta, bias;
-        size_t size;
-        std::vector<int64_t> axes;
-        std::tie(inputPrecision, inputShapes, alpha, beta, bias, size, axes) = this->GetParam();
-
+        const auto& [inputPrecision, inputShapes, alpha, beta, bias, size, axes] = this->GetParam();
         init_input_shapes({ inputShapes });
         selectedType = makeSelectedTypeStr("ref_any", inputPrecision);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/lstm_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/lstm_cell.cpp
@@ -6,6 +6,7 @@
 
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 
@@ -26,16 +27,7 @@ class LSTMCellLayerCPUTest : public testing::WithParamInterface<LSTMCellCpuSpeci
                              virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<LSTMCellCpuSpecificParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        bool decompose;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes, decompose, activations, clip, netPrecision, cpuParams, additionalConfig) = obj.param;
-
+        const auto& [inputShapes, decompose, activations, clip, netPrecision, cpuParams, additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -66,16 +58,9 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        bool decompose;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
         abs_threshold = 0.05;
-
-        std::tie(inputShapes, decompose, activations, clip, netPrecision, cpuParams, additionalConfig) = this->GetParam();
+        const auto &[inputShapes, decompose, activations, clip, netPrecision, cpuParams, additionalConfig] =
+            this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -86,8 +71,7 @@ protected:
         const size_t hiddenSize = targetStaticShapes.front()[1][1];
         const size_t inputSize = targetStaticShapes.front()[0][1];
 
-        auto it = additionalConfig.find(ov::hint::inference_precision.name());
-        if (it != additionalConfig.end() && it->second.as<ov::element::Type>() == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/matmul_sparse.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/matmul_sparse.cpp
@@ -35,15 +35,8 @@ class MatMulSparseCPUTest : public testing::WithParamInterface<MatMulSparseParam
                             virtual public SubgraphBaseTest, public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MatMulSparseParamSet>& obj) {
-        ShapeRelatedParams shapeRelatedParams;
-        ElementType inType, weiType, outType;
-        fusingSpecificParams fusingParams;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-        float weiSparseRate;
-        std::tie(shapeRelatedParams, inType, weiType, outType, fusingParams, cpuParams, additionalConfig,
-            weiSparseRate) = obj.param;
-
+        const auto& [shapeRelatedParams, inType, weiType, outType, fusingParams, cpuParams, additionalConfig,
+                     weiSparseRate] = obj.param;
         std::ostringstream result;
         result << "IS=";
         for (const auto& shape : shapeRelatedParams.inputShapes) {
@@ -136,16 +129,8 @@ protected:
 
     void SetUp() override {
         abs_threshold = 0.5f;
-
-        ShapeRelatedParams shapeRelatedParams;
-        ElementType inType, weiType, outType;
-        fusingSpecificParams fusingParams;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-        float weiSparseRate;
-
-        std::tie(shapeRelatedParams, inType, weiType, outType, fusingParams, cpuParams, additionalConfig,
-            weiSparseRate) = this->GetParam();
+        const auto& [shapeRelatedParams, inType, weiType, outType, fusingParams, cpuParams, additionalConfig,
+                     weiSparseRate] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/nonzero.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/nonzero.cpp
@@ -26,16 +26,9 @@ class NonZeroLayerCPUTest : public testing::WithParamInterface<NonZeroLayerCPUTe
                           virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<NonZeroLayerCPUTestParamsSet> obj) {
-        NonZeroLayerTestParams basicParamsSet;
-        std::pair<size_t, size_t> genData;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, genData, cpuParams) = obj.param;
+        const auto& [basicParamsSet, genData, cpuParams] = obj.param;
         std::string td;
-        ElementType netType = ElementType::dynamic;
-        InputShape inputShape;
-
-        std::tie(inputShape, netType) = basicParamsSet;
-
+        const auto& [inputShape, netType] = basicParamsSet;
         std::ostringstream result;
         result << "IS=";
         result  << ov::test::utils::partialShape2str({inputShape.first}) << "_";
@@ -70,15 +63,9 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        NonZeroLayerTestParams basicParamsSet;
-        std::pair<size_t, size_t> genData;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, genData, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, genData, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-        ElementType netType = ElementType::dynamic;
-        InputShape inputShape;
-        std::tie(inputShape, netType) = basicParamsSet;
-
+        const auto& [inputShape, netType] = basicParamsSet;
         std::tie(startFrom, range) = genData;
 
         init_input_shapes({inputShape});

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/normalize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/normalize.cpp
@@ -24,15 +24,7 @@ class NormalizeL2LayerCPUTest : public testing::WithParamInterface<NormalizeL2La
                                 virtual public SubgraphBaseTest, public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<NormalizeL2LayerCPUTestParamSet> obj) {
-        InputShape shapes;
-        ElementType inType;
-        std::vector<int64_t> axes;
-        float eps;
-        ov::op::EpsMode epsMode;
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        std::tie(shapes, inType, axes, eps, epsMode, cpuParams, fusingParams) = obj.param;
-
+        const auto& [shapes, inType, axes, eps, epsMode, cpuParams, fusingParams] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -51,15 +43,7 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        ElementType inType;
-        std::vector<int64_t> axes;
-        float eps;
-        ov::op::EpsMode epsMode;
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        std::tie(shapes, inType, axes, eps, epsMode, cpuParams, fusingParams) = this->GetParam();
-
+        const auto& [shapes, inType, axes, eps, epsMode, cpuParams, fusingParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         std::tie(postOpMgrPtr, fusedOps) = fusingParams;
         if (selectedType.empty()) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/one_hot.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/one_hot.cpp
@@ -27,15 +27,7 @@ class OneHotLayerCPUTest : public testing::WithParamInterface<oneHotCPUTestParam
                            virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<oneHotCPUTestParams>& obj) {
-        InputShape inputShape;
-        int axis;
-        std::pair<utils::InputLayerType, bool> inputType;
-        size_t depth;
-        float onValue, offValue;
-        ov::element::Type outPrc;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShape, axis, inputType, depth, onValue, offValue, outPrc, cpuParams) = obj.param;
-
+        const auto& [inputShape, axis, inputType, depth, onValue, offValue, outPrc, cpuParams] = obj.param;
         std::ostringstream result;
         if (inputShape.first.size() != 0) {
             result << "IS=(" << ov::test::utils::partialShape2str({inputShape.first}) << "_";
@@ -79,12 +71,12 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        InputShape inputShape;
-        std::pair<utils::InputLayerType, bool> inputType;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShape, Axis, inputType, Depth, OnValue, OffValue, outType, cpuParams) = this->GetParam();
-
+        const auto& [inputShape, _Axis, inputType, _Depth, _OnValue, _OffValue, _outType, cpuParams] = this->GetParam();
+        Axis = _Axis;
+        Depth = _Depth;
+        OnValue = _OnValue;
+        OffValue = _OffValue;
+        outType = _outType;
         if (inputType.second && inputType.first == utils::InputLayerType::CONSTANT) {
             generateDepth();
         }

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/pad.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/pad.cpp
@@ -32,16 +32,8 @@ class PadLayerCPUTest : public testing::WithParamInterface<PadLayerCPUTestParamS
                         virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<PadLayerCPUTestParamSet> obj) {
-        InputShape shapes;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ElementType elementType;
-        std::vector<int64_t> padsBegin, padsEnd;
-        ov::op::PadMode padMode;
-        float argPadValue;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-        std::tie(shapes, secondaryInputType, elementType, padsBegin, padsEnd, argPadValue, padMode, cpuParams, additionalConfig) = obj.param;
-
+        const auto& [shapes, secondaryInputType, elementType, padsBegin, padsEnd, argPadValue, padMode, cpuParams,
+                     additionalConfig] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -91,13 +83,11 @@ protected:
         }
     }
     void SetUp() override {
-        InputShape shapes;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ov::op::PadMode padMode;
-        ElementType dataType;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-        std::tie(shapes, secondaryInputType, dataType, padsBegin, padsEnd, padValue, padMode, cpuParams, additionalConfig) = this->GetParam();
+        const auto& [shapes, secondaryInputType, dataType, _padsBegin, _padsEnd, _padValue, padMode, cpuParams,
+                     additionalConfig] = this->GetParam();
+        padsBegin = _padsBegin;
+        padsEnd = _padsEnd;
+        padValue = _padValue;
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/prior_box.cpp
@@ -40,19 +40,7 @@ class PriorBoxLayerCPUTest : public testing::WithParamInterface<priorBoxLayerPar
         virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<priorBoxLayerParams>& obj) {
-        ov::test::ElementType netPrecision;
-        ov::test::ElementType inPrc, outPrc;
-        ov::test::InputShape inputShapes;
-        ov::test::InputShape imageShapes;
-        std::string targetDevice;
-        priorBoxSpecificParams specParams;
-        std::tie(specParams,
-                 netPrecision,
-                 inPrc, outPrc,
-                 inputShapes,
-                 imageShapes,
-                 targetDevice) = obj.param;
-
+        const auto& [specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, targetDevice] = obj.param;
         ov::op::v0::PriorBox::Attributes attributes;
         std::tie(
             attributes.min_size,
@@ -94,15 +82,8 @@ public:
 
 protected:
     void SetUp() override {
-        priorBoxSpecificParams specParams;
-
-        ov::test::ElementType netPrecision;
-        ov::test::ElementType inPrc;
-        ov::test::ElementType outPrc;
-        ov::test::InputShape inputShapes;
-        ov::test::InputShape imageShapes;
-        std::tie(specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, targetDevice) = GetParam();
-
+        const auto& [specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, _targetDevice] = GetParam();
+        targetDevice = _targetDevice;
         selectedType = makeSelectedTypeStr("ref_any", ov::test::ElementType::i32);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/prior_box_clustered.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/prior_box_clustered.cpp
@@ -36,13 +36,7 @@ class PriorBoxClusteredLayerCPUTest : public testing::WithParamInterface<priorBo
         virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<priorBoxClusteredLayerParams>& obj) {
-        ov::test::ElementType netPrecision;
-        ov::test::ElementType inPrc, outPrc;
-        ov::test::InputShape inputShapes, imageShapes;
-        std::string targetDevice;
-        priorBoxClusteredSpecificParams specParams;
-        std::tie(specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, targetDevice) = obj.param;
-
+        const auto& [specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, targetDevice] = obj.param;
         ov::op::v0::PriorBoxClustered::Attributes attributes;
         std::tie(
             attributes.widths,
@@ -80,14 +74,8 @@ public:
 
 protected:
     void SetUp() override {
-        priorBoxClusteredSpecificParams specParams;
-        ov::test::ElementType netPrecision;
-        ov::test::ElementType inPrc;
-        ov::test::ElementType outPrc;
-        ov::test::InputShape inputShapes;
-        ov::test::InputShape imageShapes;
-        std::tie(specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, targetDevice) = GetParam();
-
+        const auto& [specParams, netPrecision, inPrc, outPrc, inputShapes, imageShapes, _targetDevice] = GetParam();
+        targetDevice = _targetDevice;
         selectedType = makeSelectedTypeStr("ref_any", ov::test::ElementType::i32);
         targetDevice = ov::test::utils::DEVICE_CPU;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/proposal.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/proposal.cpp
@@ -57,30 +57,10 @@ class ProposalLayerCPUTest : public testing::WithParamInterface<proposalLayerTes
                              public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<proposalLayerTestCPUParams> obj) {
-        std::vector<InputShape> inputShapes;
-        proposalSpecificParams proposalParams;
-        ov::element::Type netPrecision;
-        std::tie(inputShapes, proposalParams, netPrecision) = obj.param;
-
-        base_size_type base_size;
-        box_coordinate_scale_type box_coordinate_scale;
-        box_size_scale_type box_size_scale;
-        clip_after_nms_type clip_after_nms;
-        clip_before_nms_type clip_before_nms;
-        feat_stride_type feat_stride;
-        framework_type framework;
-        min_size_type min_size;
-        nms_thresh_type nms_thresh;
-        normalize_type normalize;
-        post_nms_topn_type post_nms_topn;
-        pre_nms_topn_type pre_nms_topn;
-        ratio_type ratio;
-        scale_type scale;
-        std::tie(base_size, box_coordinate_scale, box_size_scale,
-                 clip_after_nms, clip_before_nms, feat_stride,
-                 framework, min_size, nms_thresh, normalize,
-                 post_nms_topn, pre_nms_topn, ratio, scale) = proposalParams;
-
+        const auto& [inputShapes, proposalParams, netPrecision] = obj.param;
+        const auto& [base_size, box_coordinate_scale, box_size_scale, clip_after_nms, clip_before_nms, feat_stride,
+                     framework, min_size, nms_thresh, normalize, post_nms_topn, pre_nms_topn, ratio, scale] =
+            proposalParams;
         std::ostringstream result;
         if (inputShapes.front().first.size() != 0) {
             result << "IS=(";
@@ -107,31 +87,10 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        proposalSpecificParams proposalParams;
-        ov::element::Type netPrecision;
-        std::tie(inputShapes, proposalParams, netPrecision) = this->GetParam();
-
-        base_size_type base_size;
-        box_coordinate_scale_type box_coordinate_scale;
-        box_size_scale_type box_size_scale;
-        clip_after_nms_type clip_after_nms;
-        clip_before_nms_type clip_before_nms;
-        feat_stride_type feat_stride;
-        framework_type framework;
-        min_size_type min_size;
-        nms_thresh_type nms_thresh;
-        normalize_type normalize;
-        post_nms_topn_type post_nms_topn;
-        pre_nms_topn_type pre_nms_topn;
-        ratio_type ratio;
-        scale_type scale;
-        std::tie(base_size, box_coordinate_scale, box_size_scale,
-                 clip_after_nms, clip_before_nms, feat_stride,
-                 framework, min_size, nms_thresh, normalize,
-                 post_nms_topn, pre_nms_topn, ratio, scale) = proposalParams;
-
+        const auto& [inputShapes, proposalParams, netPrecision] = this->GetParam();
+        const auto& [base_size, box_coordinate_scale, box_size_scale, clip_after_nms, clip_before_nms, feat_stride,
+                     framework, min_size, nms_thresh, normalize, post_nms_topn, pre_nms_topn, ratio, scale] =
+            proposalParams;
         selectedType = std::string("ref_any_") + netPrecision.to_string();
         init_input_shapes(inputShapes);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/psroi_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/psroi_pooling.cpp
@@ -35,23 +35,9 @@ class PSROIPoolingLayerCPUTest : public testing::WithParamInterface<PSROIPooling
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<PSROIPoolingLayerCPUTestParamsSet> obj) {
-        std::vector<float> proposal;
-        ov::Shape featureMapShape;
-        size_t spatialBinsX;
-        size_t spatialBinsY;
-        float spatialScale;
-        size_t groupSize;
-        size_t outputDim;
-        std::string mode;
-
-        PSROIPoolingLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ov::element::Type netPr;
-        PSROIPoolingSpecificParams psroiPar;
-        std::tie(psroiPar, netPr, td) = basicParamsSet;
-        std::tie(featureMapShape, proposal, outputDim, groupSize, spatialScale, spatialBinsX, spatialBinsY, mode) =
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [psroiPar, netPr, td] = basicParamsSet;
+        const auto& [featureMapShape, proposal, outputDim, groupSize, spatialScale, spatialBinsX, spatialBinsY, mode] =
             psroiPar;
         std::ostringstream result;
         result << "PSROIPoolingTest_";
@@ -69,26 +55,13 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<float> proposal;
-        ov::Shape featureMapShape;
-        size_t spatialBinsX;
-        size_t spatialBinsY;
-        float spatialScale;
-        size_t groupSize;
-        size_t outputDim;
-        std::string mode;
-        PSROIPoolingLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        PSROIPoolingSpecificParams psroiPoolingParams;
-        auto netPrecision = ov::element::dynamic;
-        std::tie(psroiPoolingParams, netPrecision, targetDevice) = basicParamsSet;
+        const auto& [psroiPoolingParams, netPrecision, _targetDevice] = basicParamsSet;
+        targetDevice = _targetDevice;
         inType = outType = netPrecision;
-        std::tie(featureMapShape, proposal, outputDim, groupSize, spatialScale, spatialBinsX, spatialBinsY, mode) =
+        const auto& [featureMapShape, proposal, outputDim, groupSize, spatialScale, spatialBinsX, spatialBinsY, mode] =
             psroiPoolingParams;
-
         ov::Shape proposalShape = {proposal.size() / 5, 5};
 
         auto coords = std::make_shared<ov::op::v0::Constant>(ov::element::f32, proposalShape, proposal);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/rdft.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/rdft.cpp
@@ -27,18 +27,8 @@ class RDFTTestCPU : public testing::WithParamInterface<std::tuple<ov::element::T
                            virtual public test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<std::tuple<ov::element::Type, RDFTTestCPUParams>> obj) {
-        ov::element::Type precision;
-        RDFTTestCPUParams params;
-        std::vector<InputShape> shapes;
-        std::vector<std::vector<int64_t>> axes;
-        std::vector<std::vector<int64_t>> signalSizes;
-        bool inverse;
-        bool constAxes, constSignalSizes;
-        CPUSpecificParams cpuParams;
-
-        std::tie(precision, params) = obj.param;
-        std::tie(shapes, axes, signalSizes, inverse, constAxes, constSignalSizes, cpuParams) = params;
-
+        const auto& [precision, params] = obj.param;
+        const auto& [shapes, axes, signalSizes, inverse, constAxes, constSignalSizes, cpuParams] = params;
         std::ostringstream result;
         result << "prec=" << precision;
         for (size_t i = 0; i < shapes.size(); i++) {
@@ -75,15 +65,13 @@ public:
 
 protected:
     void SetUp() override {
-        ov::element::Type precision;
-        RDFTTestCPUParams params;
-        std::vector<InputShape> shapes;
-        bool inverse;
-        CPUSpecificParams cpuParams;
         inputIdx = 0;
-
-        std::tie(precision, params) = GetParam();
-        std::tie(shapes, axes, signalSizes, inverse, constAxes, constSignalSizes, cpuParams) = params;
+        const auto& [precision, params] = GetParam();
+        const auto& [shapes, _axes, _signalSizes, inverse, _constAxes, _constSignalSizes, cpuParams] = params;
+        axes = _axes;
+        signalSizes = _signalSizes;
+        constAxes = _constAxes;
+        constSignalSizes = _constSignalSizes;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         selectedType = makeSelectedTypeStr(selectedType, precision);
         targetDevice = ov::test::utils::DEVICE_CPU;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/region_yolo.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/region_yolo.cpp
@@ -32,16 +32,8 @@ class RegionYoloCPULayerTest : public testing::WithParamInterface<regionYoloPara
                                virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<regionYoloParamsTuple> obj) {
-        InputShape inputShape;
-        regionYoloAttributes attributes;
-        std::vector<int64_t> mask;
-        ov::test::ElementType inpPrecision;
-        ov::test::ElementType outPrecision;
-        std::string targetName;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShape, attributes, mask, inpPrecision, outPrecision, additionalConfig, targetName) = obj.param;
-
+        const auto& [inputShape, attributes, mask, inpPrecision, outPrecision, additionalConfig, targetName] =
+            obj.param;
         std::ostringstream result;
         result << "IS=" << inputShape << "_";
         result << "classes=" << attributes.classes << "_";
@@ -57,15 +49,8 @@ public:
     }
 protected:
     void SetUp() override {
-        InputShape inputShape;
-        regionYoloAttributes attributes;
-        std::vector<int64_t> mask;
-        ov::test::ElementType inPrc;
-        ov::test::ElementType outPrc;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShape, attributes, mask, inPrc, outPrc, additionalConfig, targetDevice) = this->GetParam();
-
+        const auto& [inputShape, attributes, mask, inPrc, outPrc, additionalConfig, _targetDevice] = this->GetParam();
+        targetDevice = _targetDevice;
         if (inPrc == ov::test::ElementType::bf16) {
             // ticket #72342
             rel_threshold = 0.02;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/reorg_yolo.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/reorg_yolo.cpp
@@ -21,11 +21,7 @@ class ReorgYoloLayerCPUTest : public testing::WithParamInterface<ReorgYoloCPUPar
                               virtual public ov::test::SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReorgYoloCPUParamsTuple>& obj) {
-        InputShape inputShape;
-        size_t stride;
-        ElementType netPrecision;
-        TargetDevice targetDev;
-        std::tie(inputShape, stride, netPrecision, targetDev) = obj.param;
+        const auto& [inputShape, stride, netPrecision, targetDev] = obj.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_";
         for (const auto& item : inputShape.second) {
@@ -39,11 +35,8 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape inputShape;
-        size_t stride;
-        ElementType netPrecision;
-        std::tie(inputShape, stride, netPrecision, targetDevice) = this->GetParam();
-
+        const auto& [inputShape, stride, netPrecision, _targetDevice] = this->GetParam();
+        targetDevice = _targetDevice;
         init_input_shapes({inputShape});
 
         auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputDynamicShapes[0]);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/reverse_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/reverse_sequence.cpp
@@ -28,16 +28,8 @@ class ReverseSequenceLayerCPUTest : public testing::WithParamInterface<ReverseSe
                                     virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ReverseSequenceCPUTestParams> obj) {
-        int64_t batchAxisIndex;
-        int64_t seqAxisIndex;
-        ov::element::Type netPrecision;
-        std::string targetName;
-        InputShape dataInputShape;
-        InputShape seqLengthsShape;
-        utils::InputLayerType secondaryInputType;
-
-        std::tie(batchAxisIndex, seqAxisIndex, dataInputShape, seqLengthsShape, secondaryInputType, netPrecision, targetName) = obj.param;
-
+        const auto& [batchAxisIndex, seqAxisIndex, dataInputShape, seqLengthsShape, secondaryInputType, netPrecision,
+                     targetName] = obj.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({dataInputShape.first}) << "_";
         result << "TS=";
@@ -60,14 +52,9 @@ public:
 
 protected:
     void SetUp() override {
-        ov::element::Type netPrecision;
-        int64_t batchAxisIndex;
-        int64_t seqAxisIndex;
-        InputShape dataInputShape;
-        InputShape seqLengthsShape;
-        utils::InputLayerType secondaryInputType;
-
-        std::tie(batchAxisIndex, seqAxisIndex, dataInputShape, seqLengthsShape, secondaryInputType, netPrecision, targetDevice) = GetParam();
+        const auto& [batchAxisIndex, seqAxisIndex, dataInputShape, seqLengthsShape, secondaryInputType, netPrecision,
+                     _targetDevice] = GetParam();
+        targetDevice = _targetDevice;
         m_seqAxisIndex = seqAxisIndex;
 
         init_input_shapes({dataInputShape, seqLengthsShape});

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/rnn_cell.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/rnn_cell.cpp
@@ -5,6 +5,7 @@
 #include "common_test_utils/node_builders/rnn_cell.hpp"
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 
@@ -23,15 +24,7 @@ class RNNCellCPUTest : public testing::WithParamInterface<RNNCellCPUParams>,
                             virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<RNNCellCPUParams> &obj) {
-        std::vector<InputShape> inputShapes;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes, activations, clip, netPrecision, cpuParams, additionalConfig) = obj.param;
-
+        const auto& [inputShapes, activations, clip, netPrecision, cpuParams, additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -62,14 +55,7 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        std::vector<std::string> activations;
-        float clip = 0.f;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes, activations, clip, netPrecision, cpuParams, additionalConfig) = this->GetParam();
+        const auto& [inputShapes, activations, clip, netPrecision, cpuParams, additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -80,8 +66,7 @@ protected:
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        auto it = additionalConfig.find(ov::hint::inference_precision.name());
-        if (it != additionalConfig.end() && it->second.as<ov::element::Type>() == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/rnn_sequence.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/rnn_sequence.cpp
@@ -8,6 +8,7 @@
 #include "transformations/op_conversions/bidirectional_sequences_decomposition.hpp"
 #include "transformations/op_conversions/convert_sequences_to_tensor_iterator.hpp"
 #include "common_test_utils/ov_test_utils.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 
@@ -29,17 +30,8 @@ class RNNSequenceCPUTest : public testing::WithParamInterface<RNNSequenceCpuSpec
                            virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<RNNSequenceCpuSpecificParams> &obj) {
-        std::vector<InputShape> inputShapes;
-        ov::test::utils::SequenceTestsMode seqMode;
-        std::vector<std::string> activations;
-        float clip;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes, seqMode, activations, clip, direction, netPrecision, cpuParams, additionalConfig) = obj.param;
-
+        const auto& [inputShapes, seqMode, activations, clip, direction, netPrecision, cpuParams, additionalConfig] =
+            obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -71,16 +63,8 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> inputShapes;
-        ov::test::utils::SequenceTestsMode seqMode;
-        std::vector<std::string> activations;
-        float clip;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-
-        std::tie(inputShapes, seqMode, activations, clip, direction, netPrecision, cpuParams, additionalConfig) = this->GetParam();
+        const auto &[inputShapes, seqMode, activations, clip, direction, netPrecision, cpuParams, additionalConfig] =
+            this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
@@ -94,8 +78,7 @@ protected:
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
-        auto it = additionalConfig.find(ov::hint::inference_precision.name());
-        if (it != additionalConfig.end() && it->second.as<ov::element::Type>() == ov::element::bf16) {
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             selectedType = makeSelectedTypeStr(selectedType, ElementType::bf16);
         } else {
             selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roi_pooling.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roi_pooling.cpp
@@ -10,6 +10,7 @@
 
 #include "utils/cpu_test_utils.hpp"
 #include "utils/bfloat16.hpp"
+#include "utils/general_utils.h"
 #include "openvino/op/roi_pooling.hpp"
 
 using namespace CPUTestUtils;
@@ -37,21 +38,8 @@ class ROIPoolingCPULayerTest : public testing::WithParamInterface<ROIPoolingCPUT
                                public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ROIPoolingCPUTestParamsSet> obj) {
-        roiPoolingParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        ProposalGenerationMode propMode;
-        ov::AnyMap additionalConfig;
-
-        std::tie(basicParamsSet, cpuParams, propMode, additionalConfig) = obj.param;
-
-        roiPoolingShapes inputShapes;
-        std::vector<size_t> poolShape;
-        float spatial_scale;
-       utils::ROIPoolingTypes pool_method;
-        ov::element::Type netPrecision;
-        std::string targetDevice;
-        std::tie(inputShapes, poolShape, spatial_scale, pool_method, netPrecision, targetDevice) = basicParamsSet;
-
+        const auto& [basicParamsSet, cpuParams, propMode, additionalConfig] = obj.param;
+        const auto& [inputShapes, poolShape, spatial_scale, pool_method, netPrecision, targetDevice] = basicParamsSet;
         std::ostringstream result;
         result << "netPRC=" << netPrecision.to_string() << "_";
         for (const auto& shape : inputShapes) {
@@ -174,22 +162,14 @@ protected:
     }
 
     void SetUp() override {
-        roiPoolingParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        ProposalGenerationMode propMode;
-        ov::AnyMap additionalConfig;
-
-        std::tie(basicParamsSet, cpuParams, propMode, additionalConfig) = this->GetParam();
-        roiPoolingShapes inputShapes;
-        std::vector<size_t> poolShape;
-        float spatial_scale;
-       utils::ROIPoolingTypes pool_method;
-        ov::element::Type netPrecision;
-        std::tie(inputShapes, poolShape, spatial_scale, pool_method, netPrecision, targetDevice) = basicParamsSet;
-
-        auto it = additionalConfig.find(ov::hint::inference_precision.name());
-        if (it != additionalConfig.end() && it->second.as<ov::element::Type>() == ov::element::bf16)
+        const auto& [basicParamsSet, cpuParams, propMode, additionalConfig] = this->GetParam();
+        const auto& [inputShapes, poolShape, spatial_scale, pool_method, _netPrecision, _targetDevice] = basicParamsSet;
+        targetDevice = _targetDevice;
+        auto netPrecision = _netPrecision;
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             netPrecision = ov::element::bf16;
+        }
+
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roialign.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roialign.cpp
@@ -37,22 +37,9 @@ class ROIAlignLayerCPUTest : public testing::WithParamInterface<ROIAlignLayerCPU
                              public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ROIAlignLayerCPUTestParamsSet> obj) {
-        ROIAlignLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        std::string td;
-        ElementType netPrecision;
-        ROIAlignSpecificParams roiPar;
-        std::tie(roiPar, netPrecision, td) = basicParamsSet;
-
-        int pooledH;
-        int pooledW;
-        float spatialScale;
-        int samplingRatio;
-        std::string mode;
-        std::string alignedMode;
-        ROIAlignShapes inputShapes;
-        std::tie(pooledH, pooledW, spatialScale, samplingRatio, mode, alignedMode, inputShapes) = roiPar;
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [roiPar, netPrecision, td] = basicParamsSet;
+        const auto& [pooledH, pooledW, spatialScale, samplingRatio, mode, alignedMode, inputShapes] = roiPar;
         std::ostringstream result;
 
         result << netPrecision << "_IS=";
@@ -128,24 +115,11 @@ protected:
     }
 
     void SetUp() override {
-        ROIAlignLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        ROIAlignSpecificParams roiAlignParams;
-        ElementType inputPrecision;
-        std::tie(roiAlignParams, inputPrecision, targetDevice) = basicParamsSet;
-
-        int pooledH;
-        int pooledW;
-        float spatialScale;
-        int samplingRatio;
-        std::string mode;
-        std::string alignedMode;
-        ROIAlignShapes inputShapes;
-        std::tie(pooledH, pooledW, spatialScale, samplingRatio, mode, alignedMode, inputShapes) = roiAlignParams;
-
+        const auto& [roiAlignParams, inputPrecision, _targetDevice] = basicParamsSet;
+        targetDevice = _targetDevice;
+        const auto& [pooledH, pooledW, spatialScale, samplingRatio, mode, alignedMode, inputShapes] = roiAlignParams;
         init_input_shapes(inputShapes);
 
         ov::ParameterVector float_params;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roll.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/roll.cpp
@@ -22,13 +22,7 @@ class RollLayerCPUTest : public testing::WithParamInterface<RollCPUTestParams>,
                          virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<RollCPUTestParams> obj) {
-        InputShape inputShape;
-        ov::element::Type inputPrecision;
-        std::vector<int64_t> shift;
-        std::vector<int64_t> axes;
-        std::string targetDevice;
-        std::tie(inputShape, inputPrecision, shift, axes, targetDevice) = obj.param;
-
+        const auto& [inputShape, inputPrecision, shift, axes, targetDevice] = obj.param;
         std::ostringstream result;
         result << "IS=" << ov::test::utils::partialShape2str({inputShape.first}) << "_";
         result << "TS=";
@@ -45,13 +39,8 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape inputShape;
-        ov::element::Type inputPrecision;
-        std::vector<int64_t> shift;
-        std::vector<int64_t> axes;
-
-        std::tie(inputShape, inputPrecision, shift, axes, targetDevice) = GetParam();
-
+        const auto& [inputShape, inputPrecision, shift, axes, _targetDevice] = GetParam();
+        targetDevice = _targetDevice;
         init_input_shapes({inputShape});
 
         ov::ParameterVector paramsIn;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scatter_ND_update.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scatter_ND_update.cpp
@@ -28,10 +28,7 @@ class ScatterNDUpdateLayerCPUTest : public testing::WithParamInterface<scatterUp
                                     public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<scatterUpdateParams> obj) {
-        ScatterNDUpdateLayerParams scatterParams;
-        ElementType inputPrecision;
-        ElementType idxPrecision;
-        std::tie(scatterParams, inputPrecision, idxPrecision) = obj.param;
+        const auto& [scatterParams, inputPrecision, idxPrecision] = obj.param;
         const auto inputShapes = scatterParams.inputShapes;
         const auto indicesValues = scatterParams.indicesValues;
         const auto exceptionExpected = scatterParams.exceptionExpected;
@@ -96,10 +93,7 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        ScatterNDUpdateLayerParams scatterParams;
-        ElementType inputPrecision;
-        ElementType idxPrecision;
-        std::tie(scatterParams, inputPrecision, idxPrecision) = this->GetParam();
+        const auto& [scatterParams, inputPrecision, idxPrecision] = this->GetParam();
         const auto inputShapes = scatterParams.inputShapes;
         const auto indicesValues = scatterParams.indicesValues;
         const auto exceptionExpected = scatterParams.exceptionExpected;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scatter_elements_update.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scatter_elements_update.cpp
@@ -28,11 +28,7 @@ class ScatterElementsUpdateLayerCPUTest : public testing::WithParamInterface<sca
                                           public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<scatterUpdateParams> obj) {
-        ScatterElementsUpdateLayerParams scatterParams;
-        std::int64_t axis;
-        ElementType inputPrecision;
-        ElementType idxPrecision;
-        std::tie(scatterParams, axis, inputPrecision, idxPrecision) = obj.param;
+        const auto& [scatterParams, axis, inputPrecision, idxPrecision] = obj.param;
         const auto inputShapes = scatterParams.inputShapes;
         const auto indicesVals = scatterParams.indicesValues;
 
@@ -96,11 +92,7 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        ScatterElementsUpdateLayerParams scatterParams;
-        std::int64_t axis;
-        ElementType inputPrecision;
-        ElementType idxPrecision;
-        std::tie(scatterParams, axis, inputPrecision, idxPrecision) = this->GetParam();
+        const auto& [scatterParams, axis, inputPrecision, idxPrecision] = this->GetParam();
         const auto inputShapes = scatterParams.inputShapes;
         const auto indicesDescr = scatterParams.indicesValues;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scatter_update.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/scatter_update.cpp
@@ -30,10 +30,7 @@ class ScatterUpdateLayerCPUTest : public testing::WithParamInterface<scatterUpda
                                   public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<scatterUpdateParams> obj) {
-        ScatterUpdateLayerParams scatterParams;
-        ElementType inputPrecision;
-        ElementType idxPrecision;
-        std::tie(scatterParams, inputPrecision, idxPrecision) = obj.param;
+        const auto& [scatterParams, inputPrecision, idxPrecision] = obj.param;
         const auto inputShapes = scatterParams.inputShapes;
         const auto indicesDescr = scatterParams.indicesDescriprion;
         const auto axis = scatterParams.axis;
@@ -60,10 +57,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        ScatterUpdateLayerParams scatterParams;
-        ElementType inputPrecision;
-        ElementType idxPrecision;
-        std::tie(scatterParams, inputPrecision, idxPrecision) = this->GetParam();
+        const auto& [scatterParams, inputPrecision, idxPrecision] = this->GetParam();
         const auto inputShapes = scatterParams.inputShapes;
         const auto indicesDescr = scatterParams.indicesDescriprion;
         const auto axis = scatterParams.axis;

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/select.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/select.cpp
@@ -21,12 +21,7 @@ class SelectLayerCPUTest : public testing::WithParamInterface<selectParams>,
                            public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<selectParams> obj) {
-        std::vector<InputShape> shapes;
-        ElementType precision;
-        ov::op::AutoBroadcastSpec broadcast;
-        fusingSpecificParams fusingParams;
-        std::tie(shapes, precision, broadcast, fusingParams) = obj.param;
-
+        const auto& [shapes, precision, broadcast, fusingParams] = obj.param;
         std::ostringstream result;
         result << "Condition_prc_" << ElementType::boolean << "_Then_Else_prc_" << precision << "_";
         result << "IS=(";
@@ -49,11 +44,7 @@ protected:
     void SetUp() override {
         abs_threshold = 0;
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::vector<InputShape> shapes;
-        ElementType precision;
-        ov::op::AutoBroadcastSpec broadcast;
-        fusingSpecificParams fusingParams;
-        std::tie(shapes, precision, broadcast, fusingParams) = this->GetParam();
+        const auto& [shapes, precision, broadcast, fusingParams] = this->GetParam();
         init_input_shapes(shapes);
         std::tie(inFmts, outFmts, priority, selectedType) = emptyCPUSpec;
         selectedType = makeSelectedTypeStr(getPrimitiveType(), ov::element::i8);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shape_ops.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shape_ops.cpp
@@ -55,14 +55,7 @@ class ShapeOpsCPUTest : public testing::WithParamInterface<shapeOpsParams>,
                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<shapeOpsParams> obj) {
-        inputDescription inpDesc;
-        ov::test::utils::InputLayerType secondType;
-        shapeNodeType nodeType;
-        ov::element::Type prc;
-        bool specialZero;
-        element::Type_t tmpSecondInPrc;
-        std::tie(inpDesc, secondType, nodeType, prc, tmpSecondInPrc, specialZero) = obj.param;
-
+        const auto& [inpDesc, secondType, nodeType, prc, tmpSecondInPrc, specialZero] = obj.param;
         std::ostringstream result;
         result << nodeType << "_";
         result << "IS=";
@@ -138,14 +131,8 @@ protected:
     void SetUp() override {
         idx = 0;
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        inputDescription inpDesc;
-        ov::test::utils::InputLayerType secondType;
-        shapeNodeType nodeType;
-        ov::element::Type prc;
-        bool specialZero;
-        std::tie(inpDesc, secondType, nodeType, prc, secondInPrc, specialZero) = this->GetParam();
-
+        const auto& [inpDesc, secondType, nodeType, prc, _secondInPrc, specialZero] = this->GetParam();
+        secondInPrc = _secondInPrc;
         if (nodeType == shapeNodeType::ReshapeWithNonZero) {
             isWithNonZero = true;
             // the input of nonZero is FP32, but the output of nonZero is i32,

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shapeof.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shapeof.cpp
@@ -25,13 +25,8 @@ class ShapeOfLayerCPUTest : public testing::WithParamInterface<ShapeOfLayerCPUTe
                             public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ShapeOfLayerCPUTestParamsSet> obj) {
-        ShapeOfLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        ElementType netPr;
-        InputShape inputShape;
-
-        std::tie(inputShape, netPr) = basicParamsSet;
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [inputShape, netPr] = basicParamsSet;
         std::ostringstream result;
         result << "ShapeOfTest_";
         result << std::to_string(obj.index) << "_";
@@ -50,15 +45,9 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        ShapeOfLayerTestParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        auto netPrecision = ElementType::dynamic;
-        InputShape inputShape;
-        std::tie(inputShape, netPrecision) = basicParamsSet;
+        const auto& [inputShape, netPrecision] = basicParamsSet;
         init_input_shapes({inputShape});
 
         inType = ov::element::Type(netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shuffle_channels.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/shuffle_channels.cpp
@@ -22,14 +22,8 @@ class ShuffleChannelsLayerCPUTest : public testing::WithParamInterface<ShuffleCh
                                     public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ShuffleChannelsLayerCPUTestParamsSet> obj) {
-        InputShape shapes;
-        ElementType inType;
-        ov::test::shuffleChannelsSpecificParams shuffleChannelsParams;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, shuffleChannelsParams, cpuParams) = obj.param;
-        int axis, group;
-        std::tie(axis, group) = shuffleChannelsParams;
-
+        const auto& [shapes, inType, shuffleChannelsParams, cpuParams] = obj.param;
+        const auto& [axis, group] = shuffleChannelsParams;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -46,14 +40,8 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        ElementType inType;
-        ov::test::shuffleChannelsSpecificParams shuffleChannelsParams;
-        int axis, group;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, shuffleChannelsParams, cpuParams) = this->GetParam();
-        std::tie(axis, group) = shuffleChannelsParams;
-
+        const auto& [shapes, inType, shuffleChannelsParams, cpuParams] = this->GetParam();
+        const auto& [axis, group] = shuffleChannelsParams;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice.cpp
@@ -34,13 +34,7 @@ class Slice8LayerCPUTest : public testing::WithParamInterface<Slice8LayerTestCPU
                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<Slice8LayerTestCPUParam> obj) {
-        std::vector<InputShape> shapes;
-        Slice8SpecificParams params;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, params, secondaryInputType, netPrecision, cpuParams) = obj.param;
-
+        const auto& [shapes, params, secondaryInputType, netPrecision, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : shapes) {
@@ -89,11 +83,8 @@ protected:
         }
     }
     void SetUp() override {
-        std::vector<InputShape> shapes;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, sliceParams, secondaryInputType, netPrecision, cpuParams) = this->GetParam();
+        const auto& [shapes, _sliceParams, secondaryInputType, netPrecision, cpuParams] = this->GetParam();
+        sliceParams = _sliceParams;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice_scatter.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/slice_scatter.cpp
@@ -33,13 +33,7 @@ class SliceScatterLayerCPUTest : public testing::WithParamInterface<SliceScatter
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<SliceScatterLayerTestCPUParam> obj) {
-        std::vector<InputShape> shapes;
-        SliceScatterSpecificParams params;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, params, secondaryInputType, netPrecision, cpuParams) = obj.param;
-
+        const auto& [shapes, params, secondaryInputType, netPrecision, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : shapes) {
@@ -90,11 +84,8 @@ protected:
         }
     }
     void SetUp() override {
-        std::vector<InputShape> shapes;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, sliceParams, secondaryInputType, netPrecision, cpuParams) = this->GetParam();
+        const auto& [shapes, _sliceParams, secondaryInputType, netPrecision, cpuParams] = this->GetParam();
+        sliceParams = _sliceParams;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         selectedType = makeSelectedTypeStr(selectedType, netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/space_to_batch.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/space_to_batch.cpp
@@ -29,10 +29,10 @@ class SpaceToBatchCPULayerTest : public testing::WithParamInterface<SpaceToBatch
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<SpaceToBatchLayerTestCPUParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        ov::element::Type netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapes, blockShape, padsBegin, padsEnd, netPrecision, cpuParams) = obj.param;
+        const auto& [inputShapes, _blockShape, _padsBegin, _padsEnd, netPrecision, cpuParams] = obj.param;
+        blockShape = _blockShape;
+        padsBegin = _padsBegin;
+        padsEnd = _padsEnd;
         std::ostringstream result;
         if (inputShapes.front().first.size() != 0) {
             result << "IS=(";
@@ -94,10 +94,10 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::vector<InputShape> inputShapes;
-        ov::element::Type netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapes, blockShape, padsBegin, padsEnd, netPrecision, cpuParams) = this->GetParam();
+        const auto& [inputShapes, _blockShape, _padsBegin, _padsEnd, netPrecision, cpuParams] = this->GetParam();
+        blockShape = _blockShape;
+        padsBegin = _padsBegin;
+        padsEnd = _padsEnd;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         const std::vector<InputShape> inputShapesVec{inputShapes};

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/space_to_depth.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/space_to_depth.cpp
@@ -21,13 +21,7 @@ class SpaceToDepthLayerCPUTest : public testing::WithParamInterface<SpaceToDepth
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<SpaceToDepthLayerCPUTestParamSet> obj) {
-        InputShape shapes;
-        ElementType inType;
-        ov::op::v0::SpaceToDepth::SpaceToDepthMode mode;
-        std::size_t blockSize;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, mode, blockSize, cpuParams) = obj.param;
-
+        const auto& [shapes, inType, mode, blockSize, cpuParams] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -53,13 +47,7 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        ElementType inType;
-        ov::op::v0::SpaceToDepth::SpaceToDepthMode mode;
-        std::size_t blockSize;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, inType, mode, blockSize, cpuParams) = this->GetParam();
-
+        const auto& [shapes, inType, mode, blockSize, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         if (selectedType.empty()) {
             selectedType = getPrimitiveType();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/strided_slice.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/strided_slice.cpp
@@ -38,13 +38,7 @@ class StridedSliceLayerCPUTest : public testing::WithParamInterface<StridedSlice
                                  public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<StridedSliceLayerCPUTestParamSet> obj) {
-        InputShape shapes;
-        StridedSliceParams params;
-        ov::test::utils::InputLayerType secondaryInputType;
-        ElementType dataType;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, params, secondaryInputType, dataType, cpuParams) = obj.param;
-
+        const auto& [shapes, params, secondaryInputType, dataType, cpuParams] = obj.param;
         std::ostringstream results;
         results << "IS=" << ov::test::utils::partialShape2str({shapes.first}) << "_";
         results << "TS=";
@@ -92,11 +86,8 @@ protected:
     }
 
     void SetUp() override {
-        InputShape shapes;
-        ov::test::utils::InputLayerType secondaryInputType;
-        CPUSpecificParams cpuParams;
-        ov::element::Type dataType;
-        std::tie(shapes, ssParams, secondaryInputType, dataType, cpuParams) = this->GetParam();
+        const auto& [shapes, _ssParams, secondaryInputType, dataType, cpuParams] = this->GetParam();
+        ssParams = _ssParams;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         selectedType = makeSelectedTypeStr("ref", dataType);

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/tensor_iterator.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/tensor_iterator.cpp
@@ -19,11 +19,7 @@ class TensorIteratorCPUTest : public testing::WithParamInterface<TensorIteratorP
                               virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TensorIteratorParams> obj) {
-        std::vector<InputShape> shapes;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType inType;
-        std::tie(shapes, direction, inType) = obj.param;
-
+        const auto& [shapes, direction, inType] = obj.param;
         std::ostringstream result;
         for (size_t i = 0; i < shapes.size(); i++) {
             result << "Input" << i << "_";
@@ -40,11 +36,7 @@ public:
 
 protected:
     void SetUp() override {
-        std::vector<InputShape> shapes;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType inType;
-        std::tie(shapes, direction, inType) = this->GetParam();
-
+        const auto& [shapes, direction, inType] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         init_input_shapes({shapes});
 

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/tile.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/tile.cpp
@@ -22,17 +22,8 @@ class TileLayerCPUTest : public testing::WithParamInterface<TileLayerCPUTestPara
                          public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TileLayerCPUTestParamsSet> obj) {
-        TileLayerTestParamsSet basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-
-        std::vector<ov::test::InputShape> inputShapes;
-        std::vector<int64_t> repeats;
-        ov::element::Type_t netPrecision;
-        bool isRepeatsConst;
-        std::string deviceName;
-        std::tie(inputShapes, repeats, netPrecision, isRepeatsConst, deviceName) = basicParamsSet;
-
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [inputShapes, repeats, netPrecision, isRepeatsConst, deviceName] = basicParamsSet;
         std::ostringstream result;
         result << "IS=(";
         for (const auto& shape : inputShapes) {
@@ -56,17 +47,11 @@ public:
 
 protected:
     void SetUp() override {
-        TileLayerTestParamsSet basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        std::vector<ov::test::InputShape> inputShapes;
-        ov::element::Type_t netPrecision;
-        bool isRepeatsConst;
-        std::tie(inputShapes, repeatsData, netPrecision, isRepeatsConst, targetDevice) = basicParamsSet;
-
+        const auto& [inputShapes, _repeatsData, netPrecision, isRepeatsConst, _targetDevice] = basicParamsSet;
+        repeatsData = _repeatsData;
+        targetDevice = _targetDevice;
         selectedType += std::string("_") + ov::element::Type(netPrecision).get_type_name();
 
         if (inputShapes.front().first.rank() != 0) {

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/topk.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/topk.cpp
@@ -8,12 +8,16 @@
 #include "shared_test_classes/base/ov_subgraph.hpp"
 #include "utils/cpu_test_utils.hpp"
 #include "utils/filter_cpu_info.hpp"
+#include "utils/general_utils.h"
 #include "openvino/op/topk.hpp"
 
 using namespace CPUTestUtils;
 using namespace ov::test;
 using SortMode = ov::op::TopKMode;
 using SortType = ov::op::TopKSortType;
+
+namespace ov {
+namespace test {
 
 typedef std::tuple<int64_t,                     // keepK
                    int64_t,                     // axis
@@ -27,23 +31,13 @@ typedef std::tuple<int64_t,                     // keepK
     basicTopKParams;
 
 typedef std::tuple<basicTopKParams, CPUSpecificParams, ov::AnyMap> TopKLayerCPUTestParamsSet;
-
 class TopKLayerCPUTest : public testing::WithParamInterface<TopKLayerCPUTestParamsSet>,
                          virtual public SubgraphBaseTest,
                          public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<TopKLayerCPUTestParamsSet> obj) {
-        basicTopKParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-        std::tie(basicParamsSet, cpuParams, additionalConfig) = obj.param;
-
-        int64_t keepK, axis;
-        SortMode mode;
-        std::tuple<SortType, bool> sortTypeStable;
-        ElementType netPrecision, inPrc, outPrc;
-        InputShape inputShape;
-        std::tie(keepK, axis, mode, sortTypeStable, netPrecision, inPrc, outPrc, inputShape) = basicParamsSet;
+        const auto &[basicParamsSet, cpuParams, additionalConfig] = obj.param;
+        const auto &[keepK, axis, mode, sortTypeStable, netPrecision, inPrc, outPrc, inputShape] = basicParamsSet;
         SortType sort = std::get<0>(sortTypeStable);
         bool stable = std::get<1>(sortTypeStable);
 
@@ -80,27 +74,16 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        basicTopKParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        ov::AnyMap additionalConfig;
-        std::tie(basicParamsSet, cpuParams, additionalConfig) = this->GetParam();
-
+        const auto &[basicParamsSet, cpuParams, additionalConfig] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
-
-        int64_t keepK;
-        SortMode mode;
-        std::tuple<SortType, bool> sortTypeStable;
-        ElementType inPrc, outPrc;
-        InputShape inputShape;
-        std::tie(keepK, axis, mode, sortTypeStable, netPrecision, inPrc, outPrc, inputShape) = basicParamsSet;
+        const auto& [keepK, _axis, mode, sortTypeStable, _netPrecision, inPrc, outPrc, inputShape] = basicParamsSet;
+        axis = _axis;
+        netPrecision = _netPrecision;
         sort = std::get<0>(sortTypeStable);
         stable = std::get<1>(sortTypeStable);
 
-        if (additionalConfig[ov::hint::inference_precision.name()] == ov::element::bf16)
-            inPrc = outPrc = netPrecision = ElementType::bf16;
-        else
-            inPrc = outPrc = netPrecision;
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16}))
+            netPrecision = ElementType::bf16;
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         if (!ov::with_cpu_x86_avx512_core() && netPrecision == ElementType::bf16) {
@@ -240,7 +223,6 @@ private:
     ElementType netPrecision;
     bool staticShape;
 };
-
 TEST_P(TopKLayerCPUTest, CompareWithRefs) {
     run();
     CheckPluginRelatedResults(compiledModel, "TopK");
@@ -415,3 +397,5 @@ INSTANTIATE_TEST_SUITE_P(
     TopKLayerCPUTest::getTestCaseName);
 
 }  // namespace
+}  // namespace test
+}  // namespace ov

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/variadic_split.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/variadic_split.cpp
@@ -26,14 +26,7 @@ class VariadicSplitLayerCPUTest : public testing::WithParamInterface<varSplitCPU
                                   public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<varSplitCPUTestParams> obj) {
-        InputShape shapes;
-        int64_t axis;
-        LengthsPerInfer splitLengths;
-        ov::test::utils::InputLayerType lengthsType;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(shapes, axis, splitLengths, lengthsType, netPrecision, cpuParams) = obj.param;
-
+        const auto& [shapes, axis, splitLengths, lengthsType, netPrecision, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=";
         result << ov::test::utils::partialShape2str({shapes.first}) << "_";
@@ -55,14 +48,8 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        InputShape inputShapes;
-        int64_t axis;
-        ov::test::utils::InputLayerType lengthsType;
-        ElementType netPrecision;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapes, axis, lengthsPerInfer, lengthsType, netPrecision, cpuParams) = this->GetParam();
-
+        const auto& [inputShapes, axis, _lengthsPerInfer, lengthsType, netPrecision, cpuParams] = this->GetParam();
+        lengthsPerInfer = _lengthsPerInfer;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         selectedType += std::string("_") + ov::element::Type(netPrecision).to_string();
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/convert_group_conv.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/convert_group_conv.cpp
@@ -17,9 +17,7 @@ class GroupConvToConvTransformationCPUTest: public testing::WithParamInterface<g
                                             virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerCPUTestParamsSet> obj) {
-        InputShape inputShapes;
-        std::tie(inputShapes) = obj.param;
-
+        const auto& [inputShapes] = obj.param;
         std::ostringstream result;
         result << "IS=" << inputShapes;
 
@@ -30,9 +28,7 @@ protected:
     static const size_t numOfGroups = 2;
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        InputShape inputShapes;
-        std::tie(inputShapes) = this->GetParam();
-
+        const auto& [inputShapes] = this->GetParam();
         init_input_shapes({inputShapes});
 
         std::shared_ptr<Node> conv;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/convert_group_conv1d.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/convert_group_conv1d.cpp
@@ -21,10 +21,7 @@ class Conv1dConvertTransformationCPUTest : public testing::WithParamInterface<co
                                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<conv1dConvertCPUTestParamsSet> obj) {
-        InputShape inputShapes;
-        nodeType convType;
-        std::tie(convType, inputShapes) = obj.param;
-
+        const auto& [convType, inputShapes] = obj.param;
         std::ostringstream result;
         result << nodeType2str(convType) << "_";
         result << "IS=" << inputShapes;
@@ -35,10 +32,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        InputShape inputShapes;
-        nodeType convType;
-        std::tie(convType, inputShapes) = this->GetParam();
-
+        const auto& [convType, inputShapes] = this->GetParam();
         init_input_shapes({inputShapes});
 
         std::shared_ptr<Node> conv;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/convert_reduce_multi_axis.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/convert_reduce_multi_axis.cpp
@@ -23,11 +23,7 @@ class reduceTransformationCPUTest: public testing::WithParamInterface<reduceConv
                                             virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<reduceConvertCPUTestParamsSet> obj) {
-        std::vector<InputShape> inputShapes;
-        std::vector<int> axes;
-        utils::ReductionType reductionType;
-        std::tie(axes, reductionType, inputShapes) = obj.param;
-
+        const auto& [axes, reductionType, inputShapes] = obj.param;
         std::ostringstream result;
         result << "type=" << reductionType << "_";
         result << "IS=(";
@@ -42,10 +38,9 @@ protected:
     int numberOfExpectedReduce;
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::vector<int> axes;
         bool keepDims = true;
-        std::vector<InputShape> inputShapes;
-        std::tie(axes, reductionType, inputShapes) = this->GetParam();
+        const auto& [axes, _reductionType, inputShapes] = this->GetParam();
+        reductionType = _reductionType;
         numberOfExpectedReduce = axes.size();
 
         init_input_shapes(inputShapes);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/fuse_eltwise_convert.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/arm/fuse_eltwise_convert.cpp
@@ -45,10 +45,7 @@ class MergeEltwiseAndConvertTransformationCPUTest: public testing::WithParamInte
                                             public CPUTestsBase, virtual public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<eltwiseFusingCPUTestParamsSet> obj) {
-        utils::EltwiseTypes eltwiseType;
-        ElementType convertOutType;
-        std::tie(eltwiseType, convertOutType) = obj.param;
-
+        const auto& [eltwiseType, convertOutType] = obj.param;
         std::ostringstream result;
         result << "EltwiseType=" << eltwiseType << "_";
         result << "convertOutType=" << convertOutType;
@@ -59,10 +56,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        utils::EltwiseTypes eltwiseType;
-        ElementType convertOutType;
-        std::tie(eltwiseType, convertOutType) = this->GetParam();
-
+        const auto& [eltwiseType, convertOutType] = this->GetParam();
         const ov::Shape inputShape = {1, 64, 12, 12};
         ov::ParameterVector inputParams{std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputShape)};
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/concat_sdp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/concat_sdp.cpp
@@ -31,12 +31,7 @@ namespace test {
  *                              Result
  */
 std::string ConcatSDPTest::getTestCaseName(const testing::TestParamInfo<ConcatSDPTestParams>& obj) {
-    ElementType inType;
-    std::vector<InputShape> inputShapes;
-    bool forceKVU8;
-    bool hasShapeOf;
-    bool isDiffKVHeadSize;
-    std::tie(inType, inputShapes, forceKVU8, hasShapeOf, isDiffKVHeadSize) = obj.param;
+    const auto& [inType, inputShapes, forceKVU8, hasShapeOf, isDiffKVHeadSize] = obj.param;
     std::ostringstream result;
     result << "IS=";
     for (const auto& shape : inputShapes) {
@@ -60,9 +55,10 @@ std::string ConcatSDPTest::getTestCaseName(const testing::TestParamInfo<ConcatSD
 }
 
 void ConcatSDPTest::SetUp() {
-    ElementType inType;
-    std::vector<InputShape> inputShapes;
-    std::tie(inType, inputShapes, m_forceKVU8, m_hasShapeOf, m_isDiffKVHeadSize) = this->GetParam();
+    const auto& [inType, inputShapes, _m_forceKVU8, _m_hasShapeOf, _m_isDiffKVHeadSize] = this->GetParam();
+    m_forceKVU8 = _m_forceKVU8;
+    m_hasShapeOf = _m_hasShapeOf;
+    m_isDiffKVHeadSize = _m_isDiffKVHeadSize;
     targetDevice = ov::test::utils::DEVICE_CPU;
     rel_threshold = 1e-2f;
     if (inType == ElementType::bf16 || inType == ElementType::f16) {
@@ -227,13 +223,7 @@ std::vector<ov::Tensor> ConcatSDPTest::run_test(std::shared_ptr<ov::Model> model
 }
 TEST_P(ConcatSDPTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ElementType inType;
-    std::vector<InputShape> inputShapes;
-    bool forceKVU8;
-    bool hasShapeOf;
-    bool isDiffKVHeadSize;
-    std::tie(inType, inputShapes, forceKVU8, hasShapeOf, isDiffKVHeadSize) = this->GetParam();
-
+    const auto& [inType, inputShapes, forceKVU8, hasShapeOf, isDiffKVHeadSize] = this->GetParam();
     auto actualOutputs = run_test(function);
     if (!hasShapeOf) {
         CheckNumberOfNodesWithType(compiledModel, "ScaledDotProductAttention", 1);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/conv_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/conv_concat.cpp
@@ -17,21 +17,10 @@ namespace test {
 
 std::string ConvConcatSubgraphTest::getTestCaseName(testing::TestParamInfo<convConcatCPUParams> obj) {
     std::ostringstream result;
-    nodeType type;
-    commonConvParams convParams;
-    CPUSpecificParams cpuParams;
-    ov::Shape inputShapes;
-    int axis;
-    std::tie(type, convParams, cpuParams, inputShapes, axis) = obj.param;
-
+    const auto& [type, convParams, cpuParams, inputShapes, axis] = obj.param;
     result << "Type=" << nodeType2str(type) << "_";
-
-    std::vector<size_t> kernelSize, strides, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t numOutChannels, numOfGroups;
-    ov::op::PadType paddingType;
-    std::tie(kernelSize, strides, padBegin, padEnd, dilation, numOutChannels, paddingType, numOfGroups) = convParams;
-
+    const auto& [kernelSize, strides, padBegin, padEnd, dilation, numOutChannels, paddingType, numOfGroups] =
+        convParams;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
     result << "K" << ov::test::utils::vec2str(kernelSize) << "_";
     result << "S" << ov::test::utils::vec2str(strides) << "_";
@@ -51,20 +40,10 @@ std::string ConvConcatSubgraphTest::getTestCaseName(testing::TestParamInfo<convC
 
 void ConvConcatSubgraphTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-    nodeType type;
-    commonConvParams convParams;
-    CPUSpecificParams cpuParams;
-    ov::Shape inputShapes;
-    int axis;
-
-    std::tie(type, convParams, cpuParams, inputShapes, axis) = this->GetParam();
+    const auto& [type, convParams, cpuParams, inputShapes, axis] = this->GetParam();
     pluginTypeNode = nodeType2PluginType(type);
-    std::vector<size_t> kernelSize, strides, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t numOutChannels, numOfGroups;
-    ov::op::PadType paddingType;
-
-    std::tie(kernelSize, strides, padBegin, padEnd, dilation, numOutChannels, paddingType, numOfGroups) = convParams;
+    const auto& [kernelSize, strides, padBegin, padEnd, dilation, numOutChannels, paddingType, numOfGroups] =
+        convParams;
     std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
     selectedType += "_f32";

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/eltwise_chain.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/eltwise_chain.cpp
@@ -17,14 +17,8 @@ namespace test {
 using namespace ov::test::utils;
 
 std::string EltwiseChainTest::getTestCaseName(const testing::TestParamInfo<EltwiseChainTuple> &obj) {
-    std::vector<InputShape> inputShapes;
-    InputLayerType secondaryInputType;
-    std::vector<ElementType> inputPrecisions;
-    std::vector<EltwiseTypes> eltwiseOpTypes;
-    bool withQuantization;
-    ov::element::Type conversion;
-    std::string targetName;
-    std::tie(inputShapes, secondaryInputType, inputPrecisions, eltwiseOpTypes, withQuantization, conversion, targetName) = obj.param;
+    const auto& [inputShapes, secondaryInputType, inputPrecisions, eltwiseOpTypes, withQuantization, conversion,
+                 targetName] = obj.param;
     std::ostringstream results;
 
     results << "IS=(";
@@ -86,15 +80,9 @@ void EltwiseChainTest::generate_inputs(const std::vector<ov::Shape>& targetInput
 
 void EltwiseChainTest::SetUp() {
     abs_threshold = 0.1f;
-
-    std::vector<InputShape> inputShapes;
-    InputLayerType secondaryInputType;
-    std::vector<ElementType> inputPrecisions;
-    std::vector<EltwiseTypes> eltwiseOpTypes;
-    bool withQuantization;
-    ov::element::Type conversion;
-    std::tie(inputShapes, secondaryInputType, inputPrecisions, eltwiseOpTypes, withQuantization, conversion, targetDevice) = this->GetParam();
-
+    const auto& [inputShapes, secondaryInputType, inputPrecisions, eltwiseOpTypes, withQuantization, conversion,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(inputShapes);
 
     ov::ParameterVector paramVec;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/fuse_transpose_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/fuse_transpose_reorder.cpp
@@ -16,10 +16,7 @@ namespace test {
 
 std::string FuseTransposeAndReorderTest::getTestCaseName(testing::TestParamInfo<FuseTransposeAndReorderParams> obj) {
     std::ostringstream result;
-    ov::Shape input_shape;
-    ov::element::Type in_prec;
-    std::tie(input_shape, in_prec) = obj.param;
-
+    const auto& [input_shape, in_prec] = obj.param;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
     result << "Precision=" << in_prec.to_string();
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/classes/matmul_weights_decompression.cpp
@@ -11,30 +11,9 @@ namespace ov {
 namespace test {
 
 std::string MatmulWeightsDecompression::getTestCaseName(testing::TestParamInfo<MatmulWeightsDecompressionParams> obj) {
-    MatMulDecompressionShapeParams shape_params;
-    ov::test::ElementType weights_precision;
-    ov::test::ElementType decompression_precision;
-    ov::test::ElementType scale_precision;
-    bool transpose;
-    DecompressionType decompression_multiply_type;
-    DecompressionType decompression_subtract_type;
-    bool reshape_on_decompression;
-    ov::AnyMap additional_config;
-    fusingSpecificParams fusing_params;
-    bool should_fuse;
-
-    std::tie(shape_params,
-             weights_precision,
-             decompression_precision,
-             scale_precision,
-             transpose,
-             decompression_multiply_type,
-             decompression_subtract_type,
-             reshape_on_decompression,
-             additional_config,
-             fusing_params,
-             should_fuse) = obj.param;
-
+    const auto& [shape_params, weights_precision, decompression_precision, scale_precision, transpose,
+                 decompression_multiply_type, decompression_subtract_type, reshape_on_decompression, additional_config,
+                 fusing_params, should_fuse] = obj.param;
     std::ostringstream result;
     result << shape_params << "_";
     result << "weights_precision=" << weights_precision << "_";
@@ -83,31 +62,9 @@ std::shared_ptr<ov::Model> MatmulWeightsDecompression::initSubgraph(const ov::Pa
 
 void MatmulWeightsDecompression::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-
-    MatMulDecompressionShapeParams shape_params;
-    ov::test::ElementType weights_precision;
-    ov::test::ElementType decompression_precision;
-    ov::test::ElementType scale_precision;
-    bool transpose_weights;
-    DecompressionType decompression_multiply_type;
-    DecompressionType decompression_subtract_type;
-    bool reshape_on_decompression;
-    ov::AnyMap additional_config;
-    fusingSpecificParams fusing_params;
-    bool should_fuse;
-
-    std::tie(shape_params,
-                weights_precision,
-                decompression_precision,
-                scale_precision,
-                transpose_weights,
-                decompression_multiply_type,
-                decompression_subtract_type,
-                reshape_on_decompression,
-                additional_config,
-                fusing_params,
-                should_fuse) = GetParam();
-
+    const auto& [shape_params, weights_precision, decompression_precision, scale_precision, transpose_weights,
+                 decompression_multiply_type, decompression_subtract_type, reshape_on_decompression, additional_config,
+                 fusing_params, should_fuse] = GetParam();
     configuration.insert(additional_config.begin(), additional_config.end());
     std::tie(postOpMgrPtr, fusedOps) = fusing_params;
     init_input_shapes({shape_params.data_shape});

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/align_matmul_input_ranks.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/align_matmul_input_ranks.cpp
@@ -23,9 +23,7 @@ class AlignMatMulInputRanksTest : public testing::WithParamInterface<AlignMatMul
                                   virtual public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<AlignMatMulInputRanksTestParams> obj) {
-        std::pair<ov::Shape, ov::Shape> supportedInputShapes;
-        fusingSpecificParams fusingParams;
-        std::tie(supportedInputShapes, fusingParams) = obj.param;
+        const auto& [supportedInputShapes, fusingParams] = obj.param;
         ov::Shape inputShapeA = supportedInputShapes.first;
         ov::Shape inputShapeB = supportedInputShapes.second;
 
@@ -40,10 +38,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::pair<ov::Shape, ov::Shape> inShapes;
-        fusingSpecificParams fusingParams;
-        std::tie(inShapes, fusingParams) = this->GetParam();
-
+        const auto& [inShapes, fusingParams] = this->GetParam();
         if (inShapes.first.size() != inShapes.second.size())
             expectedNumOfReshapes++;  // one input will be unsqueezed
         if (inShapes.first.size() == 1 || inShapes.second.size() == 1)

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/broadcast_eltwise.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/broadcast_eltwise.cpp
@@ -24,11 +24,7 @@ class BroadcastEltwise : virtual public SubgraphBaseTest,
                       public testing::WithParamInterface<BroadcastEltwiseParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<BroadcastEltwiseParams>& obj) {
-        ElementType input_precision;
-        InputShape input_shape;
-        ov::Shape target_shape;
-        std::tie(input_precision, input_shape, target_shape) = obj.param;
-
+        const auto& [input_precision, input_shape, target_shape] = obj.param;
         std::ostringstream result;
         result << "precision=" << input_precision << "IS=(" << ov::test::utils::partialShape2str({input_shape.first}) << ")_TS=(";
         for (const auto& item : input_shape.second) {
@@ -40,9 +36,8 @@ public:
 
 protected:
     void SetUp() override {
-        ElementType input_precision;
-        InputShape input_shape;
-        std::tie(input_precision, input_shape, target_shape) = GetParam();
+        const auto& [input_precision, input_shape, _target_shape] = GetParam();
+        target_shape = _target_shape;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
         std::vector<InputShape> input_shapes{input_shape, {{}, {{target_shape.size()}}}};

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/concat_multiple_query_sdp.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/concat_multiple_query_sdp.cpp
@@ -59,15 +59,11 @@ class ConcatMultiQuerySDPTest : public testing::WithParamInterface<ConcatMultiQu
                                 public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConcatMultiQuerySDPParams>& obj) {
-        ElementType qkvType;
-        InputShapeAndTransposeOrder inputShapeAndOrders;
-        bool forceKVU8;
-        bool hasShapeOf;
-        std::tie(qkvType, inputShapeAndOrders, forceKVU8, hasShapeOf) = obj.param;
+        const auto& [qkvType, inputShapeAndOrders, forceKVU8, hasShapeOf] = obj.param;
         ElementType kvCacheType = forceKVU8 ? ov::element::Type_t::u8 : qkvType;
         std::ostringstream result;
-        std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
-        std::vector<size_t>& transposeOrder = inputShapeAndOrders.second;
+        const auto &[inputShapes, transposeOrder] = inputShapeAndOrders;
+
         result << "IS=";
         for (const auto& shape : inputShapes) {
             result << ov::test::utils::partialShape2str({shape.first}) << "_";
@@ -96,13 +92,8 @@ public:
     }
 
     void SetUp() override {
-        InputShapeAndTransposeOrder inputShapeAndOrders;
-        bool forceKVU8;
-        bool hasShapeOf;
-        ElementType qkvType;
-        std::tie(qkvType, inputShapeAndOrders, forceKVU8, hasShapeOf) = this->GetParam();
-        std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
-        std::vector<size_t>& transposeOrder = inputShapeAndOrders.second;
+        const auto& [qkvType, inputShapeAndOrders, forceKVU8, hasShapeOf] = this->GetParam();
+        const auto &[inputShapes, transposeOrder] = inputShapeAndOrders;
         targetDevice = ov::test::utils::DEVICE_CPU;
         rel_threshold = 1e-2f;
         configuration[ov::hint::inference_precision.name()] = ov::element::f32;
@@ -312,11 +303,7 @@ public:
 
 TEST_P(ConcatMultiQuerySDPTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    InputShapeAndTransposeOrder inputShapeAndOrders;
-    bool forceKVU8;
-    bool hasShapeOf;
-    ElementType qkvType;
-    std::tie(qkvType, inputShapeAndOrders, forceKVU8, hasShapeOf) = this->GetParam();
+    const auto &[qkvType, inputShapeAndOrders, forceKVU8, hasShapeOf] = this->GetParam();
     auto actualOutputs = run_test(function);
     CheckNumberOfNodesWithType(compiledModel, "ScaledDotProductAttention", 1);
     CheckNumberOfNodesWithType(compiledModel, "Concatenation", 0);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/concat_transpose_sdp_transpose.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/concat_transpose_sdp_transpose.cpp
@@ -59,15 +59,10 @@ class ConcatSDPTransposeTestBase : public testing::WithParamInterface<ConcatSDPT
                                    public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConcatSDPTransposeTestParams>& obj) {
-        ElementType inType;
-        InputShapeAndTransposeOrder inputShapeAndOrders;
-        bool hasShapeof;
-        bool quantKeyByChannel;
-        size_t groupSize;
-        std::tie(inType, inputShapeAndOrders, hasShapeof, quantKeyByChannel, groupSize) = obj.param;
+        const auto& [inType, inputShapeAndOrders, hasShapeof, quantKeyByChannel, groupSize] = obj.param;
+        const auto& [inputShapes, transposeOrder] = inputShapeAndOrders;
         std::ostringstream result;
-        std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
-        std::vector<size_t>& transposeOrder = inputShapeAndOrders.second;
+
         result << "IS=";
         for (const auto& shape : inputShapes) {
             result << ov::test::utils::partialShape2str({shape.first}) << "_";
@@ -97,11 +92,13 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        InputShapeAndTransposeOrder inputShapeAndOrders;
-        std::tie(inType, inputShapeAndOrders, hasShapeOf, quantKeyByChannel, keyGroupSize) = this->GetParam();
-        std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
+        const auto& [inType, inputShapeAndOrders, _hasShapeOf, _quantKeyByChannel, _keyGroupSize] = this->GetParam();
+        hasShapeOf = _hasShapeOf;
+        quantKeyByChannel = _quantKeyByChannel;
+        keyGroupSize = _keyGroupSize;
+        const std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
         transposeOrder = inputShapeAndOrders.second;
+
         targetDevice = ov::test::utils::DEVICE_CPU;
         rel_threshold = 1e-2f;
         configuration[ov::hint::inference_precision.name()] = ov::element::f32;
@@ -483,13 +480,7 @@ public:
 
 TEST_P(ConcatSDPTransposeTestSetState, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ElementType inType;
-    InputShapeAndTransposeOrder inputShapeAndOrders;
-    bool hasShapeOf;
-    bool quantKeyByChannel;
-    size_t groupSize;
-    std::tie(inType, inputShapeAndOrders, hasShapeOf, quantKeyByChannel, groupSize) = this->GetParam();
-
+    const auto& [inType, inputShapeAndOrders, hasShapeOf, quantKeyByChannel, groupSize] = this->GetParam();
     // skip bf16 test on avx512 platform
     if (inType == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
         GTEST_SKIP();
@@ -570,13 +561,7 @@ public:
 
 TEST_P(ConcatSDPTransposeTestWrongBeamIdx, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ElementType inType;
-    InputShapeAndTransposeOrder inputShapeAndOrders;
-    bool hasShapeOf;
-    bool quantKeyByChannel;
-    size_t groupSize;
-    std::tie(inType, inputShapeAndOrders, hasShapeOf, quantKeyByChannel, groupSize) = this->GetParam();
-
+    const auto& [inType, inputShapeAndOrders, hasShapeOf, quantKeyByChannel, groupSize] = this->GetParam();
     // skip bf16 test on avx512 platform
     if (inType == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
         GTEST_SKIP();

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/conv3d_reshape.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/conv3d_reshape.cpp
@@ -19,10 +19,7 @@ class Conv3dReshapeTest : public testing::WithParamInterface<Conv3dReshapeTestPa
                           virtual public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<Conv3dReshapeTestParams> obj) {
-        nodeType conv;
-        size_t numOut;
-        std::tie(conv, numOut) = obj.param;
-
+        const auto& [conv, numOut] = obj.param;
         std::ostringstream result;
         result << nodeType2str(conv) << "_";
         result << "NUM_OUTPUTS=" << numOut;
@@ -35,10 +32,7 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        nodeType convType;
-        size_t numOut;
-        std::tie(convType, numOut) = this->GetParam();
-
+        const auto& [convType, numOut] = this->GetParam();
         cpuNodeType = nodeType2PluginType(convType);
 
         ov::ParameterVector inputParams{

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/custom_op_scalar.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/custom_op_scalar.cpp
@@ -81,10 +81,7 @@ class CustomOpScalarCPUTest : public testing::WithParamInterface<CustomOpScalarC
                                   public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<CustomOpScalarCPUTestParams>& obj) {
-        ElementType inType;
-        InputShape inputShape;
-        std::tie(inType, inputShape) = obj.param;
-
+        const auto& [inType, inputShape] = obj.param;
         std::ostringstream result;
         result << "IS=" << inputShape << "_";
         result << "Prc=" << inType;
@@ -94,11 +91,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = utils::DEVICE_CPU;
-
-        ElementType inType;
-        InputShape inputShape;
-        std::tie(inType, inputShape) = this->GetParam();
-
+        const auto& [inType, inputShape] = this->GetParam();
         init_input_shapes({inputShape});
 
         auto in_0 = std::make_shared<ov::op::v0::Parameter>(inType, inputDynamicShapes[0]);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/custom_op_string.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/custom_op_string.cpp
@@ -155,10 +155,7 @@ class CustomOpStringCPUTest : public testing::WithParamInterface<CustomOpStringC
                                   public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<CustomOpStringCPUTestParams>& obj) {
-        ElementType in_type;
-        InputShape inputShape;
-        std::tie(in_type, inputShape) = obj.param;
-
+        const auto& [in_type, inputShape] = obj.param;
         std::ostringstream result;
         result << "IS=" << inputShape << "_";
         result << "Prc=" << in_type;
@@ -168,11 +165,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = utils::DEVICE_CPU;
-
-        ElementType in_type;
-        InputShape inputShape;
-        std::tie(in_type, inputShape) = this->GetParam();
-
+        const auto& [in_type, inputShape] = this->GetParam();
         init_input_shapes({inputShape});
 
         auto in_0 = std::make_shared<ov::op::v0::Parameter>(in_type, inputDynamicShapes[0]);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/eltwise_caching.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/eltwise_caching.cpp
@@ -77,22 +77,9 @@ class EltwiseCacheTest : public testing::WithParamInterface<EltwiseCacheTestPara
                          virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<EltwiseCacheTestParams> &obj) {
-        InputShapesTuple inputShapesTuple;
-        std::vector<ElementType> inputPrecisions;
-        std::vector<EltwiseTypes> eltwiseOpTypes;
-        bool withQuantization;
-        bool needReshape;
-        bool enforceSnippets;
-        std::string targetName;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapesTuple, inputPrecisions, eltwiseOpTypes, withQuantization, needReshape, enforceSnippets,
-                 targetName, cpuParams) = obj.param;
-
-        std::vector<InputShape> eltwiseInputShapes;
-        std::vector<std::vector<size_t>> fqInputShapes;
-        std::vector<int32_t> reshapeShape;
-        std::tie(eltwiseInputShapes, fqInputShapes, reshapeShape) = inputShapesTuple;
-
+        const auto& [inputShapesTuple, inputPrecisions, eltwiseOpTypes, withQuantization, needReshape, enforceSnippets,
+                     targetName, cpuParams] = obj.param;
+        const auto& [eltwiseInputShapes, fqInputShapes, reshapeShape] = inputShapesTuple;
         std::ostringstream results;
 
         results << "IS=(";
@@ -148,22 +135,10 @@ public:
 protected:
     void SetUp() override {
         abs_threshold = 0.1f;
-
-        InputShapesTuple inputShapesTuple;
-        std::vector<ElementType> inputPrecisions;
-        std::vector<EltwiseTypes> eltwiseOpTypes;
-        bool withQuantization;
-        bool needReshape;
-        bool enforceSnippets;
-        CPUSpecificParams cpuParams;
-        std::tie(inputShapesTuple, inputPrecisions, eltwiseOpTypes, withQuantization, needReshape, enforceSnippets,
-                 targetDevice, cpuParams) = this->GetParam();
-
-        std::vector<InputShape> eltwiseInputShapes;
-        std::vector<std::vector<size_t>> fqInputShapes;
-        std::vector<int32_t> reshapeShape;
-        std::tie(eltwiseInputShapes, fqInputShapes, reshapeShape) = inputShapesTuple;
-
+        const auto& [inputShapesTuple, inputPrecisions, eltwiseOpTypes, withQuantization, needReshape, enforceSnippets,
+                     _targetDevice, cpuParams] = this->GetParam();
+        targetDevice = _targetDevice;
+        const auto& [eltwiseInputShapes, fqInputShapes, reshapeShape] = inputShapesTuple;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         init_input_shapes(eltwiseInputShapes);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fullyconnected_strided_inputs_outputs.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fullyconnected_strided_inputs_outputs.cpp
@@ -24,10 +24,7 @@ class FullyConnectedStridedInputsOutputsTest
       virtual public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<FullyConnectedStridedInputsOutputsTestParams> obj) {
-        ov::element::Type netPrecision;
-        size_t rank;
-        std::tie(netPrecision, rank) = obj.param;
-
+        const auto& [netPrecision, rank] = obj.param;
         std::ostringstream result;
         result << "netPRC=" << netPrecision.get_type_name() << "_";
         result << "rank=" << rank;
@@ -38,10 +35,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        ov::element::Type netPrecision;
-        size_t rank;
-        std::tie(netPrecision, rank) = this->GetParam();
-
+        const auto& [netPrecision, rank] = this->GetParam();
         auto bcastTo3D = [](ov::Shape& shape) {
             shape.insert(shape.begin(), 1);
         };

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fuse_muladd_ewsimple.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fuse_muladd_ewsimple.cpp
@@ -16,10 +16,7 @@ namespace test {
 
 std::string FuseMulAddAndEwSimpleTest::getTestCaseName(testing::TestParamInfo<FuseMulAddAndEwSimpleParams> obj) {
     std::ostringstream result;
-    ov::Shape inputShape;
-    ov::element::Type inPrec;
-    std::tie(inputShape, inPrec) = obj.param;
-
+    const auto& [inputShape, inPrec] = obj.param;
     result << "IS=" << inputShape << "_";
     result << "Precision=" << inPrec.get_type_name();
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fuse_scaleshift_and_fakequantize.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fuse_scaleshift_and_fakequantize.cpp
@@ -23,12 +23,7 @@ class FuseScaleShiftAndFakeQuantizeTest : public testing::WithParamInterface<Fus
                                           virtual public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<FuseScaleShiftAndQuantizeTuple>& obj) {
-        Shape inputShape;
-        element::Type inputPrecision;
-        std::pair<std::vector<float>, std::vector<float>> scaleShift;
-        std::vector<std::vector<float>> quantizeIntervals;
-        std::string targetName;
-        std::tie(inputShape, inputPrecision, scaleShift, quantizeIntervals, targetName) = obj.param;
+        const auto& [inputShape, inputPrecision, scaleShift, quantizeIntervals, targetName] = obj.param;
         std::ostringstream results;
 
         results << "IS=" << inputShape << "_InPRC=" << inputPrecision
@@ -45,12 +40,8 @@ public:
 
 protected:
     void SetUp() override {
-        Shape inputShape;
-        element::Type inputPrecision;
-        std::pair<std::vector<float>, std::vector<float>> scaleShift;
-        std::vector<std::vector<float>> quantizeIntervals;
-        std::tie(inputShape, inputPrecision, scaleShift, quantizeIntervals, targetDevice) = this->GetParam();
-
+        const auto& [inputShape, inputPrecision, scaleShift, quantizeIntervals, _targetDevice] = this->GetParam();
+        targetDevice = _targetDevice;
         const auto param = std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputShape);
         Shape constShape = Shape(inputShape.size(), 1);
         constShape[1] = scaleShift.second.size();

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fuse_split_concat_pair_to_interpolate.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/fuse_split_concat_pair_to_interpolate.cpp
@@ -22,13 +22,7 @@ class FuseSplitConcatPairToInterpolateTest : public testing::WithParamInterface<
                                              virtual public SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<FuseSplitConcatPairToInterpolateTuple>& obj) {
-        Shape inputShape;
-        element::Type inputPrecision;
-        int axis;
-        size_t num_splits;
-        size_t scale_factor;
-        std::string targetName;
-        std::tie(inputShape, inputPrecision, axis, num_splits, scale_factor, targetName) = obj.param;
+        const auto& [inputShape, inputPrecision, axis, num_splits, scale_factor, targetName] = obj.param;
         std::ostringstream results;
 
         results << "IS=" << inputShape << "_InPRC=" << inputPrecision << "_Axis=" << axis
@@ -40,13 +34,8 @@ public:
 
 protected:
     void SetUp() override {
-        Shape inputShape;
-        element::Type inputPrecision;
-        int axis;
-        size_t num_splits;
-        size_t scale_factor;
-        std::tie(inputShape, inputPrecision, axis, num_splits, scale_factor, targetDevice) = this->GetParam();
-
+        const auto& [inputShape, inputPrecision, axis, num_splits, scale_factor, _targetDevice] = this->GetParam();
+        targetDevice = _targetDevice;
         size_t num_of_concat_inputs = num_splits * scale_factor;
 
         const auto param = std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputShape);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/lora_pattern.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/lora_pattern.cpp
@@ -51,13 +51,10 @@ using LoraPatternParams = std::tuple<ov::element::Type,  // states precision
 class LoraPatternBaseCPUTest : public SubgraphBaseTest, public testing::WithParamInterface<LoraPatternParams> {
 public:
 static std::string getTestCaseName(testing::TestParamInfo<LoraPatternParams> obj) {
-        ov::element::Type states_precision;
-        StatesPolicy states_policy;
-        std::tie(states_precision, states_policy) = obj.param;
-
-        std::ostringstream result;
-        result << "states_precision=" << states_precision << "_states_policy=" << states_policy;
-        return result.str();
+    const auto& [states_precision, states_policy] = obj.param;
+    std::ostringstream result;
+    result << "states_precision=" << states_precision << "_states_policy=" << states_policy;
+    return result.str();
     }
 
     void SetUp() override {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/matmul_decompress_convert.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/matmul_decompress_convert.cpp
@@ -8,6 +8,7 @@
 #include "transformations/rt_info/decompression.hpp"
 #include "openvino/op/concat.hpp"
 #include "openvino/op/convert.hpp"
+#include "utils/general_utils.h"
 
 using namespace CPUTestUtils;
 
@@ -93,14 +94,7 @@ class MatMulDecompressConvertTest : public testing::WithParamInterface<MatMulDec
                                     public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<MatMulDecompressConvertParams> obj) {
-        std::vector<InputShape> inputShapes;
-        std::pair<bool, bool> transpose;
-        ElementType weiElemType;
-        ov::AnyMap additionalConfig;
-        CPUSpecificParams cpuParams;
-
-        std::tie(inputShapes, transpose, weiElemType, additionalConfig, cpuParams) = obj.param;
-
+        const auto& [inputShapes, transpose, weiElemType, additionalConfig, cpuParams] = obj.param;
         std::ostringstream result;
         for (const auto& shape : inputShapes) {
             result << ov::test::utils::partialShape2str({shape.first}) << "_";
@@ -160,14 +154,7 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        std::pair<bool, bool> transpose;
-        ElementType weiConstElemType;
-        ov::AnyMap additionalConfig;
-        CPUSpecificParams cpuParams;
-
-        std::tie(inputShapes, transpose, weiConstElemType, additionalConfig, cpuParams) = this->GetParam();
+        const auto& [inputShapes, transpose, origWeiConstElemType, additionalConfig, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         init_input_shapes(inputShapes);
@@ -200,8 +187,8 @@ protected:
 
         ElementType netType = ElementType::f32;
         ElementType convertOutType = ElementType::f32;
-        auto it = additionalConfig.find(ov::hint::inference_precision.name());
-        if (it != additionalConfig.end() && it->second.as<ov::element::Type>() == ov::element::bf16) {
+        auto weiConstElemType = origWeiConstElemType;
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             convertOutType = inType = outType = netType = ElementType::bf16;
             weiConstElemType = (weiConstElemType != ElementType::f32) ? weiConstElemType : ElementType::bf16;
         } else {
@@ -418,14 +405,7 @@ class MatMulDecompressConvertTest2 : public MatMulDecompressConvertTest {
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        std::pair<bool, bool> transpose;
-        ElementType weiConstElemType;
-        ov::AnyMap additionalConfig;
-        CPUSpecificParams cpuParams;
-
-        std::tie(inputShapes, transpose, weiConstElemType, additionalConfig, cpuParams) = this->GetParam();
+        const auto& [inputShapes, transpose, origWeiConstElemType, additionalConfig, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         init_input_shapes(inputShapes);
@@ -464,8 +444,8 @@ protected:
 
         ElementType netType = ElementType::f32;
         ElementType convertOutType = ElementType::f32;
-        auto it = additionalConfig.find(ov::hint::inference_precision.name());
-        if (it != additionalConfig.end() && it->second.as<ov::element::Type>() == ov::element::bf16) {
+        auto weiConstElemType = origWeiConstElemType;
+        if (intel_cpu::contains_key_value(additionalConfig, {ov::hint::inference_precision.name(), ov::element::bf16})) {
             convertOutType = inType = outType = netType = ElementType::bf16;
             weiConstElemType = (weiConstElemType != ElementType::f32) ? weiConstElemType : ElementType::bf16;
         } else {
@@ -558,14 +538,7 @@ class MatMulDecompressConvertTest3 : public MatMulDecompressConvertTest {
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        std::pair<bool, bool> transpose;
-        ElementType weiConstElemType;
-        ov::AnyMap additionalConfig;
-        CPUSpecificParams cpuParams;
-
-        std::tie(inputShapes, transpose, weiConstElemType, additionalConfig, cpuParams) = this->GetParam();
+        const auto& [inputShapes, transpose, weiConstElemType, additionalConfig, cpuParams] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
 
         init_input_shapes(inputShapes);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/merge_transpose_reorder.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/merge_transpose_reorder.cpp
@@ -67,10 +67,7 @@ using MergeTransposeReorderTestParams = std::tuple<InputShape, ExpectedResult>;
 class MergeTransposeReorderCPUTest : public testing::WithParamInterface<MergeTransposeReorderTestParams>, virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MergeTransposeReorderTestParams> &obj) {
-        InputShape input_shape;
-        ExpectedResult expected_result;
-        std::tie(input_shape, expected_result) = obj.param;
-
+        const auto& [input_shape, expected_result] = obj.param;
         std::ostringstream results;
         results << "IS=(" << ov::test::utils::partialShape2str({input_shape.first}) << "_";
         results << ")_TS=(";
@@ -86,8 +83,8 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        InputShape input_shape;
-        std::tie(input_shape, m_expected_result) = this->GetParam();
+        const auto& [input_shape, _m_expected_result] = this->GetParam();
+        m_expected_result = _m_expected_result;
         init_input_shapes({input_shape});
 
         const auto precision = ov::element::f32;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/ngram.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/ngram.cpp
@@ -152,11 +152,7 @@ class NgramCPUTest : public testing::WithParamInterface<NgramTestParams>,
                      public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<NgramTestParams>& obj) {
-        std::vector<InputShape> input_shapes;
-        size_t k;
-        ElementType data_et;
-        ElementType idces_et;
-        std::tie(input_shapes, data_et, idces_et, k) = obj.param;
+        const auto& [input_shapes, data_et, idces_et, k] = obj.param;
         std::ostringstream results;
 
         results << "IS=(";
@@ -205,11 +201,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::vector<InputShape> inputShapes;
-        ElementType data_et;
-        ElementType idces_et;
-        size_t k;
-        std::tie(inputShapes, data_et, idces_et, k) = this->GetParam();
+        const auto& [inputShapes, data_et, idces_et, k] = this->GetParam();
         init_input_shapes(inputShapes);
         function = initNgram(inputDynamicShapes, data_et, idces_et, k);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/read_value_assign.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/read_value_assign.cpp
@@ -59,10 +59,7 @@ class ReadValueAssignTest : public testing::WithParamInterface<ReadValueAssignTe
                             public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReadValueAssignTestParams> &obj) {
-        bool use_init_subgraph = false;
-        CPUSpecificParams cpu_params;
-        std::tie(use_init_subgraph, cpu_params) = obj.param;
-
+        const auto& [use_init_subgraph, cpu_params] = obj.param;
         std::ostringstream results;
         results << "Init_Graph=" << (use_init_subgraph ? "True" : "False") << "_";
         results << CPUTestsBase::getTestCaseName(cpu_params);
@@ -76,10 +73,7 @@ public:
 
         InputShape param1_shape = {{-1, 32, -1, -1}, {tensor_shape}};
         InputShape param2_shape = {{-1, -1, -1, -1}, {tensor_shape}};
-
-        bool use_init_subgraph = false;
-        CPUSpecificParams cpu_params;
-        std::tie(use_init_subgraph, cpu_params) = this->GetParam();
+        const auto& [use_init_subgraph, cpu_params] = this->GetParam();
         std::tie(inFmts, outFmts, priority, selectedType) = cpu_params;
         selectedType = makeSelectedTypeStr(selectedType, net_prc);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/remove_convert.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/remove_convert.cpp
@@ -22,10 +22,7 @@ class RemoveUselessBF16ConvertCPUTest : public testing::WithParamInterface<Remov
                                         public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<RemoveConvertCPUTestParams>& obj) {
-        ElementType inType;
-        InputShape inputShape;
-        ov::AnyMap additionalConfig;
-        std::tie(inType, inputShape, additionalConfig) = obj.param;
+        const auto& [inType, inputShape, additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=" << inputShape << "_";
         result << "Prc=" << inType;
@@ -39,10 +36,7 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        InputShape inputShape;
-        ov::AnyMap additionalConfig;
-        std::tie(inType, inputShape, additionalConfig) = this->GetParam();
+        const auto& [inType, inputShape, additionalConfig] = this->GetParam();
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
         targetDevice = ov::test::utils::DEVICE_CPU;
         std::tie(inFmts, outFmts, priority, selectedType) =
@@ -72,10 +66,7 @@ class RemoveUselessConvertCPUTest : public testing::WithParamInterface<RemoveCon
                                     public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<RemoveConvertCPUTestParams>& obj) {
-        ElementType inType;
-        InputShape inputShape;
-        ov::AnyMap additionalConfig;
-        std::tie(inType, inputShape, additionalConfig) = obj.param;
+        const auto& [inType, inputShape, additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=" << inputShape << "_";
         result << "Prc=" << inType;
@@ -89,10 +80,7 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        InputShape inputShape;
-        ov::AnyMap additionalConfig;
-        std::tie(inType, inputShape, additionalConfig) = this->GetParam();
+        const auto& [inType, inputShape, additionalConfig] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
 
         init_input_shapes({inputShape});

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/reshape_fc.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/reshape_fc.cpp
@@ -23,17 +23,8 @@ class ReshapeFcCPUTest : public testing::WithParamInterface<ReshapeFcParams>,
                          public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ReshapeFcParams> obj) {
-        std::vector<InputShape> shapes;
-        std::vector<int> data;
-        ElementType prc;
-
-        ReshapeFcSpecParams specParams;
-        fusingSpecificParams fusingParams;
-        CPUSpecificParams cpuParams;
-
-        std::tie(specParams, fusingParams, cpuParams) = obj.param;
-        std::tie(shapes, data, prc) = specParams;
-
+        const auto& [specParams, fusingParams, cpuParams] = obj.param;
+        const auto& [shapes, data, prc] = specParams;
         std::ostringstream result;
 
         result << "IS=";
@@ -64,17 +55,8 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> shapes;
-        std::vector<int> data;
-        ElementType prc;
-
-        ReshapeFcSpecParams specParams;
-        fusingSpecificParams fusingParams;
-        CPUSpecificParams cpuParams;
-
-        std::tie(specParams, fusingParams, cpuParams) = this->GetParam();
-        std::tie(shapes, data, prc) = specParams;
+        const auto& [specParams, fusingParams, cpuParams] = this->GetParam();
+        const auto& [shapes, data, prc] = specParams;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/sdpa_group_beam_search.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/sdpa_group_beam_search.cpp
@@ -44,9 +44,7 @@ class SDPAGroupBeamSearchTest : public testing::WithParamInterface<SDPAGroupBeam
                                 public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<SDPAGroupBeamSearchTestParams>& obj) {
-        ElementType inType;
-        std::vector<InputShape> inputShapes;
-        std::tie(inType, inputShapes) = obj.param;
+        const auto& [inType, inputShapes] = obj.param;
         std::ostringstream result;
         result << "IS=";
         for (const auto& shape : inputShapes) {
@@ -67,9 +65,7 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        std::vector<InputShape> inputShapes;
-        std::tie(inType, inputShapes) = this->GetParam();
+        const auto& [inType, inputShapes] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         rel_threshold = 1e-2f;
         if (inType == ElementType::bf16) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/seq_native_order.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/seq_native_order.cpp
@@ -43,22 +43,9 @@ using SeqParams = std::tuple<SEQ_TYPE,                            // node type
 class SequenceCPUTest : public testing::WithParamInterface<SeqParams>, virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<SeqParams> &obj) {
-        SEQ_TYPE seqType;
-        size_t hidden_size, input_size;
-        InputShapeParams inShapeParams;
-        std::vector<std::string> activations;
-        float clip;
-        bool linearBeforeReset;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-        InputLayerType seqInType;
-
-        std::tie(seqType, hidden_size, input_size, inShapeParams, activations, clip, linearBeforeReset, direction, netPrecision, seqInType) = obj.param;
-
-        std::vector<ov::Dimension> bounds;
-        std::vector<TargetShapeParams> targetShapes;
-        std::tie(bounds, targetShapes) = inShapeParams;
-
+        const auto& [seqType, hidden_size, input_size, inShapeParams, activations, clip, linearBeforeReset, direction,
+                     netPrecision, seqInType] = obj.param;
+        const auto& [bounds, targetShapes] = inShapeParams;
         std::ostringstream result;
 
         if (seqType == SEQ_TYPE::GRU) {
@@ -73,8 +60,7 @@ public:
         result << "hidden_size=" << hidden_size << "_input_size=" << input_size << "_";
         result << "batch_size_dyn=" << bounds[0] << "_seq_length_dyn=" << bounds[1] << "_";
         for (const auto &ts : targetShapes) {
-            size_t bs, sl;
-            std::tie(bs, sl) = ts;
+            const auto& [bs, sl] = ts;
             result << "(bs=" << bs << "_sl=" << sl << ")_";
         }
 
@@ -92,22 +78,10 @@ protected:
     void SetUp() override {
         const size_t batch_size_pos = 0;
         const size_t seq_length_pos = 1;
-
-        SEQ_TYPE seqType;
-        size_t hidden_size, input_size;
-        InputShapeParams inShapeParams;
-        std::vector<std::string> activations;
-        float clip;
-        bool linearBeforeReset;
-        ov::op::RecurrentSequenceDirection direction;
-        ElementType netPrecision;
-
-        std::tie(seqType, hidden_size, input_size, inShapeParams, activations, clip, linearBeforeReset, direction, netPrecision, seqInType) = this->GetParam();
-
-        std::vector<ov::Dimension> bounds;
-        std::vector<TargetShapeParams> targetShapes;
-        std::tie(bounds, targetShapes) = inShapeParams;
-
+        const auto& [seqType, hidden_size, input_size, inShapeParams, activations, clip, linearBeforeReset, direction,
+                     netPrecision, _seqInType] = this->GetParam();
+        seqInType = _seqInType;
+        const auto& [bounds, targetShapes] = inShapeParams;
         targetDevice = ov::test::utils::DEVICE_CPU;
 
         seqLengthInIdx = (seqType == SEQ_TYPE::LSTM ? 3 : 2);
@@ -155,10 +129,7 @@ protected:
         // target shape
         for (const auto &ts : targetShapes) {
             std::vector<ov::Shape> currTS;
-
-            size_t bs, sl;
-            std::tie(bs, sl) = ts;
-
+            const auto& [bs, sl] = ts;
             currTS.emplace_back(std::vector<size_t>{sl, bs, input_size});
             currTS.emplace_back(std::vector<size_t>{bs, numDirections, hidden_size});
             if (seqType == SEQ_TYPE::LSTM) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/shapeof_any_layout.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/shapeof_any_layout.cpp
@@ -52,13 +52,8 @@ class ShapeOfAnyLayoutCPUTest : public testing::WithParamInterface<ShapeOfAnyLay
                             virtual public ov::test::SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ShapeOfAnyLayoutCPUTestParamsSet> obj) {
-        ShapeOfAnyLayoutParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = obj.param;
-        ElementType netPr;
-        InputShape inputShape;
-
-        std::tie(inputShape, netPr) = basicParamsSet;
+        const auto& [basicParamsSet, cpuParams] = obj.param;
+        const auto& [inputShape, netPr] = basicParamsSet;
         std::ostringstream result;
         result << "ShapeOfTest_";
         result << std::to_string(obj.index) << "_";
@@ -76,16 +71,11 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        ShapeOfAnyLayoutParams basicParamsSet;
-        CPUSpecificParams cpuParams;
-        std::tie(basicParamsSet, cpuParams) = this->GetParam();
-        std::vector<cpu_memory_format_t> eltwiseInFmts, eltwiseOutFmts;
-        std::tie(eltwiseInFmts, eltwiseOutFmts, priority, selectedType) = cpuParams;
-
-        auto netPrecision = ElementType::dynamic;
-        InputShape inputShape;
-        std::tie(inputShape, netPrecision) = basicParamsSet;
+        const auto& [basicParamsSet, cpuParams] = this->GetParam();
+        const auto& [eltwiseInFmts, eltwiseOutFmts, _priority, _selectedType] = cpuParams;
+        priority = _priority;
+        selectedType = _selectedType;
+        const auto& [inputShape, netPrecision] = basicParamsSet;
         init_input_shapes({inputShape});
 
         inType = ov::element::Type(netPrecision);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/split_matmul_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/split_matmul_concat.cpp
@@ -45,11 +45,7 @@ class SplitMatMulConcatTest : public testing::WithParamInterface<SplitMatMulConc
                                     virtual public SubgraphBaseTest, public CPUTestsBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<SplitMatMulConcatParams> obj) {
-        std::vector<InputShape> inputShapes;
-        std::pair<bool, bool> transpose;
-
-        std::tie(inputShapes, transpose) = obj.param;
-
+        const auto& [inputShapes, transpose] = obj.param;
         std::ostringstream result;
         for (const auto& shape : inputShapes) {
             result << ov::test::utils::partialShape2str({shape.first}) << "_";
@@ -80,12 +76,7 @@ protected:
 
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        std::pair<bool, bool> transpose;
-
-        std::tie(inputShapes, transpose) = this->GetParam();
-
+        const auto& [inputShapes, transpose] = this->GetParam();
         init_input_shapes(inputShapes);
 
         bool transpA = transpose.first;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/stateful_init_graph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/common/stateful_init_graph.cpp
@@ -24,11 +24,7 @@ class InitGraphStatefulModelBase : virtual public ov::test::SubgraphBaseTest,
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<InitGraphStatefulModelTestParams>& obj) {
         std::ostringstream result;
-
-        std::vector<InputShape> inputShapes;
-        bool directPair;
-        std::tie(inputShapes, directPair) = obj.param;
-
+        const auto& [inputShapes, directPair] = obj.param;
         result << "IS=";
         for (const auto& shape : inputShapes) {
             result << ov::test::utils::partialShape2str({shape.first}) << "_";
@@ -156,10 +152,8 @@ class InitGraphStatefulModel : public InitGraphStatefulModelBase {
 public:
     void SetUp() override {
         targetDevice = utils::DEVICE_CPU;
-
-        bool directPair;
-        std::tie(inputShapes, directPair) = this->GetParam();
-
+        const auto& [_inputShapes, directPair] = this->GetParam();
+        inputShapes = _inputShapes;
         init_input_shapes(inputShapes);
         ov::ParameterVector input_params;
         for (auto&& shape : inputDynamicShapes) {

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/disable_gathercompressed_quantized_model.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/disable_gathercompressed_quantized_model.cpp
@@ -34,9 +34,7 @@ class DisableGatherCompressedForQuantizedModel : public testing::WithParamInterf
                                                  virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<DisableGatherCompressedForQuantizedModelParams> obj) {
-        element::Type weight_prec;
-        InputShape inputShape1, inputShape2;
-        std::tie(weight_prec, inputShape1, inputShape2) = obj.param;
+        const auto& [weight_prec, inputShape1, inputShape2] = obj.param;
         std::ostringstream result;
         result << "weight_prec=" << weight_prec << "_" << "inputShape1=" << inputShape1 << "_"
                << "inputShape2=" << inputShape2;
@@ -46,10 +44,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = utils::DEVICE_CPU;
-        element::Type weight_prec;
-        InputShape inputShape1, inputShape2;
-        std::tie(weight_prec, inputShape1, inputShape2) = GetParam();
-
+        const auto& [weight_prec, inputShape1, inputShape2] = GetParam();
         init_input_shapes({inputShape1, inputShape2});
 
         targetDevice = utils::DEVICE_CPU;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/quantized_matmuls_with_shared_weights.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/quantized_matmuls_with_shared_weights.cpp
@@ -42,11 +42,7 @@ class QuantizedMatMulsWithSharedWeightsTest
       virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<QuantizedMatMulsWithSharedWeightsParans>& obj) {
-        InputShape shape1;
-        InputShape shape2;
-        FQInterval interval1;
-        FQInterval interval2;
-        std::tie(shape1, shape2, interval1, interval2) = obj.param;
+        const auto& [shape1, shape2, interval1, interval2] = obj.param;
         std::ostringstream result;
         result << "IS1=" << shape1 << "IS2=" << shape2 << "FQInterval1=" << interval1 << "FQInterval2=" << interval2;
         return result.str();
@@ -55,12 +51,7 @@ public:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
         abs_threshold = 1e-4;
-
-        InputShape shape1;
-        InputShape shape2;
-        FQInterval interval1;
-        FQInterval interval2;
-        std::tie(shape1, shape2, interval1, interval2) = this->GetParam();
+        const auto& [shape1, shape2, interval1, interval2] = this->GetParam();
         init_input_shapes({shape1, shape2});
 
         const auto weights = ov::test::utils::make_constant(ov::element::i8, {16, 16});

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/bf16_convert_saturation.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/bf16_convert_saturation.cpp
@@ -24,10 +24,7 @@ class BF16ConvertSaturation : public testing::WithParamInterface<selectParams>,
                               public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<selectParams> obj) {
-        InputShape shapes;
-        ElementType precision;
-        std::tie(shapes, precision) = obj.param;
-
+        const auto& [shapes, precision] = obj.param;
         std::ostringstream result;
         result << "Condition_prc_" << ElementType::boolean << "_Then_Else_prc_" << precision << "_";
         result << "IS=(" << shapes.first << ")_TS=(";
@@ -43,9 +40,7 @@ protected:
     void SetUp() override {
         abs_threshold = 0;
         targetDevice = ov::test::utils::DEVICE_CPU;
-        InputShape shapes;
-        ElementType precision;
-        std::tie(shapes, precision) = this->GetParam();
+        const auto& [shapes, precision] = this->GetParam();
         init_input_shapes({shapes});
         std::tie(inFmts, outFmts, priority, selectedType) = emptyCPUSpec;
         selectedType = makeSelectedTypeStr(getPrimitiveType(), ov::element::i8);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_sum_broadcast.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_sum_broadcast.cpp
@@ -34,13 +34,7 @@ class ConvSumInPlaceTest : public testing::WithParamInterface<convSumBroadcastPa
                            virtual public SubgraphBaseTest, public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<convSumBroadcastParamSet>& obj) {
-        InputShape convShape;
-        InputShape secondShape;
-        bool bias;
-        fusingSpecificParams fusingParams;
-        ov::AnyMap additionalConfig;
-        std::tie(convShape, secondShape, bias, fusingParams, additionalConfig) = obj.param;
-
+        const auto& [convShape, secondShape, bias, fusingParams, additionalConfig] = obj.param;
         std::ostringstream result;
         result << "IS=";
         result  << ov::test::utils::partialShape2str({convShape.first, secondShape.first}) << "_";
@@ -94,14 +88,8 @@ public:
     }
 
     void SetUp() override {
-        InputShape convShape;
-        InputShape secondShape;
-        bool bias;
         CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        ov::AnyMap additionalConfig;
-        std::tie(convShape, secondShape, bias, fusingParams, additionalConfig) = this->GetParam();
-
+        const auto& [convShape, secondShape, bias, fusingParams, additionalConfig] = this->GetParam();
         std::tie(postOpMgrPtr, fusedOps) = fusingParams;
 
         configuration.insert(additionalConfig.begin(), additionalConfig.end());

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_u8s8f32.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_u8s8f32.cpp
@@ -40,10 +40,7 @@ class ConvU8I8FP32 : public testing::WithParamInterface<ConvU8I8FP32Params>,
                      public CpuTestWithFusing {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConvU8I8FP32Params>& obj) {
-        CPUSpecificParams cpuParams;
-        fusingSpecificParams fusingParams;
-        std::tie(cpuParams, fusingParams) = obj.param;
-
+        const auto& [cpuParams, fusingParams] = obj.param;
         std::ostringstream result;
         result << "CPU_";
         result << CPUTestsBase::getTestCaseName(cpuParams);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_with_zero_point_fuse.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/conv_with_zero_point_fuse.cpp
@@ -23,10 +23,7 @@ namespace test {
 
 std::string ConvWithZeroPointFuseSubgraphTest::getTestCaseName(testing::TestParamInfo<convConcatCPUParams> obj) {
     std::ostringstream result;
-    nodeType type;
-    ov::Shape inputShapes;
-    std::tie(type, inputShapes) = obj.param;
-
+    const auto& [type, inputShapes] = obj.param;
     result << "Type=" << nodeType2str(type) << "_";
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
 
@@ -35,9 +32,7 @@ std::string ConvWithZeroPointFuseSubgraphTest::getTestCaseName(testing::TestPara
 
 void ConvWithZeroPointFuseSubgraphTest::SetUp() {
     targetDevice = ov::test::utils::DEVICE_CPU;
-    nodeType type;
-    ov::Shape inputShapes;
-    std::tie(type, inputShapes) = this->GetParam();
+    const auto& [type, inputShapes] = this->GetParam();
     pluginTypeNode = nodeType2PluginType(type);
 
     const ov::op::PadType paddingType{ov::op::PadType::EXPLICIT};

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/convert_fq_rnn_to_quantized_rnn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/convert_fq_rnn_to_quantized_rnn.cpp
@@ -32,12 +32,7 @@ class ConvertFqRnnToQuantizedRnn : public testing::WithParamInterface<ConvertFqR
                                    virtual public ov::test::SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConvertFqRnnToQuantizedRnnTestParams>& obj) {
-        std::vector<InputShape> inputShapes;
-        std::string rnnType;
-        bool quantizedHiddenState = false;
-
-        std::tie(rnnType, inputShapes, quantizedHiddenState) = obj.param;
-
+        const auto& [rnnType, inputShapes, quantizedHiddenState] = obj.param;
         auto batchSize  = inputShapes[0];
         auto inputSize  = inputShapes[1];
         auto hiddenSize = inputShapes[2];
@@ -96,13 +91,8 @@ protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
         selectedType = "ref_any_I8";
-
-        std::vector<InputShape> inputShapes;
-        std::string rnnType;
-        bool quantizedHiddenState = false;
-
-        std::tie(rnnType, inputShapes, quantizedHiddenState) = this->GetParam();
-
+        const auto& [rnnType, origInputShapes, quantizedHiddenState] = this->GetParam();
+        auto inputShapes = origInputShapes;
         if (rnnType != "LSTMSequence") // remove cell input for non-cell rnn types
             inputShapes.erase(inputShapes.begin() + cellIdx);
 

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/convert_range.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/convert_range.cpp
@@ -71,10 +71,7 @@ class ConvertRangeSubgraphCPUTest: public testing::WithParamInterface<ConvertRan
                                  virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<ConvertRangeSubgraphCPUTestParams> obj) {
-        std::map<std::string, ov::element::Type> additionalConfig;
-        std::vector<InputShape> inputShapes;
-        std::vector<ov::Shape> targetShapes;
-        std::tie(additionalConfig, inputShapes, targetShapes) = obj.param;
+        const auto& [additionalConfig, inputShapes, targetShapes] = obj.param;
         std::ostringstream result;
         result << "IS=";
         for (const auto& shape : inputShapes) {
@@ -90,16 +87,15 @@ public:
             }
             result << ")";
         }
-        result << "Prc=" << additionalConfig[ov::hint::inference_precision.name()];
+
+        if (additionalConfig.count(ov::hint::inference_precision.name())) {
+            result << "Prc=" << additionalConfig.at(ov::hint::inference_precision.name());
+        }
         return result.str();
     }
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        std::vector<InputShape> inputShapes;
-        std::vector<ov::Shape> targetShapes;
-        std::map<std::string, ov::element::Type> additionalConfig;
-        std::tie(additionalConfig, inputShapes, targetShapes) = this->GetParam();
-
+        const auto &[additionalConfig, inputShapes, targetShapes] = this->GetParam();
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         init_input_shapes(inputShapes);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/fq_layer_dq_bias.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/fq_layer_dq_bias.cpp
@@ -32,11 +32,7 @@ class FQLayerDQBias : virtual public SubgraphBaseTest,
                       public testing::WithParamInterface<FQLayerDQBiasParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<FQLayerDQBiasParams> obj) {
-        InputShape input_shape;
-        std::string layer_type;
-        bool extra_multiply;
-        std::tie(input_shape, layer_type, extra_multiply) = obj.param;
-
+        const auto& [input_shape, layer_type, extra_multiply] = obj.param;
         std::ostringstream result;
         result << "IS=(" << ov::test::utils::partialShape2str({input_shape.first}) << ")_TS=(";
         for (const auto& item : input_shape.second) {
@@ -49,11 +45,7 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape input_shape;
-        std::string layer_type;
-        bool extra_multiply;
-        std::tie(input_shape, layer_type, extra_multiply) = GetParam();
-
+        const auto& [input_shape, layer_type, extra_multiply] = GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         std::tie(inFmts, outFmts, priority, selectedType) = CPUSpecificParams{{}, {}, {}, CPUTestsBase::any_type};
         static const std::unordered_map<std::string, std::string> ngraph_type_to_plugin_type{

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/fuse_reshape_transpose_to_sdpa.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/fuse_reshape_transpose_to_sdpa.cpp
@@ -43,12 +43,10 @@ class FuseSDPAReshapeTransposeTest : virtual public ov::test::SubgraphBaseTest,
                                      public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<FuseSDPAReshapeTransposeTestParams>& obj) {
-        ElementType inType;
-        InputShapeAndReshapeOrder inputShapeAndOrders;
-        std::tie(inType, inputShapeAndOrders) = obj.param;
+        const auto& [inType, inputShapeAndOrders] = obj.param;
         std::ostringstream result;
-        std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
-        auto& reshapeOrderHS = inputShapeAndOrders.second;
+        const auto& [inputShapes, reshapeOrderHS] = inputShapeAndOrders;
+
         result << "IS=";
         for (const auto& shape : inputShapes) {
             result << ov::test::utils::partialShape2str({shape.first}) << "_";
@@ -75,11 +73,9 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        InputShapeAndReshapeOrder inputShapeAndOrders;
-        std::tie(inType, inputShapeAndOrders) = this->GetParam();
-        std::vector<InputShape>& inputShapes = inputShapeAndOrders.first;
-        auto& reshapeOrderHS = inputShapeAndOrders.second;
+        const auto& [inType, inputShapeAndOrders] = this->GetParam();
+        const auto& [inputShapes, reshapeOrderHS] = inputShapeAndOrders;
+
         targetDevice = ov::test::utils::DEVICE_CPU;
         rel_threshold = 1e-2f;
         configuration[ov::hint::inference_precision.name()] = ov::element::f32;

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/interaction.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/interaction.cpp
@@ -128,9 +128,7 @@ class IntertactionCPUTest : public testing::WithParamInterface<InteractionLayerC
                             public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<InteractionLayerCPUTestParams>& obj) {
-        ElementType inType;
-        InputShape inputShape;
-        std::tie(inType, inputShape) = obj.param;
+        const auto& [inType, inputShape] = obj.param;
         std::ostringstream result;
         result << "IS=" << inputShape << "_";
         result << "Prc=" << inType;
@@ -156,9 +154,7 @@ public:
 
 protected:
     void SetUp() override {
-        ElementType inType;
-        InputShape inputShape;
-        std::tie(inType, inputShape) = this->GetParam();
+        const auto& [inType, inputShape] = this->GetParam();
         bool with_bf16 = ov::with_cpu_x86_bfloat16() || with_cpu_x86_avx2_vnni_2();
         if (with_bf16 && (inType == ov::element::bf16 || inType == ov::element::i32)) {
             selectedType = makeSelectedTypeStr("ref_any", ov::element::bf16);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/matmul_quantized_subgraph.cpp
@@ -32,13 +32,7 @@ class MatmulBrgemmInt8Test : public testing::WithParamInterface<MatmulBrgemmInt8
                       virtual public ov::test::SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<MatmulBrgemmInt8TestParams> obj) {
-        ov::Shape supportedInputShapes;
-        bool isFC;
-        ElementType inType;
-        ElementType outType;
-        CPUSpecificParams cpuParams;
-        std::tie(supportedInputShapes, isFC, inType, outType, cpuParams) = obj.param;
-
+        const auto& [supportedInputShapes, isFC, inType, outType, cpuParams] = obj.param;
         std::ostringstream result;
         result << "IS=" << supportedInputShapes.to_string() << "_";
         result << (isFC ? "FullyConnected" : "MatMul") << "_";
@@ -56,9 +50,10 @@ protected:
     ElementType outType;
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        ov::Shape inShapes;
-        CPUSpecificParams cpuParams;
-        std::tie(inShapes, isFC, inType, outType, cpuParams) = this->GetParam();
+        const auto& [inShapes, _isFC, _inType, _outType, cpuParams] = this->GetParam();
+        isFC = _isFC;
+        inType = _inType;
+        outType = _outType;
         std::tie(inFmts, outFmts, priority, selectedType) = cpuParams;
         const auto ngPrec = ov::element::f32;
         ov::ParameterVector inputParams {std::make_shared<ov::op::v0::Parameter>(ngPrec, ov::Shape(inShapes))};

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/paged_attn.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/paged_attn.cpp
@@ -45,11 +45,7 @@ class PagedAttnTestBase : public testing::WithParamInterface<PagedAttnTestParams
                           public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<PagedAttnTestParams>& obj) {
-        ElementType inType;
-        InputShapes inputShapes;
-        bool extendBlockIndices;
-        ov::AnyMap additional_config;
-        std::tie(inType, inputShapes, extendBlockIndices, additional_config) = obj.param;
+        const auto& [inType, inputShapes, extendBlockIndices, additional_config] = obj.param;
         std::ostringstream result;
         result << "IS=";
         for (const auto& shape : inputShapes) {
@@ -216,11 +212,7 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        InputShapes inputShapes;
-        bool extendBlockIndices;
-        ov::AnyMap additional_config;
-        std::tie(inType, inputShapes, extendBlockIndices, additional_config) = this->GetParam();
+        const auto& [inType, inputShapes, extendBlockIndices, additional_config] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         rel_threshold = 1e-2f;
         configuration[ov::hint::inference_precision.name()] = ov::element::f32;
@@ -428,12 +420,8 @@ public:
 
 TEST_P(PagedAttnVSSDPATest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ElementType inType;
-    InputShapes inputShapes;
-    bool extendBlockIndices;
-    ov::AnyMap additional_config;
-    std::tie(inType, inputShapes, extendBlockIndices, additional_config) = this->GetParam();
-    bool isSageAttn = additional_config[ov::intel_cpu::enable_sage_attn.name()].as<bool>();
+    const auto& [inType, inputShapes, extendBlockIndices, additional_config] = this->GetParam();
+    const bool isSageAttn = intel_cpu::contains_key_value(additional_config, {ov::intel_cpu::enable_sage_attn.name(), true});
     if (inType == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
         GTEST_SKIP();
     if (isSageAttn && !(ov::with_cpu_x86_avx512_core_amx_int8() || CPUTestUtils::with_cpu_x86_avx2_vnni_2()))
@@ -657,12 +645,8 @@ public:
 
 TEST_P(PagedAttnVSMatmulTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ElementType inType;
-    InputShapes inputShapes;
-    bool extendBlockIndices;
-    ov::AnyMap additional_config;
-    std::tie(inType, inputShapes, extendBlockIndices, additional_config) = this->GetParam();
-    bool isSageAttn = additional_config[ov::intel_cpu::enable_sage_attn.name()].as<bool>();
+    const auto& [inType, inputShapes, extendBlockIndices, additional_config] = this->GetParam();
+    const bool isSageAttn = intel_cpu::contains_key_value(additional_config, {ov::intel_cpu::enable_sage_attn.name(), true});
     if (inType == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
         GTEST_SKIP();
     if (isSageAttn && !(ov::with_cpu_x86_avx512_core_amx_int8() || CPUTestUtils::with_cpu_x86_avx2_vnni_2()))

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/paged_attn_score.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/paged_attn_score.cpp
@@ -55,10 +55,7 @@ class PagedAttnScoreTest : public testing::WithParamInterface<PagedAttnTestParam
                            public CPUTestsBase {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<PagedAttnTestParams>& obj) {
-        ElementType inType;
-        InputShapes inputShapes;
-        uint32_t score_aggregation_window;
-        std::tie(inType, inputShapes, score_aggregation_window) = obj.param;
+        const auto& [inType, inputShapes, score_aggregation_window] = obj.param;
         std::ostringstream result;
         result << "IS=";
         for (const auto& shape : inputShapes) {
@@ -148,10 +145,7 @@ public:
     }
 
     void SetUp() override {
-        ElementType inType;
-        InputShapes inputShapes;
-        uint32_t score_aggregation_window;
-        std::tie(inType, inputShapes, score_aggregation_window) = this->GetParam();
+        const auto& [inType, inputShapes, score_aggregation_window] = this->GetParam();
         targetDevice = ov::test::utils::DEVICE_CPU;
         rel_threshold = 0.01f;
         abs_threshold = 0.01f;
@@ -493,10 +487,7 @@ public:
 
 TEST_P(PagedAttnScoreTest, CompareWithRefs) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    ElementType inType;
-    InputShapes inputShapes;
-    uint32_t score_aggregation_window;
-    std::tie(inType, inputShapes, score_aggregation_window) = this->GetParam();
+    const auto& [inType, inputShapes, score_aggregation_window] = this->GetParam();
     if (inType == ElementType::bf16 && !ov::with_cpu_x86_bfloat16())
         GTEST_SKIP();
     auto actualOutputs = run_test(function, score_aggregation_window);

--- a/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/subgraph_caching.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/subgraph_tests/src/x64/subgraph_caching.cpp
@@ -52,10 +52,7 @@ class SubgraphCacheTest : public testing::WithParamInterface<SubgraphCacheTestPa
                           virtual public SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<SubgraphCacheTestParams> &obj) {
-        std::vector<InputShape> inputShapes;
-        ElementType inputPrecision;
-        std::tie(inputShapes, inputPrecision) = obj.param;
-
+        const auto& [inputShapes, inputPrecision] = obj.param;
         std::ostringstream results;
 
          for (size_t i = 0; i < inputShapes.size(); i++) {
@@ -70,11 +67,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-
-        std::vector<InputShape> inputShapes;
-        ElementType inputPrecision;
-        std::tie(inputShapes, inputPrecision) = this->GetParam();
-
+        const auto& [inputShapes, inputPrecision] = this->GetParam();
         init_input_shapes(inputShapes);
 
         // Enable Snippets

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/concat_resize_concat.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/subgraph_tests/concat_resize_concat.cpp
@@ -23,9 +23,7 @@ class ConcatResizeConcatTest : public testing::WithParamInterface<ConcResizeConc
                                public ov::test::SubgraphBaseStaticTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ConcResizeConcParams>& obj) {
-        int channels_count;
-        int batch_count;
-        std::tie(channels_count, batch_count) = obj.param;
+        const auto& [channels_count, batch_count] = obj.param;
         std::ostringstream result;
         result << "Batches=" << batch_count << "_";
         result << "Channels=" << channels_count << "_";
@@ -36,10 +34,7 @@ public:
 protected:
     void SetUp() override {
         targetDevice = ov::test::utils::DEVICE_CPU;
-        int channels_count;
-        int batch_count;
-        std::tie(channels_count, batch_count) = this->GetParam();
-
+        const auto& [channels_count, batch_count] = this->GetParam();
         std::vector<int> dims1({batch_count, channels_count, 2, 2});
         std::vector<int> dims2({batch_count, channels_count, 3, 3});
 

--- a/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.cpp
@@ -263,13 +263,9 @@ bool CPUTestsBase::primTypeCheck(std::string primType) const {
         return selectedType.find(CPUTestsBase::any_type) != std::string::npos ||
                std::regex_match(primType, std::regex(selectedType, std::regex::icase));
 }
-
-std::string CPUTestsBase::getTestCaseName(CPUSpecificParams params) {
+std::string CPUTestsBase::getTestCaseName(const CPUSpecificParams& params) {
+    const auto& [inFmts, outFmts, priority, selectedType] = params;
     std::ostringstream result;
-    std::vector<cpu_memory_format_t> inFmts, outFmts;
-    std::vector<std::string> priority;
-    std::string selectedType;
-    std::tie(inFmts, outFmts, priority, selectedType) = params;
     if (!inFmts.empty()) {
         auto str = fmts2str(inFmts, "");
         std::replace(str.begin(), str.end(), ',', '.');
@@ -285,7 +281,6 @@ std::string CPUTestsBase::getTestCaseName(CPUSpecificParams params) {
     }
     return result.str();
 }
-
 CPUTestsBase::CPUInfo CPUTestsBase::getCPUInfo() const {
     return makeCPUInfo(inFmts, outFmts, priority);
 }

--- a/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.hpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/cpu_test_utils.hpp
@@ -124,7 +124,7 @@ using InputGenerateDataMap = std::unordered_map<size_t, ov::test::utils::InputGe
 class CPUTestsBase {
 public:
     using CPUInfo = std::map<std::string, ov::Any>;
-    static std::string getTestCaseName(CPUSpecificParams params);
+    static std::string getTestCaseName(const CPUSpecificParams& params);
     static const char* cpu_fmt2str(cpu_memory_format_t v);
     static cpu_memory_format_t cpu_str2fmt(const char* str);
     static std::string fmts2str(const std::vector<cpu_memory_format_t>& fmts, const std::string& prefix);

--- a/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
+++ b/src/plugins/intel_cpu/tests/functional/utils/fusing_test_utils.cpp
@@ -9,11 +9,8 @@
 namespace CPUTestUtils {
 
 std::string CpuTestWithFusing::getTestCaseName(fusingSpecificParams params) {
+    const auto& [postOpMgrPtr, fusedOps] = params;
     std::ostringstream result;
-    std::vector<std::string> fusedOps;
-    std::shared_ptr<postOpMgr> postOpMgrPtr;
-    std::tie(postOpMgrPtr, fusedOps) = params;
-
     if (postOpMgrPtr) {
         auto postOpsNames = postOpMgrPtr->getFusedOpsNames();
         if (!postOpsNames.empty()) {

--- a/src/plugins/intel_cpu/tests/unit/brgemm_executor_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/brgemm_executor_test.cpp
@@ -21,10 +21,7 @@ namespace brgemmUnitTest {
 class BrgemmKernelTest : public ov::test::TestsCommon, public testing::WithParamInterface<BrgemmKernelParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<BrgemmKernelParams>& obj) {
-        ov::element::Type rtPrec;
-        bool postScale;
-        size_t M, N, K;
-        std::tie(rtPrec, M, N, K, postScale) = obj.param;
+        const auto& [rtPrec, M, N, K, postScale] = obj.param;
         std::ostringstream result;
         result << "Prec=" << rtPrec.to_string();
         result << ",M=" << M;
@@ -201,10 +198,7 @@ static void run_test_post_scales(ov::element::Type rtPrec, size_t M, size_t N, s
 }
 
 TEST_P(BrgemmKernelTest, simpleGemmTest) {
-    ov::element::Type rtPrec;
-    bool postScale;
-    size_t M, N, K;
-    std::tie(rtPrec, M, N, K, postScale) = this->GetParam();
+    const auto& [rtPrec, M, N, K, postScale] = this->GetParam();
     if (rtPrec == ov::element::bf16 && !ov::with_cpu_x86_bfloat16())
         GTEST_SKIP();
     if (rtPrec == ov::element::f16 && !ov::with_cpu_x86_avx512_core_fp16())

--- a/src/plugins/intel_cpu/tests/unit/dnnl_memory_desc_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_memory_desc_test.cpp
@@ -365,10 +365,7 @@ TEST(MakeUndefinedDnnlDesc, checkLayout) {
     ov::PartialShape fullyUndef({{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}});
 
     for (const auto& item : payload) {
-        dnnl::memory::format_tag fmt;
-        dnnl::memory::dims dims;
-        std::string strFormat;
-        std::tie(fmt, dims, strFormat) = item;
+        const auto& [fmt, dims, strFormat] = item;
         const memory::desc origin(dims, dataType, fmt);
 
         auto undefDesc = DnnlExtensionUtils::makeUndefinedDesc(origin, ov::intel_cpu::Shape(fullyUndef));
@@ -399,9 +396,7 @@ TEST(MakeUndefinedDnnlDesc, extraData) {
     ov::PartialShape fullyUndef({{-1, -1}, {-1, -1}, {-1, -1}, {-1, -1}});
 
     for (const auto& item : payload) {
-        dnnl::memory::format_tag fmt;
-        dnnl::memory::dims dims;
-        std::tie(fmt, dims) = item;
+        const auto& [fmt, dims] = item;
         memory::desc origin(dims, dataType, fmt);
 
         origin.get()->extra.flags = dnnl_memory_extra_flag_compensation_conv_s8s8;

--- a/src/plugins/intel_cpu/tests/unit/dnnl_zero_dims_test.cpp
+++ b/src/plugins/intel_cpu/tests/unit/dnnl_zero_dims_test.cpp
@@ -123,9 +123,7 @@ class MemDescWithZeroDimsFmtTest: public testing::WithParamInterface<MemDescWith
                                   public MemDescWithZeroDimsBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MemDescWithZeroDimsParams> &obj) {
-        Shape shape;
-        dnnl::memory::format_tag fmt;
-        std::tie(fmt, shape) = obj.param;
+        const auto& [fmt, shape] = obj.param;
         std::ostringstream result;
         result << "Shape=" << shape.toString();
         result << "_Fmt=" << dnnl::utils::fmt2str(fmt);
@@ -193,9 +191,7 @@ class MemDescWithZeroDimsCloneNewDimsTest: public testing::WithParamInterface<Me
                                            public MemDescWithZeroDimsBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<MemDescWithZeroDimsCloneNewDimsParams> &obj) {
-        Shape shapeDynamic, shapeClone;
-        dnnl::memory::format_tag fmt;
-        std::tie(fmt, shapeDynamic, shapeClone) = obj.param;
+        const auto& [fmt, shapeDynamic, shapeClone] = obj.param;
         std::ostringstream result;
         result << "ShapeDynamic=" << shapeDynamic.toString();
         result << "_ShapeClone=" << shapeClone.toString();

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/adaptive_avg_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/adaptive_avg_pool.cpp
@@ -25,10 +25,7 @@ class AdaptiveAvgPoolV8CpuShapeInferenceTest  : public unit_test::OpCpuShapeInfe
                                                 public WithParamInterface<AdaptiveAvgPoolV8TestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<AdaptiveAvgPoolV8TestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<int32_t> tmp_axes;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_axes, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_axes, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "sd" << ov::test::utils::vec2str(tmp_axes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/adaptive_max_pool.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/adaptive_max_pool.cpp
@@ -26,10 +26,7 @@ class AdaptiveMaxPoolV8CpuShapeInferenceTest  : public unit_test::OpCpuShapeInfe
                                                 public WithParamInterface<AdaptiveMaxPoolV8TestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<AdaptiveMaxPoolV8TestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<int32_t> tmp_axes;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_axes, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_axes, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "sd" << ov::test::utils::vec2str(tmp_axes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/matmul.cpp
@@ -26,9 +26,7 @@ using matmul_test_params_t = std::tuple<StaticShape,  // Input A shape
 class CPUMatMulTest : public TestWithParam<matmul_test_params_t> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<matmul_test_params_t>& obj) {
-        StaticShape tmp_input_shape_A;
-        StaticShape tmp_input_shape_B;
-        std::tie(tmp_input_shape_A, tmp_input_shape_B) = obj.param;
+        const auto& [tmp_input_shape_A, tmp_input_shape_B] = obj.param;
         std::ostringstream result;
         result << "IA" << tmp_input_shape_A << "_";
         result << "IB" << tmp_input_shape_B;

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/one_hot.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/one_hot.cpp
@@ -29,12 +29,7 @@ class OneHotCpuShapeInferenceTest  : public unit_test::OpCpuShapeInferenceTest<o
                                       public WithParamInterface<OneHotTestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<OneHotTestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        int64_t tmp_depth;
-        int32_t tmp_on;
-        int32_t tmp_off;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_depth, tmp_on, tmp_off, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_depth, tmp_on, tmp_off, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "depth" << tmp_depth << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/prior_box.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/prior_box.cpp
@@ -33,11 +33,7 @@ class PriorBoxV0CpuShapeInferenceTest  : public unit_test::OpCpuShapeInferenceTe
                                       public WithParamInterface<PriorBoxV0TestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<PriorBoxV0TestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        op::v0::PriorBox::Attributes tmp_attrs;
-        std::vector<std::vector<int32_t>> tmp_data;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_attrs, tmp_data, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_attrs, tmp_data, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "min_size" << ov::test::utils::vec2str(tmp_attrs.min_size) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/prior_box_clustered.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/prior_box_clustered.cpp
@@ -28,11 +28,7 @@ class PriorBoxClusteredV0CpuShapeInferenceTest  : public unit_test::OpCpuShapeIn
                                                   public WithParamInterface<PriorBoxClusteredV0TestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<PriorBoxClusteredV0TestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        op::v0::PriorBoxClustered::Attributes tmp_attrs;
-        std::vector<std::vector<int32_t>> tmp_data;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_attrs, tmp_data, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_attrs, tmp_data, tmp_exp_shape] = obj.param;
         std::ostringstream result;
 
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/reshape.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/reshape.cpp
@@ -29,11 +29,7 @@ class ReshapeCpuShapeInferenceTest  : public unit_test::OpCpuShapeInferenceTest<
                                       public WithParamInterface<ReshapeTestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<ReshapeTestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<int64_t> tmp_axes;
-        StaticShape tmp_exp_shape;
-        bool tmp_specialZero;
-        std::tie(tmp_input_shapes, tmp_axes, tmp_exp_shape, tmp_specialZero) = obj.param;
+        const auto& [tmp_input_shapes, tmp_axes, tmp_exp_shape, tmp_specialZero] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "axes" << ov::test::utils::vec2str(tmp_axes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/scaled_attn.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/scaled_attn.cpp
@@ -28,11 +28,7 @@ class SDPACpuShapeInferenceTest
       public WithParamInterface<SDPATestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<SDPATestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<size_t> tmp_permute_axes;
-        unit_test::ShapeVector tmp_exp_shape;
-        bool tmp_causal = false;
-        std::tie(tmp_input_shapes, tmp_permute_axes, tmp_exp_shape, tmp_causal) = obj.param;
+        const auto& [tmp_input_shapes, tmp_permute_axes, tmp_exp_shape, tmp_causal] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "permute_axes" << ov::test::utils::vec2str(tmp_permute_axes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/squeeze.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/squeeze.cpp
@@ -26,10 +26,7 @@ class SqueezeCpuShapeInferenceTest  : public unit_test::OpCpuShapeInferenceTest<
                                       public WithParamInterface<SqueezeTestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<SqueezeTestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<int64_t> tmp_axes;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_axes, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_axes, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "axes" << ov::test::utils::vec2str(tmp_axes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/strided_slice.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/strided_slice.cpp
@@ -35,14 +35,8 @@ public:
         STRIDE = 2,
     };
     static std::string getTestCaseName(const testing::TestParamInfo<StridedSliceParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<std::vector<int32_t>> tmp_data;
-        std::vector<int64_t> tmp_begin_mask;
-        std::vector<int64_t> tmp_end_mask;
-        std::vector<int64_t> tmp_new_axis_mask;
-        std::vector<int64_t> tmp_shrink_axis_mask;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_data, tmp_begin_mask, tmp_end_mask, tmp_new_axis_mask, tmp_shrink_axis_mask, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_data, tmp_begin_mask, tmp_end_mask, tmp_new_axis_mask, tmp_shrink_axis_mask,
+                     tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "begin" << ov::test::utils::vec2str(tmp_data[BEGIN]) << "_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/transpose.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/transpose.cpp
@@ -27,10 +27,7 @@ class TransposeCpuShapeInferenceTest : public unit_test::OpCpuShapeInferenceTest
                                        public WithParamInterface<transpose_params> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<transpose_params>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<int64_t> tmp_transpose_order;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_transpose_order, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_transpose_order, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "input_shapes(" << ov::test::utils::vec2str(tmp_input_shapes) << ")_";
         result << "order(" << ov::test::utils::vec2str(tmp_transpose_order) << ")_";

--- a/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/unsqueeze.cpp
+++ b/src/plugins/intel_cpu/tests/unit/shape_inference_test/custom_shape_infer/unsqueeze.cpp
@@ -25,10 +25,7 @@ class UnsqueezeCpuShapeInferenceTest  : public unit_test::OpCpuShapeInferenceTes
                                           public WithParamInterface<UnsqueezeTestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<UnsqueezeTestParams>& obj) {
-        unit_test::ShapeVector tmp_input_shapes;
-        std::vector<int64_t> tmp_axes;
-        StaticShape tmp_exp_shape;
-        std::tie(tmp_input_shapes, tmp_axes, tmp_exp_shape) = obj.param;
+        const auto& [tmp_input_shapes, tmp_axes, tmp_exp_shape] = obj.param;
         std::ostringstream result;
         result << "IS" << ov::test::utils::vec2str(tmp_input_shapes) << "_";
         result << "axes" << ov::test::utils::vec2str(tmp_axes) << "_";

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/common/mul_add_to_fma.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/common/mul_add_to_fma.cpp
@@ -107,9 +107,10 @@ class MulAddToFMATests : public LoweringTests, public testing::WithParamInterfac
 public:
     static std::string getTestCaseName(testing::TestParamInfo<MulAddToFMAParams> obj) {
         std::vector<PartialShape> inputShapes(3);
-        size_t add_input_idx;
-        std::tie(inputShapes[0], inputShapes[1], inputShapes[2], add_input_idx) = obj.param;
-
+        const auto& [_tmp, _tmp1, _tmp2, add_input_idx] = obj.param;
+        inputShapes[0] = _tmp;
+        inputShapes[1] = _tmp1;
+        inputShapes[2] = _tmp2;
         std::ostringstream result;
         for (size_t i = 0; i < inputShapes.size(); i++)
             result << "IS[" << i << "]=" <<  ov::test::utils::partialShape2str({inputShapes[i]}) << "_";
@@ -122,8 +123,10 @@ protected:
         using PassPosition = ov::snippets::pass::PassPosition;
         LoweringTests::SetUp();
         std::vector<PartialShape> inputShapes(3);
-        size_t add_input_idx;
-        std::tie(inputShapes[0], inputShapes[1], inputShapes[2], add_input_idx) = this->GetParam();
+        const auto& [_tmp, _tmp1, _tmp2, add_input_idx] = this->GetParam();
+        inputShapes[0] = _tmp;
+        inputShapes[1] = _tmp1;
+        inputShapes[2] = _tmp2;
         const bool scalar_input = ov::shape_size(inputShapes[2].to_shape()) == 1;
         snippets_model = std::make_shared<EltwiseWithMulAddFunction>(inputShapes, add_input_idx, scalar_input);
 

--- a/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/enforce_precision.cpp
+++ b/src/plugins/intel_cpu/tests/unit/snippets_transformations/x64/enforce_precision.cpp
@@ -118,10 +118,7 @@ class EnforcePrecisionTest : public TransformationTestsF,
                              public testing::WithParamInterface<EnforcePrecisionParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<EnforcePrecisionParams> obj) {
-        std::pair<PartialShape, PartialShape> shapes;
-        EnforcePrecisionParamsValues test_values;
-        std::tie(shapes, test_values) = obj.param;
-
+        const auto& [shapes, test_values] = obj.param;
         auto to_string = [](const std::set<std::vector<element::Type>>& precisions_pack) noexcept {
             std::ostringstream result;
             result << "{";

--- a/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
+++ b/src/plugins/intel_cpu/tests/unit/transformations/move_fc_reshape_to_weights.cpp
@@ -65,12 +65,7 @@ using MoveFCReshapeToWeightsParams = std::tuple<std::pair<ov::PartialShape, ov::
 class MoveFCReshapeToWeightsTests : public TransformationTestsF, public WithParamInterface<MoveFCReshapeToWeightsParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<MoveFCReshapeToWeightsParams> obj) {
-        std::pair<ov::PartialShape, ov::Shape> input_shapes;
-        bool add_transpose;
-        ZeroPointType zp_type;
-        ZeroPointShape zp_shape;
-        std::tie(input_shapes, add_transpose, zp_type, zp_shape) = obj.param;
-
+        const auto& [input_shapes, add_transpose, zp_type, zp_shape] = obj.param;
         std::ostringstream result;
         result << "Input_shape=(" << input_shapes.first << ")_Weights_shape=(" << input_shapes.second
                << ")_add_transpose=" << add_transpose << "_zp_type=" << zp_type << "_zp_shape=" << zp_shape;
@@ -131,12 +126,7 @@ public:
 protected:
     void SetUp() override {
         TransformationTestsF::SetUp();
-        std::pair<ov::PartialShape, ov::Shape> input_shapes;
-        bool add_transpose;
-        ZeroPointType zp_type;
-        ZeroPointShape zp_shape;
-        std::tie(input_shapes, add_transpose, zp_type, zp_shape) = this->GetParam();
-
+        const auto& [input_shapes, add_transpose, zp_type, zp_shape] = this->GetParam();
         ov::Shape ref_weights_shape = input_shapes.second;
         ref_weights_shape.erase(ref_weights_shape.begin());
         model = initModel(input_shapes.first, input_shapes.second, add_transpose, zp_type, zp_shape, true);


### PR DESCRIPTION
This both simplifies and speeds up the code.
Testing on CPU plugin first.
The plan is to apply it to the whole project.
Assembly difference https://godbolt.org/z/bqdsf8ca3
Local perf difference https://quick-bench.com/q/llroDSJ6LHtdWpK9WhKTDq5LESw