### PR TITLE
[Snippets][CPU] Fix handling negative numbers in Gemm executor, adjust its testing scenarios

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/kernel_executors/gemm.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/kernel_executors/gemm.cpp
@@ -91,7 +91,7 @@ void GemmKaiKernelExecutor::execute(const GemmKaiKernelExecutor* executor, void*
                            dst_ptr,
                            dst_stride_row,
                            dst_stride_col,
-                           std::numeric_limits<float>::min(),
+                           std::numeric_limits<float>::lowest(),
                            std::numeric_limits<float>::max());
     }
 }

--- a/src/tests/functional/plugin/shared/include/snippets/matmul.hpp
+++ b/src/tests/functional/plugin/shared/include/snippets/matmul.hpp
@@ -28,6 +28,7 @@ protected:
      */
     void filter_shape_info(const std::set<size_t>& idces_to_remove);
     virtual std::shared_ptr<MatMulFunctionBase> get_builder(const std::vector<ov::element::Type>& types) = 0;
+    void generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) override;
 
     MatMulType matmul_type;
 };

--- a/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
@@ -5,6 +5,7 @@
 #include "snippets/matmul.hpp"
 
 #include "common_test_utils/common_utils.hpp"
+#include <common_test_utils/ov_tensor_utils.hpp>
 #include "functional_test_utils/skip_tests_config.hpp"
 #include "subgraph_matmul.hpp"
 
@@ -45,6 +46,25 @@ std::string MatMul::getTestCaseName(testing::TestParamInfo<ov::test::snippets::M
     }
     return result.str();
 }
+
+void MatMulBase::generate_inputs(const std::vector<ov::Shape>& targetInputStaticShapes) {
+    inputs.clear();
+    const auto& model_inputs = function->inputs();
+
+    for (int i = 0; i < model_inputs.size(); ++i) {
+        const auto& model_input = model_inputs[i];
+        ov::Tensor tensor;
+        ov::test::utils::InputGenerateData in_data;
+        // To avoid big relative errors in the vicinity of zero, only positive values are generated for bf16 precision
+        in_data.start_from = model_input.get_element_type() == ov::element::bf16 ? 0 : -1;
+        in_data.range = 2;
+        in_data.resolution = 256;
+        tensor =
+            ov::test::utils::create_and_fill_tensor(model_input.get_element_type(), targetInputStaticShapes[i], in_data);
+        inputs.insert({model_input.get_node_shared_ptr(), tensor});
+    }
+}
+
 
 void MatMul::SetUp() {
     const auto& [input_shapes,

--- a/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
+++ b/src/tests/functional/plugin/shared/src/snippets/matmul.cpp
@@ -57,7 +57,7 @@ void MatMulBase::generate_inputs(const std::vector<ov::Shape>& targetInputStatic
         ov::test::utils::InputGenerateData in_data;
         // To avoid big relative errors in the vicinity of zero, only positive values are generated for bf16 precision
         in_data.start_from = model_input.get_element_type() == ov::element::bf16 ? 0 : -1;
-        in_data.range = 2;
+        in_data.range = 5;
         in_data.resolution = 256;
         tensor =
             ov::test::utils::create_and_fill_tensor(model_input.get_element_type(), targetInputStaticShapes[i], in_data);


### PR DESCRIPTION
### Details:
 - Fix handling negative values in Gemm executor that uses KleidiAI on aarch64
 - Enable testing of Matmul on randomly generated tensor data including negative numbers

### Tickets:
 - required for 167005
