### PR TITLE
[GPU] Fix reorder format mismatch in convolution weights.

### DIFF
--- a/src/plugins/intel_gpu/tests/unit/onednn/utils_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/onednn/utils_test.cpp
@@ -286,4 +286,13 @@ TEST(keep_weights_reorder_shape_consistent_test, simple_data_formats) {
         EXPECT_TRUE(result);
         EXPECT_EQ(layout.get_partial_shape(), ov::Shape({512, 1024, 16}));
     }
+    // Test case 4: oizyx format with matching shapes
+    {
+        auto layout = cldnn::layout{ov::PartialShape{16, 1, 16, 16}, data_types::f16, format::oiyx};
+        dnnl::memory::desc desc({16, 1, 1, 16, 16}, dnnl::memory::data_type::f16, dnnl::memory::format_tag::abcde);
+        bool result = onednn::keep_weights_reorder_shape_consistent(layout, desc);
+        EXPECT_TRUE(result);
+        EXPECT_EQ(layout.format, cldnn::format::oizyx);
+        EXPECT_EQ(layout.get_partial_shape(), ov::Shape({16, 1, 1, 16, 16}));
+    }
 }

--- a/src/plugins/intel_gpu/tests/unit/onednn/utils_test.cpp
+++ b/src/plugins/intel_gpu/tests/unit/onednn/utils_test.cpp
@@ -259,3 +259,31 @@ INSTANTIATE_TEST_SUITE_P(smoke, memory_desc_to_fmt_conversion_test,
         },
     }),
     memory_desc_to_fmt_conversion_test::PrintToString);
+
+// Test for keep_weights_reorder_shape_consistent function
+TEST(keep_weights_reorder_shape_consistent_test, simple_data_formats) {
+    // Test case 1: bfyx format with matching shapes
+    {
+        auto layout = cldnn::layout{ov::PartialShape{512, 1024, 16}, data_types::f16, format::bfyx};
+        dnnl::memory::desc desc({512, 1024, 16}, dnnl::memory::data_type::f16, dnnl::memory::format_tag::abc);
+        bool result = onednn::keep_weights_reorder_shape_consistent(layout, desc);
+        EXPECT_TRUE(result);
+        EXPECT_EQ(layout.get_shape(), ov::Shape({512, 1024, 16}));
+    }
+    // Test case 2: fbyx format with matching shapes
+    {
+        auto layout = cldnn::layout{ov::PartialShape{512, 1024, 16}, data_types::f16, format::fbyx};
+        dnnl::memory::desc desc({512, 1024, 16}, dnnl::memory::data_type::f16, dnnl::memory::format_tag::abc);
+        bool result = onednn::keep_weights_reorder_shape_consistent(layout, desc);
+        EXPECT_TRUE(result);
+        EXPECT_EQ(layout.get_shape(), ov::Shape({512, 1024, 16}));
+    }
+    // Test case 3: ioyx format with matching shapes
+    {
+        auto layout = cldnn::layout{ov::PartialShape{512, 1024, 16}, data_types::f16, format::ioyx};
+        dnnl::memory::desc desc({512, 1024, 16}, dnnl::memory::data_type::f16, dnnl::memory::format_tag::abc);
+        bool result = onednn::keep_weights_reorder_shape_consistent(layout, desc);
+        EXPECT_TRUE(result);
+        EXPECT_EQ(layout.get_partial_shape(), ov::Shape({512, 1024, 16}));
+    }
+}


### PR DESCRIPTION
### Description of the issue
 - When convolution constant weights are transposed via permute, the graph optimization replaces it with reorder.
 - This causes issues for onednn reorder due to non-default format changes.
 - The fix ensures format consistency when replacing permute with reorder.

#### The code and line that caused this issue
https://github.com/openvinotoolkit/openvino/blob/689ab8b0685723dcd44176c468631e416b0146c3/src/plugins/intel_gpu/src/graph/impls/onednn/utils.cpp#L718-L757

#### Problematic graph
<img width="1574" height="823" alt="image" src="https://github.com/user-attachments/assets/31e211b7-80c6-4573-91e8-2a5b20fcd376" />

#### Checklist
 - [V] Is it a proper fix?
 - [V] Did you include test case for this fix? 
 - [V] Did you review existing test that can be extended to cover this scenario?
   - No eligible test for this.

### Tickets:
 - *168091*