### PR TITLE
[Optimize] Optimize the Windows API CreateFileW by using FILE_FLAG_SEQUENTIAL_SCAN and FILE_FLAG_OVERLAPPED

### DIFF
--- a/src/common/util/src/os/win/win_mmap_object.cpp
+++ b/src/common/util/src/os/win/win_mmap_object.cpp
@@ -72,7 +72,12 @@ public:
     void set(const std::wstring& path) {
         // Note that file can't be changed (renamed/deleted) until it's unmapped. FILE_SHARE_DELETE flag allow
         // rename/deletion, but it doesn't work with FAT32 filesystem (works on NTFS)
-        auto h = ::CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+        // auto h = ::CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+        auto h = ::CreateFileW(path.c_str(), GENERIC_READ,
+                FILE_SHARE_READ, nullptr,
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN | FILE_FLAG_OVERLAPPED,
+                nullptr);
         map(ov::util::wstring_to_string(path), h);
     }
 #endif


### PR DESCRIPTION
Mainly for LLM reload and LLM switching scenarios, it can effectively improve the performance of LLM Loading

Optimize the Windows API CreateFileW by using FILE_FLAG_SEQUENTIAL_SCAN and FILE_FLAG_OVERLAPPEDQUENTIAL_SCAN and FILE_FLAG_OVERLAPPED
- “[CreateFileW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew)”

Improve the time overhead when switching between different LLMs, 
such as : Qwen3-4B-int4 (with model cache) : 14s -> 6.09s 

### Details:
 - *item1*
 - *...*

### Tickets:
 - *ticket-id*
