### PR TITLE
[GPU] Fix nan values in SoftPlus

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -732,17 +732,17 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
                 return;
             }
 
-            auto& input = activation_node.get_dependency(0);
-            if (activation_node.get_dependencies().size() >= 3)
-                return;
-
-            if (activation_func == cldnn::activation_func::softplus) {
+            if (activation_func == cldnn::activation_func::softplus && activation_node.get_output_layout().data_type == data_types::f16) {
                 // This is WA :
                 // - SoftPlus can overflow on f16 so that jitter.cpp currently resolves by typecasting to f32
                 // - But it doesn't guarantee the case of fusion.
                 // - For now it needs to disable fusion for SoftPlus.
                 return;
             }
+
+            auto& input = activation_node.get_dependency(0);
+            if (activation_node.get_dependencies().size() >= 3)
+                return;
 
             if (!input_data_supports_fusings(input, activation_node.id()) || input.get_dependencies().empty())
                 return;

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_primitive_fusing.cpp
@@ -736,6 +736,14 @@ void prepare_primitive_fusing::fuse_simple_primitives(program &p) {
             if (activation_node.get_dependencies().size() >= 3)
                 return;
 
+            if (activation_func == cldnn::activation_func::softplus) {
+                // This is WA :
+                // - SoftPlus can overflow on f16 so that jitter.cpp currently resolves by typecasting to f32
+                // - But it doesn't guarantee the case of fusion.
+                // - For now it needs to disable fusion for SoftPlus.
+                return;
+            }
+
             if (!input_data_supports_fusings(input, activation_node.id()) || input.get_dependencies().empty())
                 return;
 

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -969,9 +969,8 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
     }
     case activation_func::softplus: {
         const JitTerm input_f = out_dt == ov::element::f16 ? JitTerm{"convert_float(input)"} : input;
-        const JitTerm output = out_dt == ov::element::f16
-                ? JitTerm{"convert_half(" + log(exp(input_f) + one).str() + ")"}
-                : JitTerm{(log(exp(input_f) + one)).str()};
+        const JitTerm output =
+            out_dt == ov::element::f16 ? JitTerm{"convert_half(" + log(exp(input_f) + one).str() + ")"} : JitTerm{(log(exp(input_f) + one)).str()};
         jit.add(make_jit_constant(macro_def, output));
         break;
     }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -968,10 +968,7 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
         break;
     }
     case activation_func::softplus: {
-        const JitTerm input_f = out_dt == ov::element::f16 ? JitTerm{"convert_float(input)"} : input;
-        const JitTerm output =
-            out_dt == ov::element::f16 ? JitTerm{"convert_half(" + log(exp(input_f) + one).str() + ")"} : JitTerm{(log(exp(input_f) + one)).str()};
-        jit.add(make_jit_constant(macro_def, output));
+        jit.add(make_jit_constant(macro_def, log(exp(input) + one)));
         break;
     }
     case activation_func::softsign: {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -968,8 +968,11 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
         break;
     }
     case activation_func::softplus: {
-        const JitTerm input_f = out_dt == ov::element::f16 ? JitTerm{"(float)input"} : input;
-        jit.add(make_jit_constant(macro_def, log(exp(input_f) + one)));
+        const JitTerm input_f = out_dt == ov::element::f16 ? JitTerm{"convert_float(input)"} : input;
+        const JitTerm output = out_dt == ov::element::f16
+                ? JitTerm{"convert_half(" + log(exp(input_f) + one).str() + ")"}
+                : JitTerm{(log(exp(input_f) + one)).str()};
+        jit.add(make_jit_constant(macro_def, output));
         break;
     }
     case activation_func::softsign: {

--- a/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl_v2/utils/fused_ops_jitter.cpp
@@ -968,7 +968,8 @@ JitConstants make_activation_jit_constants(const std::string& suffix,
         break;
     }
     case activation_func::softplus: {
-        jit.add(make_jit_constant(macro_def, log(exp(input) + one)));
+        const JitTerm input_f = out_dt == ov::element::f16 ? JitTerm{"(float)input"} : input;
+        jit.add(make_jit_constant(macro_def, log(exp(input_f) + one)));
         break;
     }
     case activation_func::softsign: {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1290,8 +1290,11 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
             break;
         }
         case ActivationFunction::SOFTPLUS: {
-            const JitTerm input_f = out_dt == Datatype::F16 ? JitTerm{"(float)input"} : input;
-            jitConstants.AddConstant(MakeJitConstant(macro_def, log(exp(input_f) + one).str()));
+            const JitTerm input_f = out_dt == Datatype::F16 ? JitTerm{"convert_float(input)"} : input;
+            const JitTerm output = out_dt == Datatype::F16
+                    ? JitTerm{"convert_half(" + (log(exp(input_f) + one)).str() + ")"}
+                    : JitTerm{(log(exp(input_f) + one)).str()};
+            jitConstants.AddConstant(MakeJitConstant(macro_def, output.str()));
             break;
         }
         case ActivationFunction::SOFTSIGN: {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1290,9 +1290,8 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
             break;
         }
         case ActivationFunction::SOFTPLUS: {
-            jitConstants.AddConstant(MakeJitConstant(
-                    macro_def,
-                    log(exp(input) + one).str()));
+            const JitTerm input_f = out_dt == Datatype::F16 ? JitTerm{"(float)input"} : input;
+            jitConstants.AddConstant(MakeJitConstant(macro_def, log(exp(input_f) + one).str()));
             break;
         }
         case ActivationFunction::SOFTSIGN: {

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -1291,9 +1291,8 @@ JitConstants MakeActivationJitConstants(ActivationFunction activation_function,
         }
         case ActivationFunction::SOFTPLUS: {
             const JitTerm input_f = out_dt == Datatype::F16 ? JitTerm{"convert_float(input)"} : input;
-            const JitTerm output = out_dt == Datatype::F16
-                    ? JitTerm{"convert_half(" + (log(exp(input_f) + one)).str() + ")"}
-                    : JitTerm{(log(exp(input_f) + one)).str()};
+            const JitTerm output =
+                out_dt == Datatype::F16 ? JitTerm{"convert_half(" + (log(exp(input_f) + one)).str() + ")"} : JitTerm{(log(exp(input_f) + one)).str()};
             jitConstants.AddConstant(MakeJitConstant(macro_def, output.str()));
             break;
         }

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_opt.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/activation/activation_kernel_opt.cpp
@@ -98,6 +98,10 @@ bool ActivationKernelOpt::Validate(const Params& p) const {
         }
     }
 
+    if (params.activations[0].function == ActivationFunction::SOFTPLUS && input_dt == Datatype::F16) {
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
+    }
+
     return true;
 }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/activation_simple_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/activation_simple_gpu_test.cpp
@@ -11,6 +11,7 @@
 #include <intel_gpu/primitives/reorder.hpp>
 #include <intel_gpu/primitives/reshape.hpp>
 #include <intel_gpu/primitives/concatenation.hpp>
+#include <intel_gpu/primitives/permute.hpp>
 #include "activation_inst.h"
 
 #include <cmath>
@@ -699,6 +700,47 @@ TEST(activation_f16_fw_gpu, pow_basic_yxfb) {
 
     for (size_t i = 0; i < output_vec.size(); ++i) {
         ASSERT_FLOAT_EQ(output_vec[i], output_ptr[i]);
+    }
+}
+
+TEST(activation_f16_fw_gpu, softplus_fused_no_overflow) {
+    auto& engine = get_test_engine();
+
+    tensor input_shape{2, 4, 2, 3};
+    auto input = engine.allocate_memory({data_types::f16, format::bfyx, input_shape});
+    set_values<ov::float16>(input, std::vector<ov::float16>(input_shape.count(), ov::float16(12.0f)));
+
+    auto zero = engine.allocate_memory({data_types::f16, format::bfyx, input_shape});
+    set_values<ov::float16>(zero, std::vector<ov::float16>(input_shape.count(), ov::float16(0.0f)));
+
+    topology topology(input_layout("input", input->get_layout()),
+                      data("zero", zero),
+                      eltwise("sum", input_info("input"), input_info("zero"), eltwise_mode::sum),
+                      activation("softplus", input_info("sum"), activation_func::softplus),
+                      permute("permute", input_info("softplus"), {0, 1, 2, 3}));
+
+    ExecutionConfig config_fuse = get_test_default_config(engine);
+    config_fuse.set_property(ov::intel_gpu::optimize_data(true));
+    network network_fuse(engine, topology, config_fuse);
+    network_fuse.set_input_data("input", input);
+    auto output_fuse = network_fuse.execute().begin()->second.get_memory();
+
+    ExecutionConfig config_unfuse = get_test_default_config(engine);
+    config_unfuse.set_property(ov::intel_gpu::optimize_data(false));
+    network network_unfuse(engine, topology, config_unfuse);
+    network_unfuse.set_input_data("input", input);
+    auto output_unfuse = network_unfuse.execute().begin()->second.get_memory();
+
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> fuse_ptr(output_fuse, get_test_stream());
+    cldnn::mem_lock<ov::float16, mem_lock_type::read> unfuse_ptr(output_unfuse, get_test_stream());
+
+    for (size_t i = 0; i < fuse_ptr.size(); ++i) {
+        float fuse_val = static_cast<float>(fuse_ptr[i]);
+        float unfuse_val = static_cast<float>(unfuse_ptr[i]);
+
+        ASSERT_FALSE(std::isinf(fuse_val));
+        ASSERT_FALSE(std::isinf(unfuse_val));
+        ASSERT_NEAR(fuse_val, unfuse_val, 1e-3f);
     }
 }
 

--- a/tests/llm/accuracy_conformance.py
+++ b/tests/llm/accuracy_conformance.py
@@ -32,7 +32,7 @@ TEST_CATALOG = {
     "Qwen/Qwen2-0.5B-Instruct": {
         "GPU": {
             "INT8": {"reference": 0.86, "threshold": 0.03},
-            "INT4": {"reference": 0.72, "threshold": 0.03},
+            "INT4": {"reference": 0.74, "threshold": 0.03},
         },
         "CPU": {
             "INT8": {"reference": 0.82, "threshold": 0.03},


### PR DESCRIPTION
### Details:
 - Typecast for `ActivationTypes::SoftPlus` to perform `exp(x)` on fp16.
 - Do not use `activation_opt` when  `ActivationTypes` is `SoftPlus` and input data type is fp16 at the same time.

### Issues:
- SoftPlus : `f(x) = ln(exp(x) + 1.)`
- When performing `exp(x)` in `f(x)`, it can be overflowing the maximum of fp16.
- So it needs to typecast for `exp(x)` when input data type is fp16.
- By the way, `activation_opt` is hardcoded to loads 4 elements at a time by re-defining variable types such as `half4`.
- For this reason, typecasting in `jitter.cpp` doesn't resolve for `half4`.
- Thus, it needs not to use `activation_opt` when `ActivationTypes` is `SoftPlus` and input data type is fp16 at the same time.
- Also `SoftPlus` should not be fused for now because the node that `SoftPlus` is fused to may use types such as `half4`, `half8`, etc.
- Fortunately none of the IRs in `cv_bench_cache` contain `SoftPlus`, so its impact is minimal.

### Graphs: Execution graph
<img width="748" height="842" alt="image" src="https://github.com/user-attachments/assets/588bb229-8ae2-4a92-a32e-7a0ffacc4cf2" />


### Checklist:
- [ ] Is it a proper fix? (Not a workaround)
- [x] Did you include test case for this fix, if necessary?
- [x] Did you review existing test that can be extended to covert this scenario? Existing functional tests for `ActivationTypes::SoftPlus` are classified as skip tests because they produces `inf` even in fp32.

### Tickets:
 - 171149
