### PR TITLE
[NPUW] Fixed null dereference in three-model-pipeline

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -737,7 +737,9 @@ std::shared_ptr<ov::Model> cut_lm_head(std::shared_ptr<ov::Model>& model) {
     std::shared_ptr<ov::Model> lm_head_model = nullptr;
     rewr.add_matcher<CutLMHead>(lm_head_model);
     rewr.run_on_model(model);
-    lm_head_model->set_friendly_name(model->get_friendly_name() + "_lm_head");
+    if (lm_head_model) {
+        lm_head_model->set_friendly_name(model->get_friendly_name() + "_lm_head");
+    }
     model->validate_nodes_and_infer_types();
 
     return lm_head_model;


### PR DESCRIPTION
### Details:
 - *Fixed null dereference in three-model-pipeline that arises if pattern to cut LM Head from LLM model doesn't match*
 - *PR into release branch: https://github.com/openvinotoolkit/openvino/pull/31770*

### Tickets:
 - *EISW-179980*
