### PR TITLE
[GPU] Fix implicit onednn concat for 64 byte misalignment regression.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -198,9 +198,6 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
             if (!concat_node.is_dynamic() || is_runtime) {
                 if (onednn_byte_offset % 64 != 0)
                     return false;
-
-                // The assumption here is that onednn will support batch 1 case.
-                onednn_byte_offset += pred_l.bytes_count();
             }
 
             for (const auto& fused_op : pred_params[idx].fused_desc) {
@@ -234,8 +231,12 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
             if (idx != 0 && input_padd._lower_size[concat_axis] != 0)
                 return false;
         }
-        if (!concat_node.is_dynamic() || is_runtime)
+        if (!concat_node.is_dynamic() || is_runtime) {
             lower_padd_in_axis += pred_params[idx].get_output_layout().get_tensor().sizes(def_fmt)[concat_axis];
+            // Accumulates byte offset for onednn 64-byte alignment. The assumption here is that onednn will support batch 1 case.
+            onednn_byte_offset += pred_l.bytes_count();
+        }
+
         idx++;
     }
 

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1779,8 +1779,11 @@ public:
         // implicit concat
         ExecutionConfig config1 = get_test_default_config(engine);
         config1.set_property(ov::intel_gpu::optimize_data(true));
-        ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
-        config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", impl}, {"pool0", impl}, {"pool1", impl} }));
+        ov::intel_gpu::ImplementationDesc onednn_impl = { fmt, std::string(""), impl_types::onednn };
+        ov::intel_gpu::ImplementationDesc ocl_impl = { fmt, std::string(""), impl_types::ocl };
+        config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"conv", onednn_impl},
+                                                                                                 {"pool0", ocl_impl},
+                                                                                                 {"pool1", onednn_impl} }));
 
         auto out_mem1 = run_concat_network(input, fmt, config1);
         cldnn::mem_lock<Type> out_ptr1(out_mem1, stream);


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved) 
 - Fix PR for https://github.com/openvinotoolkit/openvino/pull/31452 regression.
 - Solves a problem when using a mix of ocl and onednn impl in concat's input.

#### The code and line that caused this issue (if it is not changed directly) 
- In case of concat that uses impl type mixed together, byte offset calculation is incorrect. Earlier always calculate byte offset only all onednn impl inputs.

#### Reproduction step and snapshot (if applicable. Do not attach for customer model) 
- ./benchmark_app -d GPU.1 -m ww21_weekly_23.0.0-10926-b4452d56304-API2.0/densenet-121/tf/tf_meta/FP16/
INT8/1/dldt/optimized/densenet-121.xml -nstreams 1 -nireq 2 -niter 1 --hint none -infer_precision f32
 
#### Problematic graph 
 - No graph related.

#### Checklist 
 - [O] Is it a proper fix? (not a workaround) 
 - [O] Did you include test case for this fix, if necessary? 
 - [O] Did you review existing test that can be extended to cover this scenario? Which test did you review? concatenation_gpu_test.cpp
 
### Tickets:
 - *170847*
