### PR TITLE
[GPU][MTL] fix ambiguous data type for fmax in gemv

### DIFF
--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_gemv.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/fully_connected/fully_connected_kernel_gemv.cpp
@@ -177,6 +177,10 @@ JitConstants FullyConnected_GEMV::GetJitConstants(const fully_connected_params& 
     jit.AddConstant(MakeJitConstant("WEIGHTS_N", params.weights.OFM().v));
 
     auto activation_dt = GetActivationType(params);
+    // Activation is computed in F32, so we need to convert it to F32
+    if (activation_dt == Datatype::F16) {
+        activation_dt = Datatype::F32;
+    }
     jit.Merge(MakeTypeJitConstants(activation_dt, "ACTIVATION"));
     jit.Merge(MakeActivationJitConstants(params.activations, activation_dt, "_TYPED"));
 


### PR DESCRIPTION
### Details:
 - MTL run t5-small_4BIT model, fc's activation will use fmax, it will report below error, fix it by aligning the 2 input data types of fmax
 
<img width="936" height="262" alt="image" src="https://github.com/user-attachments/assets/c3dce753-01e0-4521-bf08-fed175c8ce30" />

 - *...*

### Tickets:
 - *CVS-172483*
