### PR TITLE
[GPU] Do not bias fusion when deps has more than 2 users

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -309,6 +309,9 @@ void prepare_primitive_fusing::fuse_bias(program &p) {
         if (bias_node.get_output_layout().data_type != replace_candidate.get_output_layout().data_type)
             continue;
 
+        if (replace_candidate.users.size() > 1)
+            continue;
+
         auto fuse_bias_f = [&p](program_node& prev_node, program_node& new_node, program_node& bias_node, program_node& eltw_node) {
             auto eltw_id = eltw_node.id();
             p.replace(prev_node, new_node);


### PR DESCRIPTION
### Details:
 - When dependency has more than 2 users, trying to fuse bias will result in unexpected graphs and accuracy drop.

### Issue:
- See below the graph.
- When performing `fuse_bias()`, `fullyconnected:/out/MatMul` node should only fuse `add/out/Add`.
- If `add:/out_norm/Sub` is also fused to it, `multiply:/out_norm/Mul_1` will receive unexpected input.
- Thus, `fuse_bias()` should stop if the dependency of the target node has more than 2 users. 

### Graphs:
<img width="564" height="1179" alt="image" src="https://github.com/user-attachments/assets/f7b7a12b-817a-4c98-83e9-64fd47ad3fe2" />

### Related to:
https://github.com/openvinotoolkit/openvino/blob/e11fd3dd926fdd9d03276fddb8bfcfa3487619fa/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp#L312-L313

### Checklist:
- [x]  Is it a proper fix? (Not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to covert this scenario?

### Tickets:
 - 171149
