### PR TITLE
[ONNX FE] fix data location tag */_ORT_MEM_ADDR_/* for ORT in memory data

### DIFF
--- a/src/frontends/onnx/frontend/src/core/tensor.cpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.cpp
@@ -282,7 +282,9 @@ std::shared_ptr<ov::op::v0::Constant> Tensor::get_ov_constant() const {
     }
     if (has_external_data()) {
         const auto ext_data = detail::TensorExternalData(*m_tensor_proto);
-        if (m_mmap_cache) {
+        if (ext_data.data_location() == detail::ORT_MEM_ADDR) {
+            constant = std::make_shared<ov::op::v0::Constant>(ov_type, m_shape, ext_data.load_external_mem_data());
+        } else if (m_mmap_cache) {
             constant =
                 std::make_shared<ov::op::v0::Constant>(ov_type,
                                                        m_shape,

--- a/src/frontends/onnx/frontend/src/core/tensor.hpp
+++ b/src/frontends/onnx/frontend/src/core/tensor.hpp
@@ -198,7 +198,9 @@ private:
     std::vector<T> get_external_data() const {
         const auto ext_data = detail::TensorExternalData(*m_tensor_proto);
         std::shared_ptr<ov::AlignedBuffer> buffer = nullptr;
-        if (m_mmap_cache) {
+        if (ext_data.data_location() == detail::ORT_MEM_ADDR) {
+            buffer = ext_data.load_external_mem_data();
+        } else if (m_mmap_cache) {
             buffer = ext_data.load_external_mmap_data(m_model_dir, m_mmap_cache);
         } else {
             buffer = ext_data.load_external_data(m_model_dir);

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -60,6 +60,28 @@ private:
     uint64_t m_data_length = 0;
     std::string m_sha1_digest{};
 };
+
+class MappedMemoryHolder : public ov::MappedMemory {
+public:
+    MappedMemoryHolder(char* addr_ptr, size_t length) : m_size(length) {
+        m_copied_data = std::make_shared<ov::AlignedBuffer>(length);
+        std::memcpy(m_copied_data->get_ptr<char>(), addr_ptr, length);
+    }
+
+    ~MappedMemoryHolder() {}
+
+    char* data() noexcept override {
+        return m_copied_data->get_ptr<char>();
+    }
+
+    size_t size() const noexcept override {
+        return m_size;
+    }
+
+private:
+    std::shared_ptr<ov::AlignedBuffer> m_copied_data;
+    size_t m_size = 0;
+};
 }  // namespace detail
 }  // namespace onnx
 }  // namespace frontend

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -41,6 +41,14 @@ public:
     /// \return     External binary data loaded into the SharedBuffer
     Buffer<ov::MappedMemory> load_external_mmap_data(const std::string& model_dir, MappedMemoryHandles cache) const;
 
+    /// \brief      Load external data from existing shared memory when m_data_location is ORT_MEM_ADDR
+    ///
+    /// \note       If reading data from existing shared memory fails,
+    ///             the invalid_external_data exception is thrown.
+    ///
+    /// \return     External binary data loaded into the SharedBuffer
+    Buffer<ov::AlignedBuffer> load_external_mem_data() const;
+
     /// \brief      Represets parameter of external data as string
     ///
     /// \return     State of TensorExternalData as string representation
@@ -52,6 +60,14 @@ public:
     /// \return     Returns a stored data size in bytes
     uint64_t size() const {
         return m_data_length;
+    }
+
+    /// \brief      Object contains a data location after construction. Method allows read-only access to this
+    ///             information.
+    ///
+    /// \return     Returns a stored data location
+    std::string data_location() const {
+        return m_data_location;
     }
 
 private:
@@ -69,27 +85,6 @@ location field is set to this marker, the offset field contain the address of th
 */
 const std::string ORT_MEM_ADDR = "*/_ORT_MEM_ADDR_/*";
 
-class MappedMemoryHolder : public ov::MappedMemory {
-public:
-    MappedMemoryHolder(char* addr_ptr, size_t length) : m_size(length) {
-        m_copied_data = std::make_shared<ov::AlignedBuffer>(length);
-        std::memcpy(m_copied_data->get_ptr<char>(), addr_ptr, length);
-    }
-
-    ~MappedMemoryHolder() {}
-
-    char* data() noexcept override {
-        return m_copied_data->get_ptr<char>();
-    }
-
-    size_t size() const noexcept override {
-        return m_size;
-    }
-
-private:
-    std::shared_ptr<ov::AlignedBuffer> m_copied_data;
-    size_t m_size = 0;
-};
 }  // namespace detail
 }  // namespace onnx
 }  // namespace frontend

--- a/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
+++ b/src/frontends/onnx/frontend/src/utils/tensor_external_data.hpp
@@ -61,6 +61,14 @@ private:
     std::string m_sha1_digest{};
 };
 
+/*
+As
+https://github.com/microsoft/onnxruntime/blob/4f6ae14e09729b3e3aba921de2e5bcc26d3e7768/onnxruntime/core/framework/tensorprotoutils.h#L206
+describes, this is a special marker used to indicate the external weights is already in the shared memory from ORT. if
+location field is set to this marker, the offset field contain the address of the memory.
+*/
+const std::string ORT_MEM_ADDR = "*/_ORT_MEM_ADDR_/*";
+
 class MappedMemoryHolder : public ov::MappedMemory {
 public:
     MappedMemoryHolder(char* addr_ptr, size_t length) : m_size(length) {

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -368,9 +368,8 @@ TEST_P(OnnxFeMmapFixture, onnx_external_data_from_ORT_MEM_ADDR) {
     auto fem = ov::frontend::FrontEndManager();
     auto frontend = fem.load_by_framework("onnx");
     ASSERT_NE(frontend, nullptr);
-    const bool enable_mmap = GetParam();
     std::shared_ptr<ov::frontend::InputModel> input_model;
-    ASSERT_NO_THROW(input_model = frontend->load(model_proto_ptr, enable_mmap))
+    ASSERT_NO_THROW(input_model = frontend->load(model_proto_ptr))
         << "Could not load model from modified ModelProto";
     ASSERT_NE(input_model, nullptr);
 

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+#include <onnx/onnx_pb.h>
 
 #include <algorithm>
 #include <fstream>
@@ -327,6 +328,59 @@ TEST_P(OnnxFeMmapFixture, onnx_external_data_uint4) {
     const auto model = core.read_model(path);
     auto test_case = test::TestCase(model);
     test_case.add_expected_output<uint8_t>(Shape{2, 2}, {0x80, 0x3f});
+
+    test_case.run();
+}
+
+using ::ONNX_NAMESPACE::ModelProto;
+
+TEST_P(OnnxFeMmapFixture, onnx_external_data_from_ORT_MEM_ADDR) {
+    const auto path =
+        test::utils::getModelFromTestModelZoo(string(TEST_ONNX_MODELS_DIRNAME) + "external_data/external_data.onnx");
+    std::ifstream ifs(path, std::ios::in | std::ios::binary);
+    ASSERT_TRUE(ifs.is_open()) << "Could not open model file: " << path;
+    auto model_proto = std::make_shared<ModelProto>();
+    ASSERT_TRUE(model_proto->ParseFromIstream(&ifs)) << "Could not parse ModelProto";
+    ifs.close();
+
+    std::vector<float> test_data = {2.0f, 3.0f, 4.0f, 5.0f};
+    char* data_ptr = reinterpret_cast<char*>(test_data.data());
+    uint64_t data_addr = reinterpret_cast<uint64_t>(data_ptr);
+    size_t data_size = test_data.size() * sizeof(float);
+
+    auto* graph = model_proto->mutable_graph();
+    for (auto& initializer : *graph->mutable_initializer()) {
+        if (initializer.has_data_location() && initializer.data_location() == ::ONNX_NAMESPACE::TensorProto::EXTERNAL) {
+            initializer.clear_external_data();
+            auto* location_entry = initializer.add_external_data();
+            location_entry->set_key("location");
+            location_entry->set_value("*/_ORT_MEM_ADDR_/*");
+            auto* offset_entry = initializer.add_external_data();
+            offset_entry->set_key("offset");
+            offset_entry->set_value(std::to_string(data_addr));
+            auto* length_entry = initializer.add_external_data();
+            length_entry->set_key("length");
+            length_entry->set_value(std::to_string(data_size));
+            break;
+        }
+    }
+    uint64_t model_proto_ptr = reinterpret_cast<uint64_t>(model_proto.get());
+    auto fem = ov::frontend::FrontEndManager();
+    auto frontend = fem.load_by_framework("onnx");
+    ASSERT_NE(frontend, nullptr);
+    const bool enable_mmap = GetParam();
+    std::shared_ptr<ov::frontend::InputModel> input_model;
+    ASSERT_NO_THROW(input_model = frontend->load(model_proto_ptr, enable_mmap))
+        << "Could not load model from modified ModelProto";
+    ASSERT_NE(input_model, nullptr);
+
+    std::shared_ptr<ov::Model> model;
+    ASSERT_NO_THROW(model = frontend->convert(input_model)) << "Could not convert model with ORT_MEM_ADDR";
+    ASSERT_NE(model, nullptr);
+
+    auto test_case = test::TestCase(model);
+    test_case.add_input<float>({1.f, 2.f, 3.f, 4.f});
+    test_case.add_expected_output<float>({2, 2}, {4.f, 7.f, 10.f, 13.f});
 
     test_case.run();
 }

--- a/src/frontends/onnx/tests/onnx_reader_external_data.cpp
+++ b/src/frontends/onnx/tests/onnx_reader_external_data.cpp
@@ -369,8 +369,7 @@ TEST_P(OnnxFeMmapFixture, onnx_external_data_from_ORT_MEM_ADDR) {
     auto frontend = fem.load_by_framework("onnx");
     ASSERT_NE(frontend, nullptr);
     std::shared_ptr<ov::frontend::InputModel> input_model;
-    ASSERT_NO_THROW(input_model = frontend->load(model_proto_ptr))
-        << "Could not load model from modified ModelProto";
+    ASSERT_NO_THROW(input_model = frontend->load(model_proto_ptr)) << "Could not load model from modified ModelProto";
     ASSERT_NE(input_model, nullptr);
 
     std::shared_ptr<ov::Model> model;


### PR DESCRIPTION
### Details:
 - ONNX Runtime has a magic tag \*/\_ORT_MEM_ADDR\_/\* as data location for in-memory external data, while usually the data location is a file path. OpenVINO EP only handles the file path case, if the data location is set to \*/\_ORT_MEM_ADDR\_/\* an error will be thrown.
 - `D:\onnxruntime\onnxruntime\core\providers\openvino\ov_interface.cc:68 class std::shared_ptr {}cdecl onnxruntime::openvino_ep::OVCore::ReadModel(const class std::basic_string<char,struct std::char_traits,class std::allocator > &,const class std::basic_string<char,struct std::char_traits,class std::allocator > &) const [OpenVINO-EP] [OpenVINO-EP] Exception while Reading network: invalid external data: ExternalDataInfo(data_full_path: {}/{}ORT_MEM_ADDR{}/, offset: 69492618936064, data_length: 1536)`

### Tickets:
 - *CVS-163902*
 - *CVS-166226*
