### PR TITLE
[GHA] Fix ignored CPU functional tests results in Debian 10 ARM workflow

### DIFF
--- a/.github/workflows/debian_10_arm.yml
+++ b/.github/workflows/debian_10_arm.yml
@@ -139,7 +139,7 @@ jobs:
 
   Overall_Status:
     name: ci/gha_overall_status_debian_10_arm
-    needs: [Smart_CI, Build, CXX_Unit_Tests]
+    needs: [Smart_CI, Build, CXX_Unit_Tests, CPU_Functional_Tests]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Details:
Require `CPU_Functional_Tests` to be finished for `Overall_Status` in Debian 10 ARM workflow

### Tickets:
 - N/A
