### PR TITLE
[IE-MDK][NPU] Enable canRun3RequestsConsistently tests

### DIFF
--- a/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
+++ b/src/plugins/intel_npu/tests/functional/shared_tests_instances/npu_skip_func_tests.xml
@@ -697,42 +697,14 @@ Example:
         </filters>
     </skip_config>
 
-    <!-- E#125086 -->
+    <!-- E####### -->
     <skip_config>
-        <message>Failing tests after functional tests migration to OV</message>
+        <message>Test will set NPU_TILES to -1 which is an invalid value, in this case default values don't work</message>
         <enable_rules>
             <backend>LEVEL0</backend>
-            <device>3720</device>
-            <device>4000</device>
         </enable_rules>
         <filters>
             <filter>.*OVCompiledModelPropertiesDefaultSupportedTests.CanCompileWithDefaultValueFromPlugin.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#125086 -->
-    <skip_config>
-        <message>Failing tests after functional tests migration to OV</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <device>3720</device>
-            <operating_system>windows</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*OVInferRequestPerfCountersExceptionTest.perfCountWereNotEnabledExceptionTest.*</filter>
-        </filters>
-    </skip_config>
-
-    <!-- E#125086 -->
-    <skip_config>
-        <message>Failing tests after functional tests migration to OV</message>
-        <enable_rules>
-            <backend>LEVEL0</backend>
-            <device>3720</device>
-            <operating_system>linux</operating_system>
-        </enable_rules>
-        <filters>
-            <filter>.*OVInferRequestMultithreadingTests.canRun3AsyncRequestsConsistently.*</filter>
         </filters>
     </skip_config>
 


### PR DESCRIPTION
### Details:
 - Enables perfCountWereNotEnabledExceptionTest and canRun3AsyncRequestsConsistently

### Tickets:
 - E#125086
