### PR TITLE
Support for output-specific pattern matching

### DIFF
--- a/src/core/include/openvino/pass/pattern/op/pattern.hpp
+++ b/src/core/include/openvino/pass/pattern/op/pattern.hpp
@@ -67,6 +67,9 @@ OPENVINO_API op::Predicate attrs_match(const Attributes& expected_attrs);
 OPENVINO_API op::Predicate shape_matches(const std::string& shape_notation);
 OPENVINO_API op::Predicate value_matches(const std::string& value_notation);
 
+OPENVINO_API op::Predicate output_index_matches(size_t expected_index);
+OPENVINO_API op::Predicate output_index_matches(const std::vector<size_t>& expected_indices);
+
 namespace op {
 OPENVINO_DEPRECATED("This method is deprecated. Use constructor of ov::pass::pattern::Predicate instead")
 OPENVINO_API Predicate as_value_predicate(NodePredicate pred);

--- a/src/core/src/pattern/op/pattern.cpp
+++ b/src/core/src/pattern/op/pattern.cpp
@@ -627,11 +627,12 @@ op::Predicate output_index_matches(size_t expected_index) {
 op::Predicate output_index_matches(const std::vector<size_t>& expected_indices) {
     std::string indices_str = "{";
     for (size_t i = 0; i < expected_indices.size(); ++i) {
-        if (i > 0) indices_str += ", ";
+        if (i > 0)
+            indices_str += ", ";
         indices_str += std::to_string(expected_indices[i]);
     }
     indices_str += "}";
-    
+
     return op::Predicate(
         [=](const Output<Node>& output) -> bool {
             const auto output_index = output.get_index();

--- a/src/core/src/pattern/op/pattern.cpp
+++ b/src/core/src/pattern/op/pattern.cpp
@@ -615,4 +615,29 @@ op::Predicate value_matches(const std::string& value_notation) {
         },
         "value_matches('" + value_notation + "')");
 }
+
+op::Predicate output_index_matches(size_t expected_index) {
+    return op::Predicate(
+        [=](const Output<Node>& output) -> bool {
+            return output.get_index() == expected_index;
+        },
+        "output_index_matches(" + std::to_string(expected_index) + ")");
+}
+
+op::Predicate output_index_matches(const std::vector<size_t>& expected_indices) {
+    std::string indices_str = "{";
+    for (size_t i = 0; i < expected_indices.size(); ++i) {
+        if (i > 0) indices_str += ", ";
+        indices_str += std::to_string(expected_indices[i]);
+    }
+    indices_str += "}";
+    
+    return op::Predicate(
+        [=](const Output<Node>& output) -> bool {
+            const auto output_index = output.get_index();
+            return std::find(expected_indices.begin(), expected_indices.end(), output_index) != expected_indices.end();
+        },
+        "output_index_matches(" + indices_str + ")");
+}
+
 }  // namespace ov::pass::pattern

--- a/src/core/tests/pattern.cpp
+++ b/src/core/tests/pattern.cpp
@@ -1582,7 +1582,7 @@ TEST(pattern, predicate_syntactic_sugar) {
 
 TEST(pattern, output_index_matches_predicate) {
     TestMatcher tm;
-    
+
     // Create a VariadicSplit with 3 outputs
     auto input = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 20, 30});
     auto axis = op::v0::Constant::create(element::i64, {}, {-1});
@@ -1594,20 +1594,20 @@ TEST(pattern, output_index_matches_predicate) {
     auto pred_0 = pattern::output_index_matches(0);
     auto pred_1 = pattern::output_index_matches(1);
     auto pred_2 = pattern::output_index_matches(2);
-    
-    // Test predicates directly  
+
+    // Test predicates directly
     ASSERT_TRUE(pred_0(variadic_split->output(0)));
     ASSERT_FALSE(pred_0(variadic_split->output(1)));
     ASSERT_FALSE(pred_0(variadic_split->output(2)));
-    
+
     ASSERT_FALSE(pred_1(variadic_split->output(0)));
     ASSERT_TRUE(pred_1(variadic_split->output(1)));
     ASSERT_FALSE(pred_1(variadic_split->output(2)));
-    
+
     ASSERT_FALSE(pred_2(variadic_split->output(0)));
     ASSERT_FALSE(pred_2(variadic_split->output(1)));
     ASSERT_TRUE(pred_2(variadic_split->output(2)));
-    
+
     // Test vector version
     auto pred_multi = pattern::output_index_matches({0, 2});
     ASSERT_TRUE(pred_multi(variadic_split->output(0)));
@@ -1619,72 +1619,72 @@ TEST(pattern, output_index_matches_predicate) {
     auto pattern_out1 = pattern::any_input(pattern::output_index_matches(1));
     auto pattern_out2 = pattern::any_input(pattern::output_index_matches(2));
     auto pattern_out3 = pattern::any_input(pattern::output_index_matches(3));  // non-existent output
-    
+
     // Test matching different outputs using match_value
     ASSERT_TRUE(tm.match_value(pattern_out0, variadic_split->output(0)));
     ASSERT_FALSE(tm.match_value(pattern_out0, variadic_split->output(1)));
     ASSERT_FALSE(tm.match_value(pattern_out0, variadic_split->output(2)));
-    
+
     ASSERT_FALSE(tm.match_value(pattern_out1, variadic_split->output(0)));
     ASSERT_TRUE(tm.match_value(pattern_out1, variadic_split->output(1)));
     ASSERT_FALSE(tm.match_value(pattern_out1, variadic_split->output(2)));
-    
+
     ASSERT_FALSE(tm.match_value(pattern_out2, variadic_split->output(0)));
     ASSERT_FALSE(tm.match_value(pattern_out2, variadic_split->output(1)));
     ASSERT_TRUE(tm.match_value(pattern_out2, variadic_split->output(2)));
-    
+
     ASSERT_FALSE(tm.match_value(pattern_out3, variadic_split->output(0)));
     ASSERT_FALSE(tm.match_value(pattern_out3, variadic_split->output(1)));
     ASSERT_FALSE(tm.match_value(pattern_out3, variadic_split->output(2)));
-    
+
     // Test pattern matching multiple output indices - simplified test
     auto pattern_multi = pattern::any_input(pattern::output_index_matches({0, 2}));
-    
+
     // Test with regular Matcher instead of TestMatcher
     ov::pass::pattern::Matcher m1(pattern_multi);
     ASSERT_TRUE(m1.match(variadic_split->output(0)));
-    
+
     ov::pass::pattern::Matcher m2(pattern_multi);
     ASSERT_FALSE(m2.match(variadic_split->output(1)));
-    
+
     ov::pass::pattern::Matcher m3(pattern_multi);
     ASSERT_TRUE(m3.match(variadic_split->output(2)));
 }
 
 TEST(pattern, wrap_type_with_output_index_constraint) {
     TestMatcher tm;
-    
+
     // Create a VariadicSplit with 3 outputs
     auto input = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 20, 30});
     auto axis = op::v0::Constant::create(element::i64, {}, {-1});
     auto split_lengths = op::v0::Constant::create(element::i64, {3}, {5, 10, 15});
     auto variadic_split = std::make_shared<op::v1::VariadicSplit>(input, axis, split_lengths);
     variadic_split->set_output_size(3);
-    
+
     // Create reshapes that use different outputs
     auto reshape_shape = op::v0::Constant::create(element::i64, {2}, {-1, 5});
     auto reshape0 = std::make_shared<op::v1::Reshape>(variadic_split->output(0), reshape_shape, false);
     auto reshape1 = std::make_shared<op::v1::Reshape>(variadic_split->output(1), reshape_shape, false);
     auto reshape2 = std::make_shared<op::v1::Reshape>(variadic_split->output(2), reshape_shape, false);
-    
+
     // Create patterns that match Reshape with specific VariadicSplit output
     auto vsplit_out0 = pattern::wrap_type<op::v1::VariadicSplit>(pattern::output_index_matches(0));
     auto vsplit_out1 = pattern::wrap_type<op::v1::VariadicSplit>(pattern::output_index_matches(1));
     auto vsplit_out2 = pattern::wrap_type<op::v1::VariadicSplit>(pattern::output_index_matches(2));
-    
+
     auto pattern_reshape_out0 = pattern::wrap_type<op::v1::Reshape>({vsplit_out0, pattern::any_input()});
     auto pattern_reshape_out1 = pattern::wrap_type<op::v1::Reshape>({vsplit_out1, pattern::any_input()});
     auto pattern_reshape_out2 = pattern::wrap_type<op::v1::Reshape>({vsplit_out2, pattern::any_input()});
-    
+
     // Test that patterns match only corresponding reshapes
     ASSERT_TRUE(tm.match(pattern_reshape_out0, reshape0));
     ASSERT_FALSE(tm.match(pattern_reshape_out0, reshape1));
     ASSERT_FALSE(tm.match(pattern_reshape_out0, reshape2));
-    
+
     ASSERT_FALSE(tm.match(pattern_reshape_out1, reshape0));
     ASSERT_TRUE(tm.match(pattern_reshape_out1, reshape1));
     ASSERT_FALSE(tm.match(pattern_reshape_out1, reshape2));
-    
+
     ASSERT_FALSE(tm.match(pattern_reshape_out2, reshape0));
     ASSERT_FALSE(tm.match(pattern_reshape_out2, reshape1));
     ASSERT_TRUE(tm.match(pattern_reshape_out2, reshape2));

--- a/src/core/tests/pattern.cpp
+++ b/src/core/tests/pattern.cpp
@@ -1579,3 +1579,113 @@ TEST(pattern, predicate_syntactic_sugar) {
     ASSERT_NO_THROW(pattern::wrap_type<op::v0::Relu>(pattern::wrap_type<op::v0::Relu>()));
     ASSERT_NO_THROW(pattern::wrap_type<op::v0::Relu>("[-1,0,1]"));
 }
+
+TEST(pattern, output_index_matches_predicate) {
+    TestMatcher tm;
+    
+    // Create a VariadicSplit with 3 outputs
+    auto input = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 20, 30});
+    auto axis = op::v0::Constant::create(element::i64, {}, {-1});
+    auto split_lengths = op::v0::Constant::create(element::i64, {3}, {5, 10, 15});
+    auto variadic_split = std::make_shared<op::v1::VariadicSplit>(input, axis, split_lengths);
+    variadic_split->set_output_size(3);
+
+    // Test basic output_index_matches predicate functionality
+    auto pred_0 = pattern::output_index_matches(0);
+    auto pred_1 = pattern::output_index_matches(1);
+    auto pred_2 = pattern::output_index_matches(2);
+    
+    // Test predicates directly  
+    ASSERT_TRUE(pred_0(variadic_split->output(0)));
+    ASSERT_FALSE(pred_0(variadic_split->output(1)));
+    ASSERT_FALSE(pred_0(variadic_split->output(2)));
+    
+    ASSERT_FALSE(pred_1(variadic_split->output(0)));
+    ASSERT_TRUE(pred_1(variadic_split->output(1)));
+    ASSERT_FALSE(pred_1(variadic_split->output(2)));
+    
+    ASSERT_FALSE(pred_2(variadic_split->output(0)));
+    ASSERT_FALSE(pred_2(variadic_split->output(1)));
+    ASSERT_TRUE(pred_2(variadic_split->output(2)));
+    
+    // Test vector version
+    auto pred_multi = pattern::output_index_matches({0, 2});
+    ASSERT_TRUE(pred_multi(variadic_split->output(0)));
+    ASSERT_FALSE(pred_multi(variadic_split->output(1)));
+    ASSERT_TRUE(pred_multi(variadic_split->output(2)));
+
+    // Test pattern matching specific output index
+    auto pattern_out0 = pattern::any_input(pattern::output_index_matches(0));
+    auto pattern_out1 = pattern::any_input(pattern::output_index_matches(1));
+    auto pattern_out2 = pattern::any_input(pattern::output_index_matches(2));
+    auto pattern_out3 = pattern::any_input(pattern::output_index_matches(3));  // non-existent output
+    
+    // Test matching different outputs using match_value
+    ASSERT_TRUE(tm.match_value(pattern_out0, variadic_split->output(0)));
+    ASSERT_FALSE(tm.match_value(pattern_out0, variadic_split->output(1)));
+    ASSERT_FALSE(tm.match_value(pattern_out0, variadic_split->output(2)));
+    
+    ASSERT_FALSE(tm.match_value(pattern_out1, variadic_split->output(0)));
+    ASSERT_TRUE(tm.match_value(pattern_out1, variadic_split->output(1)));
+    ASSERT_FALSE(tm.match_value(pattern_out1, variadic_split->output(2)));
+    
+    ASSERT_FALSE(tm.match_value(pattern_out2, variadic_split->output(0)));
+    ASSERT_FALSE(tm.match_value(pattern_out2, variadic_split->output(1)));
+    ASSERT_TRUE(tm.match_value(pattern_out2, variadic_split->output(2)));
+    
+    ASSERT_FALSE(tm.match_value(pattern_out3, variadic_split->output(0)));
+    ASSERT_FALSE(tm.match_value(pattern_out3, variadic_split->output(1)));
+    ASSERT_FALSE(tm.match_value(pattern_out3, variadic_split->output(2)));
+    
+    // Test pattern matching multiple output indices - simplified test
+    auto pattern_multi = pattern::any_input(pattern::output_index_matches({0, 2}));
+    
+    // Test with regular Matcher instead of TestMatcher
+    ov::pass::pattern::Matcher m1(pattern_multi);
+    ASSERT_TRUE(m1.match(variadic_split->output(0)));
+    
+    ov::pass::pattern::Matcher m2(pattern_multi);
+    ASSERT_FALSE(m2.match(variadic_split->output(1)));
+    
+    ov::pass::pattern::Matcher m3(pattern_multi);
+    ASSERT_TRUE(m3.match(variadic_split->output(2)));
+}
+
+TEST(pattern, wrap_type_with_output_index_constraint) {
+    TestMatcher tm;
+    
+    // Create a VariadicSplit with 3 outputs
+    auto input = std::make_shared<op::v0::Parameter>(element::f32, Shape{10, 20, 30});
+    auto axis = op::v0::Constant::create(element::i64, {}, {-1});
+    auto split_lengths = op::v0::Constant::create(element::i64, {3}, {5, 10, 15});
+    auto variadic_split = std::make_shared<op::v1::VariadicSplit>(input, axis, split_lengths);
+    variadic_split->set_output_size(3);
+    
+    // Create reshapes that use different outputs
+    auto reshape_shape = op::v0::Constant::create(element::i64, {2}, {-1, 5});
+    auto reshape0 = std::make_shared<op::v1::Reshape>(variadic_split->output(0), reshape_shape, false);
+    auto reshape1 = std::make_shared<op::v1::Reshape>(variadic_split->output(1), reshape_shape, false);
+    auto reshape2 = std::make_shared<op::v1::Reshape>(variadic_split->output(2), reshape_shape, false);
+    
+    // Create patterns that match Reshape with specific VariadicSplit output
+    auto vsplit_out0 = pattern::wrap_type<op::v1::VariadicSplit>(pattern::output_index_matches(0));
+    auto vsplit_out1 = pattern::wrap_type<op::v1::VariadicSplit>(pattern::output_index_matches(1));
+    auto vsplit_out2 = pattern::wrap_type<op::v1::VariadicSplit>(pattern::output_index_matches(2));
+    
+    auto pattern_reshape_out0 = pattern::wrap_type<op::v1::Reshape>({vsplit_out0, pattern::any_input()});
+    auto pattern_reshape_out1 = pattern::wrap_type<op::v1::Reshape>({vsplit_out1, pattern::any_input()});
+    auto pattern_reshape_out2 = pattern::wrap_type<op::v1::Reshape>({vsplit_out2, pattern::any_input()});
+    
+    // Test that patterns match only corresponding reshapes
+    ASSERT_TRUE(tm.match(pattern_reshape_out0, reshape0));
+    ASSERT_FALSE(tm.match(pattern_reshape_out0, reshape1));
+    ASSERT_FALSE(tm.match(pattern_reshape_out0, reshape2));
+    
+    ASSERT_FALSE(tm.match(pattern_reshape_out1, reshape0));
+    ASSERT_TRUE(tm.match(pattern_reshape_out1, reshape1));
+    ASSERT_FALSE(tm.match(pattern_reshape_out1, reshape2));
+    
+    ASSERT_FALSE(tm.match(pattern_reshape_out2, reshape0));
+    ASSERT_FALSE(tm.match(pattern_reshape_out2, reshape1));
+    ASSERT_TRUE(tm.match(pattern_reshape_out2, reshape2));
+}


### PR DESCRIPTION
### Details:
The current pattern matching system in OpenVINO's new symbols machinery has a critical limitation when dealing with multi-output operations. When patterns specify a particular output index (e.g., qkv_proj->output(0)), the pattern matcher would
   incorrectly match any output from that operation, not specifically the requested output index.

  Example of the Problem:
  // Pattern intended to match specifically output 0 of VariadicSplit
  auto pattern = wrap_type<ov::op::v1::VariadicSplit>([](const Output<Node>& output) {
      // This predicate runs on ALL outputs, not just output(0)
      return /* some condition */;
  });

  // This pattern would incorrectly match variadic_split->output(1) or output(2)
  // when we specifically wanted output(0)

  This forced developers to implement workarounds in transformation callbacks, manually checking the actual output index after pattern matching, leading to:
  - False positive matches requiring additional validation
  - Complex callback logic to filter correct outputs
  - Reduced pattern matching precision and performance
  - Error-prone transformations due to manual index verification

  Solution

  This PR introduces two new pattern predicates that enable output-specific pattern matching:

  1. Single Output Index Matching

  op::Predicate output_index_matches(size_t expected_index);

  2. Multiple Output Index Matching

  op::Predicate output_index_matches(const std::vector<size_t>& expected_indices);

  Usage Examples

  Before (requiring workarounds):
  auto pattern = wrap_type<ov::op::v1::VariadicSplit>();
  // Pattern matches any output, requiring callback validation

  matcher.register_matcher(pass, pattern, [](pattern::Matcher& m) {
      auto variadic_split = m.get_match_root();
      // Manual workaround: check if matched output is actually output(0)
      if (/* complex logic to verify output index */) {
          // Perform transformation
      }
  });
 After (clean and precise):
  auto pattern = wrap_type<ov::op::v1::VariadicSplit>(output_index_matches(0));
  // Pattern only matches output(0) specifically

  matcher.register_matcher(pass, pattern, [](pattern::Matcher& m) {
      // No additional validation needed - guaranteed to be output(0)
      // Perform transformation directly
  });

  Multiple indices support:
  auto pattern = wrap_type<ov::op::v1::VariadicSplit>(output_index_matches({0, 2}));
  // Matches only outputs 0 and 2, but not 1

### Tickets:
 - 171629
