### PR TITLE
[CPU] Enable `performance-for-range-copy.WarnOnAllAutoCopies` parameter in clang-tidy

### DIFF
--- a/src/plugins/intel_cpu/src/.clang-tidy
+++ b/src/plugins/intel_cpu/src/.clang-tidy
@@ -131,6 +131,8 @@ CheckOptions:
     value: "3"
   - key: modernize-use-override.AllowOverrideAndFinal
     value: true
+  - key: performance-for-range-copy.WarnOnAllAutoCopies
+    value: true
   - key: readability-implicit-bool-conversion.AllowIntegerConditions
     value: true
   - key: readability-implicit-bool-conversion.AllowPointerConditions

--- a/src/plugins/intel_cpu/src/edge.cpp
+++ b/src/plugins/intel_cpu/src/edge.cpp
@@ -554,7 +554,7 @@ EdgePtr Edge::getBaseEdge(int look) {
     }
 
     auto edgesForSamePort = getParent()->getChildEdgesAtPort(inputNum);
-    for (auto edge : edgesForSamePort) {
+    for (const auto& edge : edgesForSamePort) {
         if (edge.get() != this) {
             // Return once found the first inplace consumer
             if (edge->inPlace()) {
@@ -565,7 +565,7 @@ EdgePtr Edge::getBaseEdge(int look) {
 
     // Return the first output edge as the base if there is no inPlace consumers
     // thus benefits zero-copy of outputs.
-    for (auto edge : edgesForSamePort) {
+    for (const auto& edge : edgesForSamePort) {
         if (Type::Output == edge->getChild()->getType()) {
             return edge;
         }

--- a/src/plugins/intel_cpu/src/graph_optimizer.cpp
+++ b/src/plugins/intel_cpu/src/graph_optimizer.cpp
@@ -1473,7 +1473,7 @@ void GraphOptimizer::FusePoolingAndFakeQuantize(Graph& graph) {
         return node->getType() == Type::FakeQuantize && node->getAlgorithm() != Algorithm::FQBinarization;
     };
 
-    for (auto parent : graphNodes) {
+    for (const auto& parent : graphNodes) {
         if (!isSuitableParentNode(parent)) {
             continue;
         }

--- a/src/plugins/intel_cpu/src/node.h
+++ b/src/plugins/intel_cpu/src/node.h
@@ -362,7 +362,7 @@ public:
 
     virtual void addFusedNode(const NodePtr& fusingNode);
 
-    virtual void fuseInto(NodePtr& parentNode) {
+    virtual void fuseInto(const NodePtr& parentNode) {
         // The graph supports fusing only of consecutive nodes and some graph logic requires to know through which input
         // port a node was fused into parent one.
         for (size_t i = 0; i < getParentEdges().size(); i++) {

--- a/src/plugins/intel_cpu/src/nodes/eltwise.cpp
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.cpp
@@ -883,7 +883,7 @@ bool Eltwise::canBeInPlace() const {
     return getInputShapeAtPort(0) == getOutputShapeAtPort(0);
 }
 
-void Eltwise::fuseInto(NodePtr& parentNode) {
+void Eltwise::fuseInto(const NodePtr& parentNode) {
     // Handle special convolution add fusing case
     m_attrs.specialConvolutionAddFusing =
         (parentNode->getType() == Type::Convolution || parentNode->getType() == Type::BinaryConvolution) &&

--- a/src/plugins/intel_cpu/src/nodes/eltwise.h
+++ b/src/plugins/intel_cpu/src/nodes/eltwise.h
@@ -56,7 +56,7 @@ public:
                            bool isLastPostOp,
                            dnnl::memory::data_type outDataType,
                            bool allowBinary = true);
-    void fuseInto(NodePtr& parentNode) override;
+    void fuseInto(const NodePtr& parentNode) override;
     ov::element::Type getRuntimePrecision() const override;
 
     float getAlpha() const {


### PR DESCRIPTION
### Details:
 - Fix detected range-loop copies in CPU graph implementation
 - Mark `Node::fuseInto` as `const` (header and impl) to allow calls on `const` node pointers

### Tickets:
 - N/A
