### PR TITLE
[GPU] apply scales_port to save/load/hash/compare functions in resample

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp
@@ -15,7 +15,7 @@ namespace cldnn {
 struct resample : public primitive_base<resample> {
     CLDNN_DECLARE_PRIMITIVE(resample)
 
-    resample() : primitive_base("", {}), scales_port(0) {}
+    resample() : primitive_base("", {}) {}
 
     using InterpolateOp = ov::op::util::InterpolateBase;
 
@@ -129,7 +129,7 @@ struct resample : public primitive_base<resample> {
     /// @param num_filter Input filter. Only used by bilinear sample_type.
     uint32_t num_filter = 0;
     /// @param num_filter Port number of scales.
-    uint32_t scales_port;
+    uint32_t scales_port = 2;
     /// @param sizes Describing output shape for spatial axes.
     std::vector<int64_t> sizes;
     /// @param scales Scales of spatial axes, i.e. output_shape / input_shape
@@ -156,6 +156,7 @@ struct resample : public primitive_base<resample> {
     size_t hash() const override {
         size_t seed = primitive::hash();
         seed = hash_combine(seed, num_filter);
+        seed = hash_combine(seed, scales_port);
         seed = hash_range(seed, scales.begin(), scales.end());
         seed = hash_range(seed, axes.begin(), axes.end());
         seed = hash_range(seed, pads_begin.begin(), pads_begin.end());
@@ -177,6 +178,7 @@ struct resample : public primitive_base<resample> {
 
         #define cmp_fields(name) name == rhs_casted.name
         return cmp_fields(num_filter) &&
+               cmp_fields(scales_port) &&
                cmp_fields(sizes) &&
                cmp_fields(scales) &&
                cmp_fields(axes) &&
@@ -195,6 +197,7 @@ struct resample : public primitive_base<resample> {
         primitive_base<resample>::save(ob);
         ob << output_size;
         ob << num_filter;
+        ob << scales_port;
         ob << sizes;
         ob << scales;
         ob << axes;
@@ -212,6 +215,7 @@ struct resample : public primitive_base<resample> {
         primitive_base<resample>::load(ib);
         ib >> output_size;
         ib >> num_filter;
+        ib >> scales_port;
         ib >> sizes;
         ib >> scales;
         ib >> axes;


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - benchmark_app crashed when cache_dir is enabled due to 'scales_port' in resample is missing at save/load functions.
 - 'scales_port' was fixed to 2 in old code. but it updated in [PR#26260](https://github.com/openvinotoolkit/openvino/pull/26260)

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/include/intel_gpu/primitives/resample.hpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - $ benchmark_app -m models/ch_PP-OCRv4_det_infer/inference.xml -d GPU.1 -data_shape x[1,3,960,960] -api sync -niter 1 --cache_dir ./model_cache
 - model is attached in ticket

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 171152
