### PR TITLE
[GPU] Allow U8 data type for SDPA attention mask

### DIFF
--- a/src/core/src/op/scaled_dot_product_attention.cpp
+++ b/src/core/src/op/scaled_dot_product_attention.cpp
@@ -46,12 +46,12 @@ void op::v13::ScaledDotProductAttention::validate_and_infer_types() {
         const auto& attention_type = get_input_element_type(3);
         NODE_VALIDATION_CHECK(
             this,
-            attention_type.is_real() || attention_type == element::boolean || attention_type.is_dynamic(),
+            attention_type.is_real() || attention_type == element::boolean || attention_type == element::u8 || attention_type.is_dynamic(),
             "The element type of attention_mask must be either floating-point or boolean.");
     }
     for (size_t i = 1; i < input_size; i++) {
         const auto& element_type = get_input_element_type(i);
-        if (i == 3 && (element_type == element::boolean || causal)) {
+        if (i == 3 && (element_type == element::boolean || element_type == element::u8 || causal)) {
             // Skip checking attention_mask in loop when boolean or skipped to not affect merged dtype.
             continue;
         }

--- a/src/core/src/op/scaled_dot_product_attention.cpp
+++ b/src/core/src/op/scaled_dot_product_attention.cpp
@@ -44,10 +44,10 @@ void op::v13::ScaledDotProductAttention::validate_and_infer_types() {
     const auto& causal = get_causal();
     if (input_size >= 4 && !causal) {
         const auto& attention_type = get_input_element_type(3);
-        NODE_VALIDATION_CHECK(
-            this,
-            attention_type.is_real() || attention_type == element::boolean || attention_type == element::u8 || attention_type.is_dynamic(),
-            "The element type of attention_mask must be either floating-point or boolean.");
+        NODE_VALIDATION_CHECK(this,
+                              attention_type.is_real() || attention_type == element::boolean ||
+                                  attention_type == element::u8 || attention_type.is_dynamic(),
+                              "The element type of attention_mask must be either floating-point or boolean.");
     }
     for (size_t i = 1; i < input_size; i++) {
         const auto& element_type = get_input_element_type(i);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa/sdpa_base.cpp
@@ -212,7 +212,11 @@ JitConstants SDPABase::get_jit_constants(const kernel_impl_params& params) const
             jit.make("STATIC_SCALAR_ATTN_MASK_VALUE", desc->attn_mask_val.value());
             jit.make("HAS_ATTN_MASK_INPUT", 0);
         } else {
-            jit.make("HAS_ATTN_MASK_INPUT", data_inputs_num > attn_mask_id);
+            const bool has_attn_mask_input = data_inputs_num > attn_mask_id;
+            jit.make("HAS_ATTN_MASK_INPUT", has_attn_mask_input);
+            if (has_attn_mask_input && params.get_input_layout(attn_mask_id).data_type == ov::element::u8) {
+                jit.make("ATTN_MASK_TYPE_UCHAR", 1);
+            }
         }
 
         jit.make("IS_KV_COMPRESSED", desc->is_kv_compressed);

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_opt.cl
@@ -433,7 +433,11 @@ KERNEL(sdpa_opt)(
                             qk_val[seq_idx] += INPUT0_VAL_MIN;
 #elif !IS_CAUSAL && HAS_ATTN_MASK_INPUT
                         const uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0_idx, b1_idx, target_seq_idx + seq_idx, start_partition_idx + seq_len);
+#if ATTN_MASK_TYPE_UCHAR
+                        qk_val[seq_idx] += (attn_mask[attn_mask_offset] == 0 ? INPUT0_VAL_MIN : INPUT0_VAL_ZERO);
+#else
                         qk_val[seq_idx] += attn_mask[attn_mask_offset];
+#endif
 #elif defined(STATIC_SCALAR_ATTN_MASK_VALUE)
                         qk_val[seq_idx] += STATIC_SCALAR_ATTN_MASK_VALUE;
 #endif
@@ -771,13 +775,21 @@ inline MASK_VECTOR_TYPE FUNC(load_attn_mask)(OPTIONAL_SHAPE_INFO_ARG
         if (source_seq_idx + SUBGROUP_SIZE <= (uint)SOURCE_SEQ_LEN) {
             unroll_for (uint i = 0; i < SUBGROUP_SIZE; i++) {
                 const INPUT3_TYPE mask_val = attn_mask[attn_mask_offset + i];
+#if ATTN_MASK_TYPE_UCHAR
+                mask_vec[i] = mask_val == 0 ? INPUT0_VAL_MIN : INPUT0_VAL_ZERO;
+#else
                 mask_vec[i] = mask_val;
+#endif
             }
         } else {
             const uint max_mask_offset = min(source_seq_idx + SUBGROUP_SIZE, (uint)SOURCE_SEQ_LEN);
             for (uint i = 0; i < SUBGROUP_SIZE; i++) {
                 const INPUT3_TYPE mask_val = source_seq_idx + i < max_mask_offset ? attn_mask[attn_mask_offset + i] : NAN;
+#if ATTN_MASK_TYPE_UCHAR
+                mask_vec[i] = mask_val == 0 ? INPUT0_VAL_MIN : INPUT0_VAL_ZERO;
+#else
                 mask_vec[i] = mask_val;
+#endif
             }
         }
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_ref.cl
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/sdpa_ref.cl
@@ -228,7 +228,11 @@ KERNEL(sdpa_ref)(
             OUTPUT_TYPE attn_mask_val = s > target_seq_idx ? OUTPUT_VAL_MIN : 0;
 #elif !IS_CAUSAL && HAS_ATTN_MASK_INPUT
             uint attn_mask_offset = INPUT3_GET_INDEX_SAFE(b0, b1, target_seq_idx, s);
+#if ATTN_MASK_TYPE_UCHAR
+            OUTPUT_TYPE attn_mask_val = attn_mask[attn_mask_offset] == 0 ? INPUT0_VAL_MIN : INPUT0_VAL_ZERO;
+#else
             OUTPUT_TYPE attn_mask_val = attn_mask[attn_mask_offset];
+#endif
 #elif defined(STATIC_SCALAR_ATTN_MASK_VALUE)
             OUTPUT_TYPE attn_mask_val = TO_OUTPUT_TYPE(STATIC_SCALAR_ATTN_MASK_VALUE);
 #else

--- a/tests/llm/accuracy_conformance.py
+++ b/tests/llm/accuracy_conformance.py
@@ -96,9 +96,6 @@ test_scope = init_test_scope()
     test_scope,
 )
 def test_accuracy_conformance(model_path, model_type, precision, gt_data, device):
-    if device == "GPU":
-        pytest.skip("CVS-171598")
-
     target_model = OVModelForCausalLM.from_pretrained(model_path, device=device, ov_config={"KV_CACHE_PRECISION": "f16"})
     tokenizer = AutoTokenizer.from_pretrained(model_path)
 

--- a/tests/llm/accuracy_conformance.py
+++ b/tests/llm/accuracy_conformance.py
@@ -96,6 +96,9 @@ test_scope = init_test_scope()
     test_scope,
 )
 def test_accuracy_conformance(model_path, model_type, precision, gt_data, device):
+    if device == "GPU":
+        pytest.skip("CVS-171598")
+
     target_model = OVModelForCausalLM.from_pretrained(model_path, device=device, ov_config={"KV_CACHE_PRECISION": "f16"})
     tokenizer = AutoTokenizer.from_pretrained(model_path)
 


### PR DESCRIPTION
### Details:
 - Some LLMs, such as Qwen2-0.5B, the attention mask input type of IR converted from the latest transformers version(>=4.53.0) has been changed from floating-point to boolean
 - Boolean is converted to U8 by `ConvertPrecision` transformation. But this is not allowed by op validation now
 - So allow U8 data type for SDPA attention mask and relaxes op validation's condition for U8

### Tickets:
 - 171598, 171516
