### PR TITLE
[GPU] Enable int8 oneDNN 3D convolution in dynamic model.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
+++ b/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp
@@ -943,73 +943,63 @@ void layout_optimizer::set_onednn_dyn_conv_preferred_format(convolution_node& no
     OPENVINO_ASSERT(rank == output_layout.get_partial_shape().size(), "Input and output ranks must match");
     OPENVINO_ASSERT(rank <= 5, "Not supported rank");
 
+    // Data type classification
     bool i8_u8_input = (input_layout.data_type == data_types::u8 || input_layout.data_type == data_types::i8);
     bool i8_u8_output = (output_layout.data_type == data_types::u8 || output_layout.data_type == data_types::i8);
     bool is_fp16_input = (input_layout.data_type == data_types::f16);
 
+    // Helper functions to get appropriate formats based on rank
+    auto get_fsv32_format = [](size_t rank) {
+        return (rank <= 4) ? cldnn::format::b_fs_yx_fsv32 : cldnn::format::b_fs_zyx_fsv32;
+    };
+
+    auto get_fsv16_format = [](size_t rank) {
+        return (rank <= 4) ? cldnn::format::b_fs_yx_fsv16 : cldnn::format::b_fs_zyx_fsv16;
+    };
+
+    auto get_f_inner_planar_format = [](size_t rank) {
+        return (rank <= 4) ? cldnn::format::byxf : cldnn::format::bzyxf;
+    };
+
+    // Helper function to get channel count safely
+    auto get_channel_count = [](const layout& layout) -> int64_t {
+        return layout.get_partial_shape()[1].is_static() ? layout.get_partial_shape()[1].get_length() : -1;
+    };
+
+    // Get channel counts once
+    int64_t input_channels = get_channel_count(input_layout);
+    int64_t output_channels = get_channel_count(output_layout);
+
     if (i8_u8_input) {
-        // Set input format based on rank
-        if (rank <= 4) {
-            node.set_preferred_input_fmt(0, cldnn::format::b_fs_yx_fsv32);
-        } else if (rank == 5) {
-            node.set_preferred_input_fmt(0, cldnn::format::b_fs_zyx_fsv32);
-        }
+        // Set default input format for i8/u8 input
+        node.set_preferred_input_fmt(0, get_fsv32_format(rank));
 
-        // Set output format based on output data type and rank
+        // Set output format based on output data type
         if (i8_u8_output) {
-            if (rank <= 4) {
-                node.set_preferred_output_fmt(0, cldnn::format::b_fs_yx_fsv32);
-            } else if (rank == 5) {
-                node.set_preferred_output_fmt(0, cldnn::format::b_fs_zyx_fsv32);
-            }
+            node.set_preferred_output_fmt(0, get_fsv32_format(rank));
         } else {
-            if (rank <= 4) {
-                node.set_preferred_output_fmt(0, cldnn::format::b_fs_yx_fsv16);
-            } else if (rank == 5) {
-                node.set_preferred_output_fmt(0, cldnn::format::b_fs_zyx_fsv16);
-            }
+            node.set_preferred_output_fmt(0, get_fsv16_format(rank));
         }
 
-        // Special handling for shallow channels (≤ 16)
-        bool shallow_input_channels = (input_layout.get_partial_shape()[1].is_static() &&
-                                    input_layout.get_partial_shape()[1].get_length() <= 16);
-        bool shallow_output_channels = (output_layout.get_partial_shape()[1].is_static() &&
-                                      output_layout.get_partial_shape()[1].get_length() <= 16);
-
-        if (shallow_input_channels) {
-            if (rank <= 4) {
-                node.set_preferred_input_fmt(0, cldnn::format::byxf);
-            } else if (rank == 5) {
-                node.set_preferred_input_fmt(0, cldnn::format::bzyxf);
-            }
+        // Override with planar format for shallow channels (≤ 16)
+        if (input_channels > 0 && input_channels <= 16) {
+            node.set_preferred_input_fmt(0, get_f_inner_planar_format(rank));
         }
 
-        if (shallow_output_channels) {
-            if (rank <= 4) {
-                node.set_preferred_output_fmt(0, cldnn::format::byxf);
-            } else if (rank == 5) {
-                node.set_preferred_output_fmt(0, cldnn::format::bzyxf);
-            }
+        if (output_channels > 0 && output_channels <= 16) {
+            node.set_preferred_output_fmt(0, get_f_inner_planar_format(rank));
         }
     } else if (is_fp16_input) {
-        // Set output format for FP16 input
-        if (rank <= 4) {
-            node.set_preferred_output_fmt(0, format::b_fs_yx_fsv16);
-        } else if (rank == 5) {
-            node.set_preferred_output_fmt(0, format::b_fs_zyx_fsv16);
-        }
+        // Set default formats for FP16 input
+        node.set_preferred_input_fmt(0, get_fsv16_format(rank));
+        node.set_preferred_output_fmt(0, get_fsv16_format(rank));
 
-        // Use planar format for dynamic convolution with small input/output channels (≤ 4)
-        bool small_input_channels = (input_layout.get_partial_shape()[1].is_static() &&
-                                   input_layout.get_partial_shape()[1].get_length() <= 4);
-        bool small_output_channels = (output_layout.get_partial_shape()[1].is_static() &&
-                                    output_layout.get_partial_shape()[1].get_length() <= 4);
-
-        if (small_input_channels) {
+        // Override with default format for small channels (≤ 4)
+        if (input_channels > 0 && input_channels <= 4) {
             node.set_preferred_input_fmt(0, format::get_default_format(rank));
         }
 
-        if (small_output_channels) {
+        if (output_channels > 0 && output_channels <= 4) {
             node.set_preferred_output_fmt(0, format::get_default_format(rank));
         }
     }


### PR DESCRIPTION
### Description
 - When both input and output tensors have rank 5, applying format intended for rank 4 tensors leads to incorrect behavior.
 - Although the issue could have been resolved in the referenced PR, the lack of 3D convolution handling prevented a complete fix.

#### The code and line that caused this issue
 - Related PR: https://github.com/openvinotoolkit/openvino/pull/30993
 - https://github.com/openvinotoolkit/openvino/blob/7cc4b1a59a07ca9478373d2ebb62d88dcbd2e69e/src/plugins/intel_gpu/src/graph/layout_optimizer.cpp#L936-L972

#### Problematic graph
<img width="1826" height="672" alt="image" src="https://github.com/user-attachments/assets/4d16329a-36f8-49cf-bacd-57857281a5ae" />

#### Checklist
 - [V] Is it a proper fix? (not a workaround)
 - [V] Did you include test case for this fix, if necessary?
 - [V] Did you review existing test that can be extended to cover this scenario? Which test did you review?
   - quantized_onednn_convolution_u8s8f32_weights_zp/convolution_gpu_onednn_both_shapes.quantized_onednn_convolution_u8s8f32_weights_zp

### Tickets:
 - *170724*

### PR in master branch
 - https://github.com/openvinotoolkit/openvino/pull/31734 
