### PR TITLE
[GPU] Fix unet-2d ACC regression because of missing whitelist.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -251,6 +251,11 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
         } else {
             if (concat_out_l.batch() > 1)
                 return false;
+            const auto& dims_order = concat_out_l.format.dims_order();
+            for (auto dim : dims_order) {
+                if (dim == 0) continue;
+                return dim == 1;
+            }
         }
     }
     return true;

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1413,8 +1413,9 @@ using TestParamType_implicit_concat = ::testing::tuple<size_t,      // 0 - Input
     std::vector<size_t>,                                            // 1 - Inputs Features Sizes
     size_t,                                                         // 2 - Input Y Size
     size_t,                                                         // 3 - Input X Size
-    bool,                                                           // 4 - Implicit concat
-    bool>;                                                          // 5 - is_caching_test
+    format::type,                                                   // 4 - Format
+    bool,                                                           // 5 - Implicit concat
+    bool>;                                                          // 6 - is_caching_test
 struct concat_gpu_implicit : public ::testing::TestWithParam<TestParamType_implicit_concat>
 {
     tests::random_generator rg;
@@ -1431,12 +1432,13 @@ struct concat_gpu_implicit : public ::testing::TestWithParam<TestParamType_impli
             in += std::to_string(testing::get<1>(param_info.param)[i]) + "_";
         }
         in += std::to_string(testing::get<1>(param_info.param)[testing::get<1>(param_info.param).size() - 1]);
-
+        format::type fmt = testing::get<4>(param_info.param);
         return "in" + std::to_string(testing::get<0>(param_info.param))
                + "x" + in + "x" + std::to_string(testing::get<2>(param_info.param))
                + 'x' + std::to_string(testing::get<3>(param_info.param))
-               + "_implicit_concat" + std::to_string(testing::get<4>(param_info.param))
-               + "_is_caching_test" + std::to_string(testing::get<5>(param_info.param));
+               + "_format_" + format(fmt).to_string()
+               + "_implicit_concat" + std::to_string(testing::get<5>(param_info.param))
+               + "_is_caching_test" + std::to_string(testing::get<6>(param_info.param));
     }
 };
 template <typename Type>
@@ -1449,8 +1451,8 @@ public:
         const std::vector<size_t> in_features = testing::get<1>(GetParam());
         const size_t input_y = testing::get<2>(GetParam());
         const size_t input_x = testing::get<3>(GetParam());
-        const bool is_implicit_concat = testing::get<4>(GetParam());
-        const bool is_caching_test = testing::get<5>(GetParam());
+        const bool is_implicit_concat = testing::get<5>(GetParam());
+        const bool is_caching_test = testing::get<6>(GetParam());
         size_t output_f = 0;
         for (auto& f : in_features)
             output_f += f;
@@ -1540,9 +1542,9 @@ public:
         return input;
     }
 
-    void test(format::type fmt) {
+    void test() {
         auto input = generate_input();
-
+        format::type fmt = testing::get<4>(GetParam());
         // implicit concat
         ExecutionConfig config1 = get_test_default_config(get_test_engine());
         config1.set_property(ov::intel_gpu::optimize_data(true));
@@ -1568,27 +1570,27 @@ using concat_implicit_gpu_4d_f16 = concat_gpu_4d_implicit<ov::float16>;
 using concat_implicit_gpu_4d_i8 = concat_gpu_4d_implicit<int8_t>;
 
 TEST_P(concat_implicit_gpu_4d_f16, input_order_opt_b_fs_yx_fsv16) {
-    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv16));
+    ASSERT_NO_FATAL_FAILURE(test());
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_implicit_gpu_4d_f16,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 16, 16 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 16, 8 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, true, false)
+                            TestParamType_implicit_concat(1, { 16, 16 }, 2, 2, format::b_fs_yx_fsv16, true, false),
+                            TestParamType_implicit_concat(1, { 16, 8 }, 2, 2, format::b_fs_yx_fsv16, true, false),
+                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, format::b_fs_yx_fsv16, true, false)
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 
 INSTANTIATE_TEST_SUITE_P(export_import,
                         concat_implicit_gpu_4d_f16,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, true, true)
+                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, format::b_fs_yx_fsv16, true, true)
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 
 TEST_P(concat_implicit_gpu_4d_i8, input_order_opt_b_fs_yx_fsv32) {
-    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv32));
+    ASSERT_NO_FATAL_FAILURE(test());
 }
 
 #ifdef ENABLE_ONEDNN_FOR_GPU
@@ -1673,7 +1675,7 @@ public:
         const std::vector<size_t> in_features = testing::get<1>(GetParam());
         const size_t input_y = testing::get<2>(GetParam());
         const size_t input_x = testing::get<3>(GetParam());
-        const bool is_implicit_concat = testing::get<4>(GetParam());
+        const bool is_implicit_concat = testing::get<5>(GetParam());
 
         size_t output_f = 0;
         for (auto& f : in_features)
@@ -1764,7 +1766,7 @@ public:
         return input;
     }
 
-    void test(format::type fmt) {
+    void test() {
         auto& engine = get_test_engine();
         auto& stream = get_test_stream();
         if (!engine.get_device_info().supports_immad) {
@@ -1772,6 +1774,7 @@ public:
             return;
         }
         auto input = generate_input();
+        format::type fmt = testing::get<4>(GetParam());
 
         // implicit concat
         ExecutionConfig config1 = get_test_default_config(engine);
@@ -1800,32 +1803,50 @@ public:
 using concat_implicit_gpu_onednn_4d_f16 = concat_gpu_4d_implicit_onednn<ov::float16>;
 using concat_implicit_gpu_onednn_4d_i8 = concat_gpu_4d_implicit_onednn<int8_t>;
 
-TEST_P(concat_implicit_gpu_onednn_4d_f16, input_order_opt_b_fs_yx_fsv16) {
-    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv16));
+TEST_P(concat_implicit_gpu_onednn_4d_f16, default) {
+    ASSERT_NO_FATAL_FAILURE(test());
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_implicit_gpu_onednn_4d_f16,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 16, 16 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 16, 8 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 16, 16 }, 1, 1, false, false),
-                            TestParamType_implicit_concat(1, { 16, 32 }, 9, 9, false, false)
+                            TestParamType_implicit_concat(1, { 16, 16 }, 2, 2, format::b_fs_yx_fsv16, true, false),
+                            TestParamType_implicit_concat(1, { 16, 8 }, 2, 2, format::b_fs_yx_fsv16, true, false),
+                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, format::b_fs_yx_fsv16, true, false),
+                            TestParamType_implicit_concat(1, { 16, 16 }, 1, 1, format::b_fs_yx_fsv16, false, false),
+                            TestParamType_implicit_concat(1, { 16, 32 }, 9, 9, format::b_fs_yx_fsv16, false, false),
+                            TestParamType_implicit_concat(1, { 16, 16 }, 2, 2, format::bfyx, true, false),
+                            TestParamType_implicit_concat(1, { 16, 8 }, 2, 2, format::bfyx, true, false),
+                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, format::bfyx, true, false),
+                            TestParamType_implicit_concat(1, { 16, 16 }, 1, 1, format::bfyx, false, false),
+                            TestParamType_implicit_concat(1, { 16, 32 }, 9, 9, format::bfyx, false, false),
+                            TestParamType_implicit_concat(1, { 16, 16 }, 2, 2, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 16, 8 }, 2, 2, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 8, 16 }, 2, 2, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 16, 16 }, 1, 1, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 16, 32 }, 9, 9, format::byxf, false, false)
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 
-TEST_P(concat_implicit_gpu_onednn_4d_i8, input_order_opt_b_fs_yx_fsv32) {
-    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv32));
+TEST_P(concat_implicit_gpu_onednn_4d_i8, default) {
+    ASSERT_NO_FATAL_FAILURE(test());
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_implicit_gpu_onednn_4d_i8,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 32, 32 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 32, 8 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 8, 32 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(1, { 32, 32 }, 17, 17, false, false)
+                            TestParamType_implicit_concat(1, { 32, 32 }, 2, 2, format::b_fs_yx_fsv32, true, false),
+                            TestParamType_implicit_concat(1, { 32, 8 }, 2, 2, format::b_fs_yx_fsv32, true, false),
+                            TestParamType_implicit_concat(1, { 8, 32 }, 2, 2, format::b_fs_yx_fsv32, true, false),
+                            TestParamType_implicit_concat(1, { 32, 32 }, 17, 17, format::b_fs_yx_fsv32, false, false),
+                            TestParamType_implicit_concat(1, { 32, 32 }, 2, 2, format::bfyx, true, false),
+                            TestParamType_implicit_concat(1, { 32, 8 }, 2, 2, format::bfyx, true, false),
+                            TestParamType_implicit_concat(1, { 8, 32 }, 2, 2, format::bfyx, false, false),
+                            TestParamType_implicit_concat(1, { 32, 32 }, 17, 17, format::bfyx, false, false),
+                            TestParamType_implicit_concat(1, { 32, 32 }, 2, 2, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 32, 8 }, 2, 2, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 8, 32 }, 2, 2, format::byxf, false, false),
+                            TestParamType_implicit_concat(1, { 32, 32 }, 17, 17, format::byxf, false, false)
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 
@@ -1839,7 +1860,7 @@ public:
         const std::vector<size_t> in_features = testing::get<1>(GetParam()); // only use first element.
         const size_t input_y = testing::get<2>(GetParam());
         const size_t input_x = testing::get<3>(GetParam());
-        const bool is_implicit_concat = testing::get<4>(GetParam());
+        const bool is_implicit_concat = testing::get<5>(GetParam());
         size_t output_f = in_features[0];
 
         topology topology;
@@ -1933,7 +1954,7 @@ public:
         return inputs;
     }
 
-    void test(format::type fmt) {
+    void test() {
         auto& engine = get_test_engine();
         auto& stream = get_test_stream();
         if (!engine.get_device_info().supports_immad) {
@@ -1941,6 +1962,7 @@ public:
             return;
         }
         auto input = generate_input();
+        format::type fmt = testing::get<4>(GetParam());
 
         // implicit concat when batch size is 1.
         ExecutionConfig config1 = get_test_default_config(engine);
@@ -1968,15 +1990,15 @@ public:
 
 using concat_no_implicit_gpu_onednn_4d_f16 = concat_gpu_4d_explicit<ov::float16>;
 
-TEST_P(concat_no_implicit_gpu_onednn_4d_f16, input_order_opt_b_fs_yx_fsv16) {
-    ASSERT_NO_FATAL_FAILURE(test(format::b_fs_yx_fsv16));
+TEST_P(concat_no_implicit_gpu_onednn_4d_f16, default) {
+    ASSERT_NO_FATAL_FAILURE(test());
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_no_implicit_gpu_onednn_4d_f16,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 16 }, 2, 2, true, false),
-                            TestParamType_implicit_concat(2, { 16 }, 2, 2, false, false)
+                            TestParamType_implicit_concat(1, { 16 }, 2, 2, format::b_fs_yx_fsv16, true, false),
+                            TestParamType_implicit_concat(2, { 16 }, 2, 2, format::b_fs_yx_fsv16, false, false)
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 #endif


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved) 
 - Fix PR for https://github.com/openvinotoolkit/openvino/pull/31452 regression.
 - Onednn implicit concat uses memory offset. So concat axis should be always outer dimension(only F in onednn). but the white list has been removed during code clean.

#### The code and line that caused this issue (if it is not changed directly) 
- The missing ambiguous whitelist

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
- check_image_accuracy.py -m /mnt/shared/models/ -a ~/work/openvino1/bin/intel64/Release/benchmark_app -d GPU.1 -t unet-2d
 
#### Problematic graph 
 - No graph related.

#### Checklist 
 - [O] Is it a proper fix? (not a workaround) 
 - [O] Did you include test case for this fix, if necessary? 
 - [O] Did you review existing test that can be extended to cover this scenario? Which test did you review? concatenation_gpu_test.cpp

### Tickets:
 - *171710*
