### PR TITLE
[TRANSFORMATIONS][GPU] Fix bool type of attention mask decomposition issue in ScaledDotProductAttentionDecomposition

### DIFF
--- a/src/common/transformations/src/transformations/op_conversions/scaled_dot_product_attention_decomposition.cpp
+++ b/src/common/transformations/src/transformations/op_conversions/scaled_dot_product_attention_decomposition.cpp
@@ -159,9 +159,11 @@ std::shared_ptr<ov::Node> ov::pass::ScaledDotProductAttentionDecomposition::deco
             // take part in attention. A float mask of the same type as query, key, value that is added to the attention
             // score.
             if (mask.get_element_type() == element::boolean) {
+                auto zero = register_new_node(v0::Constant::create(element::f32, Shape{}, {0}))->output(0);
+                zero = register_new_node<v1::ConvertLike>(zero, scaled_atten);
                 atten_mask = register_new_node<v1::ConvertLike>(mask, scaled_atten);
                 auto inv_mask = register_new_node<v1::LogicalNot>(mask);
-                atten_mask = register_new_node<v1::Select>(inv_mask, atten_mask, minus_inf);
+                atten_mask = register_new_node<v1::Select>(inv_mask, minus_inf, zero);
             } else {
                 atten_mask = mask;
             }

--- a/src/common/transformations/tests/op_conversions/scaled_dot_product_decomposition_test.cpp
+++ b/src/common/transformations/tests/op_conversions/scaled_dot_product_decomposition_test.cpp
@@ -308,9 +308,11 @@ const std::shared_ptr<ov::Node> scaled_dot_product_attention_decomposition(std::
     if (!casual) {
         mask = attention_mask;
         if (mask.get_element_type() == element::boolean) {
+            auto zero = ov::op::v0::Constant::create(element::f32, Shape{}, {0})->output(0);
+            zero = std::make_shared<ov::op::v1::ConvertLike>(zero, scaled_atten);
             atten_mask = std::make_shared<ov::op::v1::ConvertLike>(mask, scaled_atten);
             const auto inv_mask = std::make_shared<ov::op::v1::LogicalNot>(mask);
-            atten_mask = std::make_shared<ov::op::v1::Select>(inv_mask, atten_mask, minus_inf);
+            atten_mask = std::make_shared<ov::op::v1::Select>(inv_mask, minus_inf, zero);
         } else {
             atten_mask = mask;
         }

--- a/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations_pipeline.cpp
@@ -555,6 +555,11 @@ void TransformationsPipeline::apply(std::shared_ptr<ov::Model> func) {
             if (sdpa->get_output_element_type(0) != ov::element::f16)
                 return false;
 
+            // - The attn mask type of SDPA should be fp16
+            if (!sdpa->get_causal() && sdpa->get_input_size() >= 3 && sdpa->get_input_element_type(3) != ov::element::f16) {
+                return false;
+            }
+
             // - The number of dimensions for each input is expected to be 4 or 3
             if (!(query_ps.size() == 3 || query_ps.size() == 4) ||
                 !(key_ps.size() == 3 || key_ps.size() == 4) ||


### PR DESCRIPTION
### Details:
 - In `ScaledDotProductAttentionDecomposition`, the accuracy issue was fixed because the attention mask decomposition with bool type was not aligned with [pytorch impl](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html)
 - Adds a limitation to decompose SDPA until GPU plugin fully supports boolean type attention mask

### Tickets:
 - [CVS-171516](https://jira.devtools.intel.com/browse/CVS-171516)
