### PR TITLE
[CPU] Optimize CPU convert: replace movdqu with uni_vmovdqu for better SIMD compatibility

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/cpu_convert.cpp
@@ -73,7 +73,7 @@ template <>
     const auto& f16vec = gen.xmm3;
     const auto& f32vec = gen.ymm4;
 
-    gen.movdqu(f16vec, gen.xword[src]);
+    gen.uni_vmovdqu(f16vec, gen.xword[src]);
     gen.vcvtph2ps(f32vec, f16vec);
     gen.vmovups(gen.yword[dst], f32vec);
 }
@@ -85,7 +85,7 @@ template <>
 
     gen.vmovups(f32vec, gen.yword[src]);
     gen.vcvtps2ph(f16vec, f32vec, 0);
-    gen.movdqu(gen.xword[dst], f16vec);
+    gen.uni_vmovdqu(gen.xword[dst], f16vec);
 }
 
 template <typename src_t, typename dst_t>


### PR DESCRIPTION


### Details:
 - *Replace gen.movdqu(f16vec, gen.xword[src]); with gen.uni_vmovdqu(f16vec, gen.xword[src]); for better SIMD instruction set compatibility and performance. The uni_vmovdqu generates the most suitable vector move instruction (e.g., VMOVDQU, VMOVDQU32, VMOVDQU64) depending on the target architecture and register width, ensuring optimal code generation for both AVX/AVX2/AVX512.*


### Tickets:
 - *-*
