### PR TITLE
[GHA] Disable Intel DPC++ Compiler build in pre-commits

### DIFF
--- a/.github/workflows/ubuntu_22_dpcpp.yml
+++ b/.github/workflows/ubuntu_22_dpcpp.yml
@@ -6,8 +6,8 @@ on:
         description: 'Target branch for the build; taken from event context by default'
         type: string
         required: false
-  pull_request:
-  merge_group:
+  # pull_request:
+  # merge_group:
 
 concurrency:
   # github.ref is not unique in post-commit


### PR DESCRIPTION
### Details:
This is one of the most expensive build workflows we have in cloud; as discussed with @p-durandin we don't really need it now  