### PR TITLE
[Py OV] Declare TensorVector after Tensor

### DIFF
--- a/src/bindings/python/src/pyopenvino/pyopenvino.cpp
+++ b/src/bindings/python/src/pyopenvino/pyopenvino.cpp
@@ -103,9 +103,6 @@ PYBIND11_MODULE(_pyopenvino, m) {
                     "Please ensure that environment variables (e.g. PATH, PYTHONPATH) are set correctly so that "
                     "OpenVINO Runtime and Python libraries point to same release.");
 
-    // https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#making-opaque-types
-    py::bind_vector<ov::TensorVector>(m, "TensorVector");
-
     m.def("get_version", &get_version);
     m.def(
         "serialize",
@@ -232,6 +229,8 @@ PYBIND11_MODULE(_pyopenvino, m) {
     regclass_graph_Output<ov::Node>(m, std::string(""));
     regclass_Tensor(m);
     regclass_graph_descriptor_Tensor(m);
+    // https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#making-opaque-types
+    py::bind_vector<ov::TensorVector>(m, "TensorVector");
     regclass_graph_Input(m);
     regclass_graph_Node(m);
     regclass_graph_NodeFactory(m);


### PR DESCRIPTION
### Details:
 - Fixes "Python API Stubs" in GHA
> pybind11_stubgen - [  ERROR] In openvino._pyopenvino.TensorVector.__getitem__ : Invalid expression 'ov::Tensor'
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.TensorVector.__iter__ : Invalid expression 'ov::Tensor'
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.TensorVector.__setitem__ : Invalid expression 'ov::Tensor'
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.TensorVector.append : Invalid expression 'ov::Tensor'
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.TensorVector.insert : Invalid expression 'ov::Tensor'
pybind11_stubgen - [  ERROR] In openvino._pyopenvino.TensorVector.pop : Invalid expression 'ov::Tensor'
Warning: stubgen - [WARNING] Raw C++ types/values were found in signatures extracted from docstrings.
Please check the corresponding sections of pybind11 documentation to avoid common mistakes in binding code:
 https://pybind11.readthedocs.io/en/latest/advanced/misc.html#avoiding-cpp-types-in-docstrings

 - https://github.com/openvinotoolkit/openvino/pull/31794 can be closed 

