### PR TITLE
[Snippets][Core] Enable `performance-for-range-copy.WarnOnAllAutoCopies` parameter in clang-tidy

### DIFF
--- a/src/common/snippets/.clang-tidy
+++ b/src/common/snippets/.clang-tidy
@@ -114,6 +114,8 @@ CheckOptions:
     value: "3"
   - key: modernize-use-override.AllowOverrideAndFinal
     value: true
+  - key: performance-for-range-copy.WarnOnAllAutoCopies
+    value: true
   - key: readability-implicit-bool-conversion.AllowIntegerConditions
     value: true
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/src/common/snippets/src/lowered/linear_ir_builder.cpp
+++ b/src/common/snippets/src/lowered/linear_ir_builder.cpp
@@ -32,7 +32,7 @@ std::vector<std::shared_ptr<ov::Node>> clone_nodes(const std::vector<std::shared
         if (node_map.count(node.get()) == 0) {
             // get (already) cloned arguments and clone the node
             OutputVector cloned_args;
-            for (auto input : node->inputs()) {
+            for (const auto& input : node->inputs()) {
                 ov::Output<Node> output = input.get_source_output();
                 cloned_args.push_back(output.for_node(node_map.at(output.get_node())));
             }
@@ -50,13 +50,13 @@ std::vector<std::shared_ptr<ov::Node>> clone_nodes(const std::vector<std::shared
             auto rt_info = node->get_rt_info();
             cloned_node->get_rt_info() = rt_info;
 
-            for (auto output : node->outputs()) {
+            for (const auto& output : node->outputs()) {
                 const auto& output_rt_info = output.get_rt_info();
                 auto new_output = output.for_node(cloned_node);
                 new_output.get_rt_info() = output_rt_info;
             }
 
-            for (auto input : node->inputs()) {
+            for (const auto& input : node->inputs()) {
                 const auto& output_rt_info = input.get_rt_info();
                 auto new_input = cloned_node->input(input.get_index());
                 new_input.get_rt_info() = output_rt_info;

--- a/src/core/include/openvino/core/node_output.hpp
+++ b/src/core/include/openvino/core/node_output.hpp
@@ -52,7 +52,7 @@ public:
     void reset();
 
     /// This output position for a different node
-    Output<Node> for_node(const std::shared_ptr<Node>& node);
+    Output<Node> for_node(const std::shared_ptr<Node>& node) const;
     /// \return A pointer to the node referred to by this output handle.
     Node* get_node() const;
     /// \return A `shared_ptr` to the node referred to by this output handle.

--- a/src/core/src/node_output.cpp
+++ b/src/core/src/node_output.cpp
@@ -22,7 +22,7 @@ void Output<Node>::reset() {
     m_index = 0;
 }
 
-Output<Node> Output<Node>::for_node(const std::shared_ptr<Node>& node) {
+Output<Node> Output<Node>::for_node(const std::shared_ptr<Node>& node) const {
     return Output(node, m_index);
 }
 Node* Output<Node>::get_node() const {


### PR DESCRIPTION
### Details:
 - Fix detected range-loop copies in LIR builder
 - Mark `Output<Node>::for_node` as `const` (header and impl) to allow calls on `const` outputs (no functional change)

### Tickets:
 - N/A
