### PR TITLE
[GPU] dynamic model gets the memory from non_padded_pool

### DIFF
--- a/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
+++ b/src/plugins/intel_gpu/include/intel_gpu/runtime/memory_pool.hpp
@@ -157,7 +157,6 @@ class memory_pool {
 
     std::multimap<uint64_t, memory_record> _non_padded_pool;
     std::map<layout, std::list<memory_record>, padded_pool_comparer> _padded_pool;
-    std::multimap<uint64_t, memory_record> _no_reusable_pool;
     engine* _engine;
     const ExecutionConfig& _config;
 


### PR DESCRIPTION
### Description of the issue(symptom, root-cause, how it was resolved)
In dynamic models, varying input shapes can lead to increased memory usage.
The GPU plugin reuses memory by allocating it from the padded_pool within the memory_pool.
Memory in the memory_pool is indexed by layout. However, when the memory layout changes, the key is not updated accordingly.
As a result, when it attempts to release memory, it cannot locate the previously allocated memory in the memory_pool.

#### The code and line that caused this issue (if it is not changed directly)
 - src/plugins/intel_gpu/src/runtime/memory_pool.cpp

#### Reproduction step and snapshot (if applicable. Do not attach for customer model)
 - reproducer is attached at the ticket
<img width="1539" height="546" alt="image" src="https://github.com/user-attachments/assets/7289134c-0ddb-41de-8d1f-3a6cd8431748" />


#### Checklist
 - [ ] Is it a proper fix? (not a workaround)
 - [ ] Did you include test case for this fix, if necessary?
 - [ ] Did you review existing test that can be extended to cover this scenario? Which test did you review?

### Tickets:
 - 171152
