### PR TITLE
[port, core] Open compiled model as file stream when MMAP disabled. 

### DIFF
--- a/src/inference/src/cache_manager.hpp
+++ b/src/inference/src/cache_manager.hpp
@@ -9,10 +9,12 @@
  */
 #pragma once
 
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <memory>
 #include <string>
+#include <variant>
 
 #include "openvino/runtime/shared_buffer.hpp"
 #include "openvino/runtime/tensor.hpp"
@@ -68,9 +70,14 @@ public:
     virtual void write_cache_entry(const std::string& id, StreamWriter writer) = 0;
 
     /**
+     * @brief Variant type for compiled blob representation
+     */
+    using CompiledBlobVariant = std::variant<const ov::Tensor, std::reference_wrapper<std::istream>>;
+
+    /**
      * @brief Function passing created input stream
      */
-    using StreamReader = std::function<void(ov::Tensor&)>;
+    using StreamReader = std::function<void(CompiledBlobVariant&)>;
 
     /**
      * @brief Callback when OpenVINO intends to read model from cache
@@ -137,9 +144,14 @@ private:
         ScopedLocale plocal_C(LC_ALL, "C");
         const auto blob_file_name = getBlobFile(id);
         if (std::filesystem::exists(blob_file_name)) {
-            auto compiled_blob =
-                read_tensor_data(blob_file_name, element::u8, PartialShape::dynamic(1), 0, enable_mmap);
-            reader(compiled_blob);
+            if (enable_mmap) {
+                CompiledBlobVariant compiled_blob{std::in_place_index<0>, ov::read_tensor_data(blob_file_name)};
+                reader(compiled_blob);
+            } else {
+                std::ifstream stream(blob_file_name, std::ios_base::binary);
+                CompiledBlobVariant compiled_blob{std::in_place_index<1>, std::ref(stream)};
+                reader(compiled_blob);
+            }
         }
     }
 

--- a/src/inference/src/dev/core_impl.cpp
+++ b/src/inference/src/dev/core_impl.cpp
@@ -1531,16 +1531,24 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
             cacheContent.blobId,
             cacheContent.mmap_enabled && ov::util::contains(plugin.get_property(ov::internal::supported_properties),
                                                             ov::internal::caching_with_mmap),
-            [&](ov::Tensor& compiled_blob) {
+            [&](ICacheManager::CompiledBlobVariant& compiled_blob) {
                 OV_ITT_SCOPE(FIRST_INFERENCE,
                              ov::itt::domains::LoadTime,
                              "Core::load_model_from_cache::ReadStreamAndImport");
                 ov::CompiledBlobHeader header;
                 size_t compiled_blob_offset = 0;
                 try {
-                    header.read_from_buffer(static_cast<const char*>(compiled_blob.data()),
-                                            compiled_blob.get_byte_size(),
-                                            compiled_blob_offset);
+                    ov::util::VariantVisitor header_reader{[&](const ov::Tensor& tensor) {
+                                                               header.read_from_buffer(
+                                                                   static_cast<const char*>(tensor.data()),
+                                                                   tensor.get_byte_size(),
+                                                                   compiled_blob_offset);
+                                                           },
+                                                           [&](std::reference_wrapper<std::istream> stream) {
+                                                               stream >> header;
+                                                           }};
+                    std::visit(header_reader, compiled_blob);
+
                     if (header.get_file_info() != ov::ModelCache::calculate_file_info(cacheContent.modelPath)) {
                         // Original file is changed, don't use cache
                         OPENVINO_THROW("Original model file is changed");
@@ -1594,12 +1602,19 @@ ov::SoPtr<ov::ICompiledModel> ov::CoreImpl::load_model_from_cache(
                     }
                 }
 
-                ov::Tensor compiled_blob_without_header{compiled_blob,
-                                                        {compiled_blob_offset},
-                                                        {compiled_blob.get_size()}};
-
-                compiled_model = context ? plugin.import_model(compiled_blob_without_header, context, update_config)
-                                         : plugin.import_model(compiled_blob_without_header, update_config);
+                ov::util::VariantVisitor model_importer{
+                    [&](const ov::Tensor& compiled_blob) -> ov::SoPtr<ov::ICompiledModel> {
+                        const ov::Tensor compiled_blob_without_header{compiled_blob,
+                                                                      {compiled_blob_offset},
+                                                                      {compiled_blob.get_size()}};
+                        return context ? plugin.import_model(compiled_blob_without_header, context, update_config)
+                                       : plugin.import_model(compiled_blob_without_header, update_config);
+                    },
+                    [&](std::reference_wrapper<std::istream> stream) -> ov::SoPtr<ov::ICompiledModel> {
+                        return context ? plugin.import_model(stream, context, update_config)
+                                       : plugin.import_model(stream, update_config);
+                    }};
+                compiled_model = std::visit(model_importer, compiled_blob);
             });
     } catch (const HeaderException&) {
         // For these exceptions just remove old cache and set that import didn't work

--- a/src/plugins/template/src/plugin.cpp
+++ b/src/plugins/template/src/plugin.cpp
@@ -38,7 +38,7 @@ uint64_t get_blob_data_size(std::istream& model) {
 }
 
 std::string get_model_str(std::istream& model) {
-    const auto model_size = std::min<uint64_t>(model.rdbuf()->in_avail(), get_blob_data_size(model));
+    const auto model_size = get_blob_data_size(model);
     std::string xml;
     xml.resize(model_size);
     model.read(xml.data(), model_size);
@@ -52,7 +52,7 @@ ov::Tensor read_weights(std::istream& model, const size_t weights_size) {
 }
 
 ov::Tensor get_model_weights(std::istream& model) {
-    const auto weights_size = std::min<uint64_t>(model.rdbuf()->in_avail(), get_blob_data_size(model));
+    const auto weights_size = get_blob_data_size(model);
     return weights_size != 0 ? read_weights(model, weights_size) : ov::Tensor();
 }
 


### PR DESCRIPTION
### Details:
 - When MMAP feature disabled open model from cache as stream and don't read into tensor on core level. This read may trigger additional consumption as plugin may try read stream again.

### Port of:
- #31774 

### Tickets:
 - CVS-171329