### PR TITLE
[Snippets] Replace manual RTTI implementations with `OPENVINO_RTTI_BASE`

### DIFF
--- a/src/common/snippets/include/snippets/lowered/expression.hpp
+++ b/src/common/snippets/include/snippets/lowered/expression.hpp
@@ -32,6 +32,8 @@ class Expression : public std::enable_shared_from_this<Expression> {
     friend class ExpressionPort;
 
 public:
+    OPENVINO_RTTI_BASE("Expression")
+
     Expression() = default;
     virtual ~Expression() = default;
 
@@ -115,18 +117,6 @@ public:
     ExpressionPtr clone_with_new_inputs(const ExpressionMap& expr_map, const std::shared_ptr<Node>& new_node) const;
 
     virtual bool visit_attributes(AttributeVisitor& visitor);
-
-    // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
-    // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
-    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
-        static ::ov::DiscreteTypeInfo type_info_static{"Expression"};
-        type_info_static.hash();
-        return type_info_static;
-    }
-
-    virtual const DiscreteTypeInfo& get_type_info() const {
-        return get_type_info_static();
-    }
 
     const char* get_type_name() const {
         return get_type_info().name;

--- a/src/common/snippets/include/snippets/lowered/loop_info.hpp
+++ b/src/common/snippets/include/snippets/lowered/loop_info.hpp
@@ -39,6 +39,8 @@ using LoopInfoPtr = std::shared_ptr<LoopInfo>;
  */
 class LoopInfo : public std::enable_shared_from_this<LoopInfo> {
 public:
+    OPENVINO_RTTI_BASE("LoopInfoBase")
+
     LoopInfo() = default;
     LoopInfo(size_t work_amount,
              size_t increment,
@@ -159,18 +161,6 @@ public:
      * @brief Sort Loop Ports according to the execution order of underlying expressions
      */
     virtual void sort_ports() = 0;
-
-    // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
-    // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
-    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
-        static ::ov::DiscreteTypeInfo type_info_static{"LoopInfoBase"};
-        type_info_static.hash();
-        return type_info_static;
-    }
-
-    virtual const DiscreteTypeInfo& get_type_info() const {
-        return get_type_info_static();
-    }
 
     const char* get_type_name() const {
         return get_type_info().name;

--- a/src/common/snippets/include/snippets/lowered/pass/pass.hpp
+++ b/src/common/snippets/include/snippets/lowered/pass/pass.hpp
@@ -24,19 +24,10 @@ namespace ov::snippets::lowered::pass {
  */
 class PassBase : public std::enable_shared_from_this<PassBase> {
 public:
+    OPENVINO_RTTI_BASE("snippets::lowered::pass::PassBase")
+
     PassBase() = default;
     virtual ~PassBase() = default;
-    // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
-    // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
-    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
-        static ::ov::DiscreteTypeInfo type_info_static{"snippets::lowered::pass::PassBase"};
-        type_info_static.hash();
-        return type_info_static;
-    }
-
-    virtual const DiscreteTypeInfo& get_type_info() const {
-        return get_type_info_static();
-    }
 
     const char* get_type_name() const {
         return get_type_info().name;

--- a/src/common/snippets/include/snippets/runtime_configurator.hpp
+++ b/src/common/snippets/include/snippets/runtime_configurator.hpp
@@ -31,20 +31,10 @@ namespace ov::snippets {
  */
 class RuntimeConfig {
 public:
+    OPENVINO_RTTI_BASE("RuntimeConfig")
+
     RuntimeConfig() = default;
     virtual ~RuntimeConfig() = default;
-
-    // Note that get_type_info_static and get_type_info are needed to mimic OPENVINO_RTTI interface,
-    // so the standard OPENVINO_RTTI(...) macros could be used in derived classes.
-    _OPENVINO_HIDDEN_METHOD static const ::ov::DiscreteTypeInfo& get_type_info_static() {
-        static ::ov::DiscreteTypeInfo type_info_static{"RuntimeConfig"};
-        type_info_static.hash();
-        return type_info_static;
-    }
-
-    [[nodiscard]] virtual const DiscreteTypeInfo& get_type_info() const {
-        return get_type_info_static();
-    }
 
     [[nodiscard]] const char* get_type_name() const {
         return get_type_info().name;


### PR DESCRIPTION
### Details:
Replace manual `get_type_info_static` and `get_type_info` implementations with `OPENVINO_RTTI_BASE` macro in 4 snippets framework classes:
- RuntimeConfig
- LoopInfo (LoopInfoBase)
- Expression
- PassBase

### Tickets:
 - N/A
