### PR TITLE
Fix 1D transpose test case

### DIFF
--- a/src/plugins/intel_cpu/src/nodes/common/permute_kernel.cpp
+++ b/src/plugins/intel_cpu/src/nodes/common/permute_kernel.cpp
@@ -231,15 +231,25 @@ void PermuteKernel::optimizedExecute(const uint8_t* src_data, const uint8_t* dst
 
     switch (jcp.n) {
     case 0:
-    // This is a degenerate case that is only possible if the tensor has 0 or 1st rank
-    // Such a situation is possible in the following graph:
-    //  Parameter
-    //     |
-    //  Transpose
-    //     |
-    //  Result
-    // The elimination of the Transpose node will not be performed
-    // So copy from input buffer to output buffer without any permutation
+        // This is a degenerate case that is only possible if the tensor has 0 or 1st rank
+        // Such a situation is possible in the following graph:
+        //  Parameter
+        //     |
+        //  Transpose
+        //     |
+        //  Result
+        // The elimination of the Transpose node will not be performed
+        // So copy from input buffer to output buffer without any permutation
+        if (jcp.ndims <= 1) {
+            auto arg = jit_args_permute();
+
+            arg.src = src_data;
+            arg.dst = dst_data;
+
+            (*permute_kernel)(&arg);
+            break;
+        }
+        [[fallthrough]];
     case 1:
         parallel_for(dst_dims[0], [&](int i0) {
             auto arg = jit_args_permute();

--- a/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/transpose.cpp
+++ b/src/plugins/intel_cpu/tests/functional/custom/single_layer_tests/instances/x64/transpose.cpp
@@ -173,6 +173,25 @@ INSTANTIATE_TEST_SUITE_P(smoke_dynamicShapes5D_PermutePerChannels, TransposeLaye
                                  ::testing::Values(additional_config),
                                  ::testing::Values(CPUSpecificParams{})),
                          TransposeLayerCPUTest::getTestCaseName);
+
+const std::vector<InputShape> staticInputShapes1D = {InputShape{
+    // dynamic
+    {-1},
+    // Static shapes
+    {{24}}}
+};
+
+const std::vector<std::vector<size_t>> inputOrder1D = {std::vector<size_t>{0}};
+
+INSTANTIATE_TEST_SUITE_P(smoke_staticShapes1D_Transpose, TransposeLayerCPUTest,
+                         ::testing::Combine(
+                                 ::testing::ValuesIn(staticInputShapes1D),
+                                 ::testing::ValuesIn(inputOrder1D),
+                                 ::testing::Values(ov::element::f32),
+                                 ::testing::Values(ov::test::utils::DEVICE_CPU),
+                                 ::testing::Values(additional_config),
+                                 ::testing::Values(CPUSpecificParams{})),
+                         TransposeLayerCPUTest::getTestCaseName);
 }  // namespace
 }  // namespace Transpose
 }  // namespace test


### PR DESCRIPTION
### Details:
1D transpose will run into the case of `jcp.n = 0`. When `jcp.n = 0` it should not directly fall through to `jcp.n = 1`, since for `jcp.ndims <= 1`, `parallel_for dst_dims[0]` will generate `dst_dims[0]` threads to access the same piece of memory at the same time, which may lead into heap corruption. So in this case, a single thread should be enough.

### Tickets:
 - *165449*
