### PR TITLE
[CPU] Model cache. Add PagedAttentionExtension to enable deserialization of the model

### DIFF
--- a/src/core/dev_api/openvino/op/paged_attention.hpp
+++ b/src/core/dev_api/openvino/op/paged_attention.hpp
@@ -14,6 +14,8 @@ class OPENVINO_API PagedAttentionExtension : public ov::op::Op {
 public:
     OPENVINO_OP("PagedAttentionExtension");
 
+    PagedAttentionExtension() = default;
+
     PagedAttentionExtension(const ov::OutputVector& args);
     void validate_and_infer_types() override;
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override;

--- a/src/plugins/intel_cpu/src/extension.cpp
+++ b/src/plugins/intel_cpu/src/extension.cpp
@@ -37,6 +37,7 @@
 #include "openvino/op/mvn.hpp"
 #include "openvino/op/normalize_l2.hpp"
 #include "openvino/op/not_equal.hpp"
+#include "openvino/op/paged_attention.hpp"
 #include "openvino/op/prelu.hpp"
 #include "openvino/op/reduce_logical_and.hpp"
 #include "openvino/op/reduce_logical_or.hpp"
@@ -186,6 +187,7 @@ OPENVINO_CREATE_EXTENSIONS(std::vector<ov::Extension::Ptr>({
     std::make_shared<ov::OpExtension<ov::op::internal::FullyConnectedCompressed>>(),
     std::make_shared<ov::OpExtension<ov::op::internal::FullyConnectedQuantizedLegacy>>(),
     std::make_shared<ov::OpExtension<ov::op::internal::FullyConnectedQuantized>>(),
+    std::make_shared<ov::OpExtension<ov::op::PagedAttentionExtension>>(),
     // clang-format off
     OP_EXTENSION_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::InteractionNode>>())
     OP_EXTENSION_X64(std::make_shared<ov::OpExtension<ov::intel_cpu::LLMMLPNode>>())


### PR DESCRIPTION
### Details:
 - *The PagedAttentionExtension operation is created during transformations routine and serialized into the cached model. To enable deserialization of this operation need to add it to the extensions list.*

### Tickets:
 - *168337*
