### PR TITLE
[Snippets][CPU] Introduce jit_binary_call emitter on ARM, fix large offsets issue in Gemm

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_binary_call_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_binary_call_emitter.cpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "jit_binary_call_emitter.hpp"
+
+#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <set>
+#include <vector>
+
+#include "emitters/snippets/aarch64/utils.hpp"
+#include "emitters/utils.hpp"
+#include "snippets/emitter.hpp"
+
+using namespace dnnl::impl::cpu::aarch64;
+
+namespace ov::intel_cpu::aarch64 {
+
+jit_binary_call_emitter::jit_binary_call_emitter(jit_generator* h, cpu_isa_t isa, std::set<snippets::Reg> live_regs)
+    : jit_emitter(h, isa) {
+    // Store live registers that need to be preserved
+    m_regs_to_spill = std::move(live_regs);
+}
+
+const std::set<snippets::Reg>& jit_binary_call_emitter::get_regs_to_spill() const {
+    OV_CPU_JIT_EMITTER_ASSERT(m_regs_initialized, "Binary call registers must be initialized first");
+    return m_regs_to_spill;
+}
+
+const Xbyak_aarch64::XReg& jit_binary_call_emitter::get_call_address_reg() const {
+    OV_CPU_JIT_EMITTER_ASSERT(m_regs_initialized, "Binary call registers must be initialized first");
+    return m_call_address_reg;
+}
+
+const Xbyak_aarch64::XReg& jit_binary_call_emitter::get_callee_saved_reg() const {
+    OV_CPU_JIT_EMITTER_ASSERT(m_regs_initialized, "Binary call registers must be initialized first");
+    return m_callee_saved_reg;
+}
+
+void jit_binary_call_emitter::init_binary_call_regs(size_t num_binary_args,
+                                                    const std::vector<size_t>& used_gpr_idxs) const {
+    if (m_regs_initialized) {
+        return;
+    }
+
+    // ARM64 AAPCS: X0-X7 are parameter/result registers, X8-X18 are temporary registers
+    // X19-X28 are callee-saved registers, X29 is frame pointer, X30 is link register, X31 is stack pointer
+
+    std::vector<size_t> all_used_idxs = used_gpr_idxs;
+
+    // Add ABI parameter registers to used list (X0-X7 based on num_binary_args)
+    for (size_t i = 0; i < std::min(num_binary_args, size_t(8)); i++) {
+        all_used_idxs.push_back(i);
+        m_regs_to_spill.emplace(snippets::RegType::gpr, i);
+    }
+
+    // Add special registers that should not be allocated
+    std::vector<size_t> reserved_regs = {
+        18,  // Platform register (should not be used)
+        29,  // Frame pointer (FP)
+        30,  // Link register (LR)
+        31   // Stack pointer (SP)
+    };
+    all_used_idxs.insert(all_used_idxs.end(), reserved_regs.begin(), reserved_regs.end());
+
+    // Allocate call address register from temporary registers (X8-X18, excluding X18)
+    std::vector<size_t> temp_candidates;
+    for (size_t i = 8; i < 18; i++) {
+        if (std::find(all_used_idxs.begin(), all_used_idxs.end(), i) == all_used_idxs.end()) {
+            temp_candidates.push_back(i);
+        }
+    }
+
+    OV_CPU_JIT_EMITTER_ASSERT(!temp_candidates.empty(), "No available temporary register for call address");
+    m_call_address_reg = Xbyak_aarch64::XReg(static_cast<int>(temp_candidates[0]));
+    all_used_idxs.push_back(temp_candidates[0]);
+    m_regs_to_spill.emplace(snippets::RegType::gpr, temp_candidates[0]);
+
+    // Allocate callee-saved register (X19-X28) for stack alignment
+    std::vector<size_t> callee_saved_candidates;
+    for (size_t i = 19; i < 29; i++) {
+        if (std::find(all_used_idxs.begin(), all_used_idxs.end(), i) == all_used_idxs.end()) {
+            callee_saved_candidates.push_back(i);
+        }
+    }
+
+    OV_CPU_JIT_EMITTER_ASSERT(!callee_saved_candidates.empty(), "No available callee-saved register");
+    m_callee_saved_reg = Xbyak_aarch64::XReg(static_cast<int>(callee_saved_candidates[0]));
+    m_regs_to_spill.emplace(snippets::RegType::gpr, callee_saved_candidates[0]);
+
+    m_regs_initialized = true;
+}
+
+void jit_binary_call_emitter::init_binary_call_regs(size_t num_binary_args,
+                                                    const std::vector<size_t>& in,
+                                                    const std::vector<size_t>& out) const {
+    std::vector<size_t> used_gpr_idxs = in;
+    used_gpr_idxs.insert(used_gpr_idxs.end(), out.begin(), out.end());
+    init_binary_call_regs(num_binary_args, used_gpr_idxs);
+}
+
+void jit_binary_call_emitter::emit_stack_preserve(size_t stack_size) const {
+    // ARM64 requires 16-byte stack alignment
+    const size_t alignment = 16;
+    stack_size = ov::intel_cpu::rnd_up(stack_size, alignment);
+
+    if (stack_size > 0) {
+        h->sub(h->sp, h->sp, stack_size);
+    }
+}
+
+void jit_binary_call_emitter::emit_stack_restore(size_t stack_size) const {
+    // ARM64 requires 16-byte stack alignment
+    const size_t alignment = 16;
+    stack_size = ov::intel_cpu::rnd_up(stack_size, alignment);
+
+    if (stack_size > 0) {
+        h->add(h->sp, h->sp, stack_size);
+    }
+}
+
+}  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_binary_call_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_binary_call_emitter.hpp
@@ -1,0 +1,87 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h>
+
+#include <cpu/aarch64/cpu_isa_traits.hpp>
+#include <cpu/aarch64/jit_generator.hpp>
+#include <cstddef>
+#include <set>
+#include <vector>
+
+#include "emitters/plugin/aarch64/jit_emitter.hpp"
+#include "snippets/emitter.hpp"
+
+namespace ov::intel_cpu::aarch64 {
+
+/**
+ * @brief Base class for binary call emitters on ARM64. Provides proper ABI compliance for function calls
+ * by managing register spilling, stack alignment, and calling conventions according to ARM64 AAPCS.
+ * This follows the same pattern as the x64 jit_binary_call_emitter but adapted for ARM64 architecture.
+ */
+class jit_binary_call_emitter : public jit_emitter {
+public:
+    jit_binary_call_emitter(dnnl::impl::cpu::aarch64::jit_generator* h,
+                            dnnl::impl::cpu::aarch64::cpu_isa_t isa,
+                            std::set<snippets::Reg> live_regs);
+
+    // Need at least one register to store the callable address
+    size_t aux_gprs_count() const {
+        return 1;
+    }
+
+protected:
+    /**
+     * @brief Returns a set of snippets::Reg that should be spilled in the derived emitter.
+     * This set includes live_regs passed in constructor, plus callee-saved regs and regs for ABI params.
+     */
+    const std::set<snippets::Reg>& get_regs_to_spill() const;
+
+    /**
+     * @brief Returns a GPR that can be used to store the address of the callable.
+     */
+    const Xbyak_aarch64::XReg& get_call_address_reg() const;
+
+    /**
+     * @brief Returns a callee-saved GPR that can be used for stack alignment before the call.
+     */
+    const Xbyak_aarch64::XReg& get_callee_saved_reg() const;
+
+    /**
+     * @brief Initializes registers for binary call emission according to ARM64 AAPCS.
+     * @param num_binary_args - the number of arguments of the binary that will be called
+     * @param used_gpr_idxs - indices of registers that must be preserved during aux reg allocation
+     */
+    void init_binary_call_regs(size_t num_binary_args, const std::vector<size_t>& used_gpr_idxs) const;
+
+    /**
+     * @brief Overload that takes separate input/output register vectors.
+     */
+    void init_binary_call_regs(size_t num_binary_args,
+                               const std::vector<size_t>& in,
+                               const std::vector<size_t>& out) const;
+
+    /**
+     * @brief Emit proper stack management for ARM64 function calls.
+     * @param stack_size - size of stack space to reserve (must be 16-byte aligned)
+     */
+    void emit_stack_preserve(size_t stack_size) const;
+
+    /**
+     * @brief Restore stack after ARM64 function call.
+     * @param stack_size - size of stack space to restore
+     */
+    void emit_stack_restore(size_t stack_size) const;
+
+private:
+    // All mutable because init_binary_call_regs() is called from const emit_impl()
+    mutable std::set<snippets::Reg> m_regs_to_spill;
+    mutable Xbyak_aarch64::XReg m_callee_saved_reg{31};  // Initialize to invalid reg
+    mutable Xbyak_aarch64::XReg m_call_address_reg{31};  // Initialize to invalid reg
+    mutable bool m_regs_initialized = false;
+};
+
+}  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.cpp
@@ -17,6 +17,7 @@
 
 #include "emitters/snippets/aarch64/kernel_executors/gemm.hpp"
 #include "emitters/snippets/aarch64/utils.hpp"
+#include "emitters/snippets/jit_snippets_call_args.hpp"
 #include "emitters/snippets/utils/utils.hpp"
 #include "emitters/utils.hpp"
 #include "openvino/core/node.hpp"
@@ -151,7 +152,7 @@ uintptr_t jit_gemm_emitter::get_compiled_kernel_ptr() const {
     return reinterpret_cast<const uintptr_t>(m_kernel_executor_kai.get());
 }
 
-const uintptr_t jit_gemm_emitter::get_execute_function_ptr() {
+uintptr_t jit_gemm_emitter::get_execute_function_ptr() {
     auto execute_func_ptr =
         static_cast<void (*)(const GemmKaiKernelExecutor*, const GemmKaiKernelExecutor::call_args*)>(
             GemmKaiKernelExecutor::execute);

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_gemm_emitter.hpp
@@ -4,18 +4,20 @@
 
 #pragma once
 
-#include "emitters/plugin/aarch64/jit_emitter.hpp"
+#include "emitters/snippets/aarch64/jit_binary_call_emitter.hpp"
 #include "emitters/snippets/aarch64/kernel_executors/gemm.hpp"
 #include "emitters/snippets/brgemm_generic.hpp"
+#include "snippets/emitter.hpp"
 
 namespace ov::intel_cpu::aarch64 {
 
-class jit_gemm_emitter : public jit_emitter {
+class jit_gemm_emitter : public jit_binary_call_emitter {
 public:
     jit_gemm_emitter(dnnl::impl::cpu::aarch64::jit_generator* h,
                      dnnl::impl::cpu::aarch64::cpu_isa_t isa,
                      const ov::snippets::lowered::ExpressionPtr& expr,
-                     const snippets::KernelExecutorTablePtr& kernel_table);
+                     const snippets::KernelExecutorTablePtr& kernel_table,
+                     const std::set<snippets::Reg>& live_regs = {});
 
     size_t get_inputs_count() const override {
         return 2;
@@ -27,6 +29,7 @@ public:
 protected:
     void validate_arguments(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
     void emit_impl(const std::vector<size_t>& in, const std::vector<size_t>& out) const override;
+    void emit_call(const std::vector<size_t>& mem_ptrs_idxs) const;
 
     static uintptr_t get_execute_function_ptr();
     uintptr_t get_compiled_kernel_ptr() const;

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_memory_emitters.cpp
@@ -147,9 +147,6 @@ void jit_memory_emitter::emit_code_impl(const std::vector<size_t>& in_idxs,
                ptr(reg_runtime_params,
                    static_cast<int32_t>(GET_OFF(buffer_offsets) + buffer_cluster_id * sizeof(size_t))));
         // bump the pointer
-        // TODO: Consider ISA limitations on offset size - large offsets may require multiple operations
-        //       for both h->add and h->sub instructions to handle cases where offset exceeds immediate
-        //       value limits
         h->add(data_reg, data_reg, aux_gpr);
     }
 
@@ -157,9 +154,6 @@ void jit_memory_emitter::emit_code_impl(const std::vector<size_t>& in_idxs,
 
     if (is_offset_runtime) {
         // subtract back so we leave the pointer unchanged for the caller
-        // TODO: Consider ISA limitations on offset size - large offsets may require multiple operations
-        //       for both h->add and h->sub instructions to handle cases where offset exceeds immediate
-        //       value limits
         h->sub(data_reg, data_reg, aux_gpr);
     }
 

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/kernel_executors/gemm.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/kernel_executors/gemm.cpp
@@ -96,4 +96,11 @@ void GemmKaiKernelExecutor::execute(const GemmKaiKernelExecutor* executor, void*
     }
 }
 
+void GemmKaiKernelExecutor::execute(const GemmKaiKernelExecutor* executor, const call_args* args) {
+    if (!executor || !args)
+        return;
+
+    execute(executor, const_cast<void*>(args->A), const_cast<void*>(args->B), args->C);
+}
+
 }  // namespace ov::intel_cpu::aarch64

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/kernel_executors/gemm.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/kernel_executors/gemm.hpp
@@ -54,6 +54,13 @@ struct GemmCompiledKernel {
 
 class GemmKaiKernelExecutor : public snippets::KernelExecutor<GemmKernelKaiConfig, GemmCompiledKernel> {
 public:
+    struct call_args {
+        const void* A;
+        const void* B;
+        void* C;
+        void* scratch;
+    };
+
     GemmKaiKernelExecutor(GemmKernelKaiConfig config);
 
     // No need kernel update, just update config is enough for update. The universal ukernel is reused with any config.
@@ -62,6 +69,9 @@ public:
 
     // Function that will be called in runtime to execute the kernel
     static void execute(const GemmKaiKernelExecutor* executor, void* in0, void* in1, void* out0);
+
+    // ABI-compliant execute function that takes call_args structure
+    static void execute(const GemmKaiKernelExecutor* executor, const call_args* args);
 
 private:
     void update_config(const ov::snippets::lowered::ExpressionPtr& expr,

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -510,8 +510,6 @@ std::vector<std::string> disabledTestPatterns() {
     // smoke_Snippets test cases are not supported on arm64 platforms, except for listed below
     retVector.emplace_back(R"(smoke_Snippets(?!_Eltwise|_Convert|_Transpose|_FQDecomposition_|_BroadcastSelect|_Select|_MatMul/|_MatMulBias|_Reduce|_Softmax|_AddSoftmax).*)");
     retVector.emplace_back(R"(smoke_Snippets_TransposeMatMulBias.*)");
-    // TODO: support for long offsets is required for MatMulBias tests with bigger shapes
-    retVector.emplace_back(R"(smoke_Snippets_MatMulBias.*1023.*)");
 #endif
 #if defined(_WIN32)
     retVector.emplace_back(R"(.*smoke_QuantizedConvolutionBatchNormTransposeOnWeights/QuantizedConvolutionBatchNorm.CompareWithRefs/conv_type=convolution_quantize_type=fake_quantize_intervals_type=per_(tensor|channel)_transpose_on_weights=true_device=CPU.*)");


### PR DESCRIPTION
### Details:
 - Introduce jit_binary_call emitter on ARM for calling external functions in a more unified way and switch Gemm and GemmCopyB emitters to use it
 - Fix large offsets issue in Gemm
 - Fix register allocation and splilling
 - Enable all MatMulBias tests

### Tickets:
 - *ticket-id*
