### PR TITLE
[GPU] Fix reorder format mismatch in convolution weights.

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/onednn/utils_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/onednn/utils_test.cpp
@@ -286,4 +286,13 @@ TEST(keep_weights_reorder_shape_consistent_test, simple_data_formats) {
         EXPECT_TRUE(result);
         EXPECT_EQ(layout.get_partial_shape(), ov::Shape({512, 1024, 16}));
     }
+    // Test case 4: oizyx format with matching shapes
+    {
+        auto layout = cldnn::layout{ov::PartialShape{16, 1, 16, 16}, data_types::f16, format::oiyx};
+        dnnl::memory::desc desc({16, 1, 1, 16, 16}, dnnl::memory::data_type::f16, dnnl::memory::format_tag::abcde);
+        bool result = onednn::keep_weights_reorder_shape_consistent(layout, desc);
+        EXPECT_TRUE(result);
+        EXPECT_EQ(layout.format, cldnn::format::oizyx);
+        EXPECT_EQ(layout.get_partial_shape(), ov::Shape({16, 1, 1, 16, 16}));
+    }
 }


### PR DESCRIPTION
### Description of the issue
 - When convolution constant weights are transposed via permute, the graph optimization replaces it with reorder.
 - This causes issues for onednn reorder due to non-default format changes.
 - The fix ensures format consistency when replacing permute with reorder.

#### The code and line that caused this issue
https://github.com/openvinotoolkit/openvino/blob/689ab8b0685723dcd44176c468631e416b0146c3/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp#L718-L757

#### Problematic graph
<img width="1574" height="823" alt="image" src="https://github.com/user-attachments/assets/31e211b7-80c6-4573-91e8-2a5b20fcd376" />

#### Valid Cases for Replacing Permute with Reorder (Partial Support)
| Original Format | Permute Axes Order | Resulting Shape | Changed Constant Format | Reorder | Description                  |
|-----------------|--------------------|------------------|--------------------------|---------|------------------------------|
| bfyx            | [0,1,3,2]          | [B,F,X,Y]        | bfxy                     | bfxy → bfyx | Swap X-Y axes               |
| bfyx            | [1,0,2,3]          | [F,B,Y,X]        | fbyx                     | fbyx → bfyx | Swap Batch-Feature          |
| bfyx            | [1,2,3,0]          | [F,Y,X,B]        | fyxb                     | fyxb → bfyx | Feature-first layout        |
| bfyx            | [2,3,1,0]          | [Y,X,F,B]        | yxfb                     | yxfb → bfyx | Spatial-first layout        |
| bfyx            | [0,2,3,1]          | [B,Y,X,F]        | byxf                     | byxf → bfyx | Channel-last layout         |
| bfyx            | [0,2,1,3]          | [B,Y,F,X]        | byfx                     | byfx → bfyx | Swap Y-Feature              |
| bfyx            | [0,3,1,2]          | [B,X,F,Y]        | bxfy                     | bxfy → bfyx | Move X to front             |
| bfyx            | [1,2,0,3]          | [F,Y,B,X]        | fybx                     | fybx → bfyx | Feature-Y-Batch order       |
| bfyx            | [3,0,1,2]          | [X,B,F,Y]        | xbfy                     | xbfy → bfyx | X-first layout              |
| bfyx            | [2,0,1,3]          | [Y,B,F,X]        | ybfx                     | ybfx → bfyx | Y-first layout              |

| Original Format | Permute Axes Order | Resulting Shape | Changed Constant Format | Reorder         | Description                          |
|-----------------|--------------------|------------------|--------------------------|------------------|--------------------------------------|
| oiyx            | [1,0,2,3]          | [I,O,Y,X]        | ioyx                     | ioyx → oiyx      | Swap Input-Output (Deconv)           |
| oiyx            | [2,3,1,0]          | [Y,X,I,O]        | yxio                     | yxio → oiyx      | Spatial-first layout                 |
| oiyx            | [1,2,3,0]          | [I,Y,X,O]        | iyxo                     | iyxo → oiyx      | Input-first, Output-last            |
| oiyx            | [0,2,3,1]          | [O,Y,X,I]        | oyxi                     | oyxi → oiyx      | Output-first, Input-last            |
| oiyx            | [0,2,1,3]          | [O,Y,I,X]        | oyix                     | oyix → oiyx      | Swap Y-Input                         |
| oiyx            | [0,3,1,2]          | [O,X,I,Y]        | oxiy                     | oxiy → oiyx      | Move X to front, Y to last          |


#### Checklist
 - [V] Is it a proper fix?
 - [V] Did you include test case for this fix? 
 - [V] Did you review existing test that can be extended to cover this scenario?
   - No eligible test for this.

### Tickets:
 - *168091*
