### PR TITLE
[GPU] Fix implicit int in one of kernels.

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/pa_sdpa_opt.cl
@@ -224,8 +224,8 @@ KERNEL(pa_sdpa_opt)(
             const uint hidden_stride = ADJUSTED_PAGED_ATTENTION_BLOCK_SIZE;
     #else
             const uint block_offset = block_indice * ADJUSTED_K_HEAD_SIZE * KV_HEADS_NUM * SUBGROUP_SIZE + head_idx * ADJUSTED_K_HEAD_SIZE * SUBGROUP_SIZE;
-            const key_block_offset = block_offset;
-            const hidden_stride = SUBGROUP_SIZE;
+            const uint key_block_offset = block_offset;
+            const uint hidden_stride = SUBGROUP_SIZE;
             const uint key_comp_offset = key_block_offset + K_HEAD_SIZE * PAGED_ATTENTION_BLOCK_SIZE;
             INPUT0_TYPE* key_comp_ptr = key_cache + key_comp_offset;
             INPUT0_TYPE comp_scale = key_comp_ptr[0 + sglid];


### PR DESCRIPTION
Kernels fail to compile with LLVM16+.
ISO C99 and Opencl that bases on it does not support it.