### PR TITLE
NPUW: Condition RoPE caching to the cases where it is really required

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1232,7 +1232,7 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
             rope_prefill_cacher.run_on_model(prefill_model);
         }
 
-        if (const int32_t ctx_len = max_prompt_len + min_response_len; ctx_len >= CACHE_ROPE_START) {
+        if (const uint32_t ctx_len = max_prompt_len + min_response_len; ctx_len >= CACHE_ROPE_START) {
             LOG_DEBUG("Enable RoPE Cache for kvcache");
             ov::npuw::patterns::pre_compute::RopeCache rope_generate_cacher(ctx_len);
             rope_generate_cacher.run_on_model(kvcache_model);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_compiled_model.cpp
@@ -1224,11 +1224,19 @@ ov::npuw::LLMCompiledModel::LLMCompiledModel(const std::shared_ptr<ov::Model>& m
 
     if (m_cfg.get<::intel_npu::NPUW_LLM_CACHE_ROPE>()) {
         LOG_DEBUG("Caching preROPE ");
-        ov::npuw::patterns::pre_compute::RopeCache rope_prefill_cacher(max_prompt_len);
-        rope_prefill_cacher.run_on_model(prefill_model);
+        const uint32_t CACHE_ROPE_START = 2048;
 
-        ov::npuw::patterns::pre_compute::RopeCache rope_generate_cacher(max_prompt_len + min_response_len);
-        rope_generate_cacher.run_on_model(kvcache_model);
+        if (max_prompt_len >= CACHE_ROPE_START) {
+            LOG_DEBUG("Enable RoPE Cache for prefill");
+            ov::npuw::patterns::pre_compute::RopeCache rope_prefill_cacher(max_prompt_len);
+            rope_prefill_cacher.run_on_model(prefill_model);
+        }
+
+        if (const int32_t ctx_len = max_prompt_len + min_response_len; ctx_len >= CACHE_ROPE_START) {
+            LOG_DEBUG("Enable RoPE Cache for kvcache");
+            ov::npuw::patterns::pre_compute::RopeCache rope_generate_cacher(ctx_len);
+            rope_generate_cacher.run_on_model(kvcache_model);
+        }
     }
 
     auto prefill_config =


### PR DESCRIPTION
### Details:
 - A performance regression found on 1K prompts only when running `GENERATE_HINT : BEST_PERF` (a single submission) when RoPE caching gets enabled.
 - While the actual issue should be fixed in the compiler, disable this feature for now for the shorter prompts to avoid performance degradation

### Tickets:
 - EISW-180374
