### PR TITLE
[Snippets][CPU] Enable Matmul with transposed B matrix tests

### DIFF
--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1547,7 +1547,7 @@ void Transformations::MainSnippets() {
 #elif defined(OPENVINO_ARCH_X86_64)
         return true;
 #else
-        OPENVINO_ASSERT(false, "ExplicitTransposeMatMulInputs callback is not supported on this architecture");
+        OPENVINO_THROW("ExplicitTransposeMatMulInputs callback is not supported on this architecture");
 #endif
     };
 

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1515,7 +1515,7 @@ void Transformations::MainSnippets() {
         },
         snippets::pass::TokenizeSnippets);
 
-    auto mm_supports_transpose_b = [this]([[maybe_unused]] const std::shared_ptr<const ov::Node>& n) {
+    auto mm_supports_transpose_b = [this]([[maybe_unused]] const std::shared_ptr<const ov::Node>& n) -> bool {
         [[maybe_unused]] const auto& inferencePrecision = config.inferencePrecision;
         // Note: BrgemmTPP doesn't support transposed KN natively
         // so we should extract transposes for the corresponding matmul nodes
@@ -1552,12 +1552,13 @@ void Transformations::MainSnippets() {
         return true;
 #else
         OPENVINO_THROW("ExplicitTransposeMatMulInputs callback is not supported on this architecture");
+        return false;
 #endif
     };
 
     CPU_SET_CALLBACK_COMMON(
         snippetsManager,
-        [&mm_supports_transpose_b](const std::shared_ptr<const ov::Node>& n) {
+        [&mm_supports_transpose_b](const std::shared_ptr<const ov::Node>& n) -> bool {
             return mm_supports_transpose_b(n);
         },
         snippets::pass::ExplicitTransposeMatMulInputs);

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -277,6 +277,10 @@
 #    include "openvino/op/softmax.hpp"
 #endif
 
+#if !defined(OPENVINO_ARCH_X86_64) && !defined(OPENVINO_ARCH_ARM64)
+#    include "openvino/core/except.hpp"
+#endif
+
 #if defined(OPENVINO_ARCH_ARM64)
 #    include "transformations/op_conversions/hard_sigmoid_decomposition.hpp"
 #    include "transformations/op_conversions/hsigmoid_decomposition.hpp"

--- a/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
+++ b/src/plugins/intel_cpu/src/transformations/transformation_pipeline.cpp
@@ -1515,7 +1515,9 @@ void Transformations::MainSnippets() {
         [[maybe_unused]] const auto& inferencePrecision = config.inferencePrecision;
         // Note: BrgemmTPP doesn't support transposed KN natively
         // so we should extract transposes for the corresponding matmul nodes
-#if defined(SNIPPETS_LIBXSMM_TPP)
+#if defined(OPENVINO_ARCH_ARM64)
+        return false;
+#elif defined(SNIPPETS_LIBXSMM_TPP)
         // TPP doesn't support dynamic shapes -> there will be BrgemmCPU node
         if (!n->is_dynamic()) {
             std::vector<std::vector<size_t>> layouts(3);

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -511,12 +511,10 @@ std::vector<std::string> disabledTestPatterns() {
 #if defined(OPENVINO_ARCH_ARM64)
     // Tests to be enabled on ARM64
     retVector.emplace_back(R"(smoke_Snippets_ConvAdd/ConvEltwise.CompareWithRefImpl.*)");
-    retVector.emplace_back(R"(smoke_Snippets_FullyConnectedTransposeB/MatMulTransposeB.*)");
     retVector.emplace_back(R"(smoke_Snippets_GatedMLP.*)");
     retVector.emplace_back(R"(smoke_Snippets_GroupNormalization.*)");
     retVector.emplace_back(R"(smoke_Snippets_MHA.*)");
     retVector.emplace_back(R"(smoke_Snippets_MLP_SEQ.*)");
-    retVector.emplace_back(R"(smoke_Snippets_MatMulTransposeB.*)");
     retVector.emplace_back(R"(smoke_Snippets_PrecisionPropagation_Convertion.*)");
 #endif
 #if defined(_WIN32)

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
@@ -106,16 +106,18 @@ std::vector<std::vector<ov::test::InputShape>> transpose_b_shapes{
     }
 };
 
+#ifdef OPENVINO_ARCH_ARM64
+static constexpr size_t expected_num_subgraphs = 2; // MatMul + Transpose
+#else
+static constexpr size_t expected_num_subgraphs = 1; // MatMul
+#endif
+
 INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MatMulTransposeB, MatMulTransposeB,
                          ::testing::Combine(
                              ::testing::ValuesIn(transpose_b_shapes),
                              ::testing::ValuesIn(precisions()),
                              ::testing::Values(MatMulType::MatMul),
-#ifdef OPENVINO_ARCH_ARM64
-                             ::testing::Values(2), // MatMul + Transpose
-#else
-                             ::testing::Values(1), // MatMul
-#endif
+                             ::testing::Values(expected_num_subgraphs),
                              ::testing::Values(1), // Tokenized MatMul
                              ::testing::Values(ov::test::utils::DEVICE_CPU),
                              ::testing::Values(CPUTestUtils::empty_plugin_config)),

--- a/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
+++ b/src/plugins/intel_cpu/tests/functional/shared_tests_instances/snippets/matmul.cpp
@@ -111,7 +111,11 @@ INSTANTIATE_TEST_SUITE_P(smoke_Snippets_MatMulTransposeB, MatMulTransposeB,
                              ::testing::ValuesIn(transpose_b_shapes),
                              ::testing::ValuesIn(precisions()),
                              ::testing::Values(MatMulType::MatMul),
+#ifdef OPENVINO_ARCH_ARM64
+                             ::testing::Values(2), // MatMul + Transpose
+#else
                              ::testing::Values(1), // MatMul
+#endif
                              ::testing::Values(1), // Tokenized MatMul
                              ::testing::Values(ov::test::utils::DEVICE_CPU),
                              ::testing::Values(CPUTestUtils::empty_plugin_config)),


### PR DESCRIPTION
### Details:
Since there is no MatMul kernel version that accepts transposed B matrix on ARM64, Transpose operation is extracted outside of MatMul

### Tickets:
 - required for 167005
