### PR TITLE
[PyOV] Upgrade Tensorflow and protobuf

### DIFF
--- a/src/bindings/python/constraints.txt
+++ b/src/bindings/python/constraints.txt
@@ -20,6 +20,6 @@ packaging>=22.0
 h5py>=3.1.0,<3.15.0
 docopt~=0.6.2
 paddlepaddle==3.0.0
-tensorflow>=1.15.5,<2.20.0
-protobuf>=3.18.1,<7.0.0
+tensorflow>=1.15.5,<2.21.0
+protobuf>=3.18.1,<7.0.0,!=6.31.1
 onnx==1.17.0

--- a/tests/constraints.txt
+++ b/tests/constraints.txt
@@ -10,11 +10,11 @@ scipy>=1.11.1; python_version >= "3.9"
 sympy>=1.10
 wheel>=0.38.1
 defusedxml>=0.7.1
-tensorflow>=2.5,<2.20.0
+tensorflow>=2.5,<2.21.0
 requests>=2.25.1
 opencv-python>=4.5
 paddlepaddle==2.6.2
-protobuf>=3.18.1,<7.0.0
+protobuf>=3.18.1,<7.0.0,!=6.31.1
 py>=1.9.0
 pytest>=5.0,<8.5
 pytest-dependency==0.6.0


### PR DESCRIPTION
### Details:
 - Tensorflow upgrade at https://github.com/openvinotoolkit/openvino/pull/31729 fails due to issues with protobuf
 - Installed protobuf version is correct, the issue might be related to https://github.com/tensorflow/models/issues/11192 instead
 - This PR checks if forcing pip to install a different protobuf version fixes the issue

### Tickets:
 - N/A
