### PR TITLE
Revert "Added note that recent OpenVINO releases currently unavailable via Homebrew (#31422)"

### DIFF
--- a/docs/articles_en/about-openvino/release-notes-openvino.rst
+++ b/docs/articles_en/about-openvino/release-notes-openvino.rst
@@ -328,17 +328,6 @@ Known Issues
 |   Performance regression of models on ARM due to an upgrade to the latest ACL. A corresponding issue has 
     been created in the ACL and oneDNN repositories. 
 
-| **Component: OpenVINO Homebrew Installation**
-| ID: NA
-| Description:
-|    Recent OpenVINO releases are currently unavailable via Homebrew due to an issue with
-     `protobuf` in the internal Homebrew CI infrastructure. This affects the ability
-     to build and publish formula updates. The upstream issue is actively monitored,
-     and availability will be restored as soon as it is resolved. Until then, use the
-     S3 archive as an alternative to Homebrew on Linux and macOS.
-     For more information, see :doc:`Linux Installation Guide <./../get-started/install-openvino/install-openvino-archive-linux>`
-     and :doc:`macOS Installation Guide <./../get-started/install-openvino/install-openvino-archive-macos>`.
-
 
 .. Previous 2025 releases
 .. ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/articles_en/get-started/install-openvino/install-openvino-brew.rst
+++ b/docs/articles_en/get-started/install-openvino/install-openvino-brew.rst
@@ -7,15 +7,6 @@ Install OpenVINO™ Runtime via Homebrew
                  operating systems, using Homebrew.
 
 .. note::
-    Recent OpenVINO releases are currently unavailable via Homebrew due to an issue with
-    `protobuf` in the internal Homebrew CI infrastructure. This affects the ability
-    to build and publish formula updates. The upstream issue is actively monitored,
-    and availability will be restored as soon as it is resolved.
-     
-    Until then, use the S3 archive as an alternative to Homebrew on Linux and macOS.
-    For more information, see :doc:`Linux Installation Guide <install-openvino-archive-linux>` and :doc:`macOS Installation Guide <install-openvino-archive-macos>`.
-
-.. note::
 
    Note that the `Homebrew <https://brew.sh/>`__ distribution:
 


### PR DESCRIPTION
Revert "Added note that recent OpenVINO releases currently unavailable via Homebrew (#31422)"

This reverts commit 547698444a099ee88ce7b8d1101e079cb76ef27d. The described issue was fixed. 

