### PR TITLE
[GPU] Revert src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp before PR31623

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
+++ b/src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp
@@ -61,8 +61,7 @@ struct ReduceImplementationManager : public ImplementationManager {
         auto in_dt = in_layout.data_type;
         auto out_dt = out_layout.data_type;
 
-        // onednn reduction does not support different input/output data types
-        if (in_dt != out_dt)
+        if (in_dt == data_types::f32 && out_dt == data_types::f32)
             return false;
 
         static const std::vector<format::type> supported_formats = {


### PR DESCRIPTION
### Details:
 - [GPU] Revert src/plugins/intel_gpu/src/graph/impls/onednn/reduce_onednn.hpp before PR31623 due to performance regression in several models.

### Tickets:
 - 172481
