### PR TITLE
[paddle] disable random failed test cases

### DIFF
--- a/src/frontends/paddle/tests/skip_tests_config.cpp
+++ b/src/frontends/paddle/tests/skip_tests_config.cpp
@@ -14,5 +14,10 @@ std::vector<std::string> disabledTestPatterns() {
         ".*FrontendLibCloseTest.*",
 #endif
         ".*testUnloadLibBeforeDeletingDependentObject.*",
+        // CVS-130605, CVS-170348
+        ".*paddle_yolo_box_uneven_wh_yolo_box_uneven_wh_pdmodel.*",
+        ".*paddle_loop_dyn_loop_dyn_pdmodel.*",
+        ".*paddle_scatter_test_1_scatter_test_1_pdmodel.*",
+        ".*paddle_top_k_.*",
     };
 }

--- a/src/frontends/tests/frontend/shared/src/op_fuzzy.cpp
+++ b/src/frontends/tests/frontend/shared/src/op_fuzzy.cpp
@@ -8,6 +8,7 @@
 
 #include "common_test_utils/test_case.hpp"
 #include "common_test_utils/test_control.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
 #include "utils.hpp"
 
 using namespace ov::frontend;
@@ -19,6 +20,7 @@ std::string FrontEndFuzzyOpTest::getTestCaseName(const testing::TestParamInfo<Fu
 }
 
 void FrontEndFuzzyOpTest::SetUp() {
+    SKIP_IF_CURRENT_TEST_IS_DISABLED();
     m_fem = FrontEndManager();  // re-initialize after setting up environment
     initParamTest();
 }


### PR DESCRIPTION
### Details:
 - *some paddle test cases cause random failed, disable them to make CI stable*

### Tickets:
 - *CVS-130605*
 - *CVS-170348*
