### PR TITLE
[TRANSFORMATIONS] Mark all inputs of RandomUniform's consumers in the MarkRandomUniform transformation

### DIFF
--- a/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
+++ b/src/common/transformations/src/transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.cpp
@@ -283,8 +283,12 @@ public:
 
             disable_fp16_compression(node);
             for (const auto& output : node->outputs()) {
-                for (const auto& out_inputs : output.get_target_inputs()) {
-                    mark_as_precision_sensitive(out_inputs);
+                auto target_inputs = output.get_target_inputs();
+                for (const auto& input : target_inputs) {
+                    auto consumer_node = input.get_node();
+                    for (auto input : consumer_node->inputs()) {
+                        mark_as_precision_sensitive(input);
+                    }
                 }
             }
             return false;

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -16,23 +16,28 @@
 #include "openvino/op/maximum.hpp"
 #include "openvino/op/multiply.hpp"
 #include "openvino/op/power.hpp"
+#include "openvino/op/random_uniform.hpp"
 #include "openvino/op/range.hpp"
 #include "openvino/op/reduce_mean.hpp"
 #include "openvino/op/reduce_sum.hpp"
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/sqrt.hpp"
 #include "openvino/op/tile.hpp"
+#include "openvino/op/less.hpp"
 #include "openvino/op/unsqueeze.hpp"
+#include "openvino/op/util/precision_sensitive_attribute.hpp"
 #include "openvino/opsets/opset10_decl.hpp"
 #include "openvino/opsets/opset2_decl.hpp"
 #include "openvino/pass/manager.hpp"
 #include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
+#include "transformations/convert_precision.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"
 
 using namespace testing;
 using namespace ov;
 using namespace std;
 using namespace ov::opset10;
+using namespace ov::op;
 
 TEST(TransformationTests, keep_precission_sensitive_fp32_1) {
     shared_ptr<Model> model, model_ref;
@@ -1358,4 +1363,29 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_disable_for_quant
     ASSERT_TRUE(result.valid) << result.message;
     result = fc(model, model_ref);
     ASSERT_TRUE(result.valid) << result.message;
+}
+
+TEST_F(TransformationTestsF, MarkRandomUniformAsPrecisionSensitive) {
+    auto param = std::make_shared<v0::Parameter>(ov::element::i32, ov::PartialShape{2});
+    auto random_uniform = std::make_shared<v8::RandomUniform>(param,
+                                                                v0::Constant::create(element::f32, {}, {0}),
+                                                                v0::Constant::create(element::f32, {}, {1}),
+                                                                element::f32);
+    auto less = std::make_shared<v1::Less>(random_uniform, v0::Constant::create(element::f32, {1, 1}, {0.5}));
+    auto res = std::make_shared<v0::Result>(less);
+
+    model = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{param});
+
+    precisions_map fp_convert_precision_map = {
+        {ov::element::f32, ov::element::f16}
+    };
+
+    type_to_fuse_map empty_fuse_map;
+
+    model_ref = model->clone();
+    manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
+                                                        empty_fuse_map,
+                                                        true,
+                                                        false,
+                                                        true);
 }

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -12,6 +12,7 @@
 #include "openvino/op/exp.hpp"
 #include "openvino/op/fake_quantize.hpp"
 #include "openvino/op/greater.hpp"
+#include "openvino/op/less.hpp"
 #include "openvino/op/matmul.hpp"
 #include "openvino/op/maximum.hpp"
 #include "openvino/op/multiply.hpp"
@@ -23,13 +24,12 @@
 #include "openvino/op/reshape.hpp"
 #include "openvino/op/sqrt.hpp"
 #include "openvino/op/tile.hpp"
-#include "openvino/op/less.hpp"
 #include "openvino/op/unsqueeze.hpp"
 #include "openvino/opsets/opset10_decl.hpp"
 #include "openvino/opsets/opset2_decl.hpp"
 #include "openvino/pass/manager.hpp"
-#include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
 #include "transformations/convert_precision.hpp"
+#include "transformations/fp16_compression/mark_subgraphs_to_keep_in_mixed_precision.hpp"
 #include "transformations/rt_info/disable_fp16_compression.hpp"
 
 using namespace testing;
@@ -1367,9 +1367,9 @@ TEST(TransformationTests, MarkDivWithEpsToKeepInMixedPrecision_disable_for_quant
 TEST_F(TransformationTestsF, MarkRandomUniformAsPrecisionSensitive) {
     auto param = std::make_shared<v0::Parameter>(ov::element::i32, ov::PartialShape{2});
     auto random_uniform = std::make_shared<v8::RandomUniform>(param,
-                                                                v0::Constant::create(element::f32, {}, {0}),
-                                                                v0::Constant::create(element::f32, {}, {1}),
-                                                                element::f32);
+                                                              v0::Constant::create(element::f32, {}, {0}),
+                                                              v0::Constant::create(element::f32, {}, {1}),
+                                                              element::f32);
     auto less = std::make_shared<v1::Less>(random_uniform, v0::Constant::create(element::f32, {1, 1}, {0.5}));
     auto res = std::make_shared<v0::Result>(less);
 
@@ -1383,8 +1383,8 @@ TEST_F(TransformationTestsF, MarkRandomUniformAsPrecisionSensitive) {
 
     model_ref = model->clone();
     manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
-                                                        empty_fuse_map,
-                                                        true,
-                                                        false,
-                                                        true);
+                                                      empty_fuse_map,
+                                                      true,
+                                                      false,
+                                                      true);
 }

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -25,7 +25,6 @@
 #include "openvino/op/tile.hpp"
 #include "openvino/op/less.hpp"
 #include "openvino/op/unsqueeze.hpp"
-#include "openvino/op/util/precision_sensitive_attribute.hpp"
 #include "openvino/opsets/opset10_decl.hpp"
 #include "openvino/opsets/opset2_decl.hpp"
 #include "openvino/pass/manager.hpp"

--- a/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
+++ b/src/common/transformations/tests/common_optimizations/mark_subgraph_to_keep_in_mixed_precision_test.cpp
@@ -1375,16 +1375,10 @@ TEST_F(TransformationTestsF, MarkRandomUniformAsPrecisionSensitive) {
 
     model = std::make_shared<ov::Model>(OutputVector{res}, ParameterVector{param});
 
-    precisions_map fp_convert_precision_map = {
-        {ov::element::f32, ov::element::f16}
-    };
+    precisions_map fp_convert_precision_map = {{ov::element::f32, ov::element::f16}};
 
     type_to_fuse_map empty_fuse_map;
 
     model_ref = model->clone();
-    manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map,
-                                                      empty_fuse_map,
-                                                      true,
-                                                      false,
-                                                      true);
+    manager.register_pass<ov::pass::ConvertPrecision>(fp_convert_precision_map, empty_fuse_map, true, false, true);
 }


### PR DESCRIPTION
The MarkRandomUniform transformation disables compression to FP16 on a RandomUniform node and marks target inputs of consumer nodes as precision sensitive (only target inputs). The other inputs of the consumer nodes are untouched allowing for FP32 to FP16 conversion. Because of that the following graph may take place after ConvertPrecision with the FP32 Constant being converted to FP16 causing the element types mismatch (taken from the real model):

```
 Constant ───f16────┐ 
                    │ 
  Random  ───f32──Less
  Uniform            
```

Adjust the transformation to mark not only the target inputs of the RandomUniform node as precision sensitive, but also the other nodes of the consumers to prevent the type change in ConvertPrecision.


### Tickets:
[CVS-168643](https://jira.devtools.intel.com/browse/CVS-168643)

Signed-off-by: Andrii Staikov <andrii.staikov@intel.com>