### PR TITLE
Fix "Overflowed integer argument (INTEGER_OVERFLOW)" Coverity remarks

### DIFF
--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
@@ -459,11 +459,12 @@ void BrgemmCopyBKernelExecutor::update_config(const ov::snippets::lowered::Expre
 
     const auto LDB =
         brgemm_utils::repacking::compute_K_blocked_stride(N_dim, config.get_wei_N_blk(), config.are_wei_blocked());
+    OPENVINO_ASSERT(!ov::snippets::utils::is_dynamic_value(LDB), "LDB should not be dynamic at update config stage.");
     const auto copy_B_wei_stride =
         ov::snippets::utils::get_dim_stride(expr->get_input_port(0), config.is_transposed_B() ? 0 : 1) *
         dnnl_data_type_size(config.get_original_wei_dt());
 
-    config.update(N_dim, N_blk, K_dim, K_blk, copy_B_wei_stride, LDB);
+    config.update(N_dim, N_blk, K_dim, K_blk, copy_B_wei_stride, static_cast<int64_t>(LDB));
 }
 
 void BrgemmCopyBKernelExecutor::execute(const BrgemmCopyBKernelExecutor* executor, BrgemmCopyBKernel::call_args* args) {

--- a/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
+++ b/src/plugins/intel_cpu/src/emitters/snippets/x64/kernel_executors/brgemm_copy_b.cpp
@@ -430,28 +430,33 @@ void BrgemmCopyBKernelExecutor::update_config(const ov::snippets::lowered::Expre
     const auto& loop_ids = expr->get_loop_ids();
     const snippets::lowered::LoopManagerPtr& loop_manager = linear_ir->get_loop_manager();
 
-    auto init = [&](size_t& dim, size_t& blk, size_t idx) {
+    auto init = [&](int64_t& dim, int64_t& blk, size_t idx) {
         OPENVINO_ASSERT(idx < planar_shape.size() && idx < in_subtensor.size(),
                         "Index must be less than shape/subtensor rank!");
-        dim = *(planar_shape.rbegin() + idx);
-        blk = *(in_subtensor.rbegin() + idx);
-        if (ov::snippets::utils::is_full_dim_value(blk)) {
+        auto curr_dim = *(planar_shape.rbegin() + idx);
+        auto curr_blk = *(in_subtensor.rbegin() + idx);
+        OPENVINO_ASSERT(
+            !ov::snippets::utils::is_dynamic_value(curr_dim) && !ov::snippets::utils::is_dynamic_value(curr_blk),
+            "Dimension and subtensor should not be dynamic at update config stage.");
+        dim = static_cast<int64_t>(curr_dim);
+        if (ov::snippets::utils::is_full_dim_value(curr_blk)) {
             blk = dim;
         } else {
             OPENVINO_ASSERT(loop_idx < loop_ids.size(), "Loop is missed");
             const auto& current_expanded_loop_info =
                 loop_manager->get_loop_info<ov::snippets::lowered::ExpandedLoopInfo>(loop_ids[loop_idx++]);
-            blk = current_expanded_loop_info->get_increment();
-            input_desc->set_subtensor_dim(idx, blk);
-            output_desc->set_subtensor_dim(idx, blk);
+            curr_blk = current_expanded_loop_info->get_increment();
+            input_desc->set_subtensor_dim(idx, curr_blk);
+            output_desc->set_subtensor_dim(idx, curr_blk);
+            blk = static_cast<int64_t>(curr_blk);
             OV_CPU_JIT_EMITTER_ASSERT(blk <= dim, "BrgemmCopyB has incompatible subtensor dimensions");
         }
     };
 
-    size_t K_dim = 0;
-    size_t K_blk = 0;
-    size_t N_dim = 0;
-    size_t N_blk = 0;
+    int64_t K_dim = 0;
+    int64_t K_blk = 0;
+    int64_t N_dim = 0;
+    int64_t N_blk = 0;
     //  Dimension K
     init(K_dim, K_blk, 1);
     //  Dimension N
@@ -459,12 +464,11 @@ void BrgemmCopyBKernelExecutor::update_config(const ov::snippets::lowered::Expre
 
     const auto LDB =
         brgemm_utils::repacking::compute_K_blocked_stride(N_dim, config.get_wei_N_blk(), config.are_wei_blocked());
-    OPENVINO_ASSERT(!ov::snippets::utils::is_dynamic_value(LDB), "LDB should not be dynamic at update config stage.");
     const auto copy_B_wei_stride =
         ov::snippets::utils::get_dim_stride(expr->get_input_port(0), config.is_transposed_B() ? 0 : 1) *
         dnnl_data_type_size(config.get_original_wei_dt());
 
-    config.update(N_dim, N_blk, K_dim, K_blk, copy_B_wei_stride, static_cast<int64_t>(LDB));
+    config.update(N_dim, N_blk, K_dim, K_blk, copy_B_wei_stride, LDB);
 }
 
 void BrgemmCopyBKernelExecutor::execute(const BrgemmCopyBKernelExecutor* executor, BrgemmCopyBKernel::call_args* args) {

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -107,7 +108,8 @@ void BrgemmExternalRepackingAdjuster::update_kernel(const RepackExecutorPtr& exe
         ov::snippets::utils::get_dim_in_stride(shape, layout, idx) * dnnl_data_type_size(config->get_original_wei_dt());
     const auto LDB =
         brgemm_utils::repacking::compute_K_blocked_stride(N, config->get_wei_N_blk(), config->are_wei_blocked());
-    config->update(N, N, K, K, copy_wei_stride, LDB);
+    OPENVINO_ASSERT(!ov::snippets::utils::is_dynamic_value(LDB), "LDB should not be dynamic at update kernel stage.");
+    config->update(N, N, K, K, copy_wei_stride, static_cast<int64_t>(LDB));
     executor->update_by_config(*config);
 }
 

--- a/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
+++ b/src/plugins/intel_cpu/src/transformations/snippets/x64/pass/lowered/external_repacking_adjuster.cpp
@@ -106,10 +106,13 @@ void BrgemmExternalRepackingAdjuster::update_kernel(const RepackExecutorPtr& exe
     const auto idx = config->is_transposed_B() ? 0 : 1;
     const auto copy_wei_stride =
         ov::snippets::utils::get_dim_in_stride(shape, layout, idx) * dnnl_data_type_size(config->get_original_wei_dt());
+    OPENVINO_ASSERT(!ov::snippets::utils::is_dynamic_value(N) && !ov::snippets::utils::is_dynamic_value(K),
+                    "N and K shape should not be dynamic at BrgemmExternalRepackingAdjuster update kernel stage.");
+    const auto N_signed = static_cast<int64_t>(N);
+    const auto K_signed = static_cast<int64_t>(K);
     const auto LDB =
-        brgemm_utils::repacking::compute_K_blocked_stride(N, config->get_wei_N_blk(), config->are_wei_blocked());
-    OPENVINO_ASSERT(!ov::snippets::utils::is_dynamic_value(LDB), "LDB should not be dynamic at update kernel stage.");
-    config->update(N, N, K, K, copy_wei_stride, static_cast<int64_t>(LDB));
+        brgemm_utils::repacking::compute_K_blocked_stride(N_signed, config->get_wei_N_blk(), config->are_wei_blocked());
+    config->update(N_signed, N_signed, K_signed, K_signed, copy_wei_stride, LDB);
     executor->update_by_config(*config);
 }
 


### PR DESCRIPTION
### Details:
 - *2399-806, 2399-910. Underflow: The cast of LDB to a signed type could result in a negative number.*

### Tickets:
 - *172042*
