### PR TITLE
Handle networking issues on retrieving test image for Model Hub tests

### DIFF
--- a/tests/model_hub_tests/jax/test_hf_transformers.py
+++ b/tests/model_hub_tests/jax/test_hf_transformers.py
@@ -25,7 +25,9 @@ class TestTransformersModel(TestJaxConvertModel):
         model = FlaxAutoModel.from_pretrained(model_name)
         if model_name in ['google/vit-base-patch16-224-in21k']:
             url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-            image = Image.open(requests.get(url, stream=True).raw)
+            response = requests.get(url, stream=True)
+            response.raise_for_status()
+            image = Image.open(response.raw)
             image_processor = AutoImageProcessor.from_pretrained(model_name)
             self.example = image_processor(images=image, return_tensors="np")
         elif model_name in ['albert/albert-base-v2', 'facebook/bart-base', 'ksmcg/Mistral-tiny']:
@@ -34,7 +36,9 @@ class TestTransformersModel(TestJaxConvertModel):
         elif model_name in ['openai/clip-vit-base-patch32']:
             processor = AutoProcessor.from_pretrained(model_name)
             url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-            image = Image.open(requests.get(url, stream=True).raw)
+            response = requests.get(url, stream=True)
+            response.raise_for_status()
+            image = Image.open(response.raw)
             self.example = processor(text=["a photo of a cat", "a photo of a dog"],
                                      images=image, return_tensors="np", padding=True)
         if isinstance(self.example, BatchFeature):

--- a/tests/model_hub_tests/pytorch/test_detectron2.py
+++ b/tests/model_hub_tests/pytorch/test_detectron2.py
@@ -17,7 +17,9 @@ class TestDetectron2ConvertModel(TestTorchConvertModel):
         import requests
 
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        self.image = Image.open(requests.get(url, stream=True).raw)
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        self.image = Image.open(response.raw)
         self.image = self.image.resize([640, 480])
 
         subprocess.run([sys.executable, "-m", "pip", "install",

--- a/tests/model_hub_tests/pytorch/test_hf_transformers.py
+++ b/tests/model_hub_tests/pytorch/test_hf_transformers.py
@@ -53,7 +53,9 @@ class TestTransformersModel(TestTorchConvertModel):
         self.infer_timeout = 1800
 
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        self.image = Image.open(requests.get(url, stream=True).raw)
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        self.image = Image.open(response.raw)
 
     @retry(3, exceptions=(OSError,), delay=1)
     def load_model(self, name, type):


### PR DESCRIPTION
### Details:

Without the changes in this PR on networking errors on test image retrieval the exception looks like this:
```
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x7f14a394acf0>
```

This PR adds more clarity to the error message produced in that case.