### PR TITLE
[Snippets] Enable desired clang-tidy checks not requiring additional changes

### DIFF
--- a/src/common/snippets/.clang-tidy
+++ b/src/common/snippets/.clang-tidy
@@ -30,17 +30,9 @@
 #
 ### Checks that are turned off but better be enabled later:
 # -bugprone-easily-swappable-parameters
-# -bugprone-exception-escape. There are a lot of legacy code which does not handle exceptions properly and just catches them all. Major refactoring is required to correct this.
-# -bugprone-implicit-widening-of-multiplication-result
-# -bugprone-incorrect-roundings. There are explicit ways to perform rounding (i.e. std::floor(), std::round(), etc). Requires careful updates case by case
-# -bugprone-signed-char-misuse. The source code contains valid logic when pointer to the data is interpreted as int8_t (i.e. weights tensor)
 # -cppcoreguidelines-avoid-const-or-ref-data-members
 # -google-default-arguments,
-# -google-explicit-constructor,
-# -modernize-avoid-c-arrays,
-# -misc-header-include-cycle,
 # -misc-non-private-member-variables-in-classes,
-# -misc-use-anonymous-namespace,
 # -readability-function-cognitive-complexity. Reasonable way to enforce splitting complex code into simple functions
 # -readability-isolate-declaration
 # -readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers
@@ -59,10 +51,6 @@ Checks: >
   misc-*,
   readability-*,
   -bugprone-easily-swappable-parameters,
-  -bugprone-exception-escape,
-  -bugprone-implicit-widening-of-multiplication-result,
-  -bugprone-incorrect-roundings,
-  -bugprone-signed-char-misuse,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cppcoreguidelines-avoid-do-while,
@@ -83,17 +71,13 @@ Checks: >
   -cppcoreguidelines-rvalue-reference-param-not-moved,
   -cppcoreguidelines-special-member-functions,
   -google-build-using-namespace,
-  -google-explicit-constructor,
   -google-readability-todo,
-  -modernize-avoid-c-arrays,
+  -modernize-use-trailing-return-type,
   -modernize-use-constraints,
   -modernize-use-std-numbers,
-  -modernize-use-trailing-return-type,
-  -misc-header-include-cycle,
   -misc-const-correctness,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
-  -misc-use-anonymous-namespace,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-isolate-declaration,


### PR DESCRIPTION
### Details:
Enable clang-tidy checks that were planned to be enabled and do not require any additional changes to do so

### Tickets:
 - N/A
