### PR TITLE
[Snippets][CPU] Optimize runtime offset handling in ARM64 kernel emitters and utils

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.hpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/jit_kernel_emitter.hpp
@@ -60,6 +60,13 @@ protected:
     virtual void init_data_pointers(const std::vector<Xbyak_aarch64::XReg>& arg_regs,
                                     const std::vector<Xbyak_aarch64::XReg>& data_ptr_regs) const = 0;
 
+    // Helper method to load source/destination pointers using optimized pair loads where possible
+    void load_data_pointers(const Xbyak_aarch64::XReg& reg_runtime_params,
+                            const std::vector<Xbyak_aarch64::XReg>& data_ptr_regs,
+                            size_t start_idx,
+                            size_t end_idx,
+                            int32_t base_offset) const;
+
     void emit_code_impl(const std::vector<size_t>& in_idxs,
                         const std::vector<size_t>& out_idxs,
                         const std::vector<size_t>& pool_vec_idxs,

--- a/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/aarch64/utils.cpp
@@ -190,14 +190,14 @@ void push_ptrs_with_offsets_to_stack(dnnl::impl::cpu::aarch64::jit_generator* h,
     OV_CPU_JIT_EMITTER_ASSERT(mem_ptrs.size() == stack_offsets.size(), "mem_ptrs and stack_offsets size mismatch");
 
     // Fast path: pair-store original pointers when two consecutive entries do not need adjustment
-    std::vector<char> handled(mem_ptrs.size(), 0);
+    std::vector<bool> handled(mem_ptrs.size(), false);
     for (size_t i = 0; i + 1 < mem_ptrs.size(); i += 2) {
         const bool left_static = !ov::snippets::utils::is_dynamic_value(memory_offsets[i]);
         const bool right_static = !ov::snippets::utils::is_dynamic_value(memory_offsets[i + 1]);
         if (left_static && right_static && memory_offsets[i] == 0 && memory_offsets[i + 1] == 0) {
             // stack_offsets are i*8 (contiguous) and SP is 16B aligned ⇒ stp is safe
             h->stp(mem_ptrs[i], mem_ptrs[i + 1], Xbyak_aarch64::ptr(h->sp, stack_offsets[i]));
-            handled[i] = handled[i + 1] = 1;
+            handled[i] = handled[i + 1] = true;
         }
     }
 


### PR DESCRIPTION
### Details:

Implements comprehensive ARM64 instruction fusion optimizations across the snippets CPU plugin to reduce instruction count and improve performance on ARM64 platforms.

Key optimizations:
 - Replace mul+add sequence with fused madd instruction in kernel emitter
 - Implement load-pair (LDP) for consecutive pointer loading in kernel initialization
 - Add store-pair (STP) fast path for zero-offset pointer storage in utils
 - Optimize stack memory operations with paired load/store instructions
 - Consolidate memory access patterns to leverage ARM64 addressing modes

### Tickets:
 - N/A
