### PR TITLE
[GPU] Resolve accuracy issue by implicit concat

### DIFF
--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -241,6 +241,12 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
         idx++;
     }
 
+    if (!concat_node.is_dynamic() || is_runtime) {
+        auto& input = concat_node.get_dependencies().front();
+        if (!input.first->is_type<permute>() && concat_axis != 0 && concat_axis != 1)
+            return false;
+    }
+
     // Implicit concat for onednn only when use_usm and batch 1.
     if (is_onednn_impl) {
         bool use_usm = concat_node.get_program().get_engine().use_unified_shared_memory();

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -241,11 +241,10 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
         idx++;
     }
 
-    if (!concat_node.is_dynamic() || is_runtime) {
-        auto& input = concat_node.get_dependencies().front();
-        if (!input.first->is_type<permute>() && concat_axis != 0 && concat_axis != 1)
+    if (concat_node.get_preferred_impl_type() == impl_types::onednn)
+        if (concat_axis != 1)
             return false;
-    }
+
 
     // Implicit concat for onednn only when use_usm and batch 1.
     if (is_onednn_impl) {
@@ -258,8 +257,6 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
             return true;
         } else {
             if (concat_out_l.batch() > 1)
-                return false;
-            if (concat_axis != 1)
                 return false;
             const auto& dims_order = concat_out_l.format.dims_order();
             for (auto dim : dims_order) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -194,10 +194,12 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
         }
 
         if (pred.first->get_preferred_impl_type() == impl_types::onednn) {
+            // No implicit concat for spatial axes
+            if (concat_axis > 1)
+                return false;
+
             // Onednn requires memory pointers to be aligned at least at 64-bytes to avoid potential correctness issues.
             if (!concat_node.is_dynamic() || is_runtime) {
-                if (concat_axis != 1)
-                    return false;
                 if (onednn_byte_offset % 64 != 0)
                     return false;
 
@@ -240,11 +242,6 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
             lower_padd_in_axis += pred_params[idx].get_output_layout().get_tensor().sizes(def_fmt)[concat_axis];
         idx++;
     }
-
-    if (concat_node.get_preferred_impl_type() == impl_types::onednn)
-        if (concat_axis != 1)
-            return false;
-
 
     // Implicit concat for onednn only when use_usm and batch 1.
     if (is_onednn_impl) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -193,6 +193,7 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
                 return false;
         }
 
+
         if (pred.first->get_preferred_impl_type() == impl_types::onednn) {
             // Onednn requires memory pointers to be aligned at least at 64-bytes to avoid potential correctness issues.
             if (!concat_node.is_dynamic() || is_runtime) {
@@ -238,6 +239,10 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
             lower_padd_in_axis += pred_params[idx].get_output_layout().get_tensor().sizes(def_fmt)[concat_axis];
         idx++;
     }
+
+    if (concat_node.get_preferred_impl_type() == impl_types::onednn)
+        if (concat_axis != 1)
+            return false;
 
     // Implicit concat for onednn only when use_usm and batch 1.
     if (is_onednn_impl) {

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_buffer_fusing.cpp
@@ -193,7 +193,6 @@ bool concat_in_place_optimization::match(const program_node& concat_node,
                 return false;
         }
 
-
         if (pred.first->get_preferred_impl_type() == impl_types::onednn) {
             // Onednn requires memory pointers to be aligned at least at 64-bytes to avoid potential correctness issues.
             if (!concat_node.is_dynamic() || is_runtime) {

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -494,7 +494,7 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     topology.add(reorder("reorder1", input_info("input1"), format::bfyx, data_types::f16));
     topology.add(reorder("reorder2", input_info("input2"), format::bfyx, data_types::f16));
 
-    topology.add(concatenation("concat", { input_info("reorder1"), input_info("reorder2") }, 0));
+    topology.add(concatenation("concat", { input_info("reorder1"), input_info("reorder2") }, 2));
     topology.add(permute("output", input_info("concat"), {0, 2, 3, 1}));
 
     ExecutionConfig config;

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -508,7 +508,7 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     auto prog = program::build_program(engine, topology, config, false, false);
     ASSERT_NE(prog, nullptr);
     auto& concat_node_p = prog->get_node("concat");
-    ASSERT_FALSE(concat_node_p.can_be_optimized());
+    ASSERT_TRUE(concat_node_p.can_be_optimized());
     cldnn::network net(prog, 0);
 
     auto input_memory1 = engine.allocate_memory(in_layout1);
@@ -554,7 +554,7 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     ASSERT_NE(concat_mem.get(), reorder1_mem.get());
     ASSERT_NE(concat_mem.get(), reorder2_mem.get());
     ASSERT_FALSE(concat_inst->can_be_optimized());
-    ASSERT_FALSE(concat_node_n.can_be_optimized());
+    ASSERT_TRUE(concat_node_n.can_be_optimized());
 
     for (size_t x = 0; x < out_l.count(); ++x) {
         ASSERT_EQ(ref_output[x], output_ptr[x]);

--- a/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/passes/prepare_buffer_fusing_test.cpp
@@ -494,7 +494,7 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     topology.add(reorder("reorder1", input_info("input1"), format::bfyx, data_types::f16));
     topology.add(reorder("reorder2", input_info("input2"), format::bfyx, data_types::f16));
 
-    topology.add(concatenation("concat", { input_info("reorder1"), input_info("reorder2") }, 2));
+    topology.add(concatenation("concat", { input_info("reorder1"), input_info("reorder2") }, 0));
     topology.add(permute("output", input_info("concat"), {0, 2, 3, 1}));
 
     ExecutionConfig config;
@@ -508,7 +508,7 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     auto prog = program::build_program(engine, topology, config, false, false);
     ASSERT_NE(prog, nullptr);
     auto& concat_node_p = prog->get_node("concat");
-    ASSERT_TRUE(concat_node_p.can_be_optimized());
+    ASSERT_FALSE(concat_node_p.can_be_optimized());
     cldnn::network net(prog, 0);
 
     auto input_memory1 = engine.allocate_memory(in_layout1);
@@ -554,7 +554,7 @@ TEST(prepare_buffer_fusing, in_place_concat_dynamic_onednn_batch2) {
     ASSERT_NE(concat_mem.get(), reorder1_mem.get());
     ASSERT_NE(concat_mem.get(), reorder2_mem.get());
     ASSERT_FALSE(concat_inst->can_be_optimized());
-    ASSERT_TRUE(concat_node_n.can_be_optimized());
+    ASSERT_FALSE(concat_node_n.can_be_optimized());
 
     for (size_t x = 0; x < out_l.count(); ++x) {
         ASSERT_EQ(ref_output[x], output_ptr[x]);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -2023,8 +2023,7 @@ TEST_P(concat_no_implicit_gpu_onednn_4d_f16_spatial, other_spatial) {
 INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_no_implicit_gpu_onednn_4d_f16_spatial,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 16 }, 2, 2, format::b_fs_yx_fsv16, false, false),
-                            TestParamType_implicit_concat(1, { 16 }, 2, 2, format::bfyx, false, false)
+                            TestParamType_implicit_concat(1, { 16 }, 2, 2, format::b_fs_yx_fsv16, false, false)
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 #endif

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1969,6 +1969,7 @@ public:
         config1.set_property(ov::intel_gpu::optimize_data(true));
         ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
         config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"conv", impl}}));
+        config1.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{{"concat", impl}}));
 
         auto out_mem1 = run_concat_network(input, fmt, config1);
         cldnn::mem_lock<Type> out_ptr1(out_mem1, stream);

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1853,9 +1853,7 @@ INSTANTIATE_TEST_SUITE_P(smoke,
 template <typename Type>
 struct concat_gpu_4d_explicit : public concat_gpu_implicit {
 public:
-    cldnn::memory::ptr run_concat_network(std::vector<std::vector<std::vector<std::vector<std::vector<Type>>>>> input,
-                                        format::type fmt,
-                                        ExecutionConfig config) {
+    cldnn::memory::ptr run_concat_network(std::vector<std::vector<std::vector<std::vector<std::vector<Type>>>>> input, format::type fmt, ExecutionConfig config) {
         auto data_type = ov::element::from<Type>();
         auto& engine = get_test_engine();
         const size_t batch_num = testing::get<0>(GetParam());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1851,7 +1851,7 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                         concat_gpu_implicit::PrintToStringParamName);
 
 template <typename Type>
-struct concat_gpu_4d_explicit_onednn : public concat_gpu_implicit {
+struct concat_gpu_4d_explicit : public concat_gpu_implicit {
 public:
     cldnn::memory::ptr run_concat_network(std::vector<std::vector<std::vector<std::vector<std::vector<Type>>>>> input,
                                         format::type fmt,
@@ -1990,7 +1990,7 @@ public:
     }
 };
 
-using concat_no_implicit_gpu_onednn_4d_f16 = concat_gpu_4d_explicit_onednn<ov::float16>;
+using concat_no_implicit_gpu_onednn_4d_f16 = concat_gpu_4d_explicit<ov::float16>;
 
 TEST_P(concat_no_implicit_gpu_onednn_4d_f16, default) {
     ASSERT_NO_FATAL_FAILURE(test());

--- a/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/test_cases/concatenation_gpu_test.cpp
@@ -1850,8 +1850,44 @@ INSTANTIATE_TEST_SUITE_P(smoke,
                         ),
                         concat_gpu_implicit::PrintToStringParamName);
 
+// Added parameters for exception to be explicit concat
+using TestExtendedParamType_implicit_concat = ::testing::tuple<size_t,      // 0 - Input Batch size
+    std::vector<size_t>,                                            // 1 - Inputs Features Sizes
+    size_t,                                                         // 2 - Input Y Size
+    size_t,                                                         // 3 - Input X Size
+    format::type,                                                   // 4 - Format
+    bool,                                                           // 5 - Implicit concat
+    bool,                                                           // 6 - is_caching_test
+    size_t>;                                                        // 7 - Concat axis
+struct concat_gpu_explicit : public ::testing::TestWithParam<TestExtendedParamType_implicit_concat>
+{
+    tests::random_generator rg;
+
+    void SetUp() override {
+        rg.set_seed(GET_SUITE_NAME);
+    }
+
+    static std::string
+    PrintToStringParamName(testing::TestParamInfo<TestExtendedParamType_implicit_concat> param_info)
+    {
+        std::string in;
+        for (size_t i = 0; i < testing::get<1>(param_info.param).size() - 1; i++) {
+            in += std::to_string(testing::get<1>(param_info.param)[i]) + "_";
+        }
+        in += std::to_string(testing::get<1>(param_info.param)[testing::get<1>(param_info.param).size() - 1]);
+        format::type fmt = testing::get<4>(param_info.param);
+        return "in" + std::to_string(testing::get<0>(param_info.param))
+               + "x" + in + "x" + std::to_string(testing::get<2>(param_info.param))
+               + 'x' + std::to_string(testing::get<3>(param_info.param))
+               + "_format_" + format(fmt).to_string()
+               + "_implicit_concat" + std::to_string(testing::get<5>(param_info.param))
+               + "_is_caching_test" + std::to_string(testing::get<6>(param_info.param))
+               + "_concat_axis" + std::to_string(testing::get<7>(param_info.param));
+    }
+};
+
 template <typename Type>
-struct concat_gpu_4d_explicit : public concat_gpu_implicit {
+struct concat_gpu_4d_explicit : public concat_gpu_explicit {
 public:
     cldnn::memory::ptr run_concat_network(std::vector<std::vector<std::vector<std::vector<std::vector<Type>>>>> input, format::type fmt, ExecutionConfig config) {
         auto data_type = ov::element::from<Type>();
@@ -1861,6 +1897,7 @@ public:
         const size_t input_y = testing::get<2>(GetParam());
         const size_t input_x = testing::get<3>(GetParam());
         const bool is_implicit_concat = testing::get<5>(GetParam());
+        const size_t concat_axis = testing::get<7>(GetParam());
         size_t output_f = in_features[0];
 
         topology topology;
@@ -1922,8 +1959,11 @@ public:
         }
         topology.add(data("weights" , weights_mem));
         topology.add(convolution("conv", input_info("eltwise2"), "weights", "", 1, {1, 1}, {1, 1}, {0, 0}, {0, 0}, false));
-        topology.add(concatenation("concat", {input_info("eltwise1"), input_info("eltwise2")}, 1));
+        topology.add(concatenation("concat", {input_info("eltwise1"), input_info("eltwise2")}, concat_axis));
         topology.add(reorder("reorder", input_info("concat"), layout(data_types::f32, format::bfyx, {(int32_t)batch_num, (int32_t)(output_f * 2), (int32_t)input_y, (int32_t)input_x})));
+
+        ov::intel_gpu::ImplementationDesc impl = { fmt, std::string(""), impl_types::onednn };
+        config.set_property(ov::intel_gpu::force_implementations(ov::intel_gpu::ImplForcingMap{ {"concat", impl} }));
 
         network concat_network(engine, topology, config);
         for (size_t i = 0; i < 4; i++) {
@@ -1931,9 +1971,7 @@ public:
         }
         auto outputs = concat_network.execute();
 
-        bool concat_opt_enabled = config.get_optimize_data();
-        if (concat_opt_enabled)
-            concat_opt_enabled = is_implicit_concat;
+        bool concat_opt_enabled = is_implicit_concat;
         bool concat_opt_result = std::static_pointer_cast<concatenation_inst>(concat_network.get_primitive("concat"))->get_node().can_be_optimized();
 
         EXPECT_EQ(concat_opt_enabled, concat_opt_result);
@@ -1988,17 +2026,18 @@ public:
     }
 };
 
-using concat_no_implicit_gpu_onednn_4d_f16 = concat_gpu_4d_explicit<ov::float16>;
+using concat_explicit_gpu_onednn_4d_f16 = concat_gpu_4d_explicit<ov::float16>;
 
-TEST_P(concat_no_implicit_gpu_onednn_4d_f16, default) {
+TEST_P(concat_explicit_gpu_onednn_4d_f16, default) {
     ASSERT_NO_FATAL_FAILURE(test());
 }
 
 INSTANTIATE_TEST_SUITE_P(smoke,
-                        concat_no_implicit_gpu_onednn_4d_f16,
+                        concat_explicit_gpu_onednn_4d_f16,
                         ::testing::Values(
-                            TestParamType_implicit_concat(1, { 16 }, 2, 2, format::b_fs_yx_fsv16, true, false),
-                            TestParamType_implicit_concat(2, { 16 }, 2, 2, format::b_fs_yx_fsv16, false, false)
+                            TestExtendedParamType_implicit_concat(1, { 16 }, 2, 2, format::b_fs_yx_fsv16, true, false, 1),
+                            TestExtendedParamType_implicit_concat(2, { 16 }, 2, 2, format::b_fs_yx_fsv16, false, false, 1),
+                            TestExtendedParamType_implicit_concat(1, { 16 }, 2, 2, format::b_fs_yx_fsv16, false, false, 2)
                         ),
-                        concat_gpu_implicit::PrintToStringParamName);
+                        concat_gpu_explicit::PrintToStringParamName);
 #endif


### PR DESCRIPTION
### Description of the issue
- PR for release 2025.3
 - symptom:
 1.  Accuracy issue : regression observed in output image file
<img width="246" height="267" alt="image" src="https://github.com/user-attachments/assets/1f120754-57c5-40b1-a3fb-1ccfce5d8939" />

  - root-cause:  Convolution recently changed its preferred formats to default formats if it has small IC or OC. By format propagation of Convolution-Concat layers, a Concat layer, 'concat:aten::cat/Concat_3', has bfzyx format with the fix. This concat optimized out as implicit concat even though its concat-axis is 2 with [1x3x17x?x?]. 
<img width="727" height="474" alt="image" src="https://github.com/user-attachments/assets/7c6fd5cb-6bc7-454b-bce2-f1369b2f6c97" />
<img width="1475" height="135" alt="image" src="https://github.com/user-attachments/assets/923bf405-7a16-475d-bc16-21b52453cedc" />

`GPU_Debug: ^[[1;34mprimitive_inst.cpp:^[[1;35m1700:^[[1;36mdo_runtime_in_place_concat: ^[[0m[In place concat] concat:aten::cat/Concat_3: can_be_optimized`

 - how resolved: 
Onednn implicit concat is only selected for feature axis

#### The code and line that caused this issue
 - Accuracy issue : primitive_inst.cpp:1700
  Missing logic to keep concat explicit

#### Reproduction step and snapshot
 - Execute openvino notebooks/wan2.1-text-to-video

#### Checklist
 - [x] Is it a proper fix? (not a workaround)
 - [x] Did you include test case for this fix, if necessary?
 - [x] Did you review existing test that can be extended to cover this scenario? Which test did you review? : reviewed unittests with "concat_explicit_gpu_onednn_4d_f16"

### Tickets:
 - CVS-169601
