### PR TITLE
[SHARED_TESTS] Replace 'std::tie' with structured bindings where possible

### DIFF
--- a/src/tests/functional/base_func_tests/include/behavior/compiled_model/compiled_model_base.hpp
+++ b/src/tests/functional/base_func_tests/include/behavior/compiled_model/compiled_model_base.hpp
@@ -76,9 +76,8 @@ class OVCompiledModelBaseTest : public testing::WithParamInterface<InferRequestP
                                 public OVCompiledNetworkTestBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<InferRequestParams> obj) {
-        std::string targetDevice;
-        ov::AnyMap configuration;
-        std::tie(targetDevice, configuration) = obj.param;
+        const auto& [_targetDevice, configuration] = obj.param;
+        auto targetDevice = _targetDevice;
         std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
 
         std::ostringstream result;
@@ -696,10 +695,8 @@ class CompiledModelSetType : public testing::WithParamInterface<CompiledModelSet
                              public OVCompiledNetworkTestBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<CompiledModelSetTypeParams> obj) {
-        ov::element::Type convert_type;
-        std::string target_device;
-        ov::AnyMap configuration;
-        std::tie(convert_type, target_device, configuration) = obj.param;
+        const auto& [convert_type, _target_device, configuration] = obj.param;
+        auto target_device = _target_device;
         std::replace(target_device.begin(), target_device.end(), ':', '.');
 
         std::ostringstream result;

--- a/src/tests/functional/base_func_tests/include/behavior/ov_infer_request/properties_tests.hpp
+++ b/src/tests/functional/base_func_tests/include/behavior/ov_infer_request/properties_tests.hpp
@@ -37,10 +37,7 @@ public:
     }
 
     static std::string getTestCaseName(testing::TestParamInfo<InferRequestPropertiesParams> obj) {
-        std::string target_device;
-        size_t streamExecutorNumber;
-        ov::AnyMap configuration;
-        std::tie(streamExecutorNumber, target_device, configuration) = obj.param;
+        const auto& [streamExecutorNumber, target_device, configuration] = obj.param;
         std::ostringstream result;
         result << "target_device=" << target_device << "_";
         result << "streamExecutorNumber=" << target_device << "_";

--- a/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_behavior_test_utils.hpp
+++ b/src/tests/functional/base_func_tests/include/shared_test_classes/base/ov_behavior_test_utils.hpp
@@ -132,9 +132,8 @@ class OVInferRequestTests : public testing::WithParamInterface<InferRequestParam
                             public OVInferRequestTestBase {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<InferRequestParams> obj) {
-        std::string targetDevice;
-        ov::AnyMap configuration;
-        std::tie(targetDevice, configuration) = obj.param;
+        const auto& [_targetDevice, configuration] = obj.param;
+        auto targetDevice = _targetDevice;
         std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
         std::ostringstream result;
         result << "targetDevice=" << targetDevice << "_";

--- a/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
+++ b/src/tests/functional/base_func_tests/src/base/ov_subgraph.cpp
@@ -119,15 +119,13 @@ void SubgraphBaseTest::serialize() {
 
     auto result = core->read_model(out_xml_path, out_bin_path);
 
-    bool success;
-    std::string message;
-    std::tie(success, message) = compare_functions(result,
-                                                   function,
-                                                   false,
-                                                   false,
-                                                   false,
-                                                   true,   // precision
-                                                   true);  // attributes
+    const auto& [success, message] = compare_functions(result,
+                                                       function,
+                                                       false,
+                                                       false,
+                                                       false,
+                                                       true,   // precision
+                                                       true);  // attributes
 
     EXPECT_TRUE(success) << message;
 
@@ -519,8 +517,8 @@ void SubgraphBaseTest::validate() {
 }
 
 void SubgraphBaseTest::init_thresholds() {
-    double max_abs_threshold = 0.f, max_rel_threshold = 0.f;
-    std::tie(max_abs_threshold, max_rel_threshold) = ov::test::utils::calculate_thresholds_by_model(function, functionRefs, inference_precision);
+    const auto& [max_abs_threshold, max_rel_threshold] =
+        ov::test::utils::calculate_thresholds_by_model(function, functionRefs, inference_precision);
     if (abs_threshold == disable_threshold) {
         abs_threshold = max_abs_threshold;
     }

--- a/src/tests/functional/base_func_tests/src/behavior/compiled_model/import_export.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/compiled_model/import_export.cpp
@@ -17,10 +17,8 @@ namespace test {
 namespace behavior {
 
 std::string OVCompiledGraphImportExportTest::getTestCaseName(testing::TestParamInfo<OVCompiledGraphImportExportTestParams> obj) {
-    ov::element::Type_t elementType;
-    std::string targetDevice;
-    ov::AnyMap configuration;
-    std::tie(elementType, targetDevice, configuration) = obj.param;
+    const auto& [elementType, _targetDevice, configuration] = obj.param;
+    auto targetDevice = _targetDevice;
     std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << "_";
@@ -313,10 +311,8 @@ TEST_P(OVClassCompiledModelImportExportTestP, smoke_ImportNetworkThrowWithDevice
 //
 
 std::string OVCompiledModelGraphUniqueNodeNamesTest::getTestCaseName(testing::TestParamInfo<OVCompiledModelGraphUniqueNodeNamesTestParams> obj) {
-    ov::element::Type netPrecision;
-    ov::Shape inputShapes;
-    std::string targetDevice;
-    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    const auto& [netPrecision, inputShapes, _targetDevice] = obj.param;
+    auto targetDevice = _targetDevice;
     std::replace(targetDevice.begin(), targetDevice.end(), ':', '_');
 
     std::ostringstream result;
@@ -327,10 +323,9 @@ std::string OVCompiledModelGraphUniqueNodeNamesTest::getTestCaseName(testing::Te
 }
 
 void OVCompiledModelGraphUniqueNodeNamesTest::SetUp() {
-    ov::Shape inputShape;
-    ov::element::Type netPrecision;
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    std::tie(netPrecision, inputShape, target_device) = this->GetParam();
+    const auto& [netPrecision, inputShape, _target_device] = this->GetParam();
+    target_device = _target_device;
 
     APIBaseTest::SetUp();
 
@@ -785,9 +780,7 @@ TEST_P(OVExecGraphSerializationTest, ExecutionGraph) {
     }
     ASSERT_TRUE(result.load_file(m_out_xml_path.c_str()));
 
-    bool status;
-    std::string message;
-    std::tie(status, message) = this->compare_docs(expected, result);
+    const auto& [status, message] = this->compare_docs(expected, result);
 
     ASSERT_TRUE(status) << message;
 }

--- a/src/tests/functional/base_func_tests/src/behavior/compiled_model/properties.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/compiled_model/properties.cpp
@@ -27,9 +27,8 @@ void OVClassCompiledModelEmptyPropertiesTests::SetUp() {
 }
 
 std::string OVClassCompiledModelPropertiesTests::getTestCaseName(testing::TestParamInfo<PropertiesParams> obj) {
-    std::string targetDevice;
-    AnyMap properties;
-    std::tie(targetDevice, properties) = obj.param;
+    const auto& [_targetDevice, properties] = obj.param;
+    auto targetDevice = _targetDevice;
     std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << "_";
@@ -55,9 +54,8 @@ void OVClassCompiledModelPropertiesTests::TearDown() {
 
 // check properties
 std::string OVCompileModelGetExecutionDeviceTests::getTestCaseName(testing::TestParamInfo<OvPropertiesParams> obj) {
-    std::string target_device;
-    std::pair<ov::AnyMap, std::string> userConfig;
-    std::tie(target_device, userConfig) = obj.param;
+    const auto& [_target_device, userConfig] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     auto compileModelProperties = userConfig.first;
     std::ostringstream result;
@@ -71,8 +69,9 @@ std::string OVCompileModelGetExecutionDeviceTests::getTestCaseName(testing::Test
 
 void OVCompileModelGetExecutionDeviceTests::SetUp() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    std::pair<ov::AnyMap, std::string> userConfig;
-    std::tie(target_device, userConfig) = GetParam();
+
+    const auto& [_target_device, userConfig] = GetParam();
+    target_device = _target_device;
     compileModelProperties = userConfig.first;
     expectedDeviceName = userConfig.second;
     model = ov::test::utils::make_conv_pool_relu();
@@ -164,9 +163,8 @@ TEST_P(OVClassCompiledModelPropertiesDefaultTests, CheckDefaultValues) {
 }
 
 std::string OVClassCompiledModelGetPropertyTest_Priority::getTestCaseName(testing::TestParamInfo<PriorityParams> obj) {
-    std::string target_device;
-    ov::AnyMap userConfig;
-    std::tie(target_device, userConfig) = obj.param;
+    const auto& [_target_device, userConfig] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     auto compileModelProperties = userConfig;
     std::ostringstream result;

--- a/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/infer_correctness.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/infer_correctness.cpp
@@ -89,10 +89,7 @@ void OVInferConsistencyTest::TearDown() {
 }
 std::string OVInferConsistencyTest::getTestCaseName(const
     testing::TestParamInfo<ParamType>& obj) {
-    unsigned int inferReqNumPerModel; //inferRequst nums per model
-    unsigned int inferNumPerInfer; //infer nums wil do per  inferRequest
-    std::vector<std::pair<std::string, ov::AnyMap>> deviceConfigs; // devicesConfigs
-    std::tie(inferReqNumPerModel, inferNumPerInfer, deviceConfigs) = obj.param;
+    const auto& [inferReqNumPerModel, inferNumPerInfer, deviceConfigs] = obj.param;
     std::ostringstream result;
     for (auto&& item : deviceConfigs) {
         result << "device_" << item.first << "_";

--- a/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/infer_request_dynamic.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/infer_request_dynamic.cpp
@@ -13,11 +13,8 @@ namespace test {
 namespace behavior {
 
 std::string OVInferRequestDynamicTests::getTestCaseName(testing::TestParamInfo<OVInferRequestDynamicParams> obj) {
-    std::shared_ptr<Model> func;
-    std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>> inOutShapes;
-    std::string target_device;
-    ov::AnyMap configuration;
-    std::tie(func, inOutShapes, target_device, configuration) = obj.param;
+    const auto& [func, inOutShapes, _target_device, configuration] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     std::ostringstream result;
     result << "function=" << func->get_friendly_name() << "_";

--- a/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/io_tensor.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/io_tensor.cpp
@@ -284,10 +284,8 @@ TEST_P(OVInferRequestIOTensorTest, CheckInferIsNotChangeInput) {
 }
 
 std::string OVInferRequestIOTensorSetPrecisionTest::getTestCaseName(const testing::TestParamInfo<OVInferRequestSetPrecisionParams>& obj) {
-    element::Type type;
-    std::string target_device;
-    ov::AnyMap configuration;
-    std::tie(type, target_device, configuration) = obj.param;
+    const auto& [type, _target_device, configuration] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     std::ostringstream result;
     result << "type=" << type << "_";
@@ -341,10 +339,7 @@ TEST_P(OVInferRequestIOTensorSetPrecisionTest, CanSetOutBlobWithDifferentPrecisi
 }
 
 std::string OVInferRequestCheckTensorPrecision::getTestCaseName(const testing::TestParamInfo<OVInferRequestCheckTensorPrecisionParams>& obj) {
-    element::Type type;
-    std::string target_device;
-    AnyMap configuration;
-    std::tie(type, target_device, configuration) = obj.param;
+    const auto& [type, target_device, configuration] = obj.param;
     std::ostringstream result;
     result << "type=" << type << "_";
     result << "target_device=" << target_device << "_";

--- a/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/memory_states.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/memory_states.cpp
@@ -16,11 +16,8 @@ namespace behavior {
 
 std::string OVInferRequestVariableStateTest::getTestCaseName(const testing::TestParamInfo<memoryStateParams>& obj) {
     std::ostringstream result;
-    std::shared_ptr<ov::Model> net;
-    std::string deviceName;
-    std::vector<std::string> statesToQuery;
-    ov::AnyMap configuration;
-    std::tie(net, statesToQuery, deviceName, configuration) = obj.param;
+
+    const auto& [net, statesToQuery, deviceName, configuration] = obj.param;
     result << "targetDevice=" << deviceName;
     if (!configuration.empty()) {
         using namespace ov::test::utils;

--- a/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/perf_counters.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_infer_request/perf_counters.cpp
@@ -21,9 +21,8 @@ void OVInferRequestPerfCountersTest::SetUp() {
 }
 
 std::string OVInferRequestPerfCountersTest::getTestCaseName(testing::TestParamInfo<InferRequestParams> obj) {
-    std::string targetDevice;
-    ov::AnyMap configuration;
-    std::tie(targetDevice, configuration) = obj.param;
+    const auto& [_targetDevice, configuration] = obj.param;
+    auto targetDevice = _targetDevice;
     std::replace(targetDevice.begin(), targetDevice.end(), ':', '.');
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << "_";

--- a/src/tests/functional/base_func_tests/src/behavior/ov_plugin/caching_tests.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_plugin/caching_tests.cpp
@@ -178,8 +178,11 @@ std::string CompileModelCacheTestBase::getTestCaseName(testing::TestParamInfo<co
 }
 
 void CompileModelCacheTestBase::SetUp() {
-    ovModelWithName funcPair;
-    std::tie(funcPair, m_precision, m_batchSize, targetDevice, configuration) = GetParam();
+    const auto& [funcPair, _m_precision, _m_batchSize, _targetDevice, _configuration] = GetParam();
+    m_precision = _m_precision;
+    m_batchSize = _m_batchSize;
+    targetDevice = _targetDevice;
+    configuration = _configuration;
     target_device = targetDevice;
     APIBaseTest::SetUp();
     auto fGen = std::get<0>(funcPair);
@@ -739,9 +742,8 @@ TEST_P(CompileModelLoadFromMemoryTestBase, CanLoadFromMemoryWithoutWeightsANdExe
 
 std::string CompiledKernelsCacheTest::getTestCaseName(testing::TestParamInfo<compileKernelsCacheParams> obj) {
     auto param = obj.param;
-    std::string deviceName;
-    std::pair<ov::AnyMap, std::string> userConfig;
-    std::tie(deviceName, userConfig) = obj.param;
+    const auto& [_deviceName, userConfig] = obj.param;
+    auto deviceName = _deviceName;
     std::replace(deviceName.begin(), deviceName.end(), ':', '.');
     auto properties = userConfig.first;
     std::ostringstream result;
@@ -755,8 +757,9 @@ std::string CompiledKernelsCacheTest::getTestCaseName(testing::TestParamInfo<com
 
 void CompiledKernelsCacheTest::SetUp() {
     function = ov::test::utils::make_conv_pool_relu();
-    std::pair<ov::AnyMap, std::string> userConfig;
-    std::tie(targetDevice, userConfig) = GetParam();
+
+    const auto& [_targetDevice, userConfig] = GetParam();
+    targetDevice = _targetDevice;
     target_device = targetDevice;
     APIBaseTest::SetUp();
     SKIP_IF_CURRENT_TEST_IS_DISABLED();

--- a/src/tests/functional/base_func_tests/src/behavior/ov_plugin/hetero_synthetic.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_plugin/hetero_synthetic.cpp
@@ -27,9 +27,7 @@ static std::vector<std::function<std::shared_ptr<ov::Model>()>> builders = {
 };
 
 std::string OVHeteroSyntheticTest::getTestCaseName(const ::testing::TestParamInfo<OVHeteroSyntheticTestParameters>& obj) {
-    std::vector<PluginParameter> pluginParameters;
-    FunctionParameter functionParamter;
-    std::tie(pluginParameters, functionParamter) = obj.param;
+    const auto& [pluginParameters, functionParamter] = obj.param;
     std::string name = "function=" + functionParamter._function->get_friendly_name();
     name += "_layers=";
     std::size_t num = functionParamter._majorPluginNodeIds.size() - 1;

--- a/src/tests/functional/base_func_tests/src/behavior/ov_plugin/properties_tests.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_plugin/properties_tests.cpp
@@ -13,9 +13,8 @@ namespace test {
 namespace behavior {
 
 std::string OVPropertiesTests::getTestCaseName(testing::TestParamInfo<PropertiesParams> obj) {
-    std::string target_device;
-    AnyMap properties;
-    std::tie(target_device, properties) = obj.param;
+    const auto& [_target_device, properties] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     std::ostringstream result;
     result << "target_device=" << target_device << "_";
@@ -40,10 +39,8 @@ void OVPropertiesTests::TearDown() {
 }
 
 std::string OVSetPropComplieModleGetPropTests::getTestCaseName(testing::TestParamInfo<CompileModelPropertiesParams> obj) {
-    std::string target_device;
-    AnyMap properties;
-    AnyMap compileModelProperties;
-    std::tie(target_device, properties, compileModelProperties) = obj.param;
+    const auto& [_target_device, properties, compileModelProperties] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     std::ostringstream result;
     result << "target_device=" << target_device << "_";
@@ -63,9 +60,8 @@ void OVSetPropComplieModleGetPropTests::SetUp() {
 }
 
 std::string OVPropertiesTestsWithCompileModelProps::getTestCaseName(testing::TestParamInfo<PropertiesParams> obj) {
-    std::string target_device;
-    AnyMap properties;
-    std::tie(target_device, properties) = obj.param;
+    const auto& [_target_device, properties] = obj.param;
+    auto target_device = _target_device;
     std::replace(target_device.begin(), target_device.end(), ':', '.');
     std::ostringstream result;
     result << "target_device=" << target_device << "_";
@@ -77,8 +73,9 @@ std::string OVPropertiesTestsWithCompileModelProps::getTestCaseName(testing::Tes
 
 void OVPropertiesTestsWithCompileModelProps::SetUp() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    std::string temp_device;
-    std::tie(temp_device, properties) = this->GetParam();
+
+    const auto& [temp_device, _properties] = this->GetParam();
+    properties = _properties;
 
     std::string::size_type pos = temp_device.find(":", 0);
     if (pos != std::string::npos) {

--- a/src/tests/functional/base_func_tests/src/behavior/ov_plugin/remote.cpp
+++ b/src/tests/functional/base_func_tests/src/behavior/ov_plugin/remote.cpp
@@ -11,14 +11,9 @@ namespace ov {
 namespace test {
 
 std::string OVRemoteTest::getTestCaseName(testing::TestParamInfo<RemoteTensorParams> obj) {
-    ov::element::Type element_type;
-    std::string target_device;
-    ov::AnyMap config;
-    std::pair<ov::AnyMap, ov::AnyMap> param_pair;
-    std::tie(element_type, target_device, config, param_pair) = obj.param;
-    ov::AnyMap context_parameters;
-    ov::AnyMap tensor_parameters;
-    std::tie(context_parameters, tensor_parameters) = param_pair;
+    const auto& [element_type, target_device, config, param_pair] = obj.param;
+
+    const auto& [context_parameters, tensor_parameters] = param_pair;
     std::ostringstream result;
     result << "element_type=" << element_type;
     result << "targetDevice=" << target_device;
@@ -42,8 +37,11 @@ std::string OVRemoteTest::getTestCaseName(testing::TestParamInfo<RemoteTensorPar
 
 void OVRemoteTest::SetUp() {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
-    std::pair<ov::AnyMap, ov::AnyMap> param_pair;
-    std::tie(element_type, target_device, config, param_pair) = GetParam();
+
+    const auto& [_element_type, _target_device, _config, param_pair] = GetParam();
+    element_type = _element_type;
+    target_device = _target_device;
+    config = _config;
     std::tie(context_parameters, tensor_parameters) = param_pair;
     function = ov::test::utils::make_conv_pool_relu({1, 1, 32, 32}, element_type);
     exec_network = core.compile_model(function, target_device, config);

--- a/src/tests/functional/plugin/conformance/subgraphs_dumper/src/cache/graph_cache.cpp
+++ b/src/tests/functional/plugin/conformance/subgraphs_dumper/src/cache/graph_cache.cpp
@@ -123,9 +123,8 @@ void GraphCache::update_cache(const std::shared_ptr<ov::Model>& extracted_model,
                                                                        input_info, cached_model.second.get_input_info());
                     // in case if one model is subgraph of other to update model meta info and remove subgraph from cache
                     if (std::get<0>(is_subgraph)) {
-                        std::shared_ptr<ov::Model> graph, subgraph;
-                        std::map<std::string, ov::conformance::InputInfo> graph_in_info, subgraph_in_info;
-                        std::tie(std::ignore, subgraph, graph, subgraph_in_info, graph_in_info) = is_subgraph;
+                        const auto& [_ignore, subgraph, graph, subgraph_in_info, graph_in_info] = is_subgraph;
+                        std::ignore = _ignore;
                         if (subgraph == cached_model.first) {
                             auto meta = m_graph_cache[subgraph];
                             meta.set_input_info(graph_in_info);

--- a/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
+++ b/src/tests/functional/plugin/conformance/test_runner/op_conformance_runner/src/read_ir/read_ir.cpp
@@ -30,11 +30,10 @@ namespace op_conformance {
 
 std::string ReadIRTest::getTestCaseName(const testing::TestParamInfo<ReadIRParams> &obj) {
     using namespace ov::test::utils;
+    const auto& [path_to_model, path_to_ref_tensor] = obj.param;
     std::pair<std::string, std::string> model_pair;
-    std::string path_to_model, path_to_ref_tensor, deviceName = ov::test::utils::target_device;
     ov::AnyMap config = ov::test::utils::global_plugin_config;
-    std::tie(path_to_model, path_to_ref_tensor) = obj.param;
-
+    const std::string deviceName = ov::test::utils::target_device;
     std::ostringstream result;
 
     enum class IR_TYPE {

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/group_normalization.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/single_op/group_normalization.hpp
@@ -23,13 +23,8 @@ class GroupNormalizationTest : public testing::WithParamInterface<GroupNormaliza
                                virtual public ov::test::SubgraphBaseTest {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<GroupNormalizationTestParams> &obj) {
-        ElementType netType, inType, outType;
-        InputShape shapes;
-        std::int64_t num_groups;
-        double epsilon;
-        TargetDevice targetDevice;
-        ov::AnyMap additional_config;
-        std::tie(netType, inType, outType, shapes, num_groups, epsilon, targetDevice, additional_config) = obj.param;
+        const auto& [netType, inType, outType, shapes, num_groups, epsilon, targetDevice, additional_config] =
+            obj.param;
 
         std::ostringstream result;
         result << "NetType=" << netType << "_";
@@ -53,13 +48,11 @@ public:
 
 protected:
     void SetUp() override {
-        InputShape shapes;
-        ElementType ngPrc;
-        std::int64_t num_groups;
-        double epsilon;
-        ov::AnyMap additional_config;
-
-        std::tie(ngPrc, inType, outType, shapes, num_groups, epsilon, targetDevice, additional_config) = this->GetParam();
+        const auto& [ngPrc, _inType, _outType, shapes, num_groups, epsilon, _targetDevice, additional_config] =
+            this->GetParam();
+        inType = _inType;
+        outType = _outType;
+        targetDevice = _targetDevice;
         InputShape biasInputShape = ExtractBiasShape(shapes);
         init_input_shapes({shapes, biasInputShape, biasInputShape});
         ov::ParameterVector params;

--- a/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/stateful_model.hpp
+++ b/src/tests/functional/plugin/shared/include/shared_test_classes/subgraph/stateful_model.hpp
@@ -237,9 +237,8 @@ public:
             auto outputTensor = inferRequest.get_output_tensor(0);
             ASSERT_TRUE(outputTensor);
             inferRequest.infer();
-            std::vector<float> expected_state0;
-            std::vector<float> expected_results;
-            std::tie(expected_state0, expected_results) = calc_refs();
+
+            const auto& [expected_state0, expected_results] = calc_refs();
 
             auto states = inferRequest.query_state();
             ASSERT_FALSE(states.empty());
@@ -538,9 +537,8 @@ public:
             ASSERT_TRUE(outputTensor1);
             ASSERT_TRUE(outputTensor2);
             inferRequest.infer();
-            std::vector<float> result1;
-            std::vector<float> result2;
-            std::tie(result1, result2) = calc_refs(input_shape, vec_state);
+
+            const auto& [result1, result2] = calc_refs(input_shape, vec_state);
             ASSERT_EQ(result1.size(), outputTensor1.get_shape()[1]);
             ASSERT_EQ(result2.size(), outputTensor2.get_shape()[1]);
             auto actual_res1 = outputTensor1.data<ov::element_type_traits<testPrc>::value_type>();

--- a/src/tests/functional/plugin/shared/include/subgraph_tests/parameter_result.hpp
+++ b/src/tests/functional/plugin/shared/include/subgraph_tests/parameter_result.hpp
@@ -15,8 +15,8 @@ TEST_P(ParameterResultSubgraphTest, Inference) {
 }
 
 TEST_P(ParameterResultSubgraphTest, CheckSharedTensor) {
-    ov::test::InputShape input_shape;
-    std::tie(input_shape, targetDevice) = this->GetParam();
+    const auto& [input_shape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     ov::Shape shape = input_shape.second[0];
     auto input = ov::Tensor(ov::element::f32, shape);

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/add_output.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/add_output.cpp
@@ -11,10 +11,8 @@
 
 std::string AddOutputsTest::getTestCaseName(const testing::TestParamInfo<addOutputsParams> &obj) {
     std::ostringstream results;
-    std::shared_ptr<ov::Model> net;
-    std::vector<std::string> outputsToAdd;
-    std::string deviceName;
-    std::tie(net, outputsToAdd, deviceName) = obj.param;
+
+    const auto& [net, outputsToAdd, deviceName] = obj.param;
     results << "Outputs=" << ov::test::utils::vec2str<std::string>(outputsToAdd);
     results << "Dev=" << deviceName;
     return results.str();
@@ -25,10 +23,7 @@ void AddOutputsTest::SetUp() {
 }
 
 TEST_P(AddOutputsTest, smoke_CheckOutputExist) {
-    std::shared_ptr<ov::Model> net;
-    std::vector<std::string> outputsToAdd;
-    std::string deviceName;
-    std::tie(net, outputsToAdd, deviceName) = GetParam();
+    const auto& [net, outputsToAdd, deviceName] = GetParam();
     std::vector<std::string> expectedOutputs = outputsToAdd;
     for (const auto &out : net->outputs()) {
         expectedOutputs.push_back(out.get_any_name());

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/disable_lowering_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/disable_lowering_precision.cpp
@@ -24,11 +24,8 @@ namespace ExecutionGraphTests {
 
 std::string ExecGraphDisableLoweringPrecision::getTestCaseName(testing::TestParamInfo<ExecGraphDisableLoweringPrecisionSpecificParams> obj) {
     std::ostringstream result;
-    bool disableLoweringPrecision;
-    std::string targetDevice;
-    ov::element::Type loweringPrecision;
 
-    std::tie(disableLoweringPrecision, targetDevice, loweringPrecision) = obj.param;
+    const auto& [disableLoweringPrecision, targetDevice, loweringPrecision] = obj.param;
     result << "matmul_disable_lowingprecision=" << disableLoweringPrecision << "_";
     result << "device=" << targetDevice << "_";
     result << "loweringPrecision=" << loweringPrecision.to_string();

--- a/src/tests/functional/plugin/shared/src/execution_graph_tests/runtime_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/execution_graph_tests/runtime_precision.cpp
@@ -76,10 +76,7 @@ std::shared_ptr<ov::Model> makeFakeQuantizeBinaryConvolutionFunction(const std::
 }
 
 std::string ExecGraphRuntimePrecision::getTestCaseName(testing::TestParamInfo<ExecGraphRuntimePrecisionParams> obj) {
-    RuntimePrecisionSpecificParams specificParams;
-    std::string targetDevice;
-    std::tie(specificParams, targetDevice) = obj.param;
-
+    const auto& [specificParams, targetDevice] = obj.param;
     std::ostringstream result;
     result << "Function=" << specificParams.makeFunction(specificParams.inputPrecisions)->get_friendly_name() << "_";
     result << "InPrcs=" << ov::test::utils::vec2str(specificParams.inputPrecisions) << "_";
@@ -89,8 +86,8 @@ std::string ExecGraphRuntimePrecision::getTestCaseName(testing::TestParamInfo<Ex
 }
 
 void ExecGraphRuntimePrecision::SetUp() {
-    RuntimePrecisionSpecificParams specificParams;
-    std::tie(specificParams, targetDevice) = this->GetParam();
+    const auto& [specificParams, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     expectedPrecisions = specificParams.expectedPrecisions;
     fnPtr = specificParams.makeFunction(specificParams.inputPrecisions);
 }

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/eliminate_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/eliminate_fake_quantize_transformation.cpp
@@ -16,9 +16,7 @@
 namespace LayerTestsDefinitions {
 
 std::string EliminateFakeQuantizeTransformation::getTestCaseName(const testing::TestParamInfo<EliminateFakeQuantizeTransformationParams>& obj) {
-    std::string targetDevice;
-    EliminateFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = obj.param;
+    const auto& [targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result << targetDevice << "_" <<
@@ -29,8 +27,8 @@ std::string EliminateFakeQuantizeTransformation::getTestCaseName(const testing::
 }
 
 void EliminateFakeQuantizeTransformation::SetUp() {
-    EliminateFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = this->GetParam();
+    const auto& [_targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 
@@ -51,8 +49,8 @@ TEST_P(EliminateFakeQuantizeTransformation, CompareWithRefImpl) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED();
     run();
 
-    EliminateFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = this->GetParam();
+    const auto& [_targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const auto& rtInfo = LayerTransformation::get_runtime_info();
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_dequantize_to_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_dequantize_to_fake_quantize_transformation.cpp
@@ -15,9 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string FuseDequantizeToFakeQuantizeTransformation::getTestCaseName(const testing::TestParamInfo<FuseDequantizeToFakeQuantizeTransformationParams>& obj) {
-    std::string targetDevice;
-    FuseDequantizeToFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = obj.param;
+    const auto& [targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result << targetDevice << "_" <<
@@ -33,8 +31,8 @@ std::string FuseDequantizeToFakeQuantizeTransformation::getTestCaseName(const te
 }
 
 void FuseDequantizeToFakeQuantizeTransformation::SetUp() {
-    FuseDequantizeToFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = this->GetParam();
+    const auto& [_targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_multiply_to_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_multiply_to_fake_quantize_transformation.cpp
@@ -15,9 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string FuseMultiplyToFakeQuantizeTransformation::getTestCaseName(const testing::TestParamInfo<FuseMultiplyToFakeQuantizeTransformationParams>& obj) {
-    std::string targetDevice;
-    FuseMultiplyToFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = obj.param;
+    const auto& [targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result << targetDevice << "_" <<
@@ -27,8 +25,8 @@ std::string FuseMultiplyToFakeQuantizeTransformation::getTestCaseName(const test
 }
 
 void FuseMultiplyToFakeQuantizeTransformation::SetUp() {
-    FuseMultiplyToFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = this->GetParam();
+    const auto& [_targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_subtract_to_fake_quantize_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/fuse_subtract_to_fake_quantize_transformation.cpp
@@ -15,9 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string FuseSubtractToFakeQuantizeTransformation::getTestCaseName(const testing::TestParamInfo<FuseSubtractToFakeQuantizeTransformationParams>& obj) {
-    std::string targetDevice;
-    FuseSubtractToFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = obj.param;
+    const auto& [targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result << targetDevice << "_" <<
@@ -27,8 +25,8 @@ std::string FuseSubtractToFakeQuantizeTransformation::getTestCaseName(const test
 }
 
 void FuseSubtractToFakeQuantizeTransformation::SetUp() {
-    FuseSubtractToFakeQuantizeTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = this->GetParam();
+    const auto& [_targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/gather_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/gather_transformation.cpp
@@ -15,11 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string GatherTransformation::getTestCaseName(const testing::TestParamInfo<GatherTransformationParams>& obj) {
-    ov::element::Type precision;
-    std::string targetDevice;
-    GatherTransformationTestValues testValues;
-    int opset_version;
-    std::tie(precision, targetDevice, testValues, opset_version) = obj.param;
+    const auto& [precision, targetDevice, testValues, opset_version] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -32,10 +28,8 @@ std::string GatherTransformation::getTestCaseName(const testing::TestParamInfo<G
 }
 
 void GatherTransformation::SetUp() {
-    ov::element::Type precision;
-    GatherTransformationTestValues testValues;
-    int opset_version;
-    std::tie(precision, targetDevice, testValues, opset_version) = this->GetParam();
+    const auto& [precision, _targetDevice, testValues, opset_version] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_transformation.cpp
@@ -17,11 +17,7 @@
 namespace LayerTestsDefinitions {
 
 std::string MatMulTransformation::getTestCaseName(const testing::TestParamInfo<MatMulTransformationParams>& obj) {
-    ov::element::Type precision;
-    ov::PartialShape inputShape;
-    std::string targetDevice;
-    MatMulTransformationTestValues testValues;
-    std::tie(precision, inputShape, targetDevice, testValues) = obj.param;
+    const auto& [precision, inputShape, targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -39,10 +35,8 @@ std::string MatMulTransformation::getTestCaseName(const testing::TestParamInfo<M
 
 
 void MatMulTransformation::SetUp() {
-    ov::element::Type precision;
-    ov::PartialShape inputShape;
-    MatMulTransformationTestValues testValues;
-    std::tie(precision, inputShape, targetDevice, testValues) = this->GetParam();
+    const auto& [precision, inputShape, _targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes({ testValues.inputShape1, testValues.inputShape2 });
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/mat_mul_with_constant_transformation.cpp
@@ -18,10 +18,7 @@
 namespace LayerTestsDefinitions {
 
 std::string MatMulWithConstantTransformation::getTestCaseName(const testing::TestParamInfo<MatMulWithConstantTransformationParams>& obj) {
-    ov::element::Type precision;
-    std::string targetDevice;
-    MatMulWithConstantTransformationTestValues testValues;
-    std::tie(precision, targetDevice, testValues) = obj.param;
+    const auto& [precision, targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -37,9 +34,8 @@ std::string MatMulWithConstantTransformation::getTestCaseName(const testing::Tes
 
 
 void MatMulWithConstantTransformation::SetUp() {
-    ov::element::Type precision;
-    MatMulWithConstantTransformationTestValues testValues;
-    std::tie(precision, targetDevice, testValues) = this->GetParam();
+    const auto& [precision, _targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_with_one_parent_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/multiply_with_one_parent_transformation.cpp
@@ -15,12 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string MultiplyWithOneParentTransformation::getTestCaseName(const testing::TestParamInfo<MultiplyWithOneParentTransformationParams>& obj) {
-    ov::element::Type netPrecision;
-    ov::PartialShape inputShape;
-    std::string targetDevice;
-    MultiplyWithOneParentTransformationValues values;
-
-    std::tie(netPrecision, inputShape, targetDevice, values) = obj.param;
+    const auto& [netPrecision, inputShape, targetDevice, values] = obj.param;
 
     std::ostringstream result;
     result << netPrecision << "_" << inputShape;
@@ -28,10 +23,8 @@ std::string MultiplyWithOneParentTransformation::getTestCaseName(const testing::
 }
 
 void MultiplyWithOneParentTransformation::SetUp() {
-    ov::element::Type netPrecision;
-    ov::PartialShape inputShape;
-    MultiplyWithOneParentTransformationValues values;
-    std::tie(netPrecision, inputShape, targetDevice, values) = this->GetParam();
+    const auto& [netPrecision, inputShape, _targetDevice, values] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/prelu_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/prelu_transformation.cpp
@@ -15,11 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string PReluTransformation::getTestCaseName(const testing::TestParamInfo<PReluTransformationParams>& obj) {
-    ov::element::Type precision;
-    ov::PartialShape inputShape;
-    std::string targetDevice;
-    PReluTestValues testValues;
-    std::tie(precision, inputShape, targetDevice, testValues) = obj.param;
+    const auto& [precision, inputShape, targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -32,10 +28,8 @@ std::string PReluTransformation::getTestCaseName(const testing::TestParamInfo<PR
 
 
 void PReluTransformation::SetUp() {
-    ov::element::Type precision;
-    ov::PartialShape inputShape;
-    PReluTestValues testValues;
-    std::tie(precision, inputShape, targetDevice, testValues) = this->GetParam();
+    const auto& [precision, inputShape, _targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/relu_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/relu_transformation.cpp
@@ -15,11 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string ReluTransformation::getTestCaseName(const testing::TestParamInfo<ReluTransformationParams>& obj) {
-    ov::element::Type precision;
-    ov::PartialShape inputShape;
-    std::string targetDevice;
-    ReluTestValues testValues;
-    std::tie(precision, inputShape, targetDevice, testValues) = obj.param;
+    const auto& [precision, inputShape, targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -32,10 +28,8 @@ std::string ReluTransformation::getTestCaseName(const testing::TestParamInfo<Rel
 
 
 void ReluTransformation::SetUp() {
-    ov::element::Type precision;
-    ov::PartialShape inputShape;
-    ReluTestValues testValues;
-    std::tie(precision, inputShape, targetDevice, testValues) = this->GetParam();
+    const auto& [precision, inputShape, _targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/space_to_batch_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/space_to_batch_transformation.cpp
@@ -13,10 +13,7 @@
 namespace LayerTestsDefinitions {
 
 std::string SpaceToBatchTransformation::getTestCaseName(const testing::TestParamInfo<SpaceToBatchTransformationParams>& obj) {
-    ov::element::Type input_type;
-    std::string target_device;
-    SpaceToBatchTransformationParam param;
-    std::tie(input_type, target_device, param) = obj.param;
+    const auto& [input_type, target_device, param] = obj.param;
 
     std::ostringstream result;
     result << input_type << "_" << target_device << "_" << param.input_shape << "_" << param.fake_quantize;
@@ -24,9 +21,8 @@ std::string SpaceToBatchTransformation::getTestCaseName(const testing::TestParam
 }
 
 void SpaceToBatchTransformation::SetUp() {
-    ov::element::Type input_type;
-    SpaceToBatchTransformationParam param;
-    std::tie(input_type, targetDevice, param) = this->GetParam();
+    const auto& [input_type, _targetDevice, param] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(param.input_shape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/subtract_multiply_to_multiply_add_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/subtract_multiply_to_multiply_add_transformation.cpp
@@ -15,9 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string SubtractMultiplyToMultiplyAddTransformation::getTestCaseName(const testing::TestParamInfo<SubtractMultiplyToMultiplyAddTransformationParams>& obj) {
-    std::string targetDevice;
-    SubtractMultiplyToMultiplyAddTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = obj.param;
+    const auto& [targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -29,8 +27,8 @@ std::string SubtractMultiplyToMultiplyAddTransformation::getTestCaseName(const t
 }
 
 void SubtractMultiplyToMultiplyAddTransformation::SetUp() {
-    SubtractMultiplyToMultiplyAddTransformationTestValues testValues;
-    std::tie(targetDevice, testValues) = this->GetParam();
+    const auto& [_targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/low_precision_transformations/transpose_transformation.cpp
+++ b/src/tests/functional/plugin/shared/src/low_precision_transformations/transpose_transformation.cpp
@@ -15,10 +15,7 @@
 namespace LayerTestsDefinitions {
 
 std::string TransposeTransformation::getTestCaseName(const testing::TestParamInfo<TransposeTransformationParams>& obj) {
-    ov::element::Type precision;
-    std::string targetDevice;
-    TransposeTransformationTestValues testValues;
-    std::tie(precision, targetDevice, testValues) = obj.param;
+    const auto& [precision, targetDevice, testValues] = obj.param;
 
     std::ostringstream result;
     result <<
@@ -30,9 +27,8 @@ std::string TransposeTransformation::getTestCaseName(const testing::TestParamInf
 }
 
 void TransposeTransformation::SetUp() {
-    ov::element::Type precision;
-    TransposeTransformationTestValues testValues;
-    std::tie(precision, targetDevice, testValues) = this->GetParam();
+    const auto& [precision, _targetDevice, testValues] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(testValues.inputShape);
 

--- a/src/tests/functional/plugin/shared/src/single_op/activation.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/activation.cpp
@@ -14,10 +14,8 @@ namespace ov {
 namespace test {
 using ov::test::utils::ActivationTypes;
 void ActivationLayerTest::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
-    ov::element::Type model_type;
-    std::pair<std::vector<InputShape>, ov::Shape> input_shapes;
-    std::pair<ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, model_type, input_shapes, targetDevice) = GetParam();
+    const auto& [activationDecl, model_type, input_shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     bool inPrcSigned = function->get_parameters()[0]->get_element_type().is_signed();
     int32_t data_start_from;
@@ -120,10 +118,8 @@ void ActivationLayerTest::generate_inputs(const std::vector<ov::Shape>& targetIn
 }
 
 void ActivationParamLayerTest::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
-    ov::element::Type model_type;
-    std::pair<std::vector<InputShape>, ov::Shape> input_shapes;
-    std::pair<ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, model_type, input_shapes, targetDevice) = GetParam();
+    const auto& [activationDecl, model_type, input_shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     auto activationType = activationDecl.first;
     auto constants_value = activationDecl.second;
@@ -164,11 +160,7 @@ void ActivationParamLayerTest::generate_inputs(const std::vector<ov::Shape>& tar
 }
 
 std::string ActivationLayerTest::getTestCaseName(const testing::TestParamInfo<activationParams> &obj) {
-    ov::element::Type model_type;
-    std::pair<std::vector<InputShape>, ov::Shape> input_shapes;
-    std::string target_device;
-    std::pair<ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, model_type, input_shapes, target_device) = obj.param;
+    const auto& [activationDecl, model_type, input_shapes, target_device] = obj.param;
 
     auto shapes = input_shapes.first;
     auto const_shape = input_shapes.second;
@@ -196,10 +188,8 @@ std::string ActivationLayerTest::getTestCaseName(const testing::TestParamInfo<ac
 }
 
 void ActivationLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::pair<std::vector<InputShape>, ov::Shape> input_shapes;
-    std::pair<ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, model_type, input_shapes, targetDevice) = GetParam();
+    const auto& [activationDecl, model_type, input_shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes.first);
     auto const_shape = input_shapes.second;
 
@@ -233,10 +223,8 @@ void ActivationLayerTest::SetUp() {
 }
 
 void ActivationParamLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::pair<std::vector<InputShape>, ov::Shape> input_shapes;
-    std::pair<ActivationTypes, std::vector<float>> activationDecl;
-    std::tie(activationDecl, model_type, input_shapes, targetDevice) = GetParam();
+    const auto& [activationDecl, model_type, input_shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     auto shapes = input_shapes.first;
     auto const_shape = input_shapes.second;
 

--- a/src/tests/functional/plugin/shared/src/single_op/adaptive_pooling.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/adaptive_pooling.cpp
@@ -10,13 +10,7 @@ namespace ov {
 namespace test {
 
 std::string AdaPoolLayerTest::getTestCaseName(const testing::TestParamInfo<adapoolParams>& obj) {
-    std::vector<InputShape> shapes;
-    std::vector<int> pooled_spatial_shape;
-
-    std::string pooling_mode;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(shapes, pooled_spatial_shape, pooling_mode, model_type, target_device) = obj.param;
+    const auto& [shapes, pooled_spatial_shape, pooling_mode, model_type, target_device] = obj.param;
 
     std::ostringstream result;
 
@@ -38,11 +32,8 @@ std::string AdaPoolLayerTest::getTestCaseName(const testing::TestParamInfo<adapo
 }
 
 void AdaPoolLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::vector<int> pooled_spatial_shape;
-    std::string pooling_mode;
-    ov::element::Type model_type;
-    std::tie(shapes, pooled_spatial_shape, pooling_mode, model_type, targetDevice) = this->GetParam();
+    const auto& [shapes, pooled_spatial_shape, pooling_mode, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};

--- a/src/tests/functional/plugin/shared/src/single_op/batch_norm.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/batch_norm.cpp
@@ -10,11 +10,7 @@
 namespace ov {
 namespace test {
 std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<BatchNormLayerTestParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    double epsilon;
-    std::string target_device;
-    std::tie(epsilon, model_type, shapes, target_device) = obj.param;
+    const auto& [epsilon, model_type, shapes, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -34,10 +30,8 @@ std::string BatchNormLayerTest::getTestCaseName(const testing::TestParamInfo<Bat
 }
 
 void BatchNormLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    double epsilon;
-    std::tie(epsilon, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [epsilon, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 

--- a/src/tests/functional/plugin/shared/src/single_op/batch_to_space.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/batch_to_space.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj) {
-    std::vector<InputShape> shapes;
-    std::vector<int64_t> block_shape, crops_begin, crops_end;
-    ov::element::Type model_type;
-    std::string target_name;
-    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, target_name) = obj.param;
+    const auto& [block_shape, crops_begin, crops_end, shapes, model_type, target_name] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (const auto& shape : shapes) {
@@ -33,10 +29,8 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void BatchToSpaceLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::vector<int64_t> block_shape, crops_begin, crops_end;
-    ov::element::Type model_type;
-    std::tie(block_shape, crops_begin, crops_end, shapes, model_type, targetDevice) = this->GetParam();
+    const auto& [block_shape, crops_begin, crops_end, shapes, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};

--- a/src/tests/functional/plugin/shared/src/single_op/binary_convolution.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/binary_convolution.cpp
@@ -10,19 +10,9 @@
 namespace ov {
 namespace test {
 std::string BinaryConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<binaryConvolutionTestParamsSet>& obj) {
-    binConvSpecificParams bin_conv_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
+    const auto& [bin_conv_params, model_type, shapes, target_device] = obj.param;
 
-    std::tie(bin_conv_params, model_type, shapes, target_device) = obj.param;
-
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, padEnd;
-    size_t conv_out_channels;
-    float pad_value;
-    std::tie(kernel, stride, pad_begin, padEnd, dilation, conv_out_channels, pad_type, pad_value) = bin_conv_params;
+    const auto& [kernel, stride, pad_begin, padEnd, dilation, conv_out_channels, pad_type, pad_value] = bin_conv_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -51,19 +41,12 @@ std::string BinaryConvolutionLayerTest::getTestCaseName(const testing::TestParam
 }
 
 void BinaryConvolutionLayerTest::SetUp() {
-    binConvSpecificParams bin_conv_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-
-    std::tie(bin_conv_params, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [bin_conv_params, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel_size, strides, dilations;
-    std::vector<ptrdiff_t> pads_begin, pads_end;
-    size_t num_out_channels;
-    float pad_value;
-    std::tie(kernel_size, strides, pads_begin, pads_end, dilations, num_out_channels, pad_type, pad_value) = bin_conv_params;
+    const auto& [kernel_size, strides, pads_begin, pads_end, dilations, num_out_channels, pad_type, pad_value] =
+        bin_conv_params;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
     params[0]->set_friendly_name("a_data_batch");

--- a/src/tests/functional/plugin/shared/src/single_op/broadcast.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/broadcast.cpp
@@ -12,13 +12,7 @@
 namespace ov {
 namespace test {
 std::string BroadcastLayerTest::getTestCaseName(const testing::TestParamInfo<BroadcastParamsTuple>& obj) {
-    ov::Shape target_shape;
-    ov::AxisSet axes_mapping;
-    ov::op::BroadcastType mode;
-    std::vector<InputShape> shapes;
-    ov::element::Type type;
-    std::string device_name;
-    std::tie(target_shape, axes_mapping, mode, shapes, type, device_name) = obj.param;
+    const auto& [target_shape, axes_mapping, mode, shapes, type, device_name] = obj.param;
 
     std::ostringstream result;
     result << "targetShape=" << ov::test::utils::vec2str(target_shape) << "_";
@@ -39,12 +33,8 @@ std::string BroadcastLayerTest::getTestCaseName(const testing::TestParamInfo<Bro
 }
 
 void BroadcastLayerTest::SetUp() {
-    std::vector<size_t> target_shape;
-    ov::AxisSet axes_mapping;
-    ov::op::BroadcastType mode;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(target_shape, axes_mapping, mode, shapes, model_type, targetDevice) = this->GetParam();
+    const auto& [target_shape, axes_mapping, mode, shapes, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto target_shape_const = ov::op::v0::Constant::create(ov::element::i64, {target_shape.size()}, target_shape);

--- a/src/tests/functional/plugin/shared/src/single_op/bucketize.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/bucketize.cpp
@@ -11,12 +11,7 @@ namespace ov {
 namespace test {
 
 std::string BucketizeLayerTest::getTestCaseName(const testing::TestParamInfo<bucketizeParamsTuple>& obj) {
-    std::vector<InputShape> shapes;
-    bool with_right_bound;
-    ov::element::Type in_data_type, in_buckets_type, model_type;
-    std::string target_device;
-
-    std::tie(shapes, with_right_bound, in_data_type, in_buckets_type, model_type, target_device) = obj.param;
+    const auto& [shapes, with_right_bound, in_data_type, in_buckets_type, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -43,11 +38,8 @@ std::string BucketizeLayerTest::getTestCaseName(const testing::TestParamInfo<buc
 }
 
 void BucketizeLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    bool with_right_bound;
-    ov::element::Type in_data_type, in_buckets_type, model_type;
-
-    std::tie(shapes, with_right_bound, in_data_type, in_buckets_type, model_type, targetDevice) = this->GetParam();
+    const auto& [shapes, with_right_bound, in_data_type, in_buckets_type, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto data = std::make_shared<ov::op::v0::Parameter>(in_data_type, inputDynamicShapes[0]);

--- a/src/tests/functional/plugin/shared/src/single_op/clamp.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/clamp.cpp
@@ -8,12 +8,7 @@
 namespace ov {
 namespace test {
 std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampParamsTuple>& obj) {
-    std::vector<InputShape> shapes;
-    std::pair<float, float> interval;
-    ov::element::Type model_type;
-    std::string target_device;
-
-    std::tie(shapes, interval, model_type, target_device) = obj.param;
+    const auto& [shapes, interval, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -36,10 +31,8 @@ std::string ClampLayerTest::getTestCaseName(const testing::TestParamInfo<clampPa
 }
 
 void ClampLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::pair<float, float> interval;
-    ov::element::Type model_type;
-    std::tie(shapes, interval, model_type, targetDevice) = this->GetParam();
+    const auto& [shapes, interval, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto input = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/col2im.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/col2im.cpp
@@ -18,21 +18,9 @@ namespace test {
 namespace Col2Im {
 
 std::string Col2ImLayerSharedTest::getTestCaseName(const testing::TestParamInfo<Col2ImLayerSharedTestParams>& obj) {
-    ov::element::Type data_precision;
-    ov::element::Type size_precision;
-    std::string target_device;
-    Col2ImOpsSpecificParams col2im_param;
+    const auto& [col2im_param, data_precision, size_precision, target_device] = obj.param;
 
-    std::tie(col2im_param, data_precision, size_precision, target_device) = obj.param;
-
-    ov::Shape input_shape;
-    std::vector<int64_t> output_size;
-    std::vector<int64_t> kernel_size;
-    ov::Strides strides;
-    ov::Strides dilations;
-    ov::Shape pads_begin;
-    ov::Shape pads_end;
-    std::tie(input_shape, output_size, kernel_size, strides, dilations, pads_begin, pads_end) = col2im_param;
+    const auto& [input_shape, output_size, kernel_size, strides, dilations, pads_begin, pads_end] = col2im_param;
 
     std::ostringstream result;
 
@@ -71,23 +59,11 @@ void Col2ImLayerSharedTest::generate_inputs(const std::vector<ov::Shape>& target
 }
 
 void Col2ImLayerSharedTest::SetUp() {
-    Col2ImOpsSpecificParams col2im_param;
-    ov::element::Type data_precision;
-    ov::element::Type size_precision;
-    std::string target_device;
-
-    std::tie(col2im_param, data_precision, size_precision, target_device) = this->GetParam();
+    const auto& [col2im_param, data_precision, size_precision, target_device] = this->GetParam();
 
     targetDevice = target_device;
 
-    ov::Shape data_input_shape;
-    std::vector<int64_t> outputSize;
-    std::vector<int64_t> kernelSize;
-    ov::Strides strides;
-    ov::Strides dilations;
-    ov::Shape pads_begin;
-    ov::Shape pads_end;
-    std::tie(data_input_shape, outputSize, kernelSize, strides, dilations, pads_begin, pads_end) = col2im_param;
+    const auto& [data_input_shape, outputSize, kernelSize, strides, dilations, pads_begin, pads_end] = col2im_param;
 
     auto dataParameter = std::make_shared<ov::op::v0::Parameter>(data_precision, data_input_shape);
     // Required option which is fixed size input : ov::Shape{2}

--- a/src/tests/functional/plugin/shared/src/single_op/comparison.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/comparison.cpp
@@ -13,18 +13,7 @@ using ov::test::utils::ComparisonTypes;
 using ov::test::utils::InputLayerType;
 
 std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<ComparisonTestParams> &obj) {
-    std::vector<InputShape> shapes;
-    ComparisonTypes comparison_op_type;
-    InputLayerType second_input_type;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::map<std::string, std::string> additional_config;
-    std::tie(shapes,
-             comparison_op_type,
-             second_input_type,
-             model_type,
-             device_name,
-             additional_config) = obj.param;
+    const auto& [shapes, comparison_op_type, second_input_type, model_type, device_name, additional_config] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -47,17 +36,9 @@ std::string ComparisonLayerTest::getTestCaseName(const testing::TestParamInfo<Co
 }
 
 void ComparisonLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    InputLayerType second_input_type;
-    std::map<std::string, std::string> additional_config;
-    ov::element::Type model_type;
-    ov::test::utils::ComparisonTypes comparison_op_type;
-    std::tie(shapes,
-             comparison_op_type,
-             second_input_type,
-             model_type,
-             targetDevice,
-             additional_config) = this->GetParam();
+    const auto& [shapes, comparison_op_type, second_input_type, model_type, _targetDevice, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
     configuration.insert(additional_config.begin(), additional_config.end());
     init_input_shapes(shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/concat.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/concat.cpp
@@ -9,11 +9,7 @@ namespace ov {
 namespace test {
 
 std::string ConcatLayerTest::getTestCaseName(const testing::TestParamInfo<concatParamsTuple>& obj) {
-    int axis;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string targetName;
-    std::tie(axis, shapes, model_type, targetName) = obj.param;
+    const auto& [axis, shapes, model_type, targetName] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -34,10 +30,8 @@ std::string ConcatLayerTest::getTestCaseName(const testing::TestParamInfo<concat
 }
 
 void ConcatLayerTest::SetUp() {
-    int axis;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(axis, shapes, model_type, targetDevice) = this->GetParam();
+    const auto& [axis, shapes, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     ov::ParameterVector params;
@@ -54,12 +48,7 @@ void ConcatLayerTest::SetUp() {
 }
 
 std::string ConcatStringLayerTest::getTestCaseName(const testing::TestParamInfo<ConcatStringParamsTuple>& obj) {
-    int axis;
-    std::vector<ov::Shape> shapes;
-    ov::element::Type model_type;
-    std::string targetName;
-    std::vector<std::vector<std::string>> data;
-    std::tie(axis, shapes, model_type, targetName, data) = obj.param;
+    const auto& [axis, shapes, model_type, targetName, data] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -73,10 +62,9 @@ std::string ConcatStringLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void ConcatStringLayerTest::SetUp() {
-    int axis;
-    std::vector<ov::Shape> shapes;
-    ov::element::Type model_type;
-    std::tie(axis, shapes, model_type, targetDevice, string_data) = this->GetParam();
+    const auto& [axis, shapes, model_type, _targetDevice, _string_data] = this->GetParam();
+    targetDevice = _targetDevice;
+    string_data = _string_data;
     init_input_shapes(ov::test::static_shapes_to_test_representation(shapes));
 
     ov::ParameterVector params;

--- a/src/tests/functional/plugin/shared/src/single_op/constant.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/constant.cpp
@@ -16,12 +16,7 @@ std::vector<std::string> getElements(const std::vector<std::string>& v) {
 
 std::string ConstantLayerTest::getTestCaseName(
     const testing::TestParamInfo<constantParamsTuple>& obj) {
-    ov::Shape shape;
-    ov::element::Type model_type;
-    std::vector<std::string> data_elements;
-    std::string target_device;
-
-    std::tie(shape, model_type, data_elements, target_device) = obj.param;
+    const auto& [shape, model_type, data_elements, target_device] = obj.param;
 
     std::ostringstream result;
     result << "TS={" << ov::test::utils::vec2str(shape) << "}_";
@@ -32,11 +27,8 @@ std::string ConstantLayerTest::getTestCaseName(
 }
 
 void ConstantLayerTest::SetUp() {
-    ov::Shape shape;
-    ov::element::Type model_type;
-    std::vector<std::string> data_elements;
-
-    std::tie(shape, model_type, data_elements, targetDevice) = this->GetParam();
+    const auto& [shape, model_type, data_elements, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     auto constant = ov::op::v0::Constant::create(model_type, shape, data_elements);
     auto result = std::make_shared<ov::op::v0::Result>(constant);

--- a/src/tests/functional/plugin/shared/src/single_op/conversion.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/conversion.cpp
@@ -15,12 +15,7 @@ std::map<ov::test::utils::ConversionTypes, std::string> conversionNames = {
 }
 
 std::string ConversionLayerTest::getTestCaseName(const testing::TestParamInfo<ConversionParamsTuple>& obj) {
-    ov::test::utils::ConversionTypes conversion_type;
-    ov::element::Type input_type, convert_type;
-    std::string device_name;
-    std::vector<InputShape> shapes;
-    std::tie(conversion_type, shapes, input_type, convert_type, device_name) =
-        obj.param;
+    const auto& [conversion_type, shapes, input_type, convert_type, device_name] = obj.param;
     std::ostringstream result;
     result << "conversionOpType=" << conversionNames[conversion_type] << "_";
     result << "IS=(";
@@ -42,10 +37,8 @@ std::string ConversionLayerTest::getTestCaseName(const testing::TestParamInfo<Co
 }
 
 void ConversionLayerTest::SetUp() {
-    ov::test::utils::ConversionTypes conversion_type;
-    ov::element::Type input_type, convert_type;
-    std::vector<InputShape> shapes;
-    std::tie(conversion_type, shapes, input_type, convert_type, targetDevice) = GetParam();
+    const auto& [conversion_type, shapes, input_type, convert_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     ov::ParameterVector params;

--- a/src/tests/functional/plugin/shared/src/single_op/convert_color_i420.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/convert_color_i420.cpp
@@ -11,11 +11,7 @@
 namespace ov {
 namespace test {
 std::string ConvertColorI420LayerTest::getTestCaseName(const testing::TestParamInfo<ConvertColorI420ParamsTuple> &obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type type;
-    bool conversion, single_plane;
-    std::string device_name;
-    std::tie(shapes, type, conversion, single_plane, device_name) = obj.param;
+    const auto& [shapes, type, conversion, single_plane, device_name] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -37,13 +33,10 @@ std::string ConvertColorI420LayerTest::getTestCaseName(const testing::TestParamI
 }
 
 void ConvertColorI420LayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type net_type;
-    bool conversion_to_rgb;
-    bool single_plane;
     abs_threshold = 1.1f; // I420 conversion can use various algorithms, thus some absolute deviation is allowed
     rel_threshold = 1.1f; // Ignore relative comparison for I420 convert (allow 100% relative deviation)
-    std::tie(shapes, net_type, conversion_to_rgb, single_plane, targetDevice) = GetParam();
+    const auto& [shapes, net_type, conversion_to_rgb, single_plane, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     if (single_plane) {

--- a/src/tests/functional/plugin/shared/src/single_op/convert_color_nv12.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/convert_color_nv12.cpp
@@ -12,11 +12,7 @@
 namespace ov {
 namespace test {
 std::string ConvertColorNV12LayerTest::getTestCaseName(const testing::TestParamInfo<ConvertColorNV12ParamsTuple> &obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type type;
-    bool conversion, single_plane;
-    std::string device_name;
-    std::tie(shapes, type, conversion, single_plane, device_name) = obj.param;
+    const auto& [shapes, type, conversion, single_plane, device_name] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -38,12 +34,10 @@ std::string ConvertColorNV12LayerTest::getTestCaseName(const testing::TestParamI
 }
 
 void ConvertColorNV12LayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type net_type;
-    bool conversionToRGB, single_plane;
     abs_threshold = 1.1f; // NV12 conversion can use various algorithms, thus some absolute deviation is allowed
     rel_threshold = 1.1f; // Ignore relative comparison for NV12 convert (allow 100% relative deviation)
-    std::tie(shapes, net_type, conversionToRGB, single_plane, targetDevice) = GetParam();
+    const auto& [shapes, net_type, conversionToRGB, single_plane, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     if (single_plane) {

--- a/src/tests/functional/plugin/shared/src/single_op/convolution.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/convolution.cpp
@@ -14,16 +14,9 @@
 namespace ov {
 namespace test {
 std::string ConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<convLayerTestParamsSet>& obj) {
-    convSpecificParams conv_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string targetDevice;
-    std::tie(conv_params, model_type, shapes, targetDevice) = obj.param;
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end;
-    size_t conv_out_channels;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, pad_type) = conv_params;
+    const auto& [conv_params, model_type, shapes, targetDevice] = obj.param;
+
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, pad_type] = conv_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -51,17 +44,11 @@ std::string ConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<c
 }
 
 void ConvolutionLayerTest::SetUp() {
-    convSpecificParams conv_params;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(conv_params, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [conv_params, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end;
-    size_t conv_out_channels;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, pad_type) = conv_params;
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, pad_type] = conv_params;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 

--- a/src/tests/functional/plugin/shared/src/single_op/convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/convolution_backprop_data.cpp
@@ -15,17 +15,10 @@
 namespace ov {
 namespace test {
 std::string ConvolutionBackpropDataLayerTest::getTestCaseName(const testing::TestParamInfo<convBackpropDataLayerTestParamsSet>& obj) {
-    convBackpropDataSpecificParams convBackpropDataParams;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    ov::Shape output_shapes;
-    std::string target_device;
-    std::tie(convBackpropDataParams, model_type, shapes, output_shapes, target_device) = obj.param;
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
-    size_t convOutChannels;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, convOutChannels, pad_type, out_padding) = convBackpropDataParams;
+    const auto& [convBackpropDataParams, model_type, shapes, output_shapes, target_device] = obj.param;
+
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, convOutChannels, pad_type, out_padding] =
+        convBackpropDataParams;
 
     std::ostringstream result;
     result << "IS=(";
@@ -55,18 +48,12 @@ std::string ConvolutionBackpropDataLayerTest::getTestCaseName(const testing::Tes
 }
 
 void ConvolutionBackpropDataLayerTest::SetUp() {
-    convBackpropDataSpecificParams convBackpropDataParams;
-    std::vector<InputShape> shapes;
-    ov::Shape output_shape;
-    ov::element::Type model_type;
-    std::tie(convBackpropDataParams, model_type, shapes, output_shape, targetDevice) = this->GetParam();
+    const auto& [convBackpropDataParams, model_type, shapes, output_shape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
-    size_t convOutChannels;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, convOutChannels, pad_type, out_padding) = convBackpropDataParams;
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, convOutChannels, pad_type, out_padding] =
+        convBackpropDataParams;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};
 

--- a/src/tests/functional/plugin/shared/src/single_op/ctc_greedy_decoder.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/ctc_greedy_decoder.cpp
@@ -14,11 +14,7 @@
 namespace ov {
 namespace test {
 std::string CTCGreedyDecoderLayerTest::getTestCaseName(const testing::TestParamInfo<ctcGreedyDecoderParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string targetDevice;
-    bool merge_repeated;
-    std::tie(model_type, shapes, merge_repeated, targetDevice) = obj.param;
+    const auto& [model_type, shapes, merge_repeated, targetDevice] = obj.param;
 
     std::ostringstream result;
     const char separator = '_';
@@ -43,10 +39,8 @@ std::string CTCGreedyDecoderLayerTest::getTestCaseName(const testing::TestParamI
 }
 
 void CTCGreedyDecoderLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    bool merge_repeated;
-    std::tie(model_type, shapes, merge_repeated, targetDevice) = GetParam();
+    const auto& [model_type, shapes, merge_repeated, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/ctc_loss.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/ctc_loss.cpp
@@ -12,16 +12,14 @@
 namespace ov {
 namespace test {
 std::string CTCLossLayerTest::getTestCaseName(const testing::TestParamInfo<CTCLossParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type fp_type, int_type;
-    bool preprocess_collapse_repeated, ctc_merge_repeated, unique;
-    std::vector<int> logits_length, labels_length;
-    std::vector<std::vector<int>> labels;
-    int blank_index;
-    std::string targetDevice;
-    CTCLossParamsSubset ctcLossArgsSubset;
-    std::tie(ctcLossArgsSubset, shapes, fp_type, int_type, targetDevice) = obj.param;
-    std::tie(logits_length, labels, labels_length, blank_index, preprocess_collapse_repeated, ctc_merge_repeated, unique) = ctcLossArgsSubset;
+    const auto& [ctcLossArgsSubset, shapes, fp_type, int_type, targetDevice] = obj.param;
+    const auto& [logits_length,
+                 labels,
+                 labels_length,
+                 blank_index,
+                 preprocess_collapse_repeated,
+                 ctc_merge_repeated,
+                 unique] = ctcLossArgsSubset;
 
     std::ostringstream result;
     result << "IS=(";
@@ -50,16 +48,15 @@ std::string CTCLossLayerTest::getTestCaseName(const testing::TestParamInfo<CTCLo
 }
 
 void CTCLossLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type fp_type, int_type;
-    bool preprocess_collapse_repeated, ctc_merge_repeated, unique;
-    std::vector<int> logits_length, labels_length;
-    std::vector<std::vector<int>> labels;
-    int blank_index;
-    CTCLossParamsSubset ctcLossArgsSubset;
-    std::tie(ctcLossArgsSubset, shapes, fp_type, int_type, targetDevice) = this->GetParam();
-    std::tie(logits_length, labels, labels_length, blank_index, preprocess_collapse_repeated,
-        ctc_merge_repeated, unique) = ctcLossArgsSubset;
+    const auto& [ctcLossArgsSubset, shapes, fp_type, int_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [logits_length,
+                 labels,
+                 labels_length,
+                 blank_index,
+                 preprocess_collapse_repeated,
+                 ctc_merge_repeated,
+                 unique] = ctcLossArgsSubset;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(fp_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/cum_sum.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/cum_sum.cpp
@@ -8,12 +8,7 @@
 namespace ov {
 namespace test {
 std::string CumSumLayerTest::getTestCaseName(const testing::TestParamInfo<cumSumParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    int64_t axis;
-    bool exclusive, reverse;
-    std::string targetDevice;
-    std::tie(shapes, model_type, axis, exclusive, reverse, targetDevice) = obj.param;
+    const auto& [shapes, model_type, axis, exclusive, reverse, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -37,11 +32,8 @@ std::string CumSumLayerTest::getTestCaseName(const testing::TestParamInfo<cumSum
 }
 
 void CumSumLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    bool exclusive, reverse;
-    int64_t axis;
-    std::tie(shapes, model_type, axis, exclusive, reverse, targetDevice) = this->GetParam();
+    const auto& [shapes, model_type, axis, exclusive, reverse, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     const auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/deformable_convolution.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/deformable_convolution.cpp
@@ -13,18 +13,17 @@
 namespace ov {
 namespace test {
 std::string DeformableConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<deformableConvLayerTestParamsSet>& obj) {
-    deformableConvSpecificParams convParams;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    bool with_modulation;
-    std::tie(convParams, with_modulation, model_type, shapes, target_device) = obj.param;
-    ov::op::PadType padType;
-    std::vector<size_t> stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end;
-    size_t groups, deformable_groups, conv_out_channels;
-    bool with_bilinear_interpolation_pad;
-    std::tie(stride, pad_begin, pad_end, dilation, groups, deformable_groups, conv_out_channels, padType, with_bilinear_interpolation_pad) = convParams;
+    const auto& [convParams, with_modulation, model_type, shapes, target_device] = obj.param;
+
+    const auto& [stride,
+                 pad_begin,
+                 pad_end,
+                 dilation,
+                 groups,
+                 deformable_groups,
+                 conv_out_channels,
+                 padType,
+                 with_bilinear_interpolation_pad] = convParams;
 
     std::ostringstream result;
     result << "IS=(";
@@ -55,19 +54,19 @@ std::string DeformableConvolutionLayerTest::getTestCaseName(const testing::TestP
 }
 
 void DeformableConvolutionLayerTest::SetUp() {
-    deformableConvSpecificParams convParams;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    bool with_modulation;
-    std::tie(convParams, with_modulation, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [convParams, with_modulation, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
-    ov::op::PadType padType;
-    std::vector<size_t> stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end;
-    size_t groups, deformable_groups, conv_out_channels;
-    bool with_bilinear_interpolation_pad;
-    std::tie(stride, pad_begin, pad_end, dilation, groups, deformable_groups, conv_out_channels, padType, with_bilinear_interpolation_pad) = convParams;
+    const auto& [stride,
+                 pad_begin,
+                 pad_end,
+                 dilation,
+                 groups,
+                 deformable_groups,
+                 conv_out_channels,
+                 padType,
+                 with_bilinear_interpolation_pad] = convParams;
 
     auto data = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]);
     data->set_friendly_name("a_data");

--- a/src/tests/functional/plugin/shared/src/single_op/deformable_psroi_pooling.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/deformable_psroi_pooling.cpp
@@ -13,20 +13,8 @@ namespace ov {
 namespace test {
 
 std::string DeformablePSROIPoolingLayerTest::getTestCaseName(const testing::TestParamInfo<deformablePSROILayerTestParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    int64_t outputDim;
-    int64_t groupSize;
-    float spatialScale;
-    std::vector<int64_t> spatialBinsXY;
-    float trans_std;
-    int64_t part_size;
-    std::string target_device;
-    deformablePSROISpecificParams opParams;
-
-    std::tie(opParams, shapes, model_type, target_device) = obj.param;
-    std::tie(outputDim, groupSize, spatialScale, spatialBinsXY,
-    trans_std, part_size) = opParams;
+    const auto& [opParams, shapes, model_type, target_device] = obj.param;
+    const auto& [outputDim, groupSize, spatialScale, spatialBinsXY, trans_std, part_size] = opParams;
 
     std::ostringstream result;
     result << "IS=(";
@@ -54,18 +42,11 @@ std::string DeformablePSROIPoolingLayerTest::getTestCaseName(const testing::Test
 }
 
 void DeformablePSROIPoolingLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    int64_t outputDim;
-    int64_t groupSize;
     std::string mode = "bilinear_deformable";
-    std::vector<int64_t> spatialBinsXY;
-    float trans_std, spatial_scale;
-    int64_t part_size;
-    deformablePSROISpecificParams opParams;
 
-    std::tie(opParams, shapes, model_type, targetDevice) = this->GetParam();
-    std::tie(outputDim, groupSize, spatial_scale, spatialBinsXY, trans_std, part_size) = opParams;
+    const auto& [opParams, shapes, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [outputDim, groupSize, spatial_scale, spatialBinsXY, trans_std, part_size] = opParams;
     init_input_shapes(shapes);
 
     ov::ParameterVector params;

--- a/src/tests/functional/plugin/shared/src/single_op/depth_to_space.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/depth_to_space.cpp
@@ -27,12 +27,7 @@ static inline std::string DepthToSpaceModeToString(const DepthToSpace::DepthToSp
 }
 
 std::string DepthToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<depthToSpaceParamsTuple> &obj) {
-    std::vector<InputShape> shapes;
-    DepthToSpace::DepthToSpaceMode mode;
-    std::size_t block_size;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::tie(shapes, model_type, mode, block_size, device_name) = obj.param;
+    const auto& [shapes, model_type, mode, block_size, device_name] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -55,11 +50,8 @@ std::string DepthToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void DepthToSpaceLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    DepthToSpace::DepthToSpaceMode mode;
-    std::size_t block_size;
-    ov::element::Type model_type;
-    std::tie(shapes, model_type, mode, block_size, targetDevice) = this->GetParam();
+    const auto& [shapes, model_type, mode, block_size, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/detection_output.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/detection_output.cpp
@@ -27,12 +27,10 @@ std::ostream& operator <<(std::ostream& result, const Attributes& attrs) {
 }
 
 std::string DetectionOutputLayerTest::getTestCaseName(const testing::TestParamInfo<DetectionOutputParams>& obj) {
-    DetectionOutputAttributes common_attrs;
-    ParamsWhichSizeDepends specific_attrs;
     Attributes attrs;
-    size_t batch;
-    std::string targetDevice;
-    std::tie(common_attrs, specific_attrs, batch, attrs.objectness_score, targetDevice) = obj.param;
+
+    const auto& [common_attrs, specific_attrs, batch, _objectness_score, targetDevice] = obj.param;
+    attrs.objectness_score = _objectness_score;
 
     std::tie(attrs.num_classes, attrs.background_label_id, attrs.top_k, attrs.keep_top_k, attrs.code_type, attrs.nms_threshold, attrs.confidence_threshold,
              attrs.clip_after_nms, attrs.clip_before_nms, attrs.decrease_label_id) = common_attrs;
@@ -70,11 +68,10 @@ std::string DetectionOutputLayerTest::getTestCaseName(const testing::TestParamIn
 }
 
 void DetectionOutputLayerTest::SetUp() {
-    DetectionOutputAttributes common_attrs;
-    ParamsWhichSizeDepends specific_attrs;
-    size_t batch;
     Attributes attrs;
-    std::tie(common_attrs, specific_attrs, batch, attrs.objectness_score, targetDevice) = this->GetParam();
+    const auto& [common_attrs, specific_attrs, batch, _objectness_score, _targetDevice] = this->GetParam();
+    attrs.objectness_score = _objectness_score;
+    targetDevice = _targetDevice;
 
     std::tie(attrs.num_classes, attrs.background_label_id, attrs.top_k, attrs.keep_top_k, attrs.code_type, attrs.nms_threshold, attrs.confidence_threshold,
              attrs.clip_after_nms, attrs.clip_before_nms, attrs.decrease_label_id) = common_attrs;

--- a/src/tests/functional/plugin/shared/src/single_op/einsum.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/einsum.cpp
@@ -9,13 +9,9 @@ namespace ov {
 namespace test {
 
 std::string EinsumLayerTest::getTestCaseName(const testing::TestParamInfo<EinsumLayerTestParamsSet>& obj) {
-    EinsumEquationWithInput equation_with_input;
-    ov::element::Type model_type;
-    std::string targetDevice;
-    std::tie(model_type, equation_with_input, targetDevice) = obj.param;
-    std::string equation;
-    std::vector<InputShape> shapes;
-    std::tie(equation, shapes) = equation_with_input;
+    const auto& [model_type, equation_with_input, targetDevice] = obj.param;
+
+    const auto& [equation, shapes] = equation_with_input;
 
     std::ostringstream result;
         result << "IS=(";
@@ -37,12 +33,10 @@ std::string EinsumLayerTest::getTestCaseName(const testing::TestParamInfo<Einsum
 }
 
 void EinsumLayerTest::SetUp() {
-    EinsumEquationWithInput equation_with_input;
-    ov::element::Type model_type;
-    std::tie(model_type, equation_with_input, targetDevice) = this->GetParam();
-    std::string equation;
-    std::vector<InputShape> shapes;
-    std::tie(equation, shapes) = equation_with_input;
+    const auto& [model_type, equation_with_input, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [equation, shapes] = equation_with_input;
     init_input_shapes(shapes);
 
     ov::ParameterVector params;

--- a/src/tests/functional/plugin/shared/src/single_op/eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/eltwise.cpp
@@ -15,14 +15,15 @@ using ov::test::utils::OpType;
 using ov::test::utils::EltwiseTypes;
 
 std::string EltwiseLayerTest::getTestCaseName(const testing::TestParamInfo<EltwiseTestParams>& obj) {
-    std::vector<InputShape> shapes;
-    ElementType model_type, in_type, out_type;
-    InputLayerType secondary_input_type;
-    OpType op_type;
-    EltwiseTypes eltwise_op_type;
-    std::string device_name;
-    ov::AnyMap additional_config;
-    std::tie(shapes, eltwise_op_type, secondary_input_type, op_type, model_type, in_type, out_type, device_name, additional_config) = obj.param;
+    const auto& [shapes,
+                 eltwise_op_type,
+                 secondary_input_type,
+                 op_type,
+                 model_type,
+                 in_type,
+                 out_type,
+                 device_name,
+                 additional_config] = obj.param;
     std::ostringstream results;
 
     results << "IS=(";
@@ -70,13 +71,20 @@ void EltwiseLayerTest::transformInputShapesAccordingEltwise(const ov::PartialSha
 }
 
 void EltwiseLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ElementType model_type;
-    InputLayerType secondary_input_type;
-    OpType op_type;
-    EltwiseTypes eltwise_type;
     Config additional_config;
-    std::tie(shapes, eltwise_type, secondary_input_type, op_type, model_type, inType, outType, targetDevice, configuration) = this->GetParam();
+    const auto& [shapes,
+                 eltwise_type,
+                 secondary_input_type,
+                 op_type,
+                 model_type,
+                 _inType,
+                 _outType,
+                 _targetDevice,
+                 _configuration] = this->GetParam();
+    inType = _inType;
+    outType = _outType;
+    targetDevice = _targetDevice;
+    configuration = _configuration;
     init_input_shapes(shapes);
 
     ov::ParameterVector parameters{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front())};

--- a/src/tests/functional/plugin/shared/src/single_op/embedding_bag_offsets_sum.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/embedding_bag_offsets_sum.cpp
@@ -8,15 +8,9 @@
 namespace ov {
 namespace test {
 std::string EmbeddingBagOffsetsSumLayerTest::getTestCaseName(const testing::TestParamInfo<embeddingBagOffsetsSumLayerTestParamsSet>& obj) {
-    embeddingBagOffsetsSumParams emb_params;
-    ov::element::Type model_type, ind_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    std::tie(emb_params, shapes, model_type, ind_type, target_device) = obj.param;
-    std::vector<size_t> indices, offsets;
-    size_t default_index;
-    bool with_weights, with_def_index;
-    std::tie(indices, offsets, default_index, with_weights, with_def_index) = emb_params;
+    const auto& [emb_params, shapes, model_type, ind_type, target_device] = obj.param;
+
+    const auto& [indices, offsets, default_index, with_weights, with_def_index] = emb_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -43,16 +37,11 @@ std::string EmbeddingBagOffsetsSumLayerTest::getTestCaseName(const testing::Test
 }
 
 void EmbeddingBagOffsetsSumLayerTest::SetUp() {
-    embeddingBagOffsetsSumParams emb_params;
-    ov::element::Type model_type, ind_type;
-    std::vector<InputShape> shapes;
-    std::tie(emb_params, shapes, model_type, ind_type, targetDevice) = this->GetParam();
+    const auto& [emb_params, shapes, model_type, ind_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
-    std::vector<size_t> indices, offsets;
-    bool with_weights, with_def_index;
-    size_t default_index;
-    std::tie(indices, offsets, default_index, with_weights, with_def_index) = emb_params;
+    const auto& [indices, offsets, default_index, with_weights, with_def_index] = emb_params;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
 

--- a/src/tests/functional/plugin/shared/src/single_op/embedding_bag_packed_sum.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/embedding_bag_packed_sum.cpp
@@ -8,14 +8,9 @@
 namespace ov {
 namespace test {
 std::string EmbeddingBagPackedSumLayerTest::getTestCaseName(const testing::TestParamInfo<embeddingBagPackedSumLayerTestParamsSet>& obj) {
-    embeddingBagPackedSumParams emb_params;
-    ov::element::Type model_type, ind_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    std::tie(emb_params, shapes, model_type, ind_type, target_device) = obj.param;
-    std::vector<std::vector<size_t>> indices;
-    bool with_weights;
-    std::tie(indices, with_weights) = emb_params;
+    const auto& [emb_params, shapes, model_type, ind_type, target_device] = obj.param;
+
+    const auto& [indices, with_weights] = emb_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -39,13 +34,10 @@ std::string EmbeddingBagPackedSumLayerTest::getTestCaseName(const testing::TestP
 }
 
 void EmbeddingBagPackedSumLayerTest::SetUp() {
-    embeddingBagPackedSumParams emb_params;
-    ov::element::Type model_type, ind_type;
-    std::vector<InputShape> shapes;
-    std::tie(emb_params, shapes, model_type, ind_type, targetDevice) = this->GetParam();
-    std::vector<std::vector<size_t>> indices;
-    bool with_weights;
-    std::tie(indices, with_weights) = emb_params;
+    const auto& [emb_params, shapes, model_type, ind_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [indices, with_weights] = emb_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/embedding_segments_sum.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/embedding_segments_sum.cpp
@@ -10,15 +10,9 @@ namespace ov {
 namespace test {
 
 std::string EmbeddingSegmentsSumLayerTest::getTestCaseName(const testing::TestParamInfo<embeddingSegmentsSumLayerTestParamsSet>& obj) {
-    embeddingSegmentsSumParams params;
-    ov::element::Type model_type, ind_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    std::tie(params, shapes, model_type, ind_type, target_device) = obj.param;
-    std::vector<size_t> indices, segment_ids;
-    size_t num_segments, default_index;
-    bool with_weights, with_def_index;
-    std::tie(indices, segment_ids, num_segments, default_index, with_weights, with_def_index) = params;
+    const auto& [params, shapes, model_type, ind_type, target_device] = obj.param;
+
+    const auto& [indices, segment_ids, num_segments, default_index, with_weights, with_def_index] = params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -46,16 +40,11 @@ std::string EmbeddingSegmentsSumLayerTest::getTestCaseName(const testing::TestPa
 }
 
 void EmbeddingSegmentsSumLayerTest::SetUp() {
-    embeddingSegmentsSumParams embParams;
-    ov::element::Type model_type, ind_type;
-    std::vector<InputShape> shapes;
-    std::tie(embParams, shapes, model_type, ind_type, targetDevice) = this->GetParam();
+    const auto& [embParams, shapes, model_type, ind_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
-    std::vector<size_t> indices, segment_ids;
-    bool with_weights, with_def_index;
-    size_t num_segments, default_index;
-    std::tie(indices, segment_ids, num_segments, default_index, with_weights, with_def_index) = embParams;
+    const auto& [indices, segment_ids, num_segments, default_index, with_weights, with_def_index] = embParams;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
 

--- a/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_detection_output.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_detection_output.cpp
@@ -12,22 +12,27 @@ namespace ov {
 namespace test {
 std::string ExperimentalDetectronDetectionOutputLayerTest::getTestCaseName(
         const testing::TestParamInfo<ExperimentalDetectronDetectionOutputTestParams>& obj) {
-    std::vector<ov::test::InputShape> shapes;
     ov::op::v6::ExperimentalDetectronDetectionOutput::Attributes attributes;
-    ElementType model_type;
-    std::string target_device;
-    std::tie(
-        shapes,
-        attributes.score_threshold,
-        attributes.nms_threshold,
-        attributes.max_delta_log_wh,
-        attributes.num_classes,
-        attributes.post_nms_count,
-        attributes.max_detections_per_image,
-        attributes.class_agnostic_box_regression,
-        attributes.deltas_weights,
-        model_type,
-        target_device) = obj.param;
+
+    const auto& [shapes,
+                 _score_threshold,
+                 _nms_threshold,
+                 _max_delta_log_wh,
+                 _num_classes,
+                 _post_nms_count,
+                 _max_detections_per_image,
+                 _class_agnostic_box_regression,
+                 _deltas_weights,
+                 model_type,
+                 target_device] = obj.param;
+    attributes.score_threshold = _score_threshold;
+    attributes.nms_threshold = _nms_threshold;
+    attributes.max_delta_log_wh = _max_delta_log_wh;
+    attributes.num_classes = _num_classes;
+    attributes.post_nms_count = _post_nms_count;
+    attributes.max_detections_per_image = _max_detections_per_image;
+    attributes.class_agnostic_box_regression = _class_agnostic_box_regression;
+    attributes.deltas_weights = _deltas_weights;
 
     std::ostringstream result;
 
@@ -54,23 +59,27 @@ std::string ExperimentalDetectronDetectionOutputLayerTest::getTestCaseName(
 }
 
 void ExperimentalDetectronDetectionOutputLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
     ov::op::v6::ExperimentalDetectronDetectionOutput::Attributes attributes;
 
-    ElementType model_type;
-    std::string targetName;
-    std::tie(
-        shapes,
-        attributes.score_threshold,
-        attributes.nms_threshold,
-        attributes.max_delta_log_wh,
-        attributes.num_classes,
-        attributes.post_nms_count,
-        attributes.max_detections_per_image,
-        attributes.class_agnostic_box_regression,
-        attributes.deltas_weights,
-        model_type,
-        targetName) = this->GetParam();
+    const auto& [shapes,
+                 _score_threshold,
+                 _nms_threshold,
+                 _max_delta_log_wh,
+                 _num_classes,
+                 _post_nms_count,
+                 _max_detections_per_image,
+                 _class_agnostic_box_regression,
+                 _deltas_weights,
+                 model_type,
+                 targetName] = this->GetParam();
+    attributes.score_threshold = _score_threshold;
+    attributes.nms_threshold = _nms_threshold;
+    attributes.max_delta_log_wh = _max_delta_log_wh;
+    attributes.num_classes = _num_classes;
+    attributes.post_nms_count = _post_nms_count;
+    attributes.max_detections_per_image = _max_detections_per_image;
+    attributes.class_agnostic_box_regression = _class_agnostic_box_regression;
+    attributes.deltas_weights = _deltas_weights;
 
     if (model_type == element::f16)
         abs_threshold = 0.01;

--- a/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_generate_proposals_single_image.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_generate_proposals_single_image.cpp
@@ -9,18 +9,14 @@ namespace ov {
 namespace test {
 std::string ExperimentalDetectronGenerateProposalsSingleImageLayerTest::getTestCaseName(
         const testing::TestParamInfo<ExperimentalDetectronGenerateProposalsSingleImageTestParams>& obj) {
-    std::vector<InputShape> shapes;
     ov::op::v6::ExperimentalDetectronGenerateProposalsSingleImage::Attributes attributes;
-    ElementType model_type;
-    std::string device_name;
-    std::tie(
-        shapes,
-        attributes.min_size,
-        attributes.nms_threshold,
-        attributes.post_nms_count,
-        attributes.pre_nms_count,
-        model_type,
-        device_name) = obj.param;
+
+    const auto& [shapes, _min_size, _nms_threshold, _post_nms_count, _pre_nms_count, model_type, device_name] =
+        obj.param;
+    attributes.min_size = _min_size;
+    attributes.nms_threshold = _nms_threshold;
+    attributes.post_nms_count = _post_nms_count;
+    attributes.pre_nms_count = _pre_nms_count;
 
     std::ostringstream result;
     using ov::test::operator<<;
@@ -42,18 +38,14 @@ std::string ExperimentalDetectronGenerateProposalsSingleImageLayerTest::getTestC
 }
 
 void ExperimentalDetectronGenerateProposalsSingleImageLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
     ov::op::v6::ExperimentalDetectronGenerateProposalsSingleImage::Attributes attributes;
-    ElementType model_type;
-    std::string targetName;
-    std::tie(
-        shapes,
-        attributes.min_size,
-        attributes.nms_threshold,
-        attributes.post_nms_count,
-        attributes.pre_nms_count,
-        model_type,
-        targetName) = this->GetParam();
+
+    const auto& [shapes, _min_size, _nms_threshold, _post_nms_count, _pre_nms_count, model_type, targetName] =
+        this->GetParam();
+    attributes.min_size = _min_size;
+    attributes.nms_threshold = _nms_threshold;
+    attributes.post_nms_count = _post_nms_count;
+    attributes.pre_nms_count = _pre_nms_count;
 
     inType = outType = model_type;
     targetDevice = targetName;

--- a/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_prior_grid_generator.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_prior_grid_generator.cpp
@@ -10,12 +10,9 @@ namespace test {
 
 std::string ExperimentalDetectronPriorGridGeneratorLayerTest::getTestCaseName(
         const testing::TestParamInfo<ExperimentalDetectronPriorGridGeneratorTestParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::op::v6::ExperimentalDetectronPriorGridGenerator::Attributes attributes;
     std::pair<std::string, std::vector<ov::Tensor>> inputTensors;
-    ElementType model_type;
-    std::string targetName;
-    std::tie(shapes, attributes, model_type, targetName) = obj.param;
+
+    const auto& [shapes, attributes, model_type, targetName] = obj.param;
 
     std::ostringstream result;
     using ov::test::operator<<;
@@ -38,11 +35,7 @@ std::string ExperimentalDetectronPriorGridGeneratorLayerTest::getTestCaseName(
 }
 
 void ExperimentalDetectronPriorGridGeneratorLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::op::v6::ExperimentalDetectronPriorGridGenerator::Attributes attributes;
-    ElementType model_type;
-    std::string targetName;
-    std::tie(shapes, attributes, model_type, targetName) = this->GetParam();
+    const auto& [shapes, attributes, model_type, targetName] = this->GetParam();
 
     inType = outType = model_type;
     targetDevice = targetName;

--- a/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_roifeatureextractor.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_roifeatureextractor.cpp
@@ -9,13 +9,7 @@ namespace ov {
 namespace test {
 std::string ExperimentalDetectronROIFeatureExtractorLayerTest::getTestCaseName(
         const testing::TestParamInfo<ExperimentalDetectronROIFeatureExtractorTestParams>& obj) {
-    std::vector<InputShape> shapes;
-    int64_t outputSize, sampling_ratio;
-    std::vector<int64_t> pyramid_scales;
-    bool aligned;
-    ElementType model_type;
-    std::string device_name;
-    std::tie(shapes, outputSize, sampling_ratio, pyramid_scales, aligned, model_type, device_name) = obj.param;
+    const auto& [shapes, outputSize, sampling_ratio, pyramid_scales, aligned, model_type, device_name] = obj.param;
 
     std::ostringstream result;
     if (shapes.front().first.size() != 0) {
@@ -43,13 +37,8 @@ std::string ExperimentalDetectronROIFeatureExtractorLayerTest::getTestCaseName(
 }
 
 void ExperimentalDetectronROIFeatureExtractorLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    int64_t outputSize, sampling_ratio;
-    std::vector<int64_t> pyramid_scales;
-    bool aligned;
-    ElementType model_type;
-    std::string targetName;
-    std::tie(shapes, outputSize, sampling_ratio, pyramid_scales, aligned, model_type, targetName) = this->GetParam();
+    const auto& [shapes, outputSize, sampling_ratio, pyramid_scales, aligned, model_type, targetName] =
+        this->GetParam();
 
     inType = outType = model_type;
     targetDevice = targetName;

--- a/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_topkrois.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/experimental_detectron_topkrois.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string ExperimentalDetectronTopKROIsLayerTest::getTestCaseName(const testing::TestParamInfo<ExperimentalDetectronTopKROIsTestParams>& obj) {
-    std::vector<InputShape> shapes;
-    int64_t max_rois;
-    ElementType model_type;
-    std::string device_name;
-    std::tie(shapes, max_rois, model_type, device_name) = obj.param;
+    const auto& [shapes, max_rois, model_type, device_name] = obj.param;
 
     std::ostringstream result;
     if (shapes.front().first.size() != 0) {
@@ -36,11 +32,7 @@ std::string ExperimentalDetectronTopKROIsLayerTest::getTestCaseName(const testin
 }
 
 void ExperimentalDetectronTopKROIsLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    int64_t max_rois;
-    ElementType model_type;
-    std::string targetName;
-    std::tie(shapes, max_rois, model_type, targetName) = this->GetParam();
+    const auto& [shapes, max_rois, model_type, targetName] = this->GetParam();
 
     inType = outType = model_type;
     targetDevice = targetName;

--- a/src/tests/functional/plugin/shared/src/single_op/extract_image_patches.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/extract_image_patches.cpp
@@ -13,12 +13,7 @@ namespace ov {
 namespace test {
 
 std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj) {
-    std::vector<InputShape> shapes;
-    std::vector<size_t> kernel, strides, rates;
-    ov::op::PadType pad_type;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::tie(shapes, kernel, strides, rates, pad_type, model_type, device_name) = obj.param;
+    const auto& [shapes, kernel, strides, rates, pad_type, model_type, device_name] = obj.param;
     std::ostringstream result;
 
     result << "IS=(";
@@ -43,11 +38,8 @@ std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInf
 }
 
 void ExtractImagePatchesTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::vector<size_t> kernel, strides, rates;
-    ov::op::PadType pad_type;
-    ov::element::Type model_type;
-    std::tie(shapes, kernel, strides, rates, pad_type, model_type, targetDevice) = this->GetParam();
+    const auto& [shapes, kernel, strides, rates, pad_type, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/eye.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/eye.cpp
@@ -12,12 +12,7 @@
 namespace ov {
 namespace test {
 std::string EyeLayerTest::getTestCaseName(testing::TestParamInfo<EyeLayerTestParams> obj) {
-    std::string td;
-    std::vector<ov::Shape> input_shapes;
-    ov::element::Type model_type;
-    std::vector<int> out_batch_shape;
-    std::vector<int> eye_par;
-    std::tie(input_shapes, out_batch_shape, eye_par, model_type, td) = obj.param;
+    const auto& [input_shapes, out_batch_shape, eye_par, model_type, td] = obj.param;
     std::ostringstream result;
     result << "EyeTest_";
     result << "IS=(";
@@ -35,13 +30,11 @@ std::string EyeLayerTest::getTestCaseName(testing::TestParamInfo<EyeLayerTestPar
 }
 
 void EyeLayerTest::SetUp() {
-    std::vector<ov::Shape> input_shapes;
     int row_num, col_num;
     int shift;
-    std::vector<int> out_batch_shape;
-    ov::element::Type model_type;
-    std::vector<int> eye_par;
-    std::tie(input_shapes, out_batch_shape, eye_par, model_type, targetDevice) = this->GetParam();
+
+    const auto& [input_shapes, out_batch_shape, eye_par, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     row_num = eye_par[0];
     col_num = eye_par[1];
     shift = eye_par[2];

--- a/src/tests/functional/plugin/shared/src/single_op/fake_convert.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/fake_convert.cpp
@@ -14,12 +14,7 @@ namespace test {
 std::string FakeConvertLayerTest::getTestCaseName(const testing::TestParamInfo<FakeConvertParams>& obj) {
     FakeConvertParams params = obj.param;
 
-    std::vector<InputShape> data_shapes;
-    Shape scale_shape, shift_shape;
-    element::Type_t data_prec, dst_prec;
-    bool default_shift;
-    std::string target_device;
-    std::tie(data_shapes, scale_shape, shift_shape, data_prec, dst_prec, default_shift, target_device) = params;
+    const auto& [data_shapes, scale_shape, shift_shape, data_prec, dst_prec, default_shift, target_device] = params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -46,11 +41,8 @@ std::string FakeConvertLayerTest::getTestCaseName(const testing::TestParamInfo<F
 void FakeConvertLayerTest::SetUp() {
     FakeConvertParams params = this->GetParam();
 
-    std::vector<InputShape> data_shapes;
-    Shape scale_shape, shift_shape;
-    element::Type_t data_prec, dst_prec;
-    bool default_shift;
-    std::tie(data_shapes, scale_shape, shift_shape, data_prec, dst_prec, default_shift, targetDevice) = params;
+    const auto& [data_shapes, scale_shape, shift_shape, data_prec, dst_prec, default_shift, _targetDevice] = params;
+    targetDevice = _targetDevice;
 
     init_input_shapes(data_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/fake_quantize.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/fake_quantize.cpp
@@ -13,16 +13,9 @@
 namespace ov {
 namespace test {
 std::string FakeQuantizeLayerTest::getTestCaseName(const testing::TestParamInfo<fqLayerTestParamsSet>& obj) {
-    fqSpecificParams fqParams;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    std::tie(fqParams, model_type, shapes, target_device) = obj.param;
-    size_t levels;
-    std::vector<size_t> const_shape;
-    std::vector<float> fq_direct_args;
-    ov::op::AutoBroadcastSpec broadcast;
-    std::tie(levels, const_shape, fq_direct_args, broadcast) = fqParams;
+    const auto& [fqParams, model_type, shapes, target_device] = obj.param;
+
+    const auto& [levels, const_shape, fq_direct_args, broadcast] = fqParams;
 
     std::ostringstream result;
     result << "IS=(";
@@ -49,18 +42,13 @@ std::string FakeQuantizeLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void FakeQuantizeLayerTest::SetUp() {
-    fqSpecificParams fqParams;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::tie(fqParams, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [fqParams, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     std::vector<size_t> kernel, stride, dilation;
-    size_t levels;
-    std::vector<size_t> const_shape;
-    std::vector<float> fq_direct_arg;
-    ov::op::AutoBroadcastSpec broadcast;
-    std::tie(levels, const_shape, fq_direct_arg, broadcast) = fqParams;
+
+    const auto& [levels, const_shape, fq_direct_arg, broadcast] = fqParams;
     if (fq_direct_arg.size() != 0) {
         abs_threshold = (fq_direct_arg[3] - fq_direct_arg[2]) / levels;
     }

--- a/src/tests/functional/plugin/shared/src/single_op/gather.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/gather.cpp
@@ -13,13 +13,7 @@
 namespace ov {
 namespace test {
 std::string GatherLayerTest::getTestCaseName(const testing::TestParamInfo<gatherParamsTuple> &obj) {
-    int axis;
-    std::vector<int> indices;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::tie(indices, indices_shape, axis, shapes, model_type, device_name) = obj.param;
+    const auto& [indices, indices_shape, axis, shapes, model_type, device_name] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -42,12 +36,8 @@ std::string GatherLayerTest::getTestCaseName(const testing::TestParamInfo<gather
 }
 
 void GatherLayerTest::SetUp() {
-    int axis;
-    std::vector<int> indices;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(indices, indices_shape, axis, shapes, model_type, targetDevice) = GetParam();
+    const auto& [indices, indices_shape, axis, shapes, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
     ASSERT_EQ(ov::shape_size(indices_shape), indices.size()) << "Indices vector size and provided indices shape doesn't fit each other";
 
@@ -62,13 +52,9 @@ void GatherLayerTest::SetUp() {
 }
 
 std::string Gather7LayerTest::getTestCaseName(const testing::TestParamInfo<gather7ParamsTuple>& obj) {
-    std::tuple<int, int> axis_batch_idx;
     std::vector<int> indices;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, device_name) = obj.param;
+
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, device_name] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -91,11 +77,8 @@ std::string Gather7LayerTest::getTestCaseName(const testing::TestParamInfo<gathe
 }
 
 void Gather7LayerTest::SetUp() {
-    std::tuple<int, int> axis_batch_idx;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, targetDevice) = GetParam();
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     int axis = std::get<0>(axis_batch_idx);
@@ -122,11 +105,8 @@ std::string Gather8LayerTest::getTestCaseName(const testing::TestParamInfo<gathe
 }
 
 void Gather8LayerTest::SetUp() {
-    std::tuple<int, int> axis_batch_idx;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, targetDevice) = GetParam();
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     int axis = std::get<0>(axis_batch_idx);
@@ -153,11 +133,8 @@ std::string Gather8IndiceScalarLayerTest::getTestCaseName(const testing::TestPar
 }
 
 void Gather8IndiceScalarLayerTest::SetUp() {
-    std::tuple<int, int> axis_batch_idx;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, targetDevice) = GetParam();
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     int axis = std::get<0>(axis_batch_idx);
@@ -175,17 +152,11 @@ void Gather8IndiceScalarLayerTest::SetUp() {
 }
 
 std::string Gather8withIndicesDataLayerTest::getTestCaseName(const testing::TestParamInfo<gather8withIndicesDataParamsTuple>& obj) {
-    gather7ParamsTuple basicParams;
-    std::vector<int64_t> indicesData;
-    std::tie(basicParams, indicesData) = obj.param;
+    const auto& [basicParams, indicesData] = obj.param;
 
-    std::tuple<int, int> axis_batch_idx;
     std::vector<int> indices;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, device_name) = basicParams;
+
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, device_name] = basicParams;
 
     std::ostringstream result;
     result << "IS=(";
@@ -212,15 +183,10 @@ std::string Gather8withIndicesDataLayerTest::getTestCaseName(const testing::Test
 }
 
 void Gather8withIndicesDataLayerTest::SetUp() {
-    gather7ParamsTuple basicParams;
-    std::vector<int64_t> indicesData;
-    std::tie(basicParams, indicesData) = GetParam();
+    const auto& [basicParams, indicesData] = GetParam();
 
-    std::tuple<int, int> axis_batch_idx;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, targetDevice) = basicParams;
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, _targetDevice] = basicParams;
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     int axis = std::get<0>(axis_batch_idx);
@@ -247,16 +213,10 @@ void Gather8withIndicesDataLayerTest::SetUp() {
 // Gather String support
 std::string GatherStringWithIndicesDataLayerTest::getTestCaseName(const testing::TestParamInfo<GatherStringParamsTuple>& obj) {
     const GatherStringParamsTuple& basicParams = obj.param;
-    std::vector<int64_t> indicesData;
-    std::vector<std::string> str_data;
 
-    std::tuple<int, int> axis_batch_idx;
     std::vector<int> indices;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, device_name, indicesData, str_data) = basicParams;
+
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, device_name, indicesData, str_data] = basicParams;
 
     std::ostringstream result;
     result << "IS=(";
@@ -283,12 +243,11 @@ std::string GatherStringWithIndicesDataLayerTest::getTestCaseName(const testing:
 
 void GatherStringWithIndicesDataLayerTest::SetUp() {
     const GatherStringParamsTuple& basicParams = GetParam();
-    std::vector<int64_t> indicesData;
-    std::tuple<int, int> axis_batch_idx;
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(shapes, indices_shape, axis_batch_idx, model_type, targetDevice, indicesData, string_data) = basicParams;
+
+    const auto& [shapes, indices_shape, axis_batch_idx, model_type, _targetDevice, indicesData, _string_data] =
+        basicParams;
+    targetDevice = _targetDevice;
+    string_data = _string_data;
     init_input_shapes(shapes);
 
     int axis = std::get<0>(axis_batch_idx);

--- a/src/tests/functional/plugin/shared/src/single_op/gather_elements.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/gather_elements.cpp
@@ -13,12 +13,7 @@
 namespace ov {
 namespace test {
 std::string GatherElementsLayerTest::getTestCaseName(const testing::TestParamInfo<GatherElementsParams>& obj) {
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type, indices_type;
-    int axis;
-    std::string device;
-    std::tie(shapes, indices_shape, axis, model_type, indices_type, device) = obj.param;
+    const auto& [shapes, indices_shape, axis, model_type, indices_type, device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -42,11 +37,8 @@ std::string GatherElementsLayerTest::getTestCaseName(const testing::TestParamInf
 }
 
 void GatherElementsLayerTest::SetUp() {
-    ov::Shape indices_shape;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type, indices_type;
-    int axis;
-    std::tie(shapes, indices_shape, axis, model_type, indices_type, targetDevice) = this->GetParam();
+    const auto& [shapes, indices_shape, axis, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/gather_nd.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/gather_nd.cpp
@@ -9,12 +9,7 @@
 namespace ov {
 namespace test {
 std::string GatherNDLayerTest::getTestCaseName(const testing::TestParamInfo<GatherNDParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::Shape indices_shape;
-    ov::element::Type model_type, indices_type;
-    int batch_dims;
-    std::string device;
-    std::tie(shapes, indices_shape, batch_dims, model_type, indices_type, device) = obj.param;
+    const auto& [shapes, indices_shape, batch_dims, model_type, indices_type, device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -38,11 +33,8 @@ std::string GatherNDLayerTest::getTestCaseName(const testing::TestParamInfo<Gath
 }
 
 void GatherNDLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::Shape indices_shape;
-    ov::element::Type model_type, indices_type;
-    int batch_dims;
-    std::tie(shapes, indices_shape, batch_dims, model_type, indices_type, targetDevice) = this->GetParam();
+    const auto& [shapes, indices_shape, batch_dims, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
@@ -59,11 +51,8 @@ std::string GatherND8LayerTest::getTestCaseName(const testing::TestParamInfo<Gat
 }
 
 void GatherND8LayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::Shape indices_shape;
-    ov::element::Type model_type, indices_type;
-    int batch_dims;
-    std::tie(shapes, indices_shape, batch_dims, model_type, indices_type, targetDevice) = this->GetParam();
+    const auto& [shapes, indices_shape, batch_dims, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/gather_tree.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/gather_tree.cpp
@@ -15,12 +15,7 @@ namespace test {
 using ov::test::utils::InputLayerType;
 
 std::string GatherTreeLayerTest::getTestCaseName(const testing::TestParamInfo<GatherTreeParamsTuple> &obj) {
-    ov::Shape input_shape;
-    ov::element::Type model_type;
-    InputLayerType secondary_input_type;
-    std::string device_name;
-
-    std::tie(input_shape, secondary_input_type, model_type, device_name) = obj.param;
+    const auto& [input_shape, secondary_input_type, model_type, device_name] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -31,11 +26,8 @@ std::string GatherTreeLayerTest::getTestCaseName(const testing::TestParamInfo<Ga
 }
 
 void GatherTreeLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    InputLayerType secondary_input_type;
-
-    std::tie(input_shape, secondary_input_type, model_type, targetDevice) = GetParam();
+    const auto& [input_shape, secondary_input_type, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     std::vector<ov::Shape> input_shapes_static {input_shape};
     std::vector<ov::Shape> constant_shapes_static;

--- a/src/tests/functional/plugin/shared/src/single_op/generate_proposals.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/generate_proposals.cpp
@@ -11,21 +11,22 @@ namespace ov {
 namespace test {
 std::string GenerateProposalsLayerTest::getTestCaseName(
         const testing::TestParamInfo<GenerateProposalsTestParams>& obj) {
-    std::vector<InputShape> shapes;
     ov::op::v9::GenerateProposals::Attributes attributes;
-    ov::element::Type model_type;
-    ov::element::Type roi_num_type;
-    std::string targetName;
-    std::tie(
-        shapes,
-        attributes.min_size,
-        attributes.nms_threshold,
-        attributes.post_nms_count,
-        attributes.pre_nms_count,
-        attributes.normalized,
-        model_type,
-        roi_num_type,
-        targetName) = obj.param;
+
+    const auto& [shapes,
+                 _min_size,
+                 _nms_threshold,
+                 _post_nms_count,
+                 _pre_nms_count,
+                 _normalized,
+                 model_type,
+                 roi_num_type,
+                 targetName] = obj.param;
+    attributes.min_size = _min_size;
+    attributes.nms_threshold = _nms_threshold;
+    attributes.post_nms_count = _post_nms_count;
+    attributes.pre_nms_count = _pre_nms_count;
+    attributes.normalized = _normalized;
 
     std::ostringstream result;
     using ov::test::operator<<;
@@ -51,20 +52,23 @@ std::string GenerateProposalsLayerTest::getTestCaseName(
 }
 
 void GenerateProposalsLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
     ov::op::v9::GenerateProposals::Attributes attributes;
-    ov::element::Type model_type;
-    ov::element::Type roi_num_type;
-    std::tie(
-        shapes,
-        attributes.min_size,
-        attributes.nms_threshold,
-        attributes.post_nms_count,
-        attributes.pre_nms_count,
-        attributes.normalized,
-        model_type,
-        roi_num_type,
-        targetDevice) = this->GetParam();
+
+    const auto& [shapes,
+                 _min_size,
+                 _nms_threshold,
+                 _post_nms_count,
+                 _pre_nms_count,
+                 _normalized,
+                 model_type,
+                 roi_num_type,
+                 _targetDevice] = this->GetParam();
+    attributes.min_size = _min_size;
+    attributes.nms_threshold = _nms_threshold;
+    attributes.post_nms_count = _post_nms_count;
+    attributes.pre_nms_count = _pre_nms_count;
+    attributes.normalized = _normalized;
+    targetDevice = _targetDevice;
 
     inType = outType = model_type;
     if (targetDevice == ov::test::utils::DEVICE_GPU) {

--- a/src/tests/functional/plugin/shared/src/single_op/grid_sample.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/grid_sample.cpp
@@ -12,16 +12,8 @@
 namespace ov {
 namespace test {
 std::string GridSampleLayerTest::getTestCaseName(const testing::TestParamInfo<GridSampleParams>& obj) {
-    ov::Shape data_shape;
-    ov::Shape grid_shape;
-    bool align_corners;
-    ov::op::v9::GridSample::InterpolationMode mode;
-    ov::op::v9::GridSample::PaddingMode padding_mode;
-    ov::element::Type model_type;
-    ov::element::Type grid_type;
-    std::string target_device;
-
-    std::tie(data_shape, grid_shape, align_corners, mode, padding_mode, model_type, grid_type, target_device) = obj.param;
+    const auto& [data_shape, grid_shape, align_corners, mode, padding_mode, model_type, grid_type, target_device] =
+        obj.param;
 
     std::ostringstream result;
     result << "DS=" << ov::test::utils::vec2str(data_shape) << "_";
@@ -36,15 +28,9 @@ std::string GridSampleLayerTest::getTestCaseName(const testing::TestParamInfo<Gr
 }
 
 void GridSampleLayerTest::SetUp() {
-    ov::Shape data_shape;
-    ov::Shape grid_shape;
-    bool align_corners;
-    ov::op::v9::GridSample::InterpolationMode mode;
-    ov::op::v9::GridSample::PaddingMode padding_mode;
-    ov::element::Type model_type;
-    ov::element::Type grid_type;
-
-    std::tie(data_shape, grid_shape, align_corners, mode, padding_mode, model_type, grid_type, targetDevice) = this->GetParam();
+    const auto& [data_shape, grid_shape, align_corners, mode, padding_mode, model_type, grid_type, _targetDevice] =
+        this->GetParam();
+    targetDevice = _targetDevice;
 
     auto data = std::make_shared<ov::op::v0::Parameter>(model_type, data_shape);
     auto grid = std::make_shared<ov::op::v0::Parameter>(grid_type, grid_shape);

--- a/src/tests/functional/plugin/shared/src/single_op/grn.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/grn.cpp
@@ -11,11 +11,7 @@
 namespace ov {
 namespace test {
 std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    float bias;
-    std::tie(model_type, shapes, bias, target_device) = obj.param;
+    const auto& [model_type, shapes, bias, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -37,10 +33,8 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
 }
 
 void GrnLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    float bias;
-    std::tie(model_type, shapes, bias, targetDevice) = GetParam();
+    const auto& [model_type, shapes, bias, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/group_convolution.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/group_convolution.cpp
@@ -13,16 +13,10 @@
 namespace ov {
 namespace test {
 std::string GroupConvolutionLayerTest::getTestCaseName(const testing::TestParamInfo<groupConvLayerTestParamsSet>& obj) {
-    groupConvSpecificParams group_conv_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    std::tie(group_conv_params, model_type, shapes, target_device) = obj.param;
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end;
-    size_t conv_out_channels, num_groups;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type) = group_conv_params;
+    const auto& [group_conv_params, model_type, shapes, target_device] = obj.param;
+
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type] =
+        group_conv_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -51,15 +45,11 @@ std::string GroupConvolutionLayerTest::getTestCaseName(const testing::TestParamI
 }
 
 void GroupConvolutionLayerTest::SetUp() {
-    groupConvSpecificParams group_conv_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::tie(group_conv_params, model_type, shapes, targetDevice) = this->GetParam();
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end;
-    size_t conv_out_channels, num_groups;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type) = group_conv_params;
+    const auto& [group_conv_params, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type] =
+        group_conv_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/group_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/group_convolution_backprop_data.cpp
@@ -13,17 +13,10 @@
 namespace ov {
 namespace test {
 std::string GroupConvBackpropLayerTest::getTestCaseName(testing::TestParamInfo<groupConvBackpropLayerTestParamsSet> obj) {
-    groupConvBackpropSpecificParams group_conv_backprop_data_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    ov::Shape output_shape;
-    std::string target_device;
-    std::tie(group_conv_backprop_data_params, model_type, shapes, output_shape, target_device) = obj.param;
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
-    size_t conv_out_channels, num_groups;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type, out_padding) = group_conv_backprop_data_params;
+    const auto& [group_conv_backprop_data_params, model_type, shapes, output_shape, target_device] = obj.param;
+
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type, out_padding] =
+        group_conv_backprop_data_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -54,16 +47,11 @@ std::string GroupConvBackpropLayerTest::getTestCaseName(testing::TestParamInfo<g
 }
 
 void GroupConvBackpropLayerTest::SetUp() {
-    groupConvBackpropSpecificParams group_conv_backprop_data_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    ov::Shape output_shape;
-    std::tie(group_conv_backprop_data_params, model_type, shapes, output_shape, targetDevice) = this->GetParam();
-    ov::op::PadType pad_type;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> pad_begin, pad_end, out_padding;
-    size_t conv_out_channels, num_groups;
-    std::tie(kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type, out_padding) = group_conv_backprop_data_params;
+    const auto& [group_conv_backprop_data_params, model_type, shapes, output_shape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [kernel, stride, pad_begin, pad_end, dilation, conv_out_channels, num_groups, pad_type, out_padding] =
+        group_conv_backprop_data_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/gru_cell.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/gru_cell.cpp
@@ -17,23 +17,23 @@ namespace test {
 using ov::test::utils::InputLayerType;
 
 std::string GRUCellTest::getTestCaseName(const testing::TestParamInfo<GRUCellParams> &obj) {
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    bool linear_before_reset;
+
     std::vector<std::vector<size_t>> input_shapes;
-    InputLayerType WType;
-    InputLayerType RType;
-    InputLayerType BType;
-    ov::element::Type model_type;
-    std::string targetDevice;
-    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip,
-            linear_before_reset, WType, RType, BType, model_type, targetDevice) = obj.param;
+
+    const auto& [should_decompose,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 linear_before_reset,
+                 WType,
+                 RType,
+                 BType,
+                 model_type,
+                 targetDevice] = obj.param;
     input_shapes = {
             {{batch, input_size},
             {batch, hidden_size},
@@ -59,21 +59,22 @@ std::string GRUCellTest::getTestCaseName(const testing::TestParamInfo<GRUCellPar
 }
 
 void GRUCellTest::SetUp() {
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    bool linear_before_reset;
-    InputLayerType WType;
-    InputLayerType RType;
-    InputLayerType BType;
-    ov::element::Type model_type;
-    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, linear_before_reset,
-            WType, RType, BType, model_type, targetDevice) = this->GetParam();
+
+    const auto& [should_decompose,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 linear_before_reset,
+                 WType,
+                 RType,
+                 BType,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     std::vector<std::vector<size_t>> input_shapes = {
             {{batch, input_size},

--- a/src/tests/functional/plugin/shared/src/single_op/gru_sequence.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/gru_sequence.cpp
@@ -18,19 +18,11 @@ using ov::test::utils::SequenceTestsMode;
 using ov::test::utils::is_tensor_iterator_exist;
 
 std::string GRUSequenceTest::getTestCaseName(const testing::TestParamInfo<GRUSequenceParams> &obj) {
-    std::vector<InputShape> shapes;
-    SequenceTestsMode mode;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    bool linear_before_reset;
-    ov::op::RecurrentSequenceDirection direction;
-    InputLayerType WRBType;
-    ov::element::Type type;
-    std::string targetDevice;
-    std::tie(mode, shapes, activations, clip, linear_before_reset, direction, WRBType,
-                type, targetDevice) = obj.param;
+
+    const auto& [mode, shapes, activations, clip, linear_before_reset, direction, WRBType, type, targetDevice] =
+        obj.param;
     std::ostringstream result;
     result << "mode=" << mode << "_";
     result << "IS=(";
@@ -54,17 +46,13 @@ std::string GRUSequenceTest::getTestCaseName(const testing::TestParamInfo<GRUSeq
 }
 
 void GRUSequenceTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    bool linear_before_reset;
-    ov::op::RecurrentSequenceDirection direction;
-    InputLayerType wbr_type;
-    ov::test::utils::SequenceTestsMode mode;
-    std::tie(mode, shapes, activations, clip, linear_before_reset, direction, wbr_type,
-            inType, targetDevice) = this->GetParam();
+
+    const auto& [mode, shapes, activations, clip, linear_before_reset, direction, wbr_type, _inType, _targetDevice] =
+        this->GetParam();
+    inType = _inType;
+    targetDevice = _targetDevice;
     outType = inType;
     init_input_shapes(shapes);
     rel_threshold = 1e-2;

--- a/src/tests/functional/plugin/shared/src/single_op/interpolate.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/interpolate.cpp
@@ -15,23 +15,18 @@ namespace test {
 std::string InterpolateLayerTest::getTestCaseName(const testing::TestParamInfo<InterpolateLayerTestParams>& obj) {
     using ov::test::utils::operator<<;
 
-    InterpolateSpecificParams interpolate_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    ov::Shape target_shape;
-    std::string target_device;
-    std::map<std::string, std::string> additional_config;
-    std::tie(interpolate_params, model_type, shapes, target_shape, target_device, additional_config) = obj.param;
-    std::vector<size_t> pad_begin, pad_end;
-    std::vector<int64_t> axes;
-    std::vector<float> scales;
-    bool antialias;
-    ov::op::v4::Interpolate::InterpolateMode mode;
-    ov::op::v4::Interpolate::ShapeCalcMode shape_calc_mode;
-    ov::op::v4::Interpolate::CoordinateTransformMode coordinate_transform_mode;
-    ov::op::v4::Interpolate::NearestMode nearest_mode;
-    double cube_coef;
-    std::tie(mode, shape_calc_mode, coordinate_transform_mode, nearest_mode, antialias, pad_begin, pad_end, cube_coef, axes, scales) = interpolate_params;
+    const auto& [interpolate_params, model_type, shapes, target_shape, target_device, additional_config] = obj.param;
+
+    const auto& [mode,
+                 shape_calc_mode,
+                 coordinate_transform_mode,
+                 nearest_mode,
+                 antialias,
+                 pad_begin,
+                 pad_end,
+                 cube_coef,
+                 axes,
+                 scales] = interpolate_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -63,25 +58,22 @@ std::string InterpolateLayerTest::getTestCaseName(const testing::TestParamInfo<I
 }
 
 void InterpolateLayerTest::SetUp() {
-    InterpolateSpecificParams interpolate_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    ov::Shape target_shape;
-    std::map<std::string, std::string> additional_config;
-    std::tie(interpolate_params, model_type, shapes, target_shape, targetDevice, additional_config) = this->GetParam();
-    std::vector<size_t> pad_begin, pad_end;
-    std::vector<int64_t> axes;
-    std::vector<float> scales;
-    bool antialias;
-    ov::op::v4::Interpolate::InterpolateMode mode;
-    ov::op::v4::Interpolate::ShapeCalcMode shape_calc_mode;
-    ov::op::v4::Interpolate::CoordinateTransformMode coordinate_transform_mode;
-    ov::op::v4::Interpolate::NearestMode nearest_mode;
+    const auto& [interpolate_params, model_type, shapes, target_shape, _targetDevice, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
 
     configuration.insert(additional_config.begin(), additional_config.end());
 
-    double cube_coef;
-    std::tie(mode, shape_calc_mode, coordinate_transform_mode, nearest_mode, antialias, pad_begin, pad_end, cube_coef, axes, scales) = interpolate_params;
+    const auto& [mode,
+                 shape_calc_mode,
+                 coordinate_transform_mode,
+                 nearest_mode,
+                 antialias,
+                 pad_begin,
+                 pad_end,
+                 cube_coef,
+                 axes,
+                 scales] = interpolate_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
@@ -132,25 +124,22 @@ std::shared_ptr<ov::op::v0::Constant> make_scales_or_sizes_input(ov::op::util::I
 }
 }
 void Interpolate11LayerTest::SetUp() {
-    InterpolateSpecificParams interpolate_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    ov::Shape target_shape;
-    std::map<std::string, std::string> additional_config;
-    std::tie(interpolate_params, model_type, shapes, target_shape, targetDevice, additional_config) = this->GetParam();
-    std::vector<size_t> pad_begin, pad_end;
-    std::vector<int64_t> axes;
-    std::vector<float> scales;
-    bool antialias;
-    ov::op::v4::Interpolate::InterpolateMode mode;
-    ov::op::v4::Interpolate::ShapeCalcMode shape_calc_mode;
-    ov::op::v4::Interpolate::CoordinateTransformMode coordinate_transform_mode;
-    ov::op::v4::Interpolate::NearestMode nearest_mode;
+    const auto& [interpolate_params, model_type, shapes, target_shape, _targetDevice, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
 
     configuration.insert(additional_config.begin(), additional_config.end());
 
-    double cube_coef;
-    std::tie(mode, shape_calc_mode, coordinate_transform_mode, nearest_mode, antialias, pad_begin, pad_end, cube_coef, axes, scales) = interpolate_params;
+    const auto& [mode,
+                 shape_calc_mode,
+                 coordinate_transform_mode,
+                 nearest_mode,
+                 antialias,
+                 pad_begin,
+                 pad_end,
+                 cube_coef,
+                 axes,
+                 scales] = interpolate_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/invalid_cases/proposal.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/invalid_cases/proposal.cpp
@@ -14,27 +14,18 @@ const float box_size_scale = 2.0f;
 const float box_coordinate_scale = 2.0f;
 
 std::string ProposalBehTest::getTestCaseName(testing::TestParamInfo<proposalBehTestParamsSet> obj) {
-    proposalSpecificParams proposal_params;
-    std::string target_device;
-    std::vector<float> img_info;
-    std::tie(proposal_params, img_info, target_device) = obj.param;
+    const auto& [proposal_params, img_info, target_device] = obj.param;
 
-    size_t base_size, pre_nms_topn, post_nms_topn, min_size;
-    float nms_thresh;
-    std::vector<float> ratio, scale;
-    bool clip_before_nms, clip_after_nms;
-    std::string framework;
-
-    std::tie(base_size,
-             pre_nms_topn,
-             post_nms_topn,
-             nms_thresh,
-             min_size,
-             ratio,
-             scale,
-             clip_before_nms,
-             clip_after_nms,
-             framework) = proposal_params;
+    const auto& [base_size,
+                 pre_nms_topn,
+                 post_nms_topn,
+                 nms_thresh,
+                 min_size,
+                 ratio,
+                 scale,
+                 clip_before_nms,
+                 clip_after_nms,
+                 framework] = proposal_params;
 
     std::ostringstream result;
     result << "base_size=" << base_size << "_";
@@ -54,27 +45,19 @@ std::string ProposalBehTest::getTestCaseName(testing::TestParamInfo<proposalBehT
 }
 
 void ProposalBehTest::SetUp() {
-    proposalSpecificParams proposalParams;
-    std::vector<float> img_info;
+    const auto& [proposalParams, img_info, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
-    std::tie(proposalParams, img_info, targetDevice) = this->GetParam();
-
-    size_t base_size, pre_nms_topn, post_nms_topn, min_size;
-    float nms_thresh;
-    std::vector<float> ratio, scale;
-    bool clip_before_nms, clip_after_nms;
-    std::string framework;
-
-    std::tie(base_size,
-             pre_nms_topn,
-             post_nms_topn,
-             nms_thresh,
-             min_size,
-             ratio,
-             scale,
-             clip_before_nms,
-             clip_after_nms,
-             framework) = proposalParams;
+    const auto& [base_size,
+                 pre_nms_topn,
+                 post_nms_topn,
+                 nms_thresh,
+                 min_size,
+                 ratio,
+                 scale,
+                 clip_before_nms,
+                 clip_after_nms,
+                 framework] = proposalParams;
 
     size_t bottom_w = base_size;
     size_t bottom_h = base_size;

--- a/src/tests/functional/plugin/shared/src/single_op/inverse.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/inverse.cpp
@@ -15,13 +15,7 @@ using namespace ov::test;
 namespace ov {
 namespace test {
 std::string InverseLayerTest::getTestCaseName(const testing::TestParamInfo<InverseTestParams>& obj) {
-    std::vector<InputShape> input_shape;
-    ov::element::Type element_type;
-    bool adjoint;
-    int32_t seed;
-    std::string device_name;
-
-    std::tie(input_shape, element_type, adjoint, seed, device_name) = obj.param;
+    const auto& [input_shape, element_type, adjoint, seed, device_name] = obj.param;
 
     const char separator = '_';
     std::ostringstream result;
@@ -35,11 +29,9 @@ std::string InverseLayerTest::getTestCaseName(const testing::TestParamInfo<Inver
 }
 
 void InverseLayerTest::SetUp() {
-    std::vector<InputShape> input_shape;
-    ov::element::Type element_type;
-    bool adjoint;
-
-    std::tie(input_shape, element_type, adjoint, m_seed, targetDevice) = GetParam();
+    const auto& [input_shape, element_type, adjoint, _m_seed, _targetDevice] = GetParam();
+    m_seed = _m_seed;
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shape);
 

--- a/src/tests/functional/plugin/shared/src/single_op/is_inf.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/is_inf.cpp
@@ -10,12 +10,7 @@
 namespace ov {
 namespace test {
 std::string IsInfLayerTest::getTestCaseName(const testing::TestParamInfo<IsInfParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    bool detect_negative, detect_positive;
-    std::string target_name;
-    ov::AnyMap additional_config;
-    std::tie(shapes, detect_negative, detect_positive, model_type, target_name, additional_config) = obj.param;
+    const auto& [shapes, detect_negative, detect_positive, model_type, target_name, additional_config] = obj.param;
     std::ostringstream result;
 
     result << "IS=(";
@@ -42,11 +37,9 @@ std::string IsInfLayerTest::getTestCaseName(const testing::TestParamInfo<IsInfPa
 }
 
 void IsInfLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ElementType model_type;
-    bool detect_negative, detect_positive;
-    ov::AnyMap additional_config;
-    std::tie(shapes, detect_negative, detect_positive, model_type, targetDevice, additional_config) = this->GetParam();
+    const auto& [shapes, detect_negative, detect_positive, model_type, _targetDevice, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/plugin/shared/src/single_op/log_softmax.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/log_softmax.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string LogSoftmaxLayerTest::getTestCaseName(const testing::TestParamInfo<logSoftmaxLayerTestParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    int64_t axis;
-    std::string target_device;
-    std::tie(model_type, shapes, axis, target_device) = obj.param;
+    const auto& [model_type, shapes, axis, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -50,11 +46,8 @@ void LogSoftmaxLayerTest::generate_inputs(const std::vector<ov::Shape>& target_s
 }
 
 void LogSoftmaxLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    int64_t axis;
-
-    std::tie(model_type, shapes, axis, targetDevice) = GetParam();
+    const auto& [model_type, shapes, axis, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/logical.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/logical.cpp
@@ -11,13 +11,7 @@
 namespace ov {
 namespace test {
 std::string LogicalLayerTest::getTestCaseName(const testing::TestParamInfo<LogicalTestParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::test::utils::LogicalTypes comparisonOpType;
-    ov::test::utils::InputLayerType second_input_type;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::map<std::string, std::string> additional_config;
-    std::tie(shapes, comparisonOpType, second_input_type, model_type, device_name, additional_config) = obj.param;
+    const auto& [shapes, comparisonOpType, second_input_type, model_type, device_name, additional_config] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -40,13 +34,9 @@ std::string LogicalLayerTest::getTestCaseName(const testing::TestParamInfo<Logic
 }
 
 void LogicalLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::test::utils::LogicalTypes logical_op_type;
-    ov::test::utils::InputLayerType second_input_type;
-    ov::element::Type model_type;
-    std::map<std::string, std::string> additional_config;
-
-    std::tie(shapes, logical_op_type, second_input_type, model_type, targetDevice, additional_config) = this->GetParam();
+    const auto& [shapes, logical_op_type, second_input_type, model_type, _targetDevice, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     configuration.insert(additional_config.begin(), additional_config.end());

--- a/src/tests/functional/plugin/shared/src/single_op/loop.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/loop.cpp
@@ -18,16 +18,14 @@
 namespace ov {
 namespace test {
 std::string LoopLayerTest::getTestCaseName(const testing::TestParamInfo<LoopParams> &obj) {
-    bool execute_first_iteration;
-    bool is_body_condition_const;
-    bool body_condition; // works only if is_body_condition_const ==
-    int64_t trip_count;
-    std::vector<InputShape> shapes;
-    std::vector<LOOP_IN_TYPE> input_types;
-    ov::element::Type model_type;
-    std::string targetDevice;
-    std::tie(execute_first_iteration, is_body_condition_const, body_condition, trip_count, shapes, input_types, model_type,
-                targetDevice) = obj.param;
+    const auto& [execute_first_iteration,
+                 is_body_condition_const, // works only if is_body_condition_const
+                 body_condition,
+                 trip_count,
+                 shapes,
+                 input_types,
+                 model_type,
+                 targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -55,15 +53,15 @@ std::string LoopLayerTest::getTestCaseName(const testing::TestParamInfo<LoopPara
 }
 
 void LoopLayerTest::SetUp() {
-    bool execute_first_iteration;
-    bool is_body_condition_const;
-    bool body_condition; // works only if is_body_condition_const ==
-    int64_t trip_count;
-    std::vector<InputShape> shapes;
-    std::vector<LOOP_IN_TYPE> input_types;
-    ov::element::Type model_type;
-    std::tie(execute_first_iteration, is_body_condition_const, body_condition, trip_count, shapes, input_types, model_type,
-                targetDevice) = this->GetParam();
+    const auto& [execute_first_iteration,
+                 is_body_condition_const, // works only if is_body_condition_const
+                 body_condition,
+                 trip_count,
+                 shapes,
+                 input_types,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     // Example:
@@ -128,25 +126,9 @@ void LoopLayerTest::SetUp() {
 }
 
 std::string StaticShapeLoopLayerTest::getTestCaseName(const testing::TestParamInfo<StaticShapeLoopParams> &obj) {
-    bool unrolling;
-    bool static_iter_num;
-    bool static_continue_cond;
-    int64_t max_iter_num;
-    int64_t dynamic_exit;
-    int64_t axis;
-    int64_t start_value;
-    ov::Shape data_shape;
-    ov::element::Type model_type;
-    std::string target_device;
-    auto args_papck = std::tie(static_iter_num, max_iter_num, dynamic_exit, axis);
-    std::tie(
-        unrolling,
-        static_continue_cond,
-        args_papck,
-        start_value,
-        data_shape,
-        model_type,
-        target_device) = obj.param;
+    const auto& [unrolling, static_continue_cond, args_papck, start_value, data_shape, model_type, target_device] =
+        obj.param;
+    const auto& [static_iter_num, max_iter_num, dynamic_exit, axis] = args_papck;
 
     std::ostringstream result;
     result << "unrolling=" << std::to_string(unrolling) << "_";
@@ -167,24 +149,10 @@ std::string StaticShapeLoopLayerTest::getTestCaseName(const testing::TestParamIn
 }
 
 void StaticShapeLoopLayerTest::SetUp() {
-    bool unrolling;
-    bool static_iter_num;
-    bool static_continue_cond;
-    int64_t max_iter_num;
-    int64_t dynamic_exit;
-    int64_t axis;
-    int64_t start_value;
-    ov::Shape data_shape;
-    ov::element::Type model_type;
-    auto args_papck = std::tie(static_iter_num, max_iter_num, dynamic_exit, axis);
-    std::tie(
-        unrolling,
-        static_continue_cond,
-        args_papck,
-        start_value,
-        data_shape,
-        model_type,
-        targetDevice) = GetParam();
+    const auto& [unrolling, static_continue_cond, args_papck, start_value, data_shape, model_type, _targetDevice] =
+        GetParam();
+    const auto& [static_iter_num, max_iter_num, dynamic_exit, axis] = args_papck;
+    targetDevice = _targetDevice;
 
     const auto ngShape = ov::Shape{data_shape};
     const auto scalarShape = ov::Shape{};

--- a/src/tests/functional/plugin/shared/src/single_op/lrn.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/lrn.cpp
@@ -12,13 +12,7 @@
 namespace ov {
 namespace test {
 std::string LrnLayerTest::getTestCaseName(const testing::TestParamInfo<lrnLayerTestParamsSet>& obj) {
-    double alpha, beta, bias;
-    size_t size;
-    std::vector<int64_t> axes;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string targetDevice;
-    std::tie(alpha, beta, bias, size, axes, model_type, shapes, targetDevice) = obj.param;
+    const auto& [alpha, beta, bias, size, axes, model_type, shapes, targetDevice] = obj.param;
 
     std::ostringstream result;
     const char separator = '_';
@@ -46,12 +40,8 @@ std::string LrnLayerTest::getTestCaseName(const testing::TestParamInfo<lrnLayerT
 }
 
 void LrnLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    double alpha, beta, bias;
-    size_t size;
-    std::vector<int64_t> axes;
-    std::tie(alpha, beta, bias, size, axes, model_type, shapes, targetDevice) = GetParam();
+    const auto& [alpha, beta, bias, size, axes, model_type, shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/lstm_cell.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/lstm_cell.cpp
@@ -17,21 +17,20 @@ namespace test {
 using ov::test::utils::InputLayerType;
 
 std::string LSTMCellTest::getTestCaseName(const testing::TestParamInfo<LSTMCellParams> &obj) {
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    InputLayerType WType;
-    InputLayerType RType;
-    InputLayerType BType;
-    ov::element::Type model_type;
-    std::string targetDevice;
-    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, WType, RType, BType,
-            model_type, targetDevice) = obj.param;
+
+    const auto& [should_decompose,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 WType,
+                 RType,
+                 BType,
+                 model_type,
+                 targetDevice] = obj.param;
     std::vector<std::vector<size_t>> input_shapes = {
             {{batch, input_size}, {batch, hidden_size}, {batch, hidden_size}, {4 * hidden_size, input_size},
                     {4 * hidden_size, hidden_size}, {4 * hidden_size}},
@@ -53,20 +52,21 @@ std::string LSTMCellTest::getTestCaseName(const testing::TestParamInfo<LSTMCellP
 }
 
 void LSTMCellTest::SetUp() {
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    InputLayerType WType;
-    InputLayerType RType;
-    InputLayerType BType;
-    ov::element::Type model_type;
-    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, WType, RType, BType,
-            model_type, targetDevice) = this->GetParam();
+
+    const auto& [should_decompose,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 WType,
+                 RType,
+                 BType,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     std::vector<ov::Shape> input_shapes = {
         {batch, input_size},

--- a/src/tests/functional/plugin/shared/src/single_op/lstm_sequence.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/lstm_sequence.cpp
@@ -22,21 +22,20 @@ using ov::test::utils::SequenceTestsMode;
 using ov::test::utils::InputLayerType;
 
 std::string LSTMSequenceTest::getTestCaseName(const testing::TestParamInfo<LSTMSequenceParams> &obj) {
-    SequenceTestsMode mode;
-    size_t seq_lengths;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    ov::op::RecurrentSequenceDirection direction;
-    InputLayerType WRBType;
-    ov::element::Type model_type;
-    std::string targetDevice;
-    std::tie(mode, seq_lengths, batch, hidden_size, input_size, activations, clip, direction,
-                WRBType, model_type, targetDevice) = obj.param;
+
+    const auto& [mode,
+                 seq_lengths,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 direction,
+                 WRBType,
+                 model_type,
+                 targetDevice] = obj.param;
     std::vector<std::vector<size_t>> input_shapes = {
             {{batch, input_size}, {batch, hidden_size}, {batch, hidden_size}, {4 * hidden_size, input_size},
                     {4 * hidden_size, hidden_size}, {4 * hidden_size}},
@@ -58,20 +57,21 @@ std::string LSTMSequenceTest::getTestCaseName(const testing::TestParamInfo<LSTMS
 }
 
 void LSTMSequenceTest::SetUp() {
-    SequenceTestsMode mode;
-    size_t seq_lengths;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    ov::op::RecurrentSequenceDirection direction;
-    InputLayerType WRBType;
-    ov::element::Type model_type;
-    std::tie(mode, seq_lengths, batch, hidden_size, input_size, activations, clip, direction,
-                WRBType, model_type, targetDevice) = this->GetParam();
+
+    const auto& [mode,
+                 seq_lengths,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 direction,
+                 WRBType,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     max_seq_lengths = seq_lengths;
     size_t num_directions = direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;

--- a/src/tests/functional/plugin/shared/src/single_op/mat_mul.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/mat_mul.cpp
@@ -15,13 +15,7 @@ namespace test {
 using ov::test::utils::InputLayerType;
 
 std::string MatMulLayerTest::getTestCaseName(const testing::TestParamInfo<MatMulLayerTestParamsSet> &obj) {
-    std::vector<InputShape> shapes;
-    std::pair<bool, bool> transpose;
-    ov::element::Type model_type;
-    InputLayerType secondary_input_type;
-    std::string target_device;
-    std::map<std::string, std::string> additional_config;
-    std::tie(shapes, transpose, model_type, secondary_input_type, target_device, additional_config) = obj.param;
+    const auto& [shapes, transpose, model_type, secondary_input_type, target_device, additional_config] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -50,12 +44,9 @@ std::string MatMulLayerTest::getTestCaseName(const testing::TestParamInfo<MatMul
 }
 
 void MatMulLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::pair<bool, bool> transpose;
-    ov::element::Type model_type;
-    InputLayerType secondary_input_type;
-    std::map<std::string, std::string> additional_config;
-    std::tie(shapes, transpose, model_type, secondary_input_type, targetDevice, additional_config) = this->GetParam();
+    const auto& [shapes, transpose, model_type, secondary_input_type, _targetDevice, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
     configuration.insert(additional_config.begin(), additional_config.end());
 

--- a/src/tests/functional/plugin/shared/src/single_op/matrix_nms.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/matrix_nms.cpp
@@ -8,24 +8,20 @@
 namespace ov {
 namespace test {
 std::string MatrixNmsLayerTest::getTestCaseName(const testing::TestParamInfo<NmsParams>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    op::v8::MatrixNms::SortResultType sort_result_type;
-    ov::element::Type out_type;
-    int backgroudClass;
-    op::v8::MatrixNms::DecayFunction decayFunction;
-    TopKParams top_k_params;
-    ThresholdParams threshold_params;
-    bool normalized;
-    std::string target_device;
-    std::tie(shapes, model_type, sort_result_type, out_type, top_k_params, threshold_params,
-        backgroudClass, normalized, decayFunction, target_device) = obj.param;
+    const auto& [shapes,
+                 model_type,
+                 sort_result_type,
+                 out_type,
+                 top_k_params,
+                 threshold_params,
+                 backgroudClass,
+                 normalized,
+                 decayFunction,
+                 target_device] = obj.param;
 
-    int nms_top_k, keep_top_k;
-    std::tie(nms_top_k, keep_top_k) = top_k_params;
+    const auto& [nms_top_k, keep_top_k] = top_k_params;
 
-    float score_threshold, gaussian_sigma, post_threshold;
-    std::tie(score_threshold, gaussian_sigma, post_threshold) = threshold_params;
+    const auto& [score_threshold, gaussian_sigma, post_threshold] = threshold_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -50,14 +46,24 @@ std::string MatrixNmsLayerTest::getTestCaseName(const testing::TestParamInfo<Nms
 }
 
 void MatrixNmsLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    TopKParams top_k_params;
-    ThresholdParams threshold_params;
     ov::op::v8::MatrixNms::Attributes attrs;
 
-    std::tie(shapes, model_type, attrs.sort_result_type, attrs.output_type, top_k_params, threshold_params,
-        attrs.background_class, attrs.normalized, attrs.decay_function, targetDevice) = this->GetParam();
+    const auto& [shapes,
+                 model_type,
+                 _sort_result_type,
+                 _output_type,
+                 top_k_params,
+                 threshold_params,
+                 _background_class,
+                 _normalized,
+                 _decay_function,
+                 _targetDevice] = this->GetParam();
+    attrs.sort_result_type = _sort_result_type;
+    attrs.output_type = _output_type;
+    attrs.background_class = _background_class;
+    attrs.normalized = _normalized;
+    attrs.decay_function = _decay_function;
+    targetDevice = _targetDevice;
 
     std::tie(attrs.nms_top_k, attrs.keep_top_k) = top_k_params;
     std::tie(attrs.score_threshold, attrs.gaussian_sigma, attrs.post_threshold) = threshold_params;

--- a/src/tests/functional/plugin/shared/src/single_op/memory.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/memory.cpp
@@ -21,12 +21,7 @@ namespace ov {
 namespace test {
 
 std::string MemoryLayerTest::getTestCaseName(const testing::TestParamInfo<MemoryLayerTestParams> &obj) {
-    int64_t iteration_count;
-    ov::element::Type model_type;
-    ov::Shape input_shape;
-    std::string target_device;
-    ov::test::utils::MemoryTransformation transformation;
-    std::tie(transformation, iteration_count, input_shape, model_type, target_device) = obj.param;
+    const auto& [transformation, iteration_count, input_shape, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "transformation=" << transformation << "_";
@@ -39,11 +34,9 @@ std::string MemoryLayerTest::getTestCaseName(const testing::TestParamInfo<Memory
 }
 
 void MemoryLayerTest::SetUp() {
-    ov::element::Type model_type;
-    ov::Shape input_shape;
-    ov::test::utils::MemoryTransformation transformation;
-
-    std::tie(transformation, iteration_count, input_shape, model_type, targetDevice) = this->GetParam();
+    const auto& [transformation, _iteration_count, input_shape, model_type, _targetDevice] = this->GetParam();
+    iteration_count = _iteration_count;
+    targetDevice = _targetDevice;
 
     if (transformation == ov::test::utils::MemoryTransformation::NONE) {
         CreateCommonFunc(model_type, input_shape);

--- a/src/tests/functional/plugin/shared/src/single_op/minimum_maximum.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/minimum_maximum.cpp
@@ -18,12 +18,7 @@ using ov::test::utils::InputLayerType;
 using ov::test::utils::MinMaxOpType;
 
 std::string MaxMinLayerTest::getTestCaseName(const testing::TestParamInfo<MaxMinParamsTuple> &obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string target_name;
-    InputLayerType second_input_type;
-    MinMaxOpType op_type;
-    std::tie(shapes, op_type, model_type, second_input_type, target_name) = obj.param;
+    const auto& [shapes, op_type, model_type, second_input_type, target_name] = obj.param;
     std::ostringstream result;
 
     result << "IS=(";
@@ -46,11 +41,8 @@ std::string MaxMinLayerTest::getTestCaseName(const testing::TestParamInfo<MaxMin
 }
 
 void MaxMinLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    InputLayerType second_input_type;
-    MinMaxOpType op_type;
-    std::tie(shapes, op_type, model_type, second_input_type, targetDevice) = this->GetParam();
+    const auto& [shapes, op_type, model_type, second_input_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0])};

--- a/src/tests/functional/plugin/shared/src/single_op/multiclass_nms.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/multiclass_nms.cpp
@@ -11,25 +11,22 @@
 namespace ov {
 namespace test {
 std::string MulticlassNmsLayerTest::getTestCaseName(const testing::TestParamInfo<MulticlassNmsParams>& obj) {
-    std::vector<InputShape> shapes;
-    InputTypes input_types;
-    int32_t nmsTopK, backgroundClass, keepTopK;
-    element::Type outType;
-    op::util::MulticlassNmsBase::SortResultType sortResultType;
-    InputfloatVar inFloatVar;
-    InputboolVar inboolVar;
-    std::string targetDevice;
+    const auto& [shapes,
+                 input_types,
+                 nmsTopK,
+                 inFloatVar,
+                 backgroundClass,
+                 keepTopK,
+                 outType,
+                 sortResultType,
+                 inboolVar,
+                 targetDevice] = obj.param;
 
-    std::tie(shapes, input_types, nmsTopK, inFloatVar, backgroundClass, keepTopK, outType, sortResultType, inboolVar, targetDevice) = obj.param;
+    const auto& [paramsPrec, roisnumPrec] = input_types;
 
-    ElementType paramsPrec, roisnumPrec;
-    std::tie(paramsPrec, roisnumPrec) = input_types;
+    const auto& [iouThr, scoreThr, nmsEta] = inFloatVar;
 
-    float iouThr, scoreThr, nmsEta;
-    std::tie(iouThr, scoreThr, nmsEta) = inFloatVar;
-
-    bool sortResCB, normalized;
-    std::tie(sortResCB, normalized) = inboolVar;
+    const auto& [sortResCB, normalized] = inboolVar;
 
     std::ostringstream result;
     result << "IS=(";
@@ -115,30 +112,27 @@ void MulticlassNmsLayerTest::generate_inputs(const std::vector<ov::Shape>& targe
 }
 
 void MulticlassNmsLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    InputTypes input_types;
-    size_t maxOutBoxesPerClass, backgroundClass, keepTopK;
-    element::Type outType;
-
-    op::util::MulticlassNmsBase::SortResultType sortResultType;
-
-    InputfloatVar inFloatVar;
-    InputboolVar inboolVar;
     ov::op::util::MulticlassNmsBase::Attributes attrs;
 
-    std::tie(shapes, input_types, maxOutBoxesPerClass, inFloatVar, backgroundClass, keepTopK, outType, sortResultType, inboolVar, targetDevice)
-        = this->GetParam();
+    const auto& [shapes,
+                 input_types,
+                 maxOutBoxesPerClass,
+                 inFloatVar,
+                 backgroundClass,
+                 keepTopK,
+                 outType,
+                 sortResultType,
+                 inboolVar,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
 
-    ElementType paramsPrec, roisnumPrec;
-    std::tie(paramsPrec, roisnumPrec) = input_types;
+    const auto& [paramsPrec, roisnumPrec] = input_types;
 
-    float iouThr, scoreThr, nmsEta;
-    std::tie(iouThr, scoreThr, nmsEta) = inFloatVar;
+    const auto& [iouThr, scoreThr, nmsEta] = inFloatVar;
 
-    bool sortResCB, normalized;
-    std::tie(sortResCB, normalized) = inboolVar;
+    const auto& [sortResCB, normalized] = inboolVar;
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(paramsPrec, inputDynamicShapes.at(0)),
                                 std::make_shared<ov::op::v0::Parameter>(paramsPrec, inputDynamicShapes.at(1))};

--- a/src/tests/functional/plugin/shared/src/single_op/multinomial.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/multinomial.cpp
@@ -11,17 +11,14 @@ using namespace ov::test;
 namespace ov {
 namespace test {
 std::string MultinomialLayerTest::getTestCaseName(const testing::TestParamInfo<MultinomialTestParams>& obj) {
-    std::string test_type;
-    ov::Tensor probs;
-    ov::Tensor num_samples;
-    ov::test::ElementType convert_type;
-    bool with_replacement;
-    bool log_probs;
-    std::pair<uint64_t, uint64_t> global_op_seed;
-    std::string device_name;
-
-    std::tie(test_type, probs, num_samples, convert_type, with_replacement, log_probs, global_op_seed, device_name) =
-        obj.param;
+    const auto& [test_type,
+                 probs,
+                 num_samples,
+                 convert_type,
+                 with_replacement,
+                 log_probs,
+                 global_op_seed,
+                 device_name] = obj.param;
 
     uint64_t global_seed = global_op_seed.first;
     uint64_t op_seed = global_op_seed.second;
@@ -49,16 +46,15 @@ std::string MultinomialLayerTest::getTestCaseName(const testing::TestParamInfo<M
 void MultinomialLayerTest::SetUp() {
     MultinomialTestParams test_params;
 
-    std::string test_type;
-    ov::Tensor probs;
-    ov::Tensor num_samples;
-    ov::test::ElementType convert_type;
-    bool with_replacement;
-    bool log_probs;
-    std::pair<uint64_t, uint64_t> global_op_seed;
-
-    std::tie(test_type, probs, num_samples, convert_type, with_replacement, log_probs, global_op_seed, targetDevice) =
-        GetParam();
+    const auto& [test_type,
+                 probs,
+                 num_samples,
+                 convert_type,
+                 with_replacement,
+                 log_probs,
+                 global_op_seed,
+                 _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     m_probs = probs;
     m_num_samples = num_samples;

--- a/src/tests/functional/plugin/shared/src/single_op/mvn.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/mvn.cpp
@@ -12,13 +12,7 @@
 namespace ov {
 namespace test {
 std::string Mvn1LayerTest::getTestCaseName(const testing::TestParamInfo<mvn1Params>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    ov::AxisSet axes;
-    bool across_channels, normalize_variance;
-    double eps;
-    std::string target_device;
-    std::tie(shapes, model_type, axes, across_channels, normalize_variance, eps, target_device) = obj.param;
+    const auto& [shapes, model_type, axes, across_channels, normalize_variance, eps, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -45,12 +39,8 @@ std::string Mvn1LayerTest::getTestCaseName(const testing::TestParamInfo<mvn1Para
 }
 
 void Mvn1LayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    ov::AxisSet axes;
-    bool across_channels, normalize_variance;
-    double eps;
-    std::tie(shapes, model_type, axes, across_channels, normalize_variance, eps, targetDevice) = this->GetParam();
+    const auto& [shapes, model_type, axes, across_channels, normalize_variance, eps, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
@@ -80,15 +70,7 @@ void Mvn1LayerTest::SetUp() {
 }
 
 std::string Mvn6LayerTest::getTestCaseName(const testing::TestParamInfo<mvn6Params>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    ov::element::Type axis_type;
-    std::vector<int> axes;
-    bool normalize_variance;
-    float eps;
-    std::string eps_mode;
-    std::string target_device;
-    std::tie(shapes, model_type, axis_type, axes, normalize_variance, eps, eps_mode, target_device) = obj.param;
+    const auto& [shapes, model_type, axis_type, axes, normalize_variance, eps, eps_mode, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < shapes.size(); i++) {
@@ -113,14 +95,9 @@ std::string Mvn6LayerTest::getTestCaseName(const testing::TestParamInfo<mvn6Para
 }
 
 void Mvn6LayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    ov::element::Type axis_type;
-    std::vector<int> axes;
-    bool normalize_variance;
-    float eps;
-    std::string eps_mode;
-    std::tie(shapes, model_type, axis_type, axes, normalize_variance, eps, eps_mode, targetDevice) = this->GetParam();
+    const auto& [shapes, model_type, axis_type, axes, normalize_variance, eps, eps_mode, _targetDevice] =
+        this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/non_max_suppression.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/non_max_suppression.cpp
@@ -11,30 +11,20 @@ namespace ov {
 namespace test {
 
 std::string NmsLayerTest::getTestCaseName(const testing::TestParamInfo<NmsParams>& obj) {
-    InputShapeParams input_shape_params;
-    InputTypes input_types;
-    int32_t max_out_boxes_per_class;
-    float iou_thr, score_thr, soft_nms_sigma;
-    op::v5::NonMaxSuppression::BoxEncodingType box_encoding;
-    bool sort_res_descend;
-    element::Type out_type;
-    std::string target_device;
-    std::tie(input_shape_params,
-             input_types,
-             max_out_boxes_per_class,
-             iou_thr,
-             score_thr,
-             soft_nms_sigma,
-             box_encoding,
-             sort_res_descend,
-             out_type,
-             target_device) = obj.param;
+    const auto& [input_shape_params,
+                 input_types,
+                 max_out_boxes_per_class,
+                 iou_thr,
+                 score_thr,
+                 soft_nms_sigma,
+                 box_encoding,
+                 sort_res_descend,
+                 out_type,
+                 target_device] = obj.param;
 
-    size_t num_batches, num_boxes, num_classes;
-    std::tie(num_batches, num_boxes, num_classes) = input_shape_params;
+    const auto& [num_batches, num_boxes, num_classes] = input_shape_params;
 
-    ov::element::Type params_type, max_box_type, thr_type;
-    std::tie(params_type, max_box_type, thr_type) = input_types;
+    const auto& [params_type, max_box_type, thr_type] = input_types;
 
     using ov::operator<<;
     std::ostringstream result;
@@ -49,29 +39,23 @@ std::string NmsLayerTest::getTestCaseName(const testing::TestParamInfo<NmsParams
 }
 
 void NmsLayerTest::SetUp() {
-    InputTypes input_types;
-    InputShapeParams input_shape_params;
-    int max_out_boxes_per_class;
-    float iou_thr, score_thr, soft_nms_sigma;
-    op::v5::NonMaxSuppression::BoxEncodingType box_encoding;
-    bool sort_res_descend;
-    element::Type out_type;
-    std::tie(input_shape_params,
-             input_types,
-             max_out_boxes_per_class,
-             iou_thr,
-             score_thr,
-             soft_nms_sigma,
-             box_encoding,
-             sort_res_descend,
-             out_type,
-             targetDevice) = this->GetParam();
+    const auto& [input_shape_params,
+                 input_types,
+                 max_out_boxes_per_class,
+                 iou_thr,
+                 score_thr,
+                 soft_nms_sigma,
+                 box_encoding,
+                 sort_res_descend,
+                 out_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
-    size_t num_classes;
-    std::tie(m_num_batches, m_num_boxes, num_classes) = input_shape_params;
+    const auto& [_m_num_batches, _m_num_boxes, num_classes] = input_shape_params;
+    m_num_batches = _m_num_batches;
+    m_num_boxes = _m_num_boxes;
 
-    ov::element::Type params_type, max_box_type, thr_type;
-    std::tie(params_type, max_box_type, thr_type) = input_types;
+    const auto& [params_type, max_box_type, thr_type] = input_types;
 
     const ov::Shape boxes_shape{m_num_batches, m_num_boxes, 4}, scores_shape{m_num_batches, num_classes, m_num_boxes};
 
@@ -99,34 +83,29 @@ void NmsLayerTest::SetUp() {
 }
 
 void Nms9LayerTest::SetUp() {
-    InputTypes input_types;
-    InputShapeParams input_shape_params;
-    int max_out_boxes_per_class;
-    float iou_thr, score_thr, soft_nms_sigma;
-    op::v5::NonMaxSuppression::BoxEncodingType box_encoding;
     op::v9::NonMaxSuppression::BoxEncodingType box_encoding_v9;
-    bool sort_res_descend;
-    ov::element::Type out_type;
-    std::tie(input_shape_params,
-             input_types,
-             max_out_boxes_per_class,
-             iou_thr,
-             score_thr,
-             soft_nms_sigma,
-             box_encoding,
-             sort_res_descend,
-             out_type,
-             targetDevice) = this->GetParam();
+
+    const auto& [input_shape_params,
+                 input_types,
+                 max_out_boxes_per_class,
+                 iou_thr,
+                 score_thr,
+                 soft_nms_sigma,
+                 box_encoding,
+                 sort_res_descend,
+                 out_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     box_encoding_v9 = box_encoding == op::v5::NonMaxSuppression::BoxEncodingType::CENTER
                           ? op::v9::NonMaxSuppression::BoxEncodingType::CENTER
                           : op::v9::NonMaxSuppression::BoxEncodingType::CORNER;
 
-    size_t num_classes;
-    std::tie(m_num_batches, m_num_boxes, num_classes) = input_shape_params;
+    const auto& [_m_num_batches, _m_num_boxes, num_classes] = input_shape_params;
+    m_num_batches = _m_num_batches;
+    m_num_boxes = _m_num_boxes;
 
-    ov::element::Type params_type, max_box_type, thr_type;
-    std::tie(params_type, max_box_type, thr_type) = input_types;
+    const auto& [params_type, max_box_type, thr_type] = input_types;
 
     const std::vector<size_t> boxes_shape{m_num_batches, m_num_boxes, 4}, scores_shape{m_num_batches, num_classes, m_num_boxes};
 

--- a/src/tests/functional/plugin/shared/src/single_op/nonzero.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/nonzero.cpp
@@ -13,11 +13,7 @@ namespace ov {
 namespace test {
 
 std::string NonZeroLayerTest::getTestCaseName(const testing::TestParamInfo<NonZeroLayerTestParamsSet>& obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::map<std::string, std::string> additional_config;
-    std::tie(shapes, model_type, target_device, additional_config) = obj.param;
+    const auto& [shapes, model_type, target_device, additional_config] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -38,10 +34,8 @@ std::string NonZeroLayerTest::getTestCaseName(const testing::TestParamInfo<NonZe
 }
 
 void NonZeroLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::map<std::string, std::string> additional_config;
-    std::tie(shapes, model_type, targetDevice, additional_config) = GetParam();
+    const auto& [shapes, model_type, _targetDevice, additional_config] = GetParam();
+    targetDevice = _targetDevice;
     configuration.insert(additional_config.cbegin(), additional_config.cend());
     init_input_shapes(shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/normalize_l2.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/normalize_l2.cpp
@@ -12,13 +12,7 @@
 namespace ov {
 namespace test {
 std::string NormalizeL2LayerTest::getTestCaseName(const testing::TestParamInfo<NormalizeL2LayerTestParams>& obj) {
-    std::vector<int64_t> axes;
-    float eps;
-    ov::op::EpsMode eps_mode;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string targetDevice;
-    std::tie(axes, eps, eps_mode, shapes, model_type, targetDevice) = obj.param;
+    const auto& [axes, eps, eps_mode, shapes, model_type, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -42,12 +36,8 @@ std::string NormalizeL2LayerTest::getTestCaseName(const testing::TestParamInfo<N
 }
 
 void NormalizeL2LayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    std::vector<int64_t> axes;
-    float eps;
-    ov::op::EpsMode eps_mode;
-    ov::element::Type model_type;
-    std::tie(axes, eps, eps_mode, shapes, model_type, targetDevice) = this->GetParam();
+    const auto& [axes, eps, eps_mode, shapes, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/one_hot.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/one_hot.cpp
@@ -12,15 +12,7 @@
 namespace ov {
 namespace test {
 std::string OneHotLayerTest::getTestCaseName(const testing::TestParamInfo<oneHotLayerTestParamsSet>& obj) {
-    int64_t axis;
-    ov::element::Type depth_type, set_type;
-    int64_t depth_val;
-    float on_val, off_val;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string targetDevice;
-
-    std::tie(depth_type, depth_val, set_type, on_val, off_val, axis, model_type, shapes, targetDevice) = obj.param;
+    const auto& [depth_type, depth_val, set_type, on_val, off_val, axis, model_type, shapes, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -48,13 +40,9 @@ std::string OneHotLayerTest::getTestCaseName(const testing::TestParamInfo<oneHot
 }
 
 void OneHotLayerTest::SetUp() {
-    int64_t axis;
-    ov::element::Type depth_type, set_type;
-    int64_t depth_val;
-    float on_val, off_val;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::tie(depth_type, depth_val, set_type, on_val, off_val, axis, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [depth_type, depth_val, set_type, on_val, off_val, axis, model_type, shapes, _targetDevice] =
+        this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/pad.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/pad.cpp
@@ -12,13 +12,7 @@
 namespace ov {
 namespace test {
 std::string PadLayerTest::getTestCaseName(const testing::TestParamInfo<padLayerTestParamsSet>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::vector<int64_t> pads_begin, pads_end;
-    ov::op::PadMode pad_mode;
-    float arg_pad_value;
-    std::string target_device;
-    std::tie(pads_begin, pads_end, arg_pad_value, pad_mode, model_type, shapes, target_device) = obj.param;
+    const auto& [pads_begin, pads_end, arg_pad_value, pad_mode, model_type, shapes, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -45,12 +39,8 @@ std::string PadLayerTest::getTestCaseName(const testing::TestParamInfo<padLayerT
 }
 
 void PadLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::vector<int64_t> pads_begin, pads_end;
-    ov::op::PadMode pad_mode;
-    float arg_pad_value;
-    std::tie(pads_begin, pads_end, arg_pad_value, pad_mode, model_type, shapes, targetDevice) = this->GetParam();
+    const auto& [pads_begin, pads_end, arg_pad_value, pad_mode, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/pooling.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/pooling.cpp
@@ -15,18 +15,9 @@ namespace test {
 using ov::test::utils::PoolingTypes;
 
 std::string PoolingLayerTest::getTestCaseName(const testing::TestParamInfo<poolLayerTestParamsSet>& obj) {
-    poolSpecificParams pool_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string targetDevice;
-    std::tie(pool_params, model_type, shapes, targetDevice) = obj.param;
-    PoolingTypes pool_type;
-    std::vector<size_t> kernel, stride;
-    std::vector<size_t> pad_begin, pad_end;
-    ov::op::PadType pad_type;
-    ov::op::RoundingType rounding_type;
-    bool excludePad;
-    std::tie(pool_type, kernel, stride, pad_begin, pad_end, rounding_type, pad_type, excludePad) = pool_params;
+    const auto& [pool_params, model_type, shapes, targetDevice] = obj.param;
+
+    const auto& [pool_type, kernel, stride, pad_begin, pad_end, rounding_type, pad_type, excludePad] = pool_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -62,17 +53,10 @@ std::string PoolingLayerTest::getTestCaseName(const testing::TestParamInfo<poolL
 }
 
 void PoolingLayerTest::SetUp() {
-    poolSpecificParams pool_params;
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::tie(pool_params, model_type, shapes, targetDevice) = this->GetParam();
-    PoolingTypes pool_type;
-    std::vector<size_t> kernel, stride;
-    std::vector<size_t> pad_begin, pad_end;
-    ov::op::PadType pad_type;
-    ov::op::RoundingType rounding_type;
-    bool excludePad;
-    std::tie(pool_type, kernel, stride, pad_begin, pad_end, rounding_type, pad_type, excludePad) = pool_params;
+    const auto& [pool_params, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [pool_type, kernel, stride, pad_begin, pad_end, rounding_type, pad_type, excludePad] = pool_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
@@ -90,18 +74,10 @@ void PoolingLayerTest::SetUp() {
 
 
 std::string MaxPoolingV8LayerTest::getTestCaseName(const testing::TestParamInfo<maxPoolV8LayerTestParamsSet>& obj) {
-    maxPoolV8SpecificParams pool_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    std::tie(pool_params, model_type, shapes, target_device) = obj.param;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<size_t> pad_begin, pad_end;
-    ov::op::PadType pad_type;
-    ov::op::RoundingType rounding_type;
-    ov::element::Type index_element_type;
-    int64_t axis;
-    std::tie(kernel, stride, dilation, pad_begin, pad_end, index_element_type, axis, rounding_type, pad_type) = pool_params;
+    const auto& [pool_params, model_type, shapes, target_device] = obj.param;
+
+    const auto& [kernel, stride, dilation, pad_begin, pad_end, index_element_type, axis, rounding_type, pad_type] =
+        pool_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -131,17 +107,11 @@ std::string MaxPoolingV8LayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void MaxPoolingV8LayerTest::SetUp() {
-    maxPoolV8SpecificParams pool_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::tie(pool_params, model_type, shapes, targetDevice) = this->GetParam();
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<size_t> pad_begin, pad_end;
-    ov::op::PadType pad_type;
-    ov::op::RoundingType rounding_type;
-    ov::element::Type index_element_type;
-    int64_t axis;
-    std::tie(kernel, stride, dilation, pad_begin, pad_end, index_element_type, axis, rounding_type, pad_type) = pool_params;
+    const auto& [pool_params, model_type, shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [kernel, stride, dilation, pad_begin, pad_end, index_element_type, axis, rounding_type, pad_type] =
+        pool_params;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/power.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/power.cpp
@@ -12,11 +12,7 @@
 namespace ov {
 namespace test {
 std::string PowerLayerTest::getTestCaseName(const testing::TestParamInfo<PowerParamsTuple> &obj) {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::string device_name;
-    std::vector<float> power;
-    std::tie(shapes, model_type, power, device_name) = obj.param;
+    const auto& [shapes, model_type, power, device_name] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -40,10 +36,8 @@ std::string PowerLayerTest::getTestCaseName(const testing::TestParamInfo<PowerPa
 void PowerLayerTest::SetUp() {
     abs_threshold = 0.04f;
 
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::vector<float> power;
-    std::tie(shapes, model_type, power, targetDevice) = this->GetParam();
+    const auto& [shapes, model_type, power, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/prior_box.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/prior_box.cpp
@@ -15,17 +15,21 @@
 namespace ov {
 namespace test {
 std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<priorBoxLayerParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    priorBoxSpecificParams spec_params;
-    std::tie(spec_params, model_type, shapes, target_device) = obj.param;
+    const auto& [spec_params, model_type, shapes, target_device] = obj.param;
 
-    std::vector<float> min_size, max_size, aspect_ratio, density, fixed_ratio, fixed_size, variance;
-    float step, offset;
-    bool clip, flip, scale_all_sizes, min_max_aspect_ratios_order;
-    std::tie(min_size, max_size, aspect_ratio, density, fixed_ratio, fixed_size, clip,
-             flip, step, offset, variance, scale_all_sizes, min_max_aspect_ratios_order) = spec_params;
+    const auto& [min_size,
+                 max_size,
+                 aspect_ratio,
+                 density,
+                 fixed_ratio,
+                 fixed_size,
+                 clip,
+                 flip,
+                 step,
+                 offset,
+                 variance,
+                 scale_all_sizes,
+                 min_max_aspect_ratios_order] = spec_params;
 
     std::ostringstream result;
     const char separator = '_';
@@ -61,27 +65,22 @@ std::string PriorBoxLayerTest::getTestCaseName(const testing::TestParamInfo<prio
 }
 
 void PriorBoxLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::vector<float> min_size;
-    std::vector<float> max_size;
-    std::vector<float> aspect_ratio;
-    std::vector<float> density;
-    std::vector<float> fixed_ratio;
-    std::vector<float> fixed_size;
-    std::vector<float> variance;
-    float step;
-    float offset;
-    bool clip;
-    bool flip;
-    bool scale_all_sizes;
-    bool min_max_aspect_ratios_order;
+    const auto& [spec_params, model_type, shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
-    priorBoxSpecificParams spec_params;
-    std::tie(spec_params, model_type, shapes, targetDevice) = GetParam();
-
-    std::tie(min_size, max_size, aspect_ratio, density, fixed_ratio, fixed_size, clip,
-             flip, step, offset, variance, scale_all_sizes, min_max_aspect_ratios_order) = spec_params;
+    const auto& [min_size,
+                 max_size,
+                 aspect_ratio,
+                 density,
+                 fixed_ratio,
+                 fixed_size,
+                 clip,
+                 flip,
+                 step,
+                 offset,
+                 variance,
+                 scale_all_sizes,
+                 min_max_aspect_ratios_order] = spec_params;
     init_input_shapes(shapes);
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]),

--- a/src/tests/functional/plugin/shared/src/single_op/prior_box_clustered.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/prior_box_clustered.cpp
@@ -13,16 +13,9 @@
 namespace ov {
 namespace test {
 std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParamInfo<priorBoxClusteredLayerParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> shapes;
-    std::string target_device;
-    priorBoxClusteredSpecificParams specParams;
-    std::tie(specParams, model_type, shapes, target_device) = obj.param;
+    const auto& [specParams, model_type, shapes, target_device] = obj.param;
 
-    std::vector<float> widths, heights, variances;
-    float step_width, step_height, step, offset;
-    bool clip;
-    std::tie(widths, heights, clip, step_width, step_height, step, offset, variances) = specParams;
+    const auto& [widths, heights, clip, step_width, step_height, step, offset, variances] = specParams;
 
     std::ostringstream result;
     const char separator = '_';
@@ -56,19 +49,9 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
 }
 
 void PriorBoxClusteredLayerTest::SetUp() {
-    std::vector<InputShape> shapes;
-    ov::element::Type model_type;
-    std::vector<float> widths;
-    std::vector<float> heights;
-    std::vector<float> variances;
-    float step_width;
-    float step_height;
-    float step;
-    float offset;
-    bool clip;
-    priorBoxClusteredSpecificParams specParams;
-    std::tie(specParams, model_type, shapes, targetDevice) = GetParam();
-    std::tie(widths, heights, clip, step_width, step_height, step, offset, variances) = specParams;
+    const auto& [specParams, model_type, shapes, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
+    const auto& [widths, heights, clip, step_width, step_height, step, offset, variances] = specParams;
     init_input_shapes(shapes);
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]),

--- a/src/tests/functional/plugin/shared/src/single_op/proposal.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/proposal.cpp
@@ -14,19 +14,18 @@ const float box_size_scale = 2.0f;
 const float box_coordinate_scale = 2.0f;
 
 std::string ProposalLayerTest::getTestCaseName(const testing::TestParamInfo<proposalLayerTestParamsSet>& obj) {
-    proposalSpecificParams proposal_params;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(proposal_params, model_type, target_device) = obj.param;
-    size_t base_size, pre_nms_topn, post_nms_topn, min_size;
-    float nms_thresh;
-    std::vector<float> ratio, scale;
-    bool clip_before_nms, clip_after_nms;
-    std::string framework;
+    const auto& [proposal_params, model_type, target_device] = obj.param;
 
-    std::tie(base_size, pre_nms_topn, post_nms_topn,
-             nms_thresh, min_size, ratio, scale,
-             clip_before_nms, clip_after_nms, framework) = proposal_params;
+    const auto& [base_size,
+                 pre_nms_topn,
+                 post_nms_topn,
+                 nms_thresh,
+                 min_size,
+                 ratio,
+                 scale,
+                 clip_before_nms,
+                 clip_after_nms,
+                 framework] = proposal_params;
 
     std::ostringstream result;
     result << "base_size=" << base_size << "_";
@@ -51,20 +50,19 @@ std::string ProposalLayerTest::getTestCaseName(const testing::TestParamInfo<prop
 void ProposalLayerTest::SetUp() {
     std::vector<float> img_info = {225.0f, 225.0f, 1.0f};
 
-    proposalSpecificParams proposal_params;
-    ov::element::Type model_type;
+    const auto& [proposal_params, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
-    std::tie(proposal_params, model_type, targetDevice) = this->GetParam();
-    size_t base_size, pre_nms_topn, post_nms_topn, min_size;
-    float nms_thresh;
-    std::vector<float> ratio, scale;
-    bool clip_before_nms, clip_after_nms;
-    std::string framework;
-
-    std::tie(base_size, pre_nms_topn, post_nms_topn,
-             nms_thresh, min_size, ratio, scale,
-             clip_before_nms, clip_after_nms, framework) = proposal_params;
-
+    const auto& [base_size,
+                 pre_nms_topn,
+                 post_nms_topn,
+                 nms_thresh,
+                 min_size,
+                 ratio,
+                 scale,
+                 clip_before_nms,
+                 clip_after_nms,
+                 framework] = proposal_params;
 
     size_t bottom_w = base_size;
     size_t bottom_h = base_size;

--- a/src/tests/functional/plugin/shared/src/single_op/psroi_pooling.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/psroi_pooling.cpp
@@ -8,17 +8,16 @@
 namespace ov {
 namespace test {
 std::string PSROIPoolingLayerTest::getTestCaseName(const testing::TestParamInfo<psroiParams>& obj) {
-    std::vector<size_t> input_shape;
-    std::vector<size_t> coords_shape;
-    size_t output_dim;
-    size_t group_size;
-    float spatial_scale;
-    size_t spatial_bins_x;
-    size_t spatial_bins_y;
-    std::string mode;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shape, coords_shape, output_dim, group_size, spatial_scale, spatial_bins_x, spatial_bins_y, mode, model_type, target_device) = obj.param;
+    const auto& [input_shape,
+                 coords_shape,
+                 output_dim,
+                 group_size,
+                 spatial_scale,
+                 spatial_bins_x,
+                 spatial_bins_y,
+                 mode,
+                 model_type,
+                 target_device] = obj.param;
 
     std::ostringstream result;
 
@@ -36,17 +35,17 @@ std::string PSROIPoolingLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void PSROIPoolingLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    std::vector<size_t> coords_shape;
-    size_t output_dim;
-    size_t group_size;
-    float spatial_scale;
-    size_t spatial_bins_x;
-    size_t spatial_bins_y;
-    std::string mode;
-    ov::element::Type model_type;
-    std::tie(input_shape, coords_shape, output_dim, group_size, spatial_scale,
-             spatial_bins_x, spatial_bins_y, mode, model_type, targetDevice) = this->GetParam();
+    const auto& [input_shape,
+                 coords_shape,
+                 output_dim,
+                 group_size,
+                 spatial_scale,
+                 spatial_bins_x,
+                 spatial_bins_y,
+                 mode,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape)),
                                 std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(coords_shape))};

--- a/src/tests/functional/plugin/shared/src/single_op/random_uniform.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/random_uniform.cpp
@@ -11,13 +11,7 @@
 namespace ov {
 namespace test {
 std::string RandomUniformLayerTest::getTestCaseName(const testing::TestParamInfo<RandomUniformParamsTuple> &obj) {
-    RandomUniformTypeSpecificParams random_uniform_params;
-    ov::Shape input_shape;
-    int64_t global_seed;
-    int64_t op_seed;
-    ov::op::PhiloxAlignment alignment;
-    std::string target_device;
-    std::tie(input_shape, random_uniform_params, global_seed, op_seed, alignment, target_device) = obj.param;
+    const auto& [input_shape, random_uniform_params, global_seed, op_seed, alignment, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -32,12 +26,8 @@ std::string RandomUniformLayerTest::getTestCaseName(const testing::TestParamInfo
 }
 
 void RandomUniformLayerTest::SetUp() {
-    RandomUniformTypeSpecificParams random_uniform_params;
-    ov::Shape input_shape;
-    int64_t global_seed;
-    int64_t op_seed;
-    ov::op::PhiloxAlignment alignment;
-    std::tie(input_shape, random_uniform_params, global_seed, op_seed, alignment, targetDevice) = this->GetParam();
+    const auto& [input_shape, random_uniform_params, global_seed, op_seed, alignment, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     auto model_type = random_uniform_params.model_type;
 
     // Use Parameter as input with desired model_type to properly configure execution configuration

--- a/src/tests/functional/plugin/shared/src/single_op/range.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/range.cpp
@@ -9,10 +9,7 @@
 namespace ov {
 namespace test {
 std::string RangeLayerTest::getTestCaseName(const testing::TestParamInfo<RangeParams>& obj) {
-    ov::element::Type model_type;
-    float start, stop, step;
-    std::string target_device;
-    std::tie(start, stop, step, model_type, target_device) = obj.param;
+    const auto& [start, stop, step, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     const char separator = '_';
@@ -25,9 +22,8 @@ std::string RangeLayerTest::getTestCaseName(const testing::TestParamInfo<RangePa
 }
 
 void RangeLayerTest::SetUp() {
-    ov::element::Type model_type;
-    float start, stop, step;
-    tie(start, stop, step, model_type, targetDevice) = GetParam();
+    const auto& [start, stop, step, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape()),
                                std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape()),

--- a/src/tests/functional/plugin/shared/src/single_op/rdft.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/rdft.cpp
@@ -15,13 +15,9 @@ static inline void set_real_number_generation_data(utils::InputGenerateData& inG
 }
 
 void RDFTLayerTest::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::vector<int64_t> axes;
-    std::vector<int64_t> signal_size;
-    ov::test::utils::DFTOpType op_type;
     std::string target_device;
-    std::tie(input_shape, model_type, axes, signal_size, op_type, targetDevice) = this->GetParam();
+    const auto& [input_shape, model_type, axes, signal_size, op_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     auto elemType = model_type;
 
@@ -54,13 +50,7 @@ void RDFTLayerTest::generate_inputs(const std::vector<ov::Shape>& targetInputSta
 }
 
 std::string RDFTLayerTest::getTestCaseName(const testing::TestParamInfo<RDFTParams>& obj) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::vector<int64_t> axes;
-    std::vector<int64_t> signal_size;
-    ov::test::utils::DFTOpType op_type;
-    std::string target_device;
-    std::tie(input_shape, model_type, axes, signal_size, op_type, target_device) = obj.param;
+    const auto& [input_shape, model_type, axes, signal_size, op_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -73,12 +63,8 @@ std::string RDFTLayerTest::getTestCaseName(const testing::TestParamInfo<RDFTPara
 }
 
 void RDFTLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::vector<int64_t> axes;
-    std::vector<int64_t> signal_size;
-    ov::test::utils::DFTOpType op_type;
-    std::tie(input_shape, model_type, axes, signal_size, op_type, targetDevice) = this->GetParam();
+    const auto& [input_shape, model_type, axes, signal_size, op_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape));
     auto rdft = ov::test::utils::make_rdft(param, axes, signal_size, op_type);

--- a/src/tests/functional/plugin/shared/src/single_op/reduce_ops.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/reduce_ops.cpp
@@ -9,14 +9,7 @@
 namespace ov {
 namespace test {
 std::string ReduceOpsLayerTest::getTestCaseName(const testing::TestParamInfo<reduceOpsParams>& obj) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    bool keep_dims;
-    ov::test::utils::ReductionType reduction_type;
-    std::vector<int> axes;
-    ov::test::utils::OpType op_type;
-    std::string target_device;
-    std::tie(axes, op_type, keep_dims, reduction_type, model_type, input_shape, target_device) = obj.param;
+    const auto& [axes, op_type, keep_dims, reduction_type, model_type, input_shape, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
     result << "axes=" << ov::test::utils::vec2str(axes) << "_";
@@ -29,13 +22,8 @@ std::string ReduceOpsLayerTest::getTestCaseName(const testing::TestParamInfo<red
 }
 
 void ReduceOpsLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    bool keep_dims;
-    ov::test::utils::ReductionType reduction_type;
-    std::vector<int> axes;
-    ov::test::utils::OpType op_type;
-    std::tie(axes, op_type, keep_dims, reduction_type, model_type, input_shape, targetDevice) = GetParam();
+    const auto& [axes, op_type, keep_dims, reduction_type, model_type, input_shape, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape));
 

--- a/src/tests/functional/plugin/shared/src/single_op/region_yolo.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/region_yolo.cpp
@@ -8,17 +8,16 @@
 namespace ov {
 namespace test {
 std::string RegionYoloLayerTest::getTestCaseName(const testing::TestParamInfo<regionYoloParamsTuple> &obj) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::string target_device;
-    size_t classes;
-    size_t coords;
-    size_t num_regions;
-    bool do_softmax;
-    std::vector<int64_t> mask;
-    int start_axis;
-    int end_axis;
-    std::tie(input_shape, classes, coords, num_regions, do_softmax , mask, start_axis, end_axis, model_type, target_device) = obj.param;
+    const auto& [input_shape,
+                 classes,
+                 coords,
+                 num_regions,
+                 do_softmax,
+                 mask,
+                 start_axis,
+                 end_axis,
+                 model_type,
+                 target_device] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
     result << "classes=" << classes << "_";
@@ -33,16 +32,17 @@ std::string RegionYoloLayerTest::getTestCaseName(const testing::TestParamInfo<re
 }
 
 void RegionYoloLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    size_t classes;
-    size_t coords;
-    size_t num_regions;
-    bool do_softmax;
-    std::vector<int64_t> mask;
-    int start_axis;
-    int end_axis;
-    std::tie(input_shape, classes, coords, num_regions, do_softmax, mask, start_axis, end_axis, model_type, targetDevice) = this->GetParam();
+    const auto& [input_shape,
+                 classes,
+                 coords,
+                 num_regions,
+                 do_softmax,
+                 mask,
+                 start_axis,
+                 end_axis,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape));
     auto region_yolo = std::make_shared<ov::op::v0::RegionYolo>(param, coords, classes, num_regions, do_softmax, mask, start_axis, end_axis);

--- a/src/tests/functional/plugin/shared/src/single_op/reorg_yolo.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/reorg_yolo.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string ReorgYoloLayerTest::getTestCaseName(const testing::TestParamInfo<ReorgYoloParamsTuple> &obj) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    size_t stride;
-    std::string target_device;
-    std::tie(input_shape, stride, model_type, target_device) = obj.param;
+    const auto& [input_shape, stride, model_type, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
     result << "stride=" << stride << "_";
@@ -22,10 +18,8 @@ std::string ReorgYoloLayerTest::getTestCaseName(const testing::TestParamInfo<Reo
 }
 
 void ReorgYoloLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    size_t stride;
-    std::tie(input_shape, stride, model_type, targetDevice) = this->GetParam();
+    const auto& [input_shape, stride, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape));
     auto reorg_yolo = std::make_shared<ov::op::v0::ReorgYolo>(param, stride);
     function = std::make_shared<ov::Model>(reorg_yolo->outputs(), ov::ParameterVector{param}, "ReorgYolo");

--- a/src/tests/functional/plugin/shared/src/single_op/reshape.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/reshape.cpp
@@ -8,12 +8,7 @@
 namespace ov {
 namespace test {
 std::string ReshapeLayerTest::getTestCaseName(const testing::TestParamInfo<reshapeParams>& obj) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::vector<int64_t> out_form_shapes;
-    std::string target_device;
-    bool special_zero;
-    std::tie(special_zero, model_type, input_shape, out_form_shapes, target_device) = obj.param;
+    const auto& [special_zero, model_type, input_shape, out_form_shapes, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
     result << "OS=" << ov::test::utils::vec2str(out_form_shapes) << "_";
@@ -24,11 +19,8 @@ std::string ReshapeLayerTest::getTestCaseName(const testing::TestParamInfo<resha
 }
 
 void ReshapeLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::vector<int64_t> out_form_shapes;
-    bool special_zero;
-    std::tie(special_zero, model_type, input_shape, out_form_shapes, targetDevice) = this->GetParam();
+    const auto& [special_zero, model_type, input_shape, out_form_shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape));
     auto const_node = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{out_form_shapes.size()}, out_form_shapes);

--- a/src/tests/functional/plugin/shared/src/single_op/result.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/result.cpp
@@ -7,10 +7,7 @@
 namespace ov {
 namespace test {
 std::string ResultLayerTest::getTestCaseName(const testing::TestParamInfo<ResultTestParamSet>& obj) {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shape, model_type, target_device) = obj.param;
+    const auto& [input_shape, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -20,9 +17,8 @@ std::string ResultLayerTest::getTestCaseName(const testing::TestParamInfo<Result
 }
 
 void ResultLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    ov::element::Type model_type;
-    std::tie(input_shape, model_type, targetDevice) = GetParam();
+    const auto& [input_shape, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape))};
     auto result = std::make_shared<ov::op::v0::Result>(params[0]);

--- a/src/tests/functional/plugin/shared/src/single_op/reverse.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/reverse.cpp
@@ -9,12 +9,7 @@ namespace ov {
 namespace test {
 
 std::string ReverseLayerTest::getTestCaseName(const testing::TestParamInfo<reverseParams>& obj) {
-    std::vector<size_t> input_shape;
-    std::vector<int> axes;
-    std::string mode;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shape, axes, mode, model_type, target_device) = obj.param;
+    const auto& [input_shape, axes, mode, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "in_shape=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -26,11 +21,8 @@ std::string ReverseLayerTest::getTestCaseName(const testing::TestParamInfo<rever
 }
 
 void ReverseLayerTest::SetUp() {
-    std::vector<size_t> input_shape;
-    std::vector<int> axes;
-    std::string mode;
-    ov::element::Type model_type;
-    std::tie(input_shape, axes, mode, model_type, targetDevice) = GetParam();
+    const auto& [input_shape, axes, mode, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape));
     std::shared_ptr<ov::op::v0::Constant> axes_constant;

--- a/src/tests/functional/plugin/shared/src/single_op/reverse_sequence.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/reverse_sequence.cpp
@@ -9,15 +9,13 @@
 namespace ov {
 namespace test {
 std::string ReverseSequenceLayerTest::getTestCaseName(const testing::TestParamInfo<ReverseSequenceParamsTuple> &obj) {
-    int64_t batch_axis_idx;
-    int64_t seq_axis_idx;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::vector<size_t> input_shape;
-    std::vector<size_t> second_input_shape;
-    ov::test::utils::InputLayerType secondary_input_type;
-
-    std::tie(batch_axis_idx, seq_axis_idx, input_shape, second_input_shape, secondary_input_type, model_type, target_device) = obj.param;
+    const auto& [batch_axis_idx,
+                 seq_axis_idx,
+                 input_shape,
+                 second_input_shape,
+                 secondary_input_type,
+                 model_type,
+                 target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -31,14 +29,14 @@ std::string ReverseSequenceLayerTest::getTestCaseName(const testing::TestParamIn
 }
 
 void ReverseSequenceLayerTest::SetUp() {
-    ov::element::Type model_type;
-    int64_t batch_axis_idx;
-    int64_t seq_axis_idx;
-    std::vector<size_t> input_shape;
-    std::vector<size_t> second_input_shape;
-    ov::test::utils::InputLayerType secondary_input_type;
-
-    std::tie(batch_axis_idx, seq_axis_idx, input_shape, second_input_shape, secondary_input_type, model_type, targetDevice) = GetParam();
+    const auto& [batch_axis_idx,
+                 seq_axis_idx,
+                 input_shape,
+                 second_input_shape,
+                 secondary_input_type,
+                 model_type,
+                 _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(model_type, ov::Shape(input_shape))};
     auto second_data_type = ov::element::i32; //according to the specification

--- a/src/tests/functional/plugin/shared/src/single_op/rnn_cell.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/rnn_cell.cpp
@@ -14,19 +14,17 @@ namespace test {
 using utils::InputLayerType;
 
 std::string RNNCellTest::getTestCaseName(const testing::TestParamInfo<RNNCellParams> &obj) {
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
-    float clip;
-    InputLayerType WType;
-    InputLayerType RType;
-    InputLayerType BType;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, WType, RType, BType,
-             model_type, target_device) = obj.param;
+    const auto& [should_decompose,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 WType,
+                 RType,
+                 BType,
+                 model_type,
+                 target_device] = obj.param;
     std::vector<std::vector<size_t>> input_shapes = {{batch, input_size}, {batch, hidden_size},
                                      {hidden_size, input_size}, {hidden_size, hidden_size}, {hidden_size}};
     std::ostringstream result;
@@ -46,20 +44,21 @@ std::string RNNCellTest::getTestCaseName(const testing::TestParamInfo<RNNCellPar
 }
 
 void RNNCellTest::SetUp() {
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    InputLayerType WType;
-    InputLayerType RType;
-    InputLayerType BType;
-    ov::element::Type model_type;
-    std::tie(should_decompose, batch, hidden_size, input_size, activations, clip, WType, RType, BType,
-            model_type, targetDevice) = this->GetParam();
+
+    const auto& [should_decompose,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 WType,
+                 RType,
+                 BType,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     std::vector<std::vector<size_t>> input_shapes = {{batch, input_size}, {batch, hidden_size},
                                                     {hidden_size, input_size}, {hidden_size, hidden_size}, {hidden_size}};

--- a/src/tests/functional/plugin/shared/src/single_op/rnn_sequence.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/rnn_sequence.cpp
@@ -17,21 +17,20 @@ namespace ov {
 namespace test {
 
 std::string RNNSequenceTest::getTestCaseName(const testing::TestParamInfo<RNNSequenceParams> &obj) {
-    SequenceTestsMode mode;
-    size_t seq_lengths;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    ov::op::RecurrentSequenceDirection direction;
-    ov::element::Type model_type;
-    InputLayerType WRBType;
-    std::string target_device;
-    std::tie(mode, seq_lengths, batch, hidden_size, input_size, activations, clip, direction, WRBType,
-            model_type, target_device) = obj.param;
+
+    const auto& [mode,
+                 seq_lengths,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 direction,
+                 WRBType,
+                 model_type,
+                 target_device] = obj.param;
     std::vector<std::vector<size_t>> input_shapes = {
             {{batch, input_size}, {batch, hidden_size}, {batch, hidden_size}, {hidden_size, input_size},
                     {hidden_size, hidden_size}, {hidden_size}},
@@ -52,20 +51,21 @@ std::string RNNSequenceTest::getTestCaseName(const testing::TestParamInfo<RNNSeq
 }
 
 void RNNSequenceTest::SetUp() {
-    SequenceTestsMode mode;
-    size_t seq_lengths;
-    size_t batch;
-    size_t hidden_size;
-    size_t input_size;
-    std::vector<std::string> activations;
     std::vector<float> activations_alpha;
     std::vector<float> activations_beta;
-    float clip;
-    ov::op::RecurrentSequenceDirection direction;
-    InputLayerType WRBType;
-    ov::element::Type model_type;
-    std::tie(mode, seq_lengths, batch, hidden_size, input_size, activations, clip, direction, WRBType,
-            model_type, targetDevice) = this->GetParam();
+
+    const auto& [mode,
+                 seq_lengths,
+                 batch,
+                 hidden_size,
+                 input_size,
+                 activations,
+                 clip,
+                 direction,
+                 WRBType,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     size_t num_directions = direction == ov::op::RecurrentSequenceDirection::BIDIRECTIONAL ? 2 : 1;
     std::vector<ov::Shape> input_shapes = {

--- a/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_align.cpp
@@ -12,17 +12,15 @@
 namespace ov {
 namespace test {
 std::string ROIAlignLayerTest::getTestCaseName(const testing::TestParamInfo<roialignParams>& obj) {
-    std::vector<InputShape> input_shapes;
-    ov::Shape coords_shape;
-    int pooled_h;
-    int pooled_w;
-    float spatial_scale;
-    int pooling_ratio;
-    std::string pooling_mode;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shapes, coords_shape, pooled_h, pooled_w, spatial_scale,
-    pooling_ratio, pooling_mode, model_type, target_device) = obj.param;
+    const auto& [input_shapes,
+                 coords_shape,
+                 pooled_h,
+                 pooled_w,
+                 spatial_scale,
+                 pooling_ratio,
+                 pooling_mode,
+                 model_type,
+                 target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -84,16 +82,16 @@ void ROIAlignLayerTest::fillIdxTensor(std::vector<int>& idx, int batch_size) {
 }
 
 void ROIAlignLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::Shape coords_shape;
-    int pooled_h;
-    int pooled_w;
-    float spatial_scale;
-    int pooling_ratio;
-    std::string pooling_mode;
-    ov::element::Type model_type;
-    std::tie(input_shapes, coords_shape, pooled_h, pooled_w, spatial_scale,
-    pooling_ratio, pooling_mode, model_type, targetDevice) = this->GetParam();
+    const auto& [input_shapes,
+                 coords_shape,
+                 pooled_h,
+                 pooled_w,
+                 spatial_scale,
+                 pooling_ratio,
+                 pooling_mode,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 
@@ -122,18 +120,16 @@ void ROIAlignLayerTest::SetUp() {
 }
 
 std::string ROIAlignV9LayerTest::getTestCaseName(const testing::TestParamInfo<roialignV9Params>& obj) {
-    std::vector<InputShape> input_shapes;
-    ov::Shape coords_shape;
-    int pooled_h;
-    int pooled_w;
-    float spatial_scale;
-    int pooling_ratio;
-    std::string pooling_mode;
-    std::string roi_aligned_mode;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shapes, coords_shape, pooled_h, pooled_w, spatial_scale,
-    pooling_ratio, pooling_mode, roi_aligned_mode, model_type, target_device) = obj.param;
+    const auto& [input_shapes,
+                 coords_shape,
+                 pooled_h,
+                 pooled_w,
+                 spatial_scale,
+                 pooling_ratio,
+                 pooling_mode,
+                 roi_aligned_mode,
+                 model_type,
+                 target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -162,17 +158,17 @@ std::string ROIAlignV9LayerTest::getTestCaseName(const testing::TestParamInfo<ro
 }
 
 void ROIAlignV9LayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::Shape coords_shape;
-    int pooled_h;
-    int pooled_w;
-    float spatial_scale;
-    int pooling_ratio;
-    std::string pooling_mode;
-    std::string roi_aligned_mode;
-    ov::element::Type model_type;
-    std::tie(input_shapes, coords_shape, pooled_h, pooled_w, spatial_scale,
-    pooling_ratio, pooling_mode, roi_aligned_mode, model_type, targetDevice) = this->GetParam();
+    const auto& [input_shapes,
+                 coords_shape,
+                 pooled_h,
+                 pooled_w,
+                 spatial_scale,
+                 pooling_ratio,
+                 pooling_mode,
+                 roi_aligned_mode,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/roi_pooling.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roi_pooling.cpp
@@ -8,13 +8,7 @@
 namespace ov {
 namespace test {
 std::string ROIPoolingLayerTest::getTestCaseName(const testing::TestParamInfo<roiPoolingParamsTuple>& obj) {
-    std::vector<InputShape> input_shapes;
-    ov::Shape pool_shape;
-    float spatial_scale;
-    ov::test::utils::ROIPoolingTypes pool_method;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shapes, pool_shape, spatial_scale, pool_method, model_type, target_device) = obj.param;
+    const auto& [input_shapes, pool_shape, spatial_scale, pool_method, model_type, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -46,13 +40,9 @@ std::string ROIPoolingLayerTest::getTestCaseName(const testing::TestParamInfo<ro
 }
 
 void ROIPoolingLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::Shape pool_shape;
-    float spatial_scale;
-    ov::test::utils::ROIPoolingTypes pool_method;
-    ov::element::Type model_type;
     std::string target_device;
-    std::tie(input_shapes, pool_shape, spatial_scale, pool_method, model_type, targetDevice) = this->GetParam();
+    const auto& [input_shapes, pool_shape, spatial_scale, pool_method, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     abs_threshold = 0.08f;
 

--- a/src/tests/functional/plugin/shared/src/single_op/roll.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/roll.cpp
@@ -8,12 +8,7 @@
 namespace ov {
 namespace test {
 std::string RollLayerTest::getTestCaseName(const testing::TestParamInfo<rollParams>& obj) {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    std::vector<int64_t> shift;
-    std::vector<int64_t> axes;
-    std::string target_device;
-    std::tie(input_shapes, model_type, shift, axes, target_device) = obj.param;
+    const auto& [input_shapes, model_type, shift, axes, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -37,12 +32,9 @@ std::string RollLayerTest::getTestCaseName(const testing::TestParamInfo<rollPara
 }
 
 void RollLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    std::vector<int64_t> shift;
-    std::vector<int64_t> axes;
     std::string target_device;
-    std::tie(input_shapes, model_type, shift, axes, targetDevice) = this->GetParam();
+    const auto& [input_shapes, model_type, shift, axes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/scatter_ND_update.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/scatter_ND_update.cpp
@@ -16,14 +16,8 @@ std::string ScatterNDUpdateLayerTest::getTestCaseName(const testing::TestParamIn
         return ss;
     };
 
-    scatterNDUpdateSpecParams shapes_desc;
-    std::vector<InputShape> input_shapes;
-    ov::Shape indices_shape;
-    std::vector<int> indices_value;
-    ov::element::Type model_type, indices_type;
-    std::string target_device;
-    std::tie(shapes_desc, model_type, indices_type, target_device) = obj.param;
-    std::tie(input_shapes, indices_shape, indices_value) = shapes_desc;
+    const auto& [shapes_desc, model_type, indices_type, target_device] = obj.param;
+    const auto& [input_shapes, indices_shape, indices_value] = shapes_desc;
 
     std::ostringstream result;
     result << "InputShape=" << shapes_ss(input_shapes.at(0)).str() << "_";
@@ -37,13 +31,9 @@ std::string ScatterNDUpdateLayerTest::getTestCaseName(const testing::TestParamIn
 }
 
 void ScatterNDUpdateLayerTest::SetUp() {
-    scatterNDUpdateSpecParams shapes_desc;
-    std::vector<InputShape> input_shapes;
-    ov::Shape indices_shape;
-    std::vector<int> indices_value;
-    ov::element::Type model_type, indices_type;
-    std::tie(shapes_desc, model_type, indices_type, targetDevice) = this->GetParam();
-    std::tie(input_shapes, indices_shape, indices_value) = shapes_desc;
+    const auto& [shapes_desc, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [input_shapes, indices_shape, indices_value] = shapes_desc;
 
     init_input_shapes(input_shapes);
 
@@ -63,15 +53,8 @@ std::string ScatterNDUpdate15LayerTest::getTestCaseName(const testing::TestParam
         return ss;
     };
 
-    scatterNDUpdateSpecParams shapes_desc;
-    std::vector<InputShape> input_shapes;
-    ov::Shape indices_shape;
-    std::vector<int> indices_value;
-    ov::element::Type model_type, indices_type;
-    ov::op::v15::ScatterNDUpdate::Reduction reduceMode;
-    std::string target_device;
-    std::tie(shapes_desc, reduceMode, model_type, indices_type, target_device) = obj.param;
-    std::tie(input_shapes, indices_shape, indices_value) = shapes_desc;
+    const auto& [shapes_desc, reduceMode, model_type, indices_type, target_device] = obj.param;
+    const auto& [input_shapes, indices_shape, indices_value] = shapes_desc;
 
     std::ostringstream result;
     result << "InputShape=" << shapes_ss(input_shapes.at(0)).str() << "_";
@@ -86,14 +69,9 @@ std::string ScatterNDUpdate15LayerTest::getTestCaseName(const testing::TestParam
 }
 
 void ScatterNDUpdate15LayerTest::SetUp() {
-    scatterNDUpdateSpecParams shapes_desc;
-    std::vector<InputShape> input_shapes;
-    ov::Shape indices_shape;
-    std::vector<int> indices_value;
-    ov::element::Type model_type, indices_type;
-    ov::op::v15::ScatterNDUpdate::Reduction reduceMode;
-    std::tie(shapes_desc, reduceMode, model_type, indices_type, targetDevice) = this->GetParam();
-    std::tie(input_shapes, indices_shape, indices_value) = shapes_desc;
+    const auto& [shapes_desc, reduceMode, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [input_shapes, indices_shape, indices_value] = shapes_desc;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/scatter_elements_update.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/scatter_elements_update.cpp
@@ -16,14 +16,8 @@ std::string ScatterElementsUpdateLayerTest::getTestCaseName(const testing::TestP
         return ss;
     };
 
-    axisShapeInShape shapes_desc;
-    std::vector<InputShape> input_shapes;
-    int axis;
-    std::vector<size_t> indices_value;
-    ov::element::Type model_type, indices_type;
-    std::string target_device;
-    std::tie(shapes_desc, indices_value, model_type, indices_type, target_device) = obj.param;
-    std::tie(input_shapes, axis) = shapes_desc;
+    const auto& [shapes_desc, indices_value, model_type, indices_type, target_device] = obj.param;
+    const auto& [input_shapes, axis] = shapes_desc;
     std::ostringstream result;
     result << "InputShape=" << shapes_ss(input_shapes.at(0)).str() << "_";
     result << "IndicesShape=" << ov::test::utils::vec2str(input_shapes.at(1).second) << "_";
@@ -35,14 +29,10 @@ std::string ScatterElementsUpdateLayerTest::getTestCaseName(const testing::TestP
 }
 
 void ScatterElementsUpdateLayerTest::SetUp() {
-    axisShapeInShape shapes_desc;
-    std::vector<InputShape> input_shapes;
-    int axis;
-    std::vector<size_t> indices_value;
-    ov::element::Type model_type, indices_type;
     std::string target_device;
-    std::tie(shapes_desc, indices_value, model_type, indices_type, targetDevice) = this->GetParam();
-    std::tie(input_shapes, axis) = shapes_desc;
+    const auto& [shapes_desc, indices_value, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [input_shapes, axis] = shapes_desc;
 
     init_input_shapes(input_shapes);
 
@@ -64,16 +54,9 @@ std::string ScatterElementsUpdate12LayerTest::getTestCaseName(const testing::Tes
         return ss;
     };
 
-    axisShapeInShape shapes_desc;
-    std::vector<InputShape> input_shapes;
-    int axis;
-    std::vector<int64_t> indices_value;
-    ov::op::v12::ScatterElementsUpdate::Reduction reduceMode;
-    bool useInitVal;
-    ov::element::Type model_type, indices_type;
-    std::string target_device;
-    std::tie(shapes_desc, indices_value, reduceMode, useInitVal, model_type, indices_type, target_device) = obj.param;
-    std::tie(input_shapes, axis) = shapes_desc;
+    const auto& [shapes_desc, indices_value, reduceMode, useInitVal, model_type, indices_type, target_device] =
+        obj.param;
+    const auto& [input_shapes, axis] = shapes_desc;
     std::ostringstream result;
     result << "InputShape=" << shapes_ss(input_shapes.at(0)).str() << "_";
     result << "IndicesShape=" << ov::test::utils::vec2str(input_shapes.at(1).second) << "_";
@@ -88,16 +71,11 @@ std::string ScatterElementsUpdate12LayerTest::getTestCaseName(const testing::Tes
 }
 
 void ScatterElementsUpdate12LayerTest::SetUp() {
-    axisShapeInShape shapes_desc;
-    std::vector<InputShape> input_shapes;
-    int axis;
-    std::vector<int64_t> indices_value;
-    ov::op::v12::ScatterElementsUpdate::Reduction reduceMode;
-    bool useInitVal;
-    ov::element::Type model_type, indices_type;
     std::string target_device;
-    std::tie(shapes_desc, indices_value, reduceMode, useInitVal, model_type, indices_type, targetDevice) = this->GetParam();
-    std::tie(input_shapes, axis) = shapes_desc;
+    const auto& [shapes_desc, indices_value, reduceMode, useInitVal, model_type, indices_type, _targetDevice] =
+        this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [input_shapes, axis] = shapes_desc;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/scatter_update.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/scatter_update.cpp
@@ -16,15 +16,8 @@ std::string ScatterUpdateLayerTest::getTestCaseName(const testing::TestParamInfo
         return ss;
     };
 
-    axisUpdateShapeInShape shapes_desc;
-    std::vector<InputShape> input_shapes;
-    int64_t axis;
-    ov::Shape indices_shape;
-    std::vector<int64_t> indices_value;
-    ov::element::Type model_type, indices_type;
-    std::string target_device;
-    std::tie(shapes_desc, indices_value, model_type, indices_type, target_device) = obj.param;
-    std::tie(input_shapes, indices_shape, axis) = shapes_desc;
+    const auto& [shapes_desc, indices_value, model_type, indices_type, target_device] = obj.param;
+    const auto& [input_shapes, indices_shape, axis] = shapes_desc;
 
     std::ostringstream result;
     result << "InputShape=" << shapes_ss(input_shapes.at(0)).str() << "_";
@@ -39,14 +32,9 @@ std::string ScatterUpdateLayerTest::getTestCaseName(const testing::TestParamInfo
 }
 
 void ScatterUpdateLayerTest::SetUp() {
-    axisUpdateShapeInShape shapes_desc;
-    std::vector<InputShape> input_shapes;
-    int64_t axis;
-    ov::Shape indices_shape;
-    std::vector<int64_t> indices_value;
-    ov::element::Type model_type, indices_type;
-    std::tie(shapes_desc, indices_value, model_type, indices_type, targetDevice) = this->GetParam();
-    std::tie(input_shapes, indices_shape, axis) = shapes_desc;
+    const auto& [shapes_desc, indices_value, model_type, indices_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [input_shapes, indices_shape, axis] = shapes_desc;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/search_sorted.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/search_sorted.cpp
@@ -17,17 +17,9 @@ std::string SearchSortedLayerTest::getTestCaseName(const testing::TestParamInfo<
     SearchSortedLayerTestParams basicParamsSet;
     basicParamsSet = obj.param;
 
-    SearchSortedSpecificParams searchSortedParams;
+    const auto& [searchSortedParams, inputPrecision, targetDevice] = basicParamsSet;
 
-    ElementType inputPrecision;
-    std::string targetDevice;
-    std::tie(searchSortedParams, inputPrecision, targetDevice) = basicParamsSet;
-
-    InputShape sortedInputShape;
-    InputShape valuesInputShape;
-    bool right_mode;
-
-    std::tie(sortedInputShape, valuesInputShape, right_mode) = searchSortedParams;
+    const auto& [sortedInputShape, valuesInputShape, right_mode] = searchSortedParams;
 
     std::ostringstream result;
     result << inputPrecision << "_IS=";
@@ -67,15 +59,10 @@ void SearchSortedLayerTest::SetUp() {
     SearchSortedLayerTestParams basicParamsSet;
     basicParamsSet = this->GetParam();
 
-    SearchSortedSpecificParams searchSortedParams;
+    const auto& [searchSortedParams, inputPrecision, _targetDevice] = basicParamsSet;
+    targetDevice = _targetDevice;
 
-    ElementType inputPrecision;
-    std::tie(searchSortedParams, inputPrecision, targetDevice) = basicParamsSet;
-
-    InputShape sortedInputShape;
-    InputShape valuesInputShape;
-    bool right_mode;
-    std::tie(sortedInputShape, valuesInputShape, right_mode) = searchSortedParams;
+    const auto& [sortedInputShape, valuesInputShape, right_mode] = searchSortedParams;
 
     init_input_shapes({sortedInputShape, valuesInputShape});
     auto sortedParam = std::make_shared<ov::op::v0::Parameter>(inputPrecision, inputDynamicShapes[0]);

--- a/src/tests/functional/plugin/shared/src/single_op/select.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/select.cpp
@@ -16,11 +16,7 @@ std::string SelectLayerTest::getTestCaseName(const testing::TestParamInfo<select
         return ss;
     };
 
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    ov::op::AutoBroadcastSpec broadcast;
-    std::string target_device;
-    std::tie(input_shapes, model_type, broadcast, target_device) = obj.param;
+    const auto& [input_shapes, model_type, broadcast, target_device] = obj.param;
     std::ostringstream result;
     result << "COND=BOOL" << shapes_ss(input_shapes[0]).str() <<
         "_THEN=" << model_type.to_string() << shapes_ss(input_shapes[1]).str() <<
@@ -31,10 +27,8 @@ std::string SelectLayerTest::getTestCaseName(const testing::TestParamInfo<select
 }
 
 void SelectLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    ov::op::AutoBroadcastSpec broadcast;
-    std::tie(input_shapes, model_type, broadcast, targetDevice) = this->GetParam();
+    const auto& [input_shapes, model_type, broadcast, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/shape_of.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/shape_of.cpp
@@ -8,10 +8,7 @@
 namespace ov {
 namespace test {
 std::string ShapeOfLayerTest::getTestCaseName(testing::TestParamInfo<shapeOfParams> obj) {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type, out_type;
-    std::string target_device;
-    std::tie(model_type, out_type, input_shapes, target_device) = obj.param;
+    const auto& [model_type, out_type, input_shapes, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -33,9 +30,9 @@ std::string ShapeOfLayerTest::getTestCaseName(testing::TestParamInfo<shapeOfPara
 }
 
 void ShapeOfLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    std::tie(model_type, outType, input_shapes, targetDevice) = this->GetParam();
+    const auto& [model_type, _outType, input_shapes, _targetDevice] = this->GetParam();
+    outType = _outType;
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/shuffle_channels.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/shuffle_channels.cpp
@@ -8,13 +8,9 @@
 namespace ov {
 namespace test {
 std::string ShuffleChannelsLayerTest::getTestCaseName(const testing::TestParamInfo<shuffleChannelsLayerTestParamsSet>& obj) {
-    shuffleChannelsSpecificParams test_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    std::string target_device;
-    std::tie(test_params, model_type, input_shapes, target_device) = obj.param;
-    int axis, group;
-    std::tie(axis, group) = test_params;
+    const auto& [test_params, model_type, input_shapes, target_device] = obj.param;
+
+    const auto& [axis, group] = test_params;
 
     std::ostringstream result;
     result << "IS=(";
@@ -38,13 +34,11 @@ std::string ShuffleChannelsLayerTest::getTestCaseName(const testing::TestParamIn
 }
 
 void ShuffleChannelsLayerTest::SetUp() {
-    shuffleChannelsSpecificParams test_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
     std::string target_device;
-    std::tie(test_params, model_type, input_shapes, targetDevice) = this->GetParam();
-    int axis, group;
-    std::tie(axis, group) = test_params;
+    const auto& [test_params, model_type, input_shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [axis, group] = test_params;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/slice.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/slice.cpp
@@ -8,10 +8,7 @@
 namespace ov {
 namespace test {
 std::string Slice8LayerTest::getTestCaseName(const testing::TestParamInfo<Slice8Params> &obj) {
-    Slice8SpecificParams params;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(params, model_type, target_device) = obj.param;
+    const auto& [params, model_type, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < params.shapes.size(); i++) {
@@ -36,9 +33,8 @@ std::string Slice8LayerTest::getTestCaseName(const testing::TestParamInfo<Slice8
 }
 
 void Slice8LayerTest::SetUp() {
-    Slice8SpecificParams test_params;
-    ov::element::Type model_type;
-    std::tie(test_params, model_type, targetDevice) = this->GetParam();
+    const auto& [test_params, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(test_params.shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/slice_scatter.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/slice_scatter.cpp
@@ -8,10 +8,7 @@
 namespace ov {
 namespace test {
 std::string SliceScatterLayerTest::getTestCaseName(const testing::TestParamInfo<SliceScatterParams> &obj) {
-    SliceScatterSpecificParams params;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(params, model_type, target_device) = obj.param;
+    const auto& [params, model_type, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < params.shapes.size(); i++) {
@@ -36,9 +33,8 @@ std::string SliceScatterLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void SliceScatterLayerTest::SetUp() {
-    SliceScatterSpecificParams test_params;
-    ov::element::Type model_type;
-    std::tie(test_params, model_type, targetDevice) = this->GetParam();
+    const auto& [test_params, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(test_params.shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/space_to_batch.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/space_to_batch.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string SpaceToBatchLayerTest::getTestCaseName(const testing::TestParamInfo<spaceToBatchParamsTuple> &obj) {
-    std::vector<InputShape> input_shapes;
-    std::vector<int64_t> block_shapes, pads_begin, pads_end;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(block_shapes, pads_begin, pads_end, input_shapes, model_type, target_device) = obj.param;
+    const auto& [block_shapes, pads_begin, pads_end, input_shapes, model_type, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -36,10 +32,8 @@ std::string SpaceToBatchLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void SpaceToBatchLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    std::vector<int64_t> block_shapes, pads_begin, pads_end;
-    ov::element::Type model_type;
-    std::tie(block_shapes, pads_begin, pads_end, input_shapes, model_type, targetDevice) = this->GetParam();
+    const auto& [block_shapes, pads_begin, pads_end, input_shapes, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/space_to_depth.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/space_to_depth.cpp
@@ -24,12 +24,7 @@ static inline std::string SpaceToDepthModeToString(const SpaceToDepth::SpaceToDe
 }
 
 std::string SpaceToDepthLayerTest::getTestCaseName(const testing::TestParamInfo<spaceToDepthParamsTuple> &obj) {
-    std::vector<InputShape> input_shapes;
-    SpaceToDepth::SpaceToDepthMode mode;
-    std::size_t block_size;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(input_shapes, model_type, mode, block_size, target_device) = obj.param;
+    const auto& [input_shapes, model_type, mode, block_size, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -52,11 +47,8 @@ std::string SpaceToDepthLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void SpaceToDepthLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    SpaceToDepth::SpaceToDepthMode mode;
-    std::size_t block_size;
-    ov::element::Type model_type;
-    std::tie(input_shapes, model_type, mode, block_size, targetDevice) = this->GetParam();
+    const auto& [input_shapes, model_type, mode, block_size, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/split.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/split.cpp
@@ -8,13 +8,7 @@
 namespace ov {
 namespace test {
 std::string SplitLayerTest::getTestCaseName(const testing::TestParamInfo<splitParams>& obj) {
-    size_t num_splits;
-    int64_t axis;
-    ov::element::Type model_type;
-    std::vector<size_t> out_indices;
-    std::vector<InputShape> input_shapes;
-    std::string target_device;
-    std::tie(num_splits, axis, model_type, input_shapes, out_indices, target_device) = obj.param;
+    const auto& [num_splits, axis, model_type, input_shapes, out_indices, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -41,12 +35,9 @@ std::string SplitLayerTest::getTestCaseName(const testing::TestParamInfo<splitPa
 }
 
 void SplitLayerTest::SetUp() {
-    size_t num_splits;
-    int64_t axis;
-    ov::element::Type model_type;
-    std::vector<size_t> out_indices;
-    std::vector<InputShape> input_shapes;
-    std::tie(num_splits, axis, model_type, input_shapes, out_indices, targetDevice) = this->GetParam();
+    const auto& [num_splits, axis, model_type, input_shapes, _out_indices, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    auto out_indices = _out_indices;
     if (out_indices.empty()) {
         for (int i = 0; i < num_splits; ++i)
             out_indices.push_back(i);

--- a/src/tests/functional/plugin/shared/src/single_op/squeeze_unsqueeze.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/squeeze_unsqueeze.cpp
@@ -9,11 +9,7 @@
 namespace ov {
 namespace test {
 std::string SqueezeUnsqueezeLayerTest::getTestCaseName(const testing::TestParamInfo<squeezeParams>& obj) {
-    ov::element::Type model_type;
-    ShapeAxesTuple shape_item;
-    std::string targetDevice;
-    ov::test::utils::SqueezeOpType op_type;
-    std::tie(shape_item, op_type, model_type, targetDevice) = obj.param;
+    const auto& [shape_item, op_type, model_type, targetDevice] = obj.param;
 
     std::ostringstream result;
     const char separator = '_';
@@ -38,13 +34,9 @@ std::string SqueezeUnsqueezeLayerTest::getTestCaseName(const testing::TestParamI
 }
 
 void SqueezeUnsqueezeLayerTest::SetUp() {
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    std::vector<int> axes;
-    ShapeAxesTuple shape_item;
-    ov::test::utils::SqueezeOpType op_type;
-    std::tie(shape_item, op_type, model_type, targetDevice) = GetParam();
-    std::tie(input_shapes, axes) = shape_item;
+    const auto& [shape_item, op_type, model_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
+    const auto& [input_shapes, axes] = shape_item;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/stft.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/stft.cpp
@@ -47,22 +47,21 @@ std::string STFTLayerTest::getTestCaseName(const testing::TestParamInfo<STFTPara
 }
 
 void STFTLayerTest::SetUp() {
-    std::vector<InputShape> data_shapes;
-    int64_t frame_size;          // frame size value
-    int64_t frame_step;          // frame step value
-    bool transpose_frames;       // transpose_frames
-    ElementType data_type;       // data type
-    ElementType step_size_type;  // size/step type
-    utils::InputLayerType param_type;
+    // frame size value
+    // frame step value
+    // transpose_frames
+    // data type
+    // size/step type
 
-    std::tie(data_shapes,
-             frame_size,
-             frame_step,
-             transpose_frames,
-             data_type,
-             step_size_type,
-             param_type,
-             targetDevice) = this->GetParam();
+    const auto& [data_shapes,
+                 frame_size,
+                 frame_step,
+                 transpose_frames,
+                 data_type,
+                 step_size_type,
+                 param_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(data_shapes);
 

--- a/src/tests/functional/plugin/shared/src/single_op/strided_slice.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/strided_slice.cpp
@@ -8,10 +8,7 @@
 namespace ov {
 namespace test {
 std::string StridedSliceLayerTest::getTestCaseName(const testing::TestParamInfo<StridedSliceParams> &obj) {
-    StridedSliceSpecificParams params;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(params, model_type, target_device) = obj.param;
+    const auto& [params, model_type, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < params.input_shape.size(); i++) {
@@ -40,9 +37,8 @@ std::string StridedSliceLayerTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void StridedSliceLayerTest::SetUp() {
-    StridedSliceSpecificParams ssParams;
-    ov::element::Type model_type;
-    std::tie(ssParams, model_type, targetDevice) = this->GetParam();
+    const auto& [ssParams, model_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(ssParams.input_shape);
 

--- a/src/tests/functional/plugin/shared/src/single_op/tensor_iterator.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/tensor_iterator.cpp
@@ -16,19 +16,18 @@
 namespace ov {
 namespace test {
 std::string TensorIteratorTest::getTestCaseName(const testing::TestParamInfo<TensorIteratorParams> &obj) {
-    bool should_decompose;
-    size_t seq_lengths;
-    size_t batch;
-    size_t hidden_size;
     size_t input_size = 10;
-    size_t sequence_axis;
-    ov::test::utils::TensorIteratorBody ti_body;
-    float clip;
-    ov::op::RecurrentSequenceDirection direction;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(should_decompose, seq_lengths, batch, hidden_size, sequence_axis, clip, ti_body, direction, model_type,
-                target_device) = obj.param;
+
+    const auto& [should_decompose,
+                 seq_lengths,
+                 batch,
+                 hidden_size,
+                 sequence_axis,
+                 clip,
+                 ti_body,
+                 direction,
+                 model_type,
+                 target_device] = obj.param;
     std::vector<ov::Shape> input_shapes = {};
 
     switch (ti_body) {
@@ -67,18 +66,19 @@ std::string TensorIteratorTest::getTestCaseName(const testing::TestParamInfo<Ten
 }
 
 void TensorIteratorTest::SetUp() {
-    size_t seq_lengths;
-    bool should_decompose;
-    size_t batch;
-    size_t hidden_size;
     size_t input_size = 10;
-    size_t sequence_axis;
-    ov::test::utils::TensorIteratorBody ti_body;
-    float clip;
-    ov::op::RecurrentSequenceDirection direction;
-    ov::element::Type model_type;
-    std::tie(should_decompose, seq_lengths, batch, hidden_size, sequence_axis, clip, ti_body, direction, model_type,
-                targetDevice) = this->GetParam();
+
+    const auto& [should_decompose,
+                 seq_lengths,
+                 batch,
+                 hidden_size,
+                 sequence_axis,
+                 clip,
+                 ti_body,
+                 direction,
+                 model_type,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     std::vector<ov::Shape> input_shapes;
     auto tensor_iterator = std::make_shared<ov::op::v0::TensorIterator>();
 

--- a/src/tests/functional/plugin/shared/src/single_op/tile.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/tile.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string TileLayerTest::getTestCaseName(const testing::TestParamInfo<TileLayerTestParamsSet>& obj) {
-    TileSpecificParams tile_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    std::string target_device;
-    std::tie(tile_params, model_type, input_shapes, target_device) = obj.param;
+    const auto& [tile_params, model_type, input_shapes, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -35,10 +31,8 @@ std::string TileLayerTest::getTestCaseName(const testing::TestParamInfo<TileLaye
 }
 
 void TileLayerTest::SetUp() {
-    TileSpecificParams tile_params;
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    std::tie(tile_params, model_type, input_shapes, targetDevice) = this->GetParam();
+    const auto& [tile_params, model_type, input_shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes({input_shapes});
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/topk.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/topk.cpp
@@ -10,13 +10,7 @@
 namespace ov {
 namespace test {
 std::string TopKLayerTest::getTestCaseName(const testing::TestParamInfo<TopKParams>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    std::string target_device;
-    int64_t keepK, axis;
-    ov::op::v1::TopK::Mode mode;
-    ov::op::v1::TopK::SortType sort;
-    std::tie(keepK, axis, mode, sort, model_type, input_shapes, target_device) = obj.param;
+    const auto& [keepK, axis, mode, sort, model_type, input_shapes, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -41,12 +35,8 @@ std::string TopKLayerTest::getTestCaseName(const testing::TestParamInfo<TopKPara
 }
 
 void TopKLayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    int64_t keepK, axis;
-    ov::op::v1::TopK::Mode mode;
-    ov::op::v1::TopK::SortType sort;
-    std::tie(keepK, axis, mode, sort, model_type, input_shapes, targetDevice) = this->GetParam();
+    const auto& [keepK, axis, mode, sort, model_type, input_shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());
@@ -56,14 +46,7 @@ void TopKLayerTest::SetUp() {
 }
 
 std::string TopK11LayerTest::getTestCaseName(const testing::TestParamInfo<TopK11Params>& obj) {
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    std::string target_device;
-    int64_t keepK, axis;
-    bool stable;
-    ov::op::v1::TopK::Mode mode;
-    ov::op::v1::TopK::SortType sort;
-    std::tie(keepK, axis, mode, sort, model_type, input_shapes, stable, target_device) = obj.param;
+    const auto& [keepK, axis, mode, sort, model_type, input_shapes, stable, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -89,13 +72,8 @@ std::string TopK11LayerTest::getTestCaseName(const testing::TestParamInfo<TopK11
 }
 
 void TopK11LayerTest::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    int64_t keepK, axis;
-    bool stable;
-    ov::op::v1::TopK::Mode mode;
-    ov::op::v1::TopK::SortType sort;
-    std::tie(keepK, axis, mode, sort, model_type, input_shapes, stable, targetDevice) = this->GetParam();
+    const auto& [keepK, axis, mode, sort, model_type, input_shapes, stable, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes);
 
     auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes.front());

--- a/src/tests/functional/plugin/shared/src/single_op/transpose.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/transpose.cpp
@@ -8,11 +8,7 @@
 namespace ov {
 namespace test {
 std::string TransposeLayerTest::getTestCaseName(const testing::TestParamInfo<transposeParams>& obj) {
-    ov::element::Type modelType;
-    std::vector<size_t> inputOrder;
-    std::vector<InputShape> input_shapes;
-    std::string targetDevice;
-    std::tie(inputOrder, modelType, input_shapes, targetDevice) = obj.param;
+    const auto& [inputOrder, modelType, input_shapes, targetDevice] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < input_shapes.size(); i++) {
@@ -34,10 +30,8 @@ std::string TransposeLayerTest::getTestCaseName(const testing::TestParamInfo<tra
 }
 
 void TransposeLayerTest::SetUp() {
-    std::vector<size_t> input_order;
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    std::tie(input_order, model_type, input_shapes, targetDevice) = this->GetParam();
+    const auto& [input_order, model_type, input_shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes({input_shapes});
 

--- a/src/tests/functional/plugin/shared/src/single_op/variadic_split.cpp
+++ b/src/tests/functional/plugin/shared/src/single_op/variadic_split.cpp
@@ -8,12 +8,7 @@
 namespace ov {
 namespace test {
 std::string VariadicSplitLayerTest::getTestCaseName(const testing::TestParamInfo<VariadicSplitParams>& obj) {
-    int64_t axis;
-    std::vector<size_t> num_splits;
-    ov::element::Type model_type;
-    std::vector<InputShape> input_shapes;
-    ov::test::TargetDevice target_device;
-    std::tie(num_splits, axis, model_type, input_shapes, target_device) = obj.param;
+    const auto& [num_splits, axis, model_type, input_shapes, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS=(";
@@ -37,11 +32,8 @@ std::string VariadicSplitLayerTest::getTestCaseName(const testing::TestParamInfo
 }
 
 void VariadicSplitLayerTest::SetUp() {
-    int64_t axis;
-    std::vector<size_t> num_splits;
-    std::vector<InputShape> input_shapes;
-    ov::element::Type model_type;
-    std::tie(num_splits, axis, model_type, input_shapes, targetDevice) = this->GetParam();
+    const auto& [num_splits, axis, model_type, input_shapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(input_shapes);
 

--- a/src/tests/functional/plugin/shared/src/snippets/add.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/add.cpp
@@ -12,11 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string Add::getTestCaseName(testing::TestParamInfo<ov::test::snippets::AddParams> obj) {
-    ov::test::InputShape inputShapes0, inputShapes1;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, inputShapes1, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes0, inputShapes1, type, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_";
@@ -37,9 +33,10 @@ std::string Add::getTestCaseName(testing::TestParamInfo<ov::test::snippets::AddP
 }
 
 void Add::SetUp() {
-    ov::test::InputShape inputShape0, inputShape1;
-    ov::element::Type type;
-    std::tie(inputShape0, inputShape1, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0, inputShape1, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape0, inputShape1});
     auto f = ov::test::snippets::AddFunction(inputDynamicShapes);
     function = f.getOriginal();
@@ -48,12 +45,7 @@ void Add::SetUp() {
 }
 
 std::string AddConst::getTestCaseName(testing::TestParamInfo<ov::test::snippets::AddConstParams> obj) {
-    InputShape inputShapes;
-    PartialShape constShape;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, constShape, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, constShape, type, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes.first}) << "_";
@@ -70,10 +62,10 @@ std::string AddConst::getTestCaseName(testing::TestParamInfo<ov::test::snippets:
 }
 
 void AddConst::SetUp() {
-    InputShape inputShape;
-    PartialShape constShape;
-    ov::element::Type type;
-    std::tie(inputShape, constShape, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, constShape, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({{inputShape}});
     auto f = ov::test::snippets::AddConstFunction({inputDynamicShapes}, constShape);
     function = f.getOriginal();
@@ -85,10 +77,10 @@ void AddConst::SetUp() {
 }
 
 void AddRollConst::SetUp() {
-    InputShape inputShape;
-    PartialShape constShape;
-    ov::element::Type type;
-    std::tie(inputShape, constShape, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, constShape, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape});
     auto f = ov::test::snippets::AddRollConstFunction({inputDynamicShapes}, constShape);
     function = f.getOriginal();
@@ -101,11 +93,7 @@ void AddRollConst::SetUp() {
 }
 
 std::string AddPair::getTestCaseName(testing::TestParamInfo<ov::test::snippets::AddParamsPair> obj) {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(input_shapes, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [input_shapes, type, num_nodes, num_subgraphs, targetDevice] = obj.param;
     OPENVINO_ASSERT(input_shapes.size() == 2, "Invalid input shapes vector size");
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({input_shapes[0].first}) << "_";
@@ -126,9 +114,10 @@ std::string AddPair::getTestCaseName(testing::TestParamInfo<ov::test::snippets::
 }
 
 void AddPair::SetUp() {
-    std::vector<InputShape> input_shapes;
-    ov::element::Type type;
-    std::tie(input_shapes, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [input_shapes, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes);
     auto f = ov::test::snippets::AddFunction(inputDynamicShapes);
     function = f.getOriginal();

--- a/src/tests/functional/plugin/shared/src/snippets/check_broadcast.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/check_broadcast.cpp
@@ -43,11 +43,7 @@ public:
 };
 
 std::string CheckBroadcast::getTestCaseName(testing::TestParamInfo<CheckBroadcastParams> obj) {
-    ov::element::Type input_type;
-    CheckBroadcastTestCaseParams test_case_params;
-    std::string target_device;
-
-    std::tie(input_type, test_case_params, target_device) = obj.param;
+    const auto& [input_type, test_case_params, target_device] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({test_case_params.input_shapes.first.first}) << "_";
@@ -70,10 +66,8 @@ std::string CheckBroadcast::getTestCaseName(testing::TestParamInfo<CheckBroadcas
 }
 
 void CheckBroadcast::SetUp() {
-    ov::element::Type input_type;
-    CheckBroadcastTestCaseParams test_case_params;
-
-    std::tie(input_type, test_case_params, targetDevice) = this->GetParam();
+    const auto& [input_type, test_case_params, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     ref_num_nodes = test_case_params.num_nodes;
     ref_num_subgraphs = test_case_params.num_subgraphs;
 

--- a/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/codegen_gelu.cpp
@@ -15,11 +15,7 @@ namespace test {
 namespace snippets {
 
     std::string CodegenGelu::getTestCaseName(testing::TestParamInfo<ov::test::snippets::CodegenGeluParams> obj) {
-        ov::element::Type_t netPrecision;
-        InputShape inputShapes0, inputShapes1;
-        bool useSubgraph;
-        std::string targetDevice;
-        std::tie(netPrecision, inputShapes0, inputShapes1, useSubgraph, targetDevice) = obj.param;
+        const auto& [netPrecision, inputShapes0, inputShapes1, useSubgraph, targetDevice] = obj.param;
 
         std::ostringstream result;
         result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_";

--- a/src/tests/functional/plugin/shared/src/snippets/conv_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/conv_eltwise.cpp
@@ -13,12 +13,7 @@ namespace test {
 namespace snippets {
 
     std::string ConvEltwise::getTestCaseName(testing::TestParamInfo<ov::test::snippets::ConvEltwiseParams> obj) {
-        ov::Shape inputShape0, inputShape1;
-        std::shared_ptr<ov::Node> binaryEltwise;
-        size_t num_nodes, num_subgraphs;
-        std::string targetDevice;
-        std::tie(inputShape0, inputShape1, binaryEltwise,
-                 num_nodes, num_subgraphs, targetDevice) = obj.param;
+        const auto& [inputShape0, inputShape1, binaryEltwise, num_nodes, num_subgraphs, targetDevice] = obj.param;
         std::ostringstream result;
         result << "IS[0]=" << ov::test::utils::vec2str(inputShape0) << "_";
         result << "IS[1]=" << ov::test::utils::vec2str(inputShape1) << "_";
@@ -31,10 +26,11 @@ namespace snippets {
 
     // the simplest possible eltwise operation with streaming access to the data
     void ConvEltwise::SetUp() {
-        ov::Shape inputShape0, inputShape1;
-        std::shared_ptr<ov::Node> binaryEltwise;
-        std::tie(inputShape0, inputShape1, binaryEltwise,
-                 ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+        const auto& [inputShape0, inputShape1, binaryEltwise, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] =
+            this->GetParam();
+        ref_num_nodes = _ref_num_nodes;
+        ref_num_subgraphs = _ref_num_subgraphs;
+        targetDevice = _targetDevice;
 
         init_input_shapes({{{}, {inputShape0, }}, {{}, {inputShape1, }}});
         std::vector<std::shared_ptr<ov::Node>> eltwiseOps {binaryEltwise,

--- a/src/tests/functional/plugin/shared/src/snippets/convert.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/convert.cpp
@@ -12,11 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string Convert::getTestCaseName(testing::TestParamInfo<ov::test::snippets::ConvertParams> obj) {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShape, types, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShape, types, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < inputShape.size(); ++i) {
@@ -35,9 +31,10 @@ std::string Convert::getTestCaseName(testing::TestParamInfo<ov::test::snippets::
 }
 
 void Convert::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
     auto f = ov::test::snippets::ConvertFunction(inputDynamicShapes, types.first[0], types.second[0]);
     function = f.getOriginal();
@@ -79,8 +76,8 @@ void Convert::generate_inputs(const std::vector<ov::Shape>& targetInputStaticSha
     for (int i = 0; i < funcInputs.size(); ++i) {
         const auto& funcInput = funcInputs[i];
         ov::Tensor tensor;
-        int32_t startFrom, range, resolution;
-        std::tie(startFrom, range, resolution) = params[i];
+
+        const auto& [startFrom, range, resolution] = params[i];
         ov::test::utils::InputGenerateData in_data;
         in_data.start_from = startFrom;
         in_data.range = range;
@@ -91,9 +88,10 @@ void Convert::generate_inputs(const std::vector<ov::Shape>& targetInputStaticSha
 }
 
 void ConvertInput::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
     auto f = ov::test::snippets::ConvertInputFunction(inputDynamicShapes, types.first[0], types.second[0]);
     function = f.getOriginal();
@@ -136,9 +134,10 @@ parameters ConvertInput::generate_params_random() const {
 }
 
 void ConvertOutput::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
 
     auto f = ov::test::snippets::ConvertOutputFunction(inputDynamicShapes, types.first[0], types.second[0]);
@@ -152,9 +151,10 @@ void ConvertOutput::SetUp() {
 }
 
 void ConvertStub::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
 
     auto f = ov::test::snippets::ConvertStubFunction(inputDynamicShapes, types.first[0], types.second[0]);
@@ -164,9 +164,10 @@ void ConvertStub::SetUp() {
 }
 
 void ConvertPartialInputsAndResults::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
 
     auto f = ov::test::snippets::ConvertPartialInputsAndResultsFunction(inputDynamicShapes, types.first, types.second);
@@ -175,9 +176,10 @@ void ConvertPartialInputsAndResults::SetUp() {
 }
 
 void ConvertManyOnInputs::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
 
     auto f = ov::test::snippets::ConvertManyOnInputsFunction(inputDynamicShapes, types.first);
@@ -186,9 +188,10 @@ void ConvertManyOnInputs::SetUp() {
 }
 
 void ConvertManyOnOutputs::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
 
     auto f = ov::test::snippets::ConvertManyOnOutputsFunction(inputDynamicShapes, types.first);
@@ -197,9 +200,10 @@ void ConvertManyOnOutputs::SetUp() {
 }
 
 void ConvertManyOnInputOutput::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::pair<std::vector<ov::element::Type>, std::vector<ov::element::Type>> types;
-    std::tie(inputShape, types, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, types, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
 
     auto f = ov::test::snippets::ConvertManyOnInputOutputFunction(inputDynamicShapes, types.first, types.second);

--- a/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/edge_replace.cpp
@@ -12,11 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string EdgeReplace::getTestCaseName(testing::TestParamInfo<ov::test::snippets::EdgeReplaceParams> obj) {
-    ov::PartialShape inputShape;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShape, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShape, type, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::partialShape2str({inputShape}) << "_";
@@ -28,9 +24,10 @@ std::string EdgeReplace::getTestCaseName(testing::TestParamInfo<ov::test::snippe
 }
 
 void EdgeReplace::SetUp() {
-    ov::PartialShape inputShape;
-    ov::element::Type type;
-    std::tie(inputShape, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({{{inputShape}, {inputShape.get_shape()}}});
 
     auto f = ov::test::snippets::EdgeReplaceFunction({inputShape});

--- a/src/tests/functional/plugin/shared/src/snippets/eltwise_two_results.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/eltwise_two_results.cpp
@@ -11,10 +11,7 @@ namespace test {
 namespace snippets {
 
 std::string EltwiseTwoResults::getTestCaseName(testing::TestParamInfo<ov::test::snippets::EltwiseTwoResultsParams> obj) {
-    InputShape inputShapes0, inputShapes1;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, inputShapes1, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes0, inputShapes1, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_"
@@ -35,8 +32,10 @@ std::string EltwiseTwoResults::getTestCaseName(testing::TestParamInfo<ov::test::
 }
 
 void EltwiseTwoResults::SetUp() {
-    InputShape inputShape0, inputShape1;
-    std::tie(inputShape0, inputShape1, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0, inputShape1, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape0, inputShape1});
 
     auto f = ov::test::snippets::EltwiseTwoResultsFunction({inputDynamicShapes[0], inputDynamicShapes[1]});

--- a/src/tests/functional/plugin/shared/src/snippets/enforce_precision.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/enforce_precision.cpp
@@ -12,10 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string EnforcePrecisionTest::getTestCaseName(testing::TestParamInfo<EnforcePrecisionTestParams> obj) {
-    std::vector<ov::PartialShape> input_shapes;
-    size_t num_nodes, num_subgraphs;
-    std::string targetDevice;
-    std::tie(input_shapes, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [input_shapes, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < input_shapes.size(); ++i)
@@ -27,8 +24,10 @@ std::string EnforcePrecisionTest::getTestCaseName(testing::TestParamInfo<Enforce
 }
 
 void EnforcePrecisionTest::SetUp() {
-    std::vector<ov::PartialShape> input_shapes;
-    std::tie(input_shapes, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [input_shapes, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(static_partial_shapes_to_test_representation(input_shapes));
 
     function = SubgraphRollMatMulRollFunction(input_shapes, ov::element::f32).getOriginal();

--- a/src/tests/functional/plugin/shared/src/snippets/exp.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/exp.cpp
@@ -14,11 +14,7 @@ namespace test {
 namespace snippets {
 
 std::string Exp::getTestCaseName(testing::TestParamInfo<ov::test::snippets::ExpParams> obj) {
-    ov::test::InputShape inputShapes0;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes0, type, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_";
@@ -34,9 +30,10 @@ std::string Exp::getTestCaseName(testing::TestParamInfo<ov::test::snippets::ExpP
 }
 
 void Exp::SetUp() {
-    ov::test::InputShape inputShape0;
-    ov::element::Type type;
-    std::tie(inputShape0, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape0});
     auto f = ov::test::snippets::ExpFunction(inputDynamicShapes);
     function = f.getOriginal();
@@ -45,9 +42,10 @@ void Exp::SetUp() {
 }
 
 void ExpReciprocal::SetUp() {
-    ov::test::InputShape inputShape0;
-    ov::element::Type type;
-    std::tie(inputShape0, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape0});
     auto f = ov::test::snippets::ExpReciprocalFunction(inputDynamicShapes);
     function = f.getOriginal();

--- a/src/tests/functional/plugin/shared/src/snippets/group_normalization.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/group_normalization.cpp
@@ -12,12 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string GroupNormalization::getTestCaseName(testing::TestParamInfo<ov::test::snippets::GroupNormalizationParams> obj) {
-    InputShape inputShapes;
-    size_t numGroup;
-    float eps;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, numGroup, eps, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, numGroup, eps, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::partialShape2str({inputShapes.first}) << "_";
@@ -34,10 +29,10 @@ std::string GroupNormalization::getTestCaseName(testing::TestParamInfo<ov::test:
 }
 
 void GroupNormalization::SetUp() {
-    InputShape inputShape;
-    size_t numGroup;
-    float eps;
-    std::tie(inputShape, numGroup, eps, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, numGroup, eps, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
 
     InputShape scaleShiftShape = ExtractScaleShiftShape(inputShape);
 

--- a/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
@@ -47,10 +47,17 @@ std::string MatMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::M
 }
 
 void MatMul::SetUp() {
-    std::vector<ov::test::InputShape> input_shapes;
-    std::vector<ov::element::Type> elem_types;
-    ov::AnyMap additional_config;
-    std::tie(input_shapes, elem_types, matmul_type, ref_num_nodes, ref_num_subgraphs, targetDevice, additional_config) = this->GetParam();
+    const auto& [input_shapes,
+                 elem_types,
+                 _matmul_type,
+                 _ref_num_nodes,
+                 _ref_num_subgraphs,
+                 _targetDevice,
+                 additional_config] = this->GetParam();
+    matmul_type = _matmul_type;
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes);
 
     const auto builder = get_builder(elem_types);

--- a/src/tests/functional/plugin/shared/src/snippets/max_num_params_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/max_num_params_eltwise.cpp
@@ -11,10 +11,7 @@ namespace test {
 namespace snippets {
 
 std::string MaxNumParamsEltwise::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MaxNumParamsEltwiseParams> obj) {
-    ov::test::InputShape inputShapes;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes.first}) << "_";
@@ -30,8 +27,10 @@ std::string MaxNumParamsEltwise::getTestCaseName(testing::TestParamInfo<ov::test
 }
 
 void MaxNumParamsEltwise::SetUp() {
-    ov::test::InputShape inputShape;
-    std::tie(inputShape, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     std::vector<ov::test::InputShape> expandedShapes(9, inputShape);
     init_input_shapes(expandedShapes);
 

--- a/src/tests/functional/plugin/shared/src/snippets/mha.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mha.cpp
@@ -67,23 +67,15 @@ void MHABase::SetUp() {
  }
 
 std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAParams> obj) {
-    std::vector<InputShape> input_shapes;
-    std::vector<ov::element::Type> elem_types;
-    ov::element::Type prc;
-    bool with_mul;
-    size_t thread_count;
-    std::string target_device;
-    size_t num_nodes, num_subgraphs;
-    ov::AnyMap additional_config;
-    std::tie(input_shapes,
-             elem_types,
-             prc,
-             with_mul,
-             thread_count,
-             num_nodes,
-             num_subgraphs,
-             target_device,
-             additional_config) = obj.param;
+    const auto& [input_shapes,
+                 elem_types,
+                 prc,
+                 with_mul,
+                 thread_count,
+                 num_nodes,
+                 num_subgraphs,
+                 target_device,
+                 additional_config] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < input_shapes.size(); i++)
@@ -107,14 +99,14 @@ std::string MHA::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAP
 }
 
 std::string MHAWithDynamicMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::MHAWithDynamicMulParams> obj) {
-    std::vector<InputShape> input_shapes;
-    std::vector<ov::element::Type> elem_types;
-    ov::element::Type prc;
-    size_t thread_count;
-    std::string target_device;
-    size_t num_nodes, num_subgraphs;
-    ov::AnyMap additional_config;
-    std::tie(input_shapes, elem_types, prc, thread_count, num_nodes, num_subgraphs, target_device, additional_config) = obj.param;
+    const auto& [input_shapes,
+                 elem_types,
+                 prc,
+                 thread_count,
+                 num_nodes,
+                 num_subgraphs,
+                 target_device,
+                 additional_config] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < input_shapes.size(); i++)

--- a/src/tests/functional/plugin/shared/src/snippets/mlp_seq.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/mlp_seq.cpp
@@ -73,17 +73,24 @@ std::string MLPSeq::getTestCaseName(testing::TestParamInfo<ov::test::snippets::M
 }
 
 void MLPSeq::init_params(std::vector<InputShape>& input_shapes, ov::element::Type& prc, ov::AnyMap& additional_config) {
-    std::pair <size_t, std::pair<size_t, size_t>> num_hidden_layers_with_expectations;
-    std::tie(input_shapes,
-             m_input_types,
-             prc,
-             m_thread_count,
-             targetDevice,
-             additional_config,
-             num_hidden_layers_with_expectations,
-             m_hidden_matmul_size) = this->GetParam();
-    std::pair<size_t, size_t> ref_num_subgraphs_and_nodes;
-    std::tie(m_num_hidden_layers, ref_num_subgraphs_and_nodes) = num_hidden_layers_with_expectations;
+    const auto& [_input_shapes,
+                 _m_input_types,
+                 _prc,
+                 _m_thread_count,
+                 _targetDevice,
+                 _additional_config,
+                 num_hidden_layers_with_expectations,
+                 _m_hidden_matmul_size] = this->GetParam();
+    input_shapes = _input_shapes;
+    m_input_types = _m_input_types;
+    prc = _prc;
+    m_thread_count = _m_thread_count;
+    targetDevice = _targetDevice;
+    additional_config = _additional_config;
+    m_hidden_matmul_size = _m_hidden_matmul_size;
+
+    const auto& [_m_num_hidden_layers, ref_num_subgraphs_and_nodes] = num_hidden_layers_with_expectations;
+    m_num_hidden_layers = _m_num_hidden_layers;
     std::tie(ref_num_subgraphs, ref_num_nodes) = ref_num_subgraphs_and_nodes;
 }
 

--- a/src/tests/functional/plugin/shared/src/snippets/precision_propagation_convertion.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/precision_propagation_convertion.cpp
@@ -12,11 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string PrecisionPropagationConvertion::getTestCaseName(testing::TestParamInfo<PrecisionPropagationParams> obj) {
-    std::vector<InputShape> input_shapes;
-    std::vector<float> fake_quantize_intervals;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(input_shapes, fake_quantize_intervals, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [input_shapes, fake_quantize_intervals, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < input_shapes.size(); ++i) {
@@ -35,9 +31,11 @@ std::string PrecisionPropagationConvertion::getTestCaseName(testing::TestParamIn
 }
 
 void PrecisionPropagationConvertion::SetUp() {
-    std::vector<InputShape> input_shapes;
-    std::vector<float> fake_quantize_intervals;
-    std::tie(input_shapes, fake_quantize_intervals, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [input_shapes, fake_quantize_intervals, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] =
+        this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes);
 
     function = PrecisionPropagationConvertionFunction(inputDynamicShapes, ov::element::f32, fake_quantize_intervals).getOriginal();

--- a/src/tests/functional/plugin/shared/src/snippets/reduce.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/reduce.cpp
@@ -13,13 +13,7 @@ namespace test {
 namespace snippets {
 
 std::string Reduce::getTestCaseName(testing::TestParamInfo<ov::test::snippets::ReduceParams> obj) {
-    InputShape input_shape;
-    ov::test::utils::ReductionType reduce_type;
-    std::vector<int> axes;
-    bool keep_dims;
-    size_t num_nodes, num_subgraphs;
-    std::string targetDevice;
-    std::tie(input_shape, reduce_type, axes, keep_dims, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [input_shape, reduce_type, axes, keep_dims, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::partialShape2str({input_shape.first}) << "_";
@@ -36,11 +30,11 @@ std::string Reduce::getTestCaseName(testing::TestParamInfo<ov::test::snippets::R
 }
 
 void Reduce::SetUp() {
-    InputShape input_shape;
-    ov::test::utils::ReductionType reduce_type;
-    std::vector<int> axes;
-    bool keep_dims;
-    std::tie(input_shape, reduce_type, axes, keep_dims, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [input_shape, reduce_type, axes, keep_dims, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] =
+        this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({input_shape});
 
     auto f = ov::test::snippets::ReduceFunction(inputDynamicShapes, reduce_type, axes, keep_dims);

--- a/src/tests/functional/plugin/shared/src/snippets/select.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/select.cpp
@@ -37,11 +37,7 @@ void generate_data(std::map<std::shared_ptr<ov::Node>, ov::Tensor>& data_inputs,
 } // namespace
 
 std::string Select::getTestCaseName(testing::TestParamInfo<ov::test::snippets::SelectParams> obj) {
-    InputShape inputShapes0, inputShapes1, inputShapes2;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, inputShapes1, inputShapes2, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes0, inputShapes1, inputShapes2, type, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_";
@@ -67,9 +63,11 @@ std::string Select::getTestCaseName(testing::TestParamInfo<ov::test::snippets::S
 }
 
 void Select::SetUp() {
-    InputShape inputShape0, inputShape1, inputShape2;
-    ov::element::Type type;
-    std::tie(inputShape0, inputShape1, inputShape2, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0, inputShape1, inputShape2, type, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] =
+        this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({{inputShape0}, {inputShape1}, {inputShape2}});
 
     auto f = ov::test::snippets::SelectFunction(inputDynamicShapes);
@@ -83,12 +81,14 @@ void Select::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShap
 }
 
 std::string BroadcastSelect::getTestCaseName(testing::TestParamInfo<ov::test::snippets::BroadcastSelectParams> obj) {
-    InputShape inputShapes0, inputShapes1, inputShapes2;
-    ov::PartialShape broadcastShape;
-    ov::element::Type type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, inputShapes1, inputShapes2, broadcastShape, type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes0,
+                 inputShapes1,
+                 inputShapes2,
+                 broadcastShape,
+                 type,
+                 num_nodes,
+                 num_subgraphs,
+                 targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_";
@@ -115,10 +115,17 @@ std::string BroadcastSelect::getTestCaseName(testing::TestParamInfo<ov::test::sn
 }
 
 void BroadcastSelect::SetUp() {
-    InputShape inputShape0, inputShape1, inputShape2;
-    ov::PartialShape broadcastShape;
-    ov::element::Type type;
-    std::tie(inputShape0, inputShape1, inputShape2, broadcastShape, type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0,
+                 inputShape1,
+                 inputShape2,
+                 broadcastShape,
+                 type,
+                 _ref_num_nodes,
+                 _ref_num_subgraphs,
+                 _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape0, inputShape1, inputShape2});
 
     auto f = ov::test::snippets::BroadcastSelectFunction({inputDynamicShapes[0], inputDynamicShapes[1], inputDynamicShapes[2]}, broadcastShape);

--- a/src/tests/functional/plugin/shared/src/snippets/three_inputs_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/three_inputs_eltwise.cpp
@@ -12,11 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string ThreeInputsEltwise::getTestCaseName(testing::TestParamInfo<ov::test::snippets::ThreeInputsEltwiseParams> obj) {
-    InputShape inputShapes0, inputShapes1, inputShapes2;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes0, inputShapes1, inputShapes2,
-             num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes0, inputShapes1, inputShapes2, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << ov::test::utils::partialShape2str({inputShapes0.first}) << "_";
@@ -41,9 +37,11 @@ std::string ThreeInputsEltwise::getTestCaseName(testing::TestParamInfo<ov::test:
 }
 
 void ThreeInputsEltwise::SetUp() {
-    InputShape inputShape0, inputShape1, inputShape2;
-    std::tie(inputShape0, inputShape1, inputShape2,
-             ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape0, inputShape1, inputShape2, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] =
+        this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape0, inputShape1, inputShape2});
 
     auto f = ov::test::snippets::EltwiseThreeInputsFunction(inputDynamicShapes);

--- a/src/tests/functional/plugin/shared/src/snippets/transpose.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose.cpp
@@ -12,11 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string Transpose::getTestCaseName(testing::TestParamInfo<ov::test::snippets::TransposeParams> obj) {
-    InputShape inputShapes;
-    std::vector<int> order;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, order, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, order, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << inputShapes << "_";
@@ -28,9 +24,10 @@ std::string Transpose::getTestCaseName(testing::TestParamInfo<ov::test::snippets
 }
 
 void Transpose::SetUp() {
-    InputShape inputShape;
-    std::vector<int> order;
-    std::tie(inputShape, order, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, order, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShape});
 
     auto f = ov::test::snippets::TransposeFunction(inputDynamicShapes, order);
@@ -39,11 +36,7 @@ void Transpose::SetUp() {
 }
 
 std::string TransposeMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::TransposeMulParams> obj) {
-    std::pair<InputShape, InputShape> inputShapes;
-    std::vector<int> order;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, order, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, order, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS[0]=" << inputShapes.first << "_";
@@ -56,9 +49,10 @@ std::string TransposeMul::getTestCaseName(testing::TestParamInfo<ov::test::snipp
 }
 
 void TransposeMul::SetUp() {
-    std::pair<InputShape, InputShape> inputShapes;
-    std::vector<int> order;
-    std::tie(inputShapes, order, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShapes, order, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes({inputShapes.first, inputShapes.second});
     auto f = ov::test::snippets::TransposeMulFunction(inputDynamicShapes, order);
     function = f.getOriginal();

--- a/src/tests/functional/plugin/shared/src/snippets/transpose_matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose_matmul.cpp
@@ -14,13 +14,8 @@ namespace test {
 namespace snippets {
 
 std::string TransposeMatMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::TransposeMatMulParams> obj) {
-    std::vector<InputShape> input_shapes;
-    size_t transpose_position;
-    std::vector<ov::element::Type> elem_types;
-    MatMulType matmul_type;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(input_shapes, transpose_position, elem_types, matmul_type, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [input_shapes, transpose_position, elem_types, matmul_type, num_nodes, num_subgraphs, targetDevice] =
+        obj.param;
     std::ostringstream result;
     for (size_t i = 0; i < input_shapes.size(); ++i) {
         result << "IS[" << i << "]=" << input_shapes[i] << "_";
@@ -36,9 +31,18 @@ std::string TransposeMatMul::getTestCaseName(testing::TestParamInfo<ov::test::sn
 }
 
 void TransposeMatMul::SetUp() {
-    std::vector<InputShape> input_shapes;
-    std::vector<ov::element::Type> elem_types;
-    std::tie(input_shapes, transpose_position, elem_types, matmul_type, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [input_shapes,
+                 _transpose_position,
+                 elem_types,
+                 _matmul_type,
+                 _ref_num_nodes,
+                 _ref_num_subgraphs,
+                 _targetDevice] = this->GetParam();
+    transpose_position = _transpose_position;
+    matmul_type = _matmul_type;
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(input_shapes);
 
     const auto builder = get_builder(elem_types);

--- a/src/tests/functional/plugin/shared/src/snippets/transpose_softmax.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/transpose_softmax.cpp
@@ -12,12 +12,7 @@ namespace test {
 namespace snippets {
 
 std::string TransposeSoftmax::getTestCaseName(testing::TestParamInfo<ov::test::snippets::TransposeSoftmaxParams> obj) {
-    std::vector<InputShape> inputShapes;
-    std::vector<int64_t> order;
-    int axis;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, order, axis, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, order, axis, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < inputShapes.size(); ++i) {
@@ -36,10 +31,10 @@ std::string TransposeSoftmax::getTestCaseName(testing::TestParamInfo<ov::test::s
 }
 
 void TransposeSoftmax::SetUp() {
-    std::vector<InputShape> inputShapes;
-    std::vector<int64_t> order;
-    int64_t axis;
-    std::tie(inputShapes, order, axis, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShapes, order, axis, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShapes);
 
     auto f = ov::test::snippets::TransposeSoftmaxFunction(inputDynamicShapes, order, axis);
@@ -49,10 +44,10 @@ void TransposeSoftmax::SetUp() {
 }
 
 void TransposeSoftmaxEltwise::SetUp() {
-    std::vector<InputShape> inputShapes;
-    std::vector<int64_t> order;
-    int64_t axis;
-    std::tie(inputShapes, order, axis, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShapes, order, axis, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShapes);
 
     auto f = ov::test::snippets::TransposeSoftmaxEltwiseFunction(inputDynamicShapes, order, axis);

--- a/src/tests/functional/plugin/shared/src/snippets/two_inputs_and_outputs.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/two_inputs_and_outputs.cpp
@@ -11,10 +11,7 @@ namespace test {
 namespace snippets {
 
 std::string TwoInputsAndOutputs::getTestCaseName(testing::TestParamInfo<ov::test::snippets::TwoInputsAndOutputsParams> obj) {
-    std::vector<InputShape> inputShapes;
-    std::string targetDevice;
-    size_t num_nodes, num_subgraphs;
-    std::tie(inputShapes, num_nodes, num_subgraphs, targetDevice) = obj.param;
+    const auto& [inputShapes, num_nodes, num_subgraphs, targetDevice] = obj.param;
 
     std::ostringstream result;
     for (size_t i = 0; i < inputShapes.size(); ++i) {
@@ -31,8 +28,10 @@ std::string TwoInputsAndOutputs::getTestCaseName(testing::TestParamInfo<ov::test
 }
 
 void TwoInputsAndOutputs::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::tie(inputShape, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
     auto f = ov::test::snippets::TwoInputsAndOutputsFunction(inputDynamicShapes);
     function = f.getOriginal();
@@ -41,8 +40,10 @@ void TwoInputsAndOutputs::SetUp() {
 }
 
 void TwoInputsAndOutputsWithReversedOutputs::SetUp() {
-    std::vector<InputShape> inputShape;
-    std::tie(inputShape, ref_num_nodes, ref_num_subgraphs, targetDevice) = this->GetParam();
+    const auto& [inputShape, _ref_num_nodes, _ref_num_subgraphs, _targetDevice] = this->GetParam();
+    ref_num_nodes = _ref_num_nodes;
+    ref_num_subgraphs = _ref_num_subgraphs;
+    targetDevice = _targetDevice;
     init_input_shapes(inputShape);
     auto f = ov::test::snippets::TwoInputsAndOutputsWithReversedOutputsFunction(inputDynamicShapes);
     function = f.getOriginal();

--- a/src/tests/functional/plugin/shared/src/subgraph/constant_result.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/constant_result.cpp
@@ -26,12 +26,7 @@ std::ostream& operator<<(std::ostream& os, ConstantSubgraphType type) {
 }
 
 std::string ConstantResultSubgraphTest::getTestCaseName(const testing::TestParamInfo<constResultParams>& obj) {
-    ConstantSubgraphType type;
-    ov::Shape input_shape;
-    ov::element::Type input_type;
-    std::string target_device;
-
-    std::tie(type, input_shape, input_type, target_device) = obj.param;
+    const auto& [type, input_shape, input_type, target_device] = obj.param;
     std::ostringstream result;
     result << "SubgraphType=" << type << "_";
     result << "IS=" << input_shape << "_";
@@ -66,10 +61,8 @@ void ConstantResultSubgraphTest::createGraph(const ConstantSubgraphType& type,
 }
 
 void ConstantResultSubgraphTest::SetUp() {
-    ConstantSubgraphType type;
-    ov::Shape input_shape;
-    ov::element::Type input_type;
-    std::tie(type, input_shape, input_type, targetDevice) = this->GetParam();
+    const auto& [type, input_shape, input_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     createGraph(type, input_shape, input_type);
 }

--- a/src/tests/functional/plugin/shared/src/subgraph/conv_eltwise_fusion.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/conv_eltwise_fusion.cpp
@@ -20,16 +20,9 @@ namespace ov {
 namespace test {
 
 std::string ConvEltwiseFusion::getTestCaseName(const testing::TestParamInfo<ConvEltwiseFusionParams>& obj) {
-    std::tuple<NodeTypeInfo, size_t> conv_params;
-    NodeTypeInfo conv_type, eltwise_type;
-    bool negative;
-    Shape input_shape, weights_shape, const_shape;
-    element::Type precision;
-    std::string targetName;
-    std::tie(conv_params, eltwise_type, negative, input_shape, weights_shape, const_shape, precision, targetName) =
+    const auto& [conv_params, eltwise_type, negative, input_shape, weights_shape, const_shape, precision, targetName] =
         obj.param;
-    size_t num_inputs;
-    std::tie(conv_type, num_inputs) = conv_params;
+    const auto& [conv_type, num_inputs] = conv_params;
     std::ostringstream results;
 
     results << conv_type.name << "_";
@@ -45,15 +38,16 @@ std::string ConvEltwiseFusion::getTestCaseName(const testing::TestParamInfo<Conv
 }
 
 void ConvEltwiseFusion::SetUp() {
-    std::tuple<NodeTypeInfo, size_t> conv_params;
-    NodeTypeInfo conv_type, eltwise_type;
-    bool negative;
-    Shape input_shape, weights_shape, const_shape;
-    element::Type precision;
-    size_t num_inputs;
-    std::tie(conv_params, eltwise_type, negative, input_shape, weights_shape, const_shape, precision, targetDevice) =
-        this->GetParam();
-    std::tie(conv_type, num_inputs) = conv_params;
+    const auto& [conv_params,
+                 eltwise_type,
+                 negative,
+                 input_shape,
+                 weights_shape,
+                 const_shape,
+                 precision,
+                 _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [conv_type, num_inputs] = conv_params;
     pass::Manager manager;
 
     {

--- a/src/tests/functional/plugin/shared/src/subgraph/conv_strides_opt.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/conv_strides_opt.cpp
@@ -11,10 +11,7 @@ namespace ov {
 namespace test {
 
 std::string ConvStridesOpt::getTestCaseName(const testing::TestParamInfo<ConvStridesOptParams>& obj) {
-    Shape input_shape;
-    op::PadType pad;
-    std::string targetName;
-    std::tie(input_shape, pad, targetName) = obj.param;
+    const auto& [input_shape, pad, targetName] = obj.param;
     std::ostringstream results;
 
     results << "inputShape=" << input_shape << "_";
@@ -24,9 +21,8 @@ std::string ConvStridesOpt::getTestCaseName(const testing::TestParamInfo<ConvStr
 }
 
 void ConvStridesOpt::SetUp() {
-    Shape input_shape;
-    op::PadType pad_type;
-    std::tie(input_shape, pad_type, targetDevice) = this->GetParam();
+    const auto& [input_shape, pad_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     auto param = std::make_shared<ov::op::v0::Parameter>(element::f32, input_shape);
     auto C = input_shape[1];
     auto weights1 = ov::test::utils::make_constant(element::f32, {C, C, 3, 3});

--- a/src/tests/functional/plugin/shared/src/subgraph/convert_pad_to_group_conv.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/convert_pad_to_group_conv.cpp
@@ -10,12 +10,7 @@ namespace ov {
 namespace test {
 
 std::string ConvertPadToConvTests::getTestCaseName(const testing::TestParamInfo<PadParams>& obj) {
-    ov::Shape input_shape;
-    std::string targetName;
-    std::vector<int64_t> pad_begin, pad_end;
-    ov::op::PadMode mode;
-    float value;
-    std::tie(input_shape, pad_begin, pad_end, value, mode, targetName) = obj.param;
+    const auto& [input_shape, pad_begin, pad_end, value, mode, targetName] = obj.param;
     std::ostringstream results;
 
     results << "Input" << ov::test::utils::vec2str(input_shape);
@@ -28,11 +23,8 @@ std::string ConvertPadToConvTests::getTestCaseName(const testing::TestParamInfo<
 }
 
 void ConvertPadToConvTests::SetUp() {
-    ov::Shape input_shape;
-    std::vector<int64_t> pad_begin, pad_end;
-    ov::op::PadMode mode;
-    float value;
-    std::tie(input_shape, pad_begin, pad_end, value, mode, targetDevice) = this->GetParam();
+    const auto& [input_shape, pad_begin, pad_end, value, mode, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     {
         auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, input_shape);

--- a/src/tests/functional/plugin/shared/src/subgraph/gather_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/gather_weights_decompression.cpp
@@ -44,24 +44,14 @@ void GatherWeightsDecompressionBase::check_results(const ov::element::Type& weig
 
 std::string GatherWeightsDecompression::get_test_case_name(
     testing::TestParamInfo<GatherWeightsDecompressionParams> obj) {
-    std::string target_device;
-    GatherDecompressionShapeParams shape_params;
-    ov::element::Type data_precision;
-    ov::element::Type output_precision;
-    bool decompression_sub;
-    bool reshape_on_decompression;
-    bool per_tensor_zp;
-    bool per_tensor_scale;
-
-    std::tie(target_device,
-             shape_params,
-             data_precision,
-             output_precision,
-             decompression_sub,
-             reshape_on_decompression,
-             per_tensor_zp,
-             per_tensor_scale) = obj.param;
-
+    const auto& [target_device,
+                 shape_params,
+                 data_precision,
+                 output_precision,
+                 decompression_sub,
+                 reshape_on_decompression,
+                 per_tensor_zp,
+                 per_tensor_scale] = obj.param;
     std::ostringstream result;
     result << "target_device=" << target_device << "_";
     result << shape_params << "_";
@@ -109,22 +99,15 @@ void GatherWeightsDecompression::check_results() {
 }
 
 void GatherWeightsDecompression::SetUp() {
-    GatherDecompressionShapeParams shape_params;
-    ov::element::Type data_precision;
-    ov::element::Type output_precision;
-    bool decompression_sub;
-    bool reshape_on_decompression;
-    bool per_tensor_zp;
-    bool per_tensor_scale;
-
-    std::tie(targetDevice,
-             shape_params,
-             data_precision,
-             output_precision,
-             decompression_sub,
-             reshape_on_decompression,
-             per_tensor_zp,
-             per_tensor_scale) = GetParam();
+    const auto& [_targetDevice,
+                 shape_params,
+                 data_precision,
+                 output_precision,
+                 decompression_sub,
+                 reshape_on_decompression,
+                 per_tensor_zp,
+                 per_tensor_scale] = GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes({shape_params.indices_shape, {{}, {{shape_params.data_shape}}}});
 
@@ -153,13 +136,7 @@ void GatherWeightsDecompression::SetUp() {
 // fp16/bf16 constant + convert(16bit to f32) + gather case
 std::string GatherWeightsDecompressionWithoutScale::get_test_case_name(
     testing::TestParamInfo<GatherWeightsDecompressionWithoutScaleParams> obj) {
-    std::string target_device;
-    GatherDecompressionShapeParams shape_params;
-    ov::element::Type data_precision;
-    ov::element::Type output_precision;
-
-    std::tie(target_device, shape_params, data_precision, output_precision) = obj.param;
-
+    const auto& [target_device, shape_params, data_precision, output_precision] = obj.param;
     std::ostringstream result;
     result << "target_device=" << target_device << "_";
     result << shape_params << "_";
@@ -192,11 +169,8 @@ std::shared_ptr<ov::Model> GatherWeightsDecompressionWithoutScale::init_subgraph
 }
 
 void GatherWeightsDecompressionWithoutScale::SetUp() {
-    GatherDecompressionShapeParams shape_params;
-    ov::element::Type data_precision;
-    ov::element::Type output_precision;
-
-    std::tie(targetDevice, shape_params, data_precision, output_precision) = GetParam();
+    const auto& [_targetDevice, shape_params, data_precision, output_precision] = GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes({shape_params.indices_shape, {{}, {{shape_params.data_shape}}}});
 

--- a/src/tests/functional/plugin/shared/src/subgraph/get_output_before_activation.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/get_output_before_activation.cpp
@@ -26,12 +26,7 @@ std::ostream& operator<<(std::ostream& os, const midOutputType& oType) {
 }
 
 std::string OutputBeforeActivation::getTestCaseName(const testing::TestParamInfo<outputBeforeActivationParams>& obj) {
-    std::string targetDevice;
-    ov::element::Type element_type;
-    size_t inputSize;
-    midOutputType outputType;
-    ov::AnyMap config;
-    std::tie(targetDevice, element_type, inputSize, outputType, config) = obj.param;
+    const auto& [targetDevice, element_type, inputSize, outputType, config] = obj.param;
     std::ostringstream result;
 
     result << "InputType=" << element_type << "_";
@@ -45,11 +40,8 @@ std::string OutputBeforeActivation::getTestCaseName(const testing::TestParamInfo
 }
 
 void OutputBeforeActivation::SetUp() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    midOutputType outputType;
-    std::tie(targetDevice, element_type, inputSize, outputType, config) = this->GetParam();
+    const auto& [_targetDevice, element_type, inputSize, outputType, config] = this->GetParam();
+    targetDevice = _targetDevice;
     configuration.insert(config.begin(), config.end());
 
     std::vector<size_t> input_dims{1, inputSize};

--- a/src/tests/functional/plugin/shared/src/subgraph/integer_reduce_mean.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/integer_reduce_mean.cpp
@@ -10,12 +10,7 @@ namespace ov {
 namespace test {
 
 std::string IntegerReduceMeanTest::getTestCaseName(const testing::TestParamInfo<IntegerReduceMeanParams>& obj) {
-    ov::element::Type input_precision;
-    std::vector<size_t> input_shape;
-    std::vector<size_t> axes;
-    bool quantized;
-    const char *device;
-    std::tie(input_precision, input_shape, axes, quantized, device) = obj.param;
+    const auto& [input_precision, input_shape, axes, quantized, device] = obj.param;
     std::ostringstream result;
     result << "inputPrecision=" << input_precision.to_string() << "_";
     result << "inputShape=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -29,12 +24,10 @@ std::string IntegerReduceMeanTest::getTestCaseName(const testing::TestParamInfo<
 }
 
 void IntegerReduceMeanTest::SetUp() {
-    ov::element::Type input_precision;
-    std::vector<size_t> input_shape;
-    std::vector<size_t> axes;
     std::vector<size_t> axes_shape;
-    bool quantized;
-    std::tie(input_precision, input_shape, axes, quantized, targetDevice) = this->GetParam();
+
+    const auto& [input_precision, input_shape, axes, quantized, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     axes_shape.push_back(axes.size());
 
     auto dataNode = std::make_shared<ov::op::v0::Parameter>(input_precision, ov::Shape(input_shape));

--- a/src/tests/functional/plugin/shared/src/subgraph/lora_pattern.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/lora_pattern.cpp
@@ -122,10 +122,7 @@ void LoraPatternBase::run_test_random_tensors(ov::element::Type net_type, size_t
 }
 
 std::string LoraPatternMatmul::getTestCaseName(testing::TestParamInfo<LoraMatMulParams> obj) {
-    std::string device_name;
-    ov::element::Type net_type;
-    size_t M, N, K, lora_rank;
-    std::tie(device_name, net_type, M, N, K, lora_rank) = obj.param;
+    const auto& [device_name, net_type, M, N, K, lora_rank] = obj.param;
 
     std::ostringstream result;
     result << "M=" << M << "_";
@@ -139,10 +136,8 @@ std::string LoraPatternMatmul::getTestCaseName(testing::TestParamInfo<LoraMatMul
 }
 
 void LoraPatternMatmul::SetUp() {
-    ov::element::Type netType;
-    size_t M, N, K, lora_rank;
-
-    std::tie(targetDevice, netType, M, N, K, lora_rank) = this->GetParam();
+    const auto& [_targetDevice, netType, M, N, K, lora_rank] = this->GetParam();
+    targetDevice = _targetDevice;
 
     ov::PartialShape shape_x = {-1, -1, K};
     ov::PartialShape shape_w = {N, K};
@@ -193,10 +188,7 @@ void LoraPatternMatmul::SetUp() {
 }
 
 std::string LoraPatternConvolution::getTestCaseName(testing::TestParamInfo<LoraConvolutionParams> obj) {
-    std::string device_name;
-    ov::element::Type net_type;
-    size_t num_channels, lora_rank;
-    std::tie(device_name, net_type, num_channels, lora_rank) = obj.param;
+    const auto& [device_name, net_type, num_channels, lora_rank] = obj.param;
 
     std::ostringstream result;
     result << "NumChannels=" << num_channels << "_";
@@ -208,10 +200,8 @@ std::string LoraPatternConvolution::getTestCaseName(testing::TestParamInfo<LoraC
 }
 
 void LoraPatternConvolution::SetUp() {
-    ov::element::Type netType;
-    size_t num_channels, lora_rank;
-
-    std::tie(targetDevice, netType, num_channels, lora_rank) = this->GetParam();
+    const auto& [_targetDevice, netType, num_channels, lora_rank] = this->GetParam();
+    targetDevice = _targetDevice;
 
     ov::PartialShape shape_x = {-1, num_channels, -1, -1};
 

--- a/src/tests/functional/plugin/shared/src/subgraph/matmul_const_transposes_extraction.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/matmul_const_transposes_extraction.cpp
@@ -17,9 +17,8 @@ namespace test {
 
 std::string MatMulConstTransposesExtractionTest::getTestCaseName(
     const testing::TestParamInfo<MatMulConstTransposesExtractionTestParams>& obj) {
-    MatMulConstTransposesExtractionTestShapeParams shape_params;
-    std::string device;
-    std::tie(shape_params, std::ignore, device) = obj.param;
+    const auto& [shape_params, _ignore, device] = obj.param;
+    std::ignore = _ignore;
     std::ostringstream results;
 
     results << "input=" << shape_params.input_shape << "_";
@@ -30,10 +29,10 @@ std::string MatMulConstTransposesExtractionTest::getTestCaseName(
 }
 
 void MatMulConstTransposesExtractionTest::SetUp() {
-    MatMulConstTransposesExtractionTestShapeParams shape_params;
     element::Type type = element::f32;
-    bool can_be_fused;
-    std::tie(shape_params, can_be_fused, targetDevice) = GetParam();
+
+    const auto& [shape_params, can_be_fused, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     const auto& input_shape = shape_params.input_shape;
     const auto& weights_shape = shape_params.weights_shape;
@@ -48,9 +47,9 @@ void MatMulConstTransposesExtractionTest::SetUp() {
     manager.register_pass<ov::pass::MatMulConstTransposesExtraction>();
     manager.run_passes(transformed_function);
 
-    bool functions_equal;
     auto orig_function = function->clone();
-    std::tie(functions_equal, std::ignore) = compare_functions(transformed_function, orig_function, true);
+    const auto& [functions_equal, _ignore] = compare_functions(transformed_function, orig_function, true);
+    std::ignore = _ignore;
     if (can_be_fused) {
         ASSERT_FALSE(functions_equal);
     } else {
@@ -60,9 +59,8 @@ void MatMulConstTransposesExtractionTest::SetUp() {
 
 std::string QuantizedMatMulConstTransposesExtractionTest::getTestCaseName(
     const testing::TestParamInfo<MatMulConstTransposesExtractionTestParams>& obj) {
-    MatMulConstTransposesExtractionTestShapeParams params;
-    std::string device;
-    std::tie(params, std::ignore, device) = obj.param;
+    const auto& [params, _ignore, device] = obj.param;
+    std::ignore = _ignore;
     std::ostringstream results;
 
     results << "input=" << params.input_shape
@@ -76,9 +74,8 @@ std::string QuantizedMatMulConstTransposesExtractionTest::getTestCaseName(
 }
 
 void QuantizedMatMulConstTransposesExtractionTest::SetUp() {
-    MatMulConstTransposesExtractionTestShapeParams params;
-    bool can_be_fused;
-    std::tie(params, can_be_fused, targetDevice) = GetParam();
+    const auto& [params, can_be_fused, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     const auto& input_shape = params.input_shape;
     auto weights_shape = params.weights_shape;
@@ -99,9 +96,9 @@ void QuantizedMatMulConstTransposesExtractionTest::SetUp() {
     manager.register_pass<ov::pass::MatMulConstTransposesExtraction>();
     manager.run_passes(transformed_function);
 
-    bool functions_equal;
     auto orig_function = function->clone();
-    std::tie(functions_equal, std::ignore) = compare_functions(transformed_function, orig_function, true);
+    const auto& [functions_equal, _ignore] = compare_functions(transformed_function, orig_function, true);
+    std::ignore = _ignore;
     if (can_be_fused) {
         ASSERT_FALSE(functions_equal);
     } else {

--- a/src/tests/functional/plugin/shared/src/subgraph/matmul_multiply_fusion.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/matmul_multiply_fusion.cpp
@@ -18,9 +18,8 @@ namespace ov {
 namespace test {
 
 std::string MatMulMultiplyFusion::getTestCaseName(const testing::TestParamInfo<MatMulMultiplyFusionParams>& obj) {
-    MatMulMultiplyFusionShapeParams shape_params;
-    std::string device;
-    std::tie(shape_params, std::ignore, device) = obj.param;
+    const auto& [shape_params, _ignore, device] = obj.param;
+    std::ignore = _ignore;
     std::ostringstream results;
 
     results << "input=" << shape_params.input_shape << "_";
@@ -32,10 +31,10 @@ std::string MatMulMultiplyFusion::getTestCaseName(const testing::TestParamInfo<M
 }
 
 void MatMulMultiplyFusion::SetUp() {
-    MatMulMultiplyFusionShapeParams shape_params;
     element::Type precision = element::f32;
-    bool can_be_fused;
-    std::tie(shape_params, can_be_fused, targetDevice) = GetParam();
+
+    const auto& [shape_params, can_be_fused, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     const auto& input_shape = shape_params.input_shape;
     const auto& weights_shape = shape_params.weights_shape;
@@ -53,9 +52,9 @@ void MatMulMultiplyFusion::SetUp() {
     manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     manager.run_passes(transformed_function);
 
-    bool functions_equal;
     auto orig_function = function->clone();
-    std::tie(functions_equal, std::ignore) = compare_functions(transformed_function, orig_function, true);
+    const auto& [functions_equal, _ignore] = compare_functions(transformed_function, orig_function, true);
+    std::ignore = _ignore;
     if (can_be_fused) {
         ASSERT_FALSE(functions_equal);
     } else {
@@ -65,9 +64,8 @@ void MatMulMultiplyFusion::SetUp() {
 
 std::string QuantizedMatMulMultiplyFusion::getTestCaseName(
     const testing::TestParamInfo<MatMulMultiplyFusionParams>& obj) {
-    MatMulMultiplyFusionShapeParams shape_params;
-    std::string device;
-    std::tie(shape_params, std::ignore, device) = obj.param;
+    const auto& [shape_params, _ignore, device] = obj.param;
+    std::ignore = _ignore;
     std::ostringstream results;
 
     results << "input=" << shape_params.input_shape << "_";
@@ -79,10 +77,10 @@ std::string QuantizedMatMulMultiplyFusion::getTestCaseName(
 }
 
 void QuantizedMatMulMultiplyFusion::SetUp() {
-    MatMulMultiplyFusionShapeParams shape_params;
     element::Type precision = element::f32;
-    bool can_be_fused;
-    std::tie(shape_params, can_be_fused, targetDevice) = GetParam();
+
+    const auto& [shape_params, can_be_fused, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     const auto& input_shape = shape_params.input_shape;
     auto weights_shape = shape_params.weights_shape;
@@ -111,9 +109,9 @@ void QuantizedMatMulMultiplyFusion::SetUp() {
     manager.register_pass<ov::pass::MatMulMultiplyFusion>();
     manager.run_passes(transformed_function);
 
-    bool functions_equal;
     auto orig_function = function->clone();
-    std::tie(functions_equal, std::ignore) = compare_functions(transformed_function, orig_function, true);
+    const auto& [functions_equal, _ignore] = compare_functions(transformed_function, orig_function, true);
+    std::ignore = _ignore;
     if (can_be_fused) {
         ASSERT_FALSE(functions_equal);
     } else {

--- a/src/tests/functional/plugin/shared/src/subgraph/matmul_squeeze_add.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/matmul_squeeze_add.cpp
@@ -15,12 +15,7 @@ namespace ov {
 namespace test {
 
 std::string MatmulSqueezeAddTest::getTestCaseName(const testing::TestParamInfo<matmulSqueezeAddParams>& obj) {
-    ov::element::Type element_type;
-    ov::Shape input_shape;
-    std::size_t outputSize;
-    std::string targetDevice;
-    ov::AnyMap configuration;
-    std::tie(element_type, targetDevice, configuration, input_shape, outputSize) = obj.param;
+    const auto& [element_type, targetDevice, configuration, input_shape, outputSize] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(input_shape) << "_";
@@ -35,11 +30,9 @@ std::string MatmulSqueezeAddTest::getTestCaseName(const testing::TestParamInfo<m
 
 void MatmulSqueezeAddTest::SetUp() {
     auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-    ov::element::Type element_type;
-    ov::AnyMap tempConfig;
-    ov::Shape inputShape;
-    size_t outputSize;
-    std::tie(element_type, targetDevice, tempConfig, inputShape, outputSize) = this->GetParam();
+
+    const auto& [element_type, _targetDevice, tempConfig, inputShape, outputSize] = this->GetParam();
+    targetDevice = _targetDevice;
     configuration.insert(tempConfig.begin(), tempConfig.end());
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape))};

--- a/src/tests/functional/plugin/shared/src/subgraph/memory_LSTMCell.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/memory_LSTMCell.cpp
@@ -23,13 +23,7 @@ namespace ov {
 namespace test {
 
 std::string MemoryLSTMCellTest::getTestCaseName(const testing::TestParamInfo<memoryLSTMCellParams>& obj) {
-    std::string targetDevice;
-    ov::element::Type element_type;
-    size_t inputSize;
-    size_t hiddenSize;
-    ov::AnyMap config;
-    ov::test::utils::MemoryTransformation transformation;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = obj.param;
+    const auto& [transformation, targetDevice, element_type, inputSize, hiddenSize, config] = obj.param;
     std::ostringstream result;
 
     result << "transformation=" << transformation << "_";
@@ -43,10 +37,10 @@ std::string MemoryLSTMCellTest::getTestCaseName(const testing::TestParamInfo<mem
 size_t hiddenSize;
 
 void MemoryLSTMCellTest::SetUp() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = this->GetParam();
+    const auto& [_transformation, _targetDevice, element_type, inputSize, _hiddenSize, config] = this->GetParam();
+    transformation = _transformation;
+    targetDevice = _targetDevice;
+    hiddenSize = _hiddenSize;
     configuration.insert(config.begin(), config.end());
 
     std::vector<size_t> input_dims{1, inputSize};
@@ -147,10 +141,10 @@ void MemoryLSTMCellTest::SetUp() {
 }
 
 void MemoryLSTMCellTest::switch_to_friendly_model() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = this->GetParam();
+    const auto& [_transformation, _targetDevice, element_type, inputSize, _hiddenSize, config] = this->GetParam();
+    transformation = _transformation;
+    targetDevice = _targetDevice;
+    hiddenSize = _hiddenSize;
 
     std::vector<size_t> input_dims{1, inputSize};
     std::vector<size_t> squeeze_axes{0};
@@ -203,10 +197,10 @@ void MemoryLSTMCellTest::switch_to_friendly_model() {
 }
 
 void MemoryLSTMCellTest::create_pure_tensor_iterator_model() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = this->GetParam();
+    const auto& [_transformation, _targetDevice, element_type, inputSize, _hiddenSize, config] = this->GetParam();
+    transformation = _transformation;
+    targetDevice = _targetDevice;
+    hiddenSize = _hiddenSize;
 
     std::vector<size_t> input_dims{1, inputSize};
     std::vector<size_t> squeeze_axes{0};

--- a/src/tests/functional/plugin/shared/src/subgraph/mul_conv_fusion.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/mul_conv_fusion.cpp
@@ -17,11 +17,7 @@ namespace ov {
 namespace test {
 
 std::string MulConvFusion::getTestCaseName(const testing::TestParamInfo<MulConvFusionParams>& obj) {
-    ov::NodeTypeInfo conv_type;
-    ov::Shape input_shape, weights_shape, const_shape;
-    ov::element::Type precision;
-    std::string device;
-    std::tie(conv_type, input_shape, weights_shape, const_shape, precision, std::ignore, device) = obj.param;
+    const auto& [conv_type, input_shape, weights_shape, const_shape, precision, _ignore, device] = obj.param;
     std::ostringstream results;
 
     results << conv_type.name << "_";
@@ -34,12 +30,10 @@ std::string MulConvFusion::getTestCaseName(const testing::TestParamInfo<MulConvF
 }
 
 void MulConvFusion::SetUp() {
-    ov::NodeTypeInfo conv_type;
-    ov::Shape input_shape, weights_shape, const_shape;
-    ov::element::Type precision;
-    bool is_negative;
-    std::tie(conv_type, input_shape, weights_shape, const_shape, precision, is_negative, targetDevice) =
+    const auto& [conv_type, input_shape, weights_shape, _const_shape, precision, is_negative, _targetDevice] =
         this->GetParam();
+    auto const_shape = _const_shape;
+    targetDevice = _targetDevice;
     auto param = std::make_shared<ov::op::v0::Parameter>(precision, input_shape);
     auto spatial_dims = input_shape.size() - 2;
 

--- a/src/tests/functional/plugin/shared/src/subgraph/multiple_LSTMCell.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/multiple_LSTMCell.cpp
@@ -21,13 +21,7 @@ namespace ov {
 namespace test {
 
 std::string MultipleLSTMCellTest::getTestCaseName(const testing::TestParamInfo<multipleLSTMCellParams>& obj) {
-    std::string targetDevice;
-    ov::element::Type element_type;
-    size_t inputSize;
-    size_t hiddenSize;
-    ov::AnyMap config;
-    ov::test::utils::MemoryTransformation transformation;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = obj.param;
+    const auto& [transformation, targetDevice, element_type, inputSize, hiddenSize, config] = obj.param;
     std::ostringstream result;
 
     result << "transformation=" << transformation << "_";
@@ -39,10 +33,10 @@ std::string MultipleLSTMCellTest::getTestCaseName(const testing::TestParamInfo<m
 }
 
 void MultipleLSTMCellTest::SetUp() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = this->GetParam();
+    const auto& [_transformation, _targetDevice, element_type, inputSize, _hiddenSize, config] = this->GetParam();
+    transformation = _transformation;
+    targetDevice = _targetDevice;
+    hiddenSize = _hiddenSize;
     configuration.insert(config.begin(), config.end());
 
     std::vector<size_t> input_dims{1, inputSize};
@@ -217,10 +211,10 @@ void MultipleLSTMCellTest::SetUp() {
 }
 
 void MultipleLSTMCellTest::switch_to_friendly_model() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = this->GetParam();
+    const auto& [_transformation, _targetDevice, element_type, inputSize, _hiddenSize, config] = this->GetParam();
+    transformation = _transformation;
+    targetDevice = _targetDevice;
+    hiddenSize = _hiddenSize;
 
     std::vector<size_t> input_dims{1, inputSize};
     std::vector<size_t> squeeze_axes{0};
@@ -309,10 +303,10 @@ void MultipleLSTMCellTest::switch_to_friendly_model() {
 }
 
 void MultipleLSTMCellTest::create_pure_tensor_iterator_model() {
-    ov::element::Type element_type;
-    ov::AnyMap config;
-    size_t inputSize;
-    std::tie(transformation, targetDevice, element_type, inputSize, hiddenSize, config) = this->GetParam();
+    const auto& [_transformation, _targetDevice, element_type, inputSize, _hiddenSize, config] = this->GetParam();
+    transformation = _transformation;
+    targetDevice = _targetDevice;
+    hiddenSize = _hiddenSize;
 
     std::vector<size_t> input_dims{1, inputSize};
     std::vector<size_t> squeeze_axes{0};

--- a/src/tests/functional/plugin/shared/src/subgraph/multiply_add.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/multiply_add.cpp
@@ -12,10 +12,7 @@ namespace ov {
 namespace test {
 
 std::string MultiplyAddLayerTest::getTestCaseName(const testing::TestParamInfo<MultiplyAddParamsTuple>& obj) {
-    ov::Shape inputShapes;
-    ov::element::Type element_type;
-    std::string targetName;
-    std::tie(inputShapes, element_type, targetName) = obj.param;
+    const auto& [inputShapes, element_type, targetName] = obj.param;
     std::ostringstream results;
 
     results << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
@@ -25,9 +22,8 @@ std::string MultiplyAddLayerTest::getTestCaseName(const testing::TestParamInfo<M
 }
 
 void MultiplyAddLayerTest::SetUp() {
-    ov::Shape inputShape;
-    ov::element::Type element_type;
-    std::tie(inputShape, element_type, targetDevice) = this->GetParam();
+    const auto& [inputShape, element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(element_type, ov::PartialShape(inputShape))};
 
     std::vector<size_t> constShape(inputShape.size(), 1);

--- a/src/tests/functional/plugin/shared/src/subgraph/mvn_multiply_add.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/mvn_multiply_add.cpp
@@ -13,16 +13,8 @@ namespace ov {
 namespace test {
 
 std::string MVNMultiplyAdd::getTestCaseName(const testing::TestParamInfo<mvnMultiplyAddParams>& obj) {
-    std::pair<ov::Shape, ov::Shape> shapes;
-    ov::Shape inputShapes, constantShapes;
-    ov::element::Type dataPrecision, axesPrecision;
-    std::vector<int> axes;
-    bool normalizeVariance;
-    float eps;
-    std::string epsMode;
-    std::string targetDevice;
-    std::tie(shapes, dataPrecision, axesPrecision, axes, normalizeVariance, eps, epsMode, targetDevice) = obj.param;
-    std::tie(inputShapes, constantShapes) = shapes;
+    const auto& [shapes, dataPrecision, axesPrecision, axes, normalizeVariance, eps, epsMode, targetDevice] = obj.param;
+    const auto& [inputShapes, constantShapes] = shapes;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
     result << "CS=" << ov::test::utils::vec2str(constantShapes) << "_";
@@ -37,15 +29,9 @@ std::string MVNMultiplyAdd::getTestCaseName(const testing::TestParamInfo<mvnMult
 }
 
 void MVNMultiplyAdd::SetUp() {
-    std::pair<ov::Shape, ov::Shape> shapes;
-    ov::Shape inputShapes, constantShapes;
-    ov::element::Type dataType, axesType;
-    std::vector<int> axes;
-    bool normalizeVariance;
-    float eps;
-    std::string epsMode;
-    std::tie(shapes, dataType, axesType, axes, normalizeVariance, eps, epsMode, targetDevice) = this->GetParam();
-    std::tie(inputShapes, constantShapes) = shapes;
+    const auto& [shapes, dataType, axesType, axes, normalizeVariance, eps, epsMode, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+    const auto& [inputShapes, constantShapes] = shapes;
 
     ov::ParameterVector param{std::make_shared<ov::op::v0::Parameter>(dataType, ov::Shape(inputShapes))};
     auto axesNode = ov::op::v0::Constant::create(axesType, ov::Shape{axes.size()}, axes);

--- a/src/tests/functional/plugin/shared/src/subgraph/parameter_result.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/parameter_result.cpp
@@ -8,9 +8,7 @@ namespace ov {
 namespace test {
 
 std::string ParameterResultSubgraphTest::getTestCaseName(const testing::TestParamInfo<parameterResultParams>& obj) {
-    ov::test::InputShape inShape;
-    std::string targetDevice;
-    std::tie(inShape, targetDevice) = obj.param;
+    const auto& [inShape, targetDevice] = obj.param;
     std::ostringstream result;
     result << "IS=";
     result << ov::test::utils::partialShape2str({inShape.first}) << "_";
@@ -31,8 +29,8 @@ std::shared_ptr<ov::Model> ParameterResultSubgraphTest::createModel(const ov::Pa
 }
 
 void ParameterResultSubgraphTest::SetUp() {
-    ov::test::InputShape inShape;
-    std::tie(inShape, targetDevice) = this->GetParam();
+    const auto& [inShape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes({inShape});
 

--- a/src/tests/functional/plugin/shared/src/subgraph/perm_conv_perm_concat.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/perm_conv_perm_concat.cpp
@@ -16,14 +16,7 @@ namespace ov {
 namespace test {
 
 std::string PermConvPermConcat::getTestCaseName(const testing::TestParamInfo<PermConvPermConcatParams>& obj) {
-    ov::element::Type element_type;
-    std::string targetName;
-    ov::Shape input_shape;
-    ov::Shape kernel_shape;
-    size_t output_channels;
-    ov::AnyMap configuration;
-
-    std::tie(element_type, targetName, input_shape, kernel_shape, output_channels, configuration) = obj.param;
+    const auto& [element_type, targetName, input_shape, kernel_shape, output_channels, configuration] = obj.param;
     std::ostringstream results;
 
     results << "IS=" << ov::test::utils::vec2str(std::vector<size_t>(input_shape.begin(), input_shape.end())) << "_";
@@ -38,14 +31,9 @@ std::string PermConvPermConcat::getTestCaseName(const testing::TestParamInfo<Per
 }
 
 void PermConvPermConcat::SetUp() {
-    ov::element::Type element_type;
-    ov::Shape input_shape;
-    ov::Shape kernel_shape;
-    size_t output_channels;
-    ov::AnyMap additional_config;
-
-    std::tie(element_type, targetDevice, input_shape, kernel_shape, output_channels, additional_config) =
+    const auto& [element_type, _targetDevice, input_shape, kernel_shape, output_channels, additional_config] =
         this->GetParam();
+    targetDevice = _targetDevice;
 
     if (element_type == ov::element::f32) {
         abs_threshold = 1e-5;

--- a/src/tests/functional/plugin/shared/src/subgraph/postprocess.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/postprocess.cpp
@@ -15,10 +15,7 @@ namespace ov {
 namespace test {
 
 std::string PostProcessTest::getTestCaseName(const testing::TestParamInfo<postprocessParamsTuple>& obj) {
-    std::string targetName;
-    postprocess_func func;
-
-    std::tie(func, targetName) = obj.param;
+    const auto& [func, targetName] = obj.param;
     std::ostringstream result;
     result << "Func=" << func.m_name << "_";
     result << "Device=" << targetName << "";

--- a/src/tests/functional/plugin/shared/src/subgraph/preprocess.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/preprocess.cpp
@@ -15,11 +15,7 @@ namespace ov {
 namespace test {
 
 std::string PrePostProcessTest::getTestCaseName(const testing::TestParamInfo<preprocessParamsTuple>& obj) {
-    std::string targetName;
-    preprocess_func func;
-
-    std::tie(func, targetName) = obj.param;
-
+    const auto& [func, targetName] = obj.param;
     std::ostringstream result;
     result << "Func=" << func.m_name << "_";
     result << "Device=" << targetName << "";

--- a/src/tests/functional/plugin/shared/src/subgraph/quantized_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/quantized_convolution_backprop_data.cpp
@@ -12,19 +12,10 @@ namespace ov {
 namespace test {
 
 std::string QuantConvBackpropDataLayerTest::getTestCaseName(const testing::TestParamInfo<quantConvBackpropDataLayerTestParamsSet>& obj) {
-    quantConvBackpropDataSpecificParams groupConvBackpropDataParams;
-    ov::element::Type element_type;
-    ov::Shape inputShapes;
-    std::string targetDevice;
-    std::tie(groupConvBackpropDataParams, element_type, inputShapes, targetDevice) = obj.param;
-    ov::op::PadType padType;
-    ov::Shape kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels;
-    size_t quantLevels;
-    ov::test::utils::QuantizationGranularity quantGranularity;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
+    const auto& [groupConvBackpropDataParams, element_type, inputShapes, targetDevice] = obj.param;
 
+    const auto& [kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, quantLevels, quantGranularity] =
+        groupConvBackpropDataParams;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
     result << "K" << ov::test::utils::vec2str(kernel) << "_";
@@ -42,17 +33,11 @@ std::string QuantConvBackpropDataLayerTest::getTestCaseName(const testing::TestP
 }
 
 void QuantConvBackpropDataLayerTest::SetUp() {
-    quantConvBackpropDataSpecificParams groupConvBackpropDataParams;
-    ov::Shape inputShape;
-    ov::element::Type element_type = ov::element::dynamic;
-    std::tie(groupConvBackpropDataParams, element_type, inputShape, targetDevice) = this->GetParam();
-    ov::op::PadType padType;
-    std::vector<size_t> kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels;
-    size_t quantLevels;
-    ov::test::utils::QuantizationGranularity quantGranularity;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
+    const auto& [groupConvBackpropDataParams, element_type, inputShape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, quantLevels, quantGranularity] =
+        groupConvBackpropDataParams;
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(element_type, inputShape)};
 
     std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);

--- a/src/tests/functional/plugin/shared/src/subgraph/quantized_convolution_batch_norm.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/quantized_convolution_batch_norm.cpp
@@ -59,23 +59,16 @@ std::ostream& operator<<(std::ostream& os, IntervalsType type) {
 
 std::string QuantizedConvolutionBatchNorm::getTestCaseName(const testing::TestParamInfo<QuantizedConvolutionBatchNormParams>& obj) {
     std::ostringstream name;
-    ConvType conv_type;
-    QuantizeType quantize_type;
-    IntervalsType intervals_type;
-    bool transpose_on_weights;
-    std::string device;
-    std::tie(conv_type, quantize_type, intervals_type, transpose_on_weights, device) = obj.param;
-    name << "conv_type=" << conv_type << "_quantize_type=" << quantize_type << "_intervals_type=" << intervals_type <<
-        "_transpose_on_weights=" << std::boolalpha << transpose_on_weights << "_device=" << device;
+
+    const auto& [conv_type, quantize_type, intervals_type, transpose_on_weights, device] = obj.param;
+    name << "conv_type=" << conv_type << "_quantize_type=" << quantize_type << "_intervals_type=" << intervals_type
+         << "_transpose_on_weights=" << std::boolalpha << transpose_on_weights << "_device=" << device;
     return name.str();
 }
 
 void QuantizedConvolutionBatchNorm::SetUp() {
-    ConvType conv_type;
-    QuantizeType quantize_type;
-    IntervalsType intervals_type;
-    bool transpose_on_weights;
-    std::tie(conv_type, quantize_type, intervals_type, transpose_on_weights, targetDevice) = GetParam();
+    const auto& [conv_type, quantize_type, intervals_type, transpose_on_weights, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     size_t input_channels = 3;
     size_t output_channels = 4;

--- a/src/tests/functional/plugin/shared/src/subgraph/quantized_group_convolution.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/quantized_group_convolution.cpp
@@ -12,19 +12,19 @@ namespace ov {
 namespace test {
 
 std::string QuantGroupConvLayerTest::getTestCaseName(const testing::TestParamInfo<quantGroupConvLayerTestParamsSet>& obj) {
-    quantGroupConvSpecificParams groupConvParams;
-    ov::element::Type element_type;
-    ov::Shape inputShapes;
-    std::string targetDevice;
-    std::tie(groupConvParams, element_type, inputShapes, targetDevice) = obj.param;
+    const auto& [groupConvParams, element_type, inputShapes, targetDevice] = obj.param;
     ov::op::PadType padType = ov::op::PadType::AUTO;
-    ov::Shape kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels, numGroups;
-    size_t quantLevels;
-    ov::test::utils::QuantizationGranularity quantGranularity;
-    bool quantizeWeights;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, quantLevels, quantGranularity, quantizeWeights) = groupConvParams;
+
+    const auto& [kernel,
+                 stride,
+                 padBegin,
+                 padEnd,
+                 dilation,
+                 convOutChannels,
+                 numGroups,
+                 quantLevels,
+                 quantGranularity,
+                 quantizeWeights] = groupConvParams;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
@@ -45,18 +45,20 @@ std::string QuantGroupConvLayerTest::getTestCaseName(const testing::TestParamInf
 }
 
 void QuantGroupConvLayerTest::SetUp() {
-    quantGroupConvSpecificParams groupConvParams;
-    ov::Shape inputShape;
-    ov::element::Type element_type = ov::element::dynamic;
-    std::tie(groupConvParams, element_type, inputShape, targetDevice) = this->GetParam();
+    const auto& [groupConvParams, element_type, inputShape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     ov::op::PadType padType = ov::op::PadType::AUTO;
-    ov::Shape kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels, numGroups;
-    size_t quantLevels;
-    ov::test::utils::QuantizationGranularity quantGranularity;
-    bool quantizeWeights;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, quantLevels, quantGranularity, quantizeWeights) = groupConvParams;
+
+    const auto& [kernel,
+                 stride,
+                 padBegin,
+                 padEnd,
+                 dilation,
+                 convOutChannels,
+                 numGroups,
+                 quantLevels,
+                 quantGranularity,
+                 quantizeWeights] = groupConvParams;
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape))};
 
     std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);

--- a/src/tests/functional/plugin/shared/src/subgraph/quantized_group_convolution_backprop_data.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/quantized_group_convolution_backprop_data.cpp
@@ -12,18 +12,18 @@ namespace ov {
 namespace test {
 
 std::string QuantGroupConvBackpropDataLayerTest::getTestCaseName(const testing::TestParamInfo<quantGroupConvBackpropDataLayerTestParamsSet>& obj) {
-    quantGroupConvBackpropDataSpecificParams groupConvBackpropDataParams;
-    ov::element::Type element_type;
-    ov::Shape inputShapes;
-    std::string targetDevice;
-    std::tie(groupConvBackpropDataParams, element_type, inputShapes, targetDevice) = obj.param;
-    ov::op::PadType padType;
-    ov::Shape kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels, numGroups;
-    size_t quantLevels;
-    ov::test::utils::QuantizationGranularity quantGranularity;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
+    const auto& [groupConvBackpropDataParams, element_type, inputShapes, targetDevice] = obj.param;
+
+    const auto& [kernel,
+                 stride,
+                 padBegin,
+                 padEnd,
+                 dilation,
+                 convOutChannels,
+                 numGroups,
+                 padType,
+                 quantLevels,
+                 quantGranularity] = groupConvBackpropDataParams;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
@@ -43,17 +43,19 @@ std::string QuantGroupConvBackpropDataLayerTest::getTestCaseName(const testing::
 }
 
 void QuantGroupConvBackpropDataLayerTest::SetUp() {
-    quantGroupConvBackpropDataSpecificParams groupConvBackpropDataParams;
-    ov::Shape inputShape;
-    ov::element::Type element_type = ov::element::dynamic;
-    std::tie(groupConvBackpropDataParams, element_type, inputShape, targetDevice) = this->GetParam();
-    ov::op::PadType padType;
-    ov::Shape kernel, stride, dilation;
-    std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels, numGroups;
-    size_t quantLevels;
-    ov::test::utils::QuantizationGranularity quantGranularity;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType, quantLevels, quantGranularity) = groupConvBackpropDataParams;
+    const auto& [groupConvBackpropDataParams, element_type, inputShape, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
+
+    const auto& [kernel,
+                 stride,
+                 padBegin,
+                 padEnd,
+                 dilation,
+                 convOutChannels,
+                 numGroups,
+                 padType,
+                 quantLevels,
+                 quantGranularity] = groupConvBackpropDataParams;
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape))};
 
     std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);

--- a/src/tests/functional/plugin/shared/src/subgraph/quantized_mat_mul.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/quantized_mat_mul.cpp
@@ -10,27 +10,10 @@ namespace ov {
 namespace test {
 
 std::string QuantMatMulTest::getTestCaseName(const testing::TestParamInfo<QuantMatMulLayerTestParamsSet> &obj) {
-    QuantParams quantParams0;
-    QuantParams quantParams1;
-    ov::element::Type element_type;
-    ov::Shape inputShape0;
-    ov::Shape inputShape1;
-    QuantRange inputRange0;
-    QuantRange inputRange1;
-    QuantRange outputRange0;
-    QuantRange outputRange1;
-    std::string targetDevice;
-    std::tie(quantParams0, quantParams1, element_type, inputShape0, inputShape1, targetDevice) = obj.param;
+    const auto& [quantParams0, quantParams1, element_type, inputShape0, inputShape1, targetDevice] = obj.param;
 
-    size_t quantLevels0;
-    size_t quantLevels1;
-    ov::test::utils::QuantizationGranularity quantGranularity0;
-    ov::test::utils::QuantizationGranularity quantGranularity1;
-    ov::element::Type fqPrec0;
-    ov::element::Type fqPrec1;
-    std::tie(quantLevels0, inputRange0, outputRange0, quantGranularity0, fqPrec0) = quantParams0;
-    std::tie(quantLevels1, inputRange1, outputRange1, quantGranularity1, fqPrec1) = quantParams1;
-
+    const auto& [quantLevels0, inputRange0, outputRange0, quantGranularity0, fqPrec0] = quantParams0;
+    const auto& [quantLevels1, inputRange1, outputRange1, quantGranularity1, fqPrec1] = quantParams1;
     std::ostringstream result;
     result << "IS0=" << ov::test::utils::vec2str(inputShape0) << "_";
     result << "IS1=" << ov::test::utils::vec2str(inputShape1) << "_";
@@ -50,32 +33,21 @@ std::string QuantMatMulTest::getTestCaseName(const testing::TestParamInfo<QuantM
 }
 
 void QuantMatMulTest::SetUp() {
-    QuantParams quantParams0;
-    QuantParams quantParams1;
-    ov::Shape inputShape0;
-    ov::Shape inputShape1;
-    ov::element::Type element_type;
-    std::tie(quantParams0, quantParams1, element_type, inputShape0, inputShape1, targetDevice) = this->GetParam();
+    const auto& [quantParams0, quantParams1, element_type, inputShape0, inputShape1, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
-    size_t quantLevels0;
-    size_t quantLevels1;
-    QuantRange inputRange0;
-    QuantRange inputRange1;
-    QuantRange outputRange0;
-    QuantRange outputRange1;
-    ov::test::utils::QuantizationGranularity quantGranularity0;
-    ov::test::utils::QuantizationGranularity quantGranularity1;
-    ov::element::Type fqPrec0;
-    ov::element::Type fqPrec1;
-    std::tie(quantLevels0, inputRange0, outputRange0, quantGranularity0, fqPrec0) = quantParams0;
-    std::tie(quantLevels1, inputRange1, outputRange1, quantGranularity1, fqPrec1) = quantParams1;
-
+    const auto& [quantLevels0, inputRange0, outputRange0, quantGranularity0, fqPrec0] = quantParams0;
+    const auto& [quantLevels1, inputRange1, outputRange1, quantGranularity1, fqPrec1] = quantParams1;
     ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape0)),
                                 std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape1))};
 
-    auto makeFakeQuantizeNode = [element_type](size_t quantLevels, QuantRange inputRange, QuantRange outputRange,
-            ov::test::utils::QuantizationGranularity quantGranularity, const ov::Output<ov::Node> &in, ov::Shape inputShape,
-            ov::element::Type prec) -> std::shared_ptr<ov::Node> {
+    auto makeFakeQuantizeNode = [element_type = element_type](size_t quantLevels,
+                                                              QuantRange inputRange,
+                                                              QuantRange outputRange,
+                                                              ov::test::utils::QuantizationGranularity quantGranularity,
+                                                              const ov::Output<ov::Node>& in,
+                                                              ov::Shape inputShape,
+                                                              ov::element::Type prec) -> std::shared_ptr<ov::Node> {
         std::vector<size_t> dataFqConstShapes(inputShape.size(), 1);
         if (quantGranularity == ov::test::utils::QuantizationGranularity::Perchannel)
             dataFqConstShapes[1] = inputShape[1];

--- a/src/tests/functional/plugin/shared/src/subgraph/range_add.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/range_add.cpp
@@ -13,11 +13,7 @@ namespace test {
 // ------------------------------ V0 ------------------------------
 
 std::string RangeAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<RangeParams>& obj) {
-    ov::element::Type input_type;
-    float start, stop, step;
-    std::string targetDevice;
-    std::tie(start, stop, step, input_type, targetDevice) = obj.param;
-
+    const auto& [start, stop, step, input_type, targetDevice] = obj.param;
     std::ostringstream result;
     const char separator = '_';
     result << "Start=" << start << separator;
@@ -29,9 +25,8 @@ std::string RangeAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<R
 }
 
 void RangeAddSubgraphTest::SetUp() {
-    ov::element::Type element_type;
-    float start, stop, step;
-    std::tie(start, stop, step, element_type, targetDevice) = GetParam();
+    const auto& [start, stop, step, element_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     auto startConstant = std::make_shared<ov::op::v0::Constant>(element_type, ov::Shape{}, start);
     auto stopConstant = std::make_shared<ov::op::v0::Constant>(element_type, ov::Shape{}, stop);
@@ -47,11 +42,7 @@ void RangeAddSubgraphTest::SetUp() {
 // ------------------------------ V4 ------------------------------
 
 std::string RangeNumpyAddSubgraphTest::getTestCaseName(const testing::TestParamInfo<RangeParams>& obj) {
-    ov::element::Type element_type;
-    float start, stop, step;
-    std::string targetDevice;
-    std::tie(start, stop, step, element_type, targetDevice) = obj.param;
-
+    const auto& [start, stop, step, element_type, targetDevice] = obj.param;
     std::ostringstream result;
     const char separator = '_';
     result << "Start=" << start << separator;
@@ -63,9 +54,8 @@ std::string RangeNumpyAddSubgraphTest::getTestCaseName(const testing::TestParamI
 }
 
 void RangeNumpyAddSubgraphTest::SetUp() {
-    ov::element::Type element_type;
-    float start, stop, step;
-    std::tie(start, stop, step, element_type, targetDevice) = GetParam();
+    const auto& [start, stop, step, element_type, _targetDevice] = GetParam();
+    targetDevice = _targetDevice;
 
     auto startConstant = std::make_shared<ov::op::v0::Constant>(element_type, ov::Shape{}, start);
     auto stopConstant = std::make_shared<ov::op::v0::Constant>(element_type, ov::Shape{}, stop);

--- a/src/tests/functional/plugin/shared/src/subgraph/reduce_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/reduce_eltwise.cpp
@@ -17,14 +17,7 @@
 namespace ov {
 namespace test {
 std::string ReduceEltwiseTest::getTestCaseName(const testing::TestParamInfo<ReduceEltwiseParamsTuple> &obj) {
-    ov::Shape inputShapes;
-    std::vector<int> axes;
-    ov::test::utils::OpType opType;
-    bool keepDims;
-    ov::element::Type type;
-    std::string targetName;
-    std::tie(inputShapes, axes, opType, keepDims, type, targetName) = obj.param;
-
+    const auto& [inputShapes, axes, opType, keepDims, type, targetName] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
     result << "axes=" << ov::test::utils::vec2str(axes) << "_";
@@ -36,12 +29,8 @@ std::string ReduceEltwiseTest::getTestCaseName(const testing::TestParamInfo<Redu
 }
 
 void ReduceEltwiseTest::SetUp() {
-    ov::Shape inputShape;
-    std::vector<int> axes;
-    ov::test::utils::OpType opType;
-    bool keepDims;
-    ov::element::Type type;
-    std::tie(inputShape, axes, opType, keepDims, type, targetDevice) = this->GetParam();
+    const auto& [inputShape, axes, opType, keepDims, type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(type, inputShape)};
 

--- a/src/tests/functional/plugin/shared/src/subgraph/relu_shape_of.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/relu_shape_of.cpp
@@ -10,10 +10,7 @@ namespace ov {
 namespace test {
 
 std::string ReluShapeOfSubgraphTest::getTestCaseName(const testing::TestParamInfo<ov::test::ShapeOfParams>& obj) {
-    ov::Shape inputShapes;
-    ov::element::Type element_type, output_type;
-    std::string targetDevice;
-    std::tie(element_type, output_type, inputShapes, targetDevice) = obj.param;
+    const auto& [element_type, output_type, inputShapes, targetDevice] = obj.param;
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
     result << "IET=" << element_type << "_";
@@ -23,9 +20,8 @@ std::string ReluShapeOfSubgraphTest::getTestCaseName(const testing::TestParamInf
 }
 
 void ReluShapeOfSubgraphTest::SetUp() {
-    ov::Shape inputShapes;
-    ov::element::Type element_type, output_type;
-    std::tie(element_type, output_type, inputShapes, targetDevice) = this->GetParam();
+    const auto& [element_type, output_type, inputShapes, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     ov::ParameterVector param{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShapes))};
     auto relu = std::make_shared<ov::op::v0::Relu>(param[0]);
     auto shapeOf = std::make_shared<ov::op::v3::ShapeOf>(relu, output_type);

--- a/src/tests/functional/plugin/shared/src/subgraph/reshape_permute_conv_permute_reshape_act.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/reshape_permute_conv_permute_reshape_act.cpp
@@ -11,15 +11,7 @@
 namespace ov {
 namespace test {
 std::string ConvReshapeAct::getTestCaseName(const testing::TestParamInfo<ConvReshapeActParams>& obj) {
-    ov::element::Type model_type;
-    std::string targetName;
-    std::array<size_t, 4> input_shape;
-    std::array<size_t, 2> kernel_shape;
-    size_t output_channels;
-    ov::AnyMap configuration;
-
-
-    std::tie(model_type, targetName, input_shape, kernel_shape, output_channels, configuration) = obj.param;
+    const auto& [model_type, targetName, input_shape, kernel_shape, output_channels, configuration] = obj.param;
     std::ostringstream results;
 
     results << "IS=" << ov::test::utils::vec2str(std::vector<size_t>(input_shape.begin(), input_shape.end())) << "_";
@@ -34,13 +26,9 @@ std::string ConvReshapeAct::getTestCaseName(const testing::TestParamInfo<ConvRes
 }
 
 void ConvReshapeAct::SetUp() {
-    ov::element::Type model_type;
-    std::array<size_t, 4> input_shape;
-    std::array<size_t, 2> kernel_shape;
-    size_t output_channels;
-    ov::AnyMap additional_config;
-
-    std::tie(model_type, targetDevice, input_shape, kernel_shape, output_channels, additional_config) = this->GetParam();
+    const auto& [model_type, _targetDevice, input_shape, kernel_shape, output_channels, additional_config] =
+        this->GetParam();
+    targetDevice = _targetDevice;
 
     configuration.insert(additional_config.begin(), additional_config.end());
 

--- a/src/tests/functional/plugin/shared/src/subgraph/reshape_squeeze_reshape_relu.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/reshape_squeeze_reshape_relu.cpp
@@ -14,11 +14,7 @@ namespace test {
 
 std::string ReshapeSqueezeReshapeRelu::getTestCaseName(
     const testing::TestParamInfo<ReshapeSqueezeReshapeReluTuple>& obj) {
-    ShapeAxesTuple squeezeShape;
-    ov::element::Type element_type;
-    std::string targetName;
-    ov::test::utils::SqueezeOpType opType;
-    std::tie(squeezeShape, element_type, targetName, opType) = obj.param;
+    const auto& [squeezeShape, element_type, targetName, opType] = obj.param;
     std::ostringstream results;
     results << "OpType=" << opType;
     results << "IS=" << ov::test::utils::vec2str(squeezeShape.first) << "_";
@@ -29,10 +25,8 @@ std::string ReshapeSqueezeReshapeRelu::getTestCaseName(
 }
 
 void ReshapeSqueezeReshapeRelu::SetUp() {
-    ShapeAxesTuple squeezeShape;
-    ov::element::Type element_type;
-    ov::test::utils::SqueezeOpType opType;
-    std::tie(squeezeShape, element_type, targetDevice, opType) = this->GetParam();
+    const auto& [squeezeShape, element_type, _targetDevice, opType] = this->GetParam();
+    targetDevice = _targetDevice;
     const size_t input_dim = ov::shape_size(squeezeShape.first);
     std::vector<size_t> shape_input{1, input_dim};
     ov::ParameterVector input{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(shape_input))};

--- a/src/tests/functional/plugin/shared/src/subgraph/rotary_pos_emb.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/rotary_pos_emb.cpp
@@ -87,8 +87,8 @@ void RoPETestFlux::generate_inputs(const std::vector<ov::Shape>& targetInputStat
 }
 
 void RoPETestFlux::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -106,9 +106,7 @@ void RoPETestFlux::SetUp() {
 }
 
 std::string RoPETestFlux::getTestCaseName(const testing::TestParamInfo<rope_params>& obj) {
-    std::string targetDevice;
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = obj.param;
+    const auto& [element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << ",element_type=" << element_type.to_string();
     return result.str();
@@ -250,8 +248,8 @@ void RoPETestLlama2StridedSlice::generate_inputs(const std::vector<ov::Shape>& t
 }
 
 void RoPETestLlama2StridedSlice::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -265,9 +263,7 @@ void RoPETestLlama2StridedSlice::SetUp() {
 }
 
 std::string RoPETestLlama2StridedSlice::getTestCaseName(const testing::TestParamInfo<rope_params>& obj) {
-    ov::element::Type element_type;
-    std::string targetDevice;
-    std::tie(element_type, targetDevice) = obj.param;
+    const auto& [element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << ",element_type=" << element_type.to_string();
     return result.str();
@@ -395,8 +391,8 @@ void RoPETestChatGLMStridedSlice::generate_inputs(const std::vector<ov::Shape>& 
 }
 
 void RoPETestChatGLMStridedSlice::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -409,9 +405,7 @@ void RoPETestChatGLMStridedSlice::SetUp() {
 }
 
 std::string RoPETestChatGLMStridedSlice::getTestCaseName(const testing::TestParamInfo<rope_params>& obj) {
-    std::string targetDevice;
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = obj.param;
+    const auto& [element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << ",element_type=" << element_type.to_string();
     return result.str();
@@ -533,9 +527,8 @@ void RoPETestQwen7bStridedSlice::generate_inputs(const std::vector<ov::Shape>& t
 }
 
 void RoPETestQwen7bStridedSlice::SetUp() {
-    bool specialReshape;
-    ov::element::Type element_type;
-    std::tie(specialReshape, element_type, targetDevice) = this->GetParam();
+    const auto& [specialReshape, element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     const int batch = 128;
     const int seq_length = 7;
     InputShape inpShape = {{batch, -1, 4096 + 4096 + 4096}, {{batch, seq_length, 4096 + 4096 + 4096}}};
@@ -544,10 +537,7 @@ void RoPETestQwen7bStridedSlice::SetUp() {
 }
 
 std::string RoPETestQwen7bStridedSlice::getTestCaseName(const testing::TestParamInfo<rope_params_2>& obj) {
-    bool specialReshape;
-    ov::element::Type element_type;
-    std::string targetDevice;
-    std::tie(specialReshape, element_type, targetDevice) = obj.param;
+    const auto& [specialReshape, element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "specialReshape=" << specialReshape << "_"
            << "targetDevice=" << targetDevice << "_element_type=" << element_type.to_string();
@@ -660,10 +650,7 @@ void RoPETestGPTJStridedSlice::generate_inputs(const std::vector<ov::Shape>& tar
 }
 
 std::string RoPETestGPTJStridedSlice::getTestCaseName(const testing::TestParamInfo<rope_params_2>& obj) {
-    bool hasShapeOf;
-    ov::element::Type element_type;
-    std::string targetDevice;
-    std::tie(hasShapeOf, element_type, targetDevice) = obj.param;
+    const auto& [hasShapeOf, element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "hasShapeOf=" << hasShapeOf << "_"
            << "targetDevice=" << targetDevice;
@@ -671,9 +658,8 @@ std::string RoPETestGPTJStridedSlice::getTestCaseName(const testing::TestParamIn
 }
 
 void RoPETestGPTJStridedSlice::SetUp() {
-    bool hasShapeOf;
-    ov::element::Type element_type;
-    std::tie(hasShapeOf, element_type, targetDevice) = this->GetParam();
+    const auto& [hasShapeOf, element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -821,8 +807,8 @@ void RoPETestRotateHalfWithoutTranspose::generate_inputs(const std::vector<ov::S
 }
 
 void RoPETestRotateHalfWithoutTranspose::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -836,17 +822,15 @@ void RoPETestRotateHalfWithoutTranspose::SetUp() {
 }
 
 std::string RoPETestRotateHalfWithoutTranspose::getTestCaseName(const testing::TestParamInfo<rope_params>& obj) {
-    ov::element::Type element_type;
-    std::string targetDevice;
-    std::tie(element_type, targetDevice) = obj.param;
+    const auto& [element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice <<"_element_type=" << element_type.to_string();
     return result.str();
 }
 
 void RoPETestLlama2Slice::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -913,8 +897,8 @@ std::shared_ptr<ov::Model> RoPETestLlama2Slice::buildROPE_Llama2(int batch,
 }
 
 void RoPETestChatGLMSlice::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -996,9 +980,8 @@ std::shared_ptr<ov::Model> RoPETestChatGLMSlice::buildROPE_ChatGLM(int batch, in
 }
 
 void RoPETestQwen7bSlice::SetUp() {
-    bool specialReshape;
-    ov::element::Type element_type;
-    std::tie(specialReshape, element_type, targetDevice) = this->GetParam();
+    const auto& [specialReshape, element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
     const int batch = 128;
     const int seq_length = 7;
     InputShape inpShape = {{batch, -1, 4096 + 4096 + 4096}, {{batch, seq_length, 4096 + 4096 + 4096}}};
@@ -1061,9 +1044,8 @@ std::shared_ptr<ov::Model> RoPETestQwen7bSlice::buildROPE_Qwen7b(bool specialRes
 }
 
 void RoPETestGPTJSlice::SetUp() {
-    bool hasShapeOf;
-    ov::element::Type element_type;
-    std::tie(hasShapeOf, element_type, targetDevice) = this->GetParam();
+    const auto& [hasShapeOf, element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -1250,8 +1232,8 @@ void RoPETestChatGLM2DRoPEStridedSlice::generate_inputs(const std::vector<ov::Sh
 }
 
 void RoPETestChatGLM2DRoPEStridedSlice::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int batch = 128;
     const int seq_length = 7;
@@ -1264,9 +1246,7 @@ void RoPETestChatGLM2DRoPEStridedSlice::SetUp() {
 }
 
 std::string RoPETestChatGLM2DRoPEStridedSlice::getTestCaseName(const testing::TestParamInfo<rope_params>& obj) {
-    ov::element::Type element_type;
-    std::string targetDevice;
-    std::tie(element_type, targetDevice) = obj.param;
+    const auto& [element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << "_element_type=" << element_type.to_string();
     return result.str();
@@ -1356,8 +1336,8 @@ void RoPETestChatGLMHF::generate_inputs(const std::vector<ov::Shape>& targetInpu
 }
 
 void RoPETestChatGLMHF::SetUp() {
-    ov::element::Type element_type;
-    std::tie(element_type, targetDevice) = this->GetParam();
+    const auto& [element_type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     const int seq_length = 7;
     const int num_heads = 32;
@@ -1373,9 +1353,7 @@ void RoPETestChatGLMHF::SetUp() {
 }
 
 std::string RoPETestChatGLMHF::getTestCaseName(const testing::TestParamInfo<rope_params>& obj) {
-    ov::element::Type element_type;
-    std::string targetDevice;
-    std::tie(element_type, targetDevice) = obj.param;
+    const auto& [element_type, targetDevice] = obj.param;
     std::ostringstream result;
     result << "targetDevice=" << targetDevice << "_element_type=" << element_type.to_string();
     return result.str();

--- a/src/tests/functional/plugin/shared/src/subgraph/scale_shift.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/scale_shift.cpp
@@ -13,11 +13,7 @@
 namespace ov {
 namespace test {
 std::string ScaleShiftLayerTest::getTestCaseName(const testing::TestParamInfo<ScaleShiftParamsTuple> &obj) {
-    std::vector<ov::Shape> inputShapes;
-    ov::element::Type type;
-    std::string targetName;
-    std::vector<float> scale, shift;
-    std::tie(inputShapes, type, targetName, scale, shift) = obj.param;
+    const auto& [inputShapes, type, targetName, scale, shift] = obj.param;
     std::ostringstream results;
 
     results << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
@@ -29,10 +25,8 @@ std::string ScaleShiftLayerTest::getTestCaseName(const testing::TestParamInfo<Sc
 }
 
 void ScaleShiftLayerTest::SetUp() {
-    std::vector<ov::Shape> inputShapes;
-    ov::element::Type type;
-    std::vector<float> scale, shift;
-    std::tie(inputShapes, type, targetDevice, scale, shift) = this->GetParam();
+    const auto& [inputShapes, type, _targetDevice, scale, shift] = this->GetParam();
+    targetDevice = _targetDevice;
     auto paramsShape = ov::Shape{1};
     if (inputShapes.size() > 1)
         paramsShape = inputShapes[1];

--- a/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_gather_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_gather_weights_decompression.cpp
@@ -13,19 +13,12 @@
 namespace ov {
 namespace test {
 std::string SharedMatmulAndGatherWeightsDecompression::getTestCaseName(testing::TestParamInfo<SharedMatmulAndGatherWeightsDecompressionParams> obj) {
-    std::string target_device;
-    GatherDecompressionShapeParams shape_params;
-    ov::test::ElementType weights_precision;
-    ov::test::ElementType decompression_precision;
-    bool decompression_subtract;
-    bool use_decompression_impl;
-
-    std::tie(target_device,
-             shape_params,
-             weights_precision,
-             decompression_precision,
-             decompression_subtract,
-             use_decompression_impl) = obj.param;
+    const auto& [target_device,
+                 shape_params,
+                 weights_precision,
+                 decompression_precision,
+                 decompression_subtract,
+                 use_decompression_impl] = obj.param;
 
     std::ostringstream result;
     result << "device=" << target_device << "_";
@@ -71,18 +64,13 @@ std::shared_ptr<ov::Model> SharedMatmulAndGatherWeightsDecompression::initSubgra
 }
 
 void SharedMatmulAndGatherWeightsDecompression::SetUp() {
-    GatherDecompressionShapeParams shape_params;
-    ov::test::ElementType weights_precision;
-    ov::test::ElementType decompression_precision;
-    bool decompression_subtract;
-    bool use_decompression_impl;
-
-    std::tie(targetDevice,
-             shape_params,
-             weights_precision,
-             decompression_precision,
-             decompression_subtract,
-             use_decompression_impl) = GetParam();
+    const auto& [_targetDevice,
+                 shape_params,
+                 weights_precision,
+                 decompression_precision,
+                 decompression_subtract,
+                 use_decompression_impl] = GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes({shape_params.indices_shape, shape_params.indices_shape});
 

--- a/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_weights_decompression.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/shared_matmul_weights_decompression.cpp
@@ -14,24 +14,14 @@
 namespace ov {
 namespace test {
 std::string SharedMatmulWeightsDecompression::getTestCaseName(testing::TestParamInfo<MatmulSharedWeightsDecompressionParams> obj) {
-    std::string target_device;
-    MatMulDecompressionShapeParams shape_params;
-    ov::test::ElementType weights_precision;
-    ov::test::ElementType decompression_precision;
-    bool transpose;
-    DecompressionType decompression_subtract_type;
-    bool use_decompression_impl;
-    std::map<std::string, std::string> additional_config;
-
-    std::tie(target_device,
-             shape_params,
-             weights_precision,
-             decompression_precision,
-             transpose,
-             decompression_subtract_type,
-             use_decompression_impl,
-             additional_config) = obj.param;
-
+    const auto& [target_device,
+                 shape_params,
+                 weights_precision,
+                 decompression_precision,
+                 transpose,
+                 decompression_subtract_type,
+                 use_decompression_impl,
+                 additional_config] = obj.param;
     std::ostringstream result;
     result << "device=" << target_device << "_";
     result << shape_params << "_";
@@ -92,22 +82,15 @@ std::shared_ptr<ov::Model> SharedMatmulWeightsDecompression::initSubgraph(
 }
 
 void SharedMatmulWeightsDecompression::SetUp() {
-    MatMulDecompressionShapeParams shape_params;
-    ov::test::ElementType weights_precision;
-    ov::test::ElementType decompression_precision;
-    bool transpose_weights;
-    DecompressionType decompression_subtract_type;
-    bool use_decompression_impl;
-    std::map<std::string, std::string> additional_config;
-
-    std::tie(targetDevice,
-             shape_params,
-             weights_precision,
-             decompression_precision,
-             transpose_weights,
-             decompression_subtract_type,
-             use_decompression_impl,
-             additional_config) = GetParam();
+    const auto& [_targetDevice,
+                 shape_params,
+                 weights_precision,
+                 decompression_precision,
+                 transpose_weights,
+                 decompression_subtract_type,
+                 use_decompression_impl,
+                 additional_config] = GetParam();
+    targetDevice = _targetDevice;
     init_input_shapes({shape_params.data_shape, shape_params.data_shape});
     configuration.insert(additional_config.begin(), additional_config.end());
 

--- a/src/tests/functional/plugin/shared/src/subgraph/simple_if.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/simple_if.cpp
@@ -17,11 +17,7 @@ namespace ov {
 namespace test {
 
 std::string SimpleIfTest::getTestCaseName(const testing::TestParamInfo<SimpleIfParamsTuple>& obj) {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    bool condition;
-    std::string targetName;
-    std::tie(shapes, inType, condition, targetName) = obj.param;
+    const auto& [shapes, inType, condition, targetName] = obj.param;
 
     std::ostringstream results;
     for (size_t i = 0; i < shapes.size(); i++) {
@@ -54,10 +50,8 @@ void SimpleIfTest::compare(const std::vector<ov::Tensor>& expected, const std::v
 }
 
 void SimpleIfTest::SetUp() {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    bool condition;
-    std::tie(shapes, inType, condition, targetDevice) = this->GetParam();
+    const auto& [shapes, inType, condition, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     ov::ParameterVector params;
@@ -89,10 +83,8 @@ void SimpleIfTest::SetUp() {
 }
 
 void SimpleIf2OutTest::SetUp() {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    bool condition;
-    std::tie(shapes, inType, condition, targetDevice) = this->GetParam();
+    const auto& [shapes, inType, condition, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     ov::ParameterVector params;
@@ -129,9 +121,9 @@ void SimpleIf2OutTest::SetUp() {
 }
 
 void SimpleIfNotConstConditionTest::SetUp() {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    std::tie(shapes, inType, condition, targetDevice) = this->GetParam();
+    const auto& [shapes, inType, _condition, _targetDevice] = this->GetParam();
+    condition = _condition;
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     for (auto& target : targetStaticShapes)
@@ -192,9 +184,9 @@ void SimpleIfNotConstConditionTest::generate_inputs(const std::vector<ov::Shape>
 }
 
 void SimpleIfNotConstConditionAndInternalDynamismTest::SetUp() {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    std::tie(shapes, inType, condition, targetDevice) = this->GetParam();
+    const auto& [shapes, inType, _condition, _targetDevice] = this->GetParam();
+    condition = _condition;
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     for (auto& target : targetStaticShapes)
@@ -237,9 +229,9 @@ void SimpleIfNotConstConditionAndInternalDynamismTest::SetUp() {
 }
 
 void SimpleIfNotConstConditionAndDimsIncreaseTest::SetUp() {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    std::tie(shapes, inType, condition, targetDevice) = this->GetParam();
+    const auto& [shapes, inType, _condition, _targetDevice] = this->GetParam();
+    condition = _condition;
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     for (auto& target : targetStaticShapes)
@@ -291,9 +283,9 @@ void SimpleIfNotConstConditionAndDimsIncreaseTest::compare(const std::vector<ov:
 }
 
 void SimpleIfNotConstConditionUnusedOutputPortsTest::SetUp() {
-    std::vector<ov::test::InputShape> shapes;
-    ov::test::ElementType inType;
-    std::tie(shapes, inType, condition, targetDevice) = this->GetParam();
+    const auto& [shapes, inType, _condition, _targetDevice] = this->GetParam();
+    condition = _condition;
+    targetDevice = _targetDevice;
 
     init_input_shapes(shapes);
     for (auto& target : targetStaticShapes)

--- a/src/tests/functional/plugin/shared/src/subgraph/split_concat_memory.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/split_concat_memory.cpp
@@ -11,11 +11,7 @@ namespace ov {
 namespace test {
 
 std::string SplitConcatMemory::getTestCaseName(const testing::TestParamInfo<ParamType>& obj) {
-    ov::element::Type netPrecision;
-    ov::Shape inputShapes;
-    int axis;
-    std::string targetDevice;
-    std::tie(inputShapes, netPrecision, axis, targetDevice) = obj.param;
+    const auto& [inputShapes, netPrecision, axis, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
@@ -27,9 +23,11 @@ std::string SplitConcatMemory::getTestCaseName(const testing::TestParamInfo<Para
 
 void SplitConcatMemory::SetUp() {
     abs_threshold = 0.01;
-    ov::Shape shape;
 
-    std::tie(shape, inType, axis, targetDevice) = this->GetParam();
+    const auto& [shape, _inType, _axis, _targetDevice] = this->GetParam();
+    inType = _inType;
+    axis = _axis;
+    targetDevice = _targetDevice;
 
     auto shape_14 = shape;
     shape_14[axis] /= 4;

--- a/src/tests/functional/plugin/shared/src/subgraph/split_conv_concat.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/split_conv_concat.cpp
@@ -15,10 +15,7 @@ namespace ov {
 namespace test {
 
 std::string SplitConvConcat::getTestCaseName(const testing::TestParamInfo<ov::test::BasicParams>& obj) {
-    ov::element::Type element_type;
-    ov::Shape inputShapes;
-    std::string targetDevice;
-    std::tie(element_type, inputShapes, targetDevice) = obj.param;
+    const auto& [element_type, inputShapes, targetDevice] = obj.param;
 
     std::ostringstream result;
     result << "IS=" << ov::test::utils::vec2str(inputShapes) << "_";
@@ -32,9 +29,8 @@ void SplitConvConcat::SetUp() {
 }
 
 void SplitConvConcatBase::configure_test(const ov::test::BasicParams& param) {
-    ov::Shape inputShape;
-    ov::element::Type element_type;
-    std::tie(element_type, inputShape, targetDevice) = param;
+    const auto& [element_type, inputShape, _targetDevice] = param;
+    targetDevice = _targetDevice;
 
     ov::ParameterVector params{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(inputShape))};
 

--- a/src/tests/functional/plugin/shared/src/subgraph/stridedslice_eltwise.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/stridedslice_eltwise.cpp
@@ -18,10 +18,7 @@
 namespace ov {
 namespace test {
 std::string StridedSliceEltwiseTest::getTestCaseName(const testing::TestParamInfo<StridedSliceEltwiseParamsTuple> &obj) {
-    StridedSliceEltwiseSpecificParams params;
-    ov::element::Type model_type;
-    std::string target_device;
-    std::tie(params, model_type, target_device) = obj.param;
+    const auto& [params, model_type, target_device] = obj.param;
     std::ostringstream result;
     result << "IS=(";
     for (size_t i = 0lu; i < params.input_shape.size(); i++) {
@@ -50,9 +47,8 @@ std::string StridedSliceEltwiseTest::getTestCaseName(const testing::TestParamInf
 }
 
 void StridedSliceEltwiseTest::SetUp() {
-    StridedSliceEltwiseSpecificParams ssParams;
-    ov::element::Type type;
-    std::tie(ssParams, type, targetDevice) = this->GetParam();
+    const auto& [ssParams, type, _targetDevice] = this->GetParam();
+    targetDevice = _targetDevice;
 
     init_input_shapes(ssParams.input_shape);
 

--- a/src/tests/functional/plugin/shared/src/subgraph/variadic_split_pad.cpp
+++ b/src/tests/functional/plugin/shared/src/subgraph/variadic_split_pad.cpp
@@ -11,14 +11,7 @@ namespace ov {
 namespace test {
 
 std::string VariadicSplitPad::getTestCaseName(const testing::TestParamInfo<SplitPadTuple>& obj) {
-    ov::Shape input_shape;
-    int64_t axis;
-    std::vector<size_t> numSplits, connectIndexes;
-    std::vector<int64_t> padsBegin, padsEnd;
-    ov::op::PadMode padMode;
-    ov::element::Type element_type;
-    std::string targetName;
-    std::tie(input_shape, axis, numSplits, connectIndexes, padsBegin, padsEnd, padMode, element_type, targetName) =
+    const auto& [input_shape, axis, numSplits, connectIndexes, padsBegin, padsEnd, padMode, element_type, targetName] =
         obj.param;
     std::ostringstream results;
 
@@ -35,14 +28,9 @@ std::string VariadicSplitPad::getTestCaseName(const testing::TestParamInfo<Split
 }
 
 void VariadicSplitPad::SetUp() {
-    ov::Shape input_shape;
-    int64_t axis;
-    std::vector<size_t> numSplits, connectIndexes;
-    std::vector<int64_t> padBegin, padEnd;
-    ov::op::PadMode padMode;
-    ov::element::Type element_type;
-    std::tie(input_shape, axis, numSplits, connectIndexes, padBegin, padEnd, padMode, element_type, targetDevice) =
+    const auto& [input_shape, axis, numSplits, connectIndexes, padBegin, padEnd, padMode, element_type, _targetDevice] =
         this->GetParam();
+    targetDevice = _targetDevice;
     ov::ParameterVector input{std::make_shared<ov::op::v0::Parameter>(element_type, ov::Shape(input_shape))};
 
     auto split_axis_op = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{}, axis);


### PR DESCRIPTION
This both simplifies and speeds up the code.
Assembly difference https://godbolt.org/z/bqdsf8ca3
Local perf difference https://quick-bench.com/q/llroDSJ6LHtdWpK9WhKTDq5LESw