### PR TITLE
[GPU] Set key_by_channel mode as default key quantization mode

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/options.inl
@@ -35,7 +35,7 @@ OV_CONFIG_RELEASE_OPTION(ov::hint, activations_scale_factor, -1.0f, "Scalar floa
 OV_CONFIG_RELEASE_OPTION(ov::internal, enable_lp_transformations, false, "Enable/Disable Low precision transformations set")
 OV_CONFIG_RELEASE_OPTION(ov::intel_gpu, config_file, "", "Path to custom layers config file")
 OV_CONFIG_RELEASE_OPTION(ov::hint, model, nullptr, "Shared pointer to the ov::Model")
-OV_CONFIG_RELEASE_OPTION(ov::internal, key_cache_quant_mode, ov::internal::CacheQuantMode::BY_TOKEN, "AUTO or BY_CHANNEL or BY_TOKEN")
+OV_CONFIG_RELEASE_OPTION(ov::internal, key_cache_quant_mode, ov::internal::CacheQuantMode::BY_CHANNEL, "AUTO or BY_CHANNEL or BY_TOKEN")
 OV_CONFIG_RELEASE_OPTION(ov::internal, value_cache_quant_mode, ov::internal::CacheQuantMode::BY_TOKEN, "AUTO or BY_CHANNEL or BY_TOKEN")
 
 OV_CONFIG_RELEASE_INTERNAL_OPTION(ov::intel_gpu, shape_predictor_settings, {10, 16 * 1024, 2, 1.1f}, "Preallocation settings")

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_cache_update_ref.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_cache_update_ref.cl
@@ -17,7 +17,6 @@ inline void FUNC(quantize_and_save_per_token)(__global const INPUT0_TYPE* in_dat
     INPUT0_TYPE grp_max = 0.001;
     INPUT0_TYPE max_value = INPUT0_VAL_MIN;
     INPUT0_TYPE min_value = INPUT0_VAL_MAX;
-
     unroll_for (uint i = 0; i < num_groups; i++) {
         input_data[i] = BLOCK_READN(INPUT0_TYPE, 1, in_data, in_data_offset + i * SUBGROUP_SIZE);
         max_value = fmax(max_value, input_data[i]);
@@ -63,8 +62,10 @@ inline void FUNC(quantize_and_save_by_channel_block_with_requantize)(__global co
                                     const uint token_pos_in_block,
                                     const uint new_tokens_num,
                                     const uint sglid) {
-    for (int h_sub = 0; h_sub < NUM_HEAD_SIZE_GROUPS; h_sub++) {
-        const int hidden_idx = h_sub * SUBGROUP_SIZE + sglid;
+    const int num_head_size_groups = NUM_HEAD_SIZE_GROUPS / NUM_K_HEAD_SIZE_PARTITIONS;
+    int head_size_offset = SUBGROUP_SIZE * get_group_id(2);
+    for (int h_sub = 0; h_sub < num_head_size_groups; h_sub++) {
+        const int hidden_idx = head_size_offset + h_sub * SUBGROUP_SIZE + sglid;
         const uint out_offset_per_wi = out_data_offset + hidden_idx * out_data_pitch;
         // Read original scale and zp
         INPUT0_TYPE* comp_ptr = (INPUT0_TYPE*) (&out_data[out_offset_per_wi + COMP_K_OFFSET]);
@@ -79,14 +80,14 @@ inline void FUNC(quantize_and_save_by_channel_block_with_requantize)(__global co
         #define VLOAD CAT(vload, READ_SIZE)
         IN_DATA_VEC cache_data_vec_decompressed;
         for (int j = 0; j < new_tokens_num; ++j) {
-            INPUT0_TYPE new_token = BLOCK_READN(INPUT0_TYPE, 1, in_data, in_data_offset + j * K_HEAD_SIZE * KV_HEADS_NUM + h_sub * SUBGROUP_SIZE);
-            // Read a hidden dim of the previously quantized cache => decompress
-            // TODO : current block size is 16 (same as PA block size),
-            //        but when the block size becomes different, this part should be updated as well
+            INPUT0_TYPE new_token = BLOCK_READN(INPUT0_TYPE, 1, in_data, in_data_offset + j * K_HEAD_SIZE * KV_HEADS_NUM + hidden_idx);
             cache_data_vec_decompressed[token_pos_in_block + j] = new_token;
             INPUT0_TYPE max_value = fmax(max_value, new_token);
             INPUT0_TYPE min_value = fmin(min_value, new_token);
         }
+        // Read a hidden dim of the previously quantized cache => decompress
+        // TODO : current block size is 16 (same as PA block size),
+        //        but when the block size becomes different, this part should be updated as well
         OUT_DATA_VEC prev_cache_data_vec = VLOAD(0, out_data + out_offset_per_wi);
         #undef READ_SIZE
         #undef VLOAD
@@ -202,7 +203,7 @@ KERNEL(pa_kv_cache_update)(
         // 2nd+ token
         const uint seq_idx = (uint)get_global_id(0);
         const uint head_idx = (uint)get_global_id(1);
-        const uint sglid = (uint)get_global_id(2);
+        const uint sglid = (uint)get_local_id(2);
 
         const uint past_seq_len = past_lens[seq_idx];
         const uint current_token_pos_in_block = past_seq_len % PAGED_ATTENTION_BLOCK_SIZE;
@@ -255,6 +256,7 @@ KERNEL(pa_kv_cache_update)(
         }
 #else // IS_KV_COMPRESSED
         #ifdef IS_KEY_BY_CHANNEL
+        // key by channel
         {
             FUNC_CALL(quantize_and_save_by_channel_block_with_requantize)(key_data,
                                                                         key_in_offset,
@@ -266,7 +268,15 @@ KERNEL(pa_kv_cache_update)(
                                                                         1,
                                                                         sglid);
         }
-        #else // Key per token
+        // value per token
+        if (get_group_id(2) == 0) {
+            const uint comp_v_offset = block_v_base_offset + V_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
+            INPUT0_TYPE input_data[V_HEAD_SIZE / SUBGROUP_SIZE];
+            FUNC_CALL(quantize_and_save_per_token)(value_data, value_in_offset, value_cache_data, value_out_offset, 1, comp_v_offset,
+                current_token_pos_in_block, sglid, V_HEAD_SIZE / SUBGROUP_SIZE, &input_data[0]);
+        }
+        #else
+        // IS_KEY_BY_CHANNEL false
         {
             const uint comp_k_offset = block_k_base_offset + K_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
             // key processing
@@ -274,14 +284,13 @@ KERNEL(pa_kv_cache_update)(
             FUNC_CALL(quantize_and_save_per_token)(key_data, key_in_offset, key_cache_data, key_out_offset, PAGED_ATTENTION_BLOCK_SIZE, comp_k_offset,
                 current_token_pos_in_block, sglid, K_HEAD_SIZE / SUBGROUP_SIZE, &input_data[0]);
         }
-        #endif
-        // value per token
         {
             const uint comp_v_offset = block_v_base_offset + V_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
             INPUT0_TYPE input_data[V_HEAD_SIZE / SUBGROUP_SIZE];
             FUNC_CALL(quantize_and_save_per_token)(value_data, value_in_offset, value_cache_data, value_out_offset, 1, comp_v_offset,
                 current_token_pos_in_block, sglid, V_HEAD_SIZE / SUBGROUP_SIZE, &input_data[0]);
         }
+        #endif
 #endif // IS_KV_COMPRESSED
     } else {
 
@@ -289,7 +298,6 @@ KERNEL(pa_kv_cache_update)(
         const uint block_idx = get_global_id(0);
         const uint head_idx = get_global_id(1);
         const uint sglid = get_global_id(2);
-
     
         const uint subsequence_idx = gws_seq_indexes_correspondence[block_idx];
         const uint subsequence_begin_idx = subsequence_begins[subsequence_idx];

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_cache_update_ref.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/pa_kv_cache_update_ref.cl
@@ -17,6 +17,7 @@ inline void FUNC(quantize_and_save_per_token)(__global const INPUT0_TYPE* in_dat
     INPUT0_TYPE grp_max = 0.001;
     INPUT0_TYPE max_value = INPUT0_VAL_MIN;
     INPUT0_TYPE min_value = INPUT0_VAL_MAX;
+
     unroll_for (uint i = 0; i < num_groups; i++) {
         input_data[i] = BLOCK_READN(INPUT0_TYPE, 1, in_data, in_data_offset + i * SUBGROUP_SIZE);
         max_value = fmax(max_value, input_data[i]);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -86,6 +86,18 @@ static size_t get_heads_per_wi(const size_t kv_group_size) {
     return 1;
 }
 
+static size_t get_num_k_head_size_partitions(const kv_cache_update_params& params) {
+    size_t head_size_partition = 1;
+    if (getenv("NUM") != nullptr)
+        return std::stoi(getenv("NUM"));
+    if (params.is_key_by_channel) {
+        if (params.conf.k_head_size % subgroup_size == 0)
+            head_size_partition = std::min(static_cast<size_t>(16),
+                                           std::max(static_cast<size_t>(1), static_cast<size_t>(params.conf.k_head_size / subgroup_size)));
+    }
+    return head_size_partition;
+}
+
 inline size_t get_generate_stage_block_size(size_t head_size) {
     auto preferred_block_size = {4, 2, 1};
     for (const auto& block_size : preferred_block_size) {
@@ -784,6 +796,7 @@ protected:
                 jit.make("IS_KEY_BY_CHANNEL", 1);
                 jit.make("ADJUSTED_K_HEAD_SIZE", desc->k_head_size);
                 jit.make("ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size + scales_zp_size);
+                jit.AddConstant(MakeJitConstant("NUM_K_HEAD_SIZE_PARTITIONS", get_num_k_head_size_partitions(params)));
             } else {
                 jit.make("ADJUSTED_K_HEAD_SIZE", desc->k_head_size + scales_zp_size);
                 jit.make("ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
@@ -846,8 +859,8 @@ protected:
             } else {
                 const auto& key_input = params.input_layouts[0];
                 const auto sequences_number = key_input.get_partial_shape()[0].get_length();
-
-                wgs.global = {static_cast<size_t>(sequences_number), heads_number, subgroup_size};
+                size_t head_size_partition = get_num_k_head_size_partitions(params);
+                wgs.global = {static_cast<size_t>(sequences_number), heads_number, subgroup_size * head_size_partition};
                 wgs.local = {1, 1, subgroup_size};
             }
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -89,9 +89,10 @@ static size_t get_heads_per_wi(const size_t kv_group_size) {
 static size_t get_num_k_head_size_partitions(const kv_cache_update_params& params) {
     size_t head_size_partition = 1;
     if (params.is_key_by_channel) {
-        if (params.conf.k_head_size % subgroup_size == 0)
-            head_size_partition = std::min(static_cast<size_t>(16),
-                                           std::max(static_cast<size_t>(1), static_cast<size_t>(params.conf.k_head_size / subgroup_size)));
+        if (params.conf.k_head_size % subgroup_size == 0) {
+            head_size_partition = std::max(static_cast<size_t>(1), static_cast<size_t>(params.conf.k_head_size / subgroup_size));
+            head_size_partition = std::min(static_cast<size_t>(16), head_size_partition);
+        }
     }
     return head_size_partition;
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -88,8 +88,6 @@ static size_t get_heads_per_wi(const size_t kv_group_size) {
 
 static size_t get_num_k_head_size_partitions(const kv_cache_update_params& params) {
     size_t head_size_partition = 1;
-    if (getenv("NUM") != nullptr)
-        return std::stoi(getenv("NUM"));
     if (params.is_key_by_channel) {
         if (params.conf.k_head_size % subgroup_size == 0)
             head_size_partition = std::min(static_cast<size_t>(16),

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/paged_attention_opt.cpp
@@ -268,7 +268,6 @@ public:
         jit.make("PAGED_ATTENTION_BLOCK_SIZE", paged_attention_block_size);
         jit.make("SUBGROUP_SIZE", subgroup_size);
         jit.make("SLIDING_WINDOW_SIZE", desc->sliding_window);
-        jit.make("HEADS_PER_WI", 1);
 
         bool is_kv_compressed = get_kv_compressed(params);
         jit.make("IS_KV_COMPRESSED", is_kv_compressed);
@@ -452,6 +451,7 @@ public:
         auto heads_per_wi = get_heads_per_wi(kv_group_size);
 
         // GQA
+        jit.remove("HEADS_PER_WI");
         jit.make("HEADS_PER_WI", heads_per_wi);
         jit.make("ITERATIONS_PER_KV_HEADS_GROUP", ceil_div(kv_group_size, heads_per_wi));
         jit.make("HEADS_LEFTOVERS_NUM", kv_group_size % heads_per_wi);
@@ -486,6 +486,7 @@ public:
     [[nodiscard]] JitConstants get_jit_constants(const kernel_impl_params& params) const override {
         auto jit = PagedAttentionGeneratorBase::get_jit_constants(params);
         jit.make("SDPA_STAGE_1", 1);
+        jit.make("HEADS_PER_WI", 1);
 
         const auto& in_offsets_map = params.in_port_to_shape_info_offset;
         const auto& out_offsets_map = params.out_port_to_shape_info_offset;
@@ -542,6 +543,7 @@ public:
         auto jit = PagedAttentionGeneratorBase::get_jit_constants(params);
         jit.make("SDPA_STAGE_0", 1);
         jit.make("MULTI_TOKENS_PROCESSING", 1);
+        jit.make("HEADS_PER_WI", 1);
 
         const auto desc = params.typed_desc<paged_attention>();
         const auto has_alibi = params.get_input_layout(PagedAttentionInputIdx::ALIBI).count() > 0;
@@ -632,6 +634,7 @@ public:
         auto jit = PagedAttentionGeneratorBase::get_jit_constants(params);
         jit.make("SDPA_STAGE_1", 1);
         jit.make("MULTI_TOKENS_PROCESSING", 1);
+        jit.make("HEADS_PER_WI", 1);
 
         const auto& in_offsets_map = params.in_port_to_shape_info_offset;
         const auto& out_offsets_map = params.out_port_to_shape_info_offset;
@@ -688,6 +691,7 @@ public:
     [[nodiscard]] JitConstants get_jit_constants(const kernel_impl_params& params) const override {
         auto jit = PagedAttentionGeneratorBase::get_jit_constants(params);
         jit.make("SDPA_STAGE_2", 1);
+        jit.make("HEADS_PER_WI", 1);
 
         const auto& in_offsets_map = params.in_port_to_shape_info_offset;
         const auto& out_offsets_map = params.out_port_to_shape_info_offset;

--- a/src/plugins/intel_gpu/src/runtime/execution_config.cpp
+++ b/src/plugins/intel_gpu/src/runtime/execution_config.cpp
@@ -237,7 +237,7 @@ void ExecutionConfig::apply_model_specific_options(const IRemoteContext* context
     }
 
     if (!is_set_by_user(ov::internal::key_cache_quant_mode) || get_key_cache_quant_mode() == ov::internal::CacheQuantMode::AUTO) {
-        m_key_cache_quant_mode = ov::internal::CacheQuantMode::BY_TOKEN;
+        m_key_cache_quant_mode = ov::internal::CacheQuantMode::BY_CHANNEL;
     }
 
     if (!is_set_by_user(ov::internal::value_cache_quant_mode) || get_value_cache_quant_mode() == ov::internal::CacheQuantMode::AUTO) {

--- a/src/plugins/intel_gpu/tests/unit/dynamic_execution/update_shape_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/dynamic_execution/update_shape_test.cpp
@@ -191,6 +191,7 @@ TEST(update_shape_test, max_context_len_shapeof_subgraph) {
     pa_prim.has_alibi = false;
     pa_prim.num_outputs = 1;
     pa_prim.has_rotated_blocks = false;
+    pa_prim.is_key_by_channel = true;
 
     topology topology;
     topology.add(input_layout("input_data", input_data_layout));

--- a/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/mark_shape_of_subgraphs_test.cpp
@@ -496,6 +496,7 @@ TEST(mark_shape_of_subgraphs, paged_attention_max_context_len_input) {
     pa_prim.has_alibi = false;
     pa_prim.num_outputs = 1;
     pa_prim.has_rotated_blocks = false;
+    pa_prim.is_key_by_channel = true;
 
     topology topology;
     topology.add(input_layout("query", query_layout));
@@ -531,6 +532,7 @@ TEST(mark_shape_of_subgraphs, paged_attention_max_context_len_input) {
     ExecutionConfig config = get_test_default_config(engine);
     config.set_property(ov::intel_gpu::allow_new_shape_infer(true));
     config.set_property(ov::intel_gpu::optimize_data(true));
+    config.set_property(ov::internal::key_cache_quant_mode(ov::internal::CacheQuantMode::BY_CHANNEL));
     network network(engine, topology, config);
 
     auto prog = network.get_program();


### PR DESCRIPTION
### Details:
 - Improve pa_kv_cace_update 2nd+token perf (use more parallel threads for requantization)
 - Set key_by_channel quantization as default mode 
 - perf regression checked on BMG/DG2/LNL/MTL and it was okay

### Tickets:
 - CVS-171482
