### PR TITLE
[Protopipe] Add output clamping option for OpenVINO models

### DIFF
--- a/src/plugins/intel_npu/tools/opencv_version.json
+++ b/src/plugins/intel_npu/tools/opencv_version.json
@@ -1,3 +1,3 @@
 {
-    "opencv" : "15e3cf3cc5eb05a2aaf64ebde451be6870538fa9"
+    "opencv" : "252403bbf2fc560007c2c9057db5a9a151e99dd7"
 }

--- a/src/plugins/intel_npu/tools/protopipe/README.md
+++ b/src/plugins/intel_npu/tools/protopipe/README.md
@@ -61,10 +61,12 @@ log_level: INFO
 - `iml` - **Optional**. Input model layout.
 - `oml` - **Optional**. Output model layout.
 - `reshape` - **Optional**. Set shape for input layers. For example, "input1: [1,3,224,224], input2: [1,4]" or "[1,3,224,224]" in case of one input layer.
+- `clamp_outputs` - **Optional**. Clamps all model outputs to the valid range for their precision. Requires `op` to be set for it to take effect.
 
 Examples:
 ```
 - { name: model.xml, ip: FP16, iml: NHWC, il: NCHW }
+- { name: model.xml, ip: U8, op: U8, clamp_outputs: true }
 - { name: model.xml, ip: { data: FP16 }, priority: HIGH }
 - { name: model.xml, device: NPU, config: { PERFORMANCE_HINT: THROUGHPUT } }
 ```
@@ -536,7 +538,7 @@ Iteration <number>:
 - Clone OpenCV repo:
     ```
     git clone https://github.com/opencv/opencv
-    cd opencv && git checkout 3919f33e21
+    cd opencv && git checkout 252403bbf2
     ```
 - Build OpenCV G-API:
     ```

--- a/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/parser/config.cpp
@@ -372,6 +372,10 @@ struct convert<OpenVINOParams> {
             params.config.emplace("MODEL_PRIORITY", toPriority(node["priority"].as<std::string>()));
         }
 
+        if (node["clamp_outputs"]) {
+            params.clamp_outputs = node["clamp_outputs"].as<bool>();
+        }
+
         if (node["nireq"]) {
             params.nireq = node["nireq"].as<size_t>();
         }

--- a/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/scenario/inference.hpp
@@ -94,6 +94,7 @@ struct OpenVINOParams {
     LayerVariantAttr<std::vector<size_t>> reshape;
     std::map<std::string, std::string> config;
     size_t nireq = 1u;
+    bool clamp_outputs = false;
 };
 
 struct ONNXRTParams {

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -7,6 +7,7 @@
 
 #include "scenario/inference.hpp"
 #include "utils/error.hpp"
+#include "utils/logger.hpp"
 
 #include <opencv2/gapi/infer/onnx.hpp>  // onnx::Params
 #include <opencv2/gapi/infer/ov.hpp>    // ov::Params
@@ -29,6 +30,11 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
     // NB: Pre/Post processing can be configured only for Model case.
     if (std::holds_alternative<OpenVINOParams::ModelPath>(params.path)) {
         network->cfgEnsureNamedTensors();
+
+        if (params.clamp_outputs) {
+            LOG_INFO() << "Clamping applied" << std::endl;
+            network->cfgClampOutputs();
+        }
 
         if (std::holds_alternative<int>(params.output_precision)) {
             network->cfgOutputTensorPrecision(std::get<int>(params.output_precision));

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -7,7 +7,6 @@
 
 #include "scenario/inference.hpp"
 #include "utils/error.hpp"
-#include "utils/logger.hpp"
 
 #include <opencv2/gapi/infer/onnx.hpp>  // onnx::Params
 #include <opencv2/gapi/infer/ov.hpp>    // ov::Params
@@ -37,8 +36,7 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
             network->cfgOutputTensorPrecision(std::get<AttrMap<int>>(params.output_precision));
         }
 
-        if (params.clamp_outputs && !std::holds_alternative<std::monostate>(params.output_precision)) {
-            LOG_INFO() << "Clamping outputs" << std::endl;
+        if (params.clamp_outputs) {
             network->cfgClampOutputs();
         }
 

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -31,15 +31,15 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
     if (std::holds_alternative<OpenVINOParams::ModelPath>(params.path)) {
         network->cfgEnsureNamedTensors();
 
-        if (params.clamp_outputs) {
-            LOG_INFO() << "Clamping outputs" << std::endl;
-            network->cfgClampOutputs();
-        }
-
         if (std::holds_alternative<int>(params.output_precision)) {
             network->cfgOutputTensorPrecision(std::get<int>(params.output_precision));
         } else if (std::holds_alternative<AttrMap<int>>(params.output_precision)) {
             network->cfgOutputTensorPrecision(std::get<AttrMap<int>>(params.output_precision));
+        }
+
+        if (params.clamp_outputs && !std::holds_alternative<std::monostate>(params.output_precision)) {
+            LOG_INFO() << "Clamping outputs" << std::endl;
+            network->cfgClampOutputs();
         }
 
         if (std::holds_alternative<std::string>(params.input_layout)) {

--- a/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
+++ b/src/plugins/intel_npu/tools/protopipe/src/simulation/simulation.cpp
@@ -32,7 +32,7 @@ static cv::gapi::GNetPackage getNetPackage(const std::string& tag, const OpenVIN
         network->cfgEnsureNamedTensors();
 
         if (params.clamp_outputs) {
-            LOG_INFO() << "Clamping applied" << std::endl;
+            LOG_INFO() << "Clamping outputs" << std::endl;
             network->cfgClampOutputs();
         }
 

--- a/src/plugins/intel_npu/tools/protopipe/version.hpp.in
+++ b/src/plugins/intel_npu/tools/protopipe/version.hpp.in
@@ -1,3 +1,3 @@
 #pragma once
 
-#define APP_VERSION   "v1.0.1-@GIT_SHA@"
+#define APP_VERSION   "v1.1.0-@GIT_SHA@"


### PR DESCRIPTION
### Details:
 - *Implement output clamping based on configured output precision for all model outputs. Clamping can be enabled by setting `clamp_outputs: true` in the model parameters.*

### Tickets:
 - *EISW-168451*
