### PR TITLE
[DRAFT] [GPU] Add eltwise int4 kernel and remove reorder for INT4

### DIFF
--- a/src/plugins/intel_gpu/src/graph/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/eltwise.cpp
@@ -102,7 +102,8 @@ layout eltwise_inst::calc_output_layout(eltwise_node const& node, kernel_impl_pa
 
     auto mode = desc->mode;
     // list of operations supported for integer types
-    if (input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::u8 ||
+    if (input_node_layout.data_type == data_types::i4 || input_node_layout.data_type == data_types::u4 ||
+        input_node_layout.data_type == data_types::i8 || input_node_layout.data_type == data_types::u8 ||
         input_node_layout.data_type == data_types::i32 || input_node_layout.data_type == data_types::i64) {
         std::vector<eltwise_mode> eltwise_int_modes = {eltwise_mode::sum,
                                                        eltwise_mode::sub,

--- a/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
+++ b/src/plugins/intel_gpu/src/graph/graph_optimizer/prepare_quantization.cpp
@@ -328,6 +328,7 @@ void prepare_quantization::handle_quantize_node(program& p, quantize_node& quant
 }
 
 void prepare_quantization::prepare_dequantize_merge(program& p, eltwise_node& eltwise_node) {
+    //std::cout << "dequantization_merge for node=" << eltwise_node.id() << "\n";
     for (size_t i = 1; i < eltwise_node.get_dependencies().size(); i++) {
         if (!eltwise_node.get_dependency(i).is_type<data>()) {
             return;
@@ -346,6 +347,24 @@ void prepare_quantization::prepare_dequantize_merge(program& p, eltwise_node& el
 
     auto& input = eltwise_node.input();
     const auto& stream = p.get_stream();
+    if (input.is_type<reorder>()) {
+	 // std::cout << "input name is=" << input.id() << "\n";
+	  if (eltwise_node.get_dependencies().size() > 0) {
+            program_node &reorder_node = eltwise_node.get_dependency(0);
+		if (reorder_node.get_dependencies().size() > 0) {
+           	    program_node &reorder_data = reorder_node.get_dependency(0);
+          	    if (reorder_data.get_output_layout().data_type == data_types::i4) {
+            	  //std::cout << "Remove reorder node " << reorder_node.id() << "\n";
+            	  reorder_node.can_be_optimized(true);
+            	  p.add_optimized_primitive_info(reorder_node.id());
+            	  p.extract_and_remove(reorder_node);
+   		    }
+            }       
+         }
+	  // temporary hack
+	  return;
+     }
+
 
     for (auto& user : input.get_users()) {
         if (user == &eltwise_node)
@@ -565,14 +584,19 @@ void prepare_quantization::run(program& p) {
     auto itr = p.get_processing_order().begin();
     while (itr != p.get_processing_order().end()) {
         auto &node = (*itr++);
-        if (node->is_type<quantize>()) {
+	//  std::cout << "prepare_quantization node=" << node->id() << "\n";
+       if (node->is_type<quantize>()) {
             handle_quantize_node(p, node->as<quantize>());
-        } else if (node->is_type<eltwise>()) {
+
+        }
+	  else if (node->is_type<eltwise>()) {
             prepare_dequantize_merge(p, node->as<eltwise>());
-        } else if (node->is_type<reorder>()) {
+        } 
+	  else if (node->is_type<reorder>()) {
             remove_fake_reorders(p, node->as<reorder>());
         } else if (node->is_type<fully_connected>()) {
             optimize_weights_decompression_parameters(node->as<fully_connected>(), p);
         }
+
     }
 }

--- a/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/ocl/eltwise.cpp
@@ -202,6 +202,8 @@ attach_eltwise_impl::attach_eltwise_impl() {
         std::make_tuple(data_types::u32, format::yxfb),
         std::make_tuple(data_types::i32, format::yxfb),
         std::make_tuple(data_types::i64, format::yxfb),
+        std::make_tuple(data_types::i4, format::yxfb),
+        std::make_tuple(data_types::u4, format::yxfb),
 
         std::make_tuple(data_types::f32, format::bfyx),
         std::make_tuple(data_types::f16, format::bfyx),
@@ -212,6 +214,8 @@ attach_eltwise_impl::attach_eltwise_impl() {
         std::make_tuple(data_types::u32, format::bfyx),
         std::make_tuple(data_types::i32, format::bfyx),
         std::make_tuple(data_types::i64, format::bfyx),
+        std::make_tuple(data_types::u4, format::bfyx),
+        std::make_tuple(data_types::i4, format::bfyx),
 
         std::make_tuple(data_types::f32, format::byxf),
         std::make_tuple(data_types::f16, format::byxf),
@@ -222,6 +226,8 @@ attach_eltwise_impl::attach_eltwise_impl() {
         std::make_tuple(data_types::u32, format::byxf),
         std::make_tuple(data_types::i32, format::byxf),
         std::make_tuple(data_types::i64, format::byxf),
+        std::make_tuple(data_types::i4, format::byxf),
+        std::make_tuple(data_types::u4, format::byxf),
 
         std::make_tuple(data_types::f16, format::b_fs_yx_fsv16),
         std::make_tuple(data_types::f32, format::b_fs_yx_fsv16),

--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2343,6 +2343,11 @@ void primitive_inst::update_weights() {
     if (!_impl)
         return;
 
+    if (strcmp(get_node().id().c_str(), "convert:Convert_22842333") == 0) {
+        printf("!!! in here\n");
+    }
+
+
     bool weightable_node = get_node().is_type<fully_connected>() || get_node().is_type<convolution>() || get_node().is_type<deconvolution>();
     if (!weightable_node)
         return;
@@ -2525,6 +2530,10 @@ memory::ptr primitive_inst::allocate_output(engine& _engine,
 
     auto alloc_type = use_lockable_memory ? lockable_mem_type
                     : !usm_device_allocatable ? lockable_mem_type : allocation_type::usm_device;
+
+    if (strcmp(node.id().c_str(), "convert:Convert_22842333") == 0) {
+        printf("!!! in here\n");
+    }
 
     if (is_internal) {
         bool is_reorder_weights = node.is_type<reorder>() && node.as<reorder>().get_primitive()->weights_reorder_params;

--- a/src/plugins/intel_gpu/src/graph/program_node.cpp
+++ b/src/plugins/intel_gpu/src/graph/program_node.cpp
@@ -374,6 +374,11 @@ bool program_node::is_detached(bool whole_branch) {
 
 layout program_node::calc_output_layout() const {
     bool allow_new_shape_infer = get_program().is_new_shape_infer();
+
+    if (strcmp(id().c_str(), "convert:Convert_22842333") == 0) {
+        printf("!!! in here\n");
+    }
+
     if (allow_new_shape_infer) {
         auto out_layouts = type()->calc_output_layouts(*this, *get_kernel_impl_params());
         if (!out_layouts.empty()) {

--- a/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/eltwise_simple_int4.cl
+++ b/src/plugins/intel_gpu/src/kernel_selector/cl_kernels/eltwise_simple_int4.cl
@@ -1,0 +1,37 @@
+// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "include/batch_headers/fetch_data.cl"
+
+KERNEL(eltwise_simple_int4)(INPUTS_DECLS
+                           __global OUTPUT_TYPE* output)
+{
+    const uint global_id = get_global_id(2);
+    const uint int4_id = global_id / 2;
+
+    INPUT1_TYPE in0;
+
+    if (global_id % 2 == 0) {
+       in0 =  TO_INPUT1_TYPE(input0[int4_id] & 0xF);
+    } else {
+       in0 =  TO_INPUT1_TYPE(input0[int4_id] >> 4 & 0xF);
+    }
+    INPUT1_TYPE in1 = input1[global_id];
+
+    output[global_id] = in0 * in1;
+
+    //printf("id=%d, in eltwise_simple_int4, in0=%f, in1=%f value=%f\n", get_global_id(2), in0, in1, in0 * in1);
+    /*
+    VLOAD_DECLS
+
+    MAKE_VECTOR_TYPE(OUTPUT_TYPE, 8) res;
+
+    DO_ELTWISE
+
+    res = ACTIVATION(res, ACTIVATION_PARAMS);
+
+    vstore8(res, global_id, output);
+    */
+
+}

--- a/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/jitter.cpp
@@ -132,8 +132,10 @@ std::string toCLType(WeightsType wType) {
 
 std::string toCLType(Datatype dType) {
     switch (dType) {
+        case Datatype::INT4:
         case Datatype::INT8:
             return GetTypeName<int8_t>();
+        case Datatype::UINT4:
         case Datatype::UINT8:
             return GetTypeName<uint8_t>();
         case Datatype::INT16:

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_int4.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_int4.cpp
@@ -1,0 +1,124 @@
+﻿// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "activation/activation_kernel_base.h"
+#include "eltwise_kernel_int4.h"
+#include "kernel_selector_utils.h"
+#include <string>
+#include <algorithm>
+
+namespace kernel_selector {
+
+ParamsKey EltwiseKernel_int4::GetSupportedKey() const {
+    ParamsKey k;
+    k.EnableInputDataType(Datatype::INT4);
+    k.EnableInputDataType(Datatype::UINT4);
+    k.EnableInputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::F16);
+    k.EnableOutputDataType(Datatype::F32);
+    k.EnableInputLayout(DataLayout::byxf);
+    k.EnableOutputLayout(DataLayout::byxf);
+    k.EnableInputLayout(DataLayout::bfyx);
+    k.EnableOutputLayout(DataLayout::bfyx);
+//    k.EnableAllInputLayout();
+//    k.EnableAllOutputLayout();
+    k.EnableDifferentTypes();
+    k.EnableBatching();
+    k.EnableTensorPitches();
+    k.EnableTensorOffset();
+    return k;
+}
+
+JitConstants EltwiseKernel_int4::GetJitConstants(const eltwise_params& params) const {
+    return GetJitConstantsCommon(params, true);
+}
+
+bool EltwiseKernel_int4::Validate(const Params& params) const {
+    if (!EltwiseKernelBase::Validate(params)) {
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
+    }
+
+    const auto& ewParams = static_cast<const eltwise_params&>(params);
+
+    // Only one activation can be fused.
+    if (ewParams.fused_ops.size() > 1 ||
+        (ewParams.activations.size() !=0 && ewParams.fused_ops.size() != 0)) {
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
+    }
+
+    /*
+        for (size_t i = 0; i < ewParams.inputs.size(); i++) {
+            const auto input_layout = ewParams.inputs[i].GetLayout();
+            const auto batch_size = ewParams.inputs[i].Batch().v;
+            const auto feature_size = ewParams.inputs[i].Feature().v;
+            if ((input_layout == DataLayout::b_fs_yx_fsv16 && feature_size % 16 != 0) ||
+                (input_layout == DataLayout::b_fs_yx_fsv32 && feature_size % 32 != 0) ||
+                (input_layout == DataLayout::b_fs_zyx_fsv16 && feature_size % 16 != 0) ||
+                (input_layout == DataLayout::b_fs_yx_fsv4 && feature_size % 8 != 0) ||
+                input_layout == DataLayout::fs_b_yx_fsv32 ||
+                (input_layout == DataLayout::bs_fs_yx_bsv32_fsv16 && (feature_size % 16 != 0 || batch_size % 32 != 0)) ||
+                (input_layout == DataLayout::bs_fs_yx_bsv32_fsv32 && (feature_size % 32 != 0 || batch_size % 32 != 0)))
+                DO_NOT_USE_THIS_KERNEL(params.layerID);
+        }
+        if ((ewParams.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv16 && ewParams.outputs[0].Feature().v % 16 != 0) ||
+            (ewParams.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv32 && ewParams.outputs[0].Feature().v % 32 != 0) ||
+            (ewParams.outputs[0].GetLayout() == DataLayout::b_fs_zyx_fsv16 && ewParams.outputs[0].Feature().v % 16 != 0) ||
+            (ewParams.outputs[0].GetLayout() == DataLayout::b_fs_yx_fsv4 && ewParams.outputs[0].Feature().v % 8 != 0) ||
+            ewParams.outputs[0].GetLayout() == DataLayout::fs_b_yx_fsv32 ||
+            (ewParams.outputs[0].GetLayout() == DataLayout::bs_fs_yx_bsv32_fsv16 &&
+                (ewParams.outputs[0].Feature().v % 16 != 0 || ewParams.outputs[0].Batch().v % 32 != 0)) ||
+            (ewParams.outputs[0].GetLayout() == DataLayout::bs_fs_yx_bsv32_fsv32 &&
+                (ewParams.outputs[0].Feature().v % 32 != 0 || ewParams.outputs[0].Batch().v % 32 != 0)))
+            DO_NOT_USE_THIS_KERNEL(params.layerID);
+
+    const auto& output = ewParams.outputs[0];
+    const auto count = output.PhysicalSize();
+
+    const bool bSupportedCount = (count % 8) == 0;
+
+    bool bCheckSizes = true;
+    for (size_t i = 0; i < ewParams.inputs.size(); i++) {
+        // allow only the same input sizes or scalars, without pitches
+        if (ewParams.inputs[i].PitchesDifferFromLogicalDims() ||
+            (!(ewParams.inputs[0] == ewParams.inputs[i] && ewParams.inputs[i] == ewParams.outputs[0]) &&
+             ewParams.inputs[i].PhysicalSize() != 1))
+            bCheckSizes = false;
+    }
+
+    // TODO: add support to this implementation when user requests input values updates
+    bool bCheckUpdateInput = true;
+    if (!ewParams.updateInputIds.empty())
+        bCheckUpdateInput = false;
+
+    // TODO: add support for reading from output buffer and using its values in computation
+    bool bCheckUseOutput = true;
+    for (size_t op = 0; op < ewParams.operations.size(); op++) {
+        for (size_t input_idx = 0; input_idx < ewParams.operations[op].inputs.size(); input_idx++) {
+            if (ewParams.operations[op].inputs[input_idx].mode == EltwiseInputMode::OUTPUT_BUFFER) {
+                bCheckUseOutput = false;
+                break;
+            }
+        }
+    }
+
+    if (IsUnsupportedModeForVecCode(ewParams))
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
+
+    if (!bCheckSizes || !bSupportedCount || !bCheckUpdateInput || !bCheckUseOutput) {
+        DO_NOT_USE_THIS_KERNEL(params.layerID);
+    }
+            */
+
+    //printf("!!!! in eltwise validate done \n");
+    return true;
+}
+
+KernelsData EltwiseKernel_int4::GetKernelsData(const Params& params) const {
+    return GetCommonKernelsData(params);
+}
+
+KernelsPriority EltwiseKernel_int4::GetKernelsPriority(const Params& /*params*/) const {
+    return FORCE_PRIORITY_8;
+}
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_int4.h
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_int4.h
@@ -1,0 +1,28 @@
+﻿// Copyright (C) 2018-2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "eltwise_kernel_base.h"
+
+namespace kernel_selector {
+class EltwiseKernel_int4 : public EltwiseKernelBase {
+public:
+    EltwiseKernel_int4() : EltwiseKernelBase("eltwise_simple_int4") {}
+    virtual ~EltwiseKernel_int4() {}
+
+    KernelsData GetKernelsData(const Params& params) const override;
+    KernelsPriority GetKernelsPriority(const Params& params) const override;
+    ParamsKey GetSupportedKey() const override;
+    std::vector<FusedOpType> GetSupportedFusedOps() const override {
+        return {
+            FusedOpType::ACTIVATION
+        };
+    }
+
+protected:
+    bool Validate(const Params& p) const override;
+    JitConstants GetJitConstants(const eltwise_params& params) const override;
+};
+}  // namespace kernel_selector

--- a/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_selector.cpp
+++ b/src/plugins/intel_gpu/src/kernel_selector/kernels/eltwise/eltwise_kernel_selector.cpp
@@ -8,6 +8,7 @@
 #include "eltwise_kernel_mixed_byxf_and_fs_b_yx_fsv32.h"
 #include "eltwise_kernel_fs_b_yx_fsv32.h"
 #include "eltwise_kernel_blocked_opt.h"
+#include "eltwise_kernel_int4.h"
 
 
 namespace kernel_selector {
@@ -17,6 +18,7 @@ eltwise_kernel_selector::eltwise_kernel_selector() {
     Attach<EltwiseKernel_blocked_opt>();
     Attach<EltwiseKernel_fs_b_yx_fsv32>();
     Attach<EltwiseKernel_vload8>();
+    Attach<EltwiseKernel_int4>();
 }
 
 KernelsData eltwise_kernel_selector::GetBestKernels(const Params& params) const {

--- a/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_for_periodic_funcs.cpp
+++ b/src/plugins/intel_gpu/src/plugin/transformations/disable_fp16_comp_for_periodic_funcs.cpp
@@ -50,7 +50,7 @@ static bool is_propagate_through_node(const std::shared_ptr<ov::Node>& node) {
            ov::is_type<ov::op::v1::StridedSlice>(node) ||
            ov::is_type<ov::op::v1::ReduceSum>(node) ||
            ov::is_type<ov::op::v1::ReduceMean>(node) ||
-           ov::is_type<ov::op::v8::Slice>(node) ||
+  //         ov::is_type<ov::op::v8::Slice>(node) ||
            ov::is_type<ov::op::v1::VariadicSplit>(node) ||
            ov::is_type<ov::op::v1::Split>(node) ||
            ov::is_type<ov::op::v0::Concat>(node) ||


### PR DESCRIPTION
Combine the INT4 to INT8 conversion with eltwise kernel

Temporary remove the transformation for disable fp16 compression for slide as it cause issue for deepseek-vl2-small.

CVS-168630
