### PR TITLE
[GPU] check the feature padding at onednn reorder

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.hpp
@@ -65,7 +65,7 @@ struct ReorderImplementationManager : public ImplementationManager {
             return false;
 
         // onednn doesn't support paddings
-        if (!is_supported_pad(input_layout) || !is_supported_pad(output_layout))
+        if (!is_supported_pad_for_reorder(input_layout) || !is_supported_pad_for_reorder(output_layout))
             return false;
 
         // Native impl works faster for this type of reorder
@@ -89,6 +89,20 @@ struct ReorderImplementationManager : public ImplementationManager {
             return false;
 
         return true;
+    }
+
+    static bool is_supported_pad_for_reorder(const layout& layout) {
+        // check to support the batch/spatial pad for onednn.
+        if (!is_supported_pad(layout))
+            return false;
+
+        // Check feature pad
+        const auto& pad = layout.data_padding;
+        bool no_feature_padding = true;
+        no_feature_padding &= (pad._lower_size[1] == 0);
+        no_feature_padding &= (pad._upper_size[1] == 0);
+
+        return no_feature_padding;
     }
 };
 

--- a/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp
@@ -797,11 +797,6 @@ bool is_supported_pad(const layout& layout) {
         no_spatial_padding &= (pad._upper_size[2 + i] == 0);
     }
 
-    // Check feature padding
-    bool no_feature_padding = true;
-    no_feature_padding &= (pad._lower_size[1] == 0);
-    no_feature_padding &= (pad._upper_size[1] == 0);
-
     // Onednn supports outer padding of batch axis (first element offset) if its format is 'bxxx'
     bool no_batch_padding = true;
     auto fmt = layout.format;
@@ -810,7 +805,7 @@ bool is_supported_pad(const layout& layout) {
         no_batch_padding &= (pad._upper_size[0] == 0);
     }
 
-    return (no_spatial_padding && no_feature_padding && no_batch_padding);
+    return (no_spatial_padding && no_batch_padding);
 }
 
 }  // namespace onednn


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
 - onednn reorder can not handle the feature axis padding. 'is_supported_pad()' function does not check the feature axis padding.
 - fallback to ocl if the reorder has the feature axis padding.

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/src/graph/impls/onednn/reorder_onednn.cpp
 - src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - reproducer is attached in the ticket
<img width="912" height="446" alt="image" src="https://github.com/user-attachments/assets/db41a6f7-8738-4012-b5d7-6259cb922a0e" />

#### Problematic graph
<img width="1308" height="885" alt="image" src="https://github.com/user-attachments/assets/b4ee632b-8375-4185-b7d1-b31bfe95b786" />


#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 172242
