### PR TITLE
[GPU][Qwen3-8B] Fuse type conversion only reorders to previous RMS nodes 

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/remove_redundant_reorders.cpp
@@ -22,6 +22,7 @@
 #include "fully_connected_inst.h"
 #include "group_normalization_inst.h"
 #include "mvn_inst.h"
+#include "rms_inst.h"
 
 #include <vector>
 #include <list>
@@ -457,7 +458,7 @@ void remove_redundant_reorders::run(program& p) {
                 (input.is_type<one_hot>() || input.is_type<permute>() || input.is_type<mvn>() ||
                  input.is_type<concatenation>() || input.is_type<depth_to_space>() || input.is_type<region_yolo>() ||
                  input.is_type<detection_output>() || input.is_type<gather>() || input.is_type<broadcast>() ||
-                 input.is_type<select>() || input.is_type<eltwise>()) && !input.is_constant();
+                 input.is_type<select>() || input.is_type<eltwise>() || input.is_type<rms>()) && !input.is_constant();
             if (!same_data_type && !allowed_dt_conversion_fuse)
                 continue;
 
@@ -476,7 +477,7 @@ void remove_redundant_reorders::run(program& p) {
                 // during shape inference
                 if (input.is_type<mvn>() || input.is_type<concatenation>() || input.is_type<gather>() ||
                     input.is_type<broadcast>() || input.is_type<select>() || input.is_type<eltwise>() ||
-                    (input.is_dynamic() &&
+                    input.is_type<rms>() || (input.is_dynamic() &&
                     (input.is_type<group_normalization>() || input.is_type<permute>()))) {
                     fused_primitive_desc local_desc(node.get_primitive());
                     local_desc.f_param = node.get_fuse_params();

--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -12,6 +12,7 @@
 #include "reorder_inst.h"
 #include "resample_inst.h"
 #include "reshape_inst.h"
+#include "rms_inst.h"
 #include "arg_max_min_inst.h"
 #include "shape_of_inst.h"
 #include "select_inst.h"
@@ -343,7 +344,7 @@ bool layout_optimizer::can_fuse_reorder_to_prev(program_node& prev, reorder_node
     // Because mvn and concatenation kernel can work cross-layout, if reorder only performs type conversion,
     // fusing reorder to the previous node can be done even if it is a dynamic shape case
     if ((prev.is_type<mvn>() || prev.is_type<concatenation>() || prev.is_type<gather>() || prev.is_type<broadcast>() ||
-         prev.is_type<select>() || prev.is_type<eltwise>()) &&
+         prev.is_type<select>() || prev.is_type<eltwise>() || prev.is_type<rms>()) &&
         !prev.is_in_shape_of_subgraph() && node.is_type_conversion_only() &&
         (format::is_simple_data_format(fmt_prev) && format::is_simple_data_format(fmt_next)) &&
         // If the prev node is backedge of the loop, the type will be changed by fusing reorder.

--- a/src/plugins/intel_gpu/src/graph/rms.cpp
+++ b/src/plugins/intel_gpu/src/graph/rms.cpp
@@ -15,9 +15,12 @@ layout rms_inst::calc_output_layout(rms_node const& node, kernel_impl_params con
     auto desc = impl_param.typed_desc<rms>();
     auto input_layout = impl_param.get_input_layout();
     auto output_type = desc->output_data_types[0].value_or(input_layout.data_type);
-    auto output_format = input_layout.format;
 
-    return layout(output_type, output_format, input_layout.get_tensor());
+    if (impl_param.has_fused_primitives()) {
+        output_type = impl_param.get_output_element_type();
+    }
+
+    return layout(output_type, input_layout.format, input_layout.get_tensor());
 }
 
 std::string rms_inst::to_string(rms_node const& node) {

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_bfyx_opt.h
@@ -22,7 +22,8 @@ protected:
         return {
             FusedOpType::ACTIVATION,
             FusedOpType::QUANTIZE,
-            FusedOpType::ELTWISE
+            FusedOpType::ELTWISE,
+            FusedOpType::REORDER
         };
     }
     bool Validate(const Params&) const override;

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/rms/rms_kernel_ref.h
@@ -22,7 +22,8 @@ protected:
         return {
             FusedOpType::ACTIVATION,
             FusedOpType::QUANTIZE,
-            FusedOpType::ELTWISE
+            FusedOpType::ELTWISE,
+            FusedOpType::REORDER
         };
     }
     JitConstants GetJitConstants(const rms_params& params, DispatchData dispatchData) const override;


### PR DESCRIPTION
### Details:
 - Some reorders are not being optimized out due to RMS nodes which are not supporting fusing type conversion only reorders
 - Allow type conversion reorder fusion for RMS

### Tickets:
 - 171226
